### PR TITLE
Fixes #286

### DIFF
--- a/inc/3rd-party/3rd-party.php
+++ b/inc/3rd-party/3rd-party.php
@@ -44,5 +44,6 @@ require( WP_ROCKET_3RD_PARTY_PATH . 'page-builder/visual-composer.php' );
 require( WP_ROCKET_3RD_PARTY_PATH . 'security/secupress.php' );
 require( WP_ROCKET_3RD_PARTY_PATH . 'simple-custom-css.php' );
 require( WP_ROCKET_3RD_PARTY_PATH . 'wp-retina-2x.php' );
+require( WP_ROCKET_3RD_PARTY_PATH . 'plugins/sf-move-login.php' );
 
 require( WP_ROCKET_3RD_PARTY_PATH . 'themes/divi.php' );

--- a/inc/3rd-party/plugins/sf-move-login.php
+++ b/inc/3rd-party/plugins/sf-move-login.php
@@ -16,22 +16,28 @@ endif;
  * @return array Updated array of URLs
  */
 function rocket_add_sfml_exclude_pages( $urls ) {
-	if ( defined( 'SFML_PLUGIN_DIR' ) ) { 
-		if ( ! class_exists( 'SFML_Options' ) ) {
+	if ( ! function_exists( 'sfml_get_slugs' ) ) {
+		if ( file_exists( SFML_PLUGIN_DIR . 'inc/utilities.php' ) ) {
 			include( SFML_PLUGIN_DIR . 'inc/utilities.php' );
-			include( SFML_PLUGIN_DIR . 'inc/class-sfml-options.php' );
+		} else {
+			return $urls;
 		}
-		
-		$sfml_slugs = SFML_Options::get_slugs();
-
-		foreach( $sfml_slugs as $slug ) {
-			$sfml_urls[] = rocket_clean_exclude_file( trailingslashit( home_url( $slug ) ) );
-		}
-
-		$urls = array_merge( $urls, $sfml_urls );
 	}
 
-	return $urls;
+	if ( ! class_exists( 'SFML_Options' ) && ! defined( 'SFML_NOOP_VERSION' ) ) {
+		if ( file_exists( SFML_PLUGIN_DIR . 'inc/class-sfml-options.php' ) ) {
+			include( SFML_PLUGIN_DIR . 'inc/class-sfml-options.php' );
+		} else {
+			return $urls;
+		}
+	}
+
+	$sfml_slugs = sfml_get_slugs();
+	$sfml_slugs = array_map( 'home_url', $sfml_slugs );
+	$sfml_slugs = array_map( 'trailingslashit', $sfml_slugs );
+	$sfml_slugs = array_map( 'rocket_clean_exclude_file', $sfml_slugs );
+
+	return array_merge( $urls, $sfml_slugs );
 }
 
 add_action( 'activate_sf-move-login/sf-move-login.php', 'rocket_activate_sfml', 11 );

--- a/inc/3rd-party/plugins/sf-move-login.php
+++ b/inc/3rd-party/plugins/sf-move-login.php
@@ -1,0 +1,71 @@
+<?php 
+defined( 'ABSPATH' ) or die( 'Cheatin\' uh?' );
+
+if ( defined( 'SFML_VERSION' ) && version_compare( SFML_VERSION, '2.4', '<' ) ):
+	add_filter( 'rocket_cache_reject_uri', 'rocket_add_sfml_exclude_pages' );
+	add_action( 'update_option_sfml', '__rocket_after_update_single_options', 10, 2 );
+endif;
+
+/**
+ * Exclude SF Move Login custom urls from caching
+ *
+ * @since 2.9.3 Moved to 3rd party file and improved
+ * @since 2.6
+ *
+ * @param array $urls An array of URLs to exclude from cache.
+ * @return array Updated array of URLs
+ */
+function rocket_add_sfml_exclude_pages( $urls ) {
+	if ( defined( 'SFML_PLUGIN_DIR' ) ) { 
+		if ( ! class_exists( 'SFML_Options' ) ) {
+			include( SFML_PLUGIN_DIR . 'inc/utilities.php' );
+			include( SFML_PLUGIN_DIR . 'inc/class-sfml-options.php' );
+		}
+		
+		$sfml_slugs = SFML_Options::get_slugs();
+
+		foreach( $sfml_slugs as $slug ) {
+			$sfml_urls[] = rocket_clean_exclude_file( trailingslashit( home_url( $slug ) ) );
+		}
+
+		$urls = array_merge( $urls, $sfml_urls );
+	}
+
+	return $urls;
+}
+
+add_action( 'activate_sf-move-login/sf-move-login.php', 'rocket_activate_sfml', 11 );
+/**
+ * Add SFML custom urls to caching exclusion when activating the plugin
+ *
+ * @since 2.9.3
+ */
+function rocket_activate_sfml() {
+	if ( defined( 'SFML_VERSION' ) && version_compare( SFML_VERSION, '2.4', '<' ) ) {
+		add_filter( 'rocket_cache_reject_uri', 'rocket_add_sfml_exclude_pages' );
+		
+    	// Update the WP Rocket rules on the .htaccess
+    	flush_rocket_htaccess();
+		
+    	// Regenerate the config file
+    	rocket_generate_config_file();
+    }
+}
+
+add_action( 'deactivate_sf-move-login/sf-move-login.php', 'rocket_deactivate_sfml', 11 );
+/**
+ * Remove SFML custom urls from caching exclusion when deactivating the plugin
+ *
+ * @since 2.9.3
+ */
+function rocket_deactivate_sfml() {
+	if ( defined( 'SFML_VERSION' ) && version_compare( SFML_VERSION, '2.4', '<' ) ) {
+		remove_filter( 'rocket_cache_reject_uri', 'rocket_add_sfml_exclude_pages' );
+		
+    	// Update the WP Rocket rules on the .htaccess
+    	flush_rocket_htaccess();
+		
+    	// Regenerate the config file
+    	rocket_generate_config_file();
+    }
+}

--- a/inc/admin/plugin-compatibility.php
+++ b/inc/admin/plugin-compatibility.php
@@ -5,6 +5,7 @@ defined( 'ABSPATH' ) or die( 'Cheatin\' uh?' );
  * When Woocommerce, EDD, iThemes Exchange, Jigoshop & WP-Shop options are saved or deleted,
  * we update .htaccess & config file to get the right checkout page to exclude to the cache.
  *
+ * @since 2.9.3 Support for SF Move Login moved to 3rd party file
  * @since 2.6 Add support with SF Move Login & WPS Hide Login to exclude login pages
  * @since 2.4
  */
@@ -17,7 +18,6 @@ add_action( 'update_option_wpshop_payment_return_page_id', '__rocket_after_updat
 add_action( 'update_option_wpshop_payment_return_nok_page_id', '__rocket_after_update_single_options', 10, 2 );
 add_action( 'update_option_wpshop_myaccount_page_id'	, '__rocket_after_update_single_options', 10, 2 );
 add_action( 'update_option_it-storage-exchange_settings_pages', '__rocket_after_update_single_options', 10, 2 );
-add_action( 'update_option_sfml', '__rocket_after_update_single_options', 10, 2 );
 add_action( 'update_option_whl_page', '__rocket_after_update_single_options', 10, 2 );
 function __rocket_after_update_single_options( $old_value, $value ) {
 	if ( $old_value != $value ) {
@@ -32,15 +32,12 @@ function __rocket_after_update_single_options( $old_value, $value ) {
 /**
  * We need to regenerate the config file + htaccess depending on some plugins
  *
+ * @since 2.9.3 Support for SF Move Login moved to 3rd party file
  * @since 2.6.5 Add support with SF Move Login & WPS Hide Login
  */
-add_action( 'activate_sf-move-login/sf-move-login.php', 'rocket_generate_config_file', 11 );
-add_action( 'deactivate_sf-move-login/sf-move-login.php', 'rocket_generate_config_file', 11 );
 add_action( 'activate_wps-hide-login/wps-hide-login.php', 'rocket_generate_config_file', 11 );
 add_action( 'deactivate_wps-hide-login/wps-hide-login.php', 'rocket_generate_config_file', 11 );
 
-add_action( 'activate_sf-move-login/sf-move-login.php', 'flush_rocket_htaccess', 11 );
-add_action( 'deactivate_sf-move-login/sf-move-login.php', 'flush_rocket_htaccess', 11 );
 add_action( 'activate_wps-hide-login/wps-hide-login.php', 'flush_rocket_htaccess', 11 );
 add_action( 'deactivate_wps-hide-login/wps-hide-login.php', 'flush_rocket_htaccess', 11 );
 

--- a/inc/functions/plugins.php
+++ b/inc/functions/plugins.php
@@ -245,20 +245,6 @@ function get_rocket_ecommerce_exclude_pages() {
 function get_rocket_logins_exclude_pages() {
 	$urls = array();
 
-	// SF Move Login - Don't return its slugs on deactivation
-	if ( defined( 'SFML_PLUGIN_DIR' ) && 'deactivate_sf-move-login/sf-move-login.php' != current_filter() ) { 
-		if ( ! class_exists( 'SFML_Options' ) ) {
-			include( SFML_PLUGIN_DIR . 'inc/utilities.php' );
-			include( SFML_PLUGIN_DIR . 'inc/class-sfml-options.php' );
-		}
-		
-		$urls = array_merge( $urls, SFML_Options::get_slugs() );
-		
-		foreach( $urls as $k => $url ) {
-			$urls[ $k ] = rocket_clean_exclude_file( trailingslashit( home_url( $url ) ) );
-		}
-	}
-
 	// WPS Hide Login - Don't return its slug on deactivation
 	if ( class_exists( 'WPS_Hide_Login' ) && 'deactivate_wps-hide-login/wps-hide-login.php' != current_filter() ) {
 		$urls[] = rocket_clean_exclude_file( home_url( trailingslashit( get_option( 'whl_page' ) ) ) );


### PR DESCRIPTION
Update compatibility with SF Move Login.

No longer exclude the URLs for version 2.4 and above since it's using DONOTCACHEPAGE constant.