### PR TITLE
3.4.0.5

### DIFF
--- a/inc/classes/Buffer/class-cache.php
+++ b/inc/classes/Buffer/class-cache.php
@@ -608,6 +608,12 @@ class Cache extends Abstract_Buffer {
 		}
 
 		if ( ! $http_accept || false === strpos( $http_accept, 'webp' ) ) {
+			if ( preg_match( '#Firefox/(?<version>[1-9]{2})#i', $this->config->get_server_input( 'HTTP_USER_AGENT' ), $matches ) ) {
+				if ( 66 <= (int) $matches['version'] ) {
+					return $filename . '-webp';
+				}
+			}
+
 			return $filename;
 		}
 

--- a/inc/classes/CDN/CDN.php
+++ b/inc/classes/CDN/CDN.php
@@ -244,7 +244,13 @@ class CDN {
 	public function is_excluded( $url ) {
 		$path = wp_parse_url( $url, PHP_URL_PATH );
 
-		if ( 'php' === pathinfo( $path, PATHINFO_EXTENSION ) ) {
+		$excluded_extensions = [
+			'php',
+			'html',
+			'htm',
+		];
+
+		if ( in_array( pathinfo( $path, PATHINFO_EXTENSION ), $excluded_extensions, true ) ) {
 			return true;
 		}
 

--- a/inc/classes/admin/settings/class-beacon.php
+++ b/inc/classes/admin/settings/class-beacon.php
@@ -97,6 +97,7 @@ class Beacon {
 			'lazyload'                => 'Lazyload Images',
 			'lazyload_iframes'        => 'Lazyload Iframes',
 			'lazyload_youtube'        => 'Lazyload Youtube',
+			'cache_webp'              => 'WebP Cache',
 			'minify_css'              => 'Minify CSS',
 			'minify_concatenate_css'  => 'Combine CSS',
 			'minify_js'               => 'Minify JS',

--- a/inc/classes/subscriber/CDN/CDNSubscriber.php
+++ b/inc/classes/subscriber/CDN/CDNSubscriber.php
@@ -43,8 +43,8 @@ class CDNSubscriber implements Subscriber_Interface {
 	public static function get_subscribed_events() {
 		return [
 			'rocket_buffer'           => [
-				[ 'rewrite', 32 ],
-				[ 'rewrite_srcset', 33 ],
+				[ 'rewrite', 34 ],
+				[ 'rewrite_srcset', 35 ],
 			],
 			'rocket_css_content'      => 'rewrite_css_properties',
 			'rocket_cdn_hosts'        => [ 'get_cdn_hosts', 10, 2 ],

--- a/inc/classes/subscriber/Media/class-webp-subscriber.php
+++ b/inc/classes/subscriber/Media/class-webp-subscriber.php
@@ -106,7 +106,7 @@ class Webp_Subscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events() {
 		return [
-			'rocket_buffer'                                 => [ 'convert_to_webp', 28 ],
+			'rocket_buffer'                                 => [ 'convert_to_webp', 30 ],
 			'rocket_cache_webp_setting_field'               => [
 				[ 'maybe_disable_setting_field' ],
 				[ 'webp_section_description' ],

--- a/inc/classes/subscriber/Optimization/class-lazyload-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-lazyload-subscriber.php
@@ -90,7 +90,7 @@ class Lazyload_Subscriber implements Subscriber_Interface {
 			],
 			'wp_head'              => [ 'insert_nojs_style', PHP_INT_MAX ],
 			'wp_enqueue_scripts'   => [ 'insert_youtube_thumbnail_style', PHP_INT_MAX ],
-			'rocket_buffer'        => [ 'lazyload', 30 ],
+			'rocket_buffer'        => [ 'lazyload', 32 ],
 			'rocket_lazyload_html' => 'lazyload_responsive',
 			'init'                 => 'lazyload_smilies',
 			'wp'                   => 'deactivate_lazyload_on_specific_posts',

--- a/inc/classes/subscriber/Optimization/class-minify-html-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-minify-html-subscriber.php
@@ -39,7 +39,7 @@ class Minify_HTML_Subscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events() {
 		return [
-			'rocket_buffer' => [ 'process', 34 ],
+			'rocket_buffer' => [ 'process', 28 ],
 		];
 	}
 

--- a/tests/Fixtures/CDN/original.html
+++ b/tests/Fixtures/CDN/original.html
@@ -488,6 +488,7 @@ img.emoji {
 			<p>Welcome to image alignment! The best way to demonstrate the ebb and flow of the various image positioning options is to nestle them snuggly among an ocean of words. Grab a paddle and let&rsquo;s get started.</p>
 <p>On the topic of alignment, it should be noted that users can choose from the options of <em>None</em>, <em>Left</em>, <em>Right, </em>and <em>Center</em>. In addition, they also get the options of <em>Thumbnail</em>, <em>Medium</em>, <em>Large</em> &amp; <em>Fullsize</em>.</p>
 <a href="http://example.org/page.htm">Test link</a>
+<video id="wp-custom-header-video" autoplay="" loop="" width="2000" height="800" src="http://example.org/wp-content/uploads/2019/01/Website-Intro.mp4"></video>
 <p style="text-align:center;"><img class="size-full wp-image-906 aligncenter" title="Image Alignment 580x300" alt="Image Alignment 580x300" src="http://example.org/wp-content/uploads/2013/03/image-alignment-580x300.jpg" width="580" height="300" /></p>
 <p>The image above happens to be <em><strong>centered</strong></em>.</p>
 <p><strong><img class="size-full wp-image-904 alignleft" title="Image Alignment 150x150" alt="Image Alignment 150x150" src="http://example.org/wp-content/uploads/2013/03/image-alignment-150x150.jpg" width="150" height="150" /></strong>The rest of this paragraph is filler for the sake of seeing the text wrap around the 150&#215;150 image, which is <em><strong>left aligned</strong></em>. <strong></strong></p>

--- a/tests/Fixtures/CDN/original.html
+++ b/tests/Fixtures/CDN/original.html
@@ -487,6 +487,7 @@ img.emoji {
 				<div class="entry-content">
 			<p>Welcome to image alignment! The best way to demonstrate the ebb and flow of the various image positioning options is to nestle them snuggly among an ocean of words. Grab a paddle and let&rsquo;s get started.</p>
 <p>On the topic of alignment, it should be noted that users can choose from the options of <em>None</em>, <em>Left</em>, <em>Right, </em>and <em>Center</em>. In addition, they also get the options of <em>Thumbnail</em>, <em>Medium</em>, <em>Large</em> &amp; <em>Fullsize</em>.</p>
+<a href="http://example.org/page.htm">Test link</a>
 <p style="text-align:center;"><img class="size-full wp-image-906 aligncenter" title="Image Alignment 580x300" alt="Image Alignment 580x300" src="http://example.org/wp-content/uploads/2013/03/image-alignment-580x300.jpg" width="580" height="300" /></p>
 <p>The image above happens to be <em><strong>centered</strong></em>.</p>
 <p><strong><img class="size-full wp-image-904 alignleft" title="Image Alignment 150x150" alt="Image Alignment 150x150" src="http://example.org/wp-content/uploads/2013/03/image-alignment-150x150.jpg" width="150" height="150" /></strong>The rest of this paragraph is filler for the sake of seeing the text wrap around the 150&#215;150 image, which is <em><strong>left aligned</strong></em>. <strong></strong></p>

--- a/tests/Fixtures/CDN/rewrite.html
+++ b/tests/Fixtures/CDN/rewrite.html
@@ -487,6 +487,7 @@ img.emoji {
 				<div class="entry-content">
 			<p>Welcome to image alignment! The best way to demonstrate the ebb and flow of the various image positioning options is to nestle them snuggly among an ocean of words. Grab a paddle and let&rsquo;s get started.</p>
 <p>On the topic of alignment, it should be noted that users can choose from the options of <em>None</em>, <em>Left</em>, <em>Right, </em>and <em>Center</em>. In addition, they also get the options of <em>Thumbnail</em>, <em>Medium</em>, <em>Large</em> &amp; <em>Fullsize</em>.</p>
+<a href="http://example.org/page.htm">Test link</a>
 <p style="text-align:center;"><img class="size-full wp-image-906 aligncenter" title="Image Alignment 580x300" alt="Image Alignment 580x300" src="http://cdn.example.org/wp-content/uploads/2013/03/image-alignment-580x300.jpg" width="580" height="300" /></p>
 <p>The image above happens to be <em><strong>centered</strong></em>.</p>
 <p><strong><img class="size-full wp-image-904 alignleft" title="Image Alignment 150x150" alt="Image Alignment 150x150" src="http://cdn.example.org/wp-content/uploads/2013/03/image-alignment-150x150.jpg" width="150" height="150" /></strong>The rest of this paragraph is filler for the sake of seeing the text wrap around the 150&#215;150 image, which is <em><strong>left aligned</strong></em>. <strong></strong></p>

--- a/tests/Fixtures/CDN/rewrite.html
+++ b/tests/Fixtures/CDN/rewrite.html
@@ -488,6 +488,7 @@ img.emoji {
 			<p>Welcome to image alignment! The best way to demonstrate the ebb and flow of the various image positioning options is to nestle them snuggly among an ocean of words. Grab a paddle and let&rsquo;s get started.</p>
 <p>On the topic of alignment, it should be noted that users can choose from the options of <em>None</em>, <em>Left</em>, <em>Right, </em>and <em>Center</em>. In addition, they also get the options of <em>Thumbnail</em>, <em>Medium</em>, <em>Large</em> &amp; <em>Fullsize</em>.</p>
 <a href="http://example.org/page.htm">Test link</a>
+<video id="wp-custom-header-video" autoplay="" loop="" width="2000" height="800" src="http://cdn.example.org/wp-content/uploads/2019/01/Website-Intro.mp4"></video>
 <p style="text-align:center;"><img class="size-full wp-image-906 aligncenter" title="Image Alignment 580x300" alt="Image Alignment 580x300" src="http://cdn.example.org/wp-content/uploads/2013/03/image-alignment-580x300.jpg" width="580" height="300" /></p>
 <p>The image above happens to be <em><strong>centered</strong></em>.</p>
 <p><strong><img class="size-full wp-image-904 alignleft" title="Image Alignment 150x150" alt="Image Alignment 150x150" src="http://cdn.example.org/wp-content/uploads/2013/03/image-alignment-150x150.jpg" width="150" height="150" /></strong>The rest of this paragraph is filler for the sake of seeing the text wrap around the 150&#215;150 image, which is <em><strong>left aligned</strong></em>. <strong></strong></p>

--- a/tests/Fixtures/CDN/srcset/rewrite.html
+++ b/tests/Fixtures/CDN/srcset/rewrite.html
@@ -488,6 +488,7 @@ img.emoji {
 			<p>Welcome to image alignment! The best way to demonstrate the ebb and flow of the various image positioning options is to nestle them snuggly among an ocean of words. Grab a paddle and let&rsquo;s get started.</p>
 <p>On the topic of alignment, it should be noted that users can choose from the options of <em>None</em>, <em>Left</em>, <em>Right, </em>and <em>Center</em>. In addition, they also get the options of <em>Thumbnail</em>, <em>Medium</em>, <em>Large</em> &amp; <em>Fullsize</em>.</p>
 <a href="http://example.org/page.htm">Test link</a>
+<video id="wp-custom-header-video" autoplay="" loop="" width="2000" height="800" src="http://example.org/wp-content/uploads/2019/01/Website-Intro.mp4"></video>
 <p style="text-align:center;"><img class="size-full wp-image-906 aligncenter" title="Image Alignment 580x300" alt="Image Alignment 580x300" src="http://example.org/wp-content/uploads/2013/03/image-alignment-580x300.jpg" width="580" height="300" /></p>
 <p>The image above happens to be <em><strong>centered</strong></em>.</p>
 <p><strong><img class="size-full wp-image-904 alignleft" title="Image Alignment 150x150" alt="Image Alignment 150x150" src="http://example.org/wp-content/uploads/2013/03/image-alignment-150x150.jpg" width="150" height="150" /></strong>The rest of this paragraph is filler for the sake of seeing the text wrap around the 150&#215;150 image, which is <em><strong>left aligned</strong></em>. <strong></strong></p>

--- a/tests/Fixtures/CDN/srcset/rewrite.html
+++ b/tests/Fixtures/CDN/srcset/rewrite.html
@@ -487,6 +487,7 @@ img.emoji {
 				<div class="entry-content">
 			<p>Welcome to image alignment! The best way to demonstrate the ebb and flow of the various image positioning options is to nestle them snuggly among an ocean of words. Grab a paddle and let&rsquo;s get started.</p>
 <p>On the topic of alignment, it should be noted that users can choose from the options of <em>None</em>, <em>Left</em>, <em>Right, </em>and <em>Center</em>. In addition, they also get the options of <em>Thumbnail</em>, <em>Medium</em>, <em>Large</em> &amp; <em>Fullsize</em>.</p>
+<a href="http://example.org/page.htm">Test link</a>
 <p style="text-align:center;"><img class="size-full wp-image-906 aligncenter" title="Image Alignment 580x300" alt="Image Alignment 580x300" src="http://example.org/wp-content/uploads/2013/03/image-alignment-580x300.jpg" width="580" height="300" /></p>
 <p>The image above happens to be <em><strong>centered</strong></em>.</p>
 <p><strong><img class="size-full wp-image-904 alignleft" title="Image Alignment 150x150" alt="Image Alignment 150x150" src="http://example.org/wp-content/uploads/2013/03/image-alignment-150x150.jpg" width="150" height="150" /></strong>The rest of this paragraph is filler for the sake of seeing the text wrap around the 150&#215;150 image, which is <em><strong>left aligned</strong></em>. <strong></strong></p>

--- a/tests/Integration/Subscriber/CDNSubscriber/TestGetSubscribedEvents.php
+++ b/tests/Integration/Subscriber/CDNSubscriber/TestGetSubscribedEvents.php
@@ -8,8 +8,8 @@ class TestGetSubscribedEvents extends TestCase {
     public function testShouldReturnSubscribedEventsArray() {
         $events = [
 			'rocket_buffer'           => [
-                [ 'rewrite', 32 ],
-                [ 'rewrite_srcset', 33 ],
+                [ 'rewrite', 34 ],
+                [ 'rewrite_srcset', 35 ],
             ],
 			'rocket_css_content'      => 'rewrite_css_properties',
 			'rocket_cdn_hosts'        => [ 'get_cdn_hosts', 10, 2 ],

--- a/wp-rocket.php
+++ b/wp-rocket.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Rocket
  * Plugin URI: https://wp-rocket.me
  * Description: The best WordPress performance plugin.
- * Version: 3.4.0.4
+ * Version: 3.4.0.5
  * Code Name: Scarif
  * Author: WP Media
  * Author URI: https://wp-media.me
@@ -18,7 +18,7 @@
 defined( 'ABSPATH' ) || die( 'Cheatin&#8217; uh?' );
 
 // Rocket defines.
-define( 'WP_ROCKET_VERSION',               '3.4.0.4' );
+define( 'WP_ROCKET_VERSION',               '3.4.0.5' );
 define( 'WP_ROCKET_WP_VERSION',            '4.9' );
 define( 'WP_ROCKET_PHP_VERSION',           '5.6' );
 define( 'WP_ROCKET_PRIVATE_KEY',           false );


### PR DESCRIPTION
* Bugfix: Fix an issue with WebP detection on Firefox version 66 and higher
* Bugfix: Fix an issue preventing the cache file from being served on Chrome when WebP cache is enabled
* Bugfix: Correctly excludes files from CDN when using RegEx patterns
* Bugfix: Prevent rewritting of links to HTML pages (.htm/html extensions)
* API: Keep `get_rocket_cdn_cnames()` function as an API function usable by 3rd party plugins