### PR TITLE
Introduce DONOTROCKETOPTIMIZE constant

### DIFF
--- a/inc/deprecated.php
+++ b/inc/deprecated.php
@@ -886,3 +886,41 @@ function rocket_database_optimization_scheduled() {
 function do_rocket_database_optimization() {
 	_deprecated_function( __FUNCTION__, '2.11', 'Rocket_Database_Optimisation->process_handler()' );
 }
+
+/**
+ * Declare and set value to DONOTMINIFYCSS & DONOTMINIFYJS constant
+ *
+ * @since 2.6.2
+ * @deprecated 2.11
+ * @see rocket_define_donotoptimize_constant()
+ *
+ * @param bool $value true or false.
+ */
+function rocket_define_donotminify_constants( $value ) {
+	_deprecated_function( __FUNCTION__, '2.11', 'rocket_define_donotoptimize_constant' );
+
+	if ( ! defined( 'DONOTMINIFYCSS' ) ) {
+		define( 'DONOTMINIFYCSS', (bool) $value );
+	}
+	if ( ! defined( 'DONOTMINIFYJS' ) ) {
+		define( 'DONOTMINIFYJS', (bool) $value );
+	}
+}
+
+/**
+ * Declare and set value to DONOTMASYNCCSS constant
+ *
+ * @since 2.10
+ * @deprecated 2.11
+ * @see rocket_define_donotoptimize_constant()
+ * @author Remy Perona
+ *
+ * @param bool $value true or false.
+ */
+function rocket_define_donotasync_css_constant( $value ) {
+	_deprecated_function( __FUNCTION__, '2.11', 'rocket_define_donotoptimize_constant' );
+
+	if ( ! defined( 'DONOTASYNCCSS' ) ) {
+		define( 'DONOTASYNCCSS', (bool) $value );
+	}
+}

--- a/inc/front/async-css.php
+++ b/inc/front/async-css.php
@@ -78,12 +78,7 @@ function rocket_insert_critical_css() {
 		return;
 	}
 
-	// Don't apply if DONOTCACHEPAGE is defined.
-	if ( defined( 'DONOTCACHEPAGE' ) && DONOTCACHEPAGE ) {
-		return;
-	}
-
-	if ( defined( 'DONOTASYNCCSS' ) && DONOTASYNCCSS ) {
+	if ( defined( 'DONOTROCKETOPTIMIZE' ) && DONOTROCKETOPTIMIZE ) {
 		return;
 	}
 
@@ -139,12 +134,7 @@ function rocket_insert_load_css() {
 		return;
 	}
 
-	// Don't apply if DONOTCACHEPAGE is defined.
-	if ( defined( 'DONOTCACHEPAGE' ) && DONOTCACHEPAGE ) {
-		return;
-	}
-
-	if ( defined( 'DONOTASYNCCSS' ) && DONOTASYNCCSS ) {
+	if ( defined( 'DONOTROCKETOPTIMIZE' ) && DONOTROCKETOPTIMIZE ) {
 		return;
 	}
 

--- a/inc/front/async-css.php
+++ b/inc/front/async-css.php
@@ -78,7 +78,7 @@ function rocket_insert_critical_css() {
 		return;
 	}
 
-	if ( defined( 'DONOTROCKETOPTIMIZE' ) && DONOTROCKETOPTIMIZE ) {
+	if ( ( defined( 'DONOTROCKETOPTIMIZE' ) && DONOTROCKETOPTIMIZE ) || ( defined( 'DONOTASYNCCSS' ) && DONOTASYNCCSS ) ) {
 		return;
 	}
 
@@ -134,7 +134,7 @@ function rocket_insert_load_css() {
 		return;
 	}
 
-	if ( defined( 'DONOTROCKETOPTIMIZE' ) && DONOTROCKETOPTIMIZE ) {
+	if ( defined( 'DONOTROCKETOPTIMIZE' ) && DONOTROCKETOPTIMIZE || ( defined( 'DONOTASYNCCSS' ) && DONOTASYNCCSS ) ) {
 		return;
 	}
 

--- a/inc/front/async-css.php
+++ b/inc/front/async-css.php
@@ -134,7 +134,7 @@ function rocket_insert_load_css() {
 		return;
 	}
 
-	if ( defined( 'DONOTROCKETOPTIMIZE' ) && DONOTROCKETOPTIMIZE || ( defined( 'DONOTASYNCCSS' ) && DONOTASYNCCSS ) ) {
+	if ( ( defined( 'DONOTROCKETOPTIMIZE' ) && DONOTROCKETOPTIMIZE ) || ( defined( 'DONOTASYNCCSS' ) && DONOTASYNCCSS ) ) {
 		return;
 	}
 

--- a/inc/front/cdn.php
+++ b/inc/front/cdn.php
@@ -10,6 +10,10 @@ defined( 'ABSPATH' ) || die( 'Cheatin&#8217; uh?' );
  * @return string modified URL
  */
 function rocket_cdn_file( $url ) {
+	if ( defined( 'DONOTROCKETOPTIMIZE' ) && DONOTROCKETOPTIMIZE ) {
+		return $url;
+	}
+
 	$ext = pathinfo( $url, PATHINFO_EXTENSION );
 
 	if ( is_admin() || 'php' === $ext ) {
@@ -70,6 +74,10 @@ add_filter( 'bwp_get_minify_src'        , 'rocket_cdn_file', PHP_INT_MAX );
  * @return array Array with updated src URL
  */
 function rocket_cdn_attachment_image_src( $image ) {
+	if ( defined( 'DONOTROCKETOPTIMIZE' ) && DONOTROCKETOPTIMIZE ) {
+		return $image;
+	}
+
 	if ( ! (bool) $image ) {
 		return $image;
 	}
@@ -112,6 +120,10 @@ if ( function_exists( 'wp_calculate_image_srcset' ) ) :
 	 * @return array $sources
 	 */
 	function rocket_add_cdn_on_srcset( $sources ) {
+		if ( defined( 'DONOTROCKETOPTIMIZE' ) && DONOTROCKETOPTIMIZE ) {
+			return $sources;
+		}
+
 		if ( (bool) $sources ) {
 			foreach ( $sources as $width => $data ) {
 				$sources[ $width ]['url'] = rocket_cdn_file( $data['url'] );
@@ -132,7 +144,7 @@ endif;
  */
 function rocket_cdn_images( $html ) {
 	// Don't use CDN if the image is in admin, a feed or in a post preview.
-	if ( is_admin() || is_feed() || is_preview() || empty( $html ) ) {
+	if ( is_admin() || is_feed() || is_preview() || empty( $html ) || defined( 'DONOTROCKETOPTIMIZE' ) && DONOTROCKETOPTIMIZE ) {
 		return $html;
 	}
 
@@ -215,7 +227,7 @@ add_filter( 'rocket_buffer', 'rocket_cdn_images', PHP_INT_MAX );
  * @return string modified HTML content
  */
 function rocket_cdn_inline_styles( $html ) {
-	if ( is_preview() || empty( $html ) ) {
+	if ( is_preview() || empty( $html ) || defined( 'DONOTROCKETOPTIMIZE' ) && DONOTROCKETOPTIMIZE ) {
 		return $html;
 	}
 
@@ -259,7 +271,7 @@ add_filter( 'rocket_buffer', 'rocket_cdn_inline_styles', PHP_INT_MAX );
  * @return string modified HTML content
  */
 function rocket_cdn_custom_files( $html ) {
-	if ( is_preview() || empty( $html ) ) {
+	if ( is_preview() || empty( $html ) || defined( 'DONOTROCKETOPTIMIZE' ) && DONOTROCKETOPTIMIZE ) {
 		return $html;
 	}
 
@@ -310,7 +322,7 @@ add_filter( 'rocket_buffer', 'rocket_cdn_custom_files', 12 );
  */
 function rocket_cdn_enqueue( $src ) {
 	// Don't use CDN if in admin, in login page, in register page or in a post preview.
-	if ( is_admin() || is_preview() || in_array( $GLOBALS['pagenow'], array( 'wp-login.php', 'wp-register.php' ), true ) ) {
+	if ( is_admin() || is_preview() || in_array( $GLOBALS['pagenow'], array( 'wp-login.php', 'wp-register.php' ), true ) || defined( 'DONOTROCKETOPTIMIZE' ) && DONOTROCKETOPTIMIZE ) {
 		return $src;
 	}
 

--- a/inc/front/enqueue.php
+++ b/inc/front/enqueue.php
@@ -13,11 +13,11 @@ defined( 'ABSPATH' ) || die( 'Cheatin&#8217; uh?' );
 function rocket_browser_cache_busting( $src ) {
 	$current_filter = current_filter();
 
-	if ( 'style_loader_src' === $current_filter && get_rocket_option( 'minify_css' ) && ! is_rocket_post_excluded_option( 'minify_css' ) ) {
+	if ( 'style_loader_src' === $current_filter && get_rocket_option( 'minify_css' ) && ( ! defined( 'DONOTMINIFYCSS' ) || ! DONOTMINIFYCSS ) && ! is_rocket_post_excluded_option( 'minify_css' ) ) {
 		return $src;
 	}
 
-	if ( 'script_loader_src' === $current_filter && get_rocket_option( 'minify_js' ) && ! is_rocket_post_excluded_option( 'minify_js' ) ) {
+	if ( 'script_loader_src' === $current_filter && get_rocket_option( 'minify_js' ) && ( ! defined( 'DONOTMINIFYJS' ) || ! DONOTMINIFYJS ) && ! is_rocket_post_excluded_option( 'minify_js' ) ) {
 		return $src;
 	}
 

--- a/inc/front/enqueue.php
+++ b/inc/front/enqueue.php
@@ -13,11 +13,11 @@ defined( 'ABSPATH' ) || die( 'Cheatin&#8217; uh?' );
 function rocket_browser_cache_busting( $src ) {
 	$current_filter = current_filter();
 
-	if ( 'style_loader_src' === $current_filter && get_rocket_option( 'minify_css' ) && ( ! defined( 'DONOTMINIFYCSS' ) || ! DONOTMINIFYCSS ) && ! is_rocket_post_excluded_option( 'minify_css' ) ) {
+	if ( 'style_loader_src' === $current_filter && get_rocket_option( 'minify_css' ) && ! is_rocket_post_excluded_option( 'minify_css' ) ) {
 		return $src;
 	}
 
-	if ( 'script_loader_src' === $current_filter && get_rocket_option( 'minify_js' ) && ( ! defined( 'DONOTMINIFYJS' ) || ! DONOTMINIFYJS ) && ! is_rocket_post_excluded_option( 'minify_js' ) ) {
+	if ( 'script_loader_src' === $current_filter && get_rocket_option( 'minify_js' ) && ! is_rocket_post_excluded_option( 'minify_js' ) ) {
 		return $src;
 	}
 
@@ -38,6 +38,10 @@ add_filter( 'script_loader_src', 'rocket_browser_cache_busting', PHP_INT_MAX );
  */
 function get_rocket_browser_cache_busting( $src, $current_filter = '' ) {
 	global $pagenow;
+
+	if ( defined( 'DONOTROCKETOPTIMIZE' ) && DONOTROCKETOPTIMIZE ) {
+		return $src;
+	}
 
 	if ( ! get_rocket_option( 'remove_query_strings' ) ) {
 		return $src;
@@ -153,6 +157,10 @@ function get_rocket_browser_cache_busting( $src, $current_filter = '' ) {
  */
 function rocket_cache_dynamic_resource( $src ) {
 	global $pagenow;
+
+	if ( defined( 'DONOTROCKETOPTIMIZE' ) && DONOTROCKETOPTIMIZE ) {
+		return $src;
+	}
 
 	if ( is_user_logged_in() && ! get_rocket_option( 'cache_logged_user' ) ) {
 		return $src;

--- a/inc/front/lazyload.php
+++ b/inc/front/lazyload.php
@@ -37,7 +37,7 @@ add_action( 'wp_head', 'rocket_lazyload_script', PHP_INT_MAX );
  */
 function rocket_lazyload_images( $html ) {
 	// Don't LazyLoad if process is stopped for these reasons.
-	if ( ! get_rocket_option( 'lazyload' ) || ! apply_filters( 'do_rocket_lazyload', true ) || is_feed() || is_preview() || empty( $html ) || ( defined( 'DONOTLAZYLOAD' ) && DONOTLAZYLOAD ) || wp_script_is( 'twentytwenty-twentytwenty', 'enqueued' ) ) {
+	if ( ! get_rocket_option( 'lazyload' ) || ! apply_filters( 'do_rocket_lazyload', true ) || is_feed() || is_preview() || empty( $html ) || ( defined( 'DONOTROCKETOPTIMIZE' ) && DONOTROCKETOPTIMIZE ) || wp_script_is( 'twentytwenty-twentytwenty', 'enqueued' ) ) {
 		return $html;
 	}
 
@@ -114,7 +114,7 @@ function rocket_lazyload_replace_callback( $matches ) {
  * @since 1.0
  */
 function rocket_lazyload_smilies() {
-	if ( ! get_rocket_option( 'lazyload' ) || ! apply_filters( 'do_rocket_lazyload', true, 'smilies' ) || ( defined( 'DONOTLAZYLOAD' ) && DONOTLAZYLOAD ) ) {
+	if ( ! get_rocket_option( 'lazyload' ) || ! apply_filters( 'do_rocket_lazyload', true, 'smilies' ) || ( defined( 'DONOTROCKETOPTIMIZE' ) && DONOTROCKETOPTIMIZE ) ) {
 		return;
 	}
 
@@ -241,7 +241,7 @@ function rocket_translate_smiley( $matches ) {
  */
 function rocket_lazyload_iframes( $html ) {
 	// Don't LazyLoad if process is stopped for these reasons.
-	if ( ! get_rocket_option( 'lazyload_iframes' ) || ! apply_filters( 'do_rocket_lazyload_iframes', true ) || is_feed() || is_preview() || empty( $html ) || ( defined( 'DONOTLAZYLOAD' ) && DONOTLAZYLOAD ) ) {
+	if ( ! get_rocket_option( 'lazyload_iframes' ) || ! apply_filters( 'do_rocket_lazyload_iframes', true ) || is_feed() || is_preview() || empty( $html ) || ( defined( 'DONOTROCKETOPTIMIZE' ) && DONOTROCKETOPTIMIZE ) ) {
 		return $html;
 	}
 

--- a/inc/front/lazyload.php
+++ b/inc/front/lazyload.php
@@ -37,7 +37,7 @@ add_action( 'wp_head', 'rocket_lazyload_script', PHP_INT_MAX );
  */
 function rocket_lazyload_images( $html ) {
 	// Don't LazyLoad if process is stopped for these reasons.
-	if ( ! get_rocket_option( 'lazyload' ) || ! apply_filters( 'do_rocket_lazyload', true ) || is_feed() || is_preview() || empty( $html ) || ( defined( 'DONOTROCKETOPTIMIZE' ) && DONOTROCKETOPTIMIZE ) || wp_script_is( 'twentytwenty-twentytwenty', 'enqueued' ) ) {
+	if ( ! get_rocket_option( 'lazyload' ) || ! apply_filters( 'do_rocket_lazyload', true ) || is_feed() || is_preview() || empty( $html ) || ( defined( 'DONOTROCKETOPTIMIZE' ) && DONOTROCKETOPTIMIZE ) || ( defined( 'DONOTLAZYLOAD' ) && DONOTLAZYLOAD ) || wp_script_is( 'twentytwenty-twentytwenty', 'enqueued' ) ) {
 		return $html;
 	}
 
@@ -114,7 +114,7 @@ function rocket_lazyload_replace_callback( $matches ) {
  * @since 1.0
  */
 function rocket_lazyload_smilies() {
-	if ( ! get_rocket_option( 'lazyload' ) || ! apply_filters( 'do_rocket_lazyload', true, 'smilies' ) || ( defined( 'DONOTROCKETOPTIMIZE' ) && DONOTROCKETOPTIMIZE ) ) {
+	if ( ! get_rocket_option( 'lazyload' ) || ! apply_filters( 'do_rocket_lazyload', true, 'smilies' ) || ( defined( 'DONOTROCKETOPTIMIZE' ) && DONOTROCKETOPTIMIZE ) || ( defined( 'DONOTLAZYLOAD' ) && DONOTLAZYLOAD ) ) {
 		return;
 	}
 
@@ -241,7 +241,7 @@ function rocket_translate_smiley( $matches ) {
  */
 function rocket_lazyload_iframes( $html ) {
 	// Don't LazyLoad if process is stopped for these reasons.
-	if ( ! get_rocket_option( 'lazyload_iframes' ) || ! apply_filters( 'do_rocket_lazyload_iframes', true ) || is_feed() || is_preview() || empty( $html ) || ( defined( 'DONOTROCKETOPTIMIZE' ) && DONOTROCKETOPTIMIZE ) ) {
+	if ( ! get_rocket_option( 'lazyload_iframes' ) || ! apply_filters( 'do_rocket_lazyload_iframes', true ) || is_feed() || is_preview() || empty( $html ) || ( defined( 'DONOTROCKETOPTIMIZE' ) && DONOTROCKETOPTIMIZE ) || ( defined( 'DONOTLAZYLOAD' ) && DONOTLAZYLOAD ) ) {
 		return $html;
 	}
 

--- a/inc/front/minify.php
+++ b/inc/front/minify.php
@@ -22,12 +22,12 @@ function rocket_minify_process( $buffer ) {
 	}
 
 	// Minify JavaScript.
-	if ( $enable_js && ( ! defined( 'DONOTMINIFYJS' ) || ! DONOTMINIFYJS ) && ! is_rocket_post_excluded_option( 'minify_js' ) ) {
+	if ( $enable_js && ( ! defined( 'DONOTROCKETOPTIMIZE' ) || ! DONOTROCKETOPTIMIZE ) && ! is_rocket_post_excluded_option( 'minify_js' ) ) {
 		$buffer = rocket_minify_files( $buffer, 'css' );
 	}
 
 	// Minify CSS.
-	if ( $enable_css && ( ! defined( 'DONOTMINIFYCSS' ) || ! DONOTMINIFYCSS ) && ! is_rocket_post_excluded_option( 'minify_css' ) ) {
+	if ( $enable_css && ( ! defined( 'DONOTROCKETOPTIMIZE' ) || ! DONOTROCKETOPTIMIZE ) && ! is_rocket_post_excluded_option( 'minify_css' ) ) {
 		$buffer = rocket_minify_files( $buffer, 'js' );
 	}
 

--- a/inc/front/minify.php
+++ b/inc/front/minify.php
@@ -22,12 +22,12 @@ function rocket_minify_process( $buffer ) {
 	}
 
 	// Minify JavaScript.
-	if ( $enable_js && ( ! defined( 'DONOTROCKETOPTIMIZE' ) || ! DONOTROCKETOPTIMIZE ) && ! is_rocket_post_excluded_option( 'minify_js' ) ) {
+	if ( $enable_js && ( ! defined( 'DONOTROCKETOPTIMIZE' ) || ! DONOTROCKETOPTIMIZE ) && ( ! defined( 'DONOTMINIFYCSS' ) || ! DONOTMINIFYCSS ) && ! is_rocket_post_excluded_option( 'minify_js' ) ) {
 		$buffer = rocket_minify_files( $buffer, 'css' );
 	}
 
 	// Minify CSS.
-	if ( $enable_css && ( ! defined( 'DONOTROCKETOPTIMIZE' ) || ! DONOTROCKETOPTIMIZE ) && ! is_rocket_post_excluded_option( 'minify_css' ) ) {
+	if ( $enable_css && ( ! defined( 'DONOTROCKETOPTIMIZE' ) || ! DONOTROCKETOPTIMIZE ) && ( ! defined( 'DONOTMINIFYJS' ) || ! DONOTMINIFYJS ) && ! is_rocket_post_excluded_option( 'minify_css' ) ) {
 		$buffer = rocket_minify_files( $buffer, 'js' );
 	}
 

--- a/inc/front/process.php
+++ b/inc/front/process.php
@@ -3,6 +3,7 @@ defined( 'ABSPATH' ) || die( 'Cheatin&#8217; uh?' );
 
 // Don't cache robots.txt && .htaccess directory (it's happened sometimes with weird server configuration).
 if ( strstr( $_SERVER['REQUEST_URI'], 'robots.txt' ) || strstr( $_SERVER['REQUEST_URI'], '.htaccess' ) ) {
+	rocket_define_donotoptimize_constant( true );
 	return;
 }
 
@@ -11,30 +12,31 @@ $request_uri = reset( ( $request_uri ) );
 
 // Don't cache disallowed extensions.
 if ( strtolower( $_SERVER['REQUEST_URI'] ) !== '/index.php' && in_array( pathinfo( $request_uri, PATHINFO_EXTENSION ), array( 'php', 'xml', 'xsl' ), true ) ) {
+	rocket_define_donotoptimize_constant( true );
 	return;
 }
 
 // Don't cache if user is in admin.
 if ( is_admin() ) {
+	rocket_define_donotoptimize_constant( true );
 	return;
 }
 
 if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+	rocket_define_donotoptimize_constant( true );
 	return;
 }
 
 // Don't cache the customizer preview.
 if ( isset( $_POST['wp_customize'] ) ) {
-	rocket_define_donotminify_constants( true );
-	rocket_define_donotasync_css_constant( true );
+	rocket_define_donotoptimize_constant( true );
 	return;
 }
 
 // Don't cache without GET method.
 if ( ! isset( $_SERVER['REQUEST_METHOD'] ) || 'GET' !== $_SERVER['REQUEST_METHOD'] ) {
-		rocket_define_donotminify_constants( true );
-		rocket_define_donotasync_css_constant( true );
-		return;
+	rocket_define_donotoptimize_constant( true );
+	return;
 }
 
 // Get the correct config file.
@@ -74,6 +76,7 @@ if ( realpath( $rocket_config_path . $host . '.php' ) && 0 === stripos( realpath
 
 // Exit if no config file exists.
 if ( ! $continue ) {
+	rocket_define_donotoptimize_constant( true );
 	return;
 }
 
@@ -99,29 +102,25 @@ if ( ! empty( $_GET )
 	&& ( ! isset( $_GET['ao_noptimize'] ) )
 	&& ( ! isset( $rocket_cache_query_strings ) || ! array_intersect( array_keys( $_GET ), $rocket_cache_query_strings ) )
 ) {
-	rocket_define_donotminify_constants( true );
-	rocket_define_donotasync_css_constant( true );
+	rocket_define_donotoptimize_constant( true );
 	return;
 }
 
 // Don't cache SSL.
 if ( ! isset( $rocket_cache_ssl ) && rocket_is_ssl() ) {
-	rocket_define_donotminify_constants( true );
-	rocket_define_donotasync_css_constant( true );
+	rocket_define_donotoptimize_constant( true );
 	return;
 }
 
 // Don't cache these pages.
 if ( isset( $rocket_cache_reject_uri ) && preg_match( '#^(' . $rocket_cache_reject_uri . ')$#', $request_uri ) ) {
-	rocket_define_donotminify_constants( true );
-	rocket_define_donotasync_css_constant( true );
+	rocket_define_donotoptimize_constant( true );
 	return;
 }
 
 // Don't cache page with these cookies.
 if ( isset( $rocket_cache_reject_cookies ) && preg_match( '#(' . $rocket_cache_reject_cookies . ')#', var_export( $_COOKIE, true ) ) ) {
-	rocket_define_donotminify_constants( true );
-	rocket_define_donotasync_css_constant( true );
+	rocket_define_donotoptimize_constant( true );
 	return;
 }
 
@@ -137,22 +136,19 @@ $allowed_ips = array(
 
 // Don't cache page when these cookies don't exist.
 if ( ! isset( $allowed_ips[ $ip ] ) && isset( $rocket_cache_mandatory_cookies ) && ! preg_match( '#(' . $rocket_cache_mandatory_cookies . ')#', var_export( $_COOKIE, true ) ) ) {
-	rocket_define_donotminify_constants( true );
-	rocket_define_donotasync_css_constant( true );
+	rocket_define_donotoptimize_constant( true );
 	return;
 }
 
 // Don't cache page with these user agents.
 if ( isset( $rocket_cache_reject_ua, $_SERVER['HTTP_USER_AGENT'] ) && ! empty( $rocket_cache_reject_ua ) && preg_match( '#(' . $rocket_cache_reject_ua . ')#', $_SERVER['HTTP_USER_AGENT'] ) ) {
-	rocket_define_donotminify_constants( true );
-	rocket_define_donotasync_css_constant( true );
+	rocket_define_donotoptimize_constant( true );
 	return;
 }
 
 // Don't cache if mobile detection is activated.
 if ( ! isset( $rocket_cache_mobile ) && isset( $_SERVER['HTTP_USER_AGENT'] ) && (preg_match( '#^.*(2.0\ MMP|240x320|400X240|AvantGo|BlackBerry|Blazer|Cellphone|Danger|DoCoMo|Elaine/3.0|EudoraWeb|Googlebot-Mobile|hiptop|IEMobile|KYOCERA/WX310K|LG/U990|MIDP-2.|MMEF20|MOT-V|NetFront|Newt|Nintendo\ Wii|Nitro|Nokia|Opera\ Mini|Palm|PlayStation\ Portable|portalmmm|Proxinet|ProxiNet|SHARP-TQ-GX10|SHG-i900|Small|SonyEricsson|Symbian\ OS|SymbianOS|TS21i-10|UP.Browser|UP.Link|webOS|Windows\ CE|WinWAP|YahooSeeker/M1A1-R2D2|iPhone|iPod|Android|BlackBerry9530|LG-TU915\ Obigo|LGE\ VX|webOS|Nokia5800).*#i', $_SERVER['HTTP_USER_AGENT'] ) || preg_match( '#^(w3c\ |w3c-|acs-|alav|alca|amoi|audi|avan|benq|bird|blac|blaz|brew|cell|cldc|cmd-|dang|doco|eric|hipt|htc_|inno|ipaq|ipod|jigs|kddi|keji|leno|lg-c|lg-d|lg-g|lge-|lg/u|maui|maxo|midp|mits|mmef|mobi|mot-|moto|mwbp|nec-|newt|noki|palm|pana|pant|phil|play|port|prox|qwap|sage|sams|sany|sch-|sec-|send|seri|sgh-|shar|sie-|siem|smal|smar|sony|sph-|symb|t-mo|teli|tim-|tosh|tsm-|upg1|upsi|vk-v|voda|wap-|wapa|wapi|wapp|wapr|webc|winw|winw|xda\ |xda-).*#i', substr( $_SERVER['HTTP_USER_AGENT'], 0, 4 ) )) ) {
-	rocket_define_donotminify_constants( true );
-	rocket_define_donotasync_css_constant( true );
+	rocket_define_donotoptimize_constant( true );
 	return;
 }
 
@@ -397,33 +393,16 @@ function rocket_is_ssl() {
 }
 
 /**
- * Declare and set value to DONOTMINIFYCSS & DONOTMINIFYJS constant
+ * Declares and sets value of constant preventing Optimizations
  *
- * @since 2.6.2
- *
- * @param bool $value true or false.
- */
-function rocket_define_donotminify_constants( $value ) {
-	if ( ! defined( 'DONOTMINIFYCSS' ) ) {
-		define( 'DONOTMINIFYCSS', (bool) $value );
-	}
-
-	if ( ! defined( 'DONOTMINIFYJS' ) ) {
-		define( 'DONOTMINIFYJS', (bool) $value );
-	}
-}
-
-/**
- * Declare and set value to DONOTMASYNCCSS constant
- *
- * @since 2.10
+ * @since 2.11
  * @author Remy Perona
  *
  * @param bool $value true or false.
  */
-function rocket_define_donotasync_css_constant( $value ) {
-	if ( ! defined( 'DONOTASYNCCSS' ) ) {
-		define( 'DONOTASYNCCSS', (bool) $value );
+function rocket_define_donotoptimize_constant( $value ) {
+	if ( ! defined( 'DONOTROCKETOPTIMIZE' ) ) {
+		define( 'DONOTROCKETOPTIMIZE', (bool) $value );
 	}
 }
 

--- a/inc/functions/cdn.php
+++ b/inc/functions/cdn.php
@@ -55,11 +55,11 @@ function get_rocket_cdn_url( $url, $zone = array( 'all' ) ) {
 		if ( strpos( $parse_url['path'], $home ) === false && ! preg_match( '#(' . $wp_content_dirname . '|wp-includes)#', $parse_url['path'] ) ) {
 			return $url;
 		} else {
-			$path = str_replace( $home, '', ltrim( $parse_url['path'], '//' ) );
+			$parse_url['path'] = str_replace( $home, '', ltrim( $parse_url['path'], '//' ) );
 		}
 	}
 
-	$url = untrailingslashit( $cnames[ ( abs( crc32( $path ) ) % count( $cnames ) ) ] ) . '/' . ltrim( $path, '/' ) . $parse_url['query'];
+	$url = untrailingslashit( $cnames[ ( abs( crc32( $path ) ) % count( $cnames ) ) ] ) . '/' . ltrim( $parse_url['path'], '/' ) . $parse_url['query'];
 	$url = rocket_add_url_protocol( $url );
 	return $url;
 }


### PR DESCRIPTION
Common constant to prevent applying WP Rocket optimization when the page is not cached. Previously some things like lazyload and parts of CDN were still applied.