### PR TITLE
Domain cache deletion background process

### DIFF
--- a/inc/admin/options.php
+++ b/inc/admin/options.php
@@ -52,6 +52,7 @@ function rocket_after_save_options( $oldvalue, $value ) {
 		'analytics_enabled'           => true,
 		'sucury_waf_cache_sync'       => true,
 		'sucury_waf_api_key'          => true,
+		'invalidate_domain_cache'     => true,
 	];
 
 	// Create 2 arrays to compare.

--- a/inc/admin/upgrader.php
+++ b/inc/admin/upgrader.php
@@ -153,6 +153,7 @@ function rocket_first_install() {
 				'cache_ssl'                   => rocket_is_ssl_website() ? 1 : 0,
 				'emoji'                       => 1,
 				'embeds'                      => 1,
+				'invalidate_domain_cache'     => 1,
 				'cache_reject_uri'            => [],
 				'cache_reject_cookies'        => [],
 				'cache_reject_ua'             => [],
@@ -381,6 +382,13 @@ function rocket_new_upgrade( $wp_rocket_version, $actual_version ) {
 
 	if ( version_compare( $actual_version, '3.2.2', '<' ) ) {
 		flush_rocket_htaccess();
+	}
+
+	if( version_compare( $actual_version, '3.2.3', '< ') ) {
+		$options = get_option( WP_ROCKET_SLUG );
+		$options['invalidate_domain_cache'] = 0;
+
+		update_option( WP_ROCKET_SLUG, $options );
 	}
 }
 add_action( 'wp_rocket_upgrade', 'rocket_new_upgrade', 10, 2 );

--- a/inc/admin/upgrader.php
+++ b/inc/admin/upgrader.php
@@ -153,7 +153,6 @@ function rocket_first_install() {
 				'cache_ssl'                   => rocket_is_ssl_website() ? 1 : 0,
 				'emoji'                       => 1,
 				'embeds'                      => 1,
-				'invalidate_domain_cache'     => 1,
 				'cache_reject_uri'            => [],
 				'cache_reject_cookies'        => [],
 				'cache_reject_ua'             => [],
@@ -218,6 +217,7 @@ function rocket_first_install() {
 				'facebook_pixel_cache'        => 0,
 				'sucury_waf_cache_sync'       => 0,
 				'sucury_waf_api_key'          => '',
+				'invalidate_domain_cache'     => 1,
 			)
 		)
 	);

--- a/inc/admin/upgrader.php
+++ b/inc/admin/upgrader.php
@@ -217,7 +217,7 @@ function rocket_first_install() {
 				'facebook_pixel_cache'        => 0,
 				'sucury_waf_cache_sync'       => 0,
 				'sucury_waf_api_key'          => '',
-				'invalidate_domain_cache'     => 1,
+				'invalidate_domain_cache'     => 0,
 			)
 		)
 	);

--- a/inc/classes/admin/settings/class-page.php
+++ b/inc/classes/admin/settings/class-page.php
@@ -518,6 +518,12 @@ class Page implements Subscriber_Interface {
 					],
 					'page'        => 'cache',
 				],
+				'domain_cache_invalidation_section'   => [
+					'title'       => __( 'Domain Cache Invalidation', 'rocket' ),
+					'type'        => 'fields_container',
+					'description' => __( 'Delegate deletion of the domain cache directory to a background process by invalidating the old cache.<br>Can be useful when running a huge website as the invalidation process is almost instant, and direct deletion can take a long time.', 'rocket' ),
+					'page'        => 'cache',
+				],
 			]
 		);
 
@@ -586,6 +592,14 @@ class Page implements Subscriber_Interface {
 						'HOUR_IN_SECONDS'   => __( 'Hours', 'rocket' ),
 						'DAY_IN_SECONDS'    => __( 'Days', 'rocket' ),
 					],
+				],
+				'invalidate_domain_cache' => [
+					'type'              => 'checkbox',
+					'label'             => __( 'Enable domain cache invalidation', 'rocket' ),
+					'section'           => 'domain_cache_invalidation_section',
+					'page'              => 'cache',
+					'default'           => 0,
+					'sanitize_callback' => 'sanitize_checkbox',
 				],
 			]
 		);

--- a/inc/classes/admin/settings/class-settings.php
+++ b/inc/classes/admin/settings/class-settings.php
@@ -194,6 +194,9 @@ class Settings {
 		$input['cache_mobile']            = ! empty( $input['cache_mobile'] ) ? 1 : 0;
 		$input['do_caching_mobile_files'] = ! empty( $input['do_caching_mobile_files'] ) ? 1 : 0;
 
+		// Option: Domain Cache Invalidation
+		$input['invalidate_domain_cache'] = ! empty( $input['invalidate_domain_cache'] ) ? 1 : 0;
+
 		$input['minify_google_fonts'] = ! empty( $input['minify_google_fonts'] ) ? 1 : 0;
 		$input['minify_html']         = ! empty( $input['minify_html'] ) ? 1 : 0;
 

--- a/inc/classes/class-domain-cache-deletion-process.php
+++ b/inc/classes/class-domain-cache-deletion-process.php
@@ -1,0 +1,56 @@
+<?php
+
+defined( 'ABSPATH' ) || die( 'Cheatin&#8217; uh?' );
+
+/**
+ * Background process for deleting invalidated domain cache directories
+ *
+ * @since 3.2.3
+ * @author dotSILENT
+ *
+ * @see WP_Background_Process
+ */
+class Domain_Cache_Deletion_Process extends \WP_Background_Process {
+	/**
+	 * Prefix
+	 *
+	 * @since 3.2.3
+	 * @author dotSILENT
+	 *
+	 * @var string
+	 */
+	protected $prefix = 'rocket';
+
+	/**
+	 * Specific action identifier for domain cache deletion
+	 *
+	 * @since 3.2.3
+	 * @author dotSILENT
+	 *
+	 * @var string
+	 */
+	protected $action = 'domain_cache_delete';
+
+	/**
+	 * Recursively delete the directory provided in $item
+	 *
+	 * @since 3.2.3
+	 * @author dotSILENT
+	 *
+	 * @param mixed $item Queue item to iterate over.
+	 * @return null
+	 */
+	protected function task( $item ) {
+		$dir_path = untrailingslashit( WP_ROCKET_CACHE_PATH . $item );
+
+		if( strlen( $item ) > 0 && rocket_direct_filesystem()->exists( $dir_path ) ) {
+			rocket_rrmdir( $dir_path );
+			// Double check if the directory still exists and if it does, push the item back to the queue
+			if( rocket_direct_filesystem()->exists ( $dir_path ) ) {
+				return $item;
+			}
+		}
+		return false;
+	}
+}
+

--- a/inc/classes/class-plugin.php
+++ b/inc/classes/class-plugin.php
@@ -120,6 +120,7 @@ class Plugin {
 		$subscribers[] = new Subscriber\Preload\Preload_Subscriber( new Preload\Homepage( $preload_process ), $this->options );
 		$subscribers[] = new Subscriber\Preload\Sitemap_Preload_Subscriber( new Preload\Sitemap( $preload_process ), $this->options );
 		$subscribers[] = new Subscriber\Preload\Partial_Preload_Subscriber( new Preload\Partial_Process(), $this->options );
+		$subscribers[] = new Subscriber\Domain_Cache_Deletion_Subscriber( new \Domain_Cache_Deletion_Process() );
 
 		foreach ( $subscribers as $subscriber ) {
 			$event_manager->add_subscriber( $subscriber );

--- a/inc/classes/subscriber/class-domain-cache-deletion-subscriber.php
+++ b/inc/classes/subscriber/class-domain-cache-deletion-subscriber.php
@@ -1,0 +1,87 @@
+<?php
+namespace WP_Rocket\Subscriber;
+
+use WP_Rocket\Event_Management\Subscriber_Interface;
+
+/**
+ * Subscriber for domain cache deletion background process
+ *
+ * @since 3.2.3
+ * @author dotSILENT
+ */
+class Domain_Cache_Deletion_Subscriber implements Subscriber_Interface {
+	/**
+	 * Domain cache deletion background process instance
+	 *
+	 * @since 3.2.3
+	 * @author dotSILENT
+	 *
+	 * @var Domain_Cache_Deletion_Process
+	 */
+	private $process;
+
+	/**
+	 * Stores the names of invalidated directories
+	 *
+	 * @since 3.2.3
+	 * @author dotSILENT
+	 *
+	 * @var array
+	 */
+	private $invalidated_dirs = [];
+
+	/**
+	 * Constructor
+	 *
+	 * @since 3.2.3
+	 * @author dotSILENT
+	 *
+	 * @param Domain_Cache_Deletion_Process $process Instance of the domain cache deletion process
+	 */
+	public function __construct( \Domain_Cache_Deletion_Process $process ) {
+		$this->process = $process;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function get_subscribed_events() {
+		return [
+			'after_rocket_invalidate_dir' => [ 'delete_after_invalidate_dir', 10, 2 ],
+			'shutdown'                    => [ 'maybe_dispatch', 0 ],
+		];
+	}
+
+	/**
+	 * Queues the invalidated directory for deletion
+	 *
+	 * @since 3.2.3
+	 *
+	 * @param string $oldName Old name (full path) of the directory
+	 * @param string $newName New, invalidated name (full path) of the directory
+	 * @return void
+	 */
+	public function delete_after_invalidate_dir( $oldName, $newName ) {
+		$this->invalidated_dirs[] = basename( $newName ); // we don't need to store the entire path, it's also safer this way
+	}
+
+	/**
+	 * Starts the deletion process if needed
+	 *
+	 * @since 3.2.3
+	 * @author dotSILENT
+	 *
+	 * @return void
+	 */
+	public function maybe_dispatch() {
+		if ( empty( $this->invalidated_dirs ) ) {
+			return;
+		}
+
+		foreach ( $this->invalidated_dirs as $dir ) {
+			$this->process->push_to_queue( $dir );
+		}
+
+		$this->process->save()->dispatch();
+	}
+}

--- a/inc/classes/subscriber/class-domain-cache-deletion-subscriber.php
+++ b/inc/classes/subscriber/class-domain-cache-deletion-subscriber.php
@@ -62,7 +62,8 @@ class Domain_Cache_Deletion_Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function delete_after_invalidate_dir( $oldName, $newName ) {
-		$this->invalidated_dirs[] = basename( $newName ); // we don't need to store the entire path, it's also safer this way
+		// Store only the path relative to WP_ROCKET_CACHE_PATH, it's safer this way because the process can only delete wp-rocket relative paths
+		$this->invalidated_dirs[] = str_replace( WP_ROCKET_CACHE_PATH, '', $newName );
 	}
 
 	/**

--- a/inc/classes/subscriber/preload/class-preload-subscriber.php
+++ b/inc/classes/subscriber/preload/class-preload-subscriber.php
@@ -161,6 +161,7 @@ class Preload_Subscriber implements Subscriber_Interface {
 			'analytics_enabled'           => true,
 			'sucury_waf_cache_sync'       => true,
 			'sucury_waf_api_key'          => true,
+			'domain_cache_invalidation'   => true,
 		];
 
 		// Create 2 arrays to compare.

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -746,7 +746,14 @@ function rocket_clean_domain( $lang = '' ) {
 		do_action( 'before_rocket_clean_domain', $root, $lang, $url );
 
 		$invalidate = get_rocket_option( 'invalidate_domain_cache' );
-
+		/** 
+		 * Delete the trailing slash if invalidation is enabled & clearing all languages
+		 * This way, we clear the entire domain at once and don't need to even look into the directories
+		*/
+		if( $invalidate && ! $lang ) {
+			$root = untrailingslashit( $root );
+		}
+		
 		// Delete cache domain files.
 		$dirs = glob( $root . '*', GLOB_NOSORT );
 		if ( $dirs ) {

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -953,7 +953,20 @@ function rocket_clean_cache_dir() {
 function rocket_invalidate_dir( $dir ) {
 	$dir = untrailingslashit( $dir );
 
-	do_action( 'before_rocket_invalidate_dir', $dir );
+	$parentDir = dirname( $dir );
+	// Format of new directory name: invalid_UNIQIDHASH_dirname
+	$newName = $parentDir . '/' . 'invalid_' . uniqid() . '_' . basename( $dir );
+
+	/**
+	 * Fires before the directory is invalidated
+	 * 
+	 * @since 3.2.3
+	 * @author dotSILENT
+	 * 
+	 * @param string $dir File/Directory to invalidate
+	 * @param string $newName The new name (full path) after invalidation
+	 */
+	do_action( 'before_rocket_invalidate_dir', $dir, $newName );
 
 	if( ! rocket_direct_filesystem()->is_dir( $dir ) ) {
 		// just delete it since it's a single file
@@ -961,18 +974,21 @@ function rocket_invalidate_dir( $dir ) {
 		return true;
 	}
 
-	$parentDir = dirname( $dir );
-	// Format of new directory name: invalid_UNIQIDHASH_dirname
-	$newName = 'invalid_' . uniqid() . '_' . basename( $dir );
-
-	if( ! rename($dir, $parentDir . '/' . $newName) ) {
+	if( ! rename($dir, $newName) ) {
 		// Failed to rename, fall back to default behaviour
 		return false;
 	}
 
-	// TODO queue the deletion of this invalidated directory
-
-	do_action( 'after_rocket_invalidate_dir', $dir );
+	/**
+	 * Fires after the directory was invalidated
+	 * 
+	 * @since 3.2.3
+	 * @author dotSILENT
+	 * 
+	 * @param string $dir File/Directory that was invalidated
+	 * @param string $newName The new invalidated name (full path) of the directory
+	 */
+	do_action( 'after_rocket_invalidate_dir', $dir, $newName );
 	return true;
 }
 

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -745,11 +745,20 @@ function rocket_clean_domain( $lang = '' ) {
 		*/
 		do_action( 'before_rocket_clean_domain', $root, $lang, $url );
 
+		$invalidate = 1; //get_rocket_option( 'invalidate_domain_cache' );
+
 		// Delete cache domain files.
 		$dirs = glob( $root . '*', GLOB_NOSORT );
 		if ( $dirs ) {
 			foreach ( $dirs as $dir ) {
-				rocket_rrmdir( $dir, get_rocket_i18n_to_preserve( $lang ) );
+				if( $invalidate) {
+					if( ! rocket_invalidate_dir( $dir ) ) {
+						// Failed to invalidate, fall back to rocket_rrmdir
+						rocket_rrmdir( $dir, get_rocket_i18n_to_preserve( $lang ) );
+					}
+				} else {
+					rocket_rrmdir( $dir, get_rocket_i18n_to_preserve( $lang ) );
+				}
 			}
 		}
 
@@ -931,6 +940,40 @@ function rocket_clean_cache_dir() {
 	 * @since 2.6.8
 	*/
 	do_action( 'after_rocket_clean_cache_dir' );
+}
+
+/**
+ * Invalidate directory by renaming it and queueing the deletion with WP Background Process
+ * 
+ * @author dotSILENT
+ *
+ * @param string $dir File/Directory to invalidate.
+ * @return bool
+ */
+function rocket_invalidate_dir( $dir ) {
+	$dir = untrailingslashit( $dir );
+
+	do_action( 'before_rocket_invalidate_dir', $dir );
+
+	if( ! rocket_direct_filesystem()->is_dir( $dir ) ) {
+		// just delete it since it's a single file
+		rocket_direct_filesystem()->delete( $dir );
+		return true;
+	}
+
+	$parentDir = dirname( $dir );
+	// Format of new directory name: invalid_UNIQIDHASH_dirname
+	$newName = 'invalid_' . uniqid() . '_' . basename( $dir );
+
+	if( ! rename($dir, $parentDir . '/' . $newName) ) {
+		// Failed to rename, fall back to default behaviour
+		return false;
+	}
+
+	// TODO queue the deletion of this invalidated directory
+
+	do_action( 'after_rocket_invalidate_dir', $dir );
+	return true;
 }
 
 /**

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -745,7 +745,7 @@ function rocket_clean_domain( $lang = '' ) {
 		*/
 		do_action( 'before_rocket_clean_domain', $root, $lang, $url );
 
-		$invalidate = 1; //get_rocket_option( 'invalidate_domain_cache' );
+		$invalidate = get_rocket_option( 'invalidate_domain_cache' );
 
 		// Delete cache domain files.
 		$dirs = glob( $root . '*', GLOB_NOSORT );


### PR DESCRIPTION
As for now, Clear Cache (`rocket_clean_domain()` for domain cache) uses `rocket_rrmdir()` to recursively delete all the domain directories. On huge websites with thousands of cached posts, this operation can take a very long time and exceed the maximum PHP execution time.
I've added an option in the Settings/Cache page called `Domain Cache Invalidation` which is disabled by default, when enabled the domain cache directories aren't directly deleted but their name is 'invalidated' to a unique one and picked up by the Domain_Cache_Deletion_Subscriber which queues them for deletion in the background (Domain_Cache_Deletion_Process)
In case the deletion exceeds the execution time, WP Background Processing will re-run the process after 5 minutes, so everything will be eventually deleted.
If renaming wasn't possible due to any file system error (shouldn't happen unless playing with the cache files directly from the system), it falls back to the default `rocket_rrmdir()` behaviour.

I have also noticed that sometimes (at least on Windows), `rocket_rrmdir()` deletes all the files but cannot delete the directories unless you retry it a few times. The background process handles this and has a limit of max 20 retries to prevent any looping, it never took me more than 3 repeats though.

This however doesn't preserve the directories from `get_rocket_i18n_to_preserve()` since it invalidates the entire parent directories.