### PR TITLE
Cache Busting folder structure contains a directory we cannot recurse into.

### DIFF
--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -561,10 +561,18 @@ function rocket_clean_cache_busting( $extensions = array( 'js', 'css' ) ) {
 		do_action( 'after_rocket_clean_cache_busting', $ext );
 	}
 
-	foreach ( $iterator as $item ) {
-		if ( rocket_direct_filesystem()->is_dir( $item ) ) {
-			rocket_direct_filesystem()->delete( $item );
+	try {
+		foreach ( $iterator as $item ) {
+			if ( rocket_direct_filesystem()->is_dir( $item ) ) {
+				rocket_direct_filesystem()->delete( $item );
+			}
 		}
+	} catch ( \UnexpectedValueException $e ) {
+		// Log the error
+		Logger::debug( 'Cache Busting folder structure contains a directory we cannot recurse into.', [
+			'Full error',
+			'UnexpectedValueException' => $e->getMessage(),
+		] );
 	}
 }
 


### PR DESCRIPTION
Cache Busting folder structure contains a directory we cannot recurse into, permissions do not allow to recurse the structure of busting folder.

E_ERROR was caused in line 554 of the file wp-content/plugins/wp-rocket/inc/functions/files.php

Full error is available here - https://secure.helpscout.net/conversation/963849440/124175/
Related conversation - https://wp-media.slack.com/archives/C08N8J6VC/p1569790610001900

Based on:
3.4.1 WP Rocket Minor Version doc

