### PR TITLE
Auto-exclude 4 new Inline JS patterns

### DIFF
--- a/inc/classes/optimization/JS/class-combine.php
+++ b/inc/classes/optimization/JS/class-combine.php
@@ -476,6 +476,8 @@ class Combine extends Abstract_JS_Optimization {
 			'omapi_data',
 			'tminusnow',
 			'nfForms',
+			'galleries.gallery_',
+			'wcj_evt.prodID',
 		];
 
 		$excluded_inline = array_merge( $defaults, $this->options->get( 'exclude_inline_js', [] ) );
@@ -617,6 +619,8 @@ class Combine extends Abstract_JS_Optimization {
 			'mts_view_count',
 			'act_css_tooltip',
 			'window.SLB',
+			'wpt_view_count',
+			'var dateNow',
 		];
 
 		/**


### PR DESCRIPTION
From:

1
- https://wp-media.slack.com/archives/CK74JC6JK/p1560557937078100
- No diff check available (the website was down)

2
- https://wp-media.slack.com/archives/CK74JC6JK/p1560558662078300
- https://www.diffchecker.com/wmhdR6Pz#left-2

3
- https://wp-media.slack.com/archives/CK74JC6JK/p1560562318078400
- https://www.diffchecker.com/pB3AqGb2#left-3

4
- https://wp-media.slack.com/archives/CK74JC6JK/p1560584837094200
- https://www.diffchecker.com/5BD1e5VX#left-3