### PR TITLE
Changed INT to String for FB APP_ID

### DIFF
--- a/inc/classes/busting/class-facebook-pickles.php
+++ b/inc/classes/busting/class-facebook-pickles.php
@@ -90,7 +90,7 @@ class Facebook_Pickles {
 	 * @access private
 	 * @author Grégory Viguier
 	 */
-	private $config_file_url = 'https://connect.facebook.net/signals/config/%d?v=%s&r=stable';
+	private $config_file_url = 'https://connect.facebook.net/signals/config/%s?v=%s&r=stable';
 
 	/**
 	 * Config file name (local).


### PR DESCRIPTION
Fixes: #1819 - Facebook Pixel config file - changed INT to String to have the correct FB APP_ID