### PR TITLE
Fix JS Error With Events Schedule WP Plugin

### DIFF
--- a/inc/classes/optimization/JS/class-combine.php
+++ b/inc/classes/optimization/JS/class-combine.php
@@ -316,6 +316,7 @@ class Combine extends Abstract_JS_Optimization {
 			'ANS_customer_id',
 			'tdBlock',
 			'tdLocalCache',
+			'wcs-',
 			'lazyLoadOptions',
 		] );
 	}


### PR DESCRIPTION
Fixes a JS error with the Events Schedule WP Plugin. Inline JS can't be aggregated. It would be better though if the inline aggregation excluded any inline JS with the type <script type="text/x-template" as this is normally HTML markup and it won't aggregate well into the combined JS file. 

However, this particular fix only fixes this sole plugin's issue.