### PR TITLE
Fixed #1985 - Detect and report when </html>, </body> and wp_footer() are not available.

### DIFF
--- a/inc/classes/Buffer/class-optimization.php
+++ b/inc/classes/Buffer/class-optimization.php
@@ -72,6 +72,16 @@ class Optimization extends Abstract_Buffer {
 	 * @return string         The buffered content.
 	 */
 	public function maybe_process_buffer( $buffer ) {
+		/**
+		 * Triggered before WP Rocket starts the optimization process.
+		 *
+		 * @since  3.4.2
+		 * @author Soponar Cristina
+		 *
+		 * @param string $buffer HTML content.
+		 */
+		do_action( 'before_rocket_maybe_process_buffer', $buffer );
+
 		if ( ! $this->is_html( $buffer ) ) {
 			return $buffer;
 		}

--- a/inc/classes/Buffer/class-optimization.php
+++ b/inc/classes/Buffer/class-optimization.php
@@ -80,7 +80,7 @@ class Optimization extends Abstract_Buffer {
 		 *
 		 * @param string $buffer HTML content.
 		 */
-		do_action( 'before_rocket_maybe_process_buffer', $buffer );
+		do_action( 'rocket_before_maybe_process_buffer', $buffer );
 
 		if ( ! $this->is_html( $buffer ) ) {
 			return $buffer;

--- a/inc/classes/ServiceProvider/class-common-subscribers.php
+++ b/inc/classes/ServiceProvider/class-common-subscribers.php
@@ -33,6 +33,7 @@ class Common_Subscribers extends AbstractServiceProvider {
 		'webp_subscriber',
 		'expired_cache_purge',
 		'expired_cache_purge_subscriber',
+		'detect_missing_tags',
 	];
 
 	/**
@@ -72,5 +73,6 @@ class Common_Subscribers extends AbstractServiceProvider {
 			->withArgument( $this->getContainer()->get( 'options_api' ) )
 			->withArgument( $this->getContainer()->get( 'cdn_subscriber' ) )
 			->withArgument( $this->getContainer()->get( 'beacon' ) );
+		$this->getContainer()->share( 'detect_missing_tags_subscriber', 'WP_Rocket\Subscriber\Tools\Detect_Missing_Tags_Subscriber' );
 	}
 }

--- a/inc/classes/class-plugin.php
+++ b/inc/classes/class-plugin.php
@@ -147,6 +147,7 @@ class Plugin {
 			'plugin_information_subscriber',
 			'plugin_updater_subscriber',
 			'capabilities_subscriber',
+			'detect_missing_tags_subscriber',
 		];
 
 		if ( \rocket_valid_key() ) {

--- a/inc/classes/subscriber/Tools/class-detect-missing-tags-subscriber.php
+++ b/inc/classes/subscriber/Tools/class-detect-missing-tags-subscriber.php
@@ -69,6 +69,10 @@ class Detect_Missing_Tags_Subscriber implements Subscriber_Interface {
 			return;
 		}
 
+		if ( 'settings_page_wprocket' !== $screen->id ) {
+			return;
+		}
+
 		$notice = get_transient( 'rocket_missing_tags' );
 
 		if ( $notice ) {

--- a/inc/classes/subscriber/Tools/class-detect-missing-tags-subscriber.php
+++ b/inc/classes/subscriber/Tools/class-detect-missing-tags-subscriber.php
@@ -17,7 +17,7 @@ class Detect_Missing_Tags_Subscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events() {
 		return [
-			'admin_notices'                      => 'notice_missing_tags',
+			'admin_notices'                      => 'rocket_notice_missing_tags',
 			'rocket_before_maybe_process_buffer' => 'maybe_missing_tags',
 		];
 	}
@@ -55,7 +55,7 @@ class Detect_Missing_Tags_Subscriber implements Subscriber_Interface {
 			return;
 		}
 
-		$transient    = get_transient( 'notice_missing_tags' );
+		$transient    = get_transient( 'rocket_notice_missing_tags' );
 		$transient    = is_array( $transient ) ? $transient : [];
 		$missing_tags = array_unique( array_merge( $transient, $missing_tags ) );
 
@@ -65,11 +65,11 @@ class Detect_Missing_Tags_Subscriber implements Subscriber_Interface {
 
 		// Prevent saving the transient if the notice is dismissed.
 		$boxes = get_user_meta( get_current_user_id(), 'rocket_boxes', true );
-		if ( in_array( 'notice_missing_tags', (array) $boxes, true ) ) {
+		if ( in_array( 'rocket_notice_missing_tags', (array) $boxes, true ) ) {
 			return;
 		}
 
-		set_transient( 'notice_missing_tags', $missing_tags, HOUR_IN_SECONDS );
+		set_transient( 'rocket_notice_missing_tags', $missing_tags, HOUR_IN_SECONDS );
 	}
 
 	/**
@@ -78,7 +78,7 @@ class Detect_Missing_Tags_Subscriber implements Subscriber_Interface {
 	 * @since  3.4.2
 	 * @author Soponar Cristina
 	 */
-	public function notice_missing_tags() {
+	public function rocket_notice_missing_tags() {
 		$screen = get_current_screen();
 
 		if ( ! current_user_can( 'rocket_manage_options' ) || ( 'settings_page_wprocket' !== $screen->id ) ) {
@@ -90,7 +90,7 @@ class Detect_Missing_Tags_Subscriber implements Subscriber_Interface {
 			return;
 		}
 
-		$notice = get_transient( 'notice_missing_tags' );
+		$notice = get_transient( 'rocket_notice_missing_tags' );
 		if ( empty( $notice ) || ! is_array( $notice ) ) {
 			return;
 		}

--- a/inc/classes/subscriber/Tools/class-detect-missing-tags-subscriber.php
+++ b/inc/classes/subscriber/Tools/class-detect-missing-tags-subscriber.php
@@ -1,0 +1,101 @@
+<?php
+namespace WP_Rocket\Subscriber\Tools;
+
+use WP_Rocket\Event_Management\Subscriber_Interface;
+use WP_Rocket\Logger\Logger;
+
+/**
+ * Detect and report when <html>, wp_footer() and <body> tags are missing.
+ *
+ * @since  3.4.2
+ * @author Soponar Cristina
+ */
+class Detect_Missing_Tags_Subscriber implements Subscriber_Interface {
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function get_subscribed_events() {
+		return [
+			'admin_notices'                      => 'notice_missing_tags',
+			'before_rocket_maybe_process_buffer' => 'maybe_missing_tags',
+		];
+	}
+
+	/**
+	 * Check if there is a missing </html> or </body> tag
+	 *
+	 * @since  3.4.2
+	 * @author Soponar Cristina
+	 *
+	 * @param string $html HTML content.
+	 */
+	public function maybe_missing_tags( $html ) {
+		$notice = get_transient( 'rocket_missing_tags' );
+
+		if ( $notice ) {
+			return;
+		}
+
+		Logger::info( 'START Detect_Missing_Tags_Subscriber - maybe_missing_tags ', [ 'maybe_missing_tags' ] );
+
+		// Remove all comments before testing tags. If </html> or </body> tags are commented this will identify it as a missing tag.
+		$html    = preg_replace( '/<!--([\\s\\S]*?)-->/', '', $html );
+		$is_html = true;
+		if ( ! preg_match( '/(<\/html>)/i', $html ) ) {
+			$is_html = false;
+			Logger::debug( 'Not found closing </html> tag.', [ 'maybe_missing_tags' ] );
+		}
+
+		$is_body = true;
+		if ( ! preg_match( '/(<\/body>)/i', $html ) ) {
+			$is_body = false;
+			Logger::debug( 'Not found closing </body> tag.', [ 'maybe_missing_tags' ] );
+		}
+
+		$did_wp_footer = true;
+		if ( did_action( 'wp_footer' ) === 0 ) {
+			$did_wp_footer = false;
+			Logger::debug( 'Did action did not run wp_footer() function.', [ 'maybe_missing_tags' ] );
+		}
+
+		set_transient( 'rocket_missing_tags', $is_html && $is_body && $did_wp_footer, HOUR_IN_SECONDS );
+	}
+
+	/**
+	 * This notice is displayed if there is a missing required tag or function: </html>, </body> or wp_footer()
+	 *
+	 * @since  3.4.2
+	 * @author Soponar Cristina
+	 */
+	public function notice_missing_tags() {
+		$screen = get_current_screen();
+
+		if ( ! current_user_can( 'rocket_manage_options' ) ) {
+			return;
+		}
+
+		$notice = get_transient( 'rocket_missing_tags' );
+
+		if ( ! $notice ) {
+			return;
+		}
+
+		$msg  = '<b>' . __( 'WP Rocket: ', 'rocket' ) . '</b>';
+		$msg .= esc_html__( 'Failed to detect the following requirement(s) in your theme: closing </html>, </body> or wp_footer().', 'rocket' );
+		$msg .= ' ' . sprintf(
+			/* translators: %1$s = opening link; %2$s = closing link */
+			__( 'Read the %1$sdocumentation%2$s for further guidance.', 'rocket' ),
+			// translators: Documentation exists in EN, FR; use localized URL if applicable.
+			'<a href="' . esc_url( __( 'https://docs.wp-rocket.me/article/99-pages-not-cached-or-minify-cssjs-not-working/?utm_source=wp_plugin&utm_medium=wp_rocket#theme', 'rocket' ) ) . '" rel="noopener noreferrer" target="_blank">',
+			'</a>'
+		);
+
+		\rocket_notice_html(
+			[
+				'status'  => 'info',
+				'message' => $msg,
+			]
+		);
+	}
+}

--- a/inc/classes/subscriber/Tools/class-detect-missing-tags-subscriber.php
+++ b/inc/classes/subscriber/Tools/class-detect-missing-tags-subscriber.php
@@ -31,12 +31,6 @@ class Detect_Missing_Tags_Subscriber implements Subscriber_Interface {
 	 * @param string $html HTML content.
 	 */
 	public function maybe_missing_tags( $html ) {
-		$notice = get_transient( 'rocket_missing_tags' );
-
-		if ( $notice ) {
-			return;
-		}
-
 		Logger::info( 'START Detect_Missing_Tags_Subscriber - maybe_missing_tags ', [ 'maybe_missing_tags' ] );
 
 		// Remove all comments before testing tags. If </html> or </body> tags are commented this will identify it as a missing tag.
@@ -77,7 +71,7 @@ class Detect_Missing_Tags_Subscriber implements Subscriber_Interface {
 
 		$notice = get_transient( 'rocket_missing_tags' );
 
-		if ( ! $notice ) {
+		if ( $notice ) {
 			return;
 		}
 

--- a/inc/classes/subscriber/Tools/class-detect-missing-tags-subscriber.php
+++ b/inc/classes/subscriber/Tools/class-detect-missing-tags-subscriber.php
@@ -36,12 +36,12 @@ class Detect_Missing_Tags_Subscriber implements Subscriber_Interface {
 		// Remove all comments before testing tags. If </html> or </body> tags are commented this will identify it as a missing tag.
 		$html         = preg_replace( '/<!--([\\s\\S]*?)-->/', '', $html );
 		$missing_tags = [];
-		if ( ! preg_match( '/(<\/html>)/i', $html ) ) {
+		if ( false === strpos( $html, '</html>' ) ) {
 			$missing_tags[] = '</html>';
 			Logger::debug( 'Not found closing </html> tag.', [ 'maybe_missing_tags' ] );
 		}
 
-		if ( ! preg_match( '/(<\/body>)/i', $html ) ) {
+		if ( false === strpos( $html, '</body>' ) ) {
 			$missing_tags[] = '</body>';
 			Logger::debug( 'Not found closing </body> tag.', [ 'maybe_missing_tags' ] );
 		}
@@ -81,7 +81,7 @@ class Detect_Missing_Tags_Subscriber implements Subscriber_Interface {
 	public function rocket_notice_missing_tags() {
 		$screen = get_current_screen();
 
-		if ( ! current_user_can( 'rocket_manage_options' ) || ( 'settings_page_wprocket' !== $screen->id ) ) {
+		if ( ! current_user_can( 'rocket_manage_options' ) || 'settings_page_wprocket' !== $screen->id ) {
 			return;
 		}
 

--- a/tests/Fixtures/Subscriber/Tools/original_both_html_and_body_commented.html
+++ b/tests/Fixtures/Subscriber/Tools/original_both_html_and_body_commented.html
@@ -1,0 +1,16 @@
+<html>
+    <head>
+        <title>Sample Page</title>
+        <link rel="stylesheet" href="style.css" />
+        <link rel="stylesheet" href="plugin.css" />
+    </head>
+    <body>
+        <svg width="220" height="70" xmlns="http://www.w3.org/2000/svg">
+            <title>SVG Title Demo example</title>
+            <rect x="10" y="10" width="200" height="50"
+              style="fill:wheat; stroke:blue; stroke-width:1px">
+          </svg>
+    <!-- </body> -->
+    </body>
+<!--</html> -->
+</html>

--- a/tests/Fixtures/Subscriber/Tools/original_both_html_and_body_commented.html
+++ b/tests/Fixtures/Subscriber/Tools/original_both_html_and_body_commented.html
@@ -1,16 +1,16 @@
 <html>
-    <head>
-        <title>Sample Page</title>
-        <link rel="stylesheet" href="style.css" />
-        <link rel="stylesheet" href="plugin.css" />
-    </head>
-    <body>
-        <svg width="220" height="70" xmlns="http://www.w3.org/2000/svg">
-            <title>SVG Title Demo example</title>
-            <rect x="10" y="10" width="200" height="50"
-              style="fill:wheat; stroke:blue; stroke-width:1px">
-          </svg>
-    <!-- </body> -->
-    </body>
+	<head>
+		<title>Sample Page</title>
+		<link rel="stylesheet" href="style.css" />
+		<link rel="stylesheet" href="plugin.css" />
+	</head>
+	<body>
+		<svg width="220" height="70" xmlns="http://www.w3.org/2000/svg">
+			<title>SVG Title Demo example</title>
+			<rect x="10" y="10" width="200" height="50"
+			  style="fill:wheat; stroke:blue; stroke-width:1px">
+		  </svg>
+	<!-- </body> -->
+	</body>
 <!--</html> -->
 </html>

--- a/tests/Fixtures/Subscriber/Tools/original_commented_html_and_body.html
+++ b/tests/Fixtures/Subscriber/Tools/original_commented_html_and_body.html
@@ -1,14 +1,14 @@
 <html>
-    <head>
-        <title>Sample Page</title>
-        <link rel="stylesheet" href="style.css" />
-        <link rel="stylesheet" href="plugin.css" />
-    </head>
-    <body>
-        <svg width="220" height="70" xmlns="http://www.w3.org/2000/svg">
-            <title>SVG Title Demo example</title>
-            <rect x="10" y="10" width="200" height="50"
-              style="fill:wheat; stroke:blue; stroke-width:1px">
-          </svg>
-    <!-- </body> -->
+	<head>
+		<title>Sample Page</title>
+		<link rel="stylesheet" href="style.css" />
+		<link rel="stylesheet" href="plugin.css" />
+	</head>
+	<body>
+		<svg width="220" height="70" xmlns="http://www.w3.org/2000/svg">
+			<title>SVG Title Demo example</title>
+			<rect x="10" y="10" width="200" height="50"
+			  style="fill:wheat; stroke:blue; stroke-width:1px">
+		  </svg>
+	<!-- </body> -->
 <!--</html> -->

--- a/tests/Fixtures/Subscriber/Tools/original_commented_html_and_body.html
+++ b/tests/Fixtures/Subscriber/Tools/original_commented_html_and_body.html
@@ -1,0 +1,14 @@
+<html>
+    <head>
+        <title>Sample Page</title>
+        <link rel="stylesheet" href="style.css" />
+        <link rel="stylesheet" href="plugin.css" />
+    </head>
+    <body>
+        <svg width="220" height="70" xmlns="http://www.w3.org/2000/svg">
+            <title>SVG Title Demo example</title>
+            <rect x="10" y="10" width="200" height="50"
+              style="fill:wheat; stroke:blue; stroke-width:1px">
+          </svg>
+    <!-- </body> -->
+<!--</html> -->

--- a/tests/Fixtures/Subscriber/Tools/original_html_and_body.html
+++ b/tests/Fixtures/Subscriber/Tools/original_html_and_body.html
@@ -1,0 +1,14 @@
+<html>
+    <head>
+        <title>Sample Page</title>
+        <link rel="stylesheet" href="style.css" />
+        <link rel="stylesheet" href="plugin.css" />
+    </head>
+    <body>
+        <svg width="220" height="70" xmlns="http://www.w3.org/2000/svg">
+            <title>SVG Title Demo example</title>
+            <rect x="10" y="10" width="200" height="50"
+              style="fill:wheat; stroke:blue; stroke-width:1px">
+          </svg>
+    </body>
+</html>

--- a/tests/Fixtures/Subscriber/Tools/original_html_and_body.html
+++ b/tests/Fixtures/Subscriber/Tools/original_html_and_body.html
@@ -1,14 +1,14 @@
 <html>
-    <head>
-        <title>Sample Page</title>
-        <link rel="stylesheet" href="style.css" />
-        <link rel="stylesheet" href="plugin.css" />
-    </head>
-    <body>
-        <svg width="220" height="70" xmlns="http://www.w3.org/2000/svg">
-            <title>SVG Title Demo example</title>
-            <rect x="10" y="10" width="200" height="50"
-              style="fill:wheat; stroke:blue; stroke-width:1px">
-          </svg>
-    </body>
+	<head>
+		<title>Sample Page</title>
+		<link rel="stylesheet" href="style.css" />
+		<link rel="stylesheet" href="plugin.css" />
+	</head>
+	<body>
+		<svg width="220" height="70" xmlns="http://www.w3.org/2000/svg">
+			<title>SVG Title Demo example</title>
+			<rect x="10" y="10" width="200" height="50"
+			  style="fill:wheat; stroke:blue; stroke-width:1px">
+		  </svg>
+	</body>
 </html>

--- a/tests/Fixtures/Subscriber/Tools/original_no_html_and_body.html
+++ b/tests/Fixtures/Subscriber/Tools/original_no_html_and_body.html
@@ -1,0 +1,12 @@
+<html>
+    <head>
+        <title>Sample Page</title>
+        <link rel="stylesheet" href="style.css" />
+        <link rel="stylesheet" href="plugin.css" />
+    </head>
+    <body>
+        <svg width="220" height="70" xmlns="http://www.w3.org/2000/svg">
+            <title>SVG Title Demo example</title>
+            <rect x="10" y="10" width="200" height="50"
+              style="fill:wheat; stroke:blue; stroke-width:1px">
+          </svg>

--- a/tests/Fixtures/Subscriber/Tools/original_no_html_and_body.html
+++ b/tests/Fixtures/Subscriber/Tools/original_no_html_and_body.html
@@ -1,12 +1,12 @@
 <html>
-    <head>
-        <title>Sample Page</title>
-        <link rel="stylesheet" href="style.css" />
-        <link rel="stylesheet" href="plugin.css" />
-    </head>
-    <body>
-        <svg width="220" height="70" xmlns="http://www.w3.org/2000/svg">
-            <title>SVG Title Demo example</title>
-            <rect x="10" y="10" width="200" height="50"
-              style="fill:wheat; stroke:blue; stroke-width:1px">
-          </svg>
+	<head>
+		<title>Sample Page</title>
+		<link rel="stylesheet" href="style.css" />
+		<link rel="stylesheet" href="plugin.css" />
+	</head>
+	<body>
+		<svg width="220" height="70" xmlns="http://www.w3.org/2000/svg">
+			<title>SVG Title Demo example</title>
+			<rect x="10" y="10" width="200" height="50"
+			  style="fill:wheat; stroke:blue; stroke-width:1px">
+		  </svg>

--- a/tests/Unit/Subscriber/Tools/TestDetectMissingTags.php
+++ b/tests/Unit/Subscriber/Tools/TestDetectMissingTags.php
@@ -46,7 +46,7 @@ class TestDetectMissingTags extends TestCase {
 
 		Functions\expect( 'set_transient' )
 			->once()
-			->with('notice_missing_tags', ['</html>', '</body>', 'wp_footer()'], HOUR_IN_SECONDS);
+			->with('rocket_notice_missing_tags', ['</html>', '</body>', 'wp_footer()'], HOUR_IN_SECONDS);
 
 		$missing_tag->maybe_missing_tags( $html );
 	}
@@ -63,6 +63,9 @@ class TestDetectMissingTags extends TestCase {
 		Functions\expect( 'did_action' )
 			->once()
 			->andReturn( true );
+
+		Functions\expect( 'set_transient' )
+			->never();
 
 		$missing_tag->maybe_missing_tags( $html );
 	}
@@ -95,7 +98,7 @@ class TestDetectMissingTags extends TestCase {
 
 		Functions\expect( 'set_transient' )
 			->once()
-			->with('notice_missing_tags', ['</html>', '</body>'], HOUR_IN_SECONDS);
+			->with('rocket_notice_missing_tags', ['</html>', '</body>'], HOUR_IN_SECONDS);
 
 		$missing_tag->maybe_missing_tags( $html );
 	}
@@ -112,6 +115,9 @@ class TestDetectMissingTags extends TestCase {
 		Functions\expect( 'did_action' )
 			->once()
 			->andReturn( true );
+
+		Functions\expect( 'set_transient' )
+			->never();
 
 		$missing_tag->maybe_missing_tags( $html );
 	}

--- a/tests/Unit/Subscriber/Tools/TestDetectMissingTags.php
+++ b/tests/Unit/Subscriber/Tools/TestDetectMissingTags.php
@@ -1,0 +1,124 @@
+<?php
+namespace WP_Rocket\Tests\Unit\Subscriber\Tools;
+
+use WP_Rocket\Subscriber\Tools\Detect_Missing_Tags_Subscriber;
+use WP_Rocket\Tests\Unit\TestCase;
+use Brain\Monkey\Functions;
+use WP_Rocket\Logger\Logger;
+
+class TestDetectMissingTags extends TestCase {
+
+    use \Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
+    protected function setUp() {
+        parent::setUp();
+        if ( ! defined('HOUR_IN_SECONDS') ) {
+            define('HOUR_IN_SECONDS', 60 * 60);
+        }
+    }
+
+	/**
+	 * Test Detect_Missing_Tags_Subscriber->maybe_missing_tags() with missing HTML code </html> and </body> are missing.
+	 */
+	public function testShouldIdentifyMissingHtmlAndBodyAndWPFooter() {
+		$missing_tag = new Detect_Missing_Tags_Subscriber();
+
+        $html = \file_get_contents( WP_ROCKET_PLUGIN_TESTS_ROOT . '/../Fixtures/Subscriber/Tools/original_no_html_and_body.html');
+
+        Functions\expect( 'get_transient' )
+			->once() // called once
+            ->andReturn( false );
+
+        // Called did_action('wp_footer'), test also for missing wp_footer()
+        Functions\expect( 'did_action' )
+            ->once()
+            ->andReturn( 0 );
+
+        Functions\expect( 'set_transient' )
+			->once()
+            ->with('rocket_missing_tags', false, HOUR_IN_SECONDS);
+
+        $missing_tag->maybe_missing_tags( $html );
+
+        $this->assertTrue( true ); // Prevent "risky" warning.
+    }
+
+    /**
+     * Test should identify all elements
+     */
+    public function testShouldNotIdentifyMissingTags() {
+        $missing_tag = new Detect_Missing_Tags_Subscriber();
+
+        $html = \file_get_contents( WP_ROCKET_PLUGIN_TESTS_ROOT . '/../Fixtures/Subscriber/Tools/original_html_and_body.html');
+
+        Functions\expect( 'get_transient' )
+			->once() // called once
+            ->andReturn( false );
+
+        // Called did_action('wp_footer'), test only for HTML and BODY
+        Functions\expect( 'did_action' )
+            ->once()
+            ->andReturn( true );
+
+        Functions\expect( 'set_transient' )
+			->once()
+            ->with('rocket_missing_tags', true, HOUR_IN_SECONDS);
+
+        $missing_tag->maybe_missing_tags( $html );
+
+        $this->assertTrue( true ); // Prevent "risky" warning.
+    }
+
+
+    /**
+     * Test should identify that </html> and </body> are commented
+     */
+    public function testShouldIdentifyHTMLAndBodyAreCommented(){
+        $missing_tag = new Detect_Missing_Tags_Subscriber();
+
+        $html = \file_get_contents( WP_ROCKET_PLUGIN_TESTS_ROOT . '/../Fixtures/Subscriber/Tools/original_commented_html_and_body.html');
+
+        Functions\expect( 'get_transient' )
+			->once() // called once
+            ->andReturn( false );
+
+        // Called did_action('wp_footer'), test only for HTML and BODY
+        Functions\expect( 'did_action' )
+            ->once()
+            ->andReturn( true );
+
+        Functions\expect( 'set_transient' )
+			->once()
+            ->with('rocket_missing_tags', false, HOUR_IN_SECONDS);
+
+        $missing_tag->maybe_missing_tags( $html );
+
+        $this->assertTrue( true ); // Prevent "risky" warning.
+    }
+
+    /**
+     * Test should identify that <html> and </body> are fine when are available and also commented
+     */
+    public function testShouldIdentifyFineHTMLAndBodyWhenAreCommented(){
+        $missing_tag = new Detect_Missing_Tags_Subscriber();
+
+        $html = \file_get_contents( WP_ROCKET_PLUGIN_TESTS_ROOT . '/../Fixtures/Subscriber/Tools/original_both_html_and_body_commented.html');
+
+        Functions\expect( 'get_transient' )
+			->once() // called once
+            ->andReturn( false );
+
+        // Called did_action('wp_footer'), test only for HTML and BODY
+        Functions\expect( 'did_action' )
+            ->once()
+            ->andReturn( true );
+
+        Functions\expect( 'set_transient' )
+			->once()
+            ->with('rocket_missing_tags', true, HOUR_IN_SECONDS);
+
+        $missing_tag->maybe_missing_tags( $html );
+
+        $this->assertTrue( true ); // Prevent "risky" warning.
+    }
+}

--- a/tests/Unit/Subscriber/Tools/TestDetectMissingTags.php
+++ b/tests/Unit/Subscriber/Tools/TestDetectMissingTags.php
@@ -8,14 +8,14 @@ use WP_Rocket\Logger\Logger;
 
 class TestDetectMissingTags extends TestCase {
 
-    use \Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+	use \Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 
-    protected function setUp() {
-        parent::setUp();
-        if ( ! defined('HOUR_IN_SECONDS') ) {
-            define('HOUR_IN_SECONDS', 60 * 60);
-        }
-    }
+	protected function setUp() {
+		parent::setUp();
+		if ( ! defined('HOUR_IN_SECONDS') ) {
+			define('HOUR_IN_SECONDS', 60 * 60);
+		}
+	}
 
 	/**
 	 * Test Detect_Missing_Tags_Subscriber->maybe_missing_tags() with missing HTML code </html> and </body> are missing.
@@ -23,86 +23,86 @@ class TestDetectMissingTags extends TestCase {
 	public function testShouldIdentifyMissingHtmlAndBodyAndWPFooter() {
 		$missing_tag = new Detect_Missing_Tags_Subscriber();
 
-        $html = \file_get_contents( WP_ROCKET_PLUGIN_TESTS_ROOT . '/../Fixtures/Subscriber/Tools/original_no_html_and_body.html');
+		$html = \file_get_contents( WP_ROCKET_PLUGIN_TESTS_ROOT . '/../Fixtures/Subscriber/Tools/original_no_html_and_body.html');
 
-        // Called did_action('wp_footer'), test also for missing wp_footer()
-        Functions\expect( 'did_action' )
-            ->once()
-            ->andReturn( 0 );
-
-        Functions\expect( 'set_transient' )
+		// Called did_action('wp_footer'), test also for missing wp_footer()
+		Functions\expect( 'did_action' )
 			->once()
-            ->with('rocket_missing_tags', false, HOUR_IN_SECONDS);
+			->andReturn( 0 );
 
-        $missing_tag->maybe_missing_tags( $html );
-
-        $this->assertTrue( true ); // Prevent "risky" warning.
-    }
-
-    /**
-     * Test should identify all elements
-     */
-    public function testShouldNotIdentifyMissingTags() {
-        $missing_tag = new Detect_Missing_Tags_Subscriber();
-
-        $html = \file_get_contents( WP_ROCKET_PLUGIN_TESTS_ROOT . '/../Fixtures/Subscriber/Tools/original_html_and_body.html');
-
-        // Called did_action('wp_footer'), test only for HTML and BODY
-        Functions\expect( 'did_action' )
-            ->once()
-            ->andReturn( true );
-
-        Functions\expect( 'set_transient' )
+		Functions\expect( 'set_transient' )
 			->once()
-            ->with('rocket_missing_tags', true, HOUR_IN_SECONDS);
+			->with('rocket_missing_tags', false, HOUR_IN_SECONDS);
 
-        $missing_tag->maybe_missing_tags( $html );
+		$missing_tag->maybe_missing_tags( $html );
 
-        $this->assertTrue( true ); // Prevent "risky" warning.
-    }
+		$this->assertTrue( true ); // Prevent "risky" warning.
+	}
 
+	/**
+	 * Test should identify all elements
+	 */
+	public function testShouldNotIdentifyMissingTags() {
+		$missing_tag = new Detect_Missing_Tags_Subscriber();
 
-    /**
-     * Test should identify that </html> and </body> are commented
-     */
-    public function testShouldIdentifyHTMLAndBodyAreCommented(){
-        $missing_tag = new Detect_Missing_Tags_Subscriber();
+		$html = \file_get_contents( WP_ROCKET_PLUGIN_TESTS_ROOT . '/../Fixtures/Subscriber/Tools/original_html_and_body.html');
 
-        $html = \file_get_contents( WP_ROCKET_PLUGIN_TESTS_ROOT . '/../Fixtures/Subscriber/Tools/original_commented_html_and_body.html');
-
-        // Called did_action('wp_footer'), test only for HTML and BODY
-        Functions\expect( 'did_action' )
-            ->once()
-            ->andReturn( true );
-
-        Functions\expect( 'set_transient' )
+		// Called did_action('wp_footer'), test only for HTML and BODY
+		Functions\expect( 'did_action' )
 			->once()
-            ->with('rocket_missing_tags', false, HOUR_IN_SECONDS);
+			->andReturn( true );
 
-        $missing_tag->maybe_missing_tags( $html );
-
-        $this->assertTrue( true ); // Prevent "risky" warning.
-    }
-
-    /**
-     * Test should identify that <html> and </body> are fine when are available and also commented
-     */
-    public function testShouldIdentifyFineHTMLAndBodyWhenAreCommented(){
-        $missing_tag = new Detect_Missing_Tags_Subscriber();
-
-        $html = \file_get_contents( WP_ROCKET_PLUGIN_TESTS_ROOT . '/../Fixtures/Subscriber/Tools/original_both_html_and_body_commented.html');
-
-        // Called did_action('wp_footer'), test only for HTML and BODY
-        Functions\expect( 'did_action' )
-            ->once()
-            ->andReturn( true );
-
-        Functions\expect( 'set_transient' )
+		Functions\expect( 'set_transient' )
 			->once()
-            ->with('rocket_missing_tags', true, HOUR_IN_SECONDS);
+			->with('rocket_missing_tags', true, HOUR_IN_SECONDS);
 
-        $missing_tag->maybe_missing_tags( $html );
+		$missing_tag->maybe_missing_tags( $html );
 
-        $this->assertTrue( true ); // Prevent "risky" warning.
-    }
+		$this->assertTrue( true ); // Prevent "risky" warning.
+	}
+
+
+	/**
+	 * Test should identify that </html> and </body> are commented
+	 */
+	public function testShouldIdentifyHTMLAndBodyAreCommented(){
+		$missing_tag = new Detect_Missing_Tags_Subscriber();
+
+		$html = \file_get_contents( WP_ROCKET_PLUGIN_TESTS_ROOT . '/../Fixtures/Subscriber/Tools/original_commented_html_and_body.html');
+
+		// Called did_action('wp_footer'), test only for HTML and BODY
+		Functions\expect( 'did_action' )
+			->once()
+			->andReturn( true );
+
+		Functions\expect( 'set_transient' )
+			->once()
+			->with('rocket_missing_tags', false, HOUR_IN_SECONDS);
+
+		$missing_tag->maybe_missing_tags( $html );
+
+		$this->assertTrue( true ); // Prevent "risky" warning.
+	}
+
+	/**
+	 * Test should identify that <html> and </body> are fine when are available and also commented
+	 */
+	public function testShouldIdentifyFineHTMLAndBodyWhenAreCommented(){
+		$missing_tag = new Detect_Missing_Tags_Subscriber();
+
+		$html = \file_get_contents( WP_ROCKET_PLUGIN_TESTS_ROOT . '/../Fixtures/Subscriber/Tools/original_both_html_and_body_commented.html');
+
+		// Called did_action('wp_footer'), test only for HTML and BODY
+		Functions\expect( 'did_action' )
+			->once()
+			->andReturn( true );
+
+		Functions\expect( 'set_transient' )
+			->once()
+			->with('rocket_missing_tags', true, HOUR_IN_SECONDS);
+
+		$missing_tag->maybe_missing_tags( $html );
+
+		$this->assertTrue( true ); // Prevent "risky" warning.
+	}
 }

--- a/tests/Unit/Subscriber/Tools/TestDetectMissingTags.php
+++ b/tests/Unit/Subscriber/Tools/TestDetectMissingTags.php
@@ -25,10 +25,6 @@ class TestDetectMissingTags extends TestCase {
 
         $html = \file_get_contents( WP_ROCKET_PLUGIN_TESTS_ROOT . '/../Fixtures/Subscriber/Tools/original_no_html_and_body.html');
 
-        Functions\expect( 'get_transient' )
-			->once() // called once
-            ->andReturn( false );
-
         // Called did_action('wp_footer'), test also for missing wp_footer()
         Functions\expect( 'did_action' )
             ->once()
@@ -50,10 +46,6 @@ class TestDetectMissingTags extends TestCase {
         $missing_tag = new Detect_Missing_Tags_Subscriber();
 
         $html = \file_get_contents( WP_ROCKET_PLUGIN_TESTS_ROOT . '/../Fixtures/Subscriber/Tools/original_html_and_body.html');
-
-        Functions\expect( 'get_transient' )
-			->once() // called once
-            ->andReturn( false );
 
         // Called did_action('wp_footer'), test only for HTML and BODY
         Functions\expect( 'did_action' )
@@ -78,10 +70,6 @@ class TestDetectMissingTags extends TestCase {
 
         $html = \file_get_contents( WP_ROCKET_PLUGIN_TESTS_ROOT . '/../Fixtures/Subscriber/Tools/original_commented_html_and_body.html');
 
-        Functions\expect( 'get_transient' )
-			->once() // called once
-            ->andReturn( false );
-
         // Called did_action('wp_footer'), test only for HTML and BODY
         Functions\expect( 'did_action' )
             ->once()
@@ -103,10 +91,6 @@ class TestDetectMissingTags extends TestCase {
         $missing_tag = new Detect_Missing_Tags_Subscriber();
 
         $html = \file_get_contents( WP_ROCKET_PLUGIN_TESTS_ROOT . '/../Fixtures/Subscriber/Tools/original_both_html_and_body_commented.html');
-
-        Functions\expect( 'get_transient' )
-			->once() // called once
-            ->andReturn( false );
 
         // Called did_action('wp_footer'), test only for HTML and BODY
         Functions\expect( 'did_action' )

--- a/tests/Unit/Subscriber/Tools/TestDetectMissingTags.php
+++ b/tests/Unit/Subscriber/Tools/TestDetectMissingTags.php
@@ -32,17 +32,14 @@ class TestDetectMissingTags extends TestCase {
 			->once()
 			->andReturn( 0 );
 
-		Functions\expect( 'get_transient' )
-			->once()
-			->andReturn( [] );
+		Functions\when( 'get_transient' )
+			->justReturn( [] );
 
-		Functions\expect( 'get_user_meta' )
-			->once()
-			->andReturn( [] );
+		Functions\when( 'get_user_meta' )
+			->justReturn( [] );
 
-		Functions\expect( 'get_current_user_id' )
-			->once()
-			->andReturn( 1 );
+		Functions\when( 'get_current_user_id' )
+			->justReturn( 1 );
 
 		Functions\expect( 'set_transient' )
 			->once()
@@ -84,17 +81,14 @@ class TestDetectMissingTags extends TestCase {
 			->once()
 			->andReturn( true );
 
-		Functions\expect( 'get_transient' )
-			->once()
-			->andReturn( [] );
+		Functions\when( 'get_transient' )
+			->justReturn( [] );
 
-		Functions\expect( 'get_user_meta' )
-			->once()
-			->andReturn( [] );
+		Functions\when( 'get_user_meta' )
+			->justReturn( [] );
 
-		Functions\expect( 'get_current_user_id' )
-			->once()
-			->andReturn( 1 );
+		Functions\when( 'get_current_user_id' )
+			->justReturn( 1 );
 
 		Functions\expect( 'set_transient' )
 			->once()

--- a/tests/Unit/Subscriber/Tools/TestDetectMissingTags.php
+++ b/tests/Unit/Subscriber/Tools/TestDetectMissingTags.php
@@ -36,9 +36,17 @@ class TestDetectMissingTags extends TestCase {
 			->once()
 			->andReturn( [] );
 
+		Functions\expect( 'get_user_meta' )
+			->once()
+			->andReturn( [] );
+
+		Functions\expect( 'get_current_user_id' )
+			->once()
+			->andReturn( 1 );
+
 		Functions\expect( 'set_transient' )
 			->once()
-			->with('rocket_missing_tags', ['</html>', '</body>', 'wp_footer()'], HOUR_IN_SECONDS);
+			->with('notice_missing_tags', ['</html>', '</body>', 'wp_footer()'], HOUR_IN_SECONDS);
 
 		$missing_tag->maybe_missing_tags( $html );
 	}
@@ -77,9 +85,17 @@ class TestDetectMissingTags extends TestCase {
 			->once()
 			->andReturn( [] );
 
+		Functions\expect( 'get_user_meta' )
+			->once()
+			->andReturn( [] );
+
+		Functions\expect( 'get_current_user_id' )
+			->once()
+			->andReturn( 1 );
+
 		Functions\expect( 'set_transient' )
 			->once()
-			->with('rocket_missing_tags', ['</html>', '</body>'], HOUR_IN_SECONDS);
+			->with('notice_missing_tags', ['</html>', '</body>'], HOUR_IN_SECONDS);
 
 		$missing_tag->maybe_missing_tags( $html );
 	}

--- a/tests/Unit/Subscriber/Tools/TestDetectMissingTags.php
+++ b/tests/Unit/Subscriber/Tools/TestDetectMissingTags.php
@@ -4,7 +4,6 @@ namespace WP_Rocket\Tests\Unit\Subscriber\Tools;
 use WP_Rocket\Subscriber\Tools\Detect_Missing_Tags_Subscriber;
 use WP_Rocket\Tests\Unit\TestCase;
 use Brain\Monkey\Functions;
-use WP_Rocket\Logger\Logger;
 
 class TestDetectMissingTags extends TestCase {
 
@@ -12,6 +11,9 @@ class TestDetectMissingTags extends TestCase {
 
 	protected function setUp() {
 		parent::setUp();
+
+		$this->mockCommonWpFunctions();
+
 		if ( ! defined('HOUR_IN_SECONDS') ) {
 			define('HOUR_IN_SECONDS', 60 * 60);
 		}
@@ -30,13 +32,15 @@ class TestDetectMissingTags extends TestCase {
 			->once()
 			->andReturn( 0 );
 
+		Functions\expect( 'wp_sprintf_l' )
+			->once()
+			->andReturn( '' );
+
 		Functions\expect( 'set_transient' )
 			->once()
-			->with('rocket_missing_tags', false, HOUR_IN_SECONDS);
+			->with('rocket_missing_tags', '', HOUR_IN_SECONDS);
 
 		$missing_tag->maybe_missing_tags( $html );
-
-		$this->assertTrue( true ); // Prevent "risky" warning.
 	}
 
 	/**
@@ -52,13 +56,15 @@ class TestDetectMissingTags extends TestCase {
 			->once()
 			->andReturn( true );
 
+		Functions\expect( 'wp_sprintf_l' )
+			->once()
+			->andReturn( '</html>, </body> and wp_footer()' );
+
 		Functions\expect( 'set_transient' )
 			->once()
-			->with('rocket_missing_tags', true, HOUR_IN_SECONDS);
+			->with('rocket_missing_tags', '</html>, </body> and wp_footer()', HOUR_IN_SECONDS);
 
 		$missing_tag->maybe_missing_tags( $html );
-
-		$this->assertTrue( true ); // Prevent "risky" warning.
 	}
 
 
@@ -75,13 +81,15 @@ class TestDetectMissingTags extends TestCase {
 			->once()
 			->andReturn( true );
 
+		Functions\expect( 'wp_sprintf_l' )
+			->once()
+			->andReturn( '</html> and </body>' );
+
 		Functions\expect( 'set_transient' )
 			->once()
-			->with('rocket_missing_tags', false, HOUR_IN_SECONDS);
+			->with('rocket_missing_tags', '</html> and </body>', HOUR_IN_SECONDS);
 
 		$missing_tag->maybe_missing_tags( $html );
-
-		$this->assertTrue( true ); // Prevent "risky" warning.
 	}
 
 	/**
@@ -97,12 +105,14 @@ class TestDetectMissingTags extends TestCase {
 			->once()
 			->andReturn( true );
 
+		Functions\expect( 'wp_sprintf_l' )
+			->once()
+			->andReturn( '' );
+
 		Functions\expect( 'set_transient' )
 			->once()
-			->with('rocket_missing_tags', true, HOUR_IN_SECONDS);
+			->with('rocket_missing_tags', '', HOUR_IN_SECONDS);
 
 		$missing_tag->maybe_missing_tags( $html );
-
-		$this->assertTrue( true ); // Prevent "risky" warning.
 	}
 }

--- a/tests/Unit/Subscriber/Tools/TestDetectMissingTags.php
+++ b/tests/Unit/Subscriber/Tools/TestDetectMissingTags.php
@@ -32,13 +32,13 @@ class TestDetectMissingTags extends TestCase {
 			->once()
 			->andReturn( 0 );
 
-		Functions\expect( 'wp_sprintf_l' )
+		Functions\expect( 'get_transient' )
 			->once()
-			->andReturn( '' );
+			->andReturn( [] );
 
 		Functions\expect( 'set_transient' )
 			->once()
-			->with('rocket_missing_tags', '', HOUR_IN_SECONDS);
+			->with('rocket_missing_tags', ['</html>', '</body>', 'wp_footer()'], HOUR_IN_SECONDS);
 
 		$missing_tag->maybe_missing_tags( $html );
 	}
@@ -55,14 +55,6 @@ class TestDetectMissingTags extends TestCase {
 		Functions\expect( 'did_action' )
 			->once()
 			->andReturn( true );
-
-		Functions\expect( 'wp_sprintf_l' )
-			->once()
-			->andReturn( '</html>, </body> and wp_footer()' );
-
-		Functions\expect( 'set_transient' )
-			->once()
-			->with('rocket_missing_tags', '</html>, </body> and wp_footer()', HOUR_IN_SECONDS);
 
 		$missing_tag->maybe_missing_tags( $html );
 	}
@@ -81,13 +73,13 @@ class TestDetectMissingTags extends TestCase {
 			->once()
 			->andReturn( true );
 
-		Functions\expect( 'wp_sprintf_l' )
+		Functions\expect( 'get_transient' )
 			->once()
-			->andReturn( '</html> and </body>' );
+			->andReturn( [] );
 
 		Functions\expect( 'set_transient' )
 			->once()
-			->with('rocket_missing_tags', '</html> and </body>', HOUR_IN_SECONDS);
+			->with('rocket_missing_tags', ['</html>', '</body>'], HOUR_IN_SECONDS);
 
 		$missing_tag->maybe_missing_tags( $html );
 	}
@@ -104,14 +96,6 @@ class TestDetectMissingTags extends TestCase {
 		Functions\expect( 'did_action' )
 			->once()
 			->andReturn( true );
-
-		Functions\expect( 'wp_sprintf_l' )
-			->once()
-			->andReturn( '' );
-
-		Functions\expect( 'set_transient' )
-			->once()
-			->with('rocket_missing_tags', '', HOUR_IN_SECONDS);
 
 		$missing_tag->maybe_missing_tags( $html );
 	}


### PR DESCRIPTION
Detect and report when closing </html>, </body> and wp_footer() are not available.

I created a new hook in before Optimization process starts, which is hooked in "template_redirect" hook. It seems this hook is called only from template calls and I checked it out with REST API and with FEED and even if caching is enabled for these 2 it works fine (no false positive because this hook is not called)