### PR TITLE
Require autoloader only if it exists.

### DIFF
--- a/wp-rocket.php
+++ b/wp-rocket.php
@@ -174,7 +174,9 @@ function rocket_init() {
 	$do_rocket_bot_cache_json = false;
 
 	// Composer autoload.
-	require WP_ROCKET_PATH . 'vendor/autoload.php';
+	if ( file_exists( WP_ROCKET_PATH . '/vendor/autoload.php' ) ) {
+		require WP_ROCKET_PATH . 'vendor/autoload.php';
+	}
 
 	// Call defines and functions.
 	require WP_ROCKET_FUNCTIONS_PATH . 'options.php';


### PR DESCRIPTION
It won't exist if the wordpress plugins are handled by composer, like in [Bedrock](https://github.com/roots/bedrock). With this change, the plugin will work both ways.