### PR TITLE
Fixes #1931: Minify HTML do not take into account attribute values that span multiple lines

### DIFF
--- a/inc/vendors/classes/class-minify-html.php
+++ b/inc/vendors/classes/class-minify-html.php
@@ -128,7 +128,10 @@ class Minify_HTML
 
         // trim each line.
         // @todo take into account attribute values that span multiple lines.
-        $this->_html = preg_replace('/^\\s+|\\s+$/m', '', $this->_html);
+        // Fixed attribute values which span on multiple lines. Causes double spaces "  "
+        $this->_html = preg_replace('/^\\s+|\\s+$/m', ' ', $this->_html);
+        // Fixed double spaces. Replaced with a single space
+        $this->_html = preg_replace('/  +/', ' ', $this->_html);
 
         // remove ws around block/undisplayed elements
         $this->_html = preg_replace('/\\s+(<\\/?(?:area|article|aside|base(?:font)?|blockquote|body'
@@ -248,7 +251,7 @@ class Minify_HTML
 
     protected function _removeCdata($str)
     {
-	   	$data = array();
+	    $data = array();
 
 	    if ( false !== strpos( $str, '<![CDATA[' ) ) {
 		    $data['content'] = str_replace( array( '/* <![CDATA[ */', '/* ]]> */' ), '', $str );

--- a/inc/vendors/classes/class-minify-html.php
+++ b/inc/vendors/classes/class-minify-html.php
@@ -129,9 +129,9 @@ class Minify_HTML
         // trim each line.
         // @todo take into account attribute values that span multiple lines.
         // Fixed attribute values which span on multiple lines. Causes double spaces "  "
-        $this->_html = preg_replace('/^\\s+|\\s+$/m', ' ', $this->_html);
+        $this->_html = preg_replace('/^\s+|\s+$/m', ' ', $this->_html);
         // Fixed double spaces. Replaced with a single space
-        $this->_html = preg_replace('/  +/', ' ', $this->_html);
+        $this->_html = preg_replace('/\s+/', ' ', $this->_html);
 
         // remove ws around block/undisplayed elements
         $this->_html = preg_replace('/\\s+(<\\/?(?:area|article|aside|base(?:font)?|blockquote|body'


### PR DESCRIPTION
Minify HTML will break at trimming each line when attributes span on multiple lines:

This line is causing the issue:
wp-rocket/inc/vendors/classes/class-minify-html.php

$this->_html = preg_replace('/^\\s+|\\s+$/m', '', $this->_html); 

SOLUTION:

// Fixed attribute values which span on multiple lines. Causes double spaces "  "
$this->_html = preg_replace('/^\\s+|\\s+$/m', ' ', $this->_html);
// Fixed double spaces. Replaced with a single space
$this->_html = preg_replace('/  +/', ' ', $this->_html);

