### PR TITLE
Fix #646 fatal error undefined method cancel_process()

### DIFF
--- a/inc/classes/class-rocket-critical-css.php
+++ b/inc/classes/class-rocket-critical-css.php
@@ -108,7 +108,11 @@ class Rocket_Critical_CSS {
 	 */
 	public function process_handler() {
 		$this->clean_critical_css();
-		$this->process->cancel_process();
+
+		if ( method_exists( $this->process, 'cancel_process' ) ) {
+			$this->process->cancel_process();
+		}
+
 		$this->set_items();
 
 		foreach ( $this->items as $item ) {
@@ -172,7 +176,10 @@ class Rocket_Critical_CSS {
 	 */
 	public function stop_process_on_deactivation( $old_value, $value ) {
 		if ( ! empty( $_POST[ WP_ROCKET_SLUG ] ) && isset( $old_value['async_css'], $value['async_css'] ) && ( $old_value['async_css'] !== $value['async_css'] ) && 0 === (int) $value['async_css'] ) {
-			$this->process->cancel_process();
+			if ( method_exists( $this->process, 'cancel_process' ) ) {
+				$this->process->cancel_process();
+			}
+
 			delete_transient( 'rocket_critical_css_generation_process_running' );
 			delete_transient( 'rocket_critical_css_generation_process_complete' );
 		}

--- a/inc/classes/class-rocket-database-optimization.php
+++ b/inc/classes/class-rocket-database-optimization.php
@@ -54,7 +54,7 @@ class Rocket_Database_Optimization {
 	public static function init() {
 		$self = new self();
 
-		add_action( 'init',  array( $self, 'database_optimization_scheduled' ) );
+		add_action( 'init', array( $self, 'database_optimization_scheduled' ) );
 		add_action( 'rocket_database_optimization_time_event', array( $self, 'process_handler' ) );
 		add_action( 'update_option_' . WP_ROCKET_SLUG, array( $self, 'save_optimize' ) );
 		add_action( 'admin_post_rocket_optimize_database', array( $self, 'optimize' ) );
@@ -69,7 +69,9 @@ class Rocket_Database_Optimization {
 	 * @author Remy Perona
 	 */
 	public function process_handler() {
-		$this->process->cancel_process();
+		if ( method_exists( $this->process, 'cancel_process' ) ) {
+			$this->process->cancel_process();
+		}
 
 		foreach ( $this->options as $option ) {
 			if ( get_rocket_option( 'database_' . $option, false ) ) {
@@ -163,7 +165,7 @@ class Rocket_Database_Optimization {
 				$count = $wpdb->get_var( "SELECT COUNT(comment_ID) FROM $wpdb->comments WHERE (comment_approved = 'trash' OR comment_approved = 'post-trashed')" );
 				break;
 			case 'expired_transients':
-				$time = isset( $_SERVER['REQUEST_TIME'] ) ? (int) $_SERVER['REQUEST_TIME'] : time();
+				$time  = isset( $_SERVER['REQUEST_TIME'] ) ? (int) $_SERVER['REQUEST_TIME'] : time();
 				$count = $wpdb->get_var( "SELECT COUNT(option_name) FROM $wpdb->options WHERE option_name LIKE '_transient_timeout%' AND option_value < $time" );
 				break;
 			case 'all_transients':
@@ -259,6 +261,7 @@ class Rocket_Database_Optimization {
 					 * —Kris Kristofferson
 					 *
 					 * We shall do the same, shan’t we?
+					 *
 					 * @todo Replace $k in the printf() arguments with something nicer to read.
 					 */
 				?>

--- a/inc/functions/bots.php
+++ b/inc/functions/bots.php
@@ -104,7 +104,11 @@ function run_rocket_preload_cache( $spider, $do_sitemap_preload = true ) {
 
 	if ( $do_sitemap_preload & get_rocket_option( 'sitemap_preload', false ) ) {
 		$rocket_background_process = $GLOBALS['rocket_sitemap_background_process'];
-		$rocket_background_process->cancel_process();
+
+		if ( method_exists( $rocket_background_process, 'cancel_process' ) ) {
+			$rocket_background_process->cancel_process();
+		}
+
 		delete_transient( 'rocket_sitemap_preload_running' );
 		delete_transient( 'rocket_sitemap_preload_complete' );
 		run_rocket_sitemap_preload();
@@ -229,7 +233,7 @@ function rocket_process_sitemap( $sitemap_url, $urls = array() ) {
 
 	if ( $url_count > 0 ) {
 		for ( $i = 0; $i < $url_count; $i++ ) {
-			$page_url = (string) $xml->url[ $i ]->loc;
+			$page_url   = (string) $xml->url[ $i ]->loc;
 			$tmp_urls[] = $page_url;
 		}
 	} else {
@@ -238,7 +242,7 @@ function rocket_process_sitemap( $sitemap_url, $urls = array() ) {
 		if ( $sitemap_children > 0 ) {
 			for ( $i = 0; $i < $sitemap_children; $i++ ) {
 				$sub_sitemap_url = (string) $xml->sitemap[ $i ]->loc;
-				$urls = rocket_process_sitemap( $sub_sitemap_url, $urls );
+				$urls            = rocket_process_sitemap( $sub_sitemap_url, $urls );
 			}
 		}
 	}


### PR DESCRIPTION
This is caused by the use of an outdated version of the WPBP library in other plugins, loaded before WP Rocket.

To prevent the fatal, wrap the calls to `cancel_process()` in a method exists.