### PR TITLE
Pressable compatibility

### DIFF
--- a/inc/classes/ServiceProvider/class-hostings-subscribers.php
+++ b/inc/classes/ServiceProvider/class-hostings-subscribers.php
@@ -1,0 +1,38 @@
+<?php
+namespace WP_Rocket\ServiceProvider;
+
+use League\Container\ServiceProvider\AbstractServiceProvider;
+
+/**
+ * Service provider for WP Rocket third party hostings compatibility
+ *
+ * @since 3.3
+ * @author Remy Perona
+ */
+class Hostings_Subscribers extends AbstractServiceProvider {
+
+	/**
+	 * The provides array is a way to let the container
+	 * know that a service is provided by this service
+	 * provider. Every service that is registered via
+	 * this service provider must have an alias added
+	 * to this array or it will be ignored.
+	 *
+	 * @var array
+	 */
+	protected $provides = [
+		'pressable_subscriber',
+	];
+
+	/**
+	 * Registers the subscribers in the container
+	 *
+	 * @since 3.3
+	 * @author Remy Perona
+	 *
+	 * @return void
+	 */
+	public function register() {
+		$this->getContainer()->add( 'pressable_subscriber', 'WP_Rocket\Subscriber\Third_Party\Hostings\Pressable_Subscriber' );
+	}
+}

--- a/inc/classes/class-plugin.php
+++ b/inc/classes/class-plugin.php
@@ -109,6 +109,7 @@ class Plugin {
 		$this->container->addServiceProvider( 'WP_Rocket\ServiceProvider\Preload_Subscribers' );
 		$this->container->addServiceProvider( 'WP_Rocket\ServiceProvider\Common_Subscribers' );
 		$this->container->addServiceProvider( 'WP_Rocket\ServiceProvider\Third_Party_Subscribers' );
+		$this->container->addServiceProvider( 'WP_Rocket\ServiceProvider\Hostings_Subscribers' );
 
 		$common_subscribers = [
 			'sucuri_subscriber',
@@ -120,6 +121,7 @@ class Plugin {
 			'mobile_subscriber',
 			'woocommerce_subscriber',
 			'nginx_subscriber',
+			'pressable_subscriber',
 		];
 
 		$subscribers = array_merge( $subscribers, $common_subscribers );

--- a/inc/classes/subscriber/third-party/Hostings/class-pressable-subscriber.php
+++ b/inc/classes/subscriber/third-party/Hostings/class-pressable-subscriber.php
@@ -1,0 +1,117 @@
+<?php
+namespace WP_Rocket\Subscriber\Third_Party\Hostings;
+
+use WP_Rocket\Event_Management\Subscriber_Interface;
+
+/**
+ * Subscriber for compatibility with Pressable hosting
+ *
+ * @since 3.3
+ * @author Remy Perona
+ */
+class Pressable_Subscriber implements Subscriber_Interface {
+	/**
+	 * @inheritDoc
+	 */
+	public static function get_subscribed_events() {
+		if ( ! defined( 'IS_PRESSABLE' ) || ! IS_PRESSABLE ) {
+			return [];
+		}
+
+		return [
+			'do_rocket_generate_caching_files'   => [ 'return_false', PHP_INT_MAX ],
+			'rocket_display_varnish_options_tab' => 'return_false',
+			'rocket_display_nginx_addon'         => 'return_false',
+			'rocket_cache_mandatory_cookies'     => [ 'return_empty_array', PHP_INT_MAX ],
+			'wp_rocket_loaded'                   => 'remove_advanced_cache_notices',
+			'after_rocket_clean_domain'          => 'purge_pressable_cache',
+			'rocket_url_to_path'                 => 'fix_wp_includes_path',
+			'rocket_cdn_cnames'                  => [ 'add_pressable_cdn_cname', 1 ],
+		];
+	}
+
+	/**
+	 * Wrapper for __return_false() WP function
+	 *
+	 * @since 3.3
+	 * @author Remy Perona
+	 *
+	 * @return bool
+	 */
+	public function return_false() {
+		__return_false();
+	}
+
+	/**
+	 * Wrapper for __return_empty_array() WP function
+	 *
+	 * @since 3.3
+	 * @author Remy Perona
+	 *
+	 * @return array
+	 */
+	public function return_empty_array() {
+		__return_empty_array();
+	}
+
+	/**
+	 * Remove Advanced cache notices from WP Rocket since we can't modify it
+	 *
+	 * @since 3.3
+	 * @author Remy Perona
+	 *
+	 * @return void
+	 */
+	public function remove_advanced_cache_notices() {
+		remove_action( 'admin_notices', 'rocket_warning_advanced_cache_permissions' );
+		remove_action( 'admin_notices', 'rocket_warning_advanced_cache_not_ours' );
+	}
+
+	/**
+	 * Purge Pressable cache
+	 *
+	 * @since 3.3
+	 * @author Remy Perona
+	 *
+	 * @return void
+	 */
+	public function purge_pressable_cache() {
+		wp_cache_flush();
+	}
+
+	/**
+	 * Modify wp-includes absolute path to be able to optimize assets in this directory on Pressable
+	 *
+	 * @since 3.3
+	 * @author Remy Perona
+	 *
+	 * @param string $file Absolute path to the file.
+	 * @return string
+	 */
+	public function fix_wp_includes_path( $file ) {
+		if ( ! preg_match( '#^(.+)(wp-includes(?:.+))$#is', $file ) ) {
+			return $file;
+		}
+
+		return preg_replace( '#^(.+)(wp-includes(?:.+))$#is', ABSPATH . '$2', $file );
+	}
+
+	/**
+	 * Add Pressable CDN cname to WP Rocket list to recognize assets as internal ones.
+	 *
+	 * @since 3.3
+	 * @author Remy Perona
+	 *
+	 * @param array $hosts Array of domains.
+	 * @return array
+	 */
+	public function add_pressable_cdn_cname( $hosts ) {
+		if ( ! defined( 'WP_STACK_CDN_DOMAIN' ) || ! WP_STACK_CDN_DOMAIN ) {
+			return $hosts;
+		}
+
+		$hosts[] = WP_STACK_CDN_DOMAIN;
+
+		return $hosts;
+	}
+}

--- a/inc/classes/subscriber/third-party/Hostings/class-pressable-subscriber.php
+++ b/inc/classes/subscriber/third-party/Hostings/class-pressable-subscriber.php
@@ -31,7 +31,7 @@ class Pressable_Subscriber implements Subscriber_Interface {
 	}
 
 	/**
-	 * Wrapper for __return_false() WP function
+	 * Return false
 	 *
 	 * @since 3.3
 	 * @author Remy Perona
@@ -39,11 +39,11 @@ class Pressable_Subscriber implements Subscriber_Interface {
 	 * @return bool
 	 */
 	public function return_false() {
-		__return_false();
+		return false;
 	}
 
 	/**
-	 * Wrapper for __return_empty_array() WP function
+	 * Return empty array
 	 *
 	 * @since 3.3
 	 * @author Remy Perona
@@ -51,7 +51,7 @@ class Pressable_Subscriber implements Subscriber_Interface {
 	 * @return array
 	 */
 	public function return_empty_array() {
-		__return_empty_array();
+		return [];
 	}
 
 	/**
@@ -89,10 +89,6 @@ class Pressable_Subscriber implements Subscriber_Interface {
 	 * @return string
 	 */
 	public function fix_wp_includes_path( $file ) {
-		if ( ! preg_match( '#^(.+)(wp-includes(?:.+))$#is', $file ) ) {
-			return $file;
-		}
-
 		return preg_replace( '#^(.+)(wp-includes(?:.+))$#is', ABSPATH . '$2', $file );
 	}
 

--- a/inc/functions/formatting.php
+++ b/inc/functions/formatting.php
@@ -344,8 +344,9 @@ function rocket_url_to_path( $url, $hosts = '' ) {
 	 * @author Remy Perona
 	 *
 	 * @param string $file Absolute path to the file.
+	 * @param string $url  URL of the asset.
 	 */
-	$file = apply_filters( 'rocket_url_to_path', $file );
+	$file = apply_filters( 'rocket_url_to_path', $file, $url );
 
 	if ( ! rocket_direct_filesystem()->is_readable( $file ) ) {
 		return false;

--- a/inc/functions/formatting.php
+++ b/inc/functions/formatting.php
@@ -337,6 +337,15 @@ function rocket_url_to_path( $url, $hosts = '' ) {
 	$url      = preg_replace( '/^https?:/', '', $url );
 	$file     = str_replace( $root_url, $root_dir, $url );
 	$file     = rocket_realpath( $file );
+	/**
+	 * Filters the absolute path to the asset file
+	 *
+	 * @since 3.3
+	 * @author Remy Perona
+	 *
+	 * @param string $file Absolute path to the file.
+	 */
+	$file = apply_filters( 'rocket_url_to_path', $file );
 
 	if ( ! rocket_direct_filesystem()->is_readable( $file ) ) {
 		return false;


### PR DESCRIPTION
* Prevent WP Rocket cache files creation
* Prevent display of notices related to `advanced-cache.php`
* Prevent display of Varnish and NGINX add-ons as they don't make sense on Pressable
* Auto-purge Pressable cache when WP Rocket purge cache action is triggered
* Auto-detect Pressable CDN value
* Modify absolute path for assets in `wp-includes` to fit with Pressable setup