### PR TITLE
Fixes #306 Handle CDN exclusions when using Remove Query Strings/Minify

### DIFF
--- a/inc/classes/CDN/CDN.php
+++ b/inc/classes/CDN/CDN.php
@@ -204,7 +204,7 @@ class CDN {
 	 * @param string $url URL to check.
 	 * @return boolean
 	 */
-	private function is_excluded( $url ) {
+	public function is_excluded( $url ) {
 		if ( 'php' === pathinfo( strtok( $url, '?' ), PATHINFO_EXTENSION ) ) {
 			return true;
 		}

--- a/inc/classes/optimization/CSS/class-abstract-css-optimization.php
+++ b/inc/classes/optimization/CSS/class-abstract-css-optimization.php
@@ -79,9 +79,10 @@ abstract class Abstract_CSS_Optimization extends Abstract_Optimization {
 	 * @author Remy Perona
 	 *
 	 * @param string $filename Minified filename.
+	 * @param string $original_url Original URL for this file. Optional.
 	 * @return string
 	 */
-	protected function get_minify_url( $filename ) {
+	protected function get_minify_url( $filename, $original_url = '' ) {
 		$minify_url = $this->minify_base_url . $filename;
 
 		/**
@@ -90,8 +91,9 @@ abstract class Abstract_CSS_Optimization extends Abstract_Optimization {
 		 * @since 2.1
 		 *
 		 * @param string $minify_url Minified file URL.
-		*/
-		return apply_filters( 'rocket_css_url', $minify_url );
+		 * @param string $original_url Original URL for this file.
+		 */
+		return apply_filters( 'rocket_css_url', $minify_url, $original_url );
 	}
 
 	/**

--- a/inc/classes/optimization/CSS/class-minify.php
+++ b/inc/classes/optimization/CSS/class-minify.php
@@ -105,7 +105,7 @@ class Minify extends Abstract_CSS_Optimization {
 		$filename  = preg_replace( '/\.(css)$/', '-' . $unique_id . '.css', ltrim( rocket_realpath( rocket_extract_url_component( $url, PHP_URL_PATH ) ), '/' ) );
 
 		$minified_file = $this->minify_base_path . $filename;
-		$minify_url    = $this->get_minify_url( $filename );
+		$minify_url    = $this->get_minify_url( $filename, $url );
 
 		if ( rocket_direct_filesystem()->exists( $minified_file ) ) {
 			Logger::debug( 'Minified CSS file already exists.', [

--- a/inc/classes/optimization/JS/class-abstract-js-optimization.php
+++ b/inc/classes/optimization/JS/class-abstract-js-optimization.php
@@ -117,9 +117,10 @@ class Abstract_JS_Optimization extends Abstract_Optimization {
 	 * @author Remy Perona
 	 *
 	 * @param string $filename Minified filename.
+	 * @param string $original_url Original URL for this file. Optional.
 	 * @return string
 	 */
-	protected function get_minify_url( $filename ) {
+	protected function get_minify_url( $filename, $original_url = '' ) {
 		$minify_url = $this->minify_base_url . $filename;
 
 		/**
@@ -128,8 +129,9 @@ class Abstract_JS_Optimization extends Abstract_Optimization {
 		 * @since 2.1
 		 *
 		 * @param string $minify_url Minified file URL.
-		*/
-		return apply_filters( 'rocket_js_url', $minify_url );
+		 * @param string $original_url Original URL for this file.
+		 */
+		return apply_filters( 'rocket_js_url', $minify_url, $original_url );
 	}
 
 	/**

--- a/inc/classes/optimization/JS/class-minify.php
+++ b/inc/classes/optimization/JS/class-minify.php
@@ -114,7 +114,7 @@ class Minify extends Abstract_JS_Optimization {
 		$filename  = preg_replace( '/\.js$/', '-' . $unique_id . '.js', ltrim( rocket_realpath( rocket_extract_url_component( $url, PHP_URL_PATH ) ), '/' ) );
 
 		$minified_file = $this->minify_base_path . $filename;
-		$minified_url  = $this->get_minify_url( $filename );
+		$minified_url  = $this->get_minify_url( $filename, $url );
 
 		if ( rocket_direct_filesystem()->exists( $minified_file ) ) {
 			Logger::debug( 'Minified JS file already exists.', [

--- a/inc/classes/optimization/class-remove-query-string.php
+++ b/inc/classes/optimization/class-remove-query-string.php
@@ -295,7 +295,7 @@ class Remove_Query_String extends Abstract_Optimization {
 		}
 
 		$busting_file = $this->busting_path . $filename;
-		$busting_url  = $this->get_busting_url( $filename, $extension );
+		$busting_url  = $this->get_busting_url( $filename, $extension, $url );
 
 		if ( rocket_direct_filesystem()->is_readable( $busting_file ) ) {
 			return $busting_url;
@@ -332,19 +332,20 @@ class Remove_Query_String extends Abstract_Optimization {
 	 *
 	 * @param string $filename  Cache busting filename.
 	 * @param string $extension File extension.
+	 * @param string $original_url Original URL for the file.
 	 * @return string
 	 */
-	protected function get_busting_url( $filename, $extension ) {
+	protected function get_busting_url( $filename, $extension, $original_url ) {
 		$url = $this->busting_url . $filename;
 
 		switch ( $extension ) {
 			case 'css':
 				// This filter is documented in inc/classes/optimization/css/class-abstract-css-optimization.php.
-				$url = apply_filters( 'rocket_css_url', $url );
+				$url = apply_filters( 'rocket_css_url', $url, $original_url );
 				break;
 			case 'js':
 				// This filter is documented in inc/classes/optimization/css/class-abstract-js-optimization.php.
-				$url = apply_filters( 'rocket_js_url', $url );
+				$url = apply_filters( 'rocket_js_url', $url, $original_url );
 				break;
 		}
 

--- a/inc/classes/subscriber/CDN/CDNSubscriber.php
+++ b/inc/classes/subscriber/CDN/CDNSubscriber.php
@@ -42,11 +42,13 @@ class CDNSubscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events() {
 		return [
-			'rocket_buffer'           => [ 'rewrite', 24 ],
+			'rocket_buffer'           => [ 'rewrite', 13 ],
 			'rocket_css_content'      => 'rewrite_css_properties',
 			'rocket_cdn_hosts'        => [ 'get_cdn_hosts', 10, 2 ],
 			'rocket_dns_prefetch'     => 'add_dns_prefetch_cdn',
 			'rocket_facebook_sdk_url' => 'add_cdn_url',
+			'rocket_css_url'          => [ 'add_cdn_url', 10, 2 ],
+			'rocket_js_url'           => [ 'add_cdn_url', 10, 2 ],
 		];
 	}
 
@@ -84,7 +86,7 @@ class CDNSubscriber implements Subscriber_Interface {
 		 *
 		 * @param bool true to apply CDN to properties, false otherwise
 		 */
-		$do_rewrite = apply_filters( 'do_rocket_cdn_css_properties', true );
+		$do_rewrite = apply_filters( 'do_rocket_cdn_css_properties', true ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
 
 		if ( ! $do_rewrite ) {
 			return $content;
@@ -153,9 +155,16 @@ class CDNSubscriber implements Subscriber_Interface {
 	 * @author Remy Perona
 	 *
 	 * @param string $url URL to rewrite.
+	 * @param string $original_url Original URL for this URL. Optional.
 	 * @return string
 	 */
-	public function add_cdn_url( $url ) {
+	public function add_cdn_url( $url, $original_url = '' ) {
+		if ( ! empty( $original_url ) ) {
+			if ( $this->cdn->is_excluded( $original_url ) ) {
+				return $url;
+			}
+		}
+
 		return $this->cdn->rewrite_url( $url );
 	}
 

--- a/tests/Integration/Subscriber/CDNSubscriber/TestGetSubscribedEvents.php
+++ b/tests/Integration/Subscriber/CDNSubscriber/TestGetSubscribedEvents.php
@@ -7,11 +7,13 @@ use WP_Rocket\Subscriber\CDN\CDNSubscriber;
 class TestGetSubscribedEvents extends TestCase {
     public function testShouldReturnSubscribedEventsArray() {
         $events = [
-			'rocket_buffer'           => [ 'rewrite', 24 ],
+			'rocket_buffer'           => [ 'rewrite', 13 ],
 			'rocket_css_content'      => 'rewrite_css_properties',
 			'rocket_cdn_hosts'        => [ 'get_cdn_hosts', 10, 2 ],
 			'rocket_dns_prefetch'     => 'add_dns_prefetch_cdn',
 			'rocket_facebook_sdk_url' => 'add_cdn_url',
+			'rocket_css_url'          => [ 'add_cdn_url', 10, 2 ],
+			'rocket_js_url'           => [ 'add_cdn_url', 10, 2 ],
         ];
 
         $this->assertSame(


### PR DESCRIPTION
- CDN is applied before the other optimizations
- The original URL is provided to the methods returning the minify/busting URL, and passed to the filters
- the filters check if the original URL is excluded, and return the not CDN URL if it is