### PR TITLE
Exclude CPTs and custom taxonomies from CPCSS generation

### DIFF
--- a/inc/classes/optimization/CSS/class-critical-css.php
+++ b/inc/classes/optimization/CSS/class-critical-css.php
@@ -190,6 +190,8 @@ class Critical_CSS {
 				'karma-slider',
 				'tt-gallery',
 				'xlwcty_thankyou',
+				'fusion_template',
+				'blocks',
 			]
 		);
 
@@ -246,6 +248,7 @@ class Critical_CSS {
 				'karma-slider-category',
 				'truethemes-gallery-category',
 				'coupon_campaign',
+				'element_category',
 			]
 		);
 


### PR DESCRIPTION
Exclude the following CPTs from the CPCSS generation:
* `fusion_template` - Avada Fusion Builder
* `blocks` - Flatsome UX Blocks

Exclude custom taxonomy:
* `element_category` - Avada Fusion Builder

**Related tickets:**
* https://secure.helpscout.net/conversation/883742688/113030?folderId=2135277
* https://secure.helpscout.net/conversation/886155490/113352?folderId=2135277