### PR TITLE
Fix issue 96: Assets from theme have the wrong schema

### DIFF
--- a/inc/front/cdn.php
+++ b/inc/front/cdn.php
@@ -144,7 +144,7 @@ function rocket_cdn_enqueue( $src )
 		return $src;
 	}
 
-	$src  = set_url_scheme( $src );
+	$src  = rocket_add_url_protocol( $src );
 	$zone = array( 'all', 'css_and_js' );
 
 	// Add only CSS zone


### PR DESCRIPTION
Assets from theme have the wrong schema when site is http and CDN is https
