### PR TITLE
NewsPaper Theme JS Error With Combine JS & Lazy Loading

### DIFF
--- a/inc/classes/optimization/JS/class-combine.php
+++ b/inc/classes/optimization/JS/class-combine.php
@@ -315,6 +315,7 @@ class Combine extends Abstract_JS_Optimization {
 			'ven_video_key',
 			'ANS_customer_id',
 			'tdBlock',
+			'tdLocalCache',
 			'lazyLoadOptions',
 		] );
 	}


### PR DESCRIPTION
Strange issue with the NewsPaper theme, if someone has Lazy Loading in WPRocket enabled, images in that JS will be encoded (for lazy loading like they should be example

<img width=\"218\" height=\"150\" class=\"entry-thumb\" src="data:image/gif;base64,R0lGODdhAQABAPAAAP///wAAACwAAAAAAQABAEACAkQBADs=" data-lazy-src=\"https:\/\/i1.wp.com\/example.com\/wp-content\/uploads\/2018\/01\/HP-Chromebox-G2_Front.jpg?resize=218%2C150&ssl=1\"

however, there is a JS error once it meets that base64 encoded image and it causes none of the images to load and a bunch of strange issues this simply excludes any of the inline JS that loads this to resolve the issue. (Everything else appears to load normally) (Additionally, this issue doesn't seem to appear without Lazy Load enabled).