### PR TITLE
#1013 Make settings page slug dynamic

### DIFF
--- a/inc/admin/ui/enqueue.php
+++ b/inc/admin/ui/enqueue.php
@@ -2,6 +2,23 @@
 defined( 'ABSPATH' ) || die( 'Cheatin&#8217; uh?' );
 
 /**
+ * Enqueue assets on settings page only.
+ *
+ * @since
+ * @author Caspar Hübinger
+ *
+ * @uses   WP_ROCKET_SETTINGS_PAGE_HOOK
+ * @see    /inc/main.php::rocket_define_settings_page_hook()
+ *
+ * @return void
+ */
+function rocket_settings_page_print_assets() {
+	add_action( 'admin_print_styles-' . WP_ROCKET_SETTINGS_PAGE_HOOK, 'rocket_add_admin_css_js' );
+	add_action( 'admin_print_styles-' . WP_ROCKET_SETTINGS_PAGE_HOOK, 'rocket_enqueue_modal_plugin' );
+}
+add_action( 'admin_init', 'rocket_settings_page_print_assets' );
+
+/**
  * Add the CSS and JS files for WP Rocket options page
  *
  * @since 1.0.0
@@ -17,7 +34,6 @@ function rocket_add_admin_css_js() {
 	}
 
 }
-add_action( 'admin_print_styles-settings_page_' . WP_ROCKET_PLUGIN_SLUG, 'rocket_add_admin_css_js' );
 
 /**
  * Add the CSS and JS files needed by WP Rocket everywhere on admin pages
@@ -82,4 +98,3 @@ function rocket_enqueue_modal_plugin() {
 }
 add_action( 'admin_print_styles-media-new.php', 'rocket_enqueue_modal_plugin' );
 add_action( 'admin_print_styles-upload.php', 'rocket_enqueue_modal_plugin' );
-add_action( 'admin_print_styles-settings_page_' . WP_ROCKET_PLUGIN_SLUG, 'rocket_enqueue_modal_plugin' );

--- a/inc/classes/admin/settings/class-page.php
+++ b/inc/classes/admin/settings/class-page.php
@@ -107,7 +107,8 @@ class Page {
 
 		add_action( 'admin_menu', [ $self, 'add_admin_page' ] );
 		add_action( 'admin_init', [ $self, 'configure' ] );
-		add_action( 'admin_print_footer_scripts-settings_page_wprocket', [ $self, 'insert_beacon' ] );
+		add_action( 'admin_init', [ $self, 'print_footer_scripts_page_hook' ] );
+
 		add_action( 'wp_ajax_rocket_refresh_customer_data', [ $self, 'refresh_customer_data' ] );
 		add_action( 'wp_ajax_rocket_toggle_option', [ $self, 'toggle_option' ] );
 
@@ -118,6 +119,21 @@ class Page {
 		if ( \rocket_valid_key() ) {
 			add_filter( 'rocket_settings_menu_navigation', [ $self, 'add_menu_tools_page' ] );
 		}
+	}
+
+	/**
+	 * Prints footer scripts via dynamic admin page hook.
+	 *
+	 * @since
+	 * @author Caspar Hübinger
+	 *
+	 * @uses   WP_ROCKET_SETTINGS_PAGE_HOOK
+	 * @see    /inc/main.php::rocket_define_settings_page_hook()
+	 *
+	 * @return void
+	 */
+	public function print_footer_scripts_page_hook() {
+		add_action( 'admin_print_footer_scripts-' . WP_ROCKET_SETTINGS_PAGE_HOOK, [ $this, 'insert_beacon' ] );
 	}
 
 	/**
@@ -1763,18 +1779,12 @@ class Page {
 				'cloudflare_email'            => [
 					'label'           => _x( 'Account email', 'Cloudflare', 'rocket' ),
 					'default'         => '',
-					'container_class'   => [
-						'wpr-field--split',
-					],
 					'section'         => 'cloudflare_credentials',
 					'page'            => 'cloudflare',
 				],
 				'cloudflare_zone_id'          => [
 					'label'           => _x( 'Zone ID', 'Cloudflare', 'rocket' ),
 					'default'         => '',
-					'container_class'   => [
-						'wpr-field--split',
-					],
 					'section'         => 'cloudflare_credentials',
 					'page'            => 'cloudflare',
 				],

--- a/inc/main.php
+++ b/inc/main.php
@@ -130,12 +130,13 @@ add_action( 'plugins_loaded', 'rocket_init' );
  */
 function rocket_define_settings_page_hook() {
 
-	$plugin_page = $GLOBALS['plugin_page']; // wprocket
-	$parent_page = $GLOBALS['pagenow'];     // options-general.php
+	if ( isset( $GLOBALS['plugin_page'] ) && 'wp-rocket' === $GLOBALS['plugin_page'] ) {
 
-	$page_hook = get_plugin_page_hook( $plugin_page, $parent_page );
+		$plugin_page = $GLOBALS['plugin_page']; // wprocket
+		$parent_page = $GLOBALS['pagenow'];     // options-general.php
 
-	if ( 'wprocket' === $plugin_page && ! empty( $page_hook ) ) {
+		$page_hook = get_plugin_page_hook( $plugin_page, $parent_page );
+
 		// This will be only available on WP Rocket’s settings page itself!
 		define( 'WP_ROCKET_SETTINGS_PAGE_HOOK', $page_hook );
 	} else {

--- a/inc/main.php
+++ b/inc/main.php
@@ -135,7 +135,7 @@ function rocket_define_settings_page_hook() {
 
 	$page_hook = get_plugin_page_hook( $plugin_page, $parent_page );
 
-	if ( ! empty( $page_hook ) ) {
+	if ( 'wprocket' === $plugin_page && ! empty( $page_hook ) ) {
 		// This will be only available on WP Rocket’s settings page itself!
 		define( 'WP_ROCKET_SETTINGS_PAGE_HOOK', $page_hook );
 	} else {

--- a/inc/main.php
+++ b/inc/main.php
@@ -114,6 +114,38 @@ function rocket_init() {
 add_action( 'plugins_loaded', 'rocket_init' );
 
 /**
+ * Dynamically defines page hook name for settings page.
+ *
+ * This avoids hard-coding `settings_page` as a partial of the page slug,
+ * since it can be changed to `admin_page` (possibly other values, too) in
+ * certain environments.
+ *
+ * @since
+ * @author Caspar Hübinger
+ *
+ * @see    wp-admin/admin.php
+ * @uses   get_plugin_page_hook()
+ *
+ * @return void
+ */
+function rocket_define_settings_page_hook() {
+
+	$plugin_page = $GLOBALS['plugin_page']; // wprocket
+	$parent_page = $GLOBALS['pagenow'];     // options-general.php
+
+	$page_hook = get_plugin_page_hook( $plugin_page, $parent_page );
+
+	if ( ! empty( $page_hook ) ) {
+		// This will be only available on WP Rocket’s settings page itself!
+		define( 'WP_ROCKET_SETTINGS_PAGE_HOOK', $page_hook );
+	} else {
+		// Fallback.
+		define( 'WP_ROCKET_SETTINGS_PAGE_HOOK', 'settings_page_wprocket' );
+	}
+}
+add_action( 'admin_init', 'rocket_define_settings_page_hook', 0 );
+
+/**
  * Tell WP what to do when plugin is deactivated.
  *
  * @since 1.0


### PR DESCRIPTION
Closes #1013 when merged.

- Defines a dynamic constant `WP_ROCKET_SETTINGS_PAGE_HOOK` with a
static fallback.
- Makes use of said constant where `settings_page_` was previously
hard-coded as a partial of the settings page hook name.