### PR TITLE
Fixes #915 & #787

### DIFF
--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -77,44 +77,6 @@ function get_rocket_config_file() {
 	$buffer  = '<?php' . "\n";
 	$buffer .= 'defined( \'ABSPATH\' ) or die( \'Cheatin\\\' uh?\' );' . "\n\n";
 
-	if ( apply_filters( 'rocket_override_min_documentRoot', false ) ) {
-		/**
-		 * Filter the Document Root path to use during the minification
-		 *
-		 * @since 2.7
-		 *
-		 * @param string The Document Root path.
-		*/
-		$min_documentroot = apply_filters( 'rocket_min_documentRoot', ABSPATH );
-
-		$buffer .= '$min_documentRoot = \'' . $min_documentroot . '\';' . "\n";
-	}
-
-	if ( apply_filters( 'rocket_override_min_cachepath', false ) ) {
-		/**
-		 * Filter the temp directory path to use during the minification
-		 *
-		 * @since 2.8.3
-		 *
-		 * @param string The temp path, empty to leave Minify guessing it automatically.
-		*/
-		$min_cachepath = apply_filters( 'rocket_min_cachePath', '' );
-
-		$buffer .= '$min_cachePath = \'' . $min_cachepath . '\';' . "\n";
-	}
-
-	/**
-	 * Filters the preservation of the CSS comments during minification
-	 *
-	 * @author Remy Perona
-	 * @since 2.9
-	 *
-	 * @param bool False to not preserve the comments, true to preserve.
-	 */
-	if ( apply_filters( 'rocket_minification_preserve_css_comments', false ) ) {
-		$buffer .= '$min_preserve_css_comments = true;' . "\n";
-	}
-
 	$buffer .= '$rocket_cookie_hash = \'' . COOKIEHASH . '\'' . ";\n";
 
 	/**
@@ -1122,8 +1084,17 @@ function rocket_fetch_and_cache_busting( $src, $cache_busting_paths, $abspath_sr
 	}
 
 	if ( 'style_loader_src' === $current_filter ) {
+		/**
+		 * Filters the Document Root path to use during CSS minification to rewrite paths
+		 *
+		 * @since 2.7
+		 *
+		 * @param string The Document Root path.
+		*/
+		$min_documentroot = apply_filters( 'rocket_min_documentRoot', ABSPATH );
+
 		// Rewrite import/url in CSS content to add the absolute path to the file.
-		$content = Minify_CSS_UriRewriter::rewrite( $content, dirname( $abspath_src ) );
+		$content = Minify_CSS_UriRewriter::rewrite( $content, dirname( $abspath_src ), $min_documentroot );
 	}
 
 	if ( ! rocket_direct_filesystem()->is_dir( $cache_busting_paths['bustingpath'] ) ) {

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -1091,10 +1091,10 @@ function rocket_fetch_and_cache_busting( $src, $cache_busting_paths, $abspath_sr
 		 *
 		 * @param string The Document Root path.
 		*/
-		$min_documentroot = apply_filters( 'rocket_min_documentRoot', ABSPATH );
+		$document_root = apply_filters( 'rocket_min_documentRoot', ABSPATH );
 
 		// Rewrite import/url in CSS content to add the absolute path to the file.
-		$content = Minify_CSS_UriRewriter::rewrite( $content, dirname( $abspath_src ), $min_documentroot );
+		$content = Minify_CSS_UriRewriter::rewrite( $content, dirname( $abspath_src ), $document_root );
 	}
 
 	if ( ! rocket_direct_filesystem()->is_dir( $cache_busting_paths['bustingpath'] ) ) {

--- a/inc/functions/minify.php
+++ b/inc/functions/minify.php
@@ -371,7 +371,7 @@ function rocket_minify( $files, $extension ) {
 			*/
 			$document_root = apply_filters( 'rocket_min_documentRoot', ABSPATH );
 
-			$file_content = rocket_cdn_css_properties( Minify_CSS_UriRewriter::rewrite( $file_content, dirname( $file ) ), $document_root );
+			$file_content = rocket_cdn_css_properties( Minify_CSS_UriRewriter::rewrite( $file_content, dirname( $file ), $document_root ) );
 		}
 
 		$minify->add( $file_content );

--- a/inc/functions/minify.php
+++ b/inc/functions/minify.php
@@ -369,9 +369,9 @@ function rocket_minify( $files, $extension ) {
 			 *
 			 * @param string The Document Root path.
 			*/
-			$min_documentroot = apply_filters( 'rocket_min_documentRoot', ABSPATH );
+			$document_root = apply_filters( 'rocket_min_documentRoot', ABSPATH );
 
-			$file_content = rocket_cdn_css_properties( Minify_CSS_UriRewriter::rewrite( $file_content, dirname( $file ) ), $min_documentroot );
+			$file_content = rocket_cdn_css_properties( Minify_CSS_UriRewriter::rewrite( $file_content, dirname( $file ) ), $document_root );
 		}
 
 		$minify->add( $file_content );

--- a/inc/functions/minify.php
+++ b/inc/functions/minify.php
@@ -362,7 +362,16 @@ function rocket_minify( $files, $extension ) {
 	foreach ( $files as $file ) {
 		$file_content = rocket_direct_filesystem()->get_contents( $file );
 		if ( 'css' === $extension ) {
-			$file_content = rocket_cdn_css_properties( Minify_CSS_UriRewriter::rewrite( $file_content, dirname( $file ) ) );
+			/**
+			 * Filters the Document Root path to use during CSS minification to rewrite paths
+			 *
+			 * @since 2.7
+			 *
+			 * @param string The Document Root path.
+			*/
+			$min_documentroot = apply_filters( 'rocket_min_documentRoot', ABSPATH );
+
+			$file_content = rocket_cdn_css_properties( Minify_CSS_UriRewriter::rewrite( $file_content, dirname( $file ) ), $min_documentroot );
 		}
 
 		$minify->add( $file_content );


### PR DESCRIPTION
the rewrite method uses `$_SERVER['DOCUMENT_ROOT']` if no parameter is passed for the document root. This causes issues sometimes as seen in #787.

To fix it, I'm passing ABSPATH as the document root parameter, filtered if needed, using a filter used before.