### PR TITLE
Fix #1104 custom cron schedules removed when Google Tracking addon is not active

### DIFF
--- a/inc/classes/subscriber/class-google-tracking-cache-busting-subscriber.php
+++ b/inc/classes/subscriber/class-google-tracking-cache-busting-subscriber.php
@@ -148,7 +148,7 @@ class Google_Tracking_Cache_Busting_Subscriber implements Subscriber_Interface {
 	 */
 	public function add_schedule( $schedules ) {
 		if ( ! $this->options->get( 'google_analytics_cache', 0 ) ) {
-			return;
+			return $schedules;
 		}
 
 		$schedules['weekly'] = array(


### PR DESCRIPTION
When the option is not active it was returning nothing instead of returning the array of schedules provided as a parameter.