### PR TITLE
Fixes #1620: Class not found error when WP Rocket's preloading of the Sitemap was activated

### DIFF
--- a/inc/3rd-party/plugins/seo/rank-math-seo.php
+++ b/inc/3rd-party/plugins/seo/rank-math-seo.php
@@ -83,7 +83,7 @@ add_filter( 'rocket_inputs_sanitize', 'rank_math_rocket_sitemap_option_sanitize'
  */
 function rank_math_rocket_sitemap( $sitemaps ) {
 	if ( get_rocket_option( 'rank_math_xml_sitemap', false ) ) {
-		$sitemaps[] = \RankMath\Modules\Sitemap\Router::get_base_url( 'sitemap_index.xml' );
+		$sitemaps[] = \RankMath\Sitemap\Router::get_base_url( 'sitemap_index.xml' );
 	}
 
 	return $sitemaps;


### PR DESCRIPTION
This PR fixes the compatibility issue between WP Rocket & Rank Math. The preloading of the Sitemap was not working with the latest versions of the plugins.

It is related to this issue:
https://github.com/wp-media/wp-rocket/issues/1620