### PR TITLE
Fix #1070 Prevent DOMDocument bug with closing HTML tags in inline scripts

### DIFF
--- a/inc/classes/class-plugin.php
+++ b/inc/classes/class-plugin.php
@@ -93,6 +93,7 @@ class Plugin {
 			];
 		} elseif ( \rocket_valid_key() ) {
 			$subscribers = [
+				new Subscriber\Optimization\Scripts_Escaping_Subscriber(),
 				new Subscriber\Optimization\Minify_HTML_Subscriber( $this->options ),
 				new Subscriber\Optimization\Combine_Google_Fonts_Subscriber( $this->options, $this->crawler ),
 				new Subscriber\Optimization\Minify_CSS_Subscriber( $this->options, $this->crawler ),

--- a/inc/classes/optimization/JS/class-combine.php
+++ b/inc/classes/optimization/JS/class-combine.php
@@ -184,6 +184,7 @@ class Combine extends Abstract_JS_Optimization {
 				$this->add_to_minify( $file_content );
 			} elseif ( is_null( $src ) ) {
 				$inline_js = rtrim( $node->html(), ";\n\t\r" ) . ';';
+				$inline_js = str_replace( '<\/', '</', $inline_js );
 				$content  .= $inline_js;
 
 				$this->add_to_minify( $inline_js );

--- a/inc/classes/optimization/JS/class-combine.php
+++ b/inc/classes/optimization/JS/class-combine.php
@@ -138,7 +138,7 @@ class Combine extends Abstract_JS_Optimization {
 			} elseif ( is_null( $src ) ) {
 				$type = $node->attr( 'type' );
 
-				if ( 'text/template' === $type ) {
+				if ( 'text/template' === $type || 'text/html' === $type ) {
 					return;
 				}
 

--- a/inc/classes/optimization/JS/class-combine.php
+++ b/inc/classes/optimization/JS/class-combine.php
@@ -138,6 +138,10 @@ class Combine extends Abstract_JS_Optimization {
 			} elseif ( is_null( $src ) ) {
 				$type = $node->attr( 'type' );
 
+				if ( 'text/template' === $type ) {
+					return;
+				}
+
 				if ( 'application/ld+json' === $type ) {
 					return;
 				}

--- a/inc/classes/subscriber/Optimization/class-combine-google-fonts-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-combine-google-fonts-subscriber.php
@@ -16,6 +16,7 @@ class Combine_Google_Fonts_Subscriber extends Minify_Subscriber {
 	 * @inheritDoc
 	 */
 	public static function get_subscribed_events() {
+		/** This action is documented in inc/classes/subscriber/class-google-tracking-cache-busting-subscriber.php */
 		if ( apply_filters( 'rocket_buffer_enable', true ) ) {
 			return [
 				'rocket_buffer' => [ 'process', 13 ],

--- a/inc/classes/subscriber/Optimization/class-minify-css-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-minify-css-subscriber.php
@@ -24,6 +24,7 @@ class Minify_CSS_Subscriber extends Minify_Subscriber {
 			],
 		];
 
+		/** This action is documented in inc/classes/subscriber/class-google-tracking-cache-busting-subscriber.php */
 		if ( apply_filters( 'rocket_buffer_enable', true ) ) {
 			$events['rocket_buffer'] = [ 'process', 16 ];
 		}

--- a/inc/classes/subscriber/Optimization/class-minify-html-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-minify-html-subscriber.php
@@ -38,6 +38,7 @@ class Minify_HTML_Subscriber implements Subscriber_Interface {
 	 * @inheritDoc
 	 */
 	public static function get_subscribed_events() {
+		/** This action is documented in inc/classes/subscriber/class-google-tracking-cache-busting-subscriber.php */
 		if ( apply_filters( 'rocket_buffer_enable', true ) ) {
 			return [
 				'rocket_buffer' => [ 'process', 21 ],

--- a/inc/classes/subscriber/Optimization/class-minify-js-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-minify-js-subscriber.php
@@ -25,6 +25,7 @@ class Minify_JS_Subscriber extends Minify_Subscriber {
 			],
 		];
 
+		/** This action is documented in inc/classes/subscriber/class-google-tracking-cache-busting-subscriber.php */
 		if ( apply_filters( 'rocket_buffer_enable', true ) ) {
 			$events['rocket_buffer'] = [ 'process', 14 ];
 		}

--- a/inc/classes/subscriber/Optimization/class-scripts-escaping-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-scripts-escaping-subscriber.php
@@ -37,6 +37,10 @@ class Scripts_Escaping_Subscriber implements Subscriber_Interface {
 	public function escape_html_in_scripts( $html ) {
 		preg_match_all( '/<script[^>]*?>(.*)<\/script>/msU', $html, $matches );
 
+		if ( empty( $matches[1] ) ) {
+			return $html;
+		}
+
 		foreach ( $matches[1] as $k => $match ) {
 			if ( empty( $match ) ) {
 				continue;
@@ -60,6 +64,10 @@ class Scripts_Escaping_Subscriber implements Subscriber_Interface {
 	 */
 	public function unescape_html_in_scripts( $html ) {
 		preg_match_all( '/<script[^>]*?>(.*)<\/script>/msU', $html, $matches );
+
+		if ( empty( $matches[1] ) ) {
+			return $html;
+		}
 
 		foreach ( $matches[1] as $k => $match ) {
 			if ( empty( $match ) ) {

--- a/inc/classes/subscriber/Optimization/class-scripts-escaping-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-scripts-escaping-subscriber.php
@@ -1,0 +1,75 @@
+<?php
+namespace WP_Rocket\Subscriber\Optimization;
+
+use WP_Rocket\Event_Management\Subscriber_Interface;
+
+/**
+ * Handles escaping of closing HTML tags in inline scripts to prevent them from being removed by DOMDocument
+ *
+ * @since 3.1
+ * @author Remy Perona
+ */
+class Scripts_Escaping_Subscriber implements Subscriber_Interface {
+	/**
+	 * @inheritDoc
+	 */
+	public static function get_subscribed_events() {
+		/** This action is documented in inc/classes/subscriber/class-google-tracking-cache-busting-subscriber.php */
+		if ( apply_filters( 'rocket_buffer_enable', true ) ) {
+			return [
+				'rocket_buffer' => [
+					[ 'escape_html_in_scripts', 1 ],
+					[ 'unescape_html_in_scripts', PHP_INT_MAX ],
+				],
+			];
+		}
+	}
+
+	/**
+	 * Escapes HTML closing tags contained in inline scripts to prevent them from being removed by DOMDocument
+	 *
+	 * @since 3.1
+	 * @author Remy Perona
+	 *
+	 * @param string $html HTML content.
+	 * @return string
+	 */
+	public function escape_html_in_scripts( $html ) {
+		preg_match_all( '/<script[^>]*?>(.*)<\/script>/msU', $html, $matches );
+
+		foreach ( $matches[1] as $k => $match ) {
+			if ( empty( $match ) ) {
+				continue;
+			}
+
+			$match = str_replace( '</', '<\/', $match );
+			$html  = str_replace( $matches[1][ $k ], $match, $html );
+		}
+
+		return $html;
+	}
+
+	/**
+	 * Unescapes HTML closing tags contained in inline scripts once we're done with DOMDocument
+	 *
+	 * @since 3.1
+	 * @author Remy Perona
+	 *
+	 * @param string $html HTML content.
+	 * @return string
+	 */
+	public function unescape_html_in_scripts( $html ) {
+		preg_match_all( '/<script[^>]*?>(.*)<\/script>/msU', $html, $matches );
+
+		foreach ( $matches[1] as $k => $match ) {
+			if ( empty( $match ) ) {
+				continue;
+			}
+
+			$match = str_replace( '<\/', '</', $match );
+			$html  = str_replace( $matches[1][ $k ], $match, $html );
+		}
+
+		return $html;
+	}
+}

--- a/inc/classes/traits/trait-config-updater.php
+++ b/inc/classes/traits/trait-config-updater.php
@@ -2,6 +2,16 @@
 namespace WP_Rocket\Traits;
 
 trait Config_Updater {
+	/**
+	 * Update htaccess and WP Rocket config file if the option was modified.
+	 *
+	 * @since 3.1
+	 * @author Remy Perona
+	 *
+	 * @param string $old_value Option's previous value.
+	 * @param string $value     Option's new value.
+	 * @return void
+	 */
 	public function after_update_single_option( $old_value, $value ) {
 		if ( $old_value !== $value ) {
 			$this->flush_htaccess();
@@ -9,14 +19,38 @@ trait Config_Updater {
 		}
 	}
 
+	/**
+	 * Sets the htaccess update request
+	 *
+	 * @since 3.1
+	 * @author Remy Perona
+	 *
+	 * @return void
+	 */
 	protected function flush_htaccess() {
 		wp_cache_set( 'rocket_flush_htaccess', 1 );
 	}
 
+	/**
+	 * Sets WP Rocket config file update request
+	 *
+	 * @since 3.1
+	 * @author Remy Perona
+	 *
+	 * @return void
+	 */
 	protected function generate_config_file() {
 		wp_cache_set( 'rocket_generate_config_file', 1 );
 	}
 
+	/**
+	 * Performs the files update if requested
+	 *
+	 * @since 3.1
+	 * @author Remy Perona
+	 *
+	 * @return void
+	 */
 	public function maybe_update_config() {
 		if ( wp_cache_get( 'rocket_flush_htaccess' ) ) {
 			flush_rocket_htaccess();


### PR DESCRIPTION
DOMDocument doesn't like closing HTML tags in inline scripts (because it's not valid in HTML 4, which it still relies on).

To work around that, we escape early any closing tag found in inline scripts, and unescape them either:
- before they're combined into the combined JS file
- before returning the buffer content at the end when all optimizations have been done