### PR TITLE
Fix: prevent false positive on missing tag notice

### DIFF
--- a/inc/classes/subscriber/Tools/class-detect-missing-tags-subscriber.php
+++ b/inc/classes/subscriber/Tools/class-detect-missing-tags-subscriber.php
@@ -19,6 +19,7 @@ class Detect_Missing_Tags_Subscriber implements Subscriber_Interface {
 		return [
 			'admin_notices'                      => 'rocket_notice_missing_tags',
 			'rocket_before_maybe_process_buffer' => 'maybe_missing_tags',
+			'wp_rocket_upgrade'                  => 'delete_transient_after_upgrade',
 		];
 	}
 
@@ -37,6 +38,14 @@ class Detect_Missing_Tags_Subscriber implements Subscriber_Interface {
 		}
 		// If the http response is not 200 do not report missing tags.
 		if ( http_response_code() !== 200 ) {
+			return;
+		}
+		// If content type is not HTML do not report missing tags.
+		if ( empty( $_SERVER['content_type'] ) || false === strpos( wp_unslash( $_SERVER['content_type'] ), 'text/html' ) ) {
+			return;
+		}
+		// If the content does not contain HTML Doctype, do not report missing tags.
+		if ( false === stripos( $html, '<!DOCTYPE html' ) ) {
 			return;
 		}
 		Logger::info(
@@ -174,5 +183,15 @@ class Detect_Missing_Tags_Subscriber implements Subscriber_Interface {
 		}
 
 		return '/' . esc_html( ltrim( wp_unslash( $_SERVER['REQUEST_URI'] ), '/' ) );
+	}
+
+	/**
+	 * Deletes the transient storing the missing tags when updating the plugin
+	 *
+	 * @since  3.4.2.2
+	 * @author Soponar Cristina
+	 */
+	public function delete_transient_after_upgrade() {
+		delete_transient( 'rocket_notice_missing_tags' );
 	}
 }

--- a/tests/Fixtures/Subscriber/Tools/original_both_html_and_body_commented.html
+++ b/tests/Fixtures/Subscriber/Tools/original_both_html_and_body_commented.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 	<head>
 		<title>Sample Page</title>

--- a/tests/Fixtures/Subscriber/Tools/original_commented_html_and_body.html
+++ b/tests/Fixtures/Subscriber/Tools/original_commented_html_and_body.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 	<head>
 		<title>Sample Page</title>

--- a/tests/Fixtures/Subscriber/Tools/original_html_and_body.html
+++ b/tests/Fixtures/Subscriber/Tools/original_html_and_body.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 	<head>
 		<title>Sample Page</title>

--- a/tests/Fixtures/Subscriber/Tools/original_no_html_and_body.html
+++ b/tests/Fixtures/Subscriber/Tools/original_no_html_and_body.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 	<head>
 		<title>Sample Page</title>

--- a/tests/Unit/Subscriber/Tools/TestDetectMissingTags.php
+++ b/tests/Unit/Subscriber/Tools/TestDetectMissingTags.php
@@ -24,6 +24,10 @@ class TestDetectMissingTags extends TestCase {
 
 		$html = \file_get_contents( WP_ROCKET_PLUGIN_TESTS_ROOT . '/../Fixtures/Subscriber/Tools/original_no_html_and_body.html');
 		http_response_code( 200 );
+		$_SERVER['content_type'] = 'text/html';
+
+		Functions\when( 'wp_unslash' )
+			->returnArg( );
 
 		// Called did_action('wp_footer'), test also for missing wp_footer()
 		Functions\expect( 'did_action' )
@@ -54,7 +58,9 @@ class TestDetectMissingTags extends TestCase {
 
 		$html = \file_get_contents( WP_ROCKET_PLUGIN_TESTS_ROOT . '/../Fixtures/Subscriber/Tools/original_html_and_body.html');
 		http_response_code( 200 );
-
+		$_SERVER['content_type'] = 'text/html';
+		Functions\when( 'wp_unslash' )
+			->returnArg( );
 		// Called did_action('wp_footer'), test only for HTML and BODY
 		Functions\expect( 'did_action' )
 			->once()
@@ -75,7 +81,9 @@ class TestDetectMissingTags extends TestCase {
 
 		$html = \file_get_contents( WP_ROCKET_PLUGIN_TESTS_ROOT . '/../Fixtures/Subscriber/Tools/original_commented_html_and_body.html');
 		http_response_code( 200 );
-
+		$_SERVER['content_type'] = 'text/html';
+		Functions\when( 'wp_unslash' )
+			->returnArg( );
 		// Called did_action('wp_footer'), test only for HTML and BODY
 		Functions\expect( 'did_action' )
 			->once()
@@ -105,7 +113,9 @@ class TestDetectMissingTags extends TestCase {
 
 		$html = \file_get_contents( WP_ROCKET_PLUGIN_TESTS_ROOT . '/../Fixtures/Subscriber/Tools/original_both_html_and_body_commented.html');
 		http_response_code( 200 );
-
+		$_SERVER['content_type'] = 'text/html';
+		Functions\when( 'wp_unslash' )
+			->returnArg( );
 		// Called did_action('wp_footer'), test only for HTML and BODY
 		Functions\expect( 'did_action' )
 			->once()


### PR DESCRIPTION
Fix: prevent false positive notices on missing tags </body>, </html> and wp_footer()