### PR TITLE
Fix #987 remove XML-RPC check

### DIFF
--- a/inc/main.php
+++ b/inc/main.php
@@ -17,11 +17,6 @@ function rocket_init() {
 		return;
 	}
 
-	// Nothing to do if XMLRPC request.
-	if ( defined( 'XMLRPC_REQUEST' ) ) {
-		return;
-	}
-
 	// Necessary to call correctly WP Rocket Bot for cache json.
 	global $do_rocket_bot_cache_json;
 	$do_rocket_bot_cache_json = false;


### PR DESCRIPTION
This was removed in a minor version of 2.11, but it came back in 3.0 because the code was moved to a different file before merging the minor into the 3.0. Doing 2 versions in parallel = 👎