### PR TITLE
Fixes #175

### DIFF
--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -779,7 +779,7 @@ function rocket_rrmdir( $dir, $dirs_to_preserve = array() ) {
     // Remove the hidden empty file for mobile detection on NGINX with the Rocket NGINX configuration
     $nginx_mobile_detect_file = $dir . '/.mobile-active';
 
-    if ( file_exists( $nginx_mobile_detect_file ) ) {
+    if ( is_dir( $dir ) && file_exists( $nginx_mobile_detect_file ) ) {
         @unlink( $nginx_mobile_detect_file );
     }
 


### PR DESCRIPTION
Check if current path is a directory to prevent trying to delete a non-existing .mobile-active file
