### PR TITLE
Fix clean rocket post cache on slug change when post name is empty & status is not published

### DIFF
--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -652,9 +652,7 @@ function rocket_clean_cache_theme_update( $wp_upgrader, $hook_extra ) {
  */
 function rocket_clean_post_cache_on_slug_change( $post_id, $post_data ) {
 	// Bail out if the post status is draft, pending or auto-draft.
-	if ( 'draft' === get_post_field( 'post_status', $post_id ) ||
-			'pending' === get_post_field( 'post_status', $post_id ) ||
-			'auto-draft' === get_post_field( 'post_status', $post_id ) ) {
+	if ( in_array( get_post_field( 'post_status', $post_id ), [ 'draft', 'pending', 'auto-draft' ], true ) ) {
 		return;
 	}
 	// Bail out if the slug hasn't changed.

--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -651,8 +651,20 @@ function rocket_clean_cache_theme_update( $wp_upgrader, $hook_extra ) {
  * @param array $post_data Array of unslashed post data.
  */
 function rocket_clean_post_cache_on_slug_change( $post_id, $post_data ) {
-	if ( get_post_field( 'post_name', $post_id ) !== $post_data['post_name'] ) {
-        rocket_clean_files( get_the_permalink( $post_id ) );
-    }
+	// Bail out if the post status is draft, pending or auto-draft.
+	if ( 'draft' === get_post_field( 'post_status', $post_id ) ||
+			'pending' === get_post_field( 'post_status', $post_id ) ||
+			'auto-draft' === get_post_field( 'post_status', $post_id ) ) {
+		return;
+	}
+	// Bail out if the slug hasn't changed.
+	if ( get_post_field( 'post_name', $post_id ) === $post_data['post_name'] ) {
+		return;
+	}
+	// Bail out if the old slug has changed, but is empty.
+	if ( empty( get_post_field( 'post_name', $post_id ) ) ) {
+		return;
+	}
+	rocket_clean_files( get_the_permalink( $post_id ) );
 }
 add_action( 'pre_post_update', 'rocket_clean_post_cache_on_slug_change', 10, 2 );

--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -655,14 +655,15 @@ function rocket_clean_post_cache_on_slug_change( $post_id, $post_data ) {
 	if ( in_array( get_post_field( 'post_status', $post_id ), [ 'draft', 'pending', 'auto-draft' ], true ) ) {
 		return;
 	}
+	$post_name = get_post_field( 'post_name', $post_id );
 	// Bail out if the slug hasn't changed.
-	if ( get_post_field( 'post_name', $post_id ) === $post_data['post_name'] ) {
+	if ( $post_name === $post_data['post_name'] ) {
 		return;
 	}
 	// Bail out if the old slug has changed, but is empty.
-	if ( empty( get_post_field( 'post_name', $post_id ) ) ) {
+	if ( empty( $post_name ) ) {
 		return;
 	}
 	rocket_clean_files( get_the_permalink( $post_id ) );
 }
-add_action( 'pre_post_update', 'rocket_clean_post_cache_on_slug_change', 10, 2 );
+add_action( 'pre_post_update', 'rocket_clean_post_cache_on_slug_change', PHP_INT_MAX, 2 );

--- a/tests/Unit/Common/TestRocketCleanPostCacheOnSlugChange.php
+++ b/tests/Unit/Common/TestRocketCleanPostCacheOnSlugChange.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\Inc\Common;
+
+use WP_Rocket\Tests\Unit\TestCase;
+use Brain\Monkey\Functions;
+
+/**
+ * @runTestsInSeparateProcesses
+ */
+class TestRocketCleanPostCacheOnSlugChange extends TestCase {
+	protected function setUp() {
+		parent::setUp();
+
+		Functions\when( 'get_option' )->justReturn( '' );
+
+		require WP_ROCKET_PLUGIN_ROOT . 'inc/common/purge.php';
+	}
+
+	/**
+	 * Test rocket_clean_post_cache_on_slug_change() should not fire rocket_clean_files() when the post status is
+	 * 'draft', 'pending', or 'auto-draft'.
+	 */
+	public function testShouldBailOutWhenPostStatusIsNotCorrect() {
+		$post_id   = 10;
+		$post_name = 'new-post-name-slug';
+
+		Functions\expect( 'get_the_permalink' )->never();
+		Functions\expect( 'rocket_clean_files' )->never();
+		Functions\expect( 'get_post_field' )
+			->with( 'post_name', $post_id )
+			->never();
+
+		foreach ( [ 'draft', 'pending', 'auto-draft' ] as $post_status ) {
+			Functions\expect( 'get_post_field' )
+				->once()
+				->with( 'post_status', $post_id )
+				->andReturn( $post_status );
+			$this->assertNull( rocket_clean_post_cache_on_slug_change( $post_id, [ 'post_name' => $post_name ] ) );
+		}
+	}
+
+	/**
+	 * Test rocket_clean_post_cache_on_slug_change() should not fire rocket_clean_files() when the slug (post name)
+	 * hasn't changed, i.e. meaning when the previous post name (saved in the database) is still the same as the new one
+	 * (passed into this callback).
+	 */
+	public function testShouldBailOutWhenSlugHasntChanged() {
+		$post_id   = 50;
+		$post_name = 'original-post-name-slug';
+
+		Functions\expect( 'get_the_permalink' )->never();
+		Functions\expect( 'rocket_clean_files' )->never();
+		Functions\expect( 'get_post_field' )
+			->ordered()
+			->once()
+			->with( 'post_status', $post_id )
+			->andReturn( 'publish' )
+			->andAlsoExpectIt()
+			->once()
+			->with( 'post_name', $post_id )
+			->andReturn( $post_name ); // slug hasn't changed.
+
+		$this->assertNull( rocket_clean_post_cache_on_slug_change( $post_id, [ 'post_name' => $post_name ] ) );
+	}
+
+	/**
+	 * Test rocket_clean_post_cache_on_slug_change() should not fire rocket_clean_files() when the old slug (post name),
+	 * i.e. saved in the database, is empty.
+	 */
+	public function testShouldBailOutWhenOldSlugIsEmpty() {
+		$post_id   = 100;
+		$post_name = 'new-post-name-slug';
+
+		Functions\expect( 'get_the_permalink' )->never();
+		Functions\expect( 'rocket_clean_files' )->never();
+		Functions\expect( 'get_post_field' )
+			->ordered()
+			->once()
+			->with( 'post_status', $post_id )
+			->andReturn( 'publish' )
+			->andAlsoExpectIt()
+			->once()
+			->with( 'post_name', $post_id )
+			->andReturn( '' ); // No slug saved in the database.
+
+		$this->assertNull( rocket_clean_post_cache_on_slug_change( $post_id, [ 'post_name' => $post_name ] ) );
+	}
+
+	/**
+	 * Test rocket_clean_post_cache_on_slug_change() should fire rocket_clean_files() when the existing post status is
+	 * correct
+	 * (i.e. not draft, pending, or auto-draft), the existing/old slug (post name) and new slug are the same, and the
+	 * existing/old slug is not empty.
+	 */
+	public function testShouldFireRocketCleanFiles() {
+		$post_id   = 200;
+		$post_name = 'new-post-name-slug';
+		$permalink = "https://wp-rocket.test/{$post_name}/";
+
+		Functions\expect( 'get_post_field' )
+			->ordered()
+			->once()
+			->with( 'post_status', $post_id )
+			->andReturn( 'publish' )
+			->andAlsoExpectIt()
+			->once()
+			->with( 'post_name', $post_id )
+			->andReturn( 'original-post-name-slug' );
+
+		Functions\expect( 'get_the_permalink' )
+			->once()
+			->with( $post_id )
+			->andReturn( $permalink );
+
+		Functions\expect( 'rocket_clean_files' )
+			->once()
+			->with( $permalink )
+			->andReturnNull();
+
+		$this->assertNull( rocket_clean_post_cache_on_slug_change( $post_id, [ 'post_name' => $post_name ] ) );
+	}
+}


### PR DESCRIPTION
Fix clean rocket post cache when old slug is empty and old post_status is draft , pending or auto-draft (there is no cache to be cleaned in this situation).

Fixes #1936 [per discussion here](https://github.com/wp-media/wp-rocket/issues/1936#issuecomment-561142237).

Test Cases:

- with WooCommerce Follow-up Emails plugin
In order to test it go to: Tools > Scheduled Actions > Pending and run any of the 2 actions listed
- Publishing a new post causes the whole cache to be cleared.

TODO:

[X] Test locally with 2 test cases (see above)
[X] Identify needed post statuses
[X] Unit test
[ ] Integration test - @hellofromtonya This one will be in a new PR once a few updates are made to the integration bootstrapping process.