### PR TITLE
Fixes #1707 Autoptimize & Avada lazyload compatibility

### DIFF
--- a/inc/3rd-party/plugins/autoptimize.php
+++ b/inc/3rd-party/plugins/autoptimize.php
@@ -12,6 +12,25 @@ endif;
 
 if ( class_exists( 'autoptimizeConfig' ) ) :
 	/**
+	 * Deactivate WP Rocket lazyload if Autoptimize lazyload is enabled
+	 *
+	 * @since 3.3.4
+	 * @author Remy Perona
+	 *
+	 * @param string $old_value Previous autoptimize option value.
+	 * @param string $value New autoptimize option value.
+	 * @return void
+	 */
+	function rocket_maybe_deactivate_lazyload( $old_value, $value ) {
+		if ( $value['autoptimize_imgopt_checkbox_field_3'] !== $old_value['autoptimize_imgopt_checkbox_field_3'] && 1 === (int) $value['autoptimize_imgopt_checkbox_field_3'] ) {
+			update_rocket_option( 'lazyload', 0 );
+			update_rocket_option( 'lazyload_iframes', 0 );
+			update_rocket_option( 'lazyload_youtube', 0 );
+		}
+	}
+	add_action( 'update_option_autoptimize_imgopt_settings', 'rocket_maybe_deactivate_lazyload', 10, 2 );
+
+	/**
 	 * Deactivate WP Rocket HTML Minification if Autoptimize HTML minification is enabled
 	 *
 	 * @since 2.9.5
@@ -103,8 +122,34 @@ function rocket_activate_autoptimize() {
 	if ( 'on' === get_option( 'autoptimize_css_defer' ) ) {
 		update_rocket_option( 'async_css', 0 );
 	}
+
+	$lazyload = get_option( 'autoptimize_imgopt_settings' );
+
+	if ( 1 === (int) $lazyload['autoptimize_imgopt_checkbox_field_3'] ) {
+		update_rocket_option( 'lazyload', 0 );
+		update_rocket_option( 'lazyload_iframes', 0 );
+		update_rocket_option( 'lazyload_youtube', 0 );
+	}
 }
 add_action( 'activate_autoptimize/autoptimize.php', 'rocket_activate_autoptimize', 11 );
+
+/**
+ * Disable WP Rocket lazyload fields if Autoptimize lazyload is enabled
+ *
+ * @since 3.3.4
+ * @author Remy Perona
+ *
+ * @return bool
+ */
+function rocket_maybe_disable_lazyload() {
+	$lazyload = get_option( 'autoptimize_imgopt_settings' );
+
+	if ( is_plugin_active( 'autoptimize/autoptimize.php' ) && 1 === (int) $lazyload['autoptimize_imgopt_checkbox_field_3'] ) {
+		return true;
+	}
+
+	return false;
+}
 
 /**
  * Disable WP Rocket HTML minification field if Autoptimize HTML minification is enabled

--- a/inc/3rd-party/plugins/autoptimize.php
+++ b/inc/3rd-party/plugins/autoptimize.php
@@ -22,7 +22,7 @@ if ( class_exists( 'autoptimizeConfig' ) ) :
 	 * @return void
 	 */
 	function rocket_maybe_deactivate_lazyload( $old_value, $value ) {
-		if ( $value['autoptimize_imgopt_checkbox_field_3'] !== $old_value['autoptimize_imgopt_checkbox_field_3'] && 1 === (int) $value['autoptimize_imgopt_checkbox_field_3'] ) {
+		if ( empty( $old_value['autoptimize_imgopt_checkbox_field_3'] ) && ! empty( $value['autoptimize_imgopt_checkbox_field_3'] ) ) {
 			update_rocket_option( 'lazyload', 0 );
 			update_rocket_option( 'lazyload_iframes', 0 );
 			update_rocket_option( 'lazyload_youtube', 0 );
@@ -125,7 +125,7 @@ function rocket_activate_autoptimize() {
 
 	$lazyload = get_option( 'autoptimize_imgopt_settings' );
 
-	if ( 1 === (int) $lazyload['autoptimize_imgopt_checkbox_field_3'] ) {
+	if ( ! empty( $lazyload['autoptimize_imgopt_checkbox_field_3'] ) ) {
 		update_rocket_option( 'lazyload', 0 );
 		update_rocket_option( 'lazyload_iframes', 0 );
 		update_rocket_option( 'lazyload_youtube', 0 );
@@ -144,7 +144,7 @@ add_action( 'activate_autoptimize/autoptimize.php', 'rocket_activate_autoptimize
 function rocket_maybe_disable_lazyload() {
 	$lazyload = get_option( 'autoptimize_imgopt_settings' );
 
-	if ( is_plugin_active( 'autoptimize/autoptimize.php' ) && 1 === (int) $lazyload['autoptimize_imgopt_checkbox_field_3'] ) {
+	if ( is_plugin_active( 'autoptimize/autoptimize.php' ) && ! empty( $lazyload['autoptimize_imgopt_checkbox_field_3'] ) ) {
 		return true;
 	}
 

--- a/inc/3rd-party/themes/avada.php
+++ b/inc/3rd-party/themes/avada.php
@@ -54,7 +54,7 @@ if ( 'Avada' === $current_theme->get( 'Name' ) ) {
 	 * @return void
 	 */
 	function rocket_avada_maybe_deactivate_lazyload( $old_value, $value ) {
-		if ( $value['lazy_load'] !== $old_value['lazy_load'] && 1 === (int) $value['lazy_load'] ) {
+		if ( empty( $old_value['lazy_load'] ) && ! empty( $value['lazy_load'] ) ) {
 			update_rocket_option( 'lazyload', 0 );
 		}
 	}
@@ -73,7 +73,7 @@ function rocket_avada_maybe_disable_lazyload() {
 	$avada_options = get_option( 'avada_theme_options' );
 	$current_theme = wp_get_theme();
 
-	if ( 'Avada' === $current_theme->get( 'Name' ) && 1 === (int) $avada_options['lazy_load'] ) {
+	if ( 'Avada' === $current_theme->get( 'Name' ) && ! empty( $avada_options['lazy_load'] ) ) {
 		return true;
 	}
 

--- a/inc/classes/admin/settings/class-page.php
+++ b/inc/classes/admin/settings/class-page.php
@@ -898,6 +898,8 @@ class Page {
 						'url' => $lazyload_beacon['url'],
 					],
 					'page'        => 'media',
+					// translators: %1$s = “WP Rocket”.
+					'helper' => rocket_maybe_disable_lazyload() ? sprintf( __( 'Lazyload is currently activated in <strong>Autoptimize</strong>. If you want to use %1$s’s lazyload, disable this option in Autoptimize.', 'rocket' ), WP_ROCKET_PLUGIN_NAME ) : '',
 				],
 				'emoji_section'    => [
 					'title'       => __( 'Emoji 👻', 'rocket' ),
@@ -923,9 +925,16 @@ class Page {
 					'page'              => 'media',
 					'default'           => 0,
 					'sanitize_callback' => 'sanitize_checkbox',
+					'container_class'   => [
+						rocket_maybe_disable_lazyload() ? 'wpr-isDisabled' : '',
+					],
+					'input_attr'        => [
+						'disabled' => rocket_maybe_disable_lazyload() ? 1 : 0,
+					],
 				],
 				'lazyload_iframes' => [
 					'container_class'   => [
+						rocket_maybe_disable_lazyload() ? 'wpr-isDisabled' : '',
 						'wpr-isParent',
 					],
 					'type'              => 'checkbox',
@@ -934,9 +943,13 @@ class Page {
 					'page'              => 'media',
 					'default'           => 0,
 					'sanitize_callback' => 'sanitize_checkbox',
+					'input_attr'        => [
+						'disabled' => rocket_maybe_disable_lazyload() ? 1 : 0,
+					],
 				],
 				'lazyload_youtube' => [
 					'container_class'   => [
+						rocket_maybe_disable_lazyload() ? 'wpr-isDisabled' : '',
 						'wpr-field--children',
 					],
 					'type'              => 'checkbox',
@@ -947,6 +960,9 @@ class Page {
 					'page'              => 'media',
 					'default'           => 0,
 					'sanitize_callback' => 'sanitize_checkbox',
+					'input_attr'        => [
+						'disabled' => rocket_maybe_disable_lazyload() ? 1 : 0,
+					],
 				],
 				'emoji'            => [
 					'type'              => 'checkbox',

--- a/inc/classes/admin/settings/class-page.php
+++ b/inc/classes/admin/settings/class-page.php
@@ -899,7 +899,7 @@ class Page {
 					],
 					'page'        => 'media',
 					// translators: %1$s = “WP Rocket”.
-					'helper' => rocket_maybe_disable_lazyload() ? sprintf( __( 'Lazyload is currently activated in <strong>Autoptimize</strong>. If you want to use %1$s’s lazyload, disable this option in Autoptimize.', 'rocket' ), WP_ROCKET_PLUGIN_NAME ) : '',
+					'helper'      => rocket_maybe_disable_lazyload() ? sprintf( __( 'Lazyload is currently activated in <strong>Autoptimize</strong>. If you want to use %1$s’s lazyload, disable this option in Autoptimize.', 'rocket' ), WP_ROCKET_PLUGIN_NAME ) : '',
 				],
 				'emoji_section'    => [
 					'title'       => __( 'Emoji 👻', 'rocket' ),
@@ -926,11 +926,12 @@ class Page {
 					'default'           => 0,
 					'sanitize_callback' => 'sanitize_checkbox',
 					'container_class'   => [
-						rocket_maybe_disable_lazyload() ? 'wpr-isDisabled' : '',
+						( rocket_avada_maybe_disable_lazyload() || rocket_maybe_disable_lazyload() ) ? 'wpr-isDisabled' : '',
 					],
 					'input_attr'        => [
-						'disabled' => rocket_maybe_disable_lazyload() ? 1 : 0,
+						'disabled' => ( rocket_avada_maybe_disable_lazyload() || rocket_maybe_disable_lazyload() ) ? 1 : 0,
 					],
+					'description'       => rocket_avada_maybe_disable_lazyload() ? _x('Lazyload for images is currently activated in Avada. If you want to use WP Rocket’s LazyLoad, disable this option in Avada.', 'Avada', 'rocket' ) : '',
 				],
 				'lazyload_iframes' => [
 					'container_class'   => [


### PR DESCRIPTION
Deactivate WP Rocket lazyload if Autoptimize or Avada lazyload is enabled