### PR TITLE
Fixes #292

### DIFF
--- a/inc/front/cdn.php
+++ b/inc/front/cdn.php
@@ -273,8 +273,8 @@ function rocket_cdn_custom_files( $html ) {
  * @param  string $src URL of the file
  * @return string modified URL
  */
-add_filter( 'style_loader_src', 'rocket_cdn_enqueue', PHP_INT_MAX );
-add_filter( 'script_loader_src', 'rocket_cdn_enqueue', PHP_INT_MAX );
+add_filter( 'style_loader_src', 'rocket_cdn_enqueue', PHP_INT_MAX - 1 );
+add_filter( 'script_loader_src', 'rocket_cdn_enqueue', PHP_INT_MAX - 1 );
 function rocket_cdn_enqueue( $src ) {
 	// Don't use CDN if in admin, in login page, in register page or in a post preview
 	if ( is_admin() || is_preview() || in_array( $GLOBALS['pagenow'], array( 'wp-login.php', 'wp-register.php' ) ) ) {

--- a/inc/front/enqueue.php
+++ b/inc/front/enqueue.php
@@ -12,11 +12,11 @@ defined( 'ABSPATH' ) or	die( 'Cheatin&#8217; uh?' );
  * @return string updated CSS/JS file URL
  */
 if ( ! get_rocket_option( 'minify_css' ) ) {
-    add_filter( 'style_loader_src', 'rocket_browser_cache_busting', 15 );
+    add_filter( 'style_loader_src', 'rocket_browser_cache_busting', PHP_INT_MAX );
 }
 
 if ( ! get_rocket_option( 'minify_js' ) ) {
-    add_filter( 'script_loader_src', 'rocket_browser_cache_busting', 15 );
+    add_filter( 'script_loader_src', 'rocket_browser_cache_busting', PHP_INT_MAX );
 }
 
 function rocket_browser_cache_busting( $src, $current_filter = '' ) {


### PR DESCRIPTION
Prevent a JS file from being loaded twice when Remove query strings + defer JS + CDN are active