### PR TITLE
Auto-exclude gform_ajax_frame_ & gform_post_render inline JS

### DIFF
--- a/inc/classes/optimization/JS/class-combine.php
+++ b/inc/classes/optimization/JS/class-combine.php
@@ -593,6 +593,8 @@ class Combine extends Abstract_JS_Optimization {
 			'dfads_ajax_load_ads',
 			'tie_postviews',
 			'wmp_update',
+			'gform_ajax_frame_',
+			'gform_post_render',
 		];
 
 		/**


### PR DESCRIPTION
The patterns **gform_ajax_frame_** and **gform_post_render** need to be auto-excluded from the **Inline JS to move after the combined JS file** to avoid the cache dir size issue.

https://www.diffchecker.com/2kN45mzx#left-2
https://www.diffchecker.com/e2eyTulH#left-2

Related ticket:
https://secure.helpscout.net/conversation/845256971/106654/