### PR TITLE
Coupons.com Advertisement Fix

### DIFF
--- a/inc/classes/optimization/JS/class-combine.php
+++ b/inc/classes/optimization/JS/class-combine.php
@@ -302,6 +302,7 @@ class Combine extends Abstract_JS_Optimization {
 			'GoogleAnalyticsObject',
 			'syntaxhighlighter',
 			'adsbygoogle',
+			'ci_cap_',
 			'_stq',
 			'nonce',
 			'post_id',


### PR DESCRIPTION
This excludes the inline JS added for coupons.com advertisements, to resolve display issues for advertisements.