### PR TITLE
Fixes #1945 cache race condition with multiple servers

### DIFF
--- a/inc/classes/Buffer/class-cache.php
+++ b/inc/classes/Buffer/class-cache.php
@@ -352,7 +352,14 @@ class Cache extends Abstract_Buffer {
 		rocket_direct_filesystem()->move( $temp_filepath, $cache_filepath );
 
 		if ( function_exists( 'gzencode' ) ) {
-			rocket_put_content( $temp_gzip_filepath, gzencode( $content, apply_filters( 'rocket_gzencode_level_compression', 3 ) ) );
+			/**
+			 * Filters the Gzip compression level to use for the cache file
+			 *
+			 * @param int $compression_level Compression level between 0 and 9.
+			 */
+			$compression_level = apply_filters( 'rocket_gzencode_level_compression', 3 );
+
+			rocket_put_content( $temp_gzip_filepath, gzencode( $content, $compression_level ) );
 			rocket_direct_filesystem()->move( $temp_gzip_filepath, $gzip_filepath );
 		}
 	}

--- a/inc/classes/Buffer/class-cache.php
+++ b/inc/classes/Buffer/class-cache.php
@@ -305,13 +305,7 @@ class Cache extends Abstract_Buffer {
 			}
 		}
 
-		// Save the cache file.
-		rocket_put_content( $cache_filepath, $buffer . $footprint );
-
-		if ( function_exists( 'gzencode' ) ) {
-			rocket_put_content( $cache_filepath . '_gzip', gzencode( $buffer . $footprint, apply_filters( 'rocket_gzencode_level_compression', 3 ) ) );
-		}
-
+		$this->write_cache_file( $cache_filepath, $buffer . $footprint );
 		$this->maybe_create_nginx_mobile_file( $cache_dir_path );
 
 		// Send headers with the last modified time of the cache file.
@@ -332,6 +326,37 @@ class Cache extends Abstract_Buffer {
 		);
 
 		return $buffer . $footprint;
+	}
+
+	/**
+	 * Writes the cache file(s)
+	 *
+	 * @since 3.5
+	 * @author Remy Perona
+	 *
+	 * @param string $cache_filepath Absolute path to the cache file.
+	 * @param string $content Content to write in the cache file.
+	 * @return void
+	 */
+	private function write_cache_file( $cache_filepath, $content ) {
+		$gzip_filepath      = $cache_filepath . '_gzip';
+		$temp_filepath      = $cache_filepath . '_temp';
+		$temp_gzip_filepath = $gzip_filepath . '_temp';
+
+		if ( rocket_direct_filesystem()->exists( $temp_filepath ) ) {
+			return;
+		}
+
+		// Save the cache file.
+		rocket_put_content( $temp_filepath, $content );
+		rocket_direct_filesystem()->move( $temp_filepath, $cache_filepath );
+		rocket_direct_filesystem()->delete( $temp_filepath );
+
+		if ( function_exists( 'gzencode' ) ) {
+			rocket_put_content( $temp_gzip_filepath, gzencode( $content, apply_filters( 'rocket_gzencode_level_compression', 3 ) ) );
+			rocket_direct_filesystem()->move( $temp_gzip_filepath, $gzip_filepath );
+			rocket_direct_filesystem()->delete( $temp_gzip_filepath );
+		}
 	}
 
 	/**

--- a/inc/classes/Buffer/class-cache.php
+++ b/inc/classes/Buffer/class-cache.php
@@ -350,12 +350,10 @@ class Cache extends Abstract_Buffer {
 		// Save the cache file.
 		rocket_put_content( $temp_filepath, $content );
 		rocket_direct_filesystem()->move( $temp_filepath, $cache_filepath );
-		rocket_direct_filesystem()->delete( $temp_filepath );
 
 		if ( function_exists( 'gzencode' ) ) {
 			rocket_put_content( $temp_gzip_filepath, gzencode( $content, apply_filters( 'rocket_gzencode_level_compression', 3 ) ) );
 			rocket_direct_filesystem()->move( $temp_gzip_filepath, $gzip_filepath );
-			rocket_direct_filesystem()->delete( $temp_gzip_filepath );
 		}
 	}
 

--- a/inc/classes/subscriber/Media/class-webp-subscriber.php
+++ b/inc/classes/subscriber/Media/class-webp-subscriber.php
@@ -156,7 +156,7 @@ class Webp_Subscriber implements Subscriber_Interface {
 		if ( ! $http_accept || false === strpos( $http_accept, 'webp' ) ) {
 			$user_agent = isset( $this->server['HTTP_USER_AGENT'] ) ? $this->server['HTTP_USER_AGENT'] : '';
 
-			if ( $user_agent && preg_match( '#Firefox/(?<version>[0-9]{2})#i', $this->server['HTTP_USER_AGENT'], $matches ) ) {
+			if ( $user_agent && preg_match( '#Firefox/(?<version>[0-9]{2,})#i', $this->server['HTTP_USER_AGENT'], $matches ) ) {
 				if ( 66 >= (int) $matches['version'] ) {
 					return $html;
 				}

--- a/inc/classes/subscriber/Media/class-webp-subscriber.php
+++ b/inc/classes/subscriber/Media/class-webp-subscriber.php
@@ -154,7 +154,15 @@ class Webp_Subscriber implements Subscriber_Interface {
 		}
 
 		if ( ! $http_accept || false === strpos( $http_accept, 'webp' ) ) {
-			return $html;
+			$user_agent = isset( $this->server['HTTP_USER_AGENT'] ) ? $this->server['HTTP_USER_AGENT'] : '';
+
+			if ( $user_agent && preg_match( '#Firefox/(?<version>[0-9]{2})#i', $this->server['HTTP_USER_AGENT'], $matches ) ) {
+				if ( 66 >= (int) $matches['version'] ) {
+					return $html;
+				}
+			} else {
+				return $html;
+			}
 		}
 
 		$extensions      = $this->get_extensions();


### PR DESCRIPTION
Prevent blank page when multiple servers are using the same shared filesystem. Instead of directly writing in the final cache file, we first write in a temp file, and rename it when it's done.

Also fixes an undetected issue with WebP and Firefox version > 66