### PR TITLE
Fixes #1936 - Cache cleaned when post slug / permalink is changed

### DIFF
--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -1,6 +1,6 @@
 <?php
 defined( 'ABSPATH' ) || die( 'Cheatin&#8217; uh?' );
-
+use WP_Rocket\Logger\Logger;
 // Launch hooks that deletes all the cache domain.
 add_action( 'switch_theme', 'rocket_clean_domain' );  // When user change theme.
 add_action( 'user_register', 'rocket_clean_domain' );  // When a user is added.
@@ -527,3 +527,19 @@ function rocket_clean_cache_theme_update( $wp_upgrader, $hook_extra ) {
 
 	rocket_clean_domain();
 }
+
+/**
+ * Purge WP Rocket cache on Slug / Permalink change.
+ *
+ * @since  3.4.2
+ * @author Soponar Cristina
+ *
+ * @param int   $post_id   The post ID.
+ * @param array $post_data Array of unslashed post data.
+ */
+function rocket_clean_cache_on_slug_change( $post_id, $post_data) {
+	if ( get_post_field( 'post_name', $post_id ) != $post_data['post_name'] ) {
+        rocket_clean_files( get_the_permalink( $post_id ) );
+    }
+}
+add_action( 'pre_post_update', 'rocket_clean_cache_on_slug_change', 10, 2 );

--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -1,6 +1,6 @@
 <?php
 defined( 'ABSPATH' ) || die( 'Cheatin&#8217; uh?' );
-use WP_Rocket\Logger\Logger;
+
 // Launch hooks that deletes all the cache domain.
 add_action( 'switch_theme', 'rocket_clean_domain' );  // When user change theme.
 add_action( 'user_register', 'rocket_clean_domain' );  // When a user is added.
@@ -537,9 +537,9 @@ function rocket_clean_cache_theme_update( $wp_upgrader, $hook_extra ) {
  * @param int   $post_id   The post ID.
  * @param array $post_data Array of unslashed post data.
  */
-function rocket_clean_cache_on_slug_change( $post_id, $post_data) {
-	if ( get_post_field( 'post_name', $post_id ) != $post_data['post_name'] ) {
+function rocket_clean_post_cache_on_slug_change( $post_id, $post_data ) {
+	if ( get_post_field( 'post_name', $post_id ) !== $post_data['post_name'] ) {
         rocket_clean_files( get_the_permalink( $post_id ) );
     }
 }
-add_action( 'pre_post_update', 'rocket_clean_cache_on_slug_change', 10, 2 );
+add_action( 'pre_post_update', 'rocket_clean_post_cache_on_slug_change', 10, 2 );


### PR DESCRIPTION
Cache cleaned when post slug / permalink is changed - cache cleaned for old post slug / permalink

Based on 3.4.2 Doc