### PR TITLE
Exclude strings from combination to avoid the large size of /cache/min/

### DIFF
--- a/inc/classes/optimization/JS/class-combine.php
+++ b/inc/classes/optimization/JS/class-combine.php
@@ -444,6 +444,13 @@ class Combine extends Abstract_JS_Optimization {
 			'AfsAnalyticsObject',
 			'_thriveCurrentPost',
 			'esc_login_url',
+			'fwduvpMainPlaylist',
+			'Bibblio.initRelatedContent',
+			'showUFC()',
+			'#iphorm-',
+			'#fancy-',
+			'ult-carousel-',
+			'theChampLJAuthUrl',
 		];
 
 		$excluded_inline = array_merge( $defaults, $this->options->get( 'exclude_inline_js', [] ) );


### PR DESCRIPTION
`fwduvpMainPlaylist`
*Ultimate Video Player plugin*
- https://www.diffchecker.com/Uz1UpIAj

`Bibblio.initRelatedContent`
*https://cdn.bibblio.org/rcm/3.7/bib-related-content.js*
- https://www.diffchecker.com/saF54oX8 

`showUFC()`
*Ultimate Facebook Comments plugin*
https://wordpress.org/plugins/ultimate-facebook-comments/
- https://www.diffchecker.com/9tuPjbOo

*Related ticket*
https://secure.helpscout.net/conversation/753365491/92859/?folderId=273766

---

`#iphorm-`
*iPhorm plugin*
https://codecanyon.net/item/quform-responsive-ajax-contact-form/
- https://www.diffchecker.com/8qKUzn82
- https://www.diffchecker.com/N5wNpxJX

`#fancy-`
*Fancy news plugin*
https://wordpress.org/plugins/fancy-news/
- https://www.diffchecker.com/UoDob0f9

`ult-carousel-`
*Ultimate VC Addons*
- https://www.diffchecker.com/Lf9BkZm3

*Related ticket*
https://secure.helpscout.net/conversation/753371192/92860/

---

`theChampLJAuthUrl`
*Super Socializer plugin*
https://wordpress.org/plugins/super-socializer/
- https://www.diffchecker.com/vKhHOxdN

*GitHub Issue*
https://github.com/wp-media/wp-rocket/issues/1477

*Related ticket*
https://secure.helpscout.net/conversation/751699704/92640/