### PR TITLE
Allow standard caching query parameters to be extended. 

### DIFF
--- a/inc/front/process.php
+++ b/inc/front/process.php
@@ -103,6 +103,7 @@ $rocket_remove_query_strings = [
 	'utm_medium'      => 1,
 	'utm_campaign'    => 1,
 	'utm_expid'       => 1,
+	'utm_term'        => 1,
 	'fb_action_ids'   => 1,
 	'fb_action_types' => 1,
 	'fb_source'       => 1,

--- a/inc/front/process.php
+++ b/inc/front/process.php
@@ -116,6 +116,15 @@ $rocket_remove_query_strings = [
 	'_ga'             => 1,
 ];
 
+/**
+ * Allow standard caching query parameters to be extended using a constant
+ *
+ * Example: define( 'WP_ROCKET_STANDARD_CACHING_QUERY_PARAMS', [ 'foo' => 1 ] );
+ */
+if ( defined( 'WP_ROCKET_STANDARD_CACHING_QUERY_PARAMS' ) && is_array( WP_ROCKET_STANDARD_CACHING_QUERY_PARAMS ) ) {
+	$rocket_remove_query_strings = array_merge( $rocket_remove_query_strings, WP_ROCKET_STANDARD_CACHING_QUERY_PARAMS );
+}
+
 $params = [];
 
 if ( ! empty( $_GET ) ) {


### PR DESCRIPTION
Howdy!

This PR does two things. 

1. It corrects an oversight in the solution for this issue:
https://github.com/wp-media/wp-rocket/issues/1564

`utm_term` was added to the Buffer testing class, but it doesn't appear to have been added to `inc/front/process.php`, which means the parameter was never fully implemented. (Unless I'm missing something!)

2. It adds a constant `WP_ROCKET_STANDARD_CACHING_QUERY_PARAMS` that allows users to add additional parameters for standard caching. These parameters are merged with the default list, so users are able to extend but not remove the default parameters. 

Happy to make changes if there are any issues with this proposal. 

Thanks!
Clif