### PR TITLE
Fix preloader not preloading webp cache

### DIFF
--- a/inc/classes/subscriber/Media/class-webp-subscriber.php
+++ b/inc/classes/subscriber/Media/class-webp-subscriber.php
@@ -94,15 +94,16 @@ class Webp_Subscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events() {
 		return [
-			'rocket_buffer'                           => [ 'convert_to_webp', 23 ],
-			'rocket_cache_webp_setting_field'         => [
+			'rocket_buffer'                            => [ 'convert_to_webp', 23 ],
+			'rocket_cache_webp_setting_field'          => [
 				[ 'maybe_disable_setting_field' ],
 				[ 'webp_section_description' ],
 			],
-			'rocket_disable_webp_cache'               => 'maybe_disable_webp_cache',
-			'rocket_third_party_webp_change'          => 'sync_webp_cache_with_third_party_plugins',
-			'rocket_preload_url_request_args'         => 'add_accept_header',
-			'rocket_partial_preload_url_request_args' => 'add_accept_header',
+			'rocket_disable_webp_cache'                => 'maybe_disable_webp_cache',
+			'rocket_third_party_webp_change'           => 'sync_webp_cache_with_third_party_plugins',
+			'rocket_homepage_preload_url_request_args' => 'add_accept_header',
+			'rocket_preload_url_request_args'          => 'add_accept_header',
+			'rocket_partial_preload_url_request_args'  => 'add_accept_header',
 		];
 	}
 
@@ -377,6 +378,7 @@ class Webp_Subscriber implements Subscriber_Interface {
 			return $args;
 		}
 
+		$args['headers']['Accept']      = 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8';
 		$args['headers']['HTTP_ACCEPT'] = 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8';
 
 		return $args;


### PR DESCRIPTION
The header `Accept` was missing and has been added.
Also, the request to the home page was not filtered, it has been corrected.