### PR TITLE
Fixes #1022 & #1117 Defer JS exclusion using regex

### DIFF
--- a/inc/front/deferred-js.php
+++ b/inc/front/deferred-js.php
@@ -19,21 +19,19 @@ function rocket_defer_js( $buffer ) {
 		return $buffer;
 	}
 
+	$buffer_nocomments = preg_replace( '/<!--(.*)-->/Uis', '', $buffer );
 	// Get all JS files with this regex.
-	preg_match_all( '#<script(.*)src=[\'|"]([^\'|"]+\.js?.+)[\'|"](.*)></script>#iU', $buffer, $tags_match );
+	preg_match_all( '#<script\s+([^>]+[\s\'"])?src\s*=\s*[\'"]\s*?([^\'"]+\.js(?:\?[^\'"]*)?)\s*?[\'"]([^>]+)?\/?>#iU', $buffer_nocomments, $tags_match );
 
 	if ( ! isset( $tags_match[0] ) ) {
 		return $buffer;
 	}
 
-	$exclude_defer_js = array_flip( get_rocket_exclude_defer_js() );
+	$exclude_defer_js = implode( '|', get_rocket_exclude_defer_js() );
 
 	foreach ( $tags_match[0] as $i => $tag ) {
-		// Strip query args.
-		$path = rocket_extract_url_component( $tags_match[2][ $i ] , PHP_URL_PATH );
-
 		// Check if this file should be deferred.
-		if ( isset( $exclude_defer_js[ $path ] ) ) {
+		if ( preg_match( '#(' . $exclude_defer_js . ')#i', $tags_match[2][ $i ] ) ) {
 			continue;
 		}
 
@@ -47,7 +45,7 @@ function rocket_defer_js( $buffer ) {
 			continue;
 		}
 
-		$deferred_tag = str_replace( '></script>', ' defer></script>', $tag );
+		$deferred_tag = str_replace( '>', ' defer>', $tag );
 		$buffer       = str_replace( $tag, $deferred_tag, $buffer );
 	}
 

--- a/inc/functions/options.php
+++ b/inc/functions/options.php
@@ -432,7 +432,10 @@ function get_rocket_cache_query_string() {
 function get_rocket_exclude_defer_js() {
 	global $wp_scripts;
 
-	$exclude_defer_js = array();
+	$exclude_defer_js = [
+		'gist.github.com',
+		'content.jwplatform.com',
+	];
 
 	if ( get_rocket_option( 'defer_all_js', 0 ) && get_rocket_option( 'defer_all_js_safe', 0 ) ) {
 		$jquery = site_url( $wp_scripts->registered['jquery-core']->src );
@@ -449,6 +452,10 @@ function get_rocket_exclude_defer_js() {
 	 * @param array $exclude_defer_js An array of URLs for the JS files to be excluded.
 	 */
 	$exclude_defer_js = apply_filters( 'rocket_exclude_defer_js', $exclude_defer_js );
+
+	foreach ( $exclude_defer_js as $i => $exclude ) {
+		$exclude_defer_js[ $i ] = str_replace( '#', '\#', $exclude );
+	}
 
 	return $exclude_defer_js;
 }


### PR DESCRIPTION
This allows partial match and the use of wildcards for defer JS exclusion