### PR TITLE
Fix #934: Cloudflare validation API when saving - needs proper error messages

### DIFF
--- a/inc/classes/admin/settings/class-settings.php
+++ b/inc/classes/admin/settings/class-settings.php
@@ -367,6 +367,12 @@ class Settings {
 			$input['cloudflare_api_key'] = WP_ROCKET_CF_API_KEY;
 		}
 
+		$is_api_keys_valid_cloudflare = is_api_keys_valid_cloudflare( $input['cloudflare_email'], $input['cloudflare_api_key'], $input['cloudflare_zone_id']);
+		if ( is_wp_error( $is_api_keys_valid_cloudflare ) ) {
+			$cloudflare_error_message = $is_api_keys_valid_cloudflare->get_error_message();
+			add_settings_error( 'general', 'cloudflare_api_key_invalid', __( 'Cloudflare Add-on: Credentials are invalid - ', 'rocket' ) . $cloudflare_error_message, 'error' );
+		}
+
 		// Options: Sucuri cache. And yeah, there's a typo, but now it's too late to fix ^^'.
 		$input['sucury_waf_cache_sync'] = ! empty( $input['sucury_waf_cache_sync'] ) ? 1 : 0;
 

--- a/inc/classes/admin/settings/class-settings.php
+++ b/inc/classes/admin/settings/class-settings.php
@@ -367,7 +367,8 @@ class Settings {
 			$input['cloudflare_api_key'] = WP_ROCKET_CF_API_KEY;
 		}
 
-		$is_api_keys_valid_cloudflare = is_api_keys_valid_cloudflare( $input['cloudflare_email'], $input['cloudflare_api_key'], $input['cloudflare_zone_id']);
+		// Check Cloudflare input data and display error message
+		$is_api_keys_valid_cloudflare = rocket_is_api_keys_valid_cloudflare( $input['cloudflare_email'], $input['cloudflare_api_key'], $input['cloudflare_zone_id']);
 		if ( is_wp_error( $is_api_keys_valid_cloudflare ) ) {
 			$cloudflare_error_message = $is_api_keys_valid_cloudflare->get_error_message();
 			add_settings_error( 'general', 'cloudflare_api_key_invalid', __( 'Cloudflare Add-on: Credentials are invalid - ', 'rocket' ) . $cloudflare_error_message, 'error' );

--- a/inc/classes/admin/settings/class-settings.php
+++ b/inc/classes/admin/settings/class-settings.php
@@ -368,10 +368,12 @@ class Settings {
 		}
 
 		// Check Cloudflare input data and display error message
-		$is_api_keys_valid_cloudflare = rocket_is_api_keys_valid_cloudflare( $input['cloudflare_email'], $input['cloudflare_api_key'], $input['cloudflare_zone_id']);
-		if ( is_wp_error( $is_api_keys_valid_cloudflare ) ) {
-			$cloudflare_error_message = $is_api_keys_valid_cloudflare->get_error_message();
-			add_settings_error( 'general', 'cloudflare_api_key_invalid', __( 'Cloudflare Add-on: Credentials are invalid - ', 'rocket' ) . $cloudflare_error_message, 'error' );
+		if ( get_rocket_option( 'do_cloudflare' ) ) {
+			$is_api_keys_valid_cloudflare = rocket_is_api_keys_valid_cloudflare( $input['cloudflare_email'], $input['cloudflare_api_key'], $input['cloudflare_zone_id']);
+			if ( is_wp_error( $is_api_keys_valid_cloudflare ) ) {
+				$cloudflare_error_message = $is_api_keys_valid_cloudflare->get_error_message();
+				add_settings_error( 'general', 'cloudflare_api_key_invalid', __( 'Cloudflare Add-on: Credentials are invalid - ', 'rocket' ) . $cloudflare_error_message, 'error' );
+			}
 		}
 
 		// Options: Sucuri cache. And yeah, there's a typo, but now it's too late to fix ^^'.

--- a/inc/functions/cloudflare.php
+++ b/inc/functions/cloudflare.php
@@ -1,7 +1,18 @@
 <?php
 defined( 'ABSPATH' ) || die( 'Cheatin&#8217; uh?' );
 
-function is_api_keys_valid_cloudflare( $cf_email, $cf_api_key, $cf_zone_id ) {
+/**
+ * Validate Cloudflare input data
+ *
+ * @since 3.4.1
+ * @author Soponar Cristina
+ *
+ * @param string $cf_email   - Cloudflare email
+ * @param string $cf_api_key - Cloudflare API key
+ * @param string $cf_zone_id - Cloudflare zone ID
+ * @return Object            - true if credentials are ok, WP_Error otherwise
+ */
+function rocket_is_api_keys_valid_cloudflare( $cf_email, $cf_api_key, $cf_zone_id ) {
 	if ( ! function_exists( 'curl_init' ) || ! function_exists( 'curl_exec' ) ) {
 		return new WP_Error( 'curl_disabled', __( 'Curl functions are disabled, they are required for the Cloudflare Add-on to work correctly.', 'rocket' ) );
 	}

--- a/inc/functions/cloudflare.php
+++ b/inc/functions/cloudflare.php
@@ -1,6 +1,50 @@
 <?php
 defined( 'ABSPATH' ) || die( 'Cheatin&#8217; uh?' );
 
+function is_api_keys_valid_cloudflare( $cf_email, $cf_api_key, $cf_zone_id ) {
+	if ( ! function_exists( 'curl_init' ) || ! function_exists( 'curl_exec' ) ) {
+		return new WP_Error( 'curl_disabled', __( 'Curl functions are disabled, they are required for the Cloudflare Add-on to work correctly.', 'rocket' ) );
+	}
+
+	if ( ! isset( $cf_email, $cf_api_key ) || empty( $cf_email ) || empty( $cf_api_key ) ) {
+		return new WP_Error( 'cloudflare_credentials_empty', __( 'Cloudflare Email and API key are not set.', 'rocket' ) );
+	}
+
+	if ( ! isset( $cf_zone_id ) || empty( $cf_zone_id ) ) {
+		$msg = sprintf(
+			// translators: %s = WP Rocket plugin name.
+			__( 'Missing Cloudflare zone ID. %s could not fix this automatically.', 'rocket' ),
+			WP_ROCKET_PLUGIN_NAME
+		);
+
+		$msg .= ' ' . sprintf(
+			/* translators: %1$s = opening link; %2$s = closing link */
+			__( 'Read the %1$sdocumentation%2$s for further guidance.', 'rocket' ),
+			/* translators: Documentation exists in EN, DE, FR, ES, IT; use loaclised URL if applicable */
+			'<a href="' . __( 'https://docs.wp-rocket.me/article/18-using-wp-rocket-with-cloudflare/?utm_source=wp_plugin&utm_medium=wp_rocket', 'rocket' ) . '" target="_blank">',
+			'</a>'
+		);
+
+		return new WP_Error( 'cloudflare_no_zone_id', $msg );
+	}
+
+	try {
+		$cf_api_instance = new Cloudflare\Api( $cf_email, $cf_api_key );
+		$cf_user         = $cf_api_instance->get('user/');
+		$cf_zone         = $cf_api_instance->get('zones/'.$cf_zone_id);
+
+		if ( ! isset( $cf_zone->success ) || empty( $cf_zone->success ) ) {
+			return new WP_Error( 'cloudflare_invalid_auth', $cf_zone->errors[0]->message );
+		}
+
+		if ( true === $cf_zone->success ) {
+		    return true;
+		}
+	} catch ( Exception $e ) {
+		return new WP_Error( 'cloudflare_invalid_auth', $e->getMessage() );
+	}
+}
+
 /**
  * Get a Cloudflare\Api instance
  *


### PR DESCRIPTION
Added Cloudflare validation API when saving API key, email & zone.

Needs proper error messages. Error messages coming from Cloudflare are "generic" and can lead to confusion.

Based on:
3.4.1 WP Rocket Minor Version doc

