### PR TITLE
Fixes #1659 Incorrect replacement in critical CSS output

### DIFF
--- a/inc/classes/subscriber/Optimization/class-critical-css-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-critical-css-subscriber.php
@@ -341,6 +341,8 @@ JS;
 			return $buffer;
 		}
 
+		$critical_css_content = str_replace( '\\', '\\\\', $critical_css_content );
+
 		$buffer = preg_replace( '#</title>#iU', '</title><style id="rocket-critical-css">' . wp_strip_all_tags( $critical_css_content ) . '</style>', $buffer, 1 );
 
 		return $buffer;


### PR DESCRIPTION
Escape backslash characters to prevent `preg_replace` from interpreting the CSS as a matched pattern