### PR TITLE
Add unit & integration tests for the Expired Cache Purge methods

### DIFF
--- a/inc/classes/ServiceProvider/class-common-subscribers.php
+++ b/inc/classes/ServiceProvider/class-common-subscribers.php
@@ -30,6 +30,8 @@ class Common_Subscribers extends AbstractServiceProvider {
 		'cdn',
 		'cdn_subscriber',
 		'capabilities_subscriber',
+		'expired_cache_purge',
+		'expired_cache_purge_subscriber',
 	];
 
 	/**
@@ -52,10 +54,12 @@ class Common_Subscribers extends AbstractServiceProvider {
 		$this->getContainer()->share( 'critical_css_subscriber', 'WP_Rocket\Subscriber\Optimization\Critical_CSS_Subscriber' )
 			->withArgument( $this->getContainer()->get( 'critical_css' ) )
 			->withArgument( $this->getContainer()->get( 'options' ) );
-		$this->getContainer()->share( 'cache_dir_size_check_subscriber', 'WP_Rocket\Subscriber\Tools\Cache_Dir_Size_Check_Subscriber' );
-		$this->getContainer()->share( 'automatic_cache_purge_subscriber', 'WP_Rocket\Subscriber\Cache\Automatic_Cache_Purge_Subscriber' )
-			->withArgument( $this->getContainer()->get( 'options' ) )
+		$this->getContainer()->add( 'expired_cache_purge', 'WP_Rocket\Cache\Expired_Cache_Purge' )
 			->withArgument( WP_ROCKET_CACHE_PATH );
+		$this->getContainer()->share( 'cache_dir_size_check_subscriber', 'WP_Rocket\Subscriber\Tools\Cache_Dir_Size_Check_Subscriber' );
+		$this->getContainer()->share( 'expired_cache_purge_subscriber', 'WP_Rocket\Subscriber\Cache\Expired_Cache_Purge_Subscriber' )
+			->withArgument( $this->getContainer()->get( 'options' ) )
+			->withArgument( $this->getContainer()->get( 'expired_cache_purge' ) );
 		$this->getContainer()->share( 'cdn', 'WP_Rocket\CDN\CDN' )
 			->withArgument( $this->getContainer()->get( 'options' ) );
 		$this->getContainer()->share( 'cdn_subscriber', 'WP_Rocket\Subscriber\CDN\CDNSubscriber' )

--- a/inc/classes/class-plugin.php
+++ b/inc/classes/class-plugin.php
@@ -127,7 +127,7 @@ class Plugin {
 			'sucuri_subscriber',
 			'facebook_tracking_subscriber',
 			'google_tracking_subscriber',
-			'automatic_cache_purge_subscriber',
+			'expired_cache_purge_subscriber',
 			'preload_subscriber',
 			'sitemap_preload_subscriber',
 			'partial_preload_subscriber',

--- a/inc/classes/subscriber/Cache/class-expired-cache-purge-subscriber.php
+++ b/inc/classes/subscriber/Cache/class-expired-cache-purge-subscriber.php
@@ -1,0 +1,143 @@
+<?php
+namespace WP_Rocket\Subscriber\Cache;
+
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Event_Management\Subscriber_Interface;
+use WP_Rocket\Cache\Expired_Cache_Purge;
+
+/**
+ * Event subscriber to clear cached files after lifespan.
+ *
+ * @since  3.4
+ * @author Grégory Viguier
+ */
+class Expired_Cache_Purge_Subscriber implements Subscriber_Interface {
+
+	/**
+	 * Cron name.
+	 *
+	 * @since  3.4
+	 * @author Grégory Viguier
+	 *
+	 * @var string
+	 */
+	const EVENT_NAME = 'rocket_purge_time_event';
+
+	/**
+	 * WP Rocket Options instance.
+	 *
+	 * @since  3.4
+	 * @access private
+	 * @author Grégory Viguier
+	 *
+	 * @var Options_Data
+	 */
+	private $options;
+
+	/**
+	 * Expired Cache Purge instance.
+	 *
+	 * @since 3.4
+	 * @access private
+	 * @author Remy Perona
+	 *
+	 * @var Expired_Cache_Purge
+	 */
+	private $purge;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Options_Data        $options Options instance.
+	 * @param Expired_Cache_Purge $purge   Purge instance.
+	 */
+	public function __construct( Options_Data $options, Expired_Cache_Purge $purge ) {
+		$this->options = $options;
+		$this->purge   = $purge;
+	}
+
+	/**
+	 * Return an array of events that this subscriber wants to listen to.
+	 *
+	 * @since  3.4
+	 * @access public
+	 * @author Grégory Viguier
+	 *
+	 * @return array
+	 */
+	public static function get_subscribed_events() {
+		return [
+			'init'                => 'schedule_event',
+			'rocket_deactivation' => 'unschedule_event',
+			static::EVENT_NAME    => 'purge_expired_files',
+		];
+	}
+
+
+	/** ----------------------------------------------------------------------------------------- */
+	/** HOOK CALLBACKS ========================================================================== */
+	/** ----------------------------------------------------------------------------------------- */
+
+	/**
+	 * Scheduling the cron event.
+	 * If the task is not programmed, it is automatically added.
+	 *
+	 * @since  3.4
+	 * @access public
+	 * @author Grégory Viguier
+	 */
+	public function schedule_event() {
+		if ( $this->get_cache_lifespan() && ! wp_next_scheduled( static::EVENT_NAME ) ) {
+			wp_schedule_event( time() + HOUR_IN_SECONDS, 'hourly', static::EVENT_NAME );
+		}
+	}
+
+	/**
+	 * Unschedule the event.
+	 *
+	 * @since  3.4
+	 * @access public
+	 * @author Grégory Viguier
+	 */
+	public function unschedule_event() {
+		wp_clear_scheduled_hook( static::EVENT_NAME );
+	}
+
+	/**
+	 * Perform the event action.
+	 *
+	 * @since  3.4
+	 * @access public
+	 * @author Grégory Viguier
+	 */
+	public function purge_expired_files() {
+		$this->purge->purge_expired_files( $this->get_cache_lifespan() );
+	}
+
+	/**
+	 * Get the cache lifespan in seconds.
+	 * If no value is filled in the settings, return 0. It means the purge is disabled.
+	 * If the value from the settings is filled but invalid, fallback to the initial value (10 hours).
+	 *
+	 * @since  3.4
+	 * @access public
+	 * @author Grégory Viguier
+	 *
+	 * @return int The cache lifespan in seconds.
+	 */
+	public function get_cache_lifespan() {
+		$lifespan = $this->options->get( 'purge_cron_interval' );
+
+		if ( ! $lifespan ) {
+			return 0;
+		}
+
+		$unit = $this->options->get( 'purge_cron_unit' );
+
+		if ( $lifespan < 0 || ! $unit || ! defined( $unit ) ) {
+			return 10 * HOUR_IN_SECONDS;
+		}
+
+		return $lifespan * constant( $unit );
+	}
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,6 +16,7 @@
     <testsuites>
         <testsuite name="unit">
             <directory suffix=".php">tests/Unit</directory>
+            <exclude>./tests/Unit/TestCase.php</exclude>
         </testsuite>
     </testsuites>
 

--- a/tests/Integration/Subscriber/ExpiredCachePurgeSubscriber/TestGetCacheLifespan.php
+++ b/tests/Integration/Subscriber/ExpiredCachePurgeSubscriber/TestGetCacheLifespan.php
@@ -1,0 +1,64 @@
+<?php
+namespace WP_Rocket\Tests\Integration\Subscriber\ExpiredCachePurgeSubscriber;
+
+use PHPUnit\Framework\TestCase;
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Admin\Options;
+use WP_Rocket\Cache\Expired_Cache_Purge;
+use WP_Rocket\Subscriber\Cache\Expired_Cache_Purge_Subscriber;
+
+class TestGetCacheLifespan extends TestCase {
+	public function testShouldReturnLifespan() {
+		update_option(
+			'wp_rocket_settings',
+			[
+				'purge_cron_interval' => 10,
+				'purge_cron_unit'     => HOUR_IN_SECONDS,
+			]
+		);
+
+		$options        = new Options_Data( (new Options( 'wp_rocket_'))->get( 'settings' ) );
+		$expired_cache_purge_subscriber = new Expired_Cache_Purge_Subscriber( $options, new Expired_Cache_Purge( WP_ROCKET_CACHE_PATH ) );
+
+		$this->assertSame(
+			36000,
+			$expired_cache_purge_subscriber->get_cache_lifespan()
+		);
+	}
+
+	public function testShouldReturnZeroWhenNoLifespan() {
+		update_option(
+			'wp_rocket_settings',
+			[
+				'purge_cron_interval' => 0,
+				'purge_cron_unit'     => HOUR_IN_SECONDS,
+			]
+		);
+
+		$options        = new Options_Data( (new Options( 'wp_rocket_'))->get( 'settings' ) );
+		$expired_cache_purge_subscriber = new Expired_Cache_Purge_Subscriber( $options, new Expired_Cache_Purge( WP_ROCKET_CACHE_PATH ) );
+
+		$this->assertSame(
+			0,
+			$expired_cache_purge_subscriber->get_cache_lifespan()
+		);
+	}
+
+	public function testShouldReturnDefaultValueWhenIncorrect() {
+		update_option(
+			'wp_rocket_settings',
+			[
+				'purge_cron_interval' => -10,
+				'purge_cron_unit'     => '',
+			]
+		);
+
+		$options        = new Options_Data( (new Options( 'wp_rocket_'))->get( 'settings' ) );
+		$expired_cache_purge_subscriber = new Expired_Cache_Purge_Subscriber( $options, new Expired_Cache_Purge( WP_ROCKET_CACHE_PATH ) );
+
+		$this->assertSame(
+			36000,
+			$expired_cache_purge_subscriber->get_cache_lifespan()
+		);
+	}
+}

--- a/tests/Integration/Subscriber/ExpiredCachePurgeSubscriber/TestGetSubscribedEvents.php
+++ b/tests/Integration/Subscriber/ExpiredCachePurgeSubscriber/TestGetSubscribedEvents.php
@@ -1,0 +1,20 @@
+<?php
+namespace WP_Rocket\Tests\Integration\Subscriber\ExpiredCachePurgeSubscriber;
+
+use PHPUnit\Framework\TestCase;
+use WP_Rocket\Subscriber\Cache\Expired_Cache_Purge_Subscriber;
+
+class TestGetSubscribedEvents extends TestCase {
+	public function testShouldReturnSubscribedEventsArray() {
+		$events = [
+			'init'                    => 'schedule_event',
+			'rocket_deactivation'     => 'unschedule_event',
+			'rocket_purge_time_event' => 'purge_expired_files',
+		];
+
+		$this->assertSame(
+			$events,
+			Expired_Cache_Purge_Subscriber::get_subscribed_events()
+		);
+	}
+}

--- a/tests/Integration/Subscriber/ExpiredCachePurgeSubscriber/TestScheduleEvent.php
+++ b/tests/Integration/Subscriber/ExpiredCachePurgeSubscriber/TestScheduleEvent.php
@@ -22,7 +22,7 @@ class TestScheduleEvent extends TestCase {
 
 		$expired_cache_purge_subscriber->schedule_event();
 
-		$event = wp_get_scheduled_event( 'rocket_purge_time_event' );
+		$event = wp_next_scheduled( 'rocket_purge_time_event' );
 
 		$this->assertNotFalse( $event );
 
@@ -43,7 +43,7 @@ class TestScheduleEvent extends TestCase {
 
 		$expired_cache_purge_subscriber->schedule_event();
 
-		$event = wp_get_scheduled_event( 'rocket_purge_time_event' );
+		$event = wp_next_scheduled( 'rocket_purge_time_event' );
 
 		$this->assertFalse( $event );
 	}

--- a/tests/Integration/Subscriber/ExpiredCachePurgeSubscriber/TestScheduleEvent.php
+++ b/tests/Integration/Subscriber/ExpiredCachePurgeSubscriber/TestScheduleEvent.php
@@ -1,0 +1,50 @@
+<?php
+namespace WP_Rocket\Tests\Integration\Subscriber\ExpiredCachePurgeSubscriber;
+
+use PHPUnit\Framework\TestCase;
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Admin\Options;
+use WP_Rocket\Cache\Expired_Cache_Purge;
+use WP_Rocket\Subscriber\Cache\Expired_Cache_Purge_Subscriber;
+
+class TestScheduleEvent extends TestCase {
+	public function testShouldScheduleEvent() {
+		update_option(
+			'wp_rocket_settings',
+			[
+				'purge_cron_interval' => 10,
+				'purge_cron_unit'     => HOUR_IN_SECONDS,
+			]
+		);
+
+		$options        = new Options_Data( (new Options( 'wp_rocket_'))->get( 'settings' ) );
+		$expired_cache_purge_subscriber = new Expired_Cache_Purge_Subscriber( $options, new Expired_Cache_Purge( WP_ROCKET_CACHE_PATH ) );
+
+		$expired_cache_purge_subscriber->schedule_event();
+
+		$event = wp_get_scheduled_event( 'rocket_purge_time_event' );
+
+		$this->assertNotFalse( $event );
+
+		wp_clear_scheduled_hook( 'rocket_purge_time_event' );
+	}
+
+	public function testShouldNotScheduleEventWhenNoLifespan() {
+		update_option(
+			'wp_rocket_settings',
+			[
+				'purge_cron_interval' => 0,
+				'purge_cron_unit'     => HOUR_IN_SECONDS,
+			]
+		);
+
+		$options        = new Options_Data( (new Options( 'wp_rocket_'))->get( 'settings' ) );
+		$expired_cache_purge_subscriber = new Expired_Cache_Purge_Subscriber( $options, new Expired_Cache_Purge( WP_ROCKET_CACHE_PATH ) );
+
+		$expired_cache_purge_subscriber->schedule_event();
+
+		$event = wp_get_scheduled_event( 'rocket_purge_time_event' );
+
+		$this->assertFalse( $event );
+	}
+}

--- a/tests/Unit/Cache/TestPurgeExpiredFiles.php
+++ b/tests/Unit/Cache/TestPurgeExpiredFiles.php
@@ -1,0 +1,108 @@
+<?php
+namespace WP_Rocket\Tests\Unit\Cache;
+
+use WP_Rocket\Tests\Unit\TestCase;
+use WP_Rocket\Cache\Expired_Cache_Purge;
+use Brain\Monkey\Functions;
+use org\bovigo\vfs\vfsStream,
+	org\bovigo\vfs\vfsStreamDirectory;
+
+class TestPurgeExpiredFiles extends TestCase {
+	private $cache_path;
+	private $mock_fs;
+
+	public function setUp() {
+		parent::setUp();
+
+		$structure = [
+			'wp-rocket' => [
+				'example.org' => [
+					'index.html' => '',
+					'index.html_gzip' => '',
+					'about' => [
+						'index.html'=> '',
+						'index.html_gzip' => '',
+						'index-mobile.html' => '',
+						'index-mobile.html_gzip' => '',
+					],
+					'category' => [
+						'wordpress' => [
+							'index.html' => '',
+							'index.html_gzip' => '',
+						],
+					],
+					'blog' => [
+						'index.html' => '',
+						'index.html_gzip' => '',
+					],
+				],
+			],
+		];
+
+		$this->cache_path = vfsStream::setup( 'cache', null, $structure );
+		$this->cache_path->getChild('wp-rocket')->getChild('example.org')->getChild('blog')->getChild('index.html')->lastAttributeModified( strtotime( '11 hours ago' ) );
+		$this->cache_path->getChild('wp-rocket')->getChild('example.org')->getChild('blog')->getChild('index.html_gzip')->lastAttributeModified( strtotime( '11 hours ago' ) );
+
+		$this->mock_fs = $this->getMockBuilder( 'WP_Filesystem_Direct' )
+							->setMethods( [
+								'exists',
+								'delete'
+							])
+							->getMock();
+		$this->mock_fs->method('exists')->will($this->returnCallback('file_exists'));
+		$this->mock_fs->method('delete')->will($this->returnCallback(function($file) {
+			if ( @is_file( $file ) ) {
+				@unlink( $file );
+			} elseif ( @is_dir( $file ) ) {
+				@rmdir( $file );
+			}
+		}));
+	}
+
+	public function testShouldReturnNullWhenNoLifespan() {
+		$expired_cache_purge = new Expired_Cache_Purge( $this->cache_path->getChild( 'wp-rocket' )->url() );
+
+		$this->assertNull( $expired_cache_purge->purge_expired_files( 0 ) );
+	}
+
+	public function testShouldReturnNullWhenNoURLs() {
+		Functions\When('get_rocket_i18n_uri')->justReturn(
+			[
+				null,
+				1,
+				'',
+			]
+		);
+
+		$expired_cache_purge = new Expired_Cache_Purge( $this->cache_path->getChild( 'wp-rocket' )->url() );
+
+		$this->assertNull( $expired_cache_purge->purge_expired_files( 36000 ) );
+	}
+
+	public function testShouldDeleteCacheFilesOlderThanLifespan() {
+		Functions\When('get_rocket_i18n_uri')->justReturn(
+			[
+				'http://example.org/'
+			]
+		);
+
+		Functions\When( 'rocket_direct_filesystem')->alias( function() {
+			return $this->mock_fs;
+		});
+
+		Functions\When('get_rocket_parse_url')->alias( function( $value ) {
+			return parse_url( $value );
+		} );
+
+		$expired_cache_purge = new Expired_Cache_Purge( $this->cache_path->getChild( 'wp-rocket' )->url() );
+
+		$expired_cache_purge->purge_expired_files( 36000 );
+
+		$this->assertFalse(
+			$this->cache_path->getChild('wp-rocket')->getChild('example.org')->hasChild('blog')
+		);
+		$this->assertTrue(
+			$this->cache_path->getChild('wp-rocket')->getChild('example.org')->getChild('about')->hasChild('index.html')
+		);
+	}
+}


### PR DESCRIPTION
- Split code between 2 classes
- Rename `Automatic_Cache_Purge` to `Expired_Cache_Purge`
- Reduce complexity in `Expired_Cache_Purge::purge_expired_files()`
- Add unit & integration tests