### PR TITLE
fixes #1698 Facebook Pixel add-on causes errors 404 due to filename m…

### DIFF
--- a/inc/classes/busting/class-facebook-pickles.php
+++ b/inc/classes/busting/class-facebook-pickles.php
@@ -1050,7 +1050,7 @@ class Facebook_Pickles {
 		$plugin_names = [
 			'identity',
 			'microdata',
-			'inferredevents',
+			'inferredEvents',
 			'dwell',
 			'sessions',
 			'timespent',


### PR DESCRIPTION
Fixes this:
https://github.com/wp-media/wp-rocket/issues/1698