### PR TITLE
Fixes #142: not public CPT compatibility

### DIFF
--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -104,7 +104,7 @@ function rocket_clean_post( $post_id ) {
 
     // Don't purge if post's post type is not public or not publicly queryable
     $post_type = get_post_type_object( $post->post_type );
-    if ( $post_type->public == 0  || $post_type->publicly_queryable == 0 ) {
+    if ( $post_type->public !== 1  || $post_type->publicly_queryable !== 1 ) {
         return;
     }
 	


### PR DESCRIPTION
Prevent purging when on a not public or not publicly queryable CPT, preventing them from being visited by the preload bot
