### PR TITLE
Give access to WP Rocket DI container

### DIFF
--- a/inc/classes/ServiceProvider/class-addons-subscribers.php
+++ b/inc/classes/ServiceProvider/class-addons-subscribers.php
@@ -39,13 +39,13 @@ class Addons_Subscribers extends AbstractServiceProvider {
 		$this->getContainer()->add( 'busting_factory', 'WP_Rocket\Busting\Busting_Factory' )
 			->withArgument( WP_ROCKET_CACHE_BUSTING_PATH )
 			->withArgument( WP_ROCKET_CACHE_BUSTING_URL );
-		$this->getContainer()->add( 'facebook_tracking_subscriber', 'WP_Rocket\Subscriber\Facebook_Tracking_Cache_Busting_Subscriber' )
+		$this->getContainer()->share( 'facebook_tracking_subscriber', 'WP_Rocket\Subscriber\Facebook_Tracking_Cache_Busting_Subscriber' )
 			->withArgument( $this->getContainer()->get( 'busting_factory' ) )
 			->withArgument( $this->getContainer()->get( 'options' ) );
-		$this->getContainer()->add( 'google_tracking_subscriber', 'WP_Rocket\Subscriber\Google_Tracking_Cache_Busting_Subscriber' )
+		$this->getContainer()->share( 'google_tracking_subscriber', 'WP_Rocket\Subscriber\Google_Tracking_Cache_Busting_Subscriber' )
 			->withArgument( $this->getContainer()->get( 'busting_factory' ) )
 			->withArgument( $this->getContainer()->get( 'options' ) );
-		$this->getContainer()->add( 'sucuri_subscriber', 'WP_Rocket\Subscriber\Third_Party\Plugins\Security\Sucuri_Subscriber' )
+		$this->getContainer()->share( 'sucuri_subscriber', 'WP_Rocket\Subscriber\Third_Party\Plugins\Security\Sucuri_Subscriber' )
 			->withArgument( $this->getContainer()->get( 'options' ) );
 
 	}

--- a/inc/classes/ServiceProvider/class-admin-subscribers.php
+++ b/inc/classes/ServiceProvider/class-admin-subscribers.php
@@ -36,15 +36,15 @@ class Admin_Subscribers extends AbstractServiceProvider {
 	 * @return void
 	 */
 	public function register() {
-		$this->getContainer()->add( 'settings_page_subscriber', 'WP_Rocket\Subscriber\Admin\Settings\Page_Subscriber' )
+		$this->getContainer()->share( 'settings_page_subscriber', 'WP_Rocket\Subscriber\Admin\Settings\Page_Subscriber' )
 			->withArgument( $this->getContainer()->get( 'settings_page' ) );
 		$this->getContainer()->add( 'deactivation_intent_render', 'WP_Rocket\Admin\Deactivation\Render' )
 			->withArgument( $this->getContainer()->get( 'template_path' ) . '/deactivation-intent' );
-		$this->getContainer()->add( 'deactivation_intent_subscriber', 'WP_Rocket\Subscriber\Admin\Deactivation\Deactivation_Intent_Subscriber' )
+		$this->getContainer()->share( 'deactivation_intent_subscriber', 'WP_Rocket\Subscriber\Admin\Deactivation\Deactivation_Intent_Subscriber' )
 			->withArgument( $this->getContainer()->get( 'deactivation_intent_render' ) )
 			->withArgument( $this->getContainer()->get( 'options_api' ) )
 			->withArgument( $this->getContainer()->get( 'options' ) );
-		$this->getContainer()->add( 'beacon_subscriber', 'WP_Rocket\Subscriber\Admin\Settings\Beacon_Subscriber' )
+		$this->getContainer()->share( 'beacon_subscriber', 'WP_Rocket\Subscriber\Admin\Settings\Beacon_Subscriber' )
 			->withArgument( $this->getContainer()->get( 'beacon' ) );
 	}
 }

--- a/inc/classes/ServiceProvider/class-common-subscribers.php
+++ b/inc/classes/ServiceProvider/class-common-subscribers.php
@@ -37,15 +37,15 @@ class Common_Subscribers extends AbstractServiceProvider {
 	 * @return void
 	 */
 	public function register() {
-		$this->getContainer()->add( 'heartbeat_subscriber', 'WP_Rocket\Subscriber\Heartbeat_Subscriber' )
+		$this->getContainer()->share( 'heartbeat_subscriber', 'WP_Rocket\Subscriber\Heartbeat_Subscriber' )
 			->withArgument( $this->getContainer()->get( 'options' ) );
-		$this->getContainer()->add( 'db_optimization_subscriber', 'WP_Rocket\Subscriber\Admin\Database\Optimization_Subscriber' )
+		$this->getContainer()->share( 'db_optimization_subscriber', 'WP_Rocket\Subscriber\Admin\Database\Optimization_Subscriber' )
 			->withArgument( $this->getContainer()->get( 'db_optimization' ) )
 			->withArgument( $this->getContainer()->get( 'options' ) );
 		$this->getContainer()->add( 'critical_css_generation', 'WP_Rocket\Optimization\CSS\Critical_CSS_Generation' );
 		$this->getContainer()->add( 'critical_css', 'WP_Rocket\Optimization\CSS\Critical_CSS' )
 			->withArgument( $this->getContainer()->get( 'critical_css_generation' ) );
-		$this->getContainer()->add( 'critical_css_subscriber', 'WP_Rocket\Subscriber\Optimization\Critical_CSS_Subscriber' )
+		$this->getContainer()->share( 'critical_css_subscriber', 'WP_Rocket\Subscriber\Optimization\Critical_CSS_Subscriber' )
 			->withArgument( $this->getContainer()->get( 'critical_css' ) )
 			->withArgument( $this->getContainer()->get( 'options' ) );
 	}

--- a/inc/classes/ServiceProvider/class-hostings-subscribers.php
+++ b/inc/classes/ServiceProvider/class-hostings-subscribers.php
@@ -33,6 +33,6 @@ class Hostings_Subscribers extends AbstractServiceProvider {
 	 * @return void
 	 */
 	public function register() {
-		$this->getContainer()->add( 'pressable_subscriber', 'WP_Rocket\Subscriber\Third_Party\Hostings\Pressable_Subscriber' );
+		$this->getContainer()->share( 'pressable_subscriber', 'WP_Rocket\Subscriber\Third_Party\Hostings\Pressable_Subscriber' );
 	}
 }

--- a/inc/classes/ServiceProvider/class-optimization-subscribers.php
+++ b/inc/classes/ServiceProvider/class-optimization-subscribers.php
@@ -53,7 +53,7 @@ class Optimization_Subscribers extends AbstractServiceProvider {
 			->withArgument( $this->getContainer()->get( 'config' ) );
 		$this->getContainer()->add( 'buffer_optimization', 'WP_Rocket\Buffer\Optimization' )
 			->withArgument( $this->getContainer()->get( 'tests' ) );
-		$this->getContainer()->add( 'buffer_subscriber', 'WP_Rocket\Subscriber\Optimization\Buffer_Subscriber' )
+		$this->getContainer()->share( 'buffer_subscriber', 'WP_Rocket\Subscriber\Optimization\Buffer_Subscriber' )
 			->withArgument( $this->getContainer()->get( 'buffer_optimization' ) );
 		$this->getContainer()->add( 'cache_dynamic_resource', 'WP_Rocket\Optimization\Cache_Dynamic_Resource' )
 			->withArgument( $this->getContainer()->get( 'options' ) )
@@ -65,20 +65,20 @@ class Optimization_Subscribers extends AbstractServiceProvider {
 			->withArgument( $this->getContainer()->get( 'options' ) )
 			->withArgument( WP_ROCKET_CACHE_BUSTING_PATH )
 			->withArgument( WP_ROCKET_CACHE_BUSTING_URL );
-		$this->getContainer()->add( 'ie_conditionals_subscriber', 'WP_Rocket\Subscriber\Optimization\IE_Conditionals_Subscriber' );
-		$this->getContainer()->add( 'minify_html_subscriber', 'WP_Rocket\Subscriber\Optimization\Minify_HTML_Subscriber' )
+		$this->getContainer()->share( 'ie_conditionals_subscriber', 'WP_Rocket\Subscriber\Optimization\IE_Conditionals_Subscriber' );
+		$this->getContainer()->share( 'minify_html_subscriber', 'WP_Rocket\Subscriber\Optimization\Minify_HTML_Subscriber' )
 			->withArgument( $this->getContainer()->get( 'options' ) );
-		$this->getContainer()->add( 'combine_google_fonts_subscriber', 'WP_Rocket\Subscriber\Optimization\Combine_Google_Fonts_Subscriber' )
+		$this->getContainer()->share( 'combine_google_fonts_subscriber', 'WP_Rocket\Subscriber\Optimization\Combine_Google_Fonts_Subscriber' )
 			->withArgument( $this->getContainer()->get( 'options' ) );
-		$this->getContainer()->add( 'minify_css_subscriber', 'WP_Rocket\Subscriber\Optimization\Minify_CSS_Subscriber' )
+		$this->getContainer()->share( 'minify_css_subscriber', 'WP_Rocket\Subscriber\Optimization\Minify_CSS_Subscriber' )
 			->withArgument( $this->getContainer()->get( 'options' ) );
-		$this->getContainer()->add( 'minify_js_subscriber', 'WP_Rocket\Subscriber\Optimization\Minify_JS_Subscriber' )
+		$this->getContainer()->share( 'minify_js_subscriber', 'WP_Rocket\Subscriber\Optimization\Minify_JS_Subscriber' )
 			->withArgument( $this->getContainer()->get( 'options' ) );
-		$this->getContainer()->add( 'cache_dynamic_resource_subscriber', 'WP_Rocket\Subscriber\Optimization\Cache_Dynamic_Resource_Subscriber' )
+		$this->getContainer()->share( 'cache_dynamic_resource_subscriber', 'WP_Rocket\Subscriber\Optimization\Cache_Dynamic_Resource_Subscriber' )
 			->withArgument( $this->getContainer()->get( 'cache_dynamic_resource' ) );
-		$this->getContainer()->add( 'cdn_favicons_subscriber', 'WP_Rocket\Subscriber\Optimization\CDN_Favicons_Subscriber' )
+		$this->getContainer()->share( 'cdn_favicons_subscriber', 'WP_Rocket\Subscriber\Optimization\CDN_Favicons_Subscriber' )
 			->withArgument( $this->getContainer()->get( 'cdn_favicons' ) );
-		$this->getContainer()->add( 'remove_query_string_subscriber', 'WP_Rocket\Subscriber\Optimization\Remove_Query_String_Subscriber' )
+		$this->getContainer()->share( 'remove_query_string_subscriber', 'WP_Rocket\Subscriber\Optimization\Remove_Query_String_Subscriber' )
 			->withArgument( $this->getContainer()->get( 'remove_query_string' ) );
 	}
 }

--- a/inc/classes/ServiceProvider/class-preload-subscribers.php
+++ b/inc/classes/ServiceProvider/class-preload-subscribers.php
@@ -45,13 +45,13 @@ class Preload_Subscribers extends AbstractServiceProvider {
 			->withArgument( $this->getContainer()->get( 'full_preload_process' ) );
 		$this->getContainer()->add( 'sitemap_preload', 'WP_Rocket\Preload\Sitemap' )
 			->withArgument( $this->getContainer()->get( 'full_preload_process' ) );
-		$this->getContainer()->add( 'preload_subscriber', 'WP_Rocket\Subscriber\Preload\Preload_Subscriber' )
+		$this->getContainer()->share( 'preload_subscriber', 'WP_Rocket\Subscriber\Preload\Preload_Subscriber' )
 			->withArgument( $this->getContainer()->get( 'homepage_preload' ) )
 			->withArgument( $this->getContainer()->get( 'options' ) );
-		$this->getContainer()->add( 'sitemap_preload_subscriber', 'WP_Rocket\Subscriber\Preload\Sitemap_Preload_Subscriber' )
+		$this->getContainer()->share( 'sitemap_preload_subscriber', 'WP_Rocket\Subscriber\Preload\Sitemap_Preload_Subscriber' )
 			->withArgument( $this->getContainer()->get( 'sitemap_preload' ) )
 			->withArgument( $this->getContainer()->get( 'options' ) );
-		$this->getContainer()->add( 'partial_preload_subscriber', 'WP_Rocket\Subscriber\Preload\Partial_Preload_Subscriber' )
+		$this->getContainer()->share( 'partial_preload_subscriber', 'WP_Rocket\Subscriber\Preload\Partial_Preload_Subscriber' )
 			->withArgument( $this->getContainer()->get( 'partial_preload_process' ) )
 			->withArgument( $this->getContainer()->get( 'options' ) );
 	}

--- a/inc/classes/ServiceProvider/class-third-party-subscribers.php
+++ b/inc/classes/ServiceProvider/class-third-party-subscribers.php
@@ -36,10 +36,10 @@ class Third_Party_Subscribers extends AbstractServiceProvider {
 	 * @return void
 	 */
 	public function register() {
-		$this->getContainer()->add( 'mobile_subscriber', 'WP_Rocket\Subscriber\Third_Party\Plugins\Mobile_Subscriber' );
-		$this->getContainer()->add( 'woocommerce_subscriber', 'WP_Rocket\Subscriber\Third_Party\Plugins\Ecommerce\WooCommerce_Subscriber' );
-		$this->getContainer()->add( 'elementor_subscriber', 'WP_Rocket\Subscriber\Third_Party\Plugins\PageBuilder\Elementor_Subscriber' )
+		$this->getContainer()->share( 'mobile_subscriber', 'WP_Rocket\Subscriber\Third_Party\Plugins\Mobile_Subscriber' );
+		$this->getContainer()->share( 'woocommerce_subscriber', 'WP_Rocket\Subscriber\Third_Party\Plugins\Ecommerce\WooCommerce_Subscriber' );
+		$this->getContainer()->share( 'elementor_subscriber', 'WP_Rocket\Subscriber\Third_Party\Plugins\PageBuilder\Elementor_Subscriber' )
 			->withArgument( $this->getContainer()->get( 'options' ) );
-		$this->getContainer()->add( 'syntaxhighlighter_subscriber', 'WP_Rocket\Subscriber\Third_Party\Plugins\SyntaxHighlighter_Subscriber' );
+		$this->getContainer()->share( 'syntaxhighlighter_subscriber', 'WP_Rocket\Subscriber\Third_Party\Plugins\SyntaxHighlighter_Subscriber' );
 	}
 }

--- a/inc/classes/class-plugin.php
+++ b/inc/classes/class-plugin.php
@@ -30,6 +30,15 @@ class Plugin {
 	 */
 	public function __construct( $template_path ) {
 		$this->container = new Container();
+
+		$container = $this->container;
+		add_filter(
+			'rocket_container',
+			function() use ( $container ) {
+				return $container;
+			}
+		);
+
 		$this->container->add( 'template_path', $template_path );
 	}
 
@@ -41,7 +50,7 @@ class Plugin {
 	 * @return void
 	 */
 	public function load() {
-		$this->container->add(
+		$this->container->share(
 			'event_manager',
 			function() {
 				return new Event_Manager();


### PR DESCRIPTION
With that method, a third party can access the container and the instances of the classes by using
`$container = apply_filters( 'rocket_container', '' );`

This allows to access the subscribers, and remove hooks for example, as the correct instance of the classes can be referenced that way.