### PR TITLE
Exclude inline strings to avoid the cache directory size issue

### DIFF
--- a/inc/classes/optimization/JS/class-combine.php
+++ b/inc/classes/optimization/JS/class-combine.php
@@ -529,6 +529,12 @@ class Combine extends Abstract_JS_Optimization {
 			'var categories_',
 			'"+nRemaining+"',
 			'cartsguru_cart_token',
+			'after_share_easyoptin',
+			'location_data.push',
+			'thirstyFunctions.isThirstyLink',
+			'styles: \' #custom-menu-',
+			'function svc_center_',
+			'#svc_carousel2_container_',
 		];
 
 		$excluded_inline = array_merge( $defaults, $this->options->get( 'exclude_inline_js', [] ) );


### PR DESCRIPTION
`location_data.push`
https://www.diffchecker.com/CditTFOH

`thirstyFunctions.isThirstyLink`
https://www.diffchecker.com/CQ60gzKj

`styles: ' #custom-menu-`
https://www.diffchecker.com/WPj90oHR

```
function svc_center_
#svc_carousel2_container_
```
https://www.diffchecker.com/2ceKTZaK
