### PR TITLE
Fixes: #1949 remove lazyload.js file & code when Lazyload is disabled on a specific page

### DIFF
--- a/inc/classes/subscriber/Optimization/class-lazyload-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-lazyload-subscriber.php
@@ -184,7 +184,7 @@ class Lazyload_Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function insert_youtube_thumbnail_script() {
-		if ( ! $this->can_lazyload_iframes() ) {
+		if ( ! $this->options->get( 'lazyload_youtube' ) || ! $this->can_lazyload_iframes() ) {
 			return;
 		}
 
@@ -254,7 +254,7 @@ class Lazyload_Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function insert_youtube_thumbnail_style() {
-		if ( ! $this->can_lazyload_iframes() ) {
+		if ( ! $this->options->get( 'lazyload_youtube' ) || ! $this->can_lazyload_iframes() ) {
 			return;
 		}
 
@@ -452,10 +452,6 @@ class Lazyload_Subscriber implements Subscriber_Interface {
 	 * @return boolean
 	 */
 	private function can_lazyload_iframes() {
-		if ( ! $this->options->get( 'lazyload_youtube' ) ) {
-			return false;
-		}
-
 		if ( ! $this->options->get( 'lazyload_iframes' ) ) {
 			return false;
 		}

--- a/inc/classes/subscriber/Optimization/class-lazyload-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-lazyload-subscriber.php
@@ -106,20 +106,12 @@ class Lazyload_Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function insert_lazyload_script() {
-		if ( ! $this->options->get( 'lazyload' ) && ! $this->options->get( 'lazyload_iframes' ) ) {
-			return;
-		}
-
 		if ( ! $this->can_lazyload_images() && ! $this->can_lazyload_iframes() ) {
 			return;
 		}
 
 		if ( ! $this->should_lazyload() ) {
 			return;
-		}
-
-		if ( is_rocket_post_excluded_option( 'lazyload' ) ) {
-		 return;
 		}
 
 		/**
@@ -192,7 +184,7 @@ class Lazyload_Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function insert_youtube_thumbnail_script() {
-		if ( ! $this->options->get( 'lazyload_youtube' ) || ! $this->can_lazyload_iframes() ) {
+		if ( ! $this->can_lazyload_iframes() ) {
 			return;
 		}
 
@@ -262,7 +254,7 @@ class Lazyload_Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function insert_youtube_thumbnail_style() {
-		if ( ! $this->options->get( 'lazyload_youtube' ) || ! $this->can_lazyload_iframes() ) {
+		if ( ! $this->can_lazyload_iframes() ) {
 			return;
 		}
 
@@ -328,7 +320,7 @@ class Lazyload_Subscriber implements Subscriber_Interface {
 		$buffer = $this->ignore_scripts( $html );
 		$buffer = $this->ignore_noscripts( $buffer );
 
-		if ( $this->options->get( 'lazyload_iframes' ) && $this->can_lazyload_iframes() ) {
+		if ( $this->can_lazyload_iframes() ) {
 			$args = [
 				'youtube' => $this->options->get( 'lazyload_youtube' ),
 			];
@@ -336,7 +328,7 @@ class Lazyload_Subscriber implements Subscriber_Interface {
 			$html = $this->iframe->lazyloadIframes( $html, $buffer, $args );
 		}
 
-		if ( $this->options->get( 'lazyload' ) && $this->can_lazyload_images() ) {
+		if ( $this->can_lazyload_images() ) {
 			$html = $this->image->lazyloadPictures( $html, $buffer );
 			$html = $this->image->lazyloadImages( $html, $buffer );
 
@@ -437,6 +429,10 @@ class Lazyload_Subscriber implements Subscriber_Interface {
 	 * @return boolean
 	 */
 	private function can_lazyload_images() {
+		if ( ! $this->options->get( 'lazyload' ) ) {
+			return false;
+		}
+
 		/**
 		 * Filters the lazyload application on images
 		 *
@@ -456,6 +452,14 @@ class Lazyload_Subscriber implements Subscriber_Interface {
 	 * @return boolean
 	 */
 	private function can_lazyload_iframes() {
+		if ( ! $this->options->get( 'lazyload_youtube' ) ) {
+			return false;
+		}
+
+		if ( ! $this->options->get( 'lazyload_iframes' ) ) {
+			return false;
+		}
+
 		/**
 		 * Filters the lazyload application on iframes
 		 *

--- a/inc/classes/subscriber/Optimization/class-lazyload-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-lazyload-subscriber.php
@@ -13,6 +13,7 @@ use RocketLazyload\Assets;
 use RocketLazyload\Image;
 use RocketLazyload\Iframe;
 use MatthiasMullie\Minify\JS;
+use Logger\Logger;
 
 /**
  * Lazyload Subscriber
@@ -116,6 +117,10 @@ class Lazyload_Subscriber implements Subscriber_Interface {
 
 		if ( ! $this->should_lazyload() ) {
 			return;
+		}
+
+		if ( is_rocket_post_excluded_option( 'lazyload' ) ) {
+		 return;
 		}
 
 		/**

--- a/inc/classes/subscriber/Optimization/class-lazyload-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-lazyload-subscriber.php
@@ -13,7 +13,6 @@ use RocketLazyload\Assets;
 use RocketLazyload\Image;
 use RocketLazyload\Iframe;
 use MatthiasMullie\Minify\JS;
-use Logger\Logger;
 
 /**
  * Lazyload Subscriber


### PR DESCRIPTION
Fixes #1949 - when LazyLoad is disabled on a specific page, remove lazyload.js and inline JS code related to lazy load