### PR TITLE
Fixes #2095: PHP Warning: date() expects parameter 2 to be int

### DIFF
--- a/inc/classes/admin/settings/class-page.php
+++ b/inc/classes/admin/settings/class-page.php
@@ -226,7 +226,7 @@ class Page {
 		}
 
 		$customer_data->class              = time() < $customer_data->licence_expiration ? 'wpr-isValid' : 'wpr-isInvalid';
-		$customer_data->licence_expiration = date_i18n( get_option( 'date_format' ), $customer_data->licence_expiration );
+		$customer_data->licence_expiration = date_i18n( get_option( 'date_format' ), (int) $customer_data->licence_expiration );
 
 		return $customer_data;
 	}


### PR DESCRIPTION
Make sure to pass an integer timestamp to `date_i18n()`.