### PR TITLE
Fixes #143: Homepage exclusion side effect

### DIFF
--- a/inc/admin/ui/meta-boxes.php
+++ b/inc/admin/ui/meta-boxes.php
@@ -51,11 +51,13 @@ function __rocket_display_cache_options_meta_boxes() {
         <div class="misc-pub-section">
             <?php
                 $reject_current_uri = false;
-                $rejected_uris = array_flip( get_rocket_option( 'cache_reject_uri' ) );
-                $path = rocket_clean_exclude_file( get_permalink( $post->ID ) );
+                if ( $pagenow !== 'post-new.php' ) {
+                    $rejected_uris = array_flip( get_rocket_option( 'cache_reject_uri' ) );
+                    $path = rocket_clean_exclude_file( get_permalink( $post->ID ) );
 
-                if ( isset( $rejected_uris[ $path ] ) ) {
-                    $reject_current_uri = true;
+                    if ( isset( $rejected_uris[ $path ] ) ) {
+                        $reject_current_uri = true;
+                    }
                 } ?>
             <input name="rocket_post_nocache" id="rocket_post_nocache" type="checkbox" title="<?php _e( 'Never cache this page', 'rocket' ); ?>" <?php checked( $reject_current_uri, true ); ?>><label for="rocket_post_nocache"><?php _e( 'Never cache this page', 'rocket' ); ?></label>
         </div>


### PR DESCRIPTION
If homepage is excluded from cache, prevent the box from being automatically checked for new post
