### PR TITLE
Fixed false positive for missing tags when there is a redirect

### DIFF
--- a/inc/classes/subscriber/Tools/class-detect-missing-tags-subscriber.php
+++ b/inc/classes/subscriber/Tools/class-detect-missing-tags-subscriber.php
@@ -35,24 +35,48 @@ class Detect_Missing_Tags_Subscriber implements Subscriber_Interface {
 		if ( strlen( $html ) <= 255 ) {
 			return;
 		}
-		Logger::info( 'START Detect Missing closing tags ( <html>, </body> or wp_footer() )', [ 'URI' => $this->get_raw_request_uri() ] );
+		Logger::info(
+			'START Detect Missing closing tags ( <html>, </body> or wp_footer() )',
+			[
+				'maybe_missing_tags',
+				'URI' => $this->get_raw_request_uri(),
+			]
+		);
 
 		// Remove all comments before testing tags. If </html> or </body> tags are commented this will identify it as a missing tag.
 		$html         = preg_replace( '/<!--([\\s\\S]*?)-->/', '', $html );
 		$missing_tags = [];
 		if ( false === strpos( $html, '</html>' ) ) {
 			$missing_tags[] = '</html>';
-			Logger::debug( 'Not found closing </html> tag.', [ 'URI' => $this->get_raw_request_uri() ] );
+			Logger::debug(
+				'Not found closing </html> tag.',
+				[
+					'maybe_missing_tags',
+					'URI' => $this->get_raw_request_uri()
+				]
+			);
 		}
 
 		if ( false === strpos( $html, '</body>' ) ) {
 			$missing_tags[] = '</body>';
-			Logger::debug( 'Not found closing </body> tag.', [ 'URI' => $this->get_raw_request_uri() ] );
+			Logger::debug(
+				'Not found closing </body> tag.',
+				[
+					'maybe_missing_tags',
+					'URI' => $this->get_raw_request_uri()
+				]
+			);
 		}
 
 		if ( did_action( 'wp_footer' ) === 0 ) {
 			$missing_tags[] = 'wp_footer()';
-			Logger::debug( 'wp_footer() function did not run.', [ 'URI' => $this->get_raw_request_uri() ] );
+			Logger::debug(
+				'wp_footer() function did not run.',
+				[
+					'maybe_missing_tags',
+					'URI' => $this->get_raw_request_uri()
+				]
+			);
 		}
 
 		if ( ! $missing_tags ) {
@@ -145,6 +169,6 @@ class Detect_Missing_Tags_Subscriber implements Subscriber_Interface {
 			return '';
 		}
 
-		return '/' . ltrim( $_SERVER['REQUEST_URI'], '/' );
+		return '/' . esc_html( ltrim( wp_unslash( $_SERVER['REQUEST_URI'] ), '/' ) );
 	}
 }

--- a/inc/classes/subscriber/Tools/class-detect-missing-tags-subscriber.php
+++ b/inc/classes/subscriber/Tools/class-detect-missing-tags-subscriber.php
@@ -31,24 +31,28 @@ class Detect_Missing_Tags_Subscriber implements Subscriber_Interface {
 	 * @param string $html HTML content.
 	 */
 	public function maybe_missing_tags( $html ) {
-		Logger::info( 'START Detect_Missing_Tags_Subscriber - maybe_missing_tags ', [ 'maybe_missing_tags' ] );
+		// If there is a redirect the content is empty and can display a false positive notice.
+		if ( strlen( $html ) <= 255 ) {
+			return;
+		}
+		Logger::info( 'START Detect Missing closing tags ( <html>, </body> or wp_footer() )', [ 'URI' => $this->get_raw_request_uri() ] );
 
 		// Remove all comments before testing tags. If </html> or </body> tags are commented this will identify it as a missing tag.
 		$html         = preg_replace( '/<!--([\\s\\S]*?)-->/', '', $html );
 		$missing_tags = [];
 		if ( false === strpos( $html, '</html>' ) ) {
 			$missing_tags[] = '</html>';
-			Logger::debug( 'Not found closing </html> tag.', [ 'maybe_missing_tags' ] );
+			Logger::debug( 'Not found closing </html> tag.', [ 'URI' => $this->get_raw_request_uri() ] );
 		}
 
 		if ( false === strpos( $html, '</body>' ) ) {
 			$missing_tags[] = '</body>';
-			Logger::debug( 'Not found closing </body> tag.', [ 'maybe_missing_tags' ] );
+			Logger::debug( 'Not found closing </body> tag.', [ 'URI' => $this->get_raw_request_uri() ] );
 		}
 
 		if ( did_action( 'wp_footer' ) === 0 ) {
 			$missing_tags[] = 'wp_footer()';
-			Logger::debug( 'wp_footer() function did not run.', [ 'maybe_missing_tags' ] );
+			Logger::debug( 'wp_footer() function did not run.', [ 'URI' => $this->get_raw_request_uri() ] );
 		}
 
 		if ( ! $missing_tags ) {
@@ -122,5 +126,25 @@ class Detect_Missing_Tags_Subscriber implements Subscriber_Interface {
 				'dismiss_button' => __FUNCTION__,
 			]
 		);
+	}
+
+	/**
+	 * Get the request URI.
+	 *
+	 * @since  3.4.2
+	 * @author Soponar Cristina
+	 *
+	 * @return string
+	 */
+	public function get_raw_request_uri() {
+		if ( ! isset( $_SERVER['REQUEST_URI'] ) ) {
+			return '';
+		}
+
+		if ( '' === $_SERVER['REQUEST_URI'] ) {
+			return '';
+		}
+
+		return '/' . ltrim( $_SERVER['REQUEST_URI'], '/' );
 	}
 }

--- a/inc/classes/subscriber/Tools/class-detect-missing-tags-subscriber.php
+++ b/inc/classes/subscriber/Tools/class-detect-missing-tags-subscriber.php
@@ -52,7 +52,7 @@ class Detect_Missing_Tags_Subscriber implements Subscriber_Interface {
 				'Not found closing </html> tag.',
 				[
 					'maybe_missing_tags',
-					'URI' => $this->get_raw_request_uri()
+					'URI' => $this->get_raw_request_uri(),
 				]
 			);
 		}
@@ -63,7 +63,7 @@ class Detect_Missing_Tags_Subscriber implements Subscriber_Interface {
 				'Not found closing </body> tag.',
 				[
 					'maybe_missing_tags',
-					'URI' => $this->get_raw_request_uri()
+					'URI' => $this->get_raw_request_uri(),
 				]
 			);
 		}
@@ -74,7 +74,7 @@ class Detect_Missing_Tags_Subscriber implements Subscriber_Interface {
 				'wp_footer() function did not run.',
 				[
 					'maybe_missing_tags',
-					'URI' => $this->get_raw_request_uri()
+					'URI' => $this->get_raw_request_uri(),
 				]
 			);
 		}


### PR DESCRIPTION
Fixed false positive reports for missing </html>, </body> or wp_footer() when there is a redirect and the content of the page is empty or less than 255 chars. 