### PR TITLE
Correctly check for https cache version during preload

### DIFF
--- a/inc/classes/preload/class-full-process.php
+++ b/inc/classes/preload/class-full-process.php
@@ -98,7 +98,7 @@ class Full_Process extends \WP_Background_Process {
 			$url['host'] = str_replace( '.', '_', $url['host'] );
 		}
 
-		$file_cache_path = WP_ROCKET_CACHE_PATH . $url['host'] . strtolower( $url['path'] ) . 'index.html';
+		$file_cache_path = WP_ROCKET_CACHE_PATH . $url['host'] . strtolower( $url['path'] ) . 'index' . $https . '.html';
 
 		return rocket_direct_filesystem()->exists( $file_cache_path );
 	}

--- a/inc/classes/preload/class-full-process.php
+++ b/inc/classes/preload/class-full-process.php
@@ -85,6 +85,12 @@ class Full_Process extends \WP_Background_Process {
 	 * @return bool
 	 */
 	protected function is_already_cached( $item ) {
+		static $https;
+
+		if ( ! isset( $https ) ) {
+			$https = ( is_ssl() && get_rocket_option( 'cache_ssl' ) ) ? '-https' : '';
+		}
+
 		$url = get_rocket_parse_url( $item );
 
 		/** This filter is documented in inc/front/htaccess.php */
@@ -92,7 +98,7 @@ class Full_Process extends \WP_Background_Process {
 			$url['host'] = str_replace( '.', '_', $url['host'] );
 		}
 
-		$file_cache_path = WP_ROCKET_CACHE_PATH . $url['host'] . '/' . strtolower( $url['path'] ) . '/index.html';
+		$file_cache_path = WP_ROCKET_CACHE_PATH . $url['host'] . strtolower( $url['path'] ) . 'index.html';
 
 		return rocket_direct_filesystem()->exists( $file_cache_path );
 	}

--- a/inc/classes/preload/class-homepage.php
+++ b/inc/classes/preload/class-homepage.php
@@ -65,7 +65,7 @@ class Homepage extends Abstract_Preload {
 			);
 		}
 
-		set_transient( 'rocket_preload_running', 0 );
+		set_transient( 'rocket_preload_running', 1 );
 		$this->preload_process->save()->dispatch();
 	}
 }


### PR DESCRIPTION
We were not checking for the correct cache file in the preload when the website was using https. This would cause requests to be made even though the file is already in cache.