### PR TITLE
Fixes #947 improve Kinsta compatibility

### DIFF
--- a/inc/3rd-party/hosting/kinsta.php
+++ b/inc/3rd-party/hosting/kinsta.php
@@ -6,78 +6,143 @@ if ( isset( $_SERVER['KINSTA_CACHE_ZONE'] ) ) {
 	add_filter( 'do_rocket_generate_caching_files', '__return_false', PHP_INT_MAX );
 	add_filter( 'rocket_display_varnish_options_tab', '__return_false' );
 
-	/**
-	 * Clear Kinsta cache when clearing WP Rocket cache
-	 *
-	 * @since 3.0
-	 * @author Remy Perona
-	 *
-	 * @return void
-	 */
-	function rocket_clean_kinsta_cache() {
-		global $kinsta_cache;
-		$kinsta_cache->kinsta_cache_purge->purge_complete_caches();
-	}
-	add_action( 'after_rocket_clean_domain', 'rocket_clean_kinsta_cache' );
+	global $kinsta_cache;
 
-	/**
-	 * Partially clear Kinsta cache when partially clearing WP Rocket cache
-	 *
-	 * @since 3.0
-	 * @author Remy Perona
-	 *
-	 * @param object $post Post object.
-	 * @return void
-	 */
-	function rocket_clean_kinsta_post_cache( $post ) {
-		global $kinsta_cache;
-		$kinsta_cache->kinsta_cache_purge->initiate_purge( $post->ID, 'post' );
-	}
-	add_action( 'after_rocket_clean_post', 'rocket_clean_kinsta_post_cache', 10, 1 );
-
-	/**
-	 * Remove WP Rocket functions on WP core action hooks to prevent triggering a double cache clear.
-	 *
-	 * @since 3.0
-	 * @author Remy Perona
-	 *
-	 * @return void
-	 */
-	function rocket_remove_partial_purge_hooks() {
-		// WP core action hooks rocket_clean_post() gets hooked into.
-		$clean_post_hooks = array(
-			// Disables the refreshing of partial cache when content is edited.
-			'wp_trash_post',
-			'delete_post',
-			'clean_post_cache',
-			'wp_update_comment_count',
-		);
-
-		// Remove rocket_clean_post() from core action hooks.
-		array_map(
-			function( $hook ) {
-				remove_action( $hook, 'rocket_clean_post' );
-			},
-			$clean_post_hooks
-		);
-	}
-	add_action( 'rocket_loaded', 'rocket_remove_partial_purge_hooks' );
-
-	if ( \Kinsta\CDN_Enabler::cdn_is_enabled() ) {
+	if ( isset( $kinsta_cache ) && class_exists( '\\Kinsta\\CDN_Enabler' ) ) {
 		/**
-		 * Add Kinsta CDN to WP Rocket CDN hosts list if enabled
+		 * Clear Kinsta cache when clearing WP Rocket cache
 		 *
 		 * @since 3.0
 		 * @author Remy Perona
 		 *
-		 * @param Array $hosts Array of CDN hosts.
-		 * @return Array Updated array of CDN hosts
+		 * @return void
 		 */
-		function rocket_add_kinsta_cdn_cname( $hosts ) {
-			$hosts[] = $_SERVER['KINSTA_CDN_DOMAIN'];
-
-			return $hosts;
+		function rocket_clean_kinsta_cache() {
+			global $kinsta_cache;
+			$kinsta_cache->kinsta_cache_purge->purge_complete_caches();
 		}
-		add_filter( 'rocket_cdn_cnames', 'rocket_add_kinsta_cdn_cname', 1 );
+		add_action( 'after_rocket_clean_domain', 'rocket_clean_kinsta_cache' );
+
+		/**
+		 * Partially clear Kinsta cache when partially clearing WP Rocket cache
+		 *
+		 * @since 3.0
+		 * @author Remy Perona
+		 *
+		 * @param object $post Post object.
+		 * @return void
+		 */
+		function rocket_clean_kinsta_post_cache( $post ) {
+			global $kinsta_cache;
+			$kinsta_cache->kinsta_cache_purge->initiate_purge( $post->ID, 'post' );
+		}
+		add_action( 'after_rocket_clean_post', 'rocket_clean_kinsta_post_cache', 10, 1 );
+
+		/**
+		 * Clears Kinsta cache for the homepage URL when using "Purge this URL" from the admin bar on the front end
+		 *
+		 * @since 3.0.4
+		 * @author Remy Perona
+		 *
+		 * @param string $root WP Rocket root cache path.
+		 * @param string $lang Current language.
+		 * @return void
+		 */
+		function rocket_clean_kinsta_cache_home( $root = '', $lang = '' ) {
+			$url = get_rocket_i18n_home_url( $lang );
+			$url = trailingslashit( $url ) . 'kinsta-clear-cache/';
+
+			wp_remote_get( $url, array(
+				'blocking' => false,
+			) );
+		}
+		add_action( 'after_rocket_clean_home', 'rocket_clean_kinsta_cache_home', 10, 2 );
+
+		/**
+		 * Clears Kinsta cache for a specific URL when using "Purge this URL" from the admin bar on the front end
+		 *
+		 * @since 3.0.4
+		 * @author Remy Perona
+		 *
+		 * @param string $url URL to purge.
+		 * @return void
+		 */
+		function rocket_clean_kinsta_cache_url( $url ) {
+			$url = trailingslashit( $url ) . 'kinsta-clear-cache/';
+
+			wp_remote_get( $url, array(
+				'blocking' => false,
+			) );
+		}
+		add_action( 'after_rocket_clean_file', 'rocket_clean_kinsta_cache_url' );
+
+		/**
+		 * Remove WP Rocket functions on WP core action hooks to prevent triggering a double cache clear.
+		 *
+		 * @since 3.0
+		 * @author Remy Perona
+		 *
+		 * @return void
+		 */
+		function rocket_remove_partial_purge_hooks() {
+			// WP core action hooks rocket_clean_post() gets hooked into.
+			$clean_post_hooks = array(
+				// Disables the refreshing of partial cache when content is edited.
+				'wp_trash_post',
+				'delete_post',
+				'clean_post_cache',
+				'wp_update_comment_count',
+			);
+
+			// Remove rocket_clean_post() from core action hooks.
+			array_map(
+				function( $hook ) {
+					remove_action( $hook, 'rocket_clean_post' );
+				},
+				$clean_post_hooks
+			);
+
+			remove_filter( 'rocket_clean_files', 'rocket_clean_files_users' );
+		}
+		add_action( 'wp_rocket_loaded', 'rocket_remove_partial_purge_hooks' );
+
+		if ( \Kinsta\CDN_Enabler::cdn_is_enabled() ) {
+			/**
+			 * Add Kinsta CDN to WP Rocket CDN hosts list if enabled
+			 *
+			 * @since 3.0
+			 * @author Remy Perona
+			 *
+			 * @param Array $hosts Array of CDN hosts.
+			 * @return Array Updated array of CDN hosts
+			 */
+			function rocket_add_kinsta_cdn_cname( $hosts ) {
+				$hosts[] = $_SERVER['KINSTA_CDN_DOMAIN'];
+
+				return $hosts;
+			}
+			add_filter( 'rocket_cdn_cnames', 'rocket_add_kinsta_cdn_cname', 1 );
+		}
+	} else {
+		add_action( 'admin_notices', function() {
+			if ( ! current_user_can( 'manage_options' ) ) {
+				return;
+			}
+
+			$screen = get_current_screen();
+
+			if ( 'settings_page_wprocket' !== $screen->id ) {
+				return;
+			}
+
+			rocket_notice_html(
+				array(
+					'status'      => 'error',
+					'dismissible' => '',
+					// translators: %1$s = opening link tag, %2$s = closing link tag.
+					'message'     => sprintf( __( 'Your installation seems to be missing core Kinsta files managing Cache clearing and CDN, which will prevent your Kinsta installation and WP Rocket from working correctly. Please get in touch with Kinsta support through your %1$sMyKinsta%2$s account to resolve this issue.', 'rocket' ), '<a href="https://my.kinsta.com/login/" target="_blank">', '</a>' ),
+				)
+			);
+		} );
 	}
 }

--- a/inc/3rd-party/hosting/kinsta.php
+++ b/inc/3rd-party/hosting/kinsta.php
@@ -36,7 +36,7 @@ if ( isset( $_SERVER['KINSTA_CACHE_ZONE'] ) ) {
 			global $kinsta_cache;
 			$kinsta_cache->kinsta_cache_purge->initiate_purge( $post->ID, 'post' );
 		}
-		add_action( 'after_rocket_clean_post', 'rocket_clean_kinsta_post_cache', 10, 1 );
+		add_action( 'after_rocket_clean_post', 'rocket_clean_kinsta_post_cache' );
 
 		/**
 		 * Clears Kinsta cache for the homepage URL when using "Purge this URL" from the admin bar on the front end
@@ -54,6 +54,7 @@ if ( isset( $_SERVER['KINSTA_CACHE_ZONE'] ) ) {
 
 			wp_remote_get( $url, array(
 				'blocking' => false,
+				'timeout'  => 0.01,
 			) );
 		}
 		add_action( 'after_rocket_clean_home', 'rocket_clean_kinsta_cache_home', 10, 2 );
@@ -72,6 +73,7 @@ if ( isset( $_SERVER['KINSTA_CACHE_ZONE'] ) ) {
 
 			wp_remote_get( $url, array(
 				'blocking' => false,
+				'timeout'  => 0.01,
 			) );
 		}
 		add_action( 'after_rocket_clean_file', 'rocket_clean_kinsta_cache_url' );


### PR DESCRIPTION
In this PR:
- Fix fatal error if Kinsta mu-plugin is not there (after a migration for example)
- Display a warning on WP Rocket settings page if the mu-plugin is not there, to ask the customer to get in touch with Kinsta about this
- Fix cache clear not working when using the "Purge this URL" link on the front-end