### PR TITLE
Fixes #306 Allow CDN exclusions to work with Minify/Remove Query Strings

### DIFF
--- a/inc/classes/subscriber/CDN/CDNSubscriber.php
+++ b/inc/classes/subscriber/CDN/CDNSubscriber.php
@@ -43,8 +43,8 @@ class CDNSubscriber implements Subscriber_Interface {
 	public static function get_subscribed_events() {
 		return [
 			'rocket_buffer'           => [
-				[ 'rewrite', 34 ],
-				[ 'rewrite_srcset', 35 ],
+				[ 'rewrite', 20 ],
+				[ 'rewrite_srcset', 21 ],
 			],
 			'rocket_css_content'      => 'rewrite_css_properties',
 			'rocket_cdn_hosts'        => [ 'get_cdn_hosts', 10, 2 ],

--- a/inc/classes/subscriber/Media/class-webp-subscriber.php
+++ b/inc/classes/subscriber/Media/class-webp-subscriber.php
@@ -106,17 +106,17 @@ class Webp_Subscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events() {
 		return [
-			'rocket_buffer'                                 => [ 'convert_to_webp', 30 ],
-			'rocket_cache_webp_setting_field'               => [
+			'rocket_buffer'                            => [ 'convert_to_webp', 16 ],
+			'rocket_cache_webp_setting_field'          => [
 				[ 'maybe_disable_setting_field' ],
 				[ 'webp_section_description' ],
 			],
-			'rocket_disable_webp_cache'                     => 'maybe_disable_webp_cache',
-			'rocket_third_party_webp_change'                => 'sync_webp_cache_with_third_party_plugins',
-			'rocket_homepage_preload_url_request_args'      => 'add_accept_header',
+			'rocket_disable_webp_cache'                => 'maybe_disable_webp_cache',
+			'rocket_third_party_webp_change'           => 'sync_webp_cache_with_third_party_plugins',
+			'rocket_homepage_preload_url_request_args' => 'add_accept_header',
 			'rocket_preload_after_purge_cache_request_args' => 'add_accept_header',
-			'rocket_preload_url_request_args'               => 'add_accept_header',
-			'rocket_partial_preload_url_request_args'       => 'add_accept_header',
+			'rocket_preload_url_request_args'          => 'add_accept_header',
+			'rocket_partial_preload_url_request_args'  => 'add_accept_header',
 		];
 	}
 

--- a/inc/classes/subscriber/Optimization/class-combine-google-fonts-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-combine-google-fonts-subscriber.php
@@ -16,7 +16,7 @@ class Combine_Google_Fonts_Subscriber extends Minify_Subscriber {
 	 */
 	public static function get_subscribed_events() {
 		return [
-			'rocket_buffer' => [ 'process', 20 ],
+			'rocket_buffer' => [ 'process', 28 ],
 		];
 	}
 

--- a/inc/classes/subscriber/Optimization/class-critical-css-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-critical-css-subscriber.php
@@ -43,8 +43,8 @@ class Critical_CSS_Subscriber implements Subscriber_Interface {
 			],
 			'wp_head'                                 => [ 'insert_load_css', PHP_INT_MAX ],
 			'rocket_buffer'                           => [
-				[ 'insert_critical_css_buffer', 18 ],
-				[ 'async_css', 24 ],
+				[ 'insert_critical_css_buffer', 29 ],
+				[ 'async_css', 32 ],
 			],
 			'switch_theme'                            => 'maybe_regenerate_cpcss',
 			'rocket_critical_css_generation_process_complete' => 'clean_domain_on_complete',
@@ -173,7 +173,7 @@ class Critical_CSS_Subscriber implements Subscriber_Interface {
 		$screen = get_current_screen();
 
 		if ( 'settings_page_wprocket' !== $screen->id ) {
-		    return;
+			return;
 		}
 
 		$transient = get_transient( 'rocket_critical_css_generation_process_running' );
@@ -233,7 +233,7 @@ class Critical_CSS_Subscriber implements Subscriber_Interface {
 		}
 
 		// Translators: %1$d = number of critical CSS generated, %2$d = total number of critical CSS to generate.
-		$message = '<p>' . sprintf( __( 'Critical CSS generation finished for %1$d of %2$d page types.', 'rocket' ), $transient['generated'], $transient['total'] );
+		$message  = '<p>' . sprintf( __( 'Critical CSS generation finished for %1$d of %2$d page types.', 'rocket' ), $transient['generated'], $transient['total'] );
 		$message .= ' <em> (' . date_i18n( get_option( 'date_format' ), current_time( 'timestamp' ) ) . ' @ ' . date_i18n( get_option( 'time_format' ), current_time( 'timestamp' ) ) . ') </em></p>';
 
 		if ( ! empty( $transient['items'] ) ) {

--- a/inc/classes/subscriber/Optimization/class-ie-conditionals-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-ie-conditionals-subscriber.php
@@ -27,7 +27,7 @@ class IE_Conditionals_Subscriber implements Subscriber_Interface {
 		return [
 			'rocket_buffer' => [
 				[ 'extract_ie_conditionals', 1 ],
-				[ 'inject_ie_conditionals', 26 ],
+				[ 'inject_ie_conditionals', 34 ],
 			],
 		];
 	}

--- a/inc/classes/subscriber/Optimization/class-lazyload-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-lazyload-subscriber.php
@@ -90,7 +90,7 @@ class Lazyload_Subscriber implements Subscriber_Interface {
 			],
 			'wp_head'              => [ 'insert_nojs_style', PHP_INT_MAX ],
 			'wp_enqueue_scripts'   => [ 'insert_youtube_thumbnail_style', PHP_INT_MAX ],
-			'rocket_buffer'        => [ 'lazyload', 32 ],
+			'rocket_buffer'        => [ 'lazyload', 18 ],
 			'rocket_lazyload_html' => 'lazyload_responsive',
 			'init'                 => 'lazyload_smilies',
 			'wp'                   => 'deactivate_lazyload_on_specific_posts',

--- a/inc/classes/subscriber/Optimization/class-minify-css-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-minify-css-subscriber.php
@@ -21,7 +21,7 @@ class Minify_CSS_Subscriber extends Minify_Subscriber {
 				[ 'fix_ssl_minify' ],
 				[ 'i18n_multidomain_url' ],
 			],
-			'rocket_buffer'  => [ 'process', 16 ],
+			'rocket_buffer'  => [ 'process', 26 ],
 		];
 
 		return $events;

--- a/inc/classes/subscriber/Optimization/class-minify-html-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-minify-html-subscriber.php
@@ -39,7 +39,7 @@ class Minify_HTML_Subscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events() {
 		return [
-			'rocket_buffer' => [ 'process', 28 ],
+			'rocket_buffer' => [ 'process', 14 ],
 		];
 	}
 

--- a/inc/classes/subscriber/Optimization/class-minify-js-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-minify-js-subscriber.php
@@ -22,7 +22,7 @@ class Minify_JS_Subscriber extends Minify_Subscriber {
 				[ 'fix_ssl_minify' ],
 				[ 'i18n_multidomain_url' ],
 			],
-			'rocket_buffer' => [ 'process', 12 ],
+			'rocket_buffer' => [ 'process', 22 ],
 		];
 
 		return $events;

--- a/inc/classes/subscriber/Optimization/class-remove-query-string-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-remove-query-string-subscriber.php
@@ -38,7 +38,7 @@ class Remove_Query_String_Subscriber extends Minify_Subscriber {
 	 */
 	public static function get_subscribed_events() {
 		return [
-			'rocket_buffer' => [ 'process', 22 ],
+			'rocket_buffer' => [ 'process', 30 ],
 		];
 	}
 

--- a/inc/front/deferred-js.php
+++ b/inc/front/deferred-js.php
@@ -55,4 +55,4 @@ function rocket_defer_js( $buffer ) {
 
 	return $buffer;
 }
-add_filter( 'rocket_buffer', 'rocket_defer_js', 14 );
+add_filter( 'rocket_buffer', 'rocket_defer_js', 24 );

--- a/tests/Integration/Subscriber/CDNSubscriber/TestGetSubscribedEvents.php
+++ b/tests/Integration/Subscriber/CDNSubscriber/TestGetSubscribedEvents.php
@@ -8,8 +8,8 @@ class TestGetSubscribedEvents extends TestCase {
     public function testShouldReturnSubscribedEventsArray() {
         $events = [
 			'rocket_buffer'           => [
-                [ 'rewrite', 34 ],
-                [ 'rewrite_srcset', 35 ],
+                [ 'rewrite', 20 ],
+                [ 'rewrite_srcset', 21 ],
             ],
 			'rocket_css_content'      => 'rewrite_css_properties',
 			'rocket_cdn_hosts'        => [ 'get_cdn_hosts', 10, 2 ],


### PR DESCRIPTION
Current priorities of functions hooked on `rocket_buffer` prevent the CDN exclusions from working correctly if minify CSS/JS and/or Remove Query Strings options are enabled.

Updating the order allows the exclusions to work, with CDN being applied first, and the above optimizations after.

Other priorities are updated too, to keep everything working in the right order:
- WebP needs to be after HTML minification
- Lazyload before CDN
- Defer JS after minify/combine JS
- Critical CSS insertion after minify/combine CSS and combine Google fonts
- Remove Query Strings after the 2 above
- Async CSS after the 3 above


![](https://media.giphy.com/media/21I1WOUDnct4EmSNa6/giphy.gif)