### PR TITLE
Closes #925 - Force WP Rocket caching on SG Optimizer version below 4.0.5

### DIFF
--- a/inc/3rd-party/hosting/siteground.php
+++ b/inc/3rd-party/hosting/siteground.php
@@ -23,4 +23,18 @@ if ( rocket_is_plugin_active( 'sg-cachepress/sg-cachepress.php' ) ) {
 			$sg_cachepress_supercacher->purge_cache();
 		}
 	}
+	
+	/**
+	 * Force WP Rocket caching on SG Optimizer versions before 4.0.5
+	 * 
+	 * @author Arun Basil Lal
+	 *
+	 * @link https://github.com/wp-media/wp-rocket/issues/925
+	 * @since 3.0.4
+	 */
+	$sg_optimizer_plugin_data = get_file_data( WP_PLUGIN_DIR . '/sg-cachepress/sg-cachepress.php', array( 'Version' => 'Version' ) );
+	
+	if ( version_compare( $sg_optimizer_plugin_data['Version'], '4.0.5' ) < 0 ) {
+		add_filter( 'do_rocket_generate_caching_files', '__return_true', 11 );
+	}
 }


### PR DESCRIPTION
I couldn't find a constant where SG Optimizer stored its version number so used the `get_file_data()` WordPress function. 