### PR TITLE
Fixes #1100: plugin network deactivation

### DIFF
--- a/inc/classes/admin/deactivation/class-deactivation-intent.php
+++ b/inc/classes/admin/deactivation/class-deactivation-intent.php
@@ -107,7 +107,7 @@ mixpanel.init("a36067b00a263cce0299cfd960e26ecf", {
 	public function insert_deactivation_intent_form() {
 		$current_screen = get_current_screen();
 
-		if ( 'plugins' !== $current_screen->id ) {
+		if ( 'plugins' !== $current_screen->id && 'plugins-network' !== $current_screen->id ) {
 			return;
 		}
 


### PR DESCRIPTION
On multisite, the plugin couldn't be deactivated after being network-activated. This was due to the form not being printed in the page: the JS prevents the click on the deactivation link, and then fails to display the survey.