### PR TITLE
Fixes #1644 Clear cron events on uninstall

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -25,6 +25,8 @@ delete_metadata( 'user', '', 'rocket_boxes', '', true );
 // Clear scheduled WP Rocket Cron.
 wp_clear_scheduled_hook( 'rocket_purge_time_event' );
 wp_clear_scheduled_hook( 'rocket_database_optimization_time_event' );
+wp_clear_scheduled_hook( 'rocket_google_tracking_cache_update' );
+wp_clear_scheduled_hook( 'rocket_facebook_tracking_cache_update' );
 
 /**
  * Remove all cache files.


### PR DESCRIPTION
For Facebook and Google Tracking add-ons