### PR TITLE
Add uk cookie consent compatibility

### DIFF
--- a/inc/3rd-party/3rd-party.php
+++ b/inc/3rd-party/3rd-party.php
@@ -37,7 +37,7 @@ require WP_ROCKET_3RD_PARTY_PATH . 'plugins/appbanners.php';
 require WP_ROCKET_3RD_PARTY_PATH . 'plugins/autoptimize.php';
 require WP_ROCKET_3RD_PARTY_PATH . 'plugins/envira-gallery.php';
 require WP_ROCKET_3RD_PARTY_PATH . 'plugins/cookies/cookie-notice.php';
-require WP_ROCKET_3RD_PARTY_PATH . 'plugins/cookies/cookie-consent.php';
+require WP_ROCKET_3RD_PARTY_PATH . 'plugins/cookies/uk-cookie-consent.php';
 require WP_ROCKET_3RD_PARTY_PATH . 'plugins/cookies/eu-cookie-law.php';
 require WP_ROCKET_3RD_PARTY_PATH . 'plugins/cookies/weepie-cookie-allow.php';
 require WP_ROCKET_3RD_PARTY_PATH . 'plugins/cookies/gdpr.php';

--- a/inc/3rd-party/3rd-party.php
+++ b/inc/3rd-party/3rd-party.php
@@ -37,6 +37,7 @@ require WP_ROCKET_3RD_PARTY_PATH . 'plugins/appbanners.php';
 require WP_ROCKET_3RD_PARTY_PATH . 'plugins/autoptimize.php';
 require WP_ROCKET_3RD_PARTY_PATH . 'plugins/envira-gallery.php';
 require WP_ROCKET_3RD_PARTY_PATH . 'plugins/cookies/cookie-notice.php';
+require WP_ROCKET_3RD_PARTY_PATH . 'plugins/cookies/cookie-consent.php';
 require WP_ROCKET_3RD_PARTY_PATH . 'plugins/cookies/eu-cookie-law.php';
 require WP_ROCKET_3RD_PARTY_PATH . 'plugins/cookies/weepie-cookie-allow.php';
 require WP_ROCKET_3RD_PARTY_PATH . 'plugins/cookies/gdpr.php';

--- a/inc/3rd-party/plugins/cookies/cookie-consent.php
+++ b/inc/3rd-party/plugins/cookies/cookie-consent.php
@@ -10,7 +10,7 @@
 defined( 'ABSPATH' ) || die( 'Cheatin\' uh?' );
 
 if ( class_exists( 'CTCC_Public' ) ) {
-    add_filter( 'rocket_htaccess_mod_rewrite'    , '__return_false' );
+	add_filter( 'rocket_htaccess_mod_rewrite'    , '__return_false' );
 	// Create cache version based on value set in cookie_consent_accepted cookie.
 	add_filter( 'rocket_cache_dynamic_cookies',   'rocket_get_cookie_consent_cookie' );
 	add_filter( 'rocket_cache_mandatory_cookies', 'rocket_get_cookie_consent_cookie' );
@@ -37,7 +37,7 @@ function rocket_get_cookie_consent_cookie( $cookies ) {
  * @author TheZoker
  */
 function rocket_add_cookie_consent_dynamic_cookie() {
-    add_filter( 'rocket_htaccess_mod_rewrite'    , '__return_false' );
+	add_filter( 'rocket_htaccess_mod_rewrite'    , '__return_false' );
 	// Create cache version based on value set in cookie_consent_accepted cookie.
 	add_filter( 'rocket_cache_dynamic_cookies',   'rocket_get_cookie_consent_cookie' );
 	add_filter( 'rocket_cache_mandatory_cookies', 'rocket_get_cookie_consent_cookie' );
@@ -60,7 +60,7 @@ add_action( 'activate_cookie-consent/cookie-consent.php', 'rocket_add_cookie_con
  * @author TheZoker
  */
 function rocket_remove_cookie_consent_dynamic_cookie() {
-    remove_filter( 'rocket_htaccess_mod_rewrite',    '__return_false' );
+	remove_filter( 'rocket_htaccess_mod_rewrite',    '__return_false' );
 	remove_filter( 'rocket_cache_dynamic_cookies',   'rocket_get_cookie_consent_cookie' );
 	remove_filter( 'rocket_cache_mandatory_cookies', 'rocket_get_cookie_consent_cookie' );
 

--- a/inc/3rd-party/plugins/cookies/cookie-consent.php
+++ b/inc/3rd-party/plugins/cookies/cookie-consent.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Compatibility with UK Cookie Consent.
+ *
+ * @since  3.2
+ * @author TheZoker
+ * @link   https://wordpress.org/plugins/uk-cookie-consent/
+ */
+
+defined( 'ABSPATH' ) || die( 'Cheatin\' uh?' );
+
+if ( class_exists( 'CTCC_Public' ) ) {
+    add_filter( 'rocket_htaccess_mod_rewrite'    , '__return_false' );
+	// Create cache version based on value set in cookie_consent_accepted cookie.
+	add_filter( 'rocket_cache_dynamic_cookies',   'rocket_get_cookie_consent_cookie' );
+	add_filter( 'rocket_cache_mandatory_cookies', 'rocket_get_cookie_consent_cookie' );
+}
+
+/**
+ * Return the cookie name set by Cookie Consent plugin.
+ *
+ * @since  3.2
+ * @author TheZoker
+ *
+ * @param  array $cookies List of dynamic cookies.
+ * @return array          List of dynamic cookies with the Cookie Consent cookie appended.
+ */
+function rocket_get_cookie_consent_cookie( $cookies ) {
+	$cookies[] = 'catAccCookies';
+	return $cookies;
+}
+
+/**
+ * Add dynamic cookie and mandatory cookie when Cookie Consent plugin is activated.
+ *
+ * @since  3.2
+ * @author TheZoker
+ */
+function rocket_add_cookie_consent_dynamic_cookie() {
+    add_filter( 'rocket_htaccess_mod_rewrite'    , '__return_false' );
+	// Create cache version based on value set in cookie_consent_accepted cookie.
+	add_filter( 'rocket_cache_dynamic_cookies',   'rocket_get_cookie_consent_cookie' );
+	add_filter( 'rocket_cache_mandatory_cookies', 'rocket_get_cookie_consent_cookie' );
+
+	// Update the WP Rocket rules on the .htaccess file.
+	flush_rocket_htaccess();
+
+	// Regenerate the config file.
+	rocket_generate_config_file();
+
+	// Clear WP Rocket cache.
+	rocket_clean_domain();
+}
+add_action( 'activate_cookie-consent/cookie-consent.php', 'rocket_add_cookie_consent_dynamic_cookie', 11 );
+
+/**
+ * Remove dynamic cookie when Cookie Consent plugin is deactivated.
+ *
+ * @since  3.2
+ * @author TheZoker
+ */
+function rocket_remove_cookie_consent_dynamic_cookie() {
+    remove_filter( 'rocket_htaccess_mod_rewrite',    '__return_false' );
+	remove_filter( 'rocket_cache_dynamic_cookies',   'rocket_get_cookie_consent_cookie' );
+	remove_filter( 'rocket_cache_mandatory_cookies', 'rocket_get_cookie_consent_cookie' );
+
+	// Update the WP Rocket rules on the .htaccess file.
+	flush_rocket_htaccess();
+
+	// Regenerate the config file.
+	rocket_generate_config_file();
+
+	// Clear WP Rocket cache.
+	rocket_clean_domain();
+}
+add_action( 'deactivate_cookie-consent/cookie-consent.php', 'rocket_remove_cookie_consent_dynamic_cookie', 11 );

--- a/inc/3rd-party/plugins/cookies/uk-cookie-consent.php
+++ b/inc/3rd-party/plugins/cookies/uk-cookie-consent.php
@@ -10,9 +10,9 @@
 defined( 'ABSPATH' ) || die( 'Cheatin\' uh?' );
 
 if ( class_exists( 'CTCC_Public' ) ) {
-	add_filter( 'rocket_htaccess_mod_rewrite'    , '__return_false' );
+	add_filter( 'rocket_htaccess_mod_rewrite', '__return_false' );
 	// Create cache version based on value set in cookie_consent_accepted cookie.
-	add_filter( 'rocket_cache_dynamic_cookies',   'rocket_get_cookie_uk_consent_cookie' );
+	add_filter( 'rocket_cache_dynamic_cookies', 'rocket_get_cookie_uk_consent_cookie' );
 }
 
 /**
@@ -36,9 +36,9 @@ function rocket_get_cookie_uk_consent_cookie( $cookies ) {
  * @author TheZoker
  */
 function rocket_add_uk_cookie_consent_dynamic_cookie() {
-	add_filter( 'rocket_htaccess_mod_rewrite'    , '__return_false' );
+	add_filter( 'rocket_htaccess_mod_rewrite', '__return_false' );
 	// Create cache version based on value set in cookie_consent_accepted cookie.
-	add_filter( 'rocket_cache_dynamic_cookies',   'rocket_get_cookie_uk_consent_cookie' );
+	add_filter( 'rocket_cache_dynamic_cookies', 'rocket_get_cookie_uk_consent_cookie' );
 
 	// Update the WP Rocket rules on the .htaccess file.
 	flush_rocket_htaccess();
@@ -58,8 +58,8 @@ add_action( 'activate_uk-cookie-consent/uk-cookie-consent.php', 'rocket_add_uk_c
  * @author TheZoker
  */
 function rocket_remove_uk_cookie_consent_dynamic_cookie() {
-	remove_filter( 'rocket_htaccess_mod_rewrite',    '__return_false' );
-	remove_filter( 'rocket_cache_dynamic_cookies',   'rocket_get_cookie_uk_consent_cookie' );
+	remove_filter( 'rocket_htaccess_mod_rewrite', '__return_false' );
+	remove_filter( 'rocket_cache_dynamic_cookies', 'rocket_get_cookie_uk_consent_cookie' );
 
 	// Update the WP Rocket rules on the .htaccess file.
 	flush_rocket_htaccess();

--- a/inc/3rd-party/plugins/cookies/uk-cookie-consent.php
+++ b/inc/3rd-party/plugins/cookies/uk-cookie-consent.php
@@ -13,7 +13,6 @@ if ( class_exists( 'CTCC_Public' ) ) {
 	add_filter( 'rocket_htaccess_mod_rewrite'    , '__return_false' );
 	// Create cache version based on value set in cookie_consent_accepted cookie.
 	add_filter( 'rocket_cache_dynamic_cookies',   'rocket_get_cookie_uk_consent_cookie' );
-	add_filter( 'rocket_cache_mandatory_cookies', 'rocket_get_cookie_uk_consent_cookie' );
 }
 
 /**
@@ -40,7 +39,6 @@ function rocket_add_uk_cookie_consent_dynamic_cookie() {
 	add_filter( 'rocket_htaccess_mod_rewrite'    , '__return_false' );
 	// Create cache version based on value set in cookie_consent_accepted cookie.
 	add_filter( 'rocket_cache_dynamic_cookies',   'rocket_get_cookie_uk_consent_cookie' );
-	add_filter( 'rocket_cache_mandatory_cookies', 'rocket_get_cookie_uk_consent_cookie' );
 
 	// Update the WP Rocket rules on the .htaccess file.
 	flush_rocket_htaccess();
@@ -62,7 +60,6 @@ add_action( 'activate_uk-cookie-consent/uk-cookie-consent.php', 'rocket_add_uk_c
 function rocket_remove_uk_cookie_consent_dynamic_cookie() {
 	remove_filter( 'rocket_htaccess_mod_rewrite',    '__return_false' );
 	remove_filter( 'rocket_cache_dynamic_cookies',   'rocket_get_cookie_uk_consent_cookie' );
-	remove_filter( 'rocket_cache_mandatory_cookies', 'rocket_get_cookie_uk_consent_cookie' );
 
 	// Update the WP Rocket rules on the .htaccess file.
 	flush_rocket_htaccess();

--- a/inc/3rd-party/plugins/cookies/uk-cookie-consent.php
+++ b/inc/3rd-party/plugins/cookies/uk-cookie-consent.php
@@ -12,35 +12,35 @@ defined( 'ABSPATH' ) || die( 'Cheatin\' uh?' );
 if ( class_exists( 'CTCC_Public' ) ) {
 	add_filter( 'rocket_htaccess_mod_rewrite'    , '__return_false' );
 	// Create cache version based on value set in cookie_consent_accepted cookie.
-	add_filter( 'rocket_cache_dynamic_cookies',   'rocket_get_cookie_consent_cookie' );
-	add_filter( 'rocket_cache_mandatory_cookies', 'rocket_get_cookie_consent_cookie' );
+	add_filter( 'rocket_cache_dynamic_cookies',   'rocket_get_cookie_uk_consent_cookie' );
+	add_filter( 'rocket_cache_mandatory_cookies', 'rocket_get_cookie_uk_consent_cookie' );
 }
 
 /**
- * Return the cookie name set by Cookie Consent plugin.
+ * Return the cookie name set by UK Cookie Consent plugin.
  *
  * @since  3.2
  * @author TheZoker
  *
  * @param  array $cookies List of dynamic cookies.
- * @return array          List of dynamic cookies with the Cookie Consent cookie appended.
+ * @return array          List of dynamic cookies with the UK Cookie Consent cookie appended.
  */
-function rocket_get_cookie_consent_cookie( $cookies ) {
+function rocket_get_cookie_uk_consent_cookie( $cookies ) {
 	$cookies[] = 'catAccCookies';
 	return $cookies;
 }
 
 /**
- * Add dynamic cookie and mandatory cookie when Cookie Consent plugin is activated.
+ * Add dynamic cookie and mandatory cookie when UK Cookie Consent plugin is activated.
  *
  * @since  3.2
  * @author TheZoker
  */
-function rocket_add_cookie_consent_dynamic_cookie() {
+function rocket_add_uk_cookie_consent_dynamic_cookie() {
 	add_filter( 'rocket_htaccess_mod_rewrite'    , '__return_false' );
 	// Create cache version based on value set in cookie_consent_accepted cookie.
-	add_filter( 'rocket_cache_dynamic_cookies',   'rocket_get_cookie_consent_cookie' );
-	add_filter( 'rocket_cache_mandatory_cookies', 'rocket_get_cookie_consent_cookie' );
+	add_filter( 'rocket_cache_dynamic_cookies',   'rocket_get_cookie_uk_consent_cookie' );
+	add_filter( 'rocket_cache_mandatory_cookies', 'rocket_get_cookie_uk_consent_cookie' );
 
 	// Update the WP Rocket rules on the .htaccess file.
 	flush_rocket_htaccess();
@@ -51,7 +51,7 @@ function rocket_add_cookie_consent_dynamic_cookie() {
 	// Clear WP Rocket cache.
 	rocket_clean_domain();
 }
-add_action( 'activate_cookie-consent/cookie-consent.php', 'rocket_add_cookie_consent_dynamic_cookie', 11 );
+add_action( 'activate_uk-cookie-consent/uk-cookie-consent.php', 'rocket_add_uk_cookie_consent_dynamic_cookie', 11 );
 
 /**
  * Remove dynamic cookie when Cookie Consent plugin is deactivated.
@@ -59,10 +59,10 @@ add_action( 'activate_cookie-consent/cookie-consent.php', 'rocket_add_cookie_con
  * @since  3.2
  * @author TheZoker
  */
-function rocket_remove_cookie_consent_dynamic_cookie() {
+function rocket_remove_uk_cookie_consent_dynamic_cookie() {
 	remove_filter( 'rocket_htaccess_mod_rewrite',    '__return_false' );
-	remove_filter( 'rocket_cache_dynamic_cookies',   'rocket_get_cookie_consent_cookie' );
-	remove_filter( 'rocket_cache_mandatory_cookies', 'rocket_get_cookie_consent_cookie' );
+	remove_filter( 'rocket_cache_dynamic_cookies',   'rocket_get_cookie_uk_consent_cookie' );
+	remove_filter( 'rocket_cache_mandatory_cookies', 'rocket_get_cookie_uk_consent_cookie' );
 
 	// Update the WP Rocket rules on the .htaccess file.
 	flush_rocket_htaccess();
@@ -73,4 +73,4 @@ function rocket_remove_cookie_consent_dynamic_cookie() {
 	// Clear WP Rocket cache.
 	rocket_clean_domain();
 }
-add_action( 'deactivate_cookie-consent/cookie-consent.php', 'rocket_remove_cookie_consent_dynamic_cookie', 11 );
+add_action( 'deactivate_uk-cookie-consent/uk-cookie-consent.php', 'rocket_remove_uk_cookie_consent_dynamic_cookie', 11 );


### PR DESCRIPTION
Adds compatibility for the uk cookie consent plugin:
https://wordpress.org/support/plugin/uk-cookie-consent

There is only one cookie created on consent acceptance: 
![screenshot_2018 11 08_14h11m12s_017_](https://user-images.githubusercontent.com/1368405/48200664-2b712100-e360-11e8-8b0c-989df8fa9e6a.png)
