### PR TITLE
Closes #1087 Clear Cache On Theme Update

### DIFF
--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -19,7 +19,7 @@ add_action( 'edit_link'                                             , 'rocket_cl
 add_action( 'delete_link'                                           , 'rocket_clean_domain' );  // When a link is deleted.
 add_action( 'customize_save'                                        , 'rocket_clean_domain' );  // When customizer is saved.
 add_action( 'update_option_theme_mods_' . get_option( 'stylesheet' ), 'rocket_clean_domain' ); // When location of a menu is updated.
-
+add_action( 'upgrader_process_complete'                             , 'rocket_clean_domain' );  // When a theme or plugin is updated.
 /**
  * Purge cache When a widget is updated
  *


### PR DESCRIPTION
This clears the cache when themes or plugins are updated.

Reference https://developer.wordpress.org/reference/hooks/upgrader_process_complete/
Reference https://developer.wordpress.org/reference/classes/theme_upgrader/

#1087 - Ticket referencing the issue. 

Some notes, it's totally possible to only do this when THEMES are updated by changing the parameters see the above references. However, doing so seems like a half-baked solution especially when updating things that affect the front-end and there are many plugins that do this. It's safer, in my opinion, to clear the cache on both plugin & theme updates. 

Especially since there is no prompt to clear the cache when plugins or themes are updated. 