### PR TITLE
Fixes #1632 Exclude embedded URLs from caching/optimize

### DIFF
--- a/inc/admin/upgrader.php
+++ b/inc/admin/upgrader.php
@@ -408,5 +408,10 @@ function rocket_new_upgrade( $wp_rocket_version, $actual_version ) {
 		rocket_generate_config_file();
 		rocket_clean_domain();
 	}
+
+	if ( version_compare( $actual_version, '3.3.2', '<' ) ) {
+		flush_rocket_htaccess();
+		rocket_generate_config_file();
+	}
 }
 add_action( 'wp_rocket_upgrade', 'rocket_new_upgrade', 10, 2 );

--- a/inc/functions/options.php
+++ b/inc/functions/options.php
@@ -169,6 +169,7 @@ function get_rocket_purge_cron_interval() {
 /**
  * Get all uri we don't cache.
  *
+ * @since 3.3.2 Exclude embedded URLs
  * @since 2.6   Using json_get_url_prefix() to auto-exclude the WordPress REST API.
  * @since 2.4.1 Auto-exclude WordPress REST API.
  * @since 2.0
@@ -208,6 +209,9 @@ function get_rocket_cache_reject_uri() {
 
 	// Exclude feeds.
 	$uris[] = '/(.+/)?' . $GLOBALS['wp_rewrite']->feed_base . '/?';
+
+	// Exlude embedded URLs.
+	$uris[] = '/(?:.+/)?embed/';
 
 	/**
 	 * Filter the rejected uri


### PR DESCRIPTION
Embedded URLs are loaded in an iframe on the page, optimizing them can cause display issues