### PR TITLE
Fixes #1196 Exclude common external jQuery from defer JS safe mode

### DIFF
--- a/inc/functions/options.php
+++ b/inc/functions/options.php
@@ -468,9 +468,13 @@ function get_rocket_exclude_defer_js() {
 	];
 
 	if ( get_rocket_option( 'defer_all_js', 0 ) && get_rocket_option( 'defer_all_js_safe', 0 ) ) {
-		$jquery = site_url( $wp_scripts->registered['jquery-core']->src );
+		$jquery            = site_url( $wp_scripts->registered['jquery-core']->src );
+		$jetpack_jquery    = 'c0.wp.com/c/(?:.+)/wp-includes/js/jquery/jquery.js';
+		$googleapis_jquery = 'ajax.googleapis.com/ajax/libs/jquery/(?:.+)/jquery(?:\.min)?.js';
 
 		$exclude_defer_js[] = rocket_clean_exclude_file( $jquery );
+		$exclude_defer_js[] = $jetpack_jquery;
+		$exclude_defer_js[] = $googleapis_jquery;
 	}
 
 	/**

--- a/tests/Integration/Functions/Options/TestExcludeDeferJS.php
+++ b/tests/Integration/Functions/Options/TestExcludeDeferJS.php
@@ -1,0 +1,48 @@
+<?php
+namespace WP_Rocket\Tests\Integration\Functions\Options;
+
+use PHPUnit\Framework\TestCase;
+
+class TestExcludeDeferJS extends TestCase {
+    public function testShouldReturnExcludeDeferJSArray() {
+        $exclude_defer_js = [
+            'gist.github.com',
+            'content.jwplatform.com',
+            'js.hsforms.net',
+            'www.uplaunch.com',
+            'google.com/recaptcha',
+            'widget.reviews.co.uk',
+        ];
+
+        $this->assertSame(
+            $exclude_defer_js,
+            get_rocket_exclude_defer_js()
+        );
+    }
+
+    public function testShouldReturnExcludeDeferJSArrayWhenSafeMode() {
+        $options = [
+            'defer_all_js' => 1,
+            'defer_all_js_safe' => 1,
+        ];
+
+        update_option( 'wp_rocket_settings', $options );
+
+        $exclude_defer_js = [
+            'gist.github.com',
+            'content.jwplatform.com',
+            'js.hsforms.net',
+            'www.uplaunch.com',
+            'google.com/recaptcha',
+            'widget.reviews.co.uk',
+            '/wp-includes/js/jquery/jquery.js',
+            'c0.wp.com/c/(?:.+)/wp-includes/js/jquery/jquery.js',
+            'ajax.googleapis.com/ajax/libs/jquery/(?:.+)/jquery(?:\.min)?.js',
+        ];
+
+        $this->assertSame(
+            $exclude_defer_js,
+            get_rocket_exclude_defer_js()
+        );
+    }
+}

--- a/tests/Unit/Functions/Options/TestExcludeDeferJS.php
+++ b/tests/Unit/Functions/Options/TestExcludeDeferJS.php
@@ -1,0 +1,72 @@
+<?php
+namespace WP_Rocket\Tests\Unit\Functions\Options;
+
+use PHPUnit\Framework\TestCase;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+
+/**
+ * @runTestsInSeparateProcesses
+ */
+class TestExcludeDeferJS extends TestCase {
+    protected function setUp() {
+        parent::setUp();
+        Monkey\setUp();
+
+        global $wp_scripts;
+        $wp_scripts = new \stdClass();
+        $jquery = new \stdClass();
+        $jquery->src = '/wp-includes/js/jquery/jquery.js';
+        $wp_scripts->registered = [
+            'jquery-core' => $jquery,
+        ];
+
+        require( WP_ROCKET_PLUGIN_ROOT . 'inc/functions/options.php' );
+    }
+
+    protected function tearDown() {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    public function testShouldReturnExcludeDeferJSArray() {
+        Functions\when( 'get_rocket_option' )->justReturn(0);
+
+        $exclude_defer_js = [
+            'gist.github.com',
+            'content.jwplatform.com',
+            'js.hsforms.net',
+            'www.uplaunch.com',
+            'google.com/recaptcha',
+            'widget.reviews.co.uk',
+        ];
+
+        $this->assertSame(
+            $exclude_defer_js,
+            get_rocket_exclude_defer_js()
+        );
+    }
+
+    public function testShouldReturnExcludeDeferJSArrayWhenSafeMode() {
+        Functions\when( 'get_rocket_option' )->justReturn(1);
+        Functions\when('site_url')->returnArg();
+        Functions\when('rocket_clean_exclude_file')->returnArg();
+
+        $exclude_defer_js = [
+            'gist.github.com',
+            'content.jwplatform.com',
+            'js.hsforms.net',
+            'www.uplaunch.com',
+            'google.com/recaptcha',
+            'widget.reviews.co.uk',
+            '/wp-includes/js/jquery/jquery.js',
+            'c0.wp.com/c/(?:.+)/wp-includes/js/jquery/jquery.js',
+            'ajax.googleapis.com/ajax/libs/jquery/(?:.+)/jquery(?:\.min)?.js',
+        ];
+
+        $this->assertSame(
+            $exclude_defer_js,
+            get_rocket_exclude_defer_js()
+        );
+    }
+}

--- a/tests/Unit/Optimization/CSS/Combine/TestInsertCombinedCSS.php
+++ b/tests/Unit/Optimization/CSS/Combine/TestInsertCombinedCSS.php
@@ -8,7 +8,6 @@ use Brain\Monkey\Functions;
 
 class TestInsertCombinedCSS extends TestCase {
     protected function setUp() {
-        define( 'ABSPATH', 'path' );
         parent::setUp();
         Monkey\setUp();
     }

--- a/tests/Unit/bootstrap.php
+++ b/tests/Unit/bootstrap.php
@@ -18,5 +18,10 @@ if (! file_exists($rocket_common_autoload_path . 'autoload.php')) {
     die('Whoops, we need Composer before we start running tests.  Please type: `composer install`.  When done, try running `phpunit` again.');
 }
 
+if ( ! defined( 'ABSPATH' ) ) {
+    define( 'ABSPATH', WP_ROCKET_PLUGIN_ROOT );
+}
+
 require_once $rocket_common_autoload_path . 'autoload.php';
+
 unset($rocket_common_autoload_path);


### PR DESCRIPTION
Exclude jQuery loaded from `wp.com` CDN and from `ajax.googleapis.com`