### PR TITLE
Exclude Report Broken Link JS

### DIFF
--- a/inc/classes/optimization/JS/class-combine.php
+++ b/inc/classes/optimization/JS/class-combine.php
@@ -439,6 +439,7 @@ class Combine extends Abstract_JS_Optimization {
 			'peepsotimedata',
 			'wphc_data',
 			'hc_rand_id',
+			'RBL_ADD',
 			'AfsAnalyticsObject',
 		];
 


### PR DESCRIPTION
The following plugin: https://wordpress.org/plugins/report-broken-links/

This plugin includes inline JS that includes that page's URL (for obvious reasons) this simply excludes this inline JS to avoid, the cache from generating a unique JS file per page / post / archive / etc