### PR TITLE
Closes #1597 Customization of ignored query string parameters during caching

### DIFF
--- a/inc/classes/Buffer/class-config.php
+++ b/inc/classes/Buffer/class-config.php
@@ -134,6 +134,7 @@ class Config {
 			'secret_cache_key'          => '',
 			'cache_reject_uri'          => '',
 			'cache_query_strings'       => [],
+			'cache_ignored_parameters'  => [],
 			'cache_reject_cookies'      => '',
 			'cache_reject_ua'           => '',
 			'cache_mandatory_cookies'   => '',

--- a/inc/classes/Buffer/class-tests.php
+++ b/inc/classes/Buffer/class-tests.php
@@ -1014,24 +1014,7 @@ class Tests {
 		// Remove some parameters.
 		$params = array_diff_key(
 			self::$get,
-			[
-				'utm_source'      => 1,
-				'utm_medium'      => 1,
-				'utm_campaign'    => 1,
-				'utm_expid'       => 1,
-				'utm_term'        => 1,
-				'utm_content'     => 1,
-				'fb_action_ids'   => 1,
-				'fb_action_types' => 1,
-				'fb_source'       => 1,
-				'fbclid'          => 1,
-				'gclid'           => 1,
-				'age-verified'    => 1,
-				'ao_noptimize'    => 1,
-				'usqp'            => 1,
-				'cn-reloaded'     => 1,
-				'_ga'             => 1,
-			]
+			$this->config->get_config( 'cache_ignored_parameters' )
 		);
 
 		if ( $params ) {

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -175,6 +175,7 @@ function get_rocket_config_file() {
 		}
 	}
 
+	$buffer .= '$rocket_cache_ignored_parameters = ' . call_user_func( 'var_export', rocket_get_ignored_parameters(), true ) . ";\n";
 	$buffer .= '$rocket_cache_mandatory_cookies = ' . call_user_func( 'var_export', get_rocket_cache_mandatory_cookies(), true ) . ";\n";
 
 	$buffer .= '$rocket_cache_dynamic_cookies = ' . call_user_func( 'var_export', get_rocket_cache_dynamic_cookies(), true ) . ";\n";

--- a/inc/functions/options.php
+++ b/inc/functions/options.php
@@ -152,6 +152,47 @@ function rocket_get_dns_prefetch_domains() {
 }
 
 /**
+ * Gets the parameters ignored during caching
+ *
+ * These parameters are ignored when checking the query string during caching to allow serving the default cache when they are present
+ *
+ * @since 3.4
+ * @author Remy Perona
+ *
+ * @return array
+ */
+function rocket_get_ignored_parameters() {
+	$params = [
+		'utm_source'      => 1,
+		'utm_medium'      => 1,
+		'utm_campaign'    => 1,
+		'utm_expid'       => 1,
+		'utm_term'        => 1,
+		'utm_content'     => 1,
+		'fb_action_ids'   => 1,
+		'fb_action_types' => 1,
+		'fb_source'       => 1,
+		'fbclid'          => 1,
+		'gclid'           => 1,
+		'age-verified'    => 1,
+		'ao_noptimize'    => 1,
+		'usqp'            => 1,
+		'cn-reloaded'     => 1,
+		'_ga'             => 1,
+	];
+
+	/**
+	 * Filters the ignored parameters
+	 *
+	 * @since 3.4
+	 * @author Remy Perona
+	 *
+	 * @param array $params An array of ignored parameters as array keys.
+	 */
+	return apply_filters( 'rocket_cache_ignored_parameters', $params );
+}
+
+/**
  * Get the interval task cron purge in seconds
  * This setting can be changed from the options page of the plugin
  *


### PR DESCRIPTION
Move the list of ignored query string parameters from hardcoded to the config file. The list is now filterable to be able to add/remove parameters as needed.