### PR TITLE
Fixes #2029 Exclude CDNJS Version of jQuery From Defer

### DIFF
--- a/inc/functions/options.php
+++ b/inc/functions/options.php
@@ -418,10 +418,13 @@ function get_rocket_exclude_defer_js() {
 		$jquery            = site_url( wp_scripts()->registered['jquery-core']->src );
 		$jetpack_jquery    = 'c0.wp.com/c/(?:.+)/wp-includes/js/jquery/jquery.js';
 		$googleapis_jquery = 'ajax.googleapis.com/ajax/libs/jquery/(?:.+)/jquery(?:\.min)?.js';
+		$cdnjs_jquery      = 'cdnjs.cloudflare.com/ajax/libs/jquery/(?:.+)/jquery(?:\.min)?.js';
 
 		$exclude_defer_js[] = rocket_clean_exclude_file( $jquery );
 		$exclude_defer_js[] = $jetpack_jquery;
 		$exclude_defer_js[] = $googleapis_jquery;
+		$exclude_defer_js[] = $cdnjs_jquery;
+		
 	}
 
 	/**

--- a/tests/Integration/Functions/Options/TestExcludeDeferJS.php
+++ b/tests/Integration/Functions/Options/TestExcludeDeferJS.php
@@ -37,7 +37,8 @@ class TestExcludeDeferJS extends TestCase {
             'widget.reviews.co.uk',
             '/wp-includes/js/jquery/jquery.js',
             'c0.wp.com/c/(?:.+)/wp-includes/js/jquery/jquery.js',
-            'ajax.googleapis.com/ajax/libs/jquery/(?:.+)/jquery(?:\.min)?.js',
+			'ajax.googleapis.com/ajax/libs/jquery/(?:.+)/jquery(?:\.min)?.js',
+			'cdnjs.cloudflare.com/ajax/libs/jquery/(?:.+)/jquery(?:\.min)?.js',
         ];
 
         $this->assertSame(

--- a/tests/Integration/Functions/Options/TestExcludeDeferJS.php
+++ b/tests/Integration/Functions/Options/TestExcludeDeferJS.php
@@ -37,8 +37,8 @@ class TestExcludeDeferJS extends TestCase {
             'widget.reviews.co.uk',
             '/wp-includes/js/jquery/jquery.js',
             'c0.wp.com/c/(?:.+)/wp-includes/js/jquery/jquery.js',
-			'ajax.googleapis.com/ajax/libs/jquery/(?:.+)/jquery(?:\.min)?.js',
-			'cdnjs.cloudflare.com/ajax/libs/jquery/(?:.+)/jquery(?:\.min)?.js',
+            'ajax.googleapis.com/ajax/libs/jquery/(?:.+)/jquery(?:\.min)?.js',
+            'cdnjs.cloudflare.com/ajax/libs/jquery/(?:.+)/jquery(?:\.min)?.js',
         ];
 
         $this->assertSame(

--- a/tests/Unit/Functions/Options/TestExcludeDeferJS.php
+++ b/tests/Unit/Functions/Options/TestExcludeDeferJS.php
@@ -56,8 +56,8 @@ class TestExcludeDeferJS extends TestCase {
             'widget.reviews.co.uk',
             '/wp-includes/js/jquery/jquery.js',
             'c0.wp.com/c/(?:.+)/wp-includes/js/jquery/jquery.js',
-			'ajax.googleapis.com/ajax/libs/jquery/(?:.+)/jquery(?:\.min)?.js',
-			'cdnjs.cloudflare.com/ajax/libs/jquery/(?:.+)/jquery(?:\.min)?.js',
+            'ajax.googleapis.com/ajax/libs/jquery/(?:.+)/jquery(?:\.min)?.js',
+            'cdnjs.cloudflare.com/ajax/libs/jquery/(?:.+)/jquery(?:\.min)?.js',
         ];
 
         $this->assertSame(

--- a/tests/Unit/Functions/Options/TestExcludeDeferJS.php
+++ b/tests/Unit/Functions/Options/TestExcludeDeferJS.php
@@ -56,7 +56,8 @@ class TestExcludeDeferJS extends TestCase {
             'widget.reviews.co.uk',
             '/wp-includes/js/jquery/jquery.js',
             'c0.wp.com/c/(?:.+)/wp-includes/js/jquery/jquery.js',
-            'ajax.googleapis.com/ajax/libs/jquery/(?:.+)/jquery(?:\.min)?.js',
+			'ajax.googleapis.com/ajax/libs/jquery/(?:.+)/jquery(?:\.min)?.js',
+			'cdnjs.cloudflare.com/ajax/libs/jquery/(?:.+)/jquery(?:\.min)?.js',
         ];
 
         $this->assertSame(


### PR DESCRIPTION
This excludes the CDNJS version of jQuery from defer if the jQuery safe JS option is checked. 