### PR TITLE
3.2.1.1

### DIFF
--- a/inc/3rd-party/plugins/cookies/cookie-notice.php
+++ b/inc/3rd-party/plugins/cookies/cookie-notice.php
@@ -16,7 +16,6 @@ if ( class_exists( 'Cookie_Notice' ) ) {
 	}
 	// Create cache version based on value set in cookie_notice_accepted cookie.
 	add_filter( 'rocket_cache_dynamic_cookies',   'rocket_get_cookie_notice_cookie' );
-	add_filter( 'rocket_cache_mandatory_cookies', 'rocket_get_cookie_notice_cookie' );
 }
 
 /**
@@ -46,7 +45,6 @@ function rocket_add_cookie_notice_dynamic_cookie() {
 	}
 	// Create cache version based on value set in cookie_notice_accepted cookie.
 	add_filter( 'rocket_cache_dynamic_cookies',   'rocket_get_cookie_notice_cookie' );
-	add_filter( 'rocket_cache_mandatory_cookies', 'rocket_get_cookie_notice_cookie' );
 
 	// Update the WP Rocket rules on the .htaccess file.
 	flush_rocket_htaccess();
@@ -70,7 +68,6 @@ function rocket_remove_cookie_notice_dynamic_cookie() {
 		remove_filter( 'rocket_htaccess_mod_rewrite',    '__return_false' );
 	}
 	remove_filter( 'rocket_cache_dynamic_cookies',   'rocket_get_cookie_notice_cookie' );
-	remove_filter( 'rocket_cache_mandatory_cookies', 'rocket_get_cookie_notice_cookie' );
 
 	// Update the WP Rocket rules on the .htaccess file.
 	flush_rocket_htaccess();

--- a/inc/3rd-party/plugins/cookies/gdpr.php
+++ b/inc/3rd-party/plugins/cookies/gdpr.php
@@ -11,7 +11,6 @@ defined( 'ABSPATH' ) || die( 'Cheatin\' uh?' );
 if ( class_exists( 'GDPR' ) ) {
 	add_filter( 'rocket_htaccess_mod_rewrite', '__return_false' );
 	// Create cache version based on value set in gdpr[] cookies.
-	add_filter( 'rocket_cache_mandatory_cookies', 'rocket_get_gdpr_mandatory_cookies' );
 	add_filter( 'rocket_cache_dynamic_cookies', 'rocket_get_gdpr_dynamic_cookies' );
 }
 
@@ -57,7 +56,6 @@ function rocket_add_gdpr_mandatory_cookies() {
 	add_filter( 'rocket_htaccess_mod_rewrite', '__return_false' );
 
 	// Create cache version based on value set in GDPR cookies.
-	add_filter( 'rocket_cache_mandatory_cookies', 'rocket_get_gdpr_mandatory_cookies' );
 	add_filter( 'rocket_cache_dynamic_cookies', 'rocket_get_gdpr_dynamic_cookies' );
 	// Update the WP Rocket rules on the .htaccess file.
 	flush_rocket_htaccess();
@@ -78,7 +76,6 @@ function rocket_remove_gdpr_mandatory_cookies() {
 	remove_filter( 'rocket_htaccess_mod_rewrite', '__return_false' );
 
 	// Delete the dynamic cookie filter.
-	remove_filter( 'rocket_cache_mandatory_cookies', 'rocket_get_gdpr_mandatory_cookies' );
 	remove_filter( 'rocket_cache_dynamic_cookies', 'rocket_get_gdpr_dynamic_cookies' );
 	// Update the WP Rocket rules on the .htaccess file.
 	flush_rocket_htaccess();

--- a/inc/admin/upgrader.php
+++ b/inc/admin/upgrader.php
@@ -374,5 +374,9 @@ function rocket_new_upgrade( $wp_rocket_version, $actual_version ) {
 		rocket_generate_config_file();
 		rocket_clean_domain();
 	}
+
+	if ( version_compare( $actual_version, '3.2.1.1', '<' ) ) {
+		rocket_generate_config_file();
+	}
 }
 add_action( 'wp_rocket_upgrade', 'rocket_new_upgrade', 10, 2 );

--- a/inc/classes/preload/class-abstract-preload.php
+++ b/inc/classes/preload/class-abstract-preload.php
@@ -43,4 +43,16 @@ abstract class Abstract_Preload {
 			$this->preload_process->cancel_process();
 		}
 	}
+
+	/**
+	 * Checks if a process is already running
+	 *
+	 * @since 3.2.1.1
+	 * @author Remy Perona
+	 *
+	 * @return boolean
+	 */
+	public function is_process_running() {
+		return $this->preload_process->is_process_running();
+	}
 }

--- a/inc/classes/preload/class-full-process.php
+++ b/inc/classes/preload/class-full-process.php
@@ -109,5 +109,17 @@ class Full_Process extends \WP_Background_Process {
 		parent::complete();
 	}
 
+	/**
+	 * Checks if a process is already running
+	 *
+	 * @since 3.2.1.1
+	 * @author Remy Perona
+	 *
+	 * @see WP_Background_Process::is_process_running()
+	 * @return boolean
+	 */
+	public function is_process_running() {
+		return parent::is_process_running();
+	}
 }
 

--- a/inc/classes/subscriber/preload/class-preload-subscriber.php
+++ b/inc/classes/subscriber/preload/class-preload-subscriber.php
@@ -126,6 +126,10 @@ class Preload_Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function maybe_launch_preload( $old_value, $value ) {
+		if ( $this->homepage_preloader->is_process_running() ) {
+			return;
+		}
+
 		// These values are ignored because they don't impact the cache content.
 		$ignored_options = [
 			'cache_mobile'                => true,
@@ -169,8 +173,6 @@ class Preload_Subscriber implements Subscriber_Interface {
 		}
 
 		if ( isset( $value['manual_preload'] ) && 1 === (int) $value['manual_preload'] ) {
-			$this->homepage_preloader->cancel_preload();
-			usleep( 1000000 );
 			$this->preload();
 		}
 	}

--- a/inc/functions/preload.php
+++ b/inc/functions/preload.php
@@ -26,8 +26,6 @@ function run_rocket_bot( $spider = 'cache-preload', $lang = '' ) {
 
 	$homepage_preload = new WP_Rocket\Preload\Homepage( new WP_Rocket\Preload\Full_Process() );
 
-	$homepage_preload->cancel_preload();
-	usleep( 1000000 );
 	$homepage_preload->preload( $urls );
 }
 
@@ -60,8 +58,6 @@ function run_rocket_sitemap_preload() {
 
 	$sitemap_preload = new WP_Rocket\Preload\Sitemap( new WP_Rocket\Preload\Full_Process() );
 
-	$sitemap_preload->cancel_preload();
-	usleep( 1000000 );
 	$sitemap_preload->run_preload( $sitemaps );
 }
 
@@ -84,6 +80,13 @@ function do_admin_post_rocket_preload_cache() {
 
 	/** This filter is documented in inc/admin-bar.php */
 	if ( ! current_user_can( apply_filters( 'rocket_capacity', 'manage_options' ) ) ) {
+		wp_safe_redirect( wp_get_referer() );
+		die();
+	}
+
+	$preload_process = new WP_Rocket\Preload\Full_Process();
+
+	if ( $preload_process->is_process_running() ) {
 		wp_safe_redirect( wp_get_referer() );
 		die();
 	}

--- a/wp-rocket.php
+++ b/wp-rocket.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Rocket
  * Plugin URI: https://wp-rocket.me
  * Description: The best WordPress performance plugin.
- * Version: 3.2.1
+ * Version: 3.2.1.1
  * Code Name: Dagobah
  * Author: WP Media
  * Author URI: http://wp-media.me
@@ -18,7 +18,7 @@
 defined( 'ABSPATH' ) || die( 'Cheatin&#8217; uh?' );
 
 // Rocket defines.
-define( 'WP_ROCKET_VERSION',               '3.2.1' );
+define( 'WP_ROCKET_VERSION',               '3.2.1.1' );
 define( 'WP_ROCKET_WP_VERSION',            '4.7' );
 define( 'WP_ROCKET_PHP_VERSION',           '5.4' );
 define( 'WP_ROCKET_PRIVATE_KEY',           false );


### PR DESCRIPTION
- Regression fix: Revert serve the gzip version of the cache file even without the Apache rewrite rules as its causing display issues on some configurations
- Regression fix: Remove mandatory cookies for Cookie Notice and GDPR plugins
- Bugfix: Correct an issue stopping preload too early when triggering it from the admin menu 