### PR TITLE
Fix #2118 - PHP warning: Can only flip STRING and INTEGER values!

### DIFF
--- a/inc/classes/optimization/class-abstract-optimization.php
+++ b/inc/classes/optimization/class-abstract-optimization.php
@@ -49,7 +49,7 @@ abstract class Abstract_Optimization {
 		if ( $langs ) {
 			foreach ( $langs as $lang ) {
 				$url_host = rocket_extract_url_component( $lang, PHP_URL_HOST );
-				if ( ! empty( $url_host ) && ! is_array( $url_host ) ) {
+				if ( ! empty( $url_host ) ) {
 					$hosts[] = $url_host;
 				}
 			}

--- a/inc/classes/optimization/class-abstract-optimization.php
+++ b/inc/classes/optimization/class-abstract-optimization.php
@@ -48,7 +48,10 @@ abstract class Abstract_Optimization {
 		// Get host for all langs.
 		if ( $langs ) {
 			foreach ( $langs as $lang ) {
-				$hosts[] = rocket_extract_url_component( $lang, PHP_URL_HOST );
+				$url_host = rocket_extract_url_component( $lang, PHP_URL_HOST );
+				if ( ! empty( $url_host ) && ! is_array( $url_host ) ) {
+					$hosts[] = $url_host;
+				}
 			}
 		}
 


### PR DESCRIPTION
Prevent PHP warning: Can only flip STRING and INTEGER values!
This happened when: host = NULL so I added some conditions to prevent this.

parse_url returns:
NULL - if the value is not found
string/integer/null - if the value is found and component is specified
array - if the component is not specified
So I prevented the NULL and array value from adding it to hosts. 

Based on v3.4.3 doc
