### PR TITLE
Fixes #2139 Update logic on user actions purge

### DIFF
--- a/inc/classes/ServiceProvider/class-common-subscribers.php
+++ b/inc/classes/ServiceProvider/class-common-subscribers.php
@@ -34,6 +34,7 @@ class Common_Subscribers extends AbstractServiceProvider {
 		'expired_cache_purge',
 		'expired_cache_purge_subscriber',
 		'detect_missing_tags',
+		'purge_actions_subscriber',
 	];
 
 	/**
@@ -74,5 +75,7 @@ class Common_Subscribers extends AbstractServiceProvider {
 			->withArgument( $this->getContainer()->get( 'cdn_subscriber' ) )
 			->withArgument( $this->getContainer()->get( 'beacon' ) );
 		$this->getContainer()->share( 'detect_missing_tags_subscriber', 'WP_Rocket\Subscriber\Tools\Detect_Missing_Tags_Subscriber' );
+		$this->getContainer()->share( 'purge_actions_subscriber', 'WP_Rocket\Subscriber\Cache\PurgeActionsSubscriber' )
+			->withArgument( $this->getContainer()->get( 'options' ) );
 	}
 }

--- a/inc/classes/class-plugin.php
+++ b/inc/classes/class-plugin.php
@@ -152,6 +152,7 @@ class Plugin {
 			'varnish_subscriber',
 			'cloudflare_subscriber',
 			'detect_missing_tags_subscriber',
+			'purge_actions_subscriber',
 		];
 
 		if ( \rocket_valid_key() ) {

--- a/inc/classes/subscriber/Cache/PurgeActionsSubscriber.php
+++ b/inc/classes/subscriber/Cache/PurgeActionsSubscriber.php
@@ -1,0 +1,77 @@
+<?php
+namespace WP_Rocket\Subscriber\Cache;
+
+use WP_Rocket\Event_Management\Subscriber_Interface;
+use WP_Rocket\Admin\Options_Data;
+
+/**
+ * Subscriber for the cache purge actions
+ *
+ * @since 3.5
+ * @author Remy Perona
+ */
+class PurgeActionsSubscriber implements Subscriber_Interface {
+	/**
+	 * WP Rocket options instance
+	 *
+	 * @var Options_Data
+	 */
+	private $options;
+
+	/**
+	 * Constructor
+	 *
+	 * @param Options_Data $options WP Rocket options instance.
+	 */
+	public function __construct( Options_Data $options ) {
+		$this->options = $options;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function get_subscribed_events() {
+		return [
+			'profile_update' => 'purge_user_cache',
+			'deleted_user'   => 'purge_user_cache',
+		];
+	}
+
+	/**
+	 * Purges the cache of the corresponding user
+	 *
+	 * @since 3.5
+	 * @author Remy Perona
+	 *
+	 * @param int $user_id User ID.
+	 * @return void
+	 */
+	public function purge_user_cache( $user_id ) {
+		if ( ! $this->should_purge_user_cache() ) {
+			return;
+		}
+
+		rocket_clean_user( $user_id );
+	}
+
+	/**
+	 * Checks if the user cache should be purged
+	 *
+	 * @since 3.5
+	 * @author Remy Perona
+	 *
+	 * @return boolean
+	 */
+	private function should_purge_user_cache() {
+		if ( ! $this->options->get( 'cache_logged_user', 0 ) ) {
+			return false;
+		}
+
+		// This filter is documented in /inc/functions/files.php.
+		if ( apply_filters( 'rocket_common_cache_logged_users', false ) ) {
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/inc/classes/subscriber/Cache/PurgeActionsSubscriber.php
+++ b/inc/classes/subscriber/Cache/PurgeActionsSubscriber.php
@@ -68,10 +68,6 @@ class PurgeActionsSubscriber implements Subscriber_Interface {
 		}
 
 		// This filter is documented in /inc/functions/files.php.
-		if ( apply_filters( 'rocket_common_cache_logged_users', false ) ) {
-			return false;
-		}
-
-		return true;
+		return ! (bool) apply_filters( 'rocket_common_cache_logged_users', false );
 	}
 }

--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -3,9 +3,6 @@ defined( 'ABSPATH' ) || die( 'Cheatin&#8217; uh?' );
 
 // Launch hooks that deletes all the cache domain.
 add_action( 'switch_theme', 'rocket_clean_domain' );  // When user change theme.
-add_action( 'user_register', 'rocket_clean_domain' );  // When a user is added.
-add_action( 'profile_update', 'rocket_clean_domain' );  // When a user is updated.
-add_action( 'deleted_user', 'rocket_clean_domain' );  // When a user is deleted.
 add_action( 'wp_update_nav_menu', 'rocket_clean_domain' );  // When a custom menu is update.
 add_action( 'update_option_sidebars_widgets', 'rocket_clean_domain' );  // When you change the order of widgets.
 add_action( 'update_option_category_base', 'rocket_clean_domain' );  // When category permalink prefix is update.

--- a/tests/Unit/Subscriber/Cache/PurgeActionsSubscriber/TestPurgeUserCache.php
+++ b/tests/Unit/Subscriber/Cache/PurgeActionsSubscriber/TestPurgeUserCache.php
@@ -1,0 +1,80 @@
+<?php
+namespace WP_Rocket\Tests\Unit\Subscriber\Cache\PurgeActionsSubscriber;
+
+use WP_Rocket\Subscriber\Cache\PurgeActionsSubscriber;
+use WP_Rocket\Tests\Unit\TestCase;
+use Brain\Monkey\Functions;
+use Brain\Monkey\Filters;
+
+/**
+ * @coversDefaultClass \WP_Rocket\Subscriber\Cache\PurgeActionsSubscriber
+ */
+class TestPurgeUserCache extends TestCase {
+	/**
+	 * @covers::purge_user_cache
+	 * @group purge_actions
+	 */
+	public function testShouldReturnNullWhenUserCacheDisabled() {
+		$options = $this->createMock('WP_Rocket\Admin\Options_Data');
+        $map     = [
+            [
+                'cache_logged_user',
+                0,
+                0,
+            ],
+        ];
+
+		$options->method('get')->will($this->returnValueMap($map));
+
+		$purge = new PurgeActionsSubscriber( $options );
+		$this->assertNull($purge->purge_user_cache( 1 ));
+	}
+
+	/**
+	 * @covers::purge_user_cache
+	 * @group purge_actions
+	 */
+	public function testShouldReturnNullWhenCommonUserCache() {
+		$options = $this->createMock('WP_Rocket\Admin\Options_Data');
+        $map     = [
+            [
+                'cache_logged_user',
+                0,
+                1,
+            ],
+        ];
+
+		$options->method('get')->will($this->returnValueMap($map));
+
+		Filters\expectApplied('rocket_common_cache_logged_users')
+		->once()
+		->andReturn(true);
+
+		$purge = new PurgeActionsSubscriber( $options );
+		$this->assertNull($purge->purge_user_cache( 1 ));
+	}
+
+	/**
+	 * @covers::purge_user_cache
+	 * @group purge_actions
+	 */
+	public function testShouldPurgeCacheForUserID1() {
+		$options = $this->createMock('WP_Rocket\Admin\Options_Data');
+        $map     = [
+            [
+                'cache_logged_user',
+                0,
+                1,
+            ],
+		];
+
+		$options->method('get')->will($this->returnValueMap($map));
+
+		Functions\expect('rocket_clean_user')
+		->once()
+		->with(1);
+
+		$purge = new PurgeActionsSubscriber( $options );
+		$purge->purge_user_cache( 1 );
+	}
+}

--- a/tests/Unit/Subscriber/Cache/PurgeActionsSubscriber/TestPurgeUserCache.php
+++ b/tests/Unit/Subscriber/Cache/PurgeActionsSubscriber/TestPurgeUserCache.php
@@ -8,21 +8,21 @@ use Brain\Monkey\Filters;
 
 /**
  * @coversDefaultClass \WP_Rocket\Subscriber\Cache\PurgeActionsSubscriber
+ * @group purge_actions
  */
 class TestPurgeUserCache extends TestCase {
 	/**
 	 * @covers::purge_user_cache
-	 * @group purge_actions
 	 */
-	public function testShouldReturnNullWhenUserCacheDisabled() {
+	public function testShouldNotPurgeUserCacheWhenUserCacheDisabled() {
 		$options = $this->createMock('WP_Rocket\Admin\Options_Data');
-        $map     = [
-            [
-                'cache_logged_user',
-                0,
-                0,
-            ],
-        ];
+		$map     = [
+			[
+				'cache_logged_user',
+				0,
+				0,
+			],
+		];
 
 		$options->method('get')->will($this->returnValueMap($map));
 
@@ -32,17 +32,16 @@ class TestPurgeUserCache extends TestCase {
 
 	/**
 	 * @covers::purge_user_cache
-	 * @group purge_actions
 	 */
-	public function testShouldReturnNullWhenCommonUserCache() {
+	public function testShoulNotPurgeUserCacheWhenCommonUserCacheEnabled() {
 		$options = $this->createMock('WP_Rocket\Admin\Options_Data');
-        $map     = [
-            [
-                'cache_logged_user',
-                0,
-                1,
-            ],
-        ];
+		$map     = [
+			[
+				'cache_logged_user',
+				0,
+				1,
+			],
+		];
 
 		$options->method('get')->will($this->returnValueMap($map));
 
@@ -56,16 +55,15 @@ class TestPurgeUserCache extends TestCase {
 
 	/**
 	 * @covers::purge_user_cache
-	 * @group purge_actions
 	 */
 	public function testShouldPurgeCacheForUserID1() {
 		$options = $this->createMock('WP_Rocket\Admin\Options_Data');
-        $map     = [
-            [
-                'cache_logged_user',
-                0,
-                1,
-            ],
+		$map     = [
+			[
+				'cache_logged_user',
+				0,
+				1,
+			],
 		];
 
 		$options->method('get')->will($this->returnValueMap($map));


### PR DESCRIPTION
- Removed the global purge on user creation/update/deletion
- Delete the cache for a specific user when it's updated/deleted, only if User cache option is active, and common logged-in users cache is not

This should improve cache lifetime on websites with frequent user creation (eCommerce especially), while still retaining the necessary cleaning of the user cache on sites with user-specific content like memberships or BuddyPress-based ones.

Fixes #2139 