### PR TITLE
Auto-exclude quicklinkOptions & mts_view_count inline JS

### DIFF
--- a/inc/classes/optimization/JS/class-combine.php
+++ b/inc/classes/optimization/JS/class-combine.php
@@ -459,6 +459,7 @@ class Combine extends Abstract_JS_Optimization {
 			'elementorFrontendConfig',
 			'omapi_localized',
 			'_atrk_opts',
+			'quicklinkOptions',
 		];
 
 		$excluded_inline = array_merge( $defaults, $this->options->get( 'exclude_inline_js', [] ) );
@@ -596,6 +597,7 @@ class Combine extends Abstract_JS_Optimization {
 			'wmp_update',
 			'gform_ajax_frame_',
 			'gform_post_render',
+			'mts_view_count',
 		];
 
 		/**


### PR DESCRIPTION
mts_view_count contains the post id.
quicklinkOptions contains the current URL.

Both should be auto-excluded to avoid cache dir size issue.

Related ticket:
https://secure.helpscout.net/conversation/834984595/105328/