### PR TITLE
Cloudflare validation API done only when CF inputs are changed

### DIFF
--- a/inc/admin/options.php
+++ b/inc/admin/options.php
@@ -88,6 +88,21 @@ function rocket_after_save_options( $oldvalue, $value ) {
 		rocket_clean_cache_busting();
 	}
 
+	if ( ! empty( $_POST ) &&
+			( ( isset( $oldvalue['cloudflare_email'], $value['cloudflare_email'] ) && $oldvalue['cloudflare_email'] !== $value['cloudflare_email'] ) ||
+			( isset( $oldvalue['cloudflare_api_key'], $value['cloudflare_api_key'] ) && $oldvalue['cloudflare_api_key'] !== $value['cloudflare_api_key'] ) ||
+			( isset( $oldvalue['cloudflare_zone_id'], $value['cloudflare_zone_id'] ) && $oldvalue['cloudflare_zone_id'] !== $value['cloudflare_zone_id'] ) )
+			) {
+		// Check Cloudflare input data and display error message.
+		if ( get_rocket_option( 'do_cloudflare' ) && function_exists( 'rocket_is_api_keys_valid_cloudflare' ) ) {
+			$is_api_keys_valid_cloudflare = rocket_is_api_keys_valid_cloudflare( $value['cloudflare_email'], $value['cloudflare_api_key'], $value['cloudflare_zone_id'], false );
+			if ( is_wp_error( $is_api_keys_valid_cloudflare ) ) {
+				$cloudflare_error_message = $is_api_keys_valid_cloudflare->get_error_message();
+				add_settings_error( 'general', 'cloudflare_api_key_invalid', __( 'WP Rocket: ', 'rocket' ) . '</strong>' . $cloudflare_error_message . '<strong>', 'error' );
+			}
+		}
+	}
+
 	// Update CloudFlare Development Mode.
 	$cloudflare_update_result = array();
 

--- a/inc/admin/upgrader.php
+++ b/inc/admin/upgrader.php
@@ -432,8 +432,10 @@ function rocket_new_upgrade( $wp_rocket_version, $actual_version ) {
 	}
 
 	if ( rocket_is_ssl_website() ) {
-		update_rocket_option( 'cache_ssl', 1 );
-		rocket_generate_config_file();
+		if ( 1 !== (int) get_rocket_option( 'cache_ssl' ) ) {
+			update_rocket_option( 'cache_ssl', 1 );
+			rocket_generate_config_file();
+		}
 	}
 
 	if ( version_compare( $actual_version, '3.4', '<' ) ) {

--- a/inc/classes/admin/settings/class-settings.php
+++ b/inc/classes/admin/settings/class-settings.php
@@ -367,15 +367,6 @@ class Settings {
 			$input['cloudflare_api_key'] = WP_ROCKET_CF_API_KEY;
 		}
 
-		// Check Cloudflare input data and display error message
-		if ( get_rocket_option( 'do_cloudflare' ) && function_exists( 'rocket_is_api_keys_valid_cloudflare' ) ) {
-			$is_api_keys_valid_cloudflare = rocket_is_api_keys_valid_cloudflare( $input['cloudflare_email'], $input['cloudflare_api_key'], $input['cloudflare_zone_id'], false );
-			if ( is_wp_error( $is_api_keys_valid_cloudflare ) ) {
-				$cloudflare_error_message = $is_api_keys_valid_cloudflare->get_error_message();
-				add_settings_error( 'general', 'cloudflare_api_key_invalid', __( 'WP Rocket: ', 'rocket' ) . '</strong>' . $cloudflare_error_message . '<strong>', 'error' );
-			}
-		}
-
 		// Options: Sucuri cache. And yeah, there's a typo, but now it's too late to fix ^^'.
 		$input['sucury_waf_cache_sync'] = ! empty( $input['sucury_waf_cache_sync'] ) ? 1 : 0;
 

--- a/inc/functions/cloudflare.php
+++ b/inc/functions/cloudflare.php
@@ -51,10 +51,24 @@ function rocket_is_api_keys_valid_cloudflare( $cf_email, $cf_api_key, $cf_zone_i
 
 	try {
 		$cf_api_instance = new Cloudflare\Api( $cf_email, $cf_api_key );
-		$cf_user         = $cf_api_instance->get( 'user/' );
 		$cf_zone         = $cf_api_instance->get( 'zones/' . $cf_zone_id );
 
 		if ( ! isset( $cf_zone->success ) || empty( $cf_zone->success ) ) {
+			foreach ( $cf_zone->errors as $error ) {
+				if ( $error->code === 6003 ) {
+					$msg = __( 'Incorrect Cloudflare email address or API key.', 'rocket' );
+
+					$msg .= ' ' . sprintf(
+						/* translators: %1$s = opening link; %2$s = closing link */
+						__( 'Read the %1$sdocumentation%2$s for further guidance.', 'rocket' ),
+						// translators: Documentation exists in EN, FR; use localized URL if applicable.
+						'<a href="' . esc_url( __( 'https://docs.wp-rocket.me/article/18-using-wp-rocket-with-cloudflare/?utm_source=wp_plugin&utm_medium=wp_rocket#add-on', 'rocket' ) ) . '" rel="noopener noreferrer" target="_blank">',
+						'</a>'
+					);
+
+					return new WP_Error( 'cloudflare_invalid_auth', $msg );
+				}
+			}
 			$msg = __( 'Incorrect Cloudflare Zone ID.', 'rocket' );
 
 			$msg .= ' ' . sprintf(


### PR DESCRIPTION

- The upgrade routine will stop setting cache_ssl as true, if it's already true. This save of settings during upgrade was causing Cloudflare validation during update. This makes everything more efficient.
- Cloudflare validation will only happen if the API key / email / zone ID is changed. So it isn't validated every time other settings are saved. More efficient this way.