### PR TITLE
3.2.3.1

### DIFF
--- a/inc/3rd-party/hosting/siteground.php
+++ b/inc/3rd-party/hosting/siteground.php
@@ -2,41 +2,89 @@
 defined( 'ABSPATH' ) || die( 'Cheatin&#8217; uh?' );
 
 if ( rocket_is_plugin_active( 'sg-cachepress/sg-cachepress.php' ) ) {
-	global $sg_cachepress_supercacher, $sg_cachepress_environment;
+	/**
+	 * Returns the current version of the SG Optimizer plugin
+	 *
+	 * @since 3.2.3.1
+	 * @author Remy Perona
+	 *
+	 * @return string
+	 */
+	function rocket_get_sg_optimizer_version() {
+		static $version;
 
-	if ( isset( $sg_cachepress_environment ) && $sg_cachepress_environment instanceof SG_CachePress_Environment && $sg_cachepress_environment->cache_is_enabled() ) {
-		add_action( 'wp_ajax_sg-cachepress-purge', 'rocket_clean_domain', 0 );
-		add_action( 'admin_post_sg-cachepress-purge', 'rocket_clean_domain', 0 );
-		add_action( 'after_rocket_clean_domain', 'rocket_clean_supercacher' );
-		add_filter( 'rocket_display_varnish_options_tab', '__return_false' );
-		// Prevent mandatory cookies on hosting with server cache.
-		add_filter( 'rocket_cache_mandatory_cookies', '__return_empty_array', PHP_INT_MAX );
+		if ( isset( $version ) ) {
+			return $version;
+		}
+
+		$sg_optimizer = get_file_data( WP_PLUGIN_DIR . '/sg-cachepress/sg-cachepress.php', array( 'Version' => 'Version' ) );
+		$version      = $sg_optimizer['Version'];
+
+		return $version;
 	}
 
 	/**
-	 * Call the cache server to purge the cache with SuperCacher (SiteGround) Pretty good hosting!
+	 * Checks if SG Optimizer Supercache is active
+	 *
+	 * @since 3.2.3.1
+	 * @author Remy Perona
+	 *
+	 * @return bool
+	 */
+	function rocket_is_supercacher_active() {
+		if ( version_compare( rocket_get_sg_optimizer_version(), '5.0' ) < 0 ) {
+			global $sg_cachepress_environment;
+
+			return isset( $sg_cachepress_environment ) && $sg_cachepress_environment instanceof SG_CachePress_Environment && $sg_cachepress_environment->cache_is_enabled();
+		} else {
+			return (bool) get_option( 'siteground_optimizer_enable_cache', 0 );
+		}
+	}
+
+	/**
+	 * Call the cache server to purge the cache with SuperCacher (SiteGround)
 	 *
 	 * @since 2.3
 	 *
 	 * @return void
 	 */
 	function rocket_clean_supercacher() {
-		if ( isset( $sg_cachepress_supercacher ) && $sg_cachepress_supercacher instanceof SG_CachePress_Supercacher ) {
-			$sg_cachepress_supercacher->purge_cache();
+		if ( ! rocket_is_supercacher_active() ) {
+			return;
 		}
+
+		if ( version_compare( rocket_get_sg_optimizer_version(), '5.0' ) < 0 ) {
+			if ( isset( $sg_cachepress_supercacher ) && $sg_cachepress_supercacher instanceof SG_CachePress_Supercacher ) {
+				$sg_cachepress_supercacher->purge_cache();
+			}
+		} else {
+			SiteGround_Optimizer\Supercacher\Supercacher::purge_cache();
+		}	
 	}
-	
-	/**
-	 * Force WP Rocket caching on SG Optimizer versions before 4.0.5
-	 * 
-	 * @author Arun Basil Lal
-	 *
-	 * @link https://github.com/wp-media/wp-rocket/issues/925
-	 * @since 3.0.4
-	 */
-	$sg_optimizer_plugin_data = get_file_data( WP_PLUGIN_DIR . '/sg-cachepress/sg-cachepress.php', array( 'Version' => 'Version' ) );
-	
-	if ( version_compare( $sg_optimizer_plugin_data['Version'], '4.0.5' ) < 0 ) {
-		add_filter( 'do_rocket_generate_caching_files', '__return_true', 11 );
+
+	if ( rocket_is_supercacher_active() ) {
+		add_action( 'admin_post_sg-cachepress-purge', 'rocket_clean_domain', 0 );
+		add_action( 'after_rocket_clean_domain', 'rocket_clean_supercacher' );
+		add_filter( 'rocket_display_varnish_options_tab', '__return_false' );
+		// Prevent mandatory cookies on hosting with server cache.
+		add_filter( 'rocket_cache_mandatory_cookies', '__return_empty_array', PHP_INT_MAX );
+
+		/**
+		 * Force WP Rocket caching on SG Optimizer versions before 4.0.5
+		 * 
+		 * @author Arun Basil Lal
+		 *
+		 * @link https://github.com/wp-media/wp-rocket/issues/925
+		 * @since 3.0.4
+		 */
+		if ( version_compare( rocket_get_sg_optimizer_version(), '4.0.5' ) < 0 ) {
+			add_filter( 'do_rocket_generate_caching_files', '__return_true', 11 );
+		}
+
+		if ( version_compare( rocket_get_sg_optimizer_version(), '5.0' ) < 0 ) {
+			add_action( 'wp_ajax_sg-cachepress-purge', 'rocket_clean_domain', 0 );
+		} else {
+			add_action( 'wp_ajax_admin_bar_purge_cache', 'rocket_clean_domain', 0 );
+		}
 	}
 }

--- a/inc/admin/admin.php
+++ b/inc/admin/admin.php
@@ -507,7 +507,8 @@ function rocket_handle_settings_import() {
 		rocket_settings_import_redirect( __( 'Settings import failed: incorrect filename.', 'rocket' ), 'error' );
 	}
 
-	add_filter( 'upload_mimes', 'rocket_allow_json_mime_type' );
+	add_filter( 'mime_types', 'rocket_allow_json_mime_type' );
+	add_filter( 'wp_check_filetype_and_ext', 'rocket_check_json_filetype', 10, 4 );
 
 	$file_data = wp_check_filetype_and_ext( $_FILES['import']['tmp_name'], $_FILES['import']['name'] );
 
@@ -518,9 +519,15 @@ function rocket_handle_settings_import() {
 	$_post_action    = $_POST['action'];
 	$_POST['action'] = 'wp_handle_sideload';
 	$file            = wp_handle_sideload( $_FILES['import'] );
+
+	if ( isset( $file['error'] ) ) {
+		rocket_settings_import_redirect( __( 'Settings import failed: ', 'rocket' ) . $file['error'], 'error' );
+	}
+
 	$_POST['action'] = $_post_action;
 	$settings        = rocket_direct_filesystem()->get_contents( $file['file'] );
-	remove_filter( 'upload_mimes', 'rocket_allow_json_mime_type' );
+	remove_filter( 'mime_types', 'rocket_allow_json_mime_type' );
+	remove_filter( 'wp_check_filetype_and_ext', 'rocket_check_json_filetype', 10 );
 
 	if ( 'text/plain' === $file_data['type'] ) {
 		$gz       = 'gz' . strrev( 'etalfni' );
@@ -529,6 +536,10 @@ function rocket_handle_settings_import() {
 		$settings = maybe_unserialize( $settings );
 	} elseif ( 'application/json' === $file_data['type'] ) {
 		$settings = json_decode( $settings, true );
+
+		if ( null === $settings ) {
+			rocket_settings_import_redirect( __( 'Settings import failed: unexpected file content.', 'rocket' ), 'error' );
+		}
 	}
 
 	rocket_put_content( $file['file'], '' );

--- a/wp-rocket.php
+++ b/wp-rocket.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Rocket
  * Plugin URI: https://wp-rocket.me
  * Description: The best WordPress performance plugin.
- * Version: 3.2.3
+ * Version: 3.2.3.1
  * Code Name: Dagobah
  * Author: WP Media
  * Author URI: http://wp-media.me
@@ -18,7 +18,7 @@
 defined( 'ABSPATH' ) || die( 'Cheatin&#8217; uh?' );
 
 // Rocket defines.
-define( 'WP_ROCKET_VERSION',               '3.2.3' );
+define( 'WP_ROCKET_VERSION',               '3.2.3.1' );
 define( 'WP_ROCKET_WP_VERSION',            '4.7' );
 define( 'WP_ROCKET_PHP_VERSION',           '5.4' );
 define( 'WP_ROCKET_PRIVATE_KEY',           false );


### PR DESCRIPTION
- Compatibility fix: Following SG Optimizer 5.0 update, adapt our compatibility code to also work with the new version
- Compatibility fix: Following WordPress 5.0.1 security update, re-enable WP Rocket import settings feature