### PR TITLE
Excludes Uplaunch From Defer JS

### DIFF
--- a/inc/functions/options.php
+++ b/inc/functions/options.php
@@ -446,6 +446,7 @@ function get_rocket_exclude_defer_js() {
 		'gist.github.com',
 		'content.jwplatform.com',
 		'js.hsforms.net',
+		'www.uplaunch.com',
 		'google.com/recaptcha',
 	];
 


### PR DESCRIPTION
Uplaunch can't be deferred or else the form will render twice and return a JS error on submission. The other PR deals with ignoring the combine JS which also breaks it.