### PR TITLE
Fixes #1655 advanced-cache.php issues on WP Engine

### DIFF
--- a/inc/3rd-party/hosting/wpengine.php
+++ b/inc/3rd-party/hosting/wpengine.php
@@ -21,6 +21,7 @@ if ( class_exists( 'WpeCommon' ) && function_exists( 'wpe_param' ) ) {
 	add_filter( 'rocket_display_input_varnish_auto_purge', '__return_false' );
 	// Prevent mandatory cookies on hosting with server cache.
 	add_filter( 'rocket_cache_mandatory_cookies', '__return_empty_array', PHP_INT_MAX );
+	add_filter( 'rocket_advanced_cache_file', '__return_empty_string' );
 
 	/**
 	 * Always keep WP_CACHE constant to true

--- a/inc/main.php
+++ b/inc/main.php
@@ -178,6 +178,7 @@ function rocket_activation() {
 	require WP_ROCKET_FUNCTIONS_PATH . 'htaccess.php';
 	require WP_ROCKET_3RD_PARTY_PATH . 'hosting/godaddy.php';
 	require WP_ROCKET_3RD_PARTY_PATH . 'hosting/o2switch.php';
+	require WP_ROCKET_3RD_PARTY_PATH . 'hosting/wpengine.php';
 
 	if ( rocket_valid_key() ) {
 		// Add All WP Rocket rules of the .htaccess file.


### PR DESCRIPTION
Transition from staging to live/live to staging was causing issues on WP Engine as the paths were not updated.

Since 3.3, we don't need anything in this file on WP Engine anyway, since the caching is deactivated, and the optimization is separate. So we can just rewrite an empty file.

Also fixes #1642 