### PR TITLE
Fixes #1940: Minify inline JS & CSS - prevent PREG_BACKTRACK_LIMIT_ERROR

### DIFF
--- a/inc/vendors/classes/class-minify-html.php
+++ b/inc/vendors/classes/class-minify-html.php
@@ -95,7 +95,7 @@ class Minify_HTML
         }
 
         $this->_replacementHash = 'MINIFYHTML' . md5($_SERVER['REQUEST_TIME']);
-        $this->_placeholders = array();
+        $this->_placeholders    = array();
 
         // replace SCRIPTs (and minify) with placeholders
         // preg_replace_callback - on errors the return is NULL
@@ -105,7 +105,7 @@ class Minify_HTML
             ,array($this, '_removeScriptCB')
             ,$this->_html);
 
-        if (isset($pregJs) && !empty($pregJs)) {
+        if ( isset($pregJs) && ! empty( $pregJs ) ) {
             $this->_html = $pregJs;
         }
 
@@ -117,7 +117,7 @@ class Minify_HTML
             ,array($this, '_removeStyleCB')
             ,$this->_html);
 
-        if (isset($pregCSS) && !empty($pregCSS)) {
+        if ( isset( $pregCSS ) && ! empty( $pregCSS ) ) {
             $this->_html = $pregCSS;
         }
 

--- a/inc/vendors/classes/class-minify-html.php
+++ b/inc/vendors/classes/class-minify-html.php
@@ -98,10 +98,16 @@ class Minify_HTML
         $this->_placeholders = array();
 
         // replace SCRIPTs (and minify) with placeholders
-        $this->_html = preg_replace_callback(
+        // preg_replace_callback - on errors the return is NULL
+        // On big scripts PREG_BACKTRACK_LIMIT_ERROR is reached and causes the empty page
+        $pregJs = preg_replace_callback(
             '/(\\s*)<script(\\b[^>]*?>)([\\s\\S]*?)<\\/script>(\\s*)/i'
             ,array($this, '_removeScriptCB')
             ,$this->_html);
+
+        if (isset($pregJs) && !empty($pregJs)) {
+            $this->_html = $pregJs;
+        }
 
         // replace STYLEs (and minify) with placeholders
         $this->_html = preg_replace_callback(
@@ -248,7 +254,7 @@ class Minify_HTML
 
     protected function _removeCdata($str)
     {
-	   	$data = array();
+	    $data = array();
 
 	    if ( false !== strpos( $str, '<![CDATA[' ) ) {
 		    $data['content'] = str_replace( array( '/* <![CDATA[ */', '/* ]]> */' ), '', $str );

--- a/inc/vendors/classes/class-minify-html.php
+++ b/inc/vendors/classes/class-minify-html.php
@@ -110,10 +110,16 @@ class Minify_HTML
         }
 
         // replace STYLEs (and minify) with placeholders
-        $this->_html = preg_replace_callback(
+        // preg_replace_callback - on errors the return is NULL
+        // On big scripts PREG_BACKTRACK_LIMIT_ERROR is reached and causes the empty page
+        $pregCSS = preg_replace_callback(
             '/\\s*<style(\\b[^>]*>)([\\s\\S]*?)<\\/style>\\s*/i'
             ,array($this, '_removeStyleCB')
             ,$this->_html);
+
+        if (isset($pregCSS) && !empty($pregCSS)) {
+            $this->_html = $pregCSS;
+        }
 
         // remove HTML comments (not containing IE conditional comments).
         $this->_html = preg_replace_callback(


### PR DESCRIPTION
Big inline JS scripts are causing PREG_BACKTRACK_LIMIT_ERROR and the page will be empty.
preg_replace_callback - on errors the return is NULL

Solution: if preg_replace_callback return is NULL, then do not minify any inline JS code to prevent this issue. 

The issue was identified from: WooCommerce Blocks plugin:
https://wordpress.org/plugins/woo-gutenberg-products-block/

There is excessive JS (1.5MB of JS) from it causing the issue with WP Rocket: https://wordpress.org/support/topic/causes-excessive-js/

