### PR TITLE
Fixes #1598 Exclude Divi main style from Optimize CSS Delivery

### DIFF
--- a/inc/3rd-party/themes/divi.php
+++ b/inc/3rd-party/themes/divi.php
@@ -3,7 +3,7 @@ defined( 'ABSPATH' ) || die( 'Cheatin&#8217; uh?' );
 
 $current_theme = wp_get_theme();
 
-if ( 'Divi' === $current_theme->get( 'Name' ) ) :
+if ( 'Divi' === $current_theme->get( 'Name' ) || 'Divi' === $current_theme->get( 'Template' ) ) :
 	/**
 	 * Excludes Divi's Salvatorre script from JS minification
 	 *
@@ -23,4 +23,29 @@ if ( 'Divi' === $current_theme->get( 'Name' ) ) :
 		return $excluded_js;
 	}
 	add_filter( 'rocket_exclude_js', 'rocket_exclude_js_divi' );
+
+	/**
+	 * Excludes Divi main CSS files from Optimize CSS Delivery
+	 *
+	 * Prevents a display issue with the Divi Blog Module
+	 *
+	 * @since 3.3.3
+	 * @author Remy Perona
+	 *
+	 * @param array $excluded_css An array of excluded CSS
+	 * @return array
+	 */
+	function rocket_exclude_async_css_divi( $excluded_css ) {
+		if ( ! get_rocket_option( 'async_css' ) ) {
+			return $excluded_css;
+		}
+
+		$excluded_css[] = rocket_clean_exclude_file( get_stylesheet_uri() );
+		$excluded_css[] = rocket_clean_exclude_file( get_template_directory_uri() . '/style.css' );
+
+		return $excluded_css;
+	}
+	add_filter( 'rocket_exclude_async_css', 'rocket_exclude_async_css_divi' );
+	add_filter( 'rocket_exclude_cache_busting', 'rocket_exclude_async_css_divi' );
+	add_filter( 'rocket_exclude_css', 'rocket_exclude_async_css_divi' );
 endif;

--- a/inc/classes/optimization/class-remove-query-string.php
+++ b/inc/classes/optimization/class-remove-query-string.php
@@ -67,6 +67,22 @@ class Remove_Query_String extends Abstract_Optimization {
 		$this->options      = $options;
 		$this->busting_path = $busting_path . get_current_blog_id() . '/';
 		$this->busting_url  = $busting_url . get_current_blog_id() . '/';
+	}
+
+	/**
+	 * Returns a regex-ready string with the excluded filepaths for the Remove Query Strings option
+	 *
+	 * @since 3.3.3
+	 * @author Remy Perona
+	 *
+	 * @return string
+	 */
+	protected function get_excluded_files() {
+		static $excluded_files;
+
+		if ( isset( $excluded_files ) ) {
+			return $excluded_files;
+		}
 
 		/**
 		 * Filters files to exclude from cache busting
@@ -76,16 +92,23 @@ class Remove_Query_String extends Abstract_Optimization {
 		 *
 		 * @param array $excluded_files An array of filepath to exclude.
 		 */
-		$this->excluded_files = apply_filters( 'rocket_exclude_cache_busting', array() );
+		$excluded_files = apply_filters( 'rocket_exclude_cache_busting', [] );
 
-		if ( ! empty( $this->excluded_files ) ) {
-			foreach ( $this->excluded_files as $i => $excluded_file ) {
-				// Escape character for future use in regex pattern.
-				$this->excluded_files[ $i ] = str_replace( '#', '\#', $excluded_file );
-			}
+		if ( empty( $excluded_files ) ) {
+			$excluded_files = '';
 
-			$this->excluded_files = implode( '|', $this->excluded_files );
+			return $excluded_files;
 		}
+
+		foreach ( $excluded_files as $i => $excluded_file ) {
+			// Escape character for future use in regex pattern.
+			$excluded_files[ $i ] = str_replace( '#', '\#', $excluded_file );
+		}
+
+
+		$excluded_files = implode( '|', $excluded_files );
+
+		return $excluded_files;
 	}
 
 	/**
@@ -239,7 +262,7 @@ class Remove_Query_String extends Abstract_Optimization {
 	 * @return bool
 	 */
 	protected function is_excluded( $url ) {
-		if ( ! empty( $this->excluded_files ) && preg_match( '#^' . $this->excluded_files . '$#', rocket_clean_exclude_file( $url ) ) ) {
+		if ( ! empty( $this->get_excluded_files() ) && preg_match( '#^' . $this->get_excluded_files() . '$#', rocket_clean_exclude_file( $url ) ) ) {
 			return true;
 		}
 


### PR DESCRIPTION
Also exclude the file from minification and remove query strings if Optimize CSS Delivery is active.

At the same time, correct an issue in the remove query strings class that was preventing files from being added to the exclusion, as the filter was not executed at all.