### PR TITLE
Prevent duplicating cache files without webp

### DIFF
--- a/inc/classes/subscriber/Media/class-webp-subscriber.php
+++ b/inc/classes/subscriber/Media/class-webp-subscriber.php
@@ -159,6 +159,8 @@ class Webp_Subscriber implements Subscriber_Interface {
 			$this->filesystem = \rocket_direct_filesystem();
 		}
 
+		$has_hebp = false;
+
 		foreach ( $attributes as $attribute ) {
 			if ( preg_match( '@srcset$@i', strtolower( $attribute['name'] ) ) ) {
 				/**
@@ -178,8 +180,27 @@ class Webp_Subscriber implements Subscriber_Interface {
 			}
 
 			// Replace in content.
+			$has_hebp = true;
 			$new_attr = preg_replace( '@' . $attribute['name'] . '\s*=\s*["\'][^"\']+["\']@s', $attribute['name'] . '="' . $new_value . '"', $attribute[0] );
 			$html     = str_replace( $attribute[0], $new_attr, $html );
+		}
+
+		/**
+		 * Tell if the page contains webp files.
+		 *
+		 * @since  3.4
+		 * @author Grégory Viguier
+		 *
+		 * @param bool   $has_hebp True if the page contains webp files. False otherwise.
+		 * @param string $html     The page’s html contents.
+		 */
+		$has_hebp = apply_filters( 'rocket_page_has_hebp_files', $has_hebp, $html );
+
+		// Tell the cache process if some URLs have been replaced.
+		if ( $has_hebp ) {
+			$html .= '<!-- Rocket has webp -->';
+		} else {
+			$html .= '<!-- Rocket no webp -->';
 		}
 
 		return $html;

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -715,6 +715,14 @@ function rocket_clean_home( $lang = '' ) {
 		}
 	}
 
+	// Remove the hidden empty file for webp.
+	$nowebp_detect_files = glob( $root . '/.no-webp', GLOB_BRACE | GLOB_NOSORT );
+	if ( $nowebp_detect_files ) {
+		foreach ( $nowebp_detect_files as $nowebp_detect_file ) { // no array map to use @.
+			rocket_direct_filesystem()->delete( $nowebp_detect_file );
+		}
+	}
+
 	/**
 	 * Fires after the home cache file was deleted
 	 *
@@ -1027,6 +1035,13 @@ function rocket_rrmdir( $dir, $dirs_to_preserve = array() ) {
 
 	if ( rocket_direct_filesystem()->is_dir( $dir ) && rocket_direct_filesystem()->exists( $nginx_mobile_detect_file ) ) {
 		rocket_direct_filesystem()->delete( $nginx_mobile_detect_file );
+	}
+
+	// Remove the hidden empty file for webp.
+	$nowebp_detect_file = $dir . '/.no-webp';
+
+	if ( rocket_direct_filesystem()->is_dir( $dir ) && rocket_direct_filesystem()->exists( $nowebp_detect_file ) ) {
+		rocket_direct_filesystem()->delete( $nowebp_detect_file );
 	}
 
 	if ( ! rocket_direct_filesystem()->is_dir( $dir ) ) {

--- a/inc/functions/htaccess.php
+++ b/inc/functions/htaccess.php
@@ -219,6 +219,12 @@ function get_rocket_htaccess_mod_rewrite() {
 	$gzip_rules = '';
 	$enc        = '';
 
+	if ( $is_1and1_or_force ) {
+		$cache_dir_path = str_replace( '/kunden/', '/', WP_ROCKET_CACHE_PATH ) . $http_host . '%{REQUEST_URI}';
+	} else {
+		$cache_dir_path = '%{DOCUMENT_ROOT}/' . ltrim( $cache_root, '/' ) . $http_host . '%{REQUEST_URI}';
+	}
+
 	/**
 	 * Allow to serve gzip cache file
 	 *
@@ -245,7 +251,7 @@ function get_rocket_htaccess_mod_rewrite() {
 	$rules .= 'RewriteEngine On' . PHP_EOL;
 	$rules .= 'RewriteBase ' . $home_root . PHP_EOL;
 	$rules .= get_rocket_htaccess_ssl_rewritecond();
-	$rules .= rocket_get_webp_rewritecond();
+	$rules .= rocket_get_webp_rewritecond( $cache_dir_path );
 	$rules .= $gzip_rules;
 	$rules .= 'RewriteCond %{REQUEST_METHOD} GET' . PHP_EOL;
 	$rules .= 'RewriteCond %{QUERY_STRING} =""' . PHP_EOL;
@@ -267,12 +273,7 @@ function get_rocket_htaccess_mod_rewrite() {
 		$rules .= 'RewriteCond %{HTTP_USER_AGENT} !^(' . $ua . ').* [NC]' . PHP_EOL;
 	}
 
-	if ( $is_1and1_or_force ) {
-		$rules .= 'RewriteCond "' . str_replace( '/kunden/', '/', WP_ROCKET_CACHE_PATH ) . $http_host . '%{REQUEST_URI}/index%{ENV:WPR_SSL}%{ENV:WPR_WEBP}.html' . $enc . '" -f' . PHP_EOL;
-	} else {
-		$rules .= 'RewriteCond "%{DOCUMENT_ROOT}/' . ltrim( $cache_root, '/' ) . $http_host . '%{REQUEST_URI}/index%{ENV:WPR_SSL}%{ENV:WPR_WEBP}.html' . $enc . '" -f' . PHP_EOL;
-	}
-
+	$rules .= 'RewriteCond "' . $cache_dir_path . '/index%{ENV:WPR_SSL}%{ENV:WPR_WEBP}.html' . $enc . '" -f' . PHP_EOL;
 	$rules .= 'RewriteRule .* "' . $cache_root . $http_host . '%{REQUEST_URI}/index%{ENV:WPR_SSL}%{ENV:WPR_WEBP}.html' . $enc . '" [L]' . PHP_EOL;
 	$rules .= '</IfModule>' . PHP_EOL;
 
@@ -350,14 +351,16 @@ function get_rocket_htaccess_ssl_rewritecond() {
  * @since  3.4
  * @author Grégory Viguier
  *
- * @return string $rules Rules that will be printed.
+ * @param  string $cache_dir_path Path to the cache directory, without trailing slash.
+ * @return string                 Rules that will be printed.
  */
-function rocket_get_webp_rewritecond() {
+function rocket_get_webp_rewritecond( $cache_dir_path ) {
 	if ( ! get_rocket_option( 'cache_webp' ) ) {
 		return '';
 	}
 
 	$rules  = 'RewriteCond %{HTTP_ACCEPT} image/webp' . PHP_EOL;
+	$rules .= 'RewriteCond "' . $cache_dir_path . '/.no-webp" !-f' . PHP_EOL;
 	$rules .= 'RewriteRule .* - [E=WPR_WEBP:-webp]' . PHP_EOL;
 
 	/**


### PR DESCRIPTION
When a page doesn’t contain webp files, don’t create a webp cache file identical to its non-webp version. Instead, create an empty `.no-webp` file and serve the non-webp cache.
Also fix an issue where webp files would be delivered to browsers not compatible with webp.