### PR TITLE
Fix #1566 - Improve Cloudflare disable notice

### DIFF
--- a/assets/css/wpr-admin-common.css
+++ b/assets/css/wpr-admin-common.css
@@ -1,5 +1,5 @@
 .rocket-plugins-error{overflow:hidden; padding-left:20px; list-style-type:disc}
-.rocket-plugins-error li{width:280px; line-height:25px}
+.rocket-plugins-error li{line-height:25px}
 #wp-admin-bar-purge-all-all .dashicons{font:normal 1.5em/1 'dashicons'; -webkit-font-smoothing:antialiased; vertical-align:middle; padding-right:3px; display:inline-block}
 .rocket-purchase, .dashicons.dashicons-update.rocket-dashicons:before{color:#D54E21}
 .rocket-purchase{font-weight:900}

--- a/inc/admin/ui/notices.php
+++ b/inc/admin/ui/notices.php
@@ -92,7 +92,8 @@ add_action( 'admin_notices', 'rocket_warning_plugin_modification' );
  * @since 1.3.0
  */
 function rocket_plugins_to_deactivate() {
-	$plugins = [];
+	$plugins 			  = [];
+	$plugins_explanations = [];
 
 	// Deactivate all plugins who can cause conflicts with WP Rocket.
 	$plugins = [
@@ -166,7 +167,8 @@ function rocket_plugins_to_deactivate() {
 	}
 
 	if ( get_rocket_option( 'do_cloudflare' ) ) {
-		$plugins['cloudflare'] = 'cloudflare/cloudflare.php';
+		$plugins['cloudflare'] 			   	= 'cloudflare/cloudflare.php';
+		$plugins_explanations['cloudflare'] = __( 'The Cloudflare plugin is not required because the WP Rocket Cloudflare add-on has the same functionality.', 'rocket' );
 	}
 
 	if ( get_rocket_option( 'control_heartbeat' ) ) {
@@ -194,9 +196,9 @@ function rocket_plugins_to_deactivate() {
 
 		$warning .= '<ul class="rocket-plugins-error">';
 
-		foreach ( $plugins as $plugin ) {
+		foreach ( $plugins as $k => $plugin ) {
 			$plugin_data = get_plugin_data( WP_PLUGIN_DIR . DIRECTORY_SEPARATOR . $plugin );
-			$warning    .= '<li>' . $plugin_data['Name'] . '</span> <a href="' . wp_nonce_url( admin_url( 'admin-post.php?action=deactivate_plugin&plugin=' . rawurlencode( $plugin ) ), 'deactivate_plugin' ) . '" class="button-secondary alignright">' . __( 'Deactivate', 'rocket' ) . '</a></li>';
+			$warning    .= '<li><b>' . $plugin_data['Name'] . '</b>'. ( isset($plugins_explanations[$k]) ? ' - ' . $plugins_explanations[$k] : '' ) . '</span> <a href="' . wp_nonce_url( admin_url( 'admin-post.php?action=deactivate_plugin&plugin=' . rawurlencode( $plugin ) ), 'deactivate_plugin' ) . '" class="button-secondary alignright">' . __( 'Deactivate', 'rocket' ) . '</a></li>';
 		}
 
 		$warning .= '</ul>';

--- a/inc/admin/ui/notices.php
+++ b/inc/admin/ui/notices.php
@@ -92,7 +92,7 @@ add_action( 'admin_notices', 'rocket_warning_plugin_modification' );
  * @since 1.3.0
  */
 function rocket_plugins_to_deactivate() {
-	$plugins 			  = [];
+	$plugins              = [];
 	$plugins_explanations = [];
 
 	// Deactivate all plugins who can cause conflicts with WP Rocket.
@@ -167,8 +167,8 @@ function rocket_plugins_to_deactivate() {
 	}
 
 	if ( get_rocket_option( 'do_cloudflare' ) ) {
-		$plugins['cloudflare'] 			   	= 'cloudflare/cloudflare.php';
-		$plugins_explanations['cloudflare'] = __( 'The Cloudflare plugin is not required because the WP Rocket Cloudflare add-on has the same functionality.', 'rocket' );
+		$plugins['cloudflare']              = 'cloudflare/cloudflare.php';
+		$plugins_explanations['cloudflare'] = __( 'WP Rocket Cloudflare Add-on provides similar functionalities. They can not be active at the same time.', 'rocket' );
 	}
 
 	if ( get_rocket_option( 'control_heartbeat' ) ) {
@@ -198,7 +198,7 @@ function rocket_plugins_to_deactivate() {
 
 		foreach ( $plugins as $k => $plugin ) {
 			$plugin_data = get_plugin_data( WP_PLUGIN_DIR . DIRECTORY_SEPARATOR . $plugin );
-			$warning    .= '<li><b>' . $plugin_data['Name'] . '</b>'. ( isset($plugins_explanations[$k]) ? ' - ' . $plugins_explanations[$k] : '' ) . '</span> <a href="' . wp_nonce_url( admin_url( 'admin-post.php?action=deactivate_plugin&plugin=' . rawurlencode( $plugin ) ), 'deactivate_plugin' ) . '" class="button-secondary alignright">' . __( 'Deactivate', 'rocket' ) . '</a></li>';
+			$warning    .= '<li><b>' . $plugin_data['Name'] . '</b>' . ( isset( $plugins_explanations[$k] ) ? ' - ' . $plugins_explanations[$k] : '' ) . '</span> <a href="' . wp_nonce_url( admin_url( 'admin-post.php?action=deactivate_plugin&plugin=' . rawurlencode( $plugin ) ), 'deactivate_plugin' ) . '" class="button-secondary alignright">' . __( 'Deactivate', 'rocket' ) . '</a></li>';
 		}
 
 		$warning .= '</ul>';


### PR DESCRIPTION
Improve notice when Cloudflare plugin is detected

Edited the current notice view and plugin name is in bold now with an explainer text beside it. Increased the width of .rocket-plugins-error li from 280px to 100% to allow the explainer text to fit inside:
https://www.screencast.com/t/0hKXgvhfGc6Y

Based on:
3.4.1 WP Rocket Minor Version doc
