### PR TITLE
Fixes #1086 incorrect conditional in get_rocket_htaccess_web_fonts_access()

### DIFF
--- a/inc/functions/htaccess.php
+++ b/inc/functions/htaccess.php
@@ -540,7 +540,7 @@ function get_rocket_htaccess_etag() {
  * @return string $rules Rules that will be printed
  */
 function get_rocket_htaccess_web_fonts_access() {
-	if ( false === get_rocket_option( 'cdn', false ) ) {
+	if ( ! get_rocket_option( 'cdn', false ) ) {
 		return;
 	}
 


### PR DESCRIPTION
`get_rocket_option( 'cdn', false )` will return 0 (zero) instead of false if the option exists already in the database