### PR TITLE
Remove Emoji CSS & DNS Prefetch Request

### DIFF
--- a/inc/common/emoji.php
+++ b/inc/common/emoji.php
@@ -15,6 +15,8 @@ if ( version_compare( $wp_version, '4.2' ) >= 0 && get_rocket_option( 'emoji', 0
 		remove_filter( 'the_content_feed'       , 'wp_staticize_emoji' );
 		remove_filter( 'comment_text_rss'       , 'wp_staticize_emoji' );
 		remove_filter( 'wp_mail'                , 'wp_staticize_emoji_for_email' );
+		remove_action( 'wp_print_styles'	, 'print_emoji_styles' ); 		
+		add_filter( 'emoji_svg_url'		, '__return_false' )
 	}
 	add_action( 'init', 'rocket_disable_emoji' );
 

--- a/inc/common/emoji.php
+++ b/inc/common/emoji.php
@@ -16,7 +16,7 @@ if ( version_compare( $wp_version, '4.2' ) >= 0 && get_rocket_option( 'emoji', 0
 		remove_filter( 'comment_text_rss'       , 'wp_staticize_emoji' );
 		remove_filter( 'wp_mail'                , 'wp_staticize_emoji_for_email' );
 		remove_action( 'wp_print_styles'	, 'print_emoji_styles' ); 		
-		add_filter( 'emoji_svg_url'		, '__return_false' )
+		add_filter( 'emoji_svg_url'		, '__return_false' );
 	}
 	add_action( 'init', 'rocket_disable_emoji' );
 

--- a/inc/common/emoji.php
+++ b/inc/common/emoji.php
@@ -15,7 +15,6 @@ if ( version_compare( $wp_version, '4.2' ) >= 0 && get_rocket_option( 'emoji', 0
 		remove_filter( 'the_content_feed'       , 'wp_staticize_emoji' );
 		remove_filter( 'comment_text_rss'       , 'wp_staticize_emoji' );
 		remove_filter( 'wp_mail'                , 'wp_staticize_emoji_for_email' );
-		remove_action( 'wp_print_styles'	, 'print_emoji_styles' ); 		
 		add_filter( 'emoji_svg_url'		, '__return_false' );
 	}
 	add_action( 'init', 'rocket_disable_emoji' );


### PR DESCRIPTION
This update removes the prefetch request "https://s.w.org/" & removes the inline CSS block that is loaded with it as well for the emoji. 

CSS in question:  img.wp-smiley,img.emoji{display:inline!important;border:none!important;box-shadow:none!important;height:1em!important;width:1em!important;margin:0 .07em!important;vertical-align:-0.1em!important;background:none!important;padding:0!important}