### PR TITLE
Exclude wpRestNonce (found in newspaper theme)

### DIFF
--- a/inc/classes/optimization/JS/class-combine.php
+++ b/inc/classes/optimization/JS/class-combine.php
@@ -401,6 +401,7 @@ class Combine extends Abstract_JS_Optimization {
 			'ANS_customer_id',
 			'tdBlock',
 			'tdLocalCache',
+			'wpRestNonce',
 			'"url":',
 			'lazyLoadOptions',
 			'adthrive',


### PR DESCRIPTION
Excludes the inline JS for wpRestNonce as this is dynamic and causes the cache to spin out of control on sites that are using the NewsPaper theme.

**Thank you for wanting to contribute to WP Rocket! Before submitting a pull request, please check that you’ve completed the following steps:**
- Please make sure that there aren’t existing pull requests attempting to address the issue mentioned.
- Check for related issues on the issue tracker.
- Non-trivial changes should be discussed on an issue first.
- Let us know you’re working on the issue.
- Develop in a topic branch, not master.

**Things to add in the pull request to help us:**
- Provide useful pull request description.
- Follow project commit guidelines.
- Write a good description of your PR.
- Link to the Github issue in the description.
