### PR TITLE
Fixes #2071: multiple admin notices

### DIFF
--- a/inc/admin/options.php
+++ b/inc/admin/options.php
@@ -241,51 +241,7 @@ add_action( 'update_option_' . WP_ROCKET_SLUG, 'rocket_after_save_options', 10, 
  * @return array Updated submitted options values.
  */
 function rocket_pre_main_option( $newvalue, $oldvalue ) {
-	// Make sure that fields that allow users to enter patterns are well formatted.
-	$is_form_submit = filter_input( INPUT_POST, 'option_page', FILTER_SANITIZE_STRING );
-	$is_form_submit = WP_ROCKET_PLUGIN_SLUG === $is_form_submit;
-	$errors         = [];
-	$pattern_labels = [
-		'exclude_css'       => __( 'Excluded CSS Files', 'rocket' ),
-		'exclude_inline_js' => __( 'Excluded Inline JavaScript', 'rocket' ),
-		'exclude_js'        => __( 'Excluded JavaScript Files', 'rocket' ),
-		'cache_reject_uri'  => __( 'Never Cache URL(s)', 'rocket' ),
-		'cache_reject_ua'   => __( 'Never Cache User Agent(s)', 'rocket' ),
-		'cache_purge_pages' => __( 'Always Purge URL(s)', 'rocket' ),
-		'cdn_reject_files'  => __( 'Exclude files from CDN', 'rocket' ),
-	];
-
-	foreach ( $pattern_labels as $pattern_field => $label ) {
-		if ( empty( $newvalue[ $pattern_field ] ) ) {
-			// The field is empty.
-			continue;
-		}
-
-		// Sanitize.
-		$newvalue[ $pattern_field ] = rocket_sanitize_textarea_field( $pattern_field, $newvalue[ $pattern_field ] );
-
-		// Validate.
-		$newvalue[ $pattern_field ] = array_filter(
-			$newvalue[ $pattern_field ],
-			function( $excluded ) use ( $pattern_field, $label, $is_form_submit, &$errors ) {
-				if ( false === @preg_match( '#' . str_replace( '#', '\#', $excluded ) . '#', 'dummy-sample' ) && $is_form_submit ) { // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
-					/* translators: 1 and 2 can be anything. */
-					$errors[ $pattern_field ] = sprintf( __( '%1$s: <em>%2$s</em>.', 'rocket' ), $label, esc_html( $excluded ) );
-					return false;
-				}
-
-				return true;
-			}
-		);
-	}
-
-	if ( $errors ) {
-		$error_message  = _n( 'The following pattern is invalid and has been removed:', 'The following patterns are invalid and have been removed:', count( $errors ), 'rocket' );
-		$error_message .= '<ul><li>' . implode( '</li><li>', $errors ) . '</li></ul>';
-		$errors         = [];
-
-		add_settings_error( 'general', 'invalid_patterns', $error_message, 'error' );
-	}
+	$rocket_settings_errors = [];
 
 	// Make sure that fields that allow users to enter patterns are well formatted.
 	$is_form_submit = filter_input( INPUT_POST, 'option_page', FILTER_SANITIZE_STRING );
@@ -330,7 +286,12 @@ function rocket_pre_main_option( $newvalue, $oldvalue ) {
 		$error_message .= '<ul><li>' . implode( '</li><li>', $errors ) . '</li></ul>';
 		$errors         = [];
 
-		add_settings_error( 'general', 'invalid_patterns', $error_message, 'error' );
+		$rocket_settings_errors[] = [
+			'setting' => 'general',
+			'code'    => 'invalid_patterns',
+			'message' => __( 'WP Rocket: ', 'rocket' ) . '</strong>' . $error_message . '<strong>',
+			'type'    => 'error',
+		];
 	}
 
 	// Clear WP Rocket database optimize cron if the setting has been modified.
@@ -357,9 +318,9 @@ function rocket_pre_main_option( $newvalue, $oldvalue ) {
 	}
 
 	// Save old CloudFlare settings.
-	if ( ( isset( $newvalue['cloudflare_auto_settings'], $oldvalue['cloudflare_auto_settings'] ) && $newvalue['cloudflare_auto_settings'] !== $oldvalue['cloudflare_auto_settings'] && 1 === $newvalue['cloudflare_auto_settings'] ) && 0 < (int) get_rocket_option( 'do_cloudflare' ) ) {
+	if ( isset( $newvalue['cloudflare_auto_settings'], $oldvalue['cloudflare_auto_settings'] ) && $newvalue['cloudflare_auto_settings'] !== $oldvalue['cloudflare_auto_settings'] && 1 === $newvalue['cloudflare_auto_settings'] && 0 < (int) get_rocket_option( 'do_cloudflare' ) ) {
 		$cf_settings                         = get_rocket_cloudflare_settings();
-		$newvalue['cloudflare_old_settings'] = ( ! is_wp_error( $cf_settings ) ) ? implode( ',', array_filter( $cf_settings ) ) : '';
+		$newvalue['cloudflare_old_settings'] = ! is_wp_error( $cf_settings ) ? implode( ',', array_filter( $cf_settings ) ) : '';
 	}
 
 	// Checked the SSL option if the whole website is on SSL.
@@ -372,19 +333,29 @@ function rocket_pre_main_option( $newvalue, $oldvalue ) {
 	}
 
 	$keys = get_transient( WP_ROCKET_SLUG );
+
 	if ( $keys ) {
 		delete_transient( WP_ROCKET_SLUG );
 		$newvalue = array_merge( $newvalue, $keys );
 	}
 
-	if ( ! function_exists( 'get_settings_errors' ) ) {
-		require_once ABSPATH . 'wp-admin/includes/template.php';
+	if ( ! $rocket_settings_errors ) {
+		return $newvalue;
 	}
 
-	if ( get_settings_errors() ) {
-		// Display an error notice.
-		set_transient( 'settings_errors', get_settings_errors(), 30 );
+	/**
+	 * Display an error notice.
+	 * The notices are stored directly in the transient instead of using `add_settings_error()`, to make sure they are displayed even if we’re outside an admin screen.
+	 */
+	$transient_errors = get_transient( 'settings_errors' );
+
+	if ( ! $transient_errors || ! is_array( $transient_errors ) ) {
+		$transient_errors = [];
 	}
+
+	$transient_errors = array_merge( $transient_errors, $rocket_settings_errors );
+
+	set_transient( 'settings_errors', $transient_errors, 30 );
 
 	return $newvalue;
 }

--- a/inc/classes/admin/settings/class-settings.php
+++ b/inc/classes/admin/settings/class-settings.php
@@ -185,6 +185,8 @@ class Settings {
 	 * @return array
 	 */
 	public function sanitize_callback( $input ) {
+		global $wp_settings_errors;
+
 		$input['do_beta'] = ! empty( $input['do_beta'] ) ? 1 : 0;
 
 		$input['cache_logged_user'] = ! empty( $input['cache_logged_user'] ) ? 1 : 0;
@@ -456,10 +458,28 @@ class Settings {
 			$input['secret_key']     = $checked['secret_key'];
 		}
 
-		if ( rocket_valid_key() && ! empty( $input['secret_key'] ) && ! isset( $input['ignore'] ) ) {
-			unset( $input['ignore'] );
-			add_settings_error( 'general', 'settings_updated', __( 'Settings saved.', 'rocket' ), 'updated' );
+		if ( ! empty( $input['secret_key'] ) && empty( $input['ignore'] ) && rocket_valid_key() ) {
+			// Add a "Settings saved." admin notice only if not already added.
+			$notices = array_merge( (array) $wp_settings_errors, (array) get_transient( 'settings_errors' ) );
+			$notices = array_filter(
+				$notices,
+				function( $error ) {
+					if ( ! $error || ! is_array( $error ) ) {
+						return false;
+					}
+					if ( ! isset( $error['setting'], $error['code'], $error['type'] ) ) {
+						return false;
+					}
+					return 'general' === $error['setting'] && 'settings_updated' === $error['code'] && 'updated' === $error['type'];
+				}
+			);
+
+			if ( ! $notices ) {
+				add_settings_error( 'general', 'settings_updated', __( 'Settings saved.', 'rocket' ), 'updated' );
+			}
 		}
+
+		unset( $input['ignore'] );
 
 		return apply_filters( 'rocket_input_sanitize', $input );
 	}


### PR DESCRIPTION
Don't use `get_settings_errors()` when storing new errors.
Don't add a "Settings saved" notice if already present.