### PR TITLE
Added excluded JS

### DIFF
--- a/inc/classes/optimization/JS/class-combine.php
+++ b/inc/classes/optimization/JS/class-combine.php
@@ -537,6 +537,12 @@ class Combine extends Abstract_JS_Optimization {
 			'#svc_carousel2_container_',
 			'wpseo_map_init',
 			'mdf_current_page_url',
+			'top.location,thispage',
+			'selection+pagelink',
+			'ic_window_resolution',
+			'PHP.wp_p_id',
+			'ShopifyBuy.UI.onReady(client)',
+			'orig_request_uri',
 		];
 
 		$excluded_inline = array_merge( $defaults, $this->options->get( 'exclude_inline_js', [] ) );
@@ -705,6 +711,31 @@ class Combine extends Abstract_JS_Optimization {
 			'cb_nombre',
 			'$(\'.fl-node-',
 			'function($){google_maps_'
+			'et_animation_data=',
+			'current_url="',
+			'CustomEvent.prototype=window.Event.prototype',
+			'electro-wc-product-gallery',
+			'woof_is_mobile',
+			'jQuery(\'.videonextup',
+			'wpp_params',
+			'us.templateDirectoryUri=',
+			'.fat-gallery-item',
+			'.ratingbox',
+			'user_rating.prototype.eraseCookie',
+			'test_run_nf_conditional',
+			'dpsp-networks-btns-wrapper',
+			'pa_woo_product_info',
+			'sharing_enabled_on_post_via_metabox',
+			'#product-search-field-',
+			'GOTMLS_login_offset',
+			'berocket_aapf_time_to_fix_products_style',
+			'window.vc_googleMapsPointer',
+			'sinceID_',
+			'#ut-background-video-ut-section'
+			'+window.comment_tab_width+',
+			'dfd-button-hover-in',
+			'wpseo-address-wrapper',
+			'platform.stumbleupon.com',
 		];
 
 		/**


### PR DESCRIPTION
A corrected version of this PR:
https://github.com/wp-media/wp-rocket/pull/1911

Moved scripts that require jQuery to the proper array.