### PR TITLE
Exclude Optinmonster API From Combine

### DIFF
--- a/inc/classes/optimization/JS/class-combine.php
+++ b/inc/classes/optimization/JS/class-combine.php
@@ -616,6 +616,7 @@ class Combine extends Abstract_JS_Optimization {
 			'googlesyndication.com',
 			'a.optmstr.com',
 			'a.optmnstr.com',
+			'a.opmnstr.com',
 			'adthrive.com',
 			'mediavine.com',
 			'js.hsforms.net',


### PR DESCRIPTION
Like previous patches this one excludes yet another optinmonster api url that can be used. When the JS is not excluded from combining it returns a JS error. 

[OptinMonster] A user attribute is required in the embed code.

Full JS URL: https://a.opmnstr.com/app/js/api.min.js