### PR TITLE
Exlude inline JavaScript keywords

### DIFF
--- a/inc/classes/optimization/JS/class-combine.php
+++ b/inc/classes/optimization/JS/class-combine.php
@@ -540,6 +540,8 @@ class Combine extends Abstract_JS_Optimization {
 			'advads_has_ads',
 			'wpseo_map_init',
 			'mdf_current_page_url',
+			'searchwp_live_search_params',
+			'wpp_params',
 		];
 
 		$excluded_inline = array_merge( $defaults, $this->options->get( 'exclude_inline_js', [] ) );


### PR DESCRIPTION
`searchwp_live_search_params`
https://www.diffchecker.com/S9DskgXe

`wpp_params`
https://www.diffchecker.com/dC1r6WPl
