### PR TITLE
Prepare WooCommerce product images for Lazyload

### DIFF
--- a/inc/front/lazyload.php
+++ b/inc/front/lazyload.php
@@ -158,6 +158,7 @@ add_filter( 'widget_text', 'rocket_lazyload_images', PHP_INT_MAX );
 add_filter( 'get_image_tag', 'rocket_lazyload_images', PHP_INT_MAX );
 add_filter( 'post_thumbnail_html', 'rocket_lazyload_images', PHP_INT_MAX );
 add_filter( 'genesis_get_image', 'rocket_lazyload_images', PHP_INT_MAX );
+add_filter( 'woocommerce_product_get_image', 'rocket_lazyload_images', PHP_INT_MAX );
 
 /**
  * Used to check if we have to LazyLoad this or not


### PR DESCRIPTION
It only applies to images in product loops. Not to the product image in single product page.