### PR TITLE
Fix #159: Exclude Facebook user agents from the cache

### DIFF
--- a/inc/functions/options.php
+++ b/inc/functions/options.php
@@ -269,6 +269,9 @@ function get_rocket_cache_dynamic_cookies() {
 function get_rocket_cache_reject_ua() {
 	$ua   = get_rocket_option( 'cache_reject_ua', array() );
 	$ua[] = 'facebookexternalhit';
+	$ua[] = 'FB_IAB';
+	$ua[] = 'FB4A';
+	$ua[] = 'FBAV';
 
 	/**
 	 * Filter the rejected User-Agent


### PR DESCRIPTION
 to prevent issue with lazy loading iframes option on Android and the in-app FB browser
