### PR TITLE
Fix #2103 Array to string conversion in mobile subscriber

### DIFF
--- a/inc/classes/subscriber/third-party/plugins/class-mobile-subscriber.php
+++ b/inc/classes/subscriber/third-party/plugins/class-mobile-subscriber.php
@@ -221,6 +221,7 @@ class Mobile_Subscriber implements Subscriber_Interface {
 	 */
 	public function maybe_update_mobile_cache_activation( $value, $old_value ) {
 		$plugins   = static::get_mobile_plugins();
+		$plugins   = array_keys( $plugins );
 		$value     = array_intersect( $plugins, (array) $value );
 		$old_value = array_intersect( $plugins, (array) $old_value );
 


### PR DESCRIPTION
Notice: Array to string conversion in /home/wpquicki/mega/wp-content/plugins/wp-rocket/inc/classes/subscriber/third-party/plugins/class-mobile-subscriber.php on line 224

When 3.4.2-alpha1 is installed and I rollback to 3.3.7, I get the following notice:

