### PR TITLE
Closes #247 Kinsta compatibility

### DIFF
--- a/inc/3rd-party/3rd-party.php
+++ b/inc/3rd-party/3rd-party.php
@@ -11,6 +11,7 @@ require WP_ROCKET_3RD_PARTY_PATH . 'hosting/siteground.php';
 require WP_ROCKET_3RD_PARTY_PATH . 'hosting/pressidium.php';
 require WP_ROCKET_3RD_PARTY_PATH . 'hosting/savvii.php';
 require WP_ROCKET_3RD_PARTY_PATH . 'hosting/godaddy.php';
+require WP_ROCKET_3RD_PARTY_PATH . 'hosting/kinsta.php';
 
 require WP_ROCKET_3RD_PARTY_PATH . 'plugins/geotargetingwp.php';
 require WP_ROCKET_3RD_PARTY_PATH . 'plugins/slider/revslider.php';

--- a/inc/3rd-party/hosting/kinsta.php
+++ b/inc/3rd-party/hosting/kinsta.php
@@ -1,0 +1,40 @@
+<?php
+defined( 'ABSPATH' ) || die( 'Cheatin&#8217; uh?' );
+
+if ( isset( $_SERVER['KINSTA_CACHE_ZONE'] ) ) {
+
+	add_filter( 'do_rocket_generate_caching_files', '__return_false', PHP_INT_MAX );
+	add_filter( 'rocket_display_varnish_options_tab', '__return_false' );
+
+	/**
+	 * Clear Kinsta cache when clearing WP Rocket cache
+	 *
+	 * @since 3.0
+	 * @author Remy Perona
+	 *
+	 * @return void
+	 */
+	function rocket_clean_kinsta_cache() {
+		global $KinstaCache;
+		$KinstaCache->KinstaCachePurge->purge_complete_caches();
+	}
+	add_action( 'after_rocket_clean_domain', 'rocket_clean_kinsta_cache' );
+
+	if ( Kinsta\CDNEnabler::cdn_is_enabled() ) {
+		/**
+		 * Add Kinsta CDN to WP Rocket CDN hosts list if enabled
+		 *
+		 * @since 3.0
+		 * @author Remy Perona
+		 *
+		 * @param Array $hosts Array of CDN hosts.
+		 * @return Array Updated array of CDN hosts
+		 */
+		function rocket_add_kinsta_cdn_cname( $hosts ) {
+			$hosts[] = $_SERVER['KINSTA_CDN_DOMAIN'];
+
+			return $hosts;
+		}
+		add_filter( 'rocket_cdn_cnames', 'rocket_add_kinsta_cdn_cname', 1 );
+	}
+}

--- a/inc/functions/options.php
+++ b/inc/functions/options.php
@@ -339,16 +339,13 @@ function get_rocket_cdn_reject_files() {
 /**
  * Get all CNAMES
  *
+ * @since 3.0 Don't check for WP Rocket CDN option activated to be able to use the function on Hosting with CDN auto-enabled
  * @since 2.1
  *
  * @param string $zone (default: 'all') List of zones.
  * @return array List of CNAMES
  */
 function get_rocket_cdn_cnames( $zone = 'all' ) {
-	if ( (int) get_rocket_option( 'cdn' ) === 0 ) {
-		return array();
-	}
-
 	$hosts       = array();
 	$cnames      = get_rocket_option( 'cdn_cnames', array() );
 	$cnames_zone = get_rocket_option( 'cdn_zone', array() );


### PR DESCRIPTION
- Disable WP Rocket cache
- Remove Varnish tab
- Trigger Kinsta Cache clear when WP Rocket clear cache is triggered
- Automatically detect Kinsta CDN