### PR TITLE
Exclude Beaver Builder Template Post Type From Critical CSS

### DIFF
--- a/inc/classes/optimization/CSS/class-critical-css.php
+++ b/inc/classes/optimization/CSS/class-critical-css.php
@@ -192,6 +192,7 @@ class Critical_CSS {
 				'xlwcty_thankyou',
 				'fusion_template',
 				'blocks',
+				'fl-builder-template',
 			]
 		);
 


### PR DESCRIPTION
This excludes the Beaver Builder template custom post type from the critical CSS process.