### PR TITLE
Update htaccess WP Rocket missing rules notice

### DIFF
--- a/inc/admin/ui/notices.php
+++ b/inc/admin/ui/notices.php
@@ -385,6 +385,10 @@ function rocket_warning_htaccess_permissions() {
 			return;
 	}
 
+	if ( rocket_check_htaccess_rules() ) {
+		return;
+	}
+
 	$boxes = get_user_meta( get_current_user_id(), 'rocket_boxes', true );
 
 	if ( in_array( __FUNCTION__, (array) $boxes, true ) ) {
@@ -393,15 +397,19 @@ function rocket_warning_htaccess_permissions() {
 
 	$message = rocket_notice_writing_permissions( '.htaccess' );
 
+	add_filter( 'rocket_htaccess_mod_rewrite', '__return_false' );
+
 	rocket_notice_html(
 		[
-			'status'           => 'error',
+			'status'           => 'warning',
 			'dismissible'      => '',
 			'message'          => $message,
 			'dismiss_button'   => __FUNCTION__,
 			'readonly_content' => get_rocket_htaccess_marker(),
 		]
 	);
+
+	remove_filter( 'rocket_htaccess_mod_rewrite', '__return_false' );
 }
 add_action( 'admin_notices', 'rocket_warning_htaccess_permissions' );
 

--- a/inc/admin/ui/notices.php
+++ b/inc/admin/ui/notices.php
@@ -395,21 +395,34 @@ function rocket_warning_htaccess_permissions() {
 		return;
 	}
 
-	$message = rocket_notice_writing_permissions( '.htaccess' );
+	$message = sprintf(
+		// translators: %s = plugin name.
+		__( '%s could not modify the .htaccess file due to missing writing permissions.', 'rocket' ),
+		'<strong>' . WP_ROCKET_PLUGIN_NAME . '</strong>'
+	);
+
+	$message .= '<br>' . sprintf(
+		/* translators: This is a doc title! %1$s = opening link; %2$s = closing link */
+		__( 'Troubleshoot: %1$sHow to make system files writeable%2$s', 'rocket' ),
+		/* translators: Documentation exists in EN, DE, FR, ES, IT; use loaclised URL if applicable */
+		'<a href="' . __( 'https://docs.wp-rocket.me/article/626-how-to-make-system-files-htaccess-wp-config-writeable/?utm_source=wp_plugin&utm_medium=wp_rocket', 'rocket' ) . '" target="_blank">',
+		'</a>'
+	);
 
 	add_filter( 'rocket_htaccess_mod_rewrite', '__return_false' );
 
-	rocket_notice_html(
-		[
-			'status'           => 'warning',
-			'dismissible'      => '',
-			'message'          => $message,
-			'dismiss_button'   => __FUNCTION__,
-			'readonly_content' => get_rocket_htaccess_marker(),
-		]
-	);
+	$message .= '<p>' . __( 'Don’t worry, WP Rocket’s page caching and settings will still function correctly.', 'rocket' ) . '<br>' . __( 'For optimal performance, adding the following lines into your .htaccess is recommended (not required):', 'rocket' ) . '<br><textarea readonly="readonly" id="rules" name="rules" class="large-text readonly" rows="6">' . esc_textarea( get_rocket_htaccess_marker() ) . '</textarea></p>';
 
 	remove_filter( 'rocket_htaccess_mod_rewrite', '__return_false' );
+
+	rocket_notice_html(
+		[
+			'status'         => 'warning',
+			'dismissible'    => '',
+			'message'        => $message,
+			'dismiss_button' => __FUNCTION__,
+		]
+	);
 }
 add_action( 'admin_notices', 'rocket_warning_htaccess_permissions' );
 
@@ -854,7 +867,7 @@ function rocket_notice_html( $args ) {
 			echo ( $tag ? '<p>' : '' ) . $args['message'] . ( $tag ? '</p>' : '' );
 		?>
 		<?php if ( ! empty( $args['readonly_content'] ) ) : ?>
-		<p><?php _e( 'The following code should have been written to this file:', 'rocket' ); ?>:
+		<p><?php _e( 'The following code should have been written to this file:', 'rocket' ); ?>
 			<br><textarea readonly="readonly" id="rules" name="rules" class="large-text readonly" rows="6"><?php echo esc_textarea( $args['readonly_content'] ); ?></textarea>
 		</p>
 		<?php

--- a/inc/admin/ui/notices.php
+++ b/inc/admin/ui/notices.php
@@ -411,7 +411,7 @@ function rocket_warning_htaccess_permissions() {
 
 	add_filter( 'rocket_htaccess_mod_rewrite', '__return_false' );
 
-	$message .= '<p>' . __( 'Don’t worry, WP Rocket’s page caching and settings will still function correctly.', 'rocket' ) . '<br>' . __( 'For optimal performance, adding the following lines into your .htaccess is recommended (not required):', 'rocket' ) . '<br><textarea readonly="readonly" id="rules" name="rules" class="large-text readonly" rows="6">' . esc_textarea( get_rocket_htaccess_marker() ) . '</textarea></p>';
+	$message .= '<p>' . __( 'Don’t worry, WP Rocket’s page caching and settings will still function correctly.', 'rocket' ) . '<br>' . __( 'For optimal performance, adding the following lines into your .htaccess is recommended (not required):', 'rocket' ) . '<br><textarea readonly="readonly" id="rocket_htaccess_rules" name="rocket_htaccess_rules" class="large-text readonly" rows="6">' . esc_textarea( get_rocket_htaccess_marker() ) . '</textarea></p>';
 
 	remove_filter( 'rocket_htaccess_mod_rewrite', '__return_false' );
 

--- a/inc/functions/htaccess.php
+++ b/inc/functions/htaccess.php
@@ -198,33 +198,33 @@ function get_rocket_htaccess_mod_rewrite() {
 	}
 
 	/**
-	  * Replace the dots by underscores to avoid some bugs on some shared hosting services on filenames (not multisite compatible!)
-	  *
-	  * @since 1.3.0
-	  *
-	  * @param bool true will replace the . by _.
+	 * Replace the dots by underscores to avoid some bugs on some shared hosting services on filenames (not multisite compatible!)
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param bool true will replace the . by _.
 	 */
 	$http_host = apply_filters( 'rocket_url_no_dots', false ) ? rocket_remove_url_protocol( home_url() ) : '%{HTTP_HOST}';
 
 	/**
-	  * Allow the path to be fully printed or dependant od %DOCUMENT_ROOT (forced for 1&1 by default)
-	  *
-	  * @since 1.3.0
-	  *
-	  * @param bool true will force the path to be full.
+	 * Allow the path to be fully printed or dependant od %DOCUMENT_ROOT (forced for 1&1 by default)
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param bool true will force the path to be full.
 	 */
 	$is_1and1_or_force = apply_filters( 'rocket_force_full_path', strpos( $_SERVER['DOCUMENT_ROOT'], '/kunden/' ) === 0 );
 
-	$rules = '';
+	$rules      = '';
 	$gzip_rules = '';
-	$enc = '';
+	$enc        = '';
 
 	/**
-	  * Allow to serve gzip cache file
-	  *
-	  * @since 2.4
-	  *
-	  * @param bool true will force to serve gzip cache file.
+	 * Allow to serve gzip cache file
+	 *
+	 * @since 2.4
+	 *
+	 * @param bool true will force to serve gzip cache file.
 	 */
 	if ( function_exists( 'gzencode' ) && apply_filters( 'rocket_force_gzip_htaccess_rules', true ) ) {
 		$rules = '<IfModule mod_mime.c>' . PHP_EOL;
@@ -628,4 +628,28 @@ function rocket_has_wp_htaccess_rules( $content ) {
 	 * @param string $content      .htaccess content.
 	 */
 	return apply_filters( 'rocket_has_wp_htaccess_rules', $has_wp_rules, $content );
+}
+
+/**
+ * Check if WP Rocket htaccess rules are already present in the file
+ *
+ * @since 3.3.5
+ * @author Remy Perona
+ *
+ * @return bool
+ */
+function rocket_check_htaccess_rules() {
+	$htaccess_file = get_home_path() . '.htaccess';
+
+	if ( ! rocket_direct_filesystem()->is_readable( $htaccess_file ) ) {
+		return false;
+	}
+
+	$htaccess = rocket_direct_filesystem()->get_contents( $htaccess_file );
+
+	if ( preg_match( '/\s*# BEGIN WP Rocket.*# END WP Rocket\s*?/isU', $htaccess ) ) {
+		return true;
+	}
+
+	return false;
 }


### PR DESCRIPTION
Closes #1555 
Closes #1651 

- Check if the WP Rocket rules are already present in the htaccess before displaying the notice
- Update the notice wording and switch the type from error to warning