### PR TITLE
Fixes #1111 PHP Fatal Error in deprecated function call

### DIFF
--- a/inc/deprecated.php
+++ b/inc/deprecated.php
@@ -1,4 +1,6 @@
 <?php
+use MatthiasMullie\Minify;
+
 defined( 'ABSPATH' ) || die( 'Cheatin&#8217; uh?' );
 
 /**


### PR DESCRIPTION
Make sure to import the namespace for the minify class to prevent a fatal error if a deprecated function using it is called