### PR TITLE
Fixes #1581 Improve Flywheel compatibility

### DIFF
--- a/inc/3rd-party/hosting/flywheel.php
+++ b/inc/3rd-party/hosting/flywheel.php
@@ -1,7 +1,7 @@
 <?php
 defined( 'ABSPATH' ) || die( 'Cheatin&#8217; uh?' );
 
-if ( class_exists( 'FlywheelNginxCompat' ) ) :
+if ( class_exists( 'FlywheelNginxCompat' ) ) {
 	/**
 	 * Changes the text on the Varnish one-click block.
 	 *
@@ -20,13 +20,11 @@ if ( class_exists( 'FlywheelNginxCompat' ) ) :
 
 	add_filter( 'rocket_display_input_varnish_auto_purge', '__return_false' );
 	add_filter( 'rocket_display_nginx_addon', '__return_false' );
-
-	/**
-	 * Allow to purge Varnish on Flywheel websites
-	 *
-	 * @since 2.6.8
-	 */
 	add_filter( 'do_rocket_varnish_http_purge', '__return_true' );
+	add_filter( 'do_rocket_generate_caching_files', '__return_false' );
+
+	// Prevent mandatory cookies on hosting with server cache.
+	add_filter( 'rocket_cache_mandatory_cookies', '__return_empty_array', PHP_INT_MAX );
 
 	/**
 	 * Set up the right Varnish IP for Flywheel
@@ -38,6 +36,33 @@ if ( class_exists( 'FlywheelNginxCompat' ) ) :
 	}
 	add_filter( 'rocket_varnish_ip', 'rocket_varnish_ip_on_flywheel' );
 
-	// Prevent mandatory cookies on hosting with server cache.
-	add_filter( 'rocket_cache_mandatory_cookies', '__return_empty_array', PHP_INT_MAX );
-endif;
+	/**
+	 * Remove WP Rocket functions on WP core action hooks to prevent triggering a double cache clear.
+	 *
+	 * @since 3.3.1
+	 * @author Remy Perona
+	 *
+	 * @return void
+	 */
+	function rocket_flywheel_remove_partial_purge_hooks() {
+		// WP core action hooks rocket_clean_post() gets hooked into.
+		$clean_post_hooks = array(
+			// Disables the refreshing of partial cache when content is edited.
+			'wp_trash_post',
+			'delete_post',
+			'clean_post_cache',
+			'wp_update_comment_count',
+		);
+
+		// Remove rocket_clean_post() from core action hooks.
+		array_map(
+			function( $hook ) {
+				remove_action( $hook, 'rocket_clean_post' );
+			},
+			$clean_post_hooks
+		);
+
+		remove_filter( 'rocket_clean_files', 'rocket_clean_files_users' );
+	}
+	add_action( 'wp_rocket_loaded', 'rocket_flywheel_remove_partial_purge_hooks' );
+}


### PR DESCRIPTION
* Prevent WP Rocket cache files creation
* Remove WP Rocket hooked function on clean post hooks.