### PR TITLE
Fix a small typo: ";" added twice

### DIFF
--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -59,7 +59,7 @@ function get_rocket_advanced_cache_file() {
 		[
 			\'cache_dir_path\' => \'' . WP_ROCKET_CACHE_PATH . '\',
 		]
-	) )->maybe_init_process();;' . "\n";
+	) )->maybe_init_process();' . "\n";
 	$buffer .= "} else {\n";
 	// Add a constant to provent include issue.
 	$buffer .= "\tdefine( 'WP_ROCKET_ADVANCED_CACHE_PROBLEM', true );\n";


### PR DESCRIPTION
There was a double ";" in the `advanced-cache.php` file.