### PR TITLE
Fixes #1368 Prevent fatal error if SimpleXML extension is not loaded

### DIFF
--- a/inc/classes/preload/class-sitemap.php
+++ b/inc/classes/preload/class-sitemap.php
@@ -157,6 +157,10 @@ class Sitemap extends Abstract_Preload {
 			return [];
 		}
 
+		if ( ! function_exists( 'simplexml_load_string' ) ) {
+			return [];
+		}
+
 		libxml_use_internal_errors( true );
 
 		$xml = simplexml_load_string( $xml_data );


### PR DESCRIPTION
Also display a notice if the sitemap preload option is activated and the module is not enabled