### PR TITLE
Auto-exclude some CSS files from Uncode theme to be "busted"

### DIFF
--- a/inc/3rd-party/themes/uncode.php
+++ b/inc/3rd-party/themes/uncode.php
@@ -66,10 +66,16 @@ if ( 'uncode' === strtolower( $current_theme->get( 'Name' ) ) || 'uncode' === st
 		 * @since 3.3.3
 		 * @author Remy Perona
 		 *
-		 * @param array $exclude_busting Array of JS filepaths to be excluded.
+		 * @param array $exclude_busting Array of CSS and JS filepaths to be excluded.
 		 * @return array
 		 */
 		function rocket_exclude_busting_uncode( $exclude_busting ) {
+			// CSS files.
+			$exclude_busting[] = rocket_clean_exclude_file( get_template_directory_uri() . '/library/css/style.css' );
+			$exclude_busting[] = rocket_clean_exclude_file( get_template_directory_uri() . '/library/css/uncode-icons.css' );
+			$exclude_busting[] = rocket_clean_exclude_file( get_template_directory_uri() . '/library/css/style-custom.css' );
+
+			// JS files.
 			$exclude_busting[] = rocket_clean_exclude_file( get_template_directory_uri() . '/library/js/init.js' );
 			$exclude_busting[] = rocket_clean_exclude_file( get_template_directory_uri() . '/library/js/min/init.min.js' );
 			$exclude_busting[] = rocket_clean_exclude_file( get_template_directory_uri() . '/library/js/app.js' );


### PR DESCRIPTION
With Uncode version prior to 2.10, some CSS files need to be auto-excluded from the busting system.

I found one case from our log system:
https://wp-media.slack.com/archives/CK74JC6JK/p1566246389002200