### PR TITLE
Exclude "Springbot.product_id" inline JS to avoid the cache directory size issue

### DIFF
--- a/inc/classes/optimization/JS/class-combine.php
+++ b/inc/classes/optimization/JS/class-combine.php
@@ -496,6 +496,7 @@ class Combine extends Abstract_JS_Optimization {
 			'metrilo.event',
 			'wordpress_page_root',
 			'wcct_info',
+			'Springbot.product_id',
 		];
 
 		$excluded_inline = array_merge( $defaults, $this->options->get( 'exclude_inline_js', [] ) );


### PR DESCRIPTION
Exclude "Springbot.product_id" inline JS to avoid the cache directory size issue.

**Diff file:**
https://www.diffchecker.com/a7TCCJQG

**Related Ticket:**
https://secure.helpscout.net/conversation/893164866/114243?folderId=2135277