### PR TITLE
Fixes #1193 Check for SSL using the $_SERVER superglobal values

### DIFF
--- a/inc/admin/upgrader.php
+++ b/inc/admin/upgrader.php
@@ -418,6 +418,11 @@ function rocket_new_upgrade( $wp_rocket_version, $actual_version ) {
 	}
 
 	if ( version_compare( $actual_version, '3.3.6', '<' ) ) {
+		if ( rocket_is_ssl_website() ) {
+			update_rocket_option( 'cache_ssl', 1 );
+			rocket_generate_config_file();
+		}
+
 		delete_site_transient( 'update_wprocket' );
 		delete_site_transient( 'update_wprocket_response' );
 	}

--- a/inc/functions/admin.php
+++ b/inc/functions/admin.php
@@ -124,10 +124,25 @@ function rocket_get_active_plugins() {
 /**
  * Check if the whole website is on the SSL protocol
  *
+ * @since 3.3.6 Use the superglobal $_SERVER values to detect SSL.
  * @since 2.7
  */
 function rocket_is_ssl_website() {
-	return 'https' === rocket_extract_url_component( home_url(), PHP_URL_SCHEME );
+	if ( isset( $_SERVER['HTTPS'] ) ) {
+		$https = sanitize_text_field( wp_unslash( $_SERVER['HTTPS'] ) );
+
+		if ( 'on' === strtolower( $https ) ) {
+			return true;
+		}
+
+		if ( '1' === (string) $https ) {
+			return true;
+		}
+	} elseif ( isset( $_SERVER['SERVER_PORT'] ) && '443' === (string) sanitize_text_field( wp_unslash( $_SERVER['SERVER_PORT'] ) ) ) {
+		return true;
+	}
+
+	return false;
 }
 
 /**


### PR DESCRIPTION
`home_url()` value is unreliable because of plugins used to apply SSL/HTTPS without updating the options values.