### PR TITLE
Fix #775 - Critical Path CSS Not Loaded For Custom Taxonomy Archive Page

### DIFF
--- a/inc/classes/class-rocket-critical-css.php
+++ b/inc/classes/class-rocket-critical-css.php
@@ -500,7 +500,7 @@ class Rocket_Critical_CSS {
 		} elseif ( is_tag() ) {
 			$name = 'post_tag.css';
 		} elseif ( is_tax() ) {
-			$taxonomy = get_queried_object()->term_name;
+			$taxonomy = get_queried_object()->taxonomy;
 			$name     = $taxonomy . '.css';
 		} elseif ( is_singular() ) {
 			$post_type = get_post_type();


### PR DESCRIPTION
Corrected the name of the public variable of the WP_Term class.