### PR TITLE
Fixed: Fatal error at getCTime() in expired cache purge

### DIFF
--- a/inc/classes/Cache/class-expired-cache-purge.php
+++ b/inc/classes/Cache/class-expired-cache-purge.php
@@ -326,7 +326,7 @@ class Expired_Cache_Purge {
 				$dir_deleted = $this->purge_dir( $item->getPathname(), $file_age_limit );
 				$deleted     = array_merge( $deleted, $dir_deleted );
 
-			} elseif ( $item->getCTime() < $file_age_limit ) {
+			} elseif ( $item->isFile() && $item->getCTime() < $file_age_limit ) {
 				$file_path = $item->getPathname();
 
 				/**


### PR DESCRIPTION
Fixed: Fatal error at `getCTime()` in expired cache purge

`$item->getCTime()` throws a `RuntimeException`

`CRITICAL Uncaught RuntimeException: SplFileInfo::getCTime(): stat failed for /public_html/wp-content/cache/wp-rocket/.../index-https.html_gzip in /public_html/wp-content/plugins/wp-rocket/inc/classes/Cache/class-expired-cache-purge.php:329`