### PR TITLE
Don't preload excluded pages and improve homepage URLs discovery

### DIFF
--- a/inc/classes/preload/class-full-process.php
+++ b/inc/classes/preload/class-full-process.php
@@ -46,10 +46,6 @@ class Full_Process extends \WP_Background_Process {
 			return false;
 		}
 
-		if ( false !== get_transient( 'rocket_preload_cancelled' ) ) {
-			return false;
-		}
-
 		/**
 		 * Filters the arguments for the preload request
 		 *
@@ -96,6 +92,10 @@ class Full_Process extends \WP_Background_Process {
 		/** This filter is documented in inc/front/htaccess.php */
 		if ( apply_filters( 'rocket_url_no_dots', false ) ) {
 			$url['host'] = str_replace( '.', '_', $url['host'] );
+		}
+
+		if ( empty( $url['path'] ) ) {
+			$url['path'] = '/';
 		}
 
 		$file_cache_path = WP_ROCKET_CACHE_PATH . $url['host'] . strtolower( $url['path'] ) . 'index' . $https . '.html';

--- a/inc/classes/preload/class-homepage.php
+++ b/inc/classes/preload/class-homepage.php
@@ -18,6 +18,33 @@ class Homepage extends Abstract_Preload {
 	 * @return void
 	 */
 	public function preload( $urls ) {
+		foreach ( $urls as $home_url ) {
+			$urls      = $this->get_urls( $home_url );
+			$home_host = wp_parse_url( $home_url, PHP_URL_HOST );
+
+			foreach ( $urls as $url ) {
+				if ( ! $this->should_preload( $url, $home_url, $home_host ) ) {
+					continue;
+				}
+
+				$this->preload_process->push_to_queue( $url );
+			}
+		}
+
+		set_transient( 'rocket_preload_running', 1 );
+		$this->preload_process->save()->dispatch();
+	}
+
+	/**
+	 * Gets links in the content of the URL provided
+	 *
+	 * @since 3.2.2
+	 * @author Remy Perona
+	 *
+	 * @param string $url URL to get content and links from.
+	 * @return array
+	 */
+	private function get_urls( $url ) {
 		// This filter is documented in inc/classes/preload/class-partial-process.php.
 		$args = apply_filters(
 			'rocket_partial_preload_url_request_args',
@@ -27,57 +54,130 @@ class Homepage extends Abstract_Preload {
 			]
 		);
 
-		foreach ( $urls as $home_url ) {
-			$response = wp_remote_get( $home_url, $args );
+		$response = wp_remote_get( $url, $args );
 
-			if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-				return;
-			}
-
-			$content = wp_remote_retrieve_body( $response );
-
-			preg_match_all( '/<a\s+(?:[^>]+?[\s"\']|)href\s*=\s*(["\'])(?<href>[^"\']+)\1/imU', $content, $links );
-
-			$links['href'] = array_unique($links['href']);
-      
-			$home_host = wp_parse_url( $home_url, PHP_URL_HOST );
-
-			array_walk(
-				$links['href'],
-				function( $link ) use ( $home_url, $home_host ) {
-          
-					$link = html_entity_decode($link); // & symbols in URLs are changed to &#038; when using WP Menu editor
-          
-					// make the URL absolute
-					$link_data = wp_parse_url( $link );
-					if( empty($link_data['host']) ) {
-						$link = home_url($link);
-					}
-          
-					$link = \rocket_add_url_protocol( $link );
-
-					if ( $link === $home_url ) {
-						return;
-					}
-          
-					$link_data = wp_parse_url( $link );          
-
-					if ( $home_host !== $link_data['host'] ) {
-						return;
-					}
-
-					$cache_query_strings = implode( '|', \get_rocket_cache_query_string() );
-
-					if ( ! empty( $link_data['query'] ) && ! preg_match( '/(' . $cache_query_strings . ')/iU', $link_data['query'] ) ) {
-						return;
-					}
-
-					$this->preload_process->push_to_queue( $link );
-				}
-			);
+		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return;
 		}
 
-		set_transient( 'rocket_preload_running', 1 );
-		$this->preload_process->save()->dispatch();
+		$content = wp_remote_retrieve_body( $response );
+
+		preg_match_all( '/<a\s+(?:[^>]+?[\s"\']|)href\s*=\s*(["\'])(?<href>[^"\']+)\1/imU', $content, $urls );
+
+		return array_unique( $urls['href'] );
+	}
+
+	/**
+	 * Checks if the URL should be preloaded
+	 *
+	 * @since 3.2.2
+	 * @author Remy Perona
+	 *
+	 * @param string $url URL to check.
+	 * @param string $home_url Homepage URL.
+	 * @param string $home_host Homepage host.
+	 * @return bool
+	 */
+	private function should_preload( $url, $home_url, $home_host ) {
+		$url = html_entity_decode( $url ); // & symbols in URLs are changed to &#038; when using WP Menu editor
+
+		$url_data = wp_parse_url( $url );
+
+		if ( empty( $url_data ) ) {
+			return false;
+		}
+
+		if ( isset( $url_data['fragment'] ) ) {
+			return false;
+		}
+
+		if ( empty( $url_data['host'] ) ) {
+			$url = home_url( $url );
+		}
+
+		$url = \rocket_add_url_protocol( $url );
+
+		if ( $url === $home_url ) {
+			return false;
+		}
+
+		if ( $home_host !== $url_data['host'] ) {
+			return false;
+		}
+
+		if ( $this->is_file_url( $url ) ) {
+			return false;
+		}
+
+		if ( preg_match( '#^(' . \get_rocket_cache_reject_uri() . ')$#', $url_data['path'] ) ) {
+			return false;
+		}
+
+		$cache_query_strings = implode( '|', \get_rocket_cache_query_string() );
+
+		if ( ! empty( $url_data['query'] ) && ! preg_match( '/(' . $cache_query_strings . ')/iU', $url_data['query'] ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Checks if URL is an URL to a file
+	 *
+	 * @since 3.2.2
+	 * @author Remy Perona
+	 *
+	 * @param string $url URL to check.
+	 * @return bool
+	 */
+	private function is_file_url( $url ) {
+		/**
+		 * Filters the list of files types to check when getting URLs on the homepage
+		 *
+		 * @since 3.2.2
+		 * @author Remy Perona
+		 *
+		 * @param array $file_types Array of file extensions.
+		 */
+		$file_types = apply_filters(
+			'rocket_preload_file_types',
+			[
+				'jpg',
+				'jpeg',
+				'jpe',
+				'png',
+				'gif',
+				'webp',
+				'bmp',
+				'tiff',
+				'mp3',
+				'ogg',
+				'mp4',
+				'm4v',
+				'avi',
+				'mov',
+				'flv',
+				'swf',
+				'webm',
+				'pdf',
+				'doc',
+				'docx',
+				'txt',
+				'zip',
+				'tar',
+				'bz2',
+				'tgz',
+				'rar',
+			]
+		);
+
+		$file_types = implode( '|', $file_types );
+
+		if ( preg_match( '#\.' . $file_types . '$#iU', $url ) ) {
+			return true;
+		}
+
+		return false;
 	}
 }

--- a/inc/classes/preload/class-sitemap.php
+++ b/inc/classes/preload/class-sitemap.php
@@ -57,6 +57,12 @@ class Sitemap extends Abstract_Preload {
 		foreach ( $urls_group as $urls ) {
 			$urls = array_flip( array_flip( $urls ) );
 			foreach ( $urls as $url ) {
+				$path = wp_parse_url( $url, PHP_URL_PATH );
+
+				if ( isset( $path ) && preg_match( '#^(' . \get_rocket_cache_reject_uri() . ')$#', $path ) ) {
+					continue;
+				}
+
 				$this->preload_process->push_to_queue( $url );
 			}
 		}

--- a/inc/classes/subscriber/preload/class-partial-preload-subscriber.php
+++ b/inc/classes/subscriber/preload/class-partial-preload-subscriber.php
@@ -149,6 +149,12 @@ class Partial_Preload_Subscriber implements Subscriber_Interface {
 		$this->urls = array_unique( $this->urls );
 
 		foreach ( $this->urls as $url ) {
+			$path = wp_parse_url( $url, PHP_URL_PATH );
+
+			if ( isset( $path ) && preg_match( '#^(' . \get_rocket_cache_reject_uri() . ')$#', $path ) ) {
+				continue;
+			}
+
 			$this->partial_preload->push_to_queue( $url );
 		}
 


### PR DESCRIPTION
- Remove excluded from cache pages from all preload
- Improve homepage URLs discovery by removing URLs to files, fragment URLs, URLs to excluded from cache pages
- Fix partial preload already cached method