### PR TITLE
Fixes #1542 Prevent PHP warning if themes value is not an array

### DIFF
--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -482,6 +482,10 @@ function rocket_clean_cache_theme_update( $wp_upgrader, $hook_extra ) {
 		$current_theme->get_stylesheet(), // Child theme.
 	];
 
+	if ( ! is_array( $hook_extra['themes'] ) ) {
+		return;
+	}
+
 	if ( ! array_intersect( $hook_extra['themes'], $themes ) ) {
 		return;
 	}


### PR DESCRIPTION
It should never happen but it seems to happen anyway