### PR TITLE
Fixes #1088 Remove Mandatory cookies on hosting with server side cache

### DIFF
--- a/inc/3rd-party/hosting/flywheel.php
+++ b/inc/3rd-party/hosting/flywheel.php
@@ -36,4 +36,7 @@ if ( class_exists( 'FlywheelNginxCompat' ) ) :
 		return '127.0.0.1';
 	}
 	add_filter( 'rocket_varnish_ip', 'rocket_varnish_ip_on_flywheel' );
+
+	// Prevent mandatory cookies on hosting with server cache.
+	add_filter( 'rocket_cache_mandatory_cookies', '__return_empty_array', PHP_INT_MAX );
 endif;

--- a/inc/3rd-party/hosting/godaddy.php
+++ b/inc/3rd-party/hosting/godaddy.php
@@ -21,6 +21,8 @@ if ( class_exists( 'WPaaS\Plugin' ) ) :
 	add_filter( 'rocket_display_input_varnish_auto_purge', '__return_false' );
 
 	add_filter( 'set_rocket_wp_cache_define', '__return_true' );
+	// Prevent mandatory cookies on hosting with server cache.
+	add_filter( 'rocket_cache_mandatory_cookies', '__return_empty_array', PHP_INT_MAX );
 
 	/**
 	 * Remove expiration on HTML to prevent issue with Varnish cache.

--- a/inc/3rd-party/hosting/kinsta.php
+++ b/inc/3rd-party/hosting/kinsta.php
@@ -5,6 +5,8 @@ if ( isset( $_SERVER['KINSTA_CACHE_ZONE'] ) ) {
 
 	add_filter( 'do_rocket_generate_caching_files', '__return_false', PHP_INT_MAX );
 	add_filter( 'rocket_display_varnish_options_tab', '__return_false' );
+	// Prevent mandatory cookies on hosting with server cache.
+	add_filter( 'rocket_cache_mandatory_cookies', '__return_empty_array', PHP_INT_MAX );
 
 	global $kinsta_cache;
 

--- a/inc/3rd-party/hosting/o2switch.php
+++ b/inc/3rd-party/hosting/o2switch.php
@@ -19,6 +19,8 @@ if ( defined( 'O2SWITCH_VARNISH_PURGE_KEY' ) ) {
 	add_filter( 'rocket_varnish_field_settings', 'rocket_o2switch_varnish_field' );
 
 	add_filter( 'rocket_display_input_varnish_auto_purge', '__return_false' );
+	// Prevent mandatory cookies on hosting with server cache.
+	add_filter( 'rocket_cache_mandatory_cookies', '__return_empty_array', PHP_INT_MAX );
 
 	/**
 	 * Purge all the domain

--- a/inc/3rd-party/hosting/pressidium.php
+++ b/inc/3rd-party/hosting/pressidium.php
@@ -19,6 +19,8 @@ if ( defined( 'WP_NINUKIS_WP_NAME' ) ) {
 	add_filter( 'rocket_varnish_field_settings', 'rocket_pressidium_varnish_field' );
 
 	add_filter( 'rocket_display_input_varnish_auto_purge', '__return_false' );
+	// Prevent mandatory cookies on hosting with server cache.
+	add_filter( 'rocket_cache_mandatory_cookies', '__return_empty_array', PHP_INT_MAX );
 
 	/**
 	 * Clear WP Rocket cache after purged the Varnish cache via Pressidium Hosting

--- a/inc/3rd-party/hosting/savvii.php
+++ b/inc/3rd-party/hosting/savvii.php
@@ -19,6 +19,8 @@ if ( class_exists( '\\Savvii\\CacheFlusherPlugin' ) & class_exists( '\\Savvii\\O
 	add_filter( 'rocket_varnish_field_settings', 'rocket_savvii_varnish_field' );
 
 	add_filter( 'rocket_display_input_varnish_auto_purge', '__return_false' );
+	// Prevent mandatory cookies on hosting with server cache.
+	add_filter( 'rocket_cache_mandatory_cookies', '__return_empty_array', PHP_INT_MAX );
 
 	/**
 	 * Clear WP Rocket cache after purged the Varnish cache via Savvii Hosting

--- a/inc/3rd-party/hosting/siteground.php
+++ b/inc/3rd-party/hosting/siteground.php
@@ -9,6 +9,8 @@ if ( rocket_is_plugin_active( 'sg-cachepress/sg-cachepress.php' ) ) {
 		add_action( 'admin_post_sg-cachepress-purge', 'rocket_clean_domain', 0 );
 		add_action( 'after_rocket_clean_domain', 'rocket_clean_supercacher' );
 		add_filter( 'rocket_display_varnish_options_tab', '__return_false' );
+		// Prevent mandatory cookies on hosting with server cache.
+		add_filter( 'rocket_cache_mandatory_cookies', '__return_empty_array', PHP_INT_MAX );
 	}
 
 	/**

--- a/inc/3rd-party/hosting/wp-serveur.php
+++ b/inc/3rd-party/hosting/wp-serveur.php
@@ -8,6 +8,8 @@ if ( defined( 'DB_HOST' ) && strpos( DB_HOST, '.wpserveur.net' ) !== false ) {
 	 * @since 2.6.11
 	 */
 	add_filter( 'do_rocket_varnish_http_purge', '__return_true' );
+	// Prevent mandatory cookies on hosting with server cache.
+	add_filter( 'rocket_cache_mandatory_cookies', '__return_empty_array', PHP_INT_MAX );
 
 	/**
 	 * Changes the text on the Varnish one-click block.

--- a/inc/3rd-party/hosting/wpengine.php
+++ b/inc/3rd-party/hosting/wpengine.php
@@ -19,6 +19,8 @@ if ( class_exists( 'WpeCommon' ) && function_exists( 'wpe_param' ) ) {
 	add_filter( 'rocket_varnish_field_settings', 'rocket_wpengine_varnish_field' );
 
 	add_filter( 'rocket_display_input_varnish_auto_purge', '__return_false' );
+	// Prevent mandatory cookies on hosting with server cache.
+	add_filter( 'rocket_cache_mandatory_cookies', '__return_empty_array', PHP_INT_MAX );
 
 	/**
 	 * Always keep WP_CACHE constant to true

--- a/inc/admin/upgrader.php
+++ b/inc/admin/upgrader.php
@@ -363,5 +363,9 @@ function rocket_new_upgrade( $wp_rocket_version, $actual_version ) {
 			}
 		}
 	}
+
+	if ( version_compare( $actual_version, '3.2.1', '<' ) ) {
+		rocket_generate_config_file();
+	}
 }
 add_action( 'wp_rocket_upgrade', 'rocket_new_upgrade', 10, 2 );


### PR DESCRIPTION
#1088 

The mandatory cookies can prevent optimizations from being applied on the first load that will be cached by the server-side caching in place.

By removing them on those specific hostings we can be sure optimizations are always applied.