### PR TITLE
Minifies/Combines/Cache busts assets with a relative URL

### DIFF
--- a/inc/functions/formatting.php
+++ b/inc/functions/formatting.php
@@ -332,7 +332,7 @@ function rocket_url_to_path( $url, $hosts = '' ) {
 	if ( isset( $hosts[ $url_host ] ) && 'home' !== $hosts[ $url_host ] ) {
 		$url = str_replace( $url_host, wp_parse_url( site_url(), PHP_URL_HOST ), $url );
 	}
-	
+
 	$root_url = preg_replace( '/^https?:/', '', $root_url );
 	$url      = preg_replace( '/^https?:/', '', $url );
 	$file     = str_replace( $root_url, $root_dir, $url );

--- a/inc/functions/formatting.php
+++ b/inc/functions/formatting.php
@@ -325,7 +325,7 @@ function rocket_url_to_path( $url, $hosts = '' ) {
 	// relative path.
 	if ( null === $url_host ) {
 		$subdir_levels = substr_count( preg_replace( '/https?:\/\//', '', site_url() ), '/' );
-		$url           = site_url() . str_repeat( '/..', $subdir_levels ) . $url;
+		$url           = trailingslashit( site_url() . str_repeat( '/..', $subdir_levels ) ) . ltrim( $url, '/' );
 	}
 
 	// CDN.


### PR DESCRIPTION
Assets with a relative URL, without a starting slash, were not optimized because the generated URL in formatting.php was incorrect