### PR TITLE
Fix: https://github.com/wp-media/wp-rocket/issues/1529

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
 	],
     "require": {
 		"php": ">=5.4.0",
-		"a5hleyrich/wp-background-processing": "1.3",
+		"a5hleyrich/wp-background-processing": "^1.0",
 		"composer/installers": "~1.0",
 		"jamesryanbell/cloudflare": "^1.11",
 		"matthiasmullie/minify": "1.3.*",


### PR DESCRIPTION
Update Composer.json to require version "^1.0", of "a5hleyrich/wp-background-processing" which is the current latest in wp-packagist (instead of 1.3, which does not exist and causes composer install to fail on it's dependencies).

Note: This may need to be "1.0.1 ", I'm not sure what else it will affect.

Also Note: I'm not sure which Topic branch is appropriate here besides master, this should surely be a really simple fix? Unless I'm barking up completely the wrong tree!
