### PR TITLE
Exclude "widget.reviewability.com" from JS combination

### DIFF
--- a/inc/classes/optimization/JS/class-combine.php
+++ b/inc/classes/optimization/JS/class-combine.php
@@ -519,6 +519,7 @@ class Combine extends Abstract_JS_Optimization {
 			'dsms0mj1bbhn4.cloudfront.net',
 			'nutrifox.com',
 			'code.tidio.co',
+			'widget.reviewability.com',
 		];
 
 		$excluded_external = array_merge( $defaults, $this->options->get( 'exclude_js', [] ) );


### PR DESCRIPTION
When the Testimonials Widget plugin is used, the `widget.reviewability.com` URIs are combined.
This results in the reviews not being displayed and the same goes for a review pop-up.

Excluding the following from combination, resolves the issue:
`widget.reviewability.com`

**Related ticket:**
https://secure.helpscout.net/conversation/718536510/88298?folderId=273766