### PR TITLE
Fix #2038 - Remove Purge OpCache when Restrict API is enabled

### DIFF
--- a/inc/common/admin-bar.php
+++ b/inc/common/admin-bar.php
@@ -174,7 +174,13 @@ function rocket_admin_bar( $wp_admin_bar ) {
 		/**
 		 * Purge OPCache content if OPcache is active.
 		 */
-		if ( function_exists( 'opcache_reset' ) ) {
+        $restrict_api     = ini_get( 'opcache.restrict_api' );
+		$can_restrict_api = true;
+        if ( $restrict_api && strpos( __FILE__, $restrict_api ) !== 0 ) {
+            $can_restrict_api = false;
+        }
+
+		if ( function_exists( 'opcache_reset' ) && $can_restrict_api ) {
 			$action = 'rocket_purge_opcache';
 
 			$wp_admin_bar->add_menu(

--- a/inc/common/admin-bar.php
+++ b/inc/common/admin-bar.php
@@ -174,11 +174,11 @@ function rocket_admin_bar( $wp_admin_bar ) {
 		/**
 		 * Purge OPCache content if OPcache is active.
 		 */
-        $restrict_api     = ini_get( 'opcache.restrict_api' );
+		$restrict_api     = ini_get( 'opcache.restrict_api' );
 		$can_restrict_api = true;
-        if ( $restrict_api && strpos( __FILE__, $restrict_api ) !== 0 ) {
-            $can_restrict_api = false;
-        }
+		if ( $restrict_api && strpos( __FILE__, $restrict_api ) !== 0 ) {
+		    $can_restrict_api = false;
+		}
 
 		if ( function_exists( 'opcache_reset' ) && $can_restrict_api ) {
 			$action = 'rocket_purge_opcache';

--- a/views/settings/page-sections/dashboard.php
+++ b/views/settings/page-sections/dashboard.php
@@ -144,11 +144,11 @@ defined( 'ABSPATH' ) || die( 'Cheatin&#8217; uh?' );
 					<?php endif; ?>
 
 					<?php
-                    $restrict_api     = ini_get( 'opcache.restrict_api' );
-                    $can_restrict_api = true;
-                    if ( $restrict_api && strpos(__FILE__, $restrict_api) !== 0 ) {
-                        $can_restrict_api = false;
-                    }
+					$restrict_api     = ini_get( 'opcache.restrict_api' );
+					$can_restrict_api = true;
+					if ( $restrict_api && strpos(__FILE__, $restrict_api) !== 0 ) {
+					    $can_restrict_api = false;
+					}
 					if ( function_exists( 'opcache_reset' ) && current_user_can( 'rocket_purge_opcache' ) && $can_restrict_api ) : ?>
 					<div class="wpr-field">
 						<h4 class="wpr-title3"><?php esc_html_e( 'Purge OPCache content', 'rocket' ); ?></h4>

--- a/views/settings/page-sections/dashboard.php
+++ b/views/settings/page-sections/dashboard.php
@@ -143,7 +143,13 @@ defined( 'ABSPATH' ) || die( 'Cheatin&#8217; uh?' );
 					</div>
 					<?php endif; ?>
 
-					<?php if ( function_exists( 'opcache_reset' ) && current_user_can( 'rocket_purge_opcache' ) ) : ?>
+					<?php
+                    $restrict_api     = ini_get( 'opcache.restrict_api' );
+                    $can_restrict_api = true;
+                    if ( $restrict_api && strpos(__FILE__, $restrict_api) !== 0 ) {
+                        $can_restrict_api = false;
+                    }
+					if ( function_exists( 'opcache_reset' ) && current_user_can( 'rocket_purge_opcache' ) && $can_restrict_api ) : ?>
 					<div class="wpr-field">
 						<h4 class="wpr-title3"><?php esc_html_e( 'Purge OPCache content', 'rocket' ); ?></h4>
 						<?php


### PR DESCRIPTION
When OPCache clearing via API isn't possible because of opcache.restrict_api in php.ini, it's best to remove the Purge OPCache links from:

WP Rocket Admin bar - https://jmp.sh/o8NuVrq
Quick actions in WP Rocket dashboard - https://jmp.sh/uW2Skxv