### PR TITLE
Fixes #2084 Correctly purge expired cache when using multilingual plugins

### DIFF
--- a/inc/classes/Cache/class-expired-cache-purge.php
+++ b/inc/classes/Cache/class-expired-cache-purge.php
@@ -80,7 +80,7 @@ class Expired_Cache_Purge {
 			return;
 		}
 
-		$urls = array_unique( $urls, true );
+		$urls = array_unique( $urls );
 
 		if ( empty( $this->filesystem ) ) {
 			$this->filesystem = rocket_direct_filesystem();

--- a/tests/Unit/Cache/TestPurgeExpiredFiles.php
+++ b/tests/Unit/Cache/TestPurgeExpiredFiles.php
@@ -35,6 +35,10 @@ class TestPurgeExpiredFiles extends TestCase {
 						'index.html' => '',
 						'index.html_gzip' => '',
 					],
+					'en' => [
+						'index.html' => '',
+						'index.html_gzip' => '',
+					],
 				],
 				'example.org-Greg-594d03f6ae698691165999' => [
 					'index.html' => '',
@@ -47,6 +51,7 @@ class TestPurgeExpiredFiles extends TestCase {
 		$this->cache_path->getChild('wp-rocket')->getChild('example.org')->getChild('blog')->getChild('index.html')->lastAttributeModified( strtotime( '11 hours ago' ) );
 		$this->cache_path->getChild('wp-rocket')->getChild('example.org')->getChild('blog')->getChild('index.html_gzip')->lastAttributeModified( strtotime( '11 hours ago' ) );
 		$this->cache_path->getChild('wp-rocket')->getChild('example.org-Greg-594d03f6ae698691165999')->getChild('index.html')->lastAttributeModified( strtotime( '11 hours ago' ) );
+		$this->cache_path->getChild('wp-rocket')->getChild('example.org')->getChild('en')->getChild('index.html')->lastAttributeModified( strtotime( '11 hours ago' ) );
 
 		$this->mock_fs = $this->getMockBuilder( 'WP_Filesystem_Direct' )
 							->setMethods( [
@@ -111,6 +116,40 @@ class TestPurgeExpiredFiles extends TestCase {
 		);
 		$this->assertFalse(
 			$this->cache_path->getChild('wp-rocket')->getChild('example.org-Greg-594d03f6ae698691165999')->hasChild('index.html')
+		);
+	}
+
+	public function testShouldDeleteCacheFilesOlderThanLifespanWhenMultilingual() {
+		Functions\When('get_rocket_i18n_uri')->justReturn(
+			[
+				'http://example.org/en',
+				'http://example.org/',
+			]
+		);
+
+		Functions\When( 'rocket_direct_filesystem')->alias( function() {
+			return $this->mock_fs;
+		});
+
+		Functions\When('get_rocket_parse_url')->alias( function( $value ) {
+			return parse_url( $value );
+		} );
+
+		$expired_cache_purge = new Expired_Cache_Purge( $this->cache_path->getChild( 'wp-rocket' )->url() );
+
+		$expired_cache_purge->purge_expired_files( 36000 );
+
+		$this->assertFalse(
+			$this->cache_path->getChild('wp-rocket')->getChild('example.org')->hasChild('blog')
+		);
+		$this->assertTrue(
+			$this->cache_path->getChild('wp-rocket')->getChild('example.org')->getChild('about')->hasChild('index.html')
+		);
+		$this->assertFalse(
+			$this->cache_path->getChild('wp-rocket')->getChild('example.org-Greg-594d03f6ae698691165999')->hasChild('index.html')
+		);
+		$this->assertFalse(
+			$this->cache_path->getChild('wp-rocket')->getChild('example.org')->getChild('en')->hasChild('index.html')
 		);
 	}
 }


### PR DESCRIPTION
- Remove the incorrect parameter used for `array_unique()`
- Update unit tests to add a test for multilingual setup