### PR TITLE
Closes #1377 Display error messages when preload fails

### DIFF
--- a/inc/classes/preload/class-homepage.php
+++ b/inc/classes/preload/class-homepage.php
@@ -61,7 +61,21 @@ class Homepage extends Abstract_Preload {
 
 		$response = wp_remote_get( $url, $args );
 
+		$errors = get_transient( 'rocket_preload_errors' );
+
+		if ( is_wp_error( $response ) ) {
+			// Translators: %1$s is an URL, %2$s is the error message.
+			$errors['errors'][] = sprintf( __( 'Could not gather links on %1$s because of the following error: %2$s', 'rocket' ), $url, $response->get_error_message() );
+
+			set_transient( 'rocket_preload_errors', $errors );
+			return false;
+		}
+
 		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			// Translators: %1$s is an URL, %2$s is the HTTP response code.
+			$errors['errors'][] = sprintf( __( 'Could not gather links on %1$s because it returned the following response code: %2$s', 'rocket' ), $url, wp_remote_retrieve_response_code( $response ) );
+
+			set_transient( 'rocket_preload_errors', $errors );
 			return false;
 		}
 

--- a/inc/classes/preload/class-homepage.php
+++ b/inc/classes/preload/class-homepage.php
@@ -59,9 +59,10 @@ class Homepage extends Abstract_Preload {
 			]
 		);
 
-		$response = wp_remote_get( $url, $args );
-
-		$errors = get_transient( 'rocket_preload_errors' );
+		$response         = wp_remote_get( $url, $args );
+		$errors           = get_transient( 'rocket_preload_errors' );
+		$errors           = is_array( $errors ) ? $errors : [];
+		$errors['errors'] = isset( $errors['errors'] ) && is_array( $errors['errors'] ) ? $errors['errors'] : [];
 
 		if ( is_wp_error( $response ) ) {
 			// Translators: %1$s is an URL, %2$s is the error message.

--- a/inc/classes/preload/class-sitemap.php
+++ b/inc/classes/preload/class-sitemap.php
@@ -100,8 +100,10 @@ class Sitemap extends Abstract_Preload {
 			]
 		);
 
-		$sitemap = wp_remote_get( esc_url( $sitemap_url ), $args );
-		$errors  = get_transient( 'rocket_preload_errors' );
+		$sitemap          = wp_remote_get( esc_url( $sitemap_url ), $args );
+		$errors           = get_transient( 'rocket_preload_errors' );
+		$errors           = is_array( $errors ) ? $errors : [];
+		$errors['errors'] = isset( $errors['errors'] ) && is_array( $errors['errors'] ) ? $errors['errors'] : [];
 
 		if ( is_wp_error( $sitemap ) ) {
 			// Translators: %1$s is a XML sitemap URL, %2$s is the error message.

--- a/inc/classes/subscriber/preload/class-preload-subscriber.php
+++ b/inc/classes/subscriber/preload/class-preload-subscriber.php
@@ -236,10 +236,10 @@ class Preload_Subscriber implements Subscriber_Interface {
 
 		if ( false === $running ) {
 			return;
-		}
+		}   
 
-		// translators: %1$d = Number of pages preloaded.
-		$message = '<p>' . sprintf( __( 'Preload: %1$d uncached pages have now been preloaded. (refresh to see progress)', 'rocket' ), $running ) . '</p>';
+		// translators: %1$s = Number of pages preloaded.
+		$message = '<p>' . sprintf( _n( 'Preload: %1$s uncached page has now been preloaded. (refresh to see progress)', 'Preload: %1$s uncached pages have now been preloaded. (refresh to see progress)', $running, 'rocket' ), number_format_i18n( $running ) ) . '</p>';
 
 		$errors = get_transient( 'rocket_preload_errors' );
 

--- a/inc/classes/subscriber/preload/class-preload-subscriber.php
+++ b/inc/classes/subscriber/preload/class-preload-subscriber.php
@@ -52,7 +52,7 @@ class Preload_Subscriber implements Subscriber_Interface {
 	public static function get_subscribed_events() {
 		return [
 			'admin_notices'                   => [
-				[ 'notice_preload_triggered'],
+				[ 'notice_preload_triggered' ],
 				[ 'notice_preload_running' ],
 				[ 'notice_preload_complete' ],
 			],
@@ -215,7 +215,7 @@ class Preload_Subscriber implements Subscriber_Interface {
 	}
 
 	/**
-	 * This notice is displayed when the sitemap preload is running
+	 * This notice is displayed when the preload is running
 	 *
 	 * @since 3.2
 	 * @author Remy Perona
@@ -238,10 +238,22 @@ class Preload_Subscriber implements Subscriber_Interface {
 			return;
 		}
 
+		// translators: %1$d = Number of pages preloaded.
+		$message = '<p>' . sprintf( __( 'Preload: %1$d uncached pages have now been preloaded. (refresh to see progress)', 'rocket' ), $running ) . '</p>';
+
+		$errors = get_transient( 'rocket_preload_errors' );
+
+		if ( false !== $errors ) {
+			$message .= '<p>' . _n( 'The following error happened during gathering of the URLs to preload:', 'The following errors happened during gathering of the URLs to preload:', count( $errors['errors'] ), 'rocket' ) . '</p>';
+
+			foreach ( $errors['errors'] as $error ) {
+				$message .= '<p>' . $error . '</p>';
+			}
+		}
+
 		\rocket_notice_html(
 			[
-				// translators: %1$d = Number of pages preloaded.
-				'message'     => sprintf( __( 'Preload: %1$d uncached pages have now been preloaded. (refresh to see progress)', 'rocket' ), $running ),
+				'message'     => $message,
 				'dismissible' => 'notice-preload-running',
 				'action'      => 'stop_preload',
 			]
@@ -273,6 +285,7 @@ class Preload_Subscriber implements Subscriber_Interface {
 		}
 
 		delete_transient( 'rocket_preload_complete' );
+		delete_transient( 'rocket_preload_errors' );
 
 		\rocket_notice_html(
 			[


### PR DESCRIPTION
Add a transient to store the error messages when an URL can't be reached or the content is not good, and display them in the preload running notice.