### PR TITLE
Fix #1479 - Rename "Save Settings" to "Validate License"

### DIFF
--- a/inc/classes/admin/settings/class-page.php
+++ b/inc/classes/admin/settings/class-page.php
@@ -162,7 +162,8 @@ class Page {
 	 * @return void
 	 */
 	public function render_page() {
-		if ( rocket_valid_key() ) {
+		$rocket_valid_key = rocket_valid_key();
+		if ( $rocket_valid_key ) {
 			$this->dashboard_section();
 			$this->cache_section();
 			$this->assets_section();
@@ -185,7 +186,7 @@ class Page {
 
 		$this->render->set_hidden_settings( $this->settings->get_hidden_settings() );
 
-		echo $this->render->generate( 'page', [ 'slug' => $this->slug ] );
+		echo $this->render->generate( 'page', [ 'slug' => $this->slug, 'rocket_valid_key' => $rocket_valid_key ] );
 	}
 
 	/**

--- a/inc/classes/admin/settings/class-page.php
+++ b/inc/classes/admin/settings/class-page.php
@@ -186,7 +186,7 @@ class Page {
 
 		$this->render->set_hidden_settings( $this->settings->get_hidden_settings() );
 
-		echo $this->render->generate( 'page', [ 'slug' => $this->slug, 'rocket_valid_key' => $rocket_valid_key ] );
+		echo $this->render->generate( 'page', [ 'slug' => $this->slug, 'btn_submit_text' => $rocket_valid_key ? __( 'Save Changes', 'rocket' ) : __( 'Validate License', 'rocket' ) ] );
 	}
 
 	/**

--- a/views/settings/page.php
+++ b/views/settings/page.php
@@ -37,7 +37,7 @@ settings_errors( $data['slug'] ); ?>
 				<?php settings_fields( $data['slug'] ); ?>
 				<?php $this->render_form_sections(); ?>
 				<?php $this->render_hidden_fields(); ?>
-				<input type="submit" class="wpr-button" id="wpr-options-submit" value="<?php esc_attr_e( 'Save Changes', 'rocket' ); ?>">
+				<input type="submit" class="wpr-button" id="wpr-options-submit" value="<?php $data['rocket_valid_key'] ? esc_attr_e( 'Save Changes', 'rocket' ) : esc_attr_e( 'Validate License', 'rocket' ); ?>">
 			</form>
 			<?php
 			if ( rocket_valid_key() ) {

--- a/views/settings/page.php
+++ b/views/settings/page.php
@@ -37,7 +37,7 @@ settings_errors( $data['slug'] ); ?>
 				<?php settings_fields( $data['slug'] ); ?>
 				<?php $this->render_form_sections(); ?>
 				<?php $this->render_hidden_fields(); ?>
-				<input type="submit" class="wpr-button" id="wpr-options-submit" value="<?php $data['rocket_valid_key'] ? esc_attr_e( 'Save Changes', 'rocket' ) : esc_attr_e( 'Validate License', 'rocket' ); ?>">
+				<input type="submit" class="wpr-button" id="wpr-options-submit" value="<?php echo esc_attr( $data['btn_submit_text'] ); ?>">
 			</form>
 			<?php
 			if ( rocket_valid_key() ) {


### PR DESCRIPTION
License Validation - Rename "Save Settings" to "Validate License"

Based on v.3.4.3 minor release doc