### PR TITLE
Fixes #928: How to prevent htaccess corruption?

### DIFF
--- a/inc/classes/logger/class-logger.php
+++ b/inc/classes/logger/class-logger.php
@@ -486,7 +486,7 @@ class Logger {
 		}
 
 		// Save the file.
-		$chmod = defined( 'FS_CHMOD_FILE' ) ? FS_CHMOD_FILE : 0644;
+		$chmod = rocket_get_filesystem_perms( 'file' );
 		$filesystem->put_contents( $file_path, $content, $chmod );
 	}
 

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -357,7 +357,7 @@ function set_rocket_wp_cache_define( $turn_it_on ) {
 	@fclose( $handle );
 
 	// Update the writing permissions of wp-config.php file.
-	$chmod = defined( 'FS_CHMOD_FILE' ) ? FS_CHMOD_FILE : 0644;
+	$chmod = rocket_get_filesystem_perms( 'file' );
 	rocket_direct_filesystem()->chmod( $config_file_path, $chmod );
 }
 
@@ -1021,7 +1021,7 @@ function rocket_direct_filesystem() {
  * @return bool
  */
 function rocket_mkdir( $dir ) {
-	$chmod = defined( 'FS_CHMOD_DIR' ) ? FS_CHMOD_DIR : ( fileperms( WP_CONTENT_DIR ) & 0777 | 0755 );
+	$chmod = rocket_get_filesystem_perms( 'dir' );
 	return rocket_direct_filesystem()->mkdir( $dir, $chmod );
 }
 
@@ -1074,8 +1074,75 @@ function rocket_mkdir_p( $target ) {
  * @return bool
  */
 function rocket_put_content( $file, $content ) {
-	$chmod = defined( 'FS_CHMOD_FILE' ) ? FS_CHMOD_FILE : 0644;
+	$chmod = rocket_get_filesystem_perms( 'file' );
 	return rocket_direct_filesystem()->put_contents( $file, $content, $chmod );
+}
+
+/**
+ * Get the permissions to apply to files and folders.
+ *
+ * Reminder:
+ * `$perm = fileperms( $file );`
+ *
+ *  WHAT                                         | TYPE   | FILE   | FOLDER |
+ * ----------------------------------------------+--------+--------+--------|
+ * `$perm`                                       | int    | 33188  | 16877  |
+ * `substr( decoct( $perm ), -4 )`               | string | '0644' | '0755' |
+ * `substr( sprintf( '%o', $perm ), -4 )`        | string | '0644' | '0755' |
+ * `$perm & 0777`                                | int    | 420    | 493    |
+ * `decoct( $perm & 0777 )`                      | string | '644'  | '755'  |
+ * `substr( sprintf( '%o', $perm & 0777 ), -4 )` | string | '644'  | '755'  |
+ *
+ * @since  3.2.4
+ * @author Grégory Viguier
+ *
+ * @param  string $type The type: 'dir' or 'file'.
+ * @return int          Octal integer.
+ */
+function rocket_get_filesystem_perms( $type ) {
+	static $perms = [];
+
+	// Allow variants.
+	switch ( $type ) {
+		case 'dir':
+		case 'dirs':
+		case 'folder':
+		case 'folders':
+			$type = 'dir';
+			break;
+
+		case 'file':
+		case 'files':
+			$type = 'file';
+			break;
+
+		default:
+			return 0755;
+	}
+
+	if ( isset( $perms[ $type ] ) ) {
+		return $perms[ $type ];
+	}
+
+	// If the constants are not defined, use fileperms() like WordPress does.
+	switch ( $type ) {
+		case 'dir':
+			if ( defined( 'FS_CHMOD_DIR' ) ) {
+				$perms[ $type ] = FS_CHMOD_DIR;
+			} else {
+				$perms[ $type ] = fileperms( ABSPATH ) & 0777 | 0755;
+			}
+			break;
+
+		case 'file':
+			if ( defined( 'FS_CHMOD_FILE' ) ) {
+				$perms[ $type ] = FS_CHMOD_FILE;
+			} else {
+				$perms[ $type ] = fileperms( ABSPATH . 'index.php' ) & 0777 | 0644;
+			}
+	}
+
+	return $perms[ $type ];
 }
 
 /**

--- a/inc/functions/htaccess.php
+++ b/inc/functions/htaccess.php
@@ -2,49 +2,66 @@
 defined( 'ABSPATH' ) || die( 'Cheatin&#8217; uh?' );
 
 /**
- * Used to flush the .htaccess file
+ * Used to flush the .htaccess file.
  *
- * @since 1.1.0 Remove empty spacings when .htaccess is generated
  * @since 1.0
+ * @since 1.1.0 Remove empty spacings when .htaccess is generated.
  *
- * @param bool $force (default: false).
- * @return void
+ * @param  bool $remove_rules True to remove WPR rules, false to renew them. Default is false.
+ * @return bool               True on success, false otherwise.
  */
-function flush_rocket_htaccess( $force = false ) {
+function flush_rocket_htaccess( $remove_rules = false ) {
 	global $is_apache;
 
 	if ( ! $is_apache ) {
-		return;
+		return false;
 	}
 
-	$rules = '';
 	$htaccess_file = get_home_path() . '.htaccess';
 
-	if ( rocket_direct_filesystem()->is_writable( $htaccess_file ) ) {
-		// Get content of .htaccess file.
-		$ftmp = rocket_direct_filesystem()->get_contents( $htaccess_file );
-
-		// Remove the WP Rocket marker.
-		$ftmp = preg_replace( '/# BEGIN WP Rocket(.*)# END WP Rocket/isU', '', $ftmp );
-
-		/**
-		 * Determine if empty lines should be removed in the .htaccess file
-		 *
-		 * @since 2.10.7
-		 * @author Remy Perona
-		 * @param boolean $remove_empty_lines True to remove, false otherwise.
-		 */
-		if ( apply_filters( 'rocket_remove_empty_lines', true ) ) {
-			$ftmp = str_replace( "\n\n" , "\n" , $ftmp );
-		}
-
-		if ( false === $force ) {
-			$rules = get_rocket_htaccess_marker();
-		}
-
-		// Update the .htacces file.
-		rocket_put_content( $htaccess_file, $rules . $ftmp );
+	if ( ! rocket_direct_filesystem()->is_writable( $htaccess_file ) ) {
+		// The file is not writable or does not exist.
+		return false;
 	}
+
+	// Get content of .htaccess file.
+	$ftmp = rocket_direct_filesystem()->get_contents( $htaccess_file );
+
+	if ( false === $ftmp ) {
+		// Could not get the file contents.
+		return false;
+	}
+
+	// Check if the file contains the WP rules, before modifying anything.
+	$has_wp_rules = rocket_has_wp_htaccess_rules( $ftmp );
+
+	// Remove the WP Rocket marker.
+	$ftmp = preg_replace( '/\s*# BEGIN WP Rocket.*# END WP Rocket\s*?/isU', PHP_EOL . PHP_EOL, $ftmp );
+	$ftmp = ltrim( $ftmp );
+
+	if ( ! $remove_rules ) {
+		$ftmp = get_rocket_htaccess_marker() . PHP_EOL . $ftmp;
+	}
+
+	/**
+	 * Determine if empty lines should be removed in the .htaccess file.
+	 *
+	 * @since  2.10.7
+	 * @author Remy Perona
+	 *
+	 * @param boolean $remove_empty_lines True to remove, false otherwise.
+	 */
+	if ( apply_filters( 'rocket_remove_empty_lines', true ) ) {
+		$ftmp = preg_replace( "/\n+/", PHP_EOL, $ftmp );
+	}
+
+	// Make sure the WP rules are still there.
+	if ( $has_wp_rules && ! rocket_has_wp_htaccess_rules( $ftmp ) ) {
+		return false;
+	}
+
+	// Update the .htacces file.
+	return rocket_put_content( $htaccess_file, $ftmp );
 }
 
 /**
@@ -95,7 +112,7 @@ function rocket_htaccess_rules_test( $rules_name ) {
  */
 function get_rocket_htaccess_marker() {
 	// Recreate WP Rocket marker.
-	$marker  = '# BEGIN WP Rocket v' . WP_ROCKET_VERSION . PHP_EOL;
+	$marker = '# BEGIN WP Rocket v' . WP_ROCKET_VERSION . PHP_EOL;
 
 	/**
 	 * Add custom rules before rules added by WP Rocket
@@ -576,4 +593,32 @@ function get_rocket_htaccess_web_fonts_access() {
 	$rules = apply_filters( 'rocket_htaccess_web_fonts_access', $rules );
 
 	return $rules;
+}
+
+/**
+ * Tell if WP rewrite rules are present in a given string.
+ *
+ * @since  3.2.4
+ * @author Grégory Viguier
+ *
+ * @param  string $content Htaccess content.
+ * @return bool
+ */
+function rocket_has_wp_htaccess_rules( $content ) {
+	if ( is_multisite() ) {
+		$has_wp_rules = strpos( $content, '# add a trailing slash to /wp-admin' ) !== false;
+	} else {
+		$has_wp_rules = strpos( $content, '# BEGIN WordPress' ) !== false;
+	}
+
+	/**
+	 * Tell if WP rewrite rules are present in a given string.
+	 *
+	 * @since  3.2.4
+	 * @author Grégory Viguier
+	 *
+	 * @param bool   $has_wp_rules True when present. False otherwise.
+	 * @param string $content      .htaccess content.
+	 */
+	return apply_filters( 'rocket_has_wp_htaccess_rules', $has_wp_rules, $content );
 }


### PR DESCRIPTION
- Introduced `rocket_has_wp_htaccess_rules()` to detect WP rules.
- Improved `flush_rocket_htaccess()`. It also now returns a boolean based on the success of the process. Also renamed the parameter for something a bit easier to understand.
- Improved the emty lines removal behind the filter `rocket_remove_empty_lines`.
- Fixed WPR adding multiple empty lines after its rules when the filter `rocket_remove_empty_lines` is filtered to `false`.
- Introduced `rocket_get_filesystem_perms()` to get the permissions to apply to files and dirs.

Regex tests:
- https://regex101.com/r/xJoQze/1
- https://regex101.com/r/6FpB2r/1