### PR TITLE
Fix #1092 Prevent display of the show sidebar slider on license screen

### DIFF
--- a/views/settings/page.php
+++ b/views/settings/page.php
@@ -42,7 +42,6 @@ settings_errors( $data['slug'] ); ?>
 			<?php
 			if ( rocket_valid_key() ) {
 				$this->render_tools_section();
-			}
 			?>
 			<div class="wpr-Content-tips">
 				<div class="wpr-radio wpr-radio--reverse wpr-radio--tips">
@@ -53,6 +52,9 @@ settings_errors( $data['slug'] ); ?>
 						<?php _e( 'Show Sidebar', 'rocket' ); ?></label>
 				</div>
 			</div>
+			<?php
+			}
+			?>
 		</section>
 
 		<aside class="wpr-Sidebar">


### PR DESCRIPTION
Only display the slider if the license key has been validated