### PR TITLE
Fixes #1234 Improve query strings handling in process.php

### DIFF
--- a/inc/front/process.php
+++ b/inc/front/process.php
@@ -153,16 +153,15 @@ if ( ! empty( $_GET ) ) {
 
 	if ( ! empty( $params ) ) {
 		ksort( $params );
-	}
-}
 
-if ( isset( $params ) ) {
-	$query_string = '?';
-	foreach ( $params as $key => $value ) {
-		$query_string .= $key . '=' . $value . '&';
-	}
+		$query_string = '?';
 
-	$request_uri .= rtrim( $query_string, '&' );
+		foreach ( $params as $key => $value ) {
+			$query_string .= $key . '=' . $value . '&';
+		}
+
+		$request_uri .= rtrim( $query_string, '&' );
+	}
 }
 
 $rocket_ignore_query_strings = [

--- a/inc/front/process.php
+++ b/inc/front/process.php
@@ -83,7 +83,7 @@ if ( ! isset( $_SERVER['REQUEST_METHOD'] ) || 'GET' !== $_SERVER['REQUEST_METHOD
 
 // Get the correct config file.
 $rocket_config_path      = WP_CONTENT_DIR . '/wp-rocket-config/';
-$real_rocket_config_path = realpath( $rocket_config_path ) . DIRECTORY_SEPARATOR;
+$rocket_real_config_path = realpath( $rocket_config_path ) . DIRECTORY_SEPARATOR;
 
 $host = isset( $_SERVER['HTTP_HOST'] ) ? $_SERVER['HTTP_HOST'] : (string) time();
 $host = preg_replace( '/:\d+$/', '', $host );
@@ -91,7 +91,7 @@ $host = trim( strtolower( $host ), '.' );
 $host = rawurlencode( $host );
 
 $continue = false;
-if ( realpath( $rocket_config_path . $host . '.php' ) && 0 === stripos( realpath( $rocket_config_path . $host . '.php' ), $real_rocket_config_path ) ) {
+if ( realpath( $rocket_config_path . $host . '.php' ) && 0 === stripos( realpath( $rocket_config_path . $host . '.php' ), $rocket_real_config_path ) ) {
 	include $rocket_config_path . $host . '.php';
 	$continue = true;
 } else {
@@ -102,13 +102,13 @@ if ( realpath( $rocket_config_path . $host . '.php' ) && 0 === stripos( realpath
 	foreach ( $path as $p ) {
 		static $dir;
 
-		if ( realpath( $rocket_config_path . $host . '.' . $p . '.php' ) && 0 === stripos( realpath( $rocket_config_path . $host . '.' . $p . '.php' ), $real_rocket_config_path ) ) {
+		if ( realpath( $rocket_config_path . $host . '.' . $p . '.php' ) && 0 === stripos( realpath( $rocket_config_path . $host . '.' . $p . '.php' ), $rocket_real_config_path ) ) {
 			include $rocket_config_path . $host . '.' . $p . '.php';
 			$continue = true;
 			break;
 		}
 
-		if ( realpath( $rocket_config_path . $host . '.' . $dir . $p . '.php' ) && 0 === stripos( realpath( $rocket_config_path . $host . '.' . $dir . $p . '.php' ), $real_rocket_config_path ) ) {
+		if ( realpath( $rocket_config_path . $host . '.' . $dir . $p . '.php' ) && 0 === stripos( realpath( $rocket_config_path . $host . '.' . $dir . $p . '.php' ), $rocket_real_config_path ) ) {
 			include $rocket_config_path . $host . '.' . $dir . $p . '.php';
 			$continue = true;
 			break;
@@ -126,27 +126,54 @@ if ( ! $continue ) {
 	return;
 }
 
-$request_uri = ( isset( $rocket_cache_query_strings ) && array_intersect( array_keys( $_GET ), $rocket_cache_query_strings ) ) || isset( $_GET['lp-variation-id'] ) || isset( $_GET['lang'] ) || isset( $_GET['s'] ) ? $_SERVER['REQUEST_URI'] : $request_uri;
-
 /**
- * Don't cache with variables but the cache is enabled if the visitor comes from an RSS feed, a Facebook action or Google Adsense tracking
+ * Don't cache with query strings parameters but the cache is served if the visitor comes from an RSS feed, a Facebook action or Google Adsense tracking
  *
  * @since 2.3 Add query strings which can be cached via the options page.
- * @since 2.1 Add compatibilty with WordPress Landing Pages (permalink_name and lp-variation-id)
+ * @since 2.1 Add compatibility with WordPress Landing Pages (permalink_name and lp-variation-id)
  * @since 2.1 Add compabitiliy with qTranslate and translation plugin with query string "lang"
  */
+$rocket_remove_query_strings = [
+	'utm_source'      => 1,
+	'utm_medium'      => 1,
+	'utm_campaign'    => 1,
+	'utm_expid'       => 1,
+	'fb_action_ids'   => 1,
+	'fb_action_types' => 1,
+	'fb_source'       => 1,
+	'fbclid'          => 1,
+	'gclid'           => 1,
+	'age-verified'    => 1,
+	'ao_noptimize'    => 1,
+	'usqp'            => 1,
+];
+
+if ( ! empty( $_GET ) ) {
+	$params = array_diff_key( $_GET, $rocket_remove_query_strings );
+
+	if ( ! empty( $params ) ) {
+		ksort( $params );
+	}
+}
+
+if ( isset( $params ) ) {
+	$query_string = '?';
+	foreach ( $params as $key => $value ) {
+		$query_string .= $key . '=' . $value . '&';
+	}
+
+	$request_uri .= rtrim( $query_string, '&' );
+}
+
+$rocket_ignore_query_strings = [
+	'lang'            => 1,
+	's'               => 1,
+	'permalink_name'  => 1,
+	'lp-variation-id' => 1,
+];
+
 if ( ! empty( $_GET )
-	&& ( ! isset( $_GET['utm_source'], $_GET['utm_medium'], $_GET['utm_campaign'] ) )
-	&& ( ! isset( $_GET['utm_expid'] ) )
-	&& ( ! isset( $_GET['fb_action_ids'], $_GET['fb_action_types'], $_GET['fb_source'] ) )
-	&& ( ! isset( $_GET['gclid'] ) )
-	&& ( ! isset( $_GET['permalink_name'] ) )
-	&& ( ! isset( $_GET['lp-variation-id'] ) )
-	&& ( ! isset( $_GET['lang'] ) )
-	&& ( ! isset( $_GET['s'] ) )
-	&& ( ! isset( $_GET['age-verified'] ) )
-	&& ( ! isset( $_GET['ao_noptimize'] ) )
-	&& ( ! isset( $_GET['usqp'] ) )
+	&& ( ! array_diff_key( $_GET, $rocket_ignore_query_strings ) )
 	&& ( ! isset( $rocket_cache_query_strings ) || ! array_intersect( array_keys( $_GET ), $rocket_cache_query_strings ) )
 ) {
 	rocket_define_donotoptimize_constant( true );


### PR DESCRIPTION
- Remove safe-to-ignore parameters from the requested URL
- Reorder remaining parameters alphabetically

This improves 2 things:
- An URL with a parameter to be cached will no longer contained unneeded parameters, which was previously creating different cache files for nothing
- The same cache file will be used whatever the order of the parameters is, instead of creating a new one if the order is different