### PR TITLE
Autoexclude act_css_tooltip from Inline JS

### DIFF
--- a/inc/classes/optimization/JS/class-combine.php
+++ b/inc/classes/optimization/JS/class-combine.php
@@ -598,6 +598,7 @@ class Combine extends Abstract_JS_Optimization {
 			'gform_ajax_frame_',
 			'gform_post_render',
 			'mts_view_count',
+			'act_css_tooltip',
 		];
 
 		/**


### PR DESCRIPTION
The pattern is included into jQuery function. Need to be excluded after the concatenated JS file.
https://www.diffchecker.com/X4TZhxDK#left-2