### PR TITLE
Fix 117: illegal offset type in WPML

### DIFF
--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -530,7 +530,7 @@ function rocket_clean_home_feeds() {
  * @return void
  */
 function rocket_clean_domain( $lang = '' ) {
-	$urls = ( ! $lang || is_object( $lang ) ) ? get_rocket_i18n_uri() : get_rocket_i18n_home_url( $lang );
+	$urls = ( ! $lang || is_object( $lang ) || is_array( $lang ) ) ? get_rocket_i18n_uri() : get_rocket_i18n_home_url( $lang );
 	$urls = (array) $urls;
 
 	/**


### PR DESCRIPTION
because $lang is an array instead of a string
