### PR TITLE
Minor string update: specified support languages

### DIFF
--- a/inc/admin/ui/modules/support.php
+++ b/inc/admin/ui/modules/support.php
@@ -60,8 +60,8 @@ add_settings_field(
 		array(
 			'type'         => 'helper_help',
 			'description'  =>
-			/* translators: line break recommended, but not mandatory  */
-			__( '<strong>Now be specific!</strong><br>We have pre-filled the form with some questions for you to phrase your description along.', 'rocket' )
+			/* translators: line breaks recommended, but not mandatory  */
+			__( '<strong>Now be specific!</strong><br>We have pre-filled the form with some questions for you to phrase your description along.<br>We speak English, French, German, Italian, Serbian, and Spanish.', 'rocket' )
 		),
 		array(
 			'type'         => 'textarea',


### PR DESCRIPTION
Since the example content of our form gets translated into all the languages, people rightfully assume they can send a message in the language they see being used in the form.

That had led to us receiving support requests in Dutch, Chinese, and other languages we do not speak. ;)

This update extends the description of the support form to mention the languages currently spoken across our support team.