### PR TITLE
Compatibility with Alexa Metrics Certification

### DIFF
--- a/inc/classes/optimization/JS/class-combine.php
+++ b/inc/classes/optimization/JS/class-combine.php
@@ -458,6 +458,7 @@ class Combine extends Abstract_JS_Optimization {
 			'ad_block_',
 			'elementorFrontendConfig',
 			'omapi_localized',
+			'_atrk_opts',
 		];
 
 		$excluded_inline = array_merge( $defaults, $this->options->get( 'exclude_inline_js', [] ) );


### PR DESCRIPTION
Alexa Metrics is using an inline JS script to validate a website's certification.

By default when we have the combine JS option turned on, this inline JS is included into our minified file. Then, the certification can't be validated.

We need to auto-exclude it by using the pattern: **_atrk_opts**

Related ticket support:
https://secure.helpscout.net/conversation/844467252/106548?folderId=273768