### PR TITLE
Exclude "function reenableButton", "#wpnbio-show", "e.Newsletter2GoTrackingObject" inline JS to avoid the cache directory size issue

### DIFF
--- a/inc/classes/optimization/JS/class-combine.php
+++ b/inc/classes/optimization/JS/class-combine.php
@@ -503,6 +503,9 @@ class Combine extends Abstract_JS_Optimization {
 			'wcct_info',
 			'Springbot.product_id',
 			'cedexisData',
+			'function reenableButton',
+			'#wpnbio-show',
+			'e.Newsletter2GoTrackingObject',
 		];
 
 		$excluded_inline = array_merge( $defaults, $this->options->get( 'exclude_inline_js', [] ) );


### PR DESCRIPTION
https://www.diffchecker.com/bwJ3UKhA
function reenableButton

https://www.diffchecker.com/0XTgKXsF
Exclude: #wpnbio-show / Plugin Render SeedProd Notification Bar Pro

https://www.screencast.com/t/FQV98UC27LB9
https://secure.helpscout.net/conversation/906601448/116512?folderId=3083222
e.Newsletter2GoTrackingObject