### PR TITLE
Elementor page builder compatibility file

### DIFF
--- a/inc/3rd-party/3rd-party.php
+++ b/inc/3rd-party/3rd-party.php
@@ -39,6 +39,7 @@ require( WP_ROCKET_3RD_PARTY_PATH . 'yoast-seo.php' );
 require( WP_ROCKET_3RD_PARTY_PATH . 'all-in-one-seo-pack.php' );
 require( WP_ROCKET_3RD_PARTY_PATH . 'wp-rest-api.php' );
 require( WP_ROCKET_3RD_PARTY_PATH . 'page-builder/beaver-builder.php' );
+require( WP_ROCKET_3RD_PARTY_PATH . 'page-builder/elementor.php' );
 require( WP_ROCKET_3RD_PARTY_PATH . 'page-builder/thrive-visual-editor.php' );
 require( WP_ROCKET_3RD_PARTY_PATH . 'page-builder/visual-composer.php' );
 require( WP_ROCKET_3RD_PARTY_PATH . 'security/secupress.php' );

--- a/inc/3rd-party/page-builder/elementor.php
+++ b/inc/3rd-party/page-builder/elementor.php
@@ -1,0 +1,20 @@
+<?php
+defined( 'ABSPATH' ) or die( 'Cheatin\' uh?' );
+
+if ( defined( 'ELEMENTOR_VERSION' ) ) :
+
+    /**
+     * Excludes Elementor scripts from JS minification
+     *
+     * @since 2.9.x
+     *
+     * @param Array $excluded_handle An array of JS handles enqueued in WordPress
+     * @return Array the updated array of handles
+     */
+    add_filter( 'rocket_exclude_js', 'rocket_exclude_js_elementor' );
+    function rocket_exclude_js_elementor( $excluded_js ) {
+        $excluded_js[] = '/(.*)/elementor/(.*).js';
+        return $excluded_js;
+    }
+
+endif;

--- a/inc/3rd-party/page-builder/elementor.php
+++ b/inc/3rd-party/page-builder/elementor.php
@@ -6,7 +6,7 @@ if ( defined( 'ELEMENTOR_VERSION' ) ) :
     /**
      * Excludes Elementor scripts from JS minification
      *
-     * @since 2.9.x
+     * @since 2.9.5
      *
      * @param Array $excluded_handle An array of JS handles enqueued in WordPress
      * @return Array the updated array of handles


### PR DESCRIPTION
The Elementor page builder generated pages don't work with WP Rocket (Minify mode activated). 
https://elementor.com/
There is a free and pro version.

I had to exclude every asset files like:
http://domain/wp-content/plugins/elementor/assets/*