### PR TITLE
Improved the way to get the "webp header"

### DIFF
--- a/inc/classes/Buffer/class-cache.php
+++ b/inc/classes/Buffer/class-cache.php
@@ -600,18 +600,14 @@ class Cache extends Abstract_Buffer {
 			return $filename;
 		}
 
-		if ( function_exists( 'apache_request_headers' ) ) {
+		$http_accept = $this->config->get_server_input( 'HTTP_ACCEPT', '' );
+
+		if ( ! $http_accept && function_exists( 'apache_request_headers' ) ) {
 			$headers     = apache_request_headers();
-			$http_accept = ( isset( $headers['Accept'] ) ) ? $headers['Accept'] : '';
-		} else {
-			$http_accept = $this->config->get_server_input( 'HTTP_ACCEPT', '' );
+			$http_accept = isset( $headers['Accept'] ) ? $headers['Accept'] : '';
 		}
 
-		if ( ! $http_accept ) {
-			return $filename;
-		}
-
-		if ( false === strpos( $http_accept, 'webp' ) ) {
+		if ( ! $http_accept || false === strpos( $http_accept, 'webp' ) ) {
 			return $filename;
 		}
 

--- a/inc/classes/subscriber/Media/class-webp-subscriber.php
+++ b/inc/classes/subscriber/Media/class-webp-subscriber.php
@@ -145,11 +145,11 @@ class Webp_Subscriber implements Subscriber_Interface {
 		}
 
 		// Only to supporting browsers.
-		if ( function_exists( 'apache_request_headers' ) ) {
+		$http_accept = isset( $this->server['HTTP_ACCEPT'] ) ? $this->server['HTTP_ACCEPT'] : '';
+
+		if ( ! $http_accept && function_exists( 'apache_request_headers' ) ) {
 			$headers     = apache_request_headers();
 			$http_accept = isset( $headers['Accept'] ) ? $headers['Accept'] : '';
-		} else {
-			$http_accept = isset( $this->server['HTTP_ACCEPT'] ) ? $this->server['HTTP_ACCEPT'] : '';
 		}
 
 		if ( ! $http_accept || false === strpos( $http_accept, 'webp' ) ) {


### PR DESCRIPTION
`apache_request_headers()` doesn’t seem to be reliable, while `$_SERVER` seems to be. So let’s use `$_SERVER` first, then `apache_request_headers()` only as fallback.