### PR TITLE
Fixes: #1323,#1326 - Facebook Pixel Addon need to run FB.init()

### DIFF
--- a/inc/classes/busting/class-facebook-sdk.php
+++ b/inc/classes/busting/class-facebook-sdk.php
@@ -100,6 +100,12 @@ class Facebook_SDK extends Abstract_Busting {
 
 		$html      = str_replace( $tag, $replace_tag, $html );
 		$file_path = $this->get_busting_file_path( $locale );
+		$xfbml     = $this->get_xfbml_from_url( $tag );
+		$app_id    = $this->get_appId_from_url( $tag );
+		$version   = $this->get_version_from_url( $tag );
+
+		// Add FB async init.
+		$html .= '<script>window.fbAsyncInit = function fbAsyncInit () {FB.init({appId: \'' . $app_id . '\',xfbml: ' . $xfbml . ',version: \'' . $version . '\'})}</script>';
 
 		$this->is_replaced = true;
 
@@ -453,6 +459,66 @@ class Facebook_SDK extends Abstract_Busting {
 		}
 
 		return $matches['locale'];
+	}
+
+	/**
+	 * Extract XFBML from a URL to bust.
+	 *
+	 * @since  3.4.3
+	 * @access private
+	 * @author Soponar Cristina
+	 *
+	 * @param  string $url Any string containing the URL to bust.
+	 * @return string|bool The XFBML on success. False on failure.
+	 */
+	private function get_xfbml_from_url( $url ) {
+		$pattern = '@//connect\.facebook\.net/(?<locale>[a-zA-Z_-]+)/sdk\.js#xfbml=(?<xfbml>[0-9]+)&version=(?<version>[a-zA-Z0-9.]+)&appId=(?<appId>[0-9]+)@i';
+
+		if ( ! preg_match( $pattern, $url, $matches ) ) {
+			return false;
+		}
+
+		return $matches['xfbml'];
+	}
+
+	/**
+	 * Extract appId from a URL to bust.
+	 *
+	 * @since  3.4.3
+	 * @access private
+	 * @author Soponar Cristina
+	 *
+	 * @param  string $url Any string containing the URL to bust.
+	 * @return string|bool The appId on success. False on failure.
+	 */
+	private function get_appId_from_url( $url ) {
+		$pattern = '@//connect\.facebook\.net/(?<locale>[a-zA-Z_-]+)/sdk\.js#xfbml=(?<xfbml>[0-9]+)&version=(?<version>[a-zA-Z0-9.]+)&appId=(?<appId>[0-9]+)@i';
+
+		if ( ! preg_match( $pattern, $url, $matches ) ) {
+			return false;
+		}
+
+		return $matches['appId'];
+	}
+
+	/**
+	 * Extract version from a URL to bust.
+	 *
+	 * @since  3.4.3
+	 * @access private
+	 * @author Soponar Cristina
+	 *
+	 * @param  string $url Any string containing the URL to bust.
+	 * @return string|bool The version on success. False on failure.
+	 */
+	private function get_version_from_url( $url ) {
+		$pattern = '@//connect\.facebook\.net/(?<locale>[a-zA-Z_-]+)/sdk\.js#xfbml=(?<xfbml>[0-9]+)&version=(?<version>[a-zA-Z0-9.]+)&appId=(?<appId>[0-9]+)@i';
+
+		if ( ! preg_match( $pattern, $url, $matches ) ) {
+			return false;
+		}
+
+		return $matches['version'];
 	}
 
 	/** ----------------------------------------------------------------------------------------- */

--- a/inc/classes/busting/class-facebook-sdk.php
+++ b/inc/classes/busting/class-facebook-sdk.php
@@ -100,12 +100,15 @@ class Facebook_SDK extends Abstract_Busting {
 
 		$html      = str_replace( $tag, $replace_tag, $html );
 		$file_path = $this->get_busting_file_path( $locale );
-		$xfbml     = $this->get_xfbml_from_url( $tag );
-		$app_id    = $this->get_appId_from_url( $tag );
-		$version   = $this->get_version_from_url( $tag );
+		$xfbml     = $this->get_xfbml_from_url( $tag ); // Default value should be set to false.
+		$app_id    = $this->get_appId_from_url( $tag ); // APP_ID is the only required value.
+		$version   = false === $this->get_version_from_url( $tag ) ? 'v5.0' : $this->get_version_from_url( $tag ); // If version is not available set it to the latest: v.5.0.
 
-		// Add FB async init.
-		$html .= '<script>window.fbAsyncInit = function fbAsyncInit () {FB.init({appId: \'' . $app_id . '\',xfbml: ' . $xfbml . ',version: \'' . $version . '\'})}</script>';
+		if ( false !== $app_id ) {
+			// Add FB async init.
+			$fb_async_script = '<script>window.fbAsyncInit = function fbAsyncInit () {FB.init({appId: \'' . $app_id . '\',xfbml: ' . $xfbml . ',version: \'' . $version . '\'})}</script>';
+			$html            = str_replace( '</body>', $fb_async_script . '</body>', $html );
+		}
 
 		$this->is_replaced = true;
 

--- a/inc/classes/busting/class-facebook-sdk.php
+++ b/inc/classes/busting/class-facebook-sdk.php
@@ -472,7 +472,7 @@ class Facebook_SDK extends Abstract_Busting {
 	 * @return string|bool The XFBML on success. False on failure.
 	 */
 	private function get_xfbml_from_url( $url ) {
-		$pattern = '@//connect\.facebook\.net/(?<locale>[a-zA-Z_-]+)/sdk\.js#xfbml=(?<xfbml>[0-9]+)&version=(?<version>[a-zA-Z0-9.]+)&appId=(?<appId>[0-9]+)@i';
+		$pattern = '@//connect\.facebook\.net/(?<locale>[a-zA-Z_-]+)/sdk\.js#(?:.+&)?xfbml=(?<xfbml>[0-9]+)@i';
 
 		if ( ! preg_match( $pattern, $url, $matches ) ) {
 			return false;
@@ -492,7 +492,7 @@ class Facebook_SDK extends Abstract_Busting {
 	 * @return string|bool The appId on success. False on failure.
 	 */
 	private function get_appId_from_url( $url ) {
-		$pattern = '@//connect\.facebook\.net/(?<locale>[a-zA-Z_-]+)/sdk\.js#xfbml=(?<xfbml>[0-9]+)&version=(?<version>[a-zA-Z0-9.]+)&appId=(?<appId>[0-9]+)@i';
+		$pattern = '@//connect\.facebook\.net/(?<locale>[a-zA-Z_-]+)/sdk\.js#(?:.+&)?appId=(?<appId>[0-9]+)@i';
 
 		if ( ! preg_match( $pattern, $url, $matches ) ) {
 			return false;
@@ -512,7 +512,7 @@ class Facebook_SDK extends Abstract_Busting {
 	 * @return string|bool The version on success. False on failure.
 	 */
 	private function get_version_from_url( $url ) {
-		$pattern = '@//connect\.facebook\.net/(?<locale>[a-zA-Z_-]+)/sdk\.js#xfbml=(?<xfbml>[0-9]+)&version=(?<version>[a-zA-Z0-9.]+)&appId=(?<appId>[0-9]+)@i';
+		$pattern = '@//connect\.facebook\.net/(?<locale>[a-zA-Z_-]+)/sdk\.js#(?:.+&)?version=(?<version>[a-zA-Z0-9.]+)@i';
 
 		if ( ! preg_match( $pattern, $url, $matches ) ) {
 			return false;

--- a/inc/classes/busting/class-facebook-sdk.php
+++ b/inc/classes/busting/class-facebook-sdk.php
@@ -98,11 +98,12 @@ class Facebook_SDK extends Abstract_Busting {
 			return $html;
 		}
 
-		$html      = str_replace( $tag, $replace_tag, $html );
-		$file_path = $this->get_busting_file_path( $locale );
-		$xfbml     = $this->get_xfbml_from_url( $tag ); // Default value should be set to false.
-		$app_id    = $this->get_appId_from_url( $tag ); // APP_ID is the only required value.
-		$version   = false === $this->get_version_from_url( $tag ) ? 'v5.0' : $this->get_version_from_url( $tag ); // If version is not available set it to the latest: v.5.0.
+		$html        = str_replace( $tag, $replace_tag, $html );
+		$file_path   = $this->get_busting_file_path( $locale );
+		$xfbml       = $this->get_xfbml_from_url( $tag ); // Default value should be set to false.
+		$app_id      = $this->get_appId_from_url( $tag ); // APP_ID is the only required value.
+		$url_version = $this->get_version_from_url( $tag );
+		$version     = false === $url_version ? 'v5.0' : $url_version; // If version is not available set it to the latest: v.5.0.
 
 		if ( false !== $app_id ) {
 			// Add FB async init.


### PR DESCRIPTION
Add FB.init() when Facebook Pizel Addon is enabled:

```
<script>
  window.fbAsyncInit = function() {
    FB.init({
      appId            : 'your-app-id',
      autoLogAppEvents : true,
      xfbml            : true,
      version          : 'v5.0'
    });
  };
</script>
```