### PR TITLE
Update filters priorities

### DIFF
--- a/inc/classes/subscriber/CDN/CDNSubscriber.php
+++ b/inc/classes/subscriber/CDN/CDNSubscriber.php
@@ -42,7 +42,7 @@ class CDNSubscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events() {
 		return [
-			'rocket_buffer'           => [ 'rewrite', 13 ],
+			'rocket_buffer'           => [ 'rewrite', 32 ],
 			'rocket_css_content'      => 'rewrite_css_properties',
 			'rocket_cdn_hosts'        => [ 'get_cdn_hosts', 10, 2 ],
 			'rocket_dns_prefetch'     => 'add_dns_prefetch_cdn',

--- a/inc/classes/subscriber/Media/class-webp-subscriber.php
+++ b/inc/classes/subscriber/Media/class-webp-subscriber.php
@@ -106,7 +106,7 @@ class Webp_Subscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events() {
 		return [
-			'rocket_buffer'                                 => [ 'convert_to_webp', 23 ],
+			'rocket_buffer'                                 => [ 'convert_to_webp', 28 ],
 			'rocket_cache_webp_setting_field'               => [
 				[ 'maybe_disable_setting_field' ],
 				[ 'webp_section_description' ],

--- a/inc/classes/subscriber/Optimization/class-combine-google-fonts-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-combine-google-fonts-subscriber.php
@@ -16,7 +16,7 @@ class Combine_Google_Fonts_Subscriber extends Minify_Subscriber {
 	 */
 	public static function get_subscribed_events() {
 		return [
-			'rocket_buffer' => [ 'process', 17 ],
+			'rocket_buffer' => [ 'process', 20 ],
 		];
 	}
 

--- a/inc/classes/subscriber/Optimization/class-critical-css-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-critical-css-subscriber.php
@@ -42,8 +42,8 @@ class Critical_CSS_Subscriber implements Subscriber_Interface {
 			],
 			'wp_head'                                 => [ 'insert_load_css', PHP_INT_MAX ],
 			'rocket_buffer'                           => [
-				[ 'insert_critical_css_buffer', 12 ],
-				[ 'async_css', 20 ],
+				[ 'insert_critical_css_buffer', 18 ],
+				[ 'async_css', 24 ],
 			],
 			'switch_theme'                            => 'maybe_regenerate_cpcss',
 			'rocket_critical_css_generation_process_complete' => 'clean_domain_on_complete',

--- a/inc/classes/subscriber/Optimization/class-ie-conditionals-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-ie-conditionals-subscriber.php
@@ -27,7 +27,7 @@ class IE_Conditionals_Subscriber implements Subscriber_Interface {
 		return [
 			'rocket_buffer' => [
 				[ 'extract_ie_conditionals', 1 ],
-				[ 'inject_ie_conditionals', 20 ],
+				[ 'inject_ie_conditionals', 26 ],
 			],
 		];
 	}

--- a/inc/classes/subscriber/Optimization/class-lazyload-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-lazyload-subscriber.php
@@ -90,7 +90,7 @@ class Lazyload_Subscriber implements Subscriber_Interface {
 			],
 			'wp_head'              => [ 'insert_nojs_style', PHP_INT_MAX ],
 			'wp_enqueue_scripts'   => [ 'insert_youtube_thumbnail_style', PHP_INT_MAX ],
-			'rocket_buffer'        => [ 'lazyload', 25 ],
+			'rocket_buffer'        => [ 'lazyload', 30 ],
 			'rocket_lazyload_html' => 'lazyload_responsive',
 			'init'                 => 'lazyload_smilies',
 			'wp'                   => 'deactivate_lazyload_on_specific_posts',

--- a/inc/classes/subscriber/Optimization/class-minify-html-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-minify-html-subscriber.php
@@ -39,7 +39,7 @@ class Minify_HTML_Subscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events() {
 		return [
-			'rocket_buffer' => [ 'process', 21 ],
+			'rocket_buffer' => [ 'process', 34 ],
 		];
 	}
 

--- a/inc/classes/subscriber/Optimization/class-minify-js-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-minify-js-subscriber.php
@@ -22,7 +22,7 @@ class Minify_JS_Subscriber extends Minify_Subscriber {
 				[ 'fix_ssl_minify' ],
 				[ 'i18n_multidomain_url' ],
 			],
-			'rocket_buffer' => [ 'process', 14 ],
+			'rocket_buffer' => [ 'process', 12 ],
 		];
 
 		return $events;

--- a/inc/classes/subscriber/Optimization/class-remove-query-string-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-remove-query-string-subscriber.php
@@ -38,7 +38,7 @@ class Remove_Query_String_Subscriber extends Minify_Subscriber {
 	 */
 	public static function get_subscribed_events() {
 		return [
-			'rocket_buffer' => [ 'process', 19 ],
+			'rocket_buffer' => [ 'process', 22 ],
 		];
 	}
 

--- a/inc/front/deferred-js.php
+++ b/inc/front/deferred-js.php
@@ -55,4 +55,4 @@ function rocket_defer_js( $buffer ) {
 
 	return $buffer;
 }
-add_filter( 'rocket_buffer', 'rocket_defer_js', 15 );
+add_filter( 'rocket_buffer', 'rocket_defer_js', 14 );

--- a/tests/Integration/Subscriber/CDNSubscriber/TestGetSubscribedEvents.php
+++ b/tests/Integration/Subscriber/CDNSubscriber/TestGetSubscribedEvents.php
@@ -7,7 +7,7 @@ use WP_Rocket\Subscriber\CDN\CDNSubscriber;
 class TestGetSubscribedEvents extends TestCase {
     public function testShouldReturnSubscribedEventsArray() {
         $events = [
-			'rocket_buffer'           => [ 'rewrite', 13 ],
+			'rocket_buffer'           => [ 'rewrite', 32 ],
 			'rocket_css_content'      => 'rewrite_css_properties',
 			'rocket_cdn_hosts'        => [ 'get_cdn_hosts', 10, 2 ],
 			'rocket_dns_prefetch'     => 'add_dns_prefetch_cdn',


### PR DESCRIPTION
Current priorities were causing an issue when critical CSS and combine CSS were active at the same time, since 3.4.

Critical CSS priority was changed during 3.4 beta because of an issue with the new CDN priority.

This PR should fix any priority issue by updating all of them and making sure everything is applied in the correct order.

Extract IE => 1
Facebook => 10
Google => 10
JS min/combine => 12
Defer JS => 14
CSS min/combine => 16
Critical CSS => 18
Google fonts => 20
Remove Query Strings => 22
Async CSS => 24
Insert IE => 26
WebP => 28
Lazyload => 30
CDN => 32
HTML min => 34