### PR TITLE
Added external JS file exclusion

### DIFF
--- a/inc/classes/optimization/JS/class-combine.php
+++ b/inc/classes/optimization/JS/class-combine.php
@@ -631,6 +631,7 @@ class Combine extends Abstract_JS_Optimization {
 			'code.tidio.co',
 			'www.uplaunch.com',
 			'widget.reviewability.com',
+			'ck.page',
 		];
 
 		$excluded_external = array_merge( $defaults, $this->options->get( 'exclude_js', [] ) );


### PR DESCRIPTION
Added ConvertKit plugin domain URL to the exclusion list. There are a couple of tickets related to this plugin. No need to exclude it from deferring as it already has the async attribute.