### PR TITLE
Fixed #1904 Clean the archive page of a CPT with SSL

### DIFF
--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -121,9 +121,15 @@ function rocket_clean_post( $post_id, $post = null ) {
 	if ( 'post' !== $post->post_type ) {
 		$post_type_archive = get_post_type_archive_link( get_post_type( $post_id ) );
 		if ( $post_type_archive ) {
+			// Rename the caching filename for SSL URLs.
+			$filename = 'index';
+			if ( is_ssl() ) {
+				$filename .= '-https';
+			}
+
 			$post_type_archive = trailingslashit( $post_type_archive );
-			array_push( $purge_urls, $post_type_archive . 'index.html' );
-			array_push( $purge_urls, $post_type_archive . 'index.html_gzip' );
+			array_push( $purge_urls, $post_type_archive . $filename . '.html' );
+			array_push( $purge_urls, $post_type_archive . $filename . '.html_gzip' );
 			array_push( $purge_urls, $post_type_archive . $GLOBALS['wp_rewrite']->pagination_base );
 		}
 	}


### PR DESCRIPTION
Fixed clean archive page of a CPT with SLL, basically index.html and index.html_gzip must contain -https since SSL cache is active.

Based on 3.4.2