### PR TITLE
Closes #1445 Include the Rank Math SEO file

### DIFF
--- a/inc/3rd-party/3rd-party.php
+++ b/inc/3rd-party/3rd-party.php
@@ -48,6 +48,7 @@ require WP_ROCKET_3RD_PARTY_PATH . 'plugins/disqus.php';
 require WP_ROCKET_3RD_PARTY_PATH . 'plugins/custom-login.php';
 require WP_ROCKET_3RD_PARTY_PATH . 'plugins/mobile/amp.php';
 require WP_ROCKET_3RD_PARTY_PATH . 'plugins/mobile/wp-appkit.php';
+require WP_ROCKET_3RD_PARTY_PATH . 'plugins/seo/rank-math-seo.php';
 require WP_ROCKET_3RD_PARTY_PATH . 'plugins/seo/yoast-seo.php';
 require WP_ROCKET_3RD_PARTY_PATH . 'plugins/seo/the-seo-framework.php';
 require WP_ROCKET_3RD_PARTY_PATH . 'plugins/seo/all-in-one-seo-pack.php';


### PR DESCRIPTION
Added a line of code, making sure that the entry of Rank Math shows up properly in WP Rocket's preload settings.

Closes #1445 