### PR TITLE
Exclude inline patterns from being combined.

### DIFF
--- a/inc/classes/optimization/JS/class-combine.php
+++ b/inc/classes/optimization/JS/class-combine.php
@@ -458,6 +458,8 @@ class Combine extends Abstract_JS_Optimization {
 			'ad_block_',
 			'elementorFrontendConfig',
 			'omapi_localized',
+			'dataTable({',
+			'rankMath = {',
 		];
 
 		$excluded_inline = array_merge( $defaults, $this->options->get( 'exclude_inline_js', [] ) );


### PR DESCRIPTION
`dataTable({`
https://www.diffchecker.com/PTJsGHOA

TablePress plugin
/wp-content/plugins/tablepress/js/jquery.datatables.min.js

---
`var rankMath = {`
https://www.diffchecker.com/lPVGCbve

Rank Math
https://wordpress.org/plugins/seo-by-rank-math/

---
**Related ticket**
https://secure.helpscout.net/conversation/834984595/105328/
