### PR TITLE
Add Filter for query string parameters to be treated as standard cache

### DIFF
--- a/inc/front/process.php
+++ b/inc/front/process.php
@@ -133,7 +133,7 @@ if ( ! $continue ) {
  * @since 2.1 Add compatibility with WordPress Landing Pages (permalink_name and lp-variation-id)
  * @since 2.1 Add compabitiliy with qTranslate and translation plugin with query string "lang"
  */
-$rocket_remove_query_strings = [
+$rocket_remove_query_strings = apply_filters( 'rocket_remove_query_strings', [
 	'utm_source'      => 1,
 	'utm_medium'      => 1,
 	'utm_campaign'    => 1,
@@ -148,7 +148,7 @@ $rocket_remove_query_strings = [
 	'usqp'            => 1,
 	'cn-reloaded'     => 1,
 	'_ga'             => 1,
-];
+]);
 
 $params = [];
 


### PR DESCRIPTION
Example of how the Filter could be used.  Would this work?

add_filter('rocket_remove_query_strings', 'custom_remove_query_strings' );
function custom_remove_query_strings( $query_strings ){

    $new_strings = [
	'inf_contact_key' => 1,
	];
 
	$query_strings = array_merge($new_strings, $query_strings);
    
    return $query_strings;
}

**Thank you for wanting to contribute to WP Rocket! Before submitting a pull request, please check that you’ve completed the following steps:**
- Please make sure that there aren’t existing pull requests attempting to address the issue mentioned.
- Check for related issues on the issue tracker.
- Non-trivial changes should be discussed on an issue first.
- Let us know you’re working on the issue.
- Develop in a topic branch, not master.

**Things to add in the pull request to help us:**
- Provide useful pull request description.
- Follow project commit guidelines.
- Write a good description of your PR.
- Link to the Github issue in the description.
