### PR TITLE
Exclude Inline JS That Is URL Dynamic

### DIFF
--- a/inc/classes/optimization/JS/class-combine.php
+++ b/inc/classes/optimization/JS/class-combine.php
@@ -329,6 +329,7 @@ class Combine extends Abstract_JS_Optimization {
 			'ANS_customer_id',
 			'tdBlock',
 			'tdLocalCache',
+			'"url":',
 			'lazyLoadOptions',
 			'adthrive',
 		] );


### PR DESCRIPTION
There was a post on Facebook, that mentioned users were having a lot of JS files spun up and so I logged into my own host SiteGround, and sure enough, there were about 10GB of JS files from the inline JS aggregation (and above average CPU / process usage). 

So the site in question is actually one of my own little when I am bored projects. 

https://www.thearcadecorner.com

The JS was nearly identical on every page except one minor difference
 
<script type="43b67df4e4d228e8c0359ab6-text/javascript">/* <![CDATA[ */ var ghostpool_script = {"lightbox":"group_images","url":"https:\/\/www.thearcadecorner.com\/watch-latest-pixar-short\/","max_num_pages":"0","get_template_directory_uri":"https:\/\/www.thearcadecorner.com\/wp-content\/themes\/huber"}; /* ]]> */</script>

The URL constant in that JS is dependent on the page you are on, therefore anytime you visit a different page the JS would be slightly different causing each page to have a different JS file. 

Essentially, this looks to be a common theme amongst ThemeForest themes (And other themes in the premium market) so I think excluding the above pattern is a good fit to avoid this problem any thoughts?