### PR TITLE
Fix #705 - rocket_realpath() compatibility on Windows servers

### DIFF
--- a/inc/functions/formatting.php
+++ b/inc/functions/formatting.php
@@ -282,7 +282,14 @@ function rocket_realpath( $file, $absolute = true, $hosts = '' ) {
 		}
 	}
 
-	return '/' . join( '/', $path );
+	$slash_prefix = '/';
+	
+	// Don't prefix slash on Windows servers
+	if ( 'WIN' === strtoupper( substr( PHP_OS, 0, 3 ) ) ) {
+		$slash_prefix = '';
+	}
+	
+	return $slash_prefix . join( '/', $path );
 }
 
 /**


### PR DESCRIPTION
Global variables $is_IIS and $is_iis7 are false on windows systems (localhost) that uses Apache (xampp). Checking for windows based on value of PHP_OS contant instead. Tested positively on localhost, apache and windows servers.