### PR TITLE
Fixes #1912 Add webfont.min.js from defer js

### DIFF
--- a/inc/functions/options.php
+++ b/inc/functions/options.php
@@ -412,6 +412,7 @@ function get_rocket_exclude_defer_js() {
 		'www.uplaunch.com',
 		'google.com/recaptcha',
 		'widget.reviews.co.uk',
+		'jupiterx/lib/admin/assets/lib/webfont/webfont.min.js'
 	];
 
 	if ( get_rocket_option( 'defer_all_js', 0 ) && get_rocket_option( 'defer_all_js_safe', 0 ) ) {

--- a/inc/functions/options.php
+++ b/inc/functions/options.php
@@ -412,7 +412,7 @@ function get_rocket_exclude_defer_js() {
 		'www.uplaunch.com',
 		'google.com/recaptcha',
 		'widget.reviews.co.uk',
-		'jupiterx/lib/admin/assets/lib/webfont/webfont.min.js'
+		'lib/admin/assets/lib/webfont/webfont.min.js'
 	];
 
 	if ( get_rocket_option( 'defer_all_js', 0 ) && get_rocket_option( 'defer_all_js_safe', 0 ) ) {

--- a/tests/Integration/Functions/Options/TestExcludeDeferJS.php
+++ b/tests/Integration/Functions/Options/TestExcludeDeferJS.php
@@ -12,6 +12,7 @@ class TestExcludeDeferJS extends TestCase {
             'www.uplaunch.com',
             'google.com/recaptcha',
             'widget.reviews.co.uk',
+            'lib/admin/assets/lib/webfont/webfont.min.js',
         ];
 
         $this->assertSame(
@@ -35,6 +36,7 @@ class TestExcludeDeferJS extends TestCase {
             'www.uplaunch.com',
             'google.com/recaptcha',
             'widget.reviews.co.uk',
+            'lib/admin/assets/lib/webfont/webfont.min.js',
             '/wp-includes/js/jquery/jquery.js',
             'c0.wp.com/c/(?:.+)/wp-includes/js/jquery/jquery.js',
             'ajax.googleapis.com/ajax/libs/jquery/(?:.+)/jquery(?:\.min)?.js',

--- a/tests/Unit/Functions/Options/TestExcludeDeferJS.php
+++ b/tests/Unit/Functions/Options/TestExcludeDeferJS.php
@@ -24,6 +24,7 @@ class TestExcludeDeferJS extends TestCase {
             'www.uplaunch.com',
             'google.com/recaptcha',
             'widget.reviews.co.uk',
+            'lib/admin/assets/lib/webfont/webfont.min.js',
         ];
 
         $this->assertSame(
@@ -54,6 +55,7 @@ class TestExcludeDeferJS extends TestCase {
             'www.uplaunch.com',
             'google.com/recaptcha',
             'widget.reviews.co.uk',
+            'lib/admin/assets/lib/webfont/webfont.min.js',
             '/wp-includes/js/jquery/jquery.js',
             'c0.wp.com/c/(?:.+)/wp-includes/js/jquery/jquery.js',
             'ajax.googleapis.com/ajax/libs/jquery/(?:.+)/jquery(?:\.min)?.js',


### PR DESCRIPTION
Using JupiterX theme you can integrate your Adobe Fonts / Typekit:
`<script type='text/javascript' src='http://example.com/wp-content/themes/jupiterx/lib/admin/assets/lib/webfont/webfont.min.js?ver=1.6.26'></script>`
`<script type='text/javascript'> WebFont.load({ typekit: { id:'xxxxxxx' } }); </script>`

Remove `/wp-content/themes/jupiterx/lib/admin/assets/lib/webfont/webfont.min.js` from defer JS in order to prevent undefined WebFont.load.

Based on 3.4.2 Doc