### PR TITLE
Change hook to remove advanced-cache.php notices on Pressable

### DIFF
--- a/inc/classes/subscriber/third-party/Hostings/class-pressable-subscriber.php
+++ b/inc/classes/subscriber/third-party/Hostings/class-pressable-subscriber.php
@@ -22,7 +22,7 @@ class Pressable_Subscriber implements Subscriber_Interface {
 			'do_rocket_generate_caching_files'   => [ 'return_false', PHP_INT_MAX ],
 			'rocket_display_varnish_options_tab' => 'return_false',
 			'rocket_cache_mandatory_cookies'     => [ 'return_empty_array', PHP_INT_MAX ],
-			'wp_rocket_loaded'                   => 'remove_advanced_cache_notices',
+			'admin_init'                         => 'remove_advanced_cache_notices',
 			'after_rocket_clean_domain'          => 'purge_pressable_cache',
 			'rocket_url_to_path'                 => 'fix_wp_includes_path',
 			'rocket_cdn_cnames'                  => [ 'add_pressable_cdn_cname', 1 ],


### PR DESCRIPTION
From `wp_rocket_loaded` to `admin_init`, as the previous one was not preventing display on plugin activation.