### PR TITLE
Change the wording for Minify HTML in the options meta-box.

### DIFF
--- a/inc/admin/ui/meta-boxes.php
+++ b/inc/admin/ui/meta-boxes.php
@@ -72,7 +72,7 @@ function rocket_display_cache_options_meta_boxes() {
 			$fields = array(
 				'lazyload'         => __( 'LazyLoad for images', 'rocket' ),
 				'lazyload_iframes' => __( 'LazyLoad for iframes/videos', 'rocket' ),
-				'minify_html'      => __( 'Minify/combine HTML', 'rocket' ),
+				'minify_html'      => __( 'Minify HTML', 'rocket' ),
 				'minify_css'       => __( 'Minify/combine CSS', 'rocket' ),
 				'minify_js'        => __( 'Minify/combine JS', 'rocket' ),
 				'cdn'              => __( 'CDN', 'rocket' ),


### PR DESCRIPTION
This is just a minor change of the **Minify HTML** feature wording in WP Rocket's options meta-box.