### PR TITLE
Fix #993 correctly rewrite referenced file paths in CSS files

### DIFF
--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -1091,7 +1091,7 @@ function rocket_fetch_and_cache_busting( $src, $cache_busting_paths, $abspath_sr
 		 *
 		 * @param string The Document Root path.
 		*/
-		$document_root = apply_filters( 'rocket_min_documentRoot', ABSPATH );
+		$document_root = apply_filters( 'rocket_min_documentRoot', wp_normalize_path( dirname( $_SERVER['SCRIPT_FILENAME'] ) ) );
 
 		// Rewrite import/url in CSS content to add the absolute path to the file.
 		$content = Minify_CSS_UriRewriter::rewrite( $content, dirname( $abspath_src ), $document_root );

--- a/inc/functions/minify.php
+++ b/inc/functions/minify.php
@@ -369,7 +369,7 @@ function rocket_minify( $files, $extension ) {
 			 *
 			 * @param string The Document Root path.
 			*/
-			$document_root = apply_filters( 'rocket_min_documentRoot', ABSPATH );
+			$document_root = apply_filters( 'rocket_min_documentRoot', wp_normalize_path( dirname( $_SERVER['SCRIPT_FILENAME'] ) ) );
 
 			$file_content = rocket_cdn_css_properties( Minify_CSS_UriRewriter::rewrite( $file_content, dirname( $file ), $document_root ) );
 		}


### PR DESCRIPTION
@Screenfeed do you see any problem with using `SCRIPT_FILENAME` here?