### PR TITLE
Improves bootstrapping test suites.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,6 +74,10 @@
 	},
 	"scripts": {
 		"test-unit":"\"vendor/bin/phpunit\" --testsuite unit --colors=always --configuration tests/Unit/phpunit.xml.dist",
-		"test-integration": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist"
+		"test-integration": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist",
+		"run-tests": [
+			"@test-unit",
+			"@test-integration"
+		]
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,7 @@
 		}
 	},
 	"scripts": {
-		"test-unit":"\"vendor/bin/phpunit\" --testsuite unit --colors=always",
+		"test-unit":"\"vendor/bin/phpunit\" --testsuite unit --colors=always --configuration tests/Unit/phpunit.xml.dist",
 		"test-integration": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist"
 	}
 }

--- a/tests/Integration/Buffer/Tests/TestIsSpeedTool.php
+++ b/tests/Integration/Buffer/Tests/TestIsSpeedTool.php
@@ -1,7 +1,7 @@
 <?php
 namespace WP_Rocket\Tests\Integration\Buffer\Tests;
 
-use PHPUnit\Framework\TestCase;
+use WP_Rocket\Tests\Integration\TestCase;
 use WP_Rocket\Buffer\Tests;
 use WP_Rocket\Buffer\Config;
 

--- a/tests/Integration/Functions/Options/TestExcludeDeferJS.php
+++ b/tests/Integration/Functions/Options/TestExcludeDeferJS.php
@@ -1,7 +1,7 @@
 <?php
 namespace WP_Rocket\Tests\Integration\Functions\Options;
 
-use PHPUnit\Framework\TestCase;
+use WP_Rocket\Tests\Integration\TestCase;
 
 class TestExcludeDeferJS extends TestCase {
     public function testShouldReturnExcludeDeferJSArray() {

--- a/tests/Integration/Optimization/CSS/Combine/TestInsertCombinedCSS.php
+++ b/tests/Integration/Optimization/CSS/Combine/TestInsertCombinedCSS.php
@@ -1,7 +1,7 @@
 <?php
 namespace WP_Rocket\Tests\Integration\Optimize\CSS\Combine;
 
-use PHPUnit\Framework\TestCase;
+use WP_Rocket\Tests\Integration\TestCase;
 use WP_Rocket\Optimization\CSS\Combine;
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Admin\Options;

--- a/tests/Integration/Optimization/CSS/CombineGoogleFonts/TestOptimize.php
+++ b/tests/Integration/Optimization/CSS/CombineGoogleFonts/TestOptimize.php
@@ -1,7 +1,7 @@
 <?php
 namespace WP_Rocket\Tests\Integration\Optimize\CSS\CombineGoogleFonts;
 
-use PHPUnit\Framework\TestCase;
+use WP_Rocket\Tests\Integration\TestCase;
 use WP_Rocket\Optimization\CSS\Combine_Google_Fonts;
 
 class TestOptimize extends TestCase {

--- a/tests/Integration/Subscriber/CDNSubscriber/TestGetCDNHosts.php
+++ b/tests/Integration/Subscriber/CDNSubscriber/TestGetCDNHosts.php
@@ -1,7 +1,7 @@
 <?php
 namespace WP_Rocket\Tests\Integration\Subscriber\CDNSubscriber;
 
-use PHPUnit\Framework\TestCase;
+use WP_Rocket\Tests\Integration\TestCase;
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Admin\Options;
 use WP_Rocket\CDN\CDN;

--- a/tests/Integration/Subscriber/CDNSubscriber/TestGetSubscribedEvents.php
+++ b/tests/Integration/Subscriber/CDNSubscriber/TestGetSubscribedEvents.php
@@ -1,7 +1,7 @@
 <?php
 namespace WP_Rocket\Tests\Integration\Subscriber\CDNSubscriber;
 
-use PHPUnit\Framework\TestCase;
+use WP_Rocket\Tests\Integration\TestCase;
 use WP_Rocket\Subscriber\CDN\CDNSubscriber;
 
 class TestGetSubscribedEvents extends TestCase {

--- a/tests/Integration/Subscriber/CDNSubscriber/TestRewrite.php
+++ b/tests/Integration/Subscriber/CDNSubscriber/TestRewrite.php
@@ -1,7 +1,7 @@
 <?php
 namespace WP_Rocket\Tests\Integration\Subscriber\CDNSubscriber;
 
-use PHPUnit\Framework\TestCase;
+use WP_Rocket\Tests\Integration\TestCase;
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Admin\Options;
 use WP_Rocket\CDN\CDN;

--- a/tests/Integration/Subscriber/CDNSubscriber/TestRewriteCSSProperties.php
+++ b/tests/Integration/Subscriber/CDNSubscriber/TestRewriteCSSProperties.php
@@ -1,7 +1,7 @@
 <?php
 namespace WP_Rocket\Tests\Integration\Subscriber\CDNSubscriber;
 
-use PHPUnit\Framework\TestCase;
+use WP_Rocket\Tests\Integration\TestCase;
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Admin\Options;
 use WP_Rocket\CDN\CDN;

--- a/tests/Integration/Subscriber/CDNSubscriber/TestRewriteSrcset.php
+++ b/tests/Integration/Subscriber/CDNSubscriber/TestRewriteSrcset.php
@@ -1,7 +1,7 @@
 <?php
 namespace WP_Rocket\Tests\Integration\Subscriber\CDNSubscriber;
 
-use PHPUnit\Framework\TestCase;
+use WP_Rocket\Tests\Integration\TestCase;
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Admin\Options;
 use WP_Rocket\CDN\CDN;

--- a/tests/Integration/Subscriber/ExpiredCachePurgeSubscriber/TestGetCacheLifespan.php
+++ b/tests/Integration/Subscriber/ExpiredCachePurgeSubscriber/TestGetCacheLifespan.php
@@ -1,7 +1,7 @@
 <?php
 namespace WP_Rocket\Tests\Integration\Subscriber\ExpiredCachePurgeSubscriber;
 
-use PHPUnit\Framework\TestCase;
+use WP_Rocket\Tests\Integration\TestCase;
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Admin\Options;
 use WP_Rocket\Cache\Expired_Cache_Purge;

--- a/tests/Integration/Subscriber/ExpiredCachePurgeSubscriber/TestGetSubscribedEvents.php
+++ b/tests/Integration/Subscriber/ExpiredCachePurgeSubscriber/TestGetSubscribedEvents.php
@@ -1,7 +1,7 @@
 <?php
 namespace WP_Rocket\Tests\Integration\Subscriber\ExpiredCachePurgeSubscriber;
 
-use PHPUnit\Framework\TestCase;
+use WP_Rocket\Tests\Integration\TestCase;
 use WP_Rocket\Subscriber\Cache\Expired_Cache_Purge_Subscriber;
 
 class TestGetSubscribedEvents extends TestCase {

--- a/tests/Integration/Subscriber/ExpiredCachePurgeSubscriber/TestScheduleEvent.php
+++ b/tests/Integration/Subscriber/ExpiredCachePurgeSubscriber/TestScheduleEvent.php
@@ -1,7 +1,7 @@
 <?php
 namespace WP_Rocket\Tests\Integration\Subscriber\ExpiredCachePurgeSubscriber;
 
-use PHPUnit\Framework\TestCase;
+use WP_Rocket\Tests\Integration\TestCase;
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Admin\Options;
 use WP_Rocket\Cache\Expired_Cache_Purge;

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Test Case for all of the integration tests.
+ *
+ * @package WP_Rocket\Tests\Integration
+ */
+
+namespace WP_Rocket\Tests\Integration;
+
+use Brain\Monkey;
+use WP_UnitTestCase;
+
+class TestCase extends WP_UnitTestCase {
+	/**
+	 * Prepares the test environment before each test.
+	 */
+	public function setUp() {
+		parent::setUp();
+		Monkey\setUp();
+	}
+
+	/**
+	 * Cleans up the test environment after each test.
+	 */
+	public function tearDown() {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+}

--- a/tests/Integration/bootstrap.php
+++ b/tests/Integration/bootstrap.php
@@ -5,37 +5,36 @@
  * @package WP_Rocket\Tests\Integration
  */
 
-if (version_compare(phpversion(), '5.6.0', '<')) {
-    die('WP Rocket Plugin Integration Tests require PHP 5.6 or higher.');
-}
+namespace WP_Rocket\Tests\Integration;
 
-// Define testing constants.
-define('WP_ROCKET_PLUGIN_TESTS_ROOT', __DIR__);
-define('WP_ROCKET_PLUGIN_ROOT', dirname(dirname(__DIR__)));
+use function WP_Rocket\Tests\init_test_suite;
+
+require_once dirname( dirname( __FILE__ ) ) . '/boostrap-functions.php';
+init_test_suite( 'Integration' );
 
 /**
  * Gets the WP tests suite directory
  *
  * @return string
  */
-function WPRocketPluginGetWPTestsDir()
-{
-    $tests_dir = getenv('WP_TESTS_DIR');
+function WPRocketPluginGetWPTestsDir() {
+	$tests_dir = getenv( 'WP_TESTS_DIR' );
 
-    // Travis CI & Vagrant SSH tests directory.
-    if (empty($tests_dir)) {
-        $tests_dir = '/tmp/wordpress-tests-lib';
-    }
-    // If the tests' includes directory does not exist, try a relative path to Core tests directory.
-    if (! file_exists($tests_dir . '/includes/')) {
-        $tests_dir = '../../../../tests/phpunit';
-    }
-    // Check it again. If it doesn't exist, stop here and post a message as to why we stopped.
-    if (! file_exists($tests_dir . '/includes/')) {
-        trigger_error('Unable to run the integration tests, as the WordPress test suite could not be located.', E_USER_ERROR);  // @codingStandardsIgnoreLine.
-    }
-    // Strip off the trailing directory separator, if it exists.
-    return rtrim($tests_dir, DIRECTORY_SEPARATOR);
+	// Travis CI & Vagrant SSH tests directory.
+	if ( empty( $tests_dir ) ) {
+		$tests_dir = '/tmp/wordpress-tests-lib';
+	}
+	// If the tests' includes directory does not exist, try a relative path to Core tests directory.
+	if ( ! file_exists( $tests_dir . '/includes/' ) ) {
+		$tests_dir = '../../../../tests/phpunit';
+	}
+	// Check it again. If it doesn't exist, stop here and post a message as to why we stopped.
+	if ( ! file_exists( $tests_dir . '/includes/' ) ) {
+		trigger_error( 'Unable to run the integration tests, as the WordPress test suite could not be located.', E_USER_ERROR );  // @codingStandardsIgnoreLine.
+	}
+
+	// Strip off the trailing directory separator, if it exists.
+	return rtrim( $tests_dir, DIRECTORY_SEPARATOR );
 }
 
 $rocket_tests_dir = WPRocketPluginGetWPTestsDir();
@@ -46,12 +45,12 @@ require_once $rocket_tests_dir . '/includes/functions.php';
 /**
  * Manually load the plugin being tested.
  */
-function rocket_manually_load_plugin()
-{
-    require WP_ROCKET_PLUGIN_ROOT . '/wp-rocket.php';
+function rocket_manually_load_plugin() {
+	require WP_ROCKET_PLUGIN_ROOT . '/wp-rocket.php';
 }
-tests_add_filter('muplugins_loaded', 'rocket_manually_load_plugin');
+
+tests_add_filter( 'muplugins_loaded', __NAMESPACE__ . '\rocket_manually_load_plugin' );
 
 require_once $rocket_tests_dir . '/includes/bootstrap.php';
 
-unset($rocket_tests_dir);
+unset( $rocket_tests_dir );

--- a/tests/Integration/bootstrap.php
+++ b/tests/Integration/bootstrap.php
@@ -13,44 +13,51 @@ require_once dirname( dirname( __FILE__ ) ) . '/boostrap-functions.php';
 init_test_suite( 'Integration' );
 
 /**
- * Gets the WP tests suite directory
+ * Get the WordPress' tests suite directory.
  *
- * @return string
+ * @return string Returns The directory path to the WordPress testing environment.
  */
-function WPRocketPluginGetWPTestsDir() {
+function get_wp_tests_dir() {
 	$tests_dir = getenv( 'WP_TESTS_DIR' );
 
 	// Travis CI & Vagrant SSH tests directory.
 	if ( empty( $tests_dir ) ) {
 		$tests_dir = '/tmp/wordpress-tests-lib';
 	}
+
 	// If the tests' includes directory does not exist, try a relative path to Core tests directory.
 	if ( ! file_exists( $tests_dir . '/includes/' ) ) {
 		$tests_dir = '../../../../tests/phpunit';
 	}
+
 	// Check it again. If it doesn't exist, stop here and post a message as to why we stopped.
 	if ( ! file_exists( $tests_dir . '/includes/' ) ) {
-		trigger_error( 'Unable to run the integration tests, as the WordPress test suite could not be located.', E_USER_ERROR );  // @codingStandardsIgnoreLine.
+		trigger_error( 'Unable to run the integration tests, because the WordPress test suite could not be located.', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- Valid use case for our testing suite.
 	}
 
 	// Strip off the trailing directory separator, if it exists.
 	return rtrim( $tests_dir, DIRECTORY_SEPARATOR );
 }
 
-$rocket_tests_dir = WPRocketPluginGetWPTestsDir();
-
-// Give access to tests_add_filter() function.
-require_once $rocket_tests_dir . '/includes/functions.php';
-
 /**
- * Manually load the plugin being tested.
+ * Bootstraps the integration testing environment with WordPress and WP Rocket.
+ *
+ * @param string $wp_tests_dir The directory path to the WordPress testing environment.
  */
-function rocket_manually_load_plugin() {
-	require WP_ROCKET_PLUGIN_ROOT . '/wp-rocket.php';
+function bootstrap_integration_suite( $wp_tests_dir ) {
+	// Give access to tests_add_filter() function.
+	require_once $wp_tests_dir . '/includes/functions.php';
+
+	// Manually load the plugin being tested.
+	tests_add_filter(
+		'muplugins_loaded',
+		function() {
+			require WP_ROCKET_PLUGIN_ROOT . '/wp-rocket.php';
+		}
+	);
+
+	// Start up the WP testing environment.
+	require_once $wp_tests_dir . '/includes/bootstrap.php';
 }
 
-tests_add_filter( 'muplugins_loaded', __NAMESPACE__ . '\rocket_manually_load_plugin' );
-
-require_once $rocket_tests_dir . '/includes/bootstrap.php';
-
-unset( $rocket_tests_dir );
+bootstrap_integration_suite( get_wp_tests_dir() );

--- a/tests/Integration/phpunit.xml.dist
+++ b/tests/Integration/phpunit.xml.dist
@@ -16,6 +16,7 @@
 	<testsuites>
 		<testsuite name="integration">
 			<directory suffix=".php">.</directory>
+			<exclude>TestCase.php</exclude>
 		</testsuite>
 	</testsuites>
 </phpunit>

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -1,15 +1,27 @@
 <?php
+/**
+ * Test Case for all of the unit tests.
+ *
+ * @package WP_Rocket\Tests\Unit
+ */
+
 namespace WP_Rocket\Tests\Unit;
 
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 use Brain\Monkey;
 
 class TestCase extends PHPUnitTestCase {
+	/**
+	 * Prepares the test environment before each test.
+	 */
 	protected function setUp() {
 		parent::setUp();
 		Monkey\setUp();
 	}
 
+	/**
+	 * Cleans up the test environment after each test.
+	 */
 	protected function tearDown() {
 		Monkey\tearDown();
 		parent::tearDown();

--- a/tests/Unit/bootstrap.php
+++ b/tests/Unit/bootstrap.php
@@ -5,23 +5,9 @@
  * @package WP_Rocket\Tests\Unit
  */
 
-if (version_compare(phpversion(), '5.6.0', '<')) {
-    die('WP Rocket Plugin Unit Tests require PHP 5.6 or higher.');
-}
+namespace WP_Rocket\Tests\Unit;
 
-define('WP_ROCKET_PLUGIN_TESTS_ROOT', __DIR__);
-define('WP_ROCKET_PLUGIN_ROOT', dirname(dirname(__DIR__)) . DIRECTORY_SEPARATOR);
+use function WP_Rocket\Tests\init_test_suite;
 
-$rocket_common_autoload_path = WP_ROCKET_PLUGIN_ROOT . 'vendor/';
-
-if (! file_exists($rocket_common_autoload_path . 'autoload.php')) {
-    die('Whoops, we need Composer before we start running tests.  Please type: `composer install`.  When done, try running `phpunit` again.');
-}
-
-if ( ! defined( 'ABSPATH' ) ) {
-    define( 'ABSPATH', WP_ROCKET_PLUGIN_ROOT );
-}
-
-require_once $rocket_common_autoload_path . 'autoload.php';
-
-unset($rocket_common_autoload_path);
+require_once dirname( dirname( __FILE__ ) ) . '/boostrap-functions.php';
+init_test_suite( 'Unit' );

--- a/tests/Unit/phpunit.xml.dist
+++ b/tests/Unit/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.3/phpunit.xsd"
-         bootstrap="tests/Unit/bootstrap.php"
+         bootstrap="bootstrap.php"
          backupGlobals="false"
          colors="true"
          beStrictAboutCoversAnnotation="true"
@@ -15,8 +15,8 @@
 
     <testsuites>
         <testsuite name="unit">
-            <directory suffix=".php">tests/Unit</directory>
-            <exclude>./tests/Unit/TestCase.php</exclude>
+            <directory suffix=".php">.</directory>
+            <exclude>TestCase.php</exclude>
         </testsuite>
     </testsuites>
 

--- a/tests/boostrap-functions.php
+++ b/tests/boostrap-functions.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Common bootstrap functionality.
+ *
+ * @package WP_Rocket\Tests\Unit
+ */
+
+namespace WP_Rocket\Tests;
+
+/**
+ * Initialize the test suite.
+ *
+ * @param string $test_suite Directory name of the test suite. Default is 'Unit'.
+ */
+function init_test_suite( $test_suite = 'Unit' ) {
+	check_readiness();
+
+	init_constants( $test_suite );
+
+	// Load the Composer autoloader.
+	require_once WP_ROCKET_PLUGIN_ROOT . '/vendor/autoload.php';
+}
+
+/**
+ * Check the system's readiness to run the tests.
+ */
+function check_readiness() {
+	if ( version_compare( phpversion(), '5.6.0', '<' ) ) {
+		trigger_error( 'Beans Unit Tests require PHP 5.6 or higher.', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- Valid use case for our testing suite.
+	}
+
+	if ( ! file_exists( dirname( __DIR__ ) . '/vendor/autoload.php' ) ) {
+		trigger_error( 'Whoops, we need Composer before we start running tests.  Please type: `composer install`.  When done, try running `phpunit` again.', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- Valid use case for our testing suite.
+	}
+}
+
+/**
+ * Initialize the constants.
+ *
+ * @param string $test_suite_folder Directory name of the test suite.
+ */
+function init_constants( $test_suite_folder ) {
+	define( 'WP_ROCKET_PLUGIN_ROOT', dirname( __DIR__ ) . DIRECTORY_SEPARATOR );
+	define( 'WP_ROCKET_PLUGIN_TESTS_ROOT', __DIR__ . DIRECTORY_SEPARATOR . $test_suite_folder );
+
+	if ( 'Unit' === $test_suite_folder && ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', WP_ROCKET_PLUGIN_ROOT );
+	}
+}

--- a/tests/boostrap-functions.php
+++ b/tests/boostrap-functions.php
@@ -19,6 +19,9 @@ function init_test_suite( $test_suite = 'Unit' ) {
 
 	// Load the Composer autoloader.
 	require_once WP_ROCKET_PLUGIN_ROOT . '/vendor/autoload.php';
+
+	// Load Patchwork before everything else in order to allow us to redefine WordPress, 3rd party, and WP Rocket functions.
+	require_once WP_ROCKET_PLUGIN_ROOT . '/vendor/antecedent/patchwork/Patchwork.php';
 }
 
 /**

--- a/tests/boostrap-functions.php
+++ b/tests/boostrap-functions.php
@@ -29,7 +29,7 @@ function init_test_suite( $test_suite = 'Unit' ) {
  */
 function check_readiness() {
 	if ( version_compare( phpversion(), '5.6.0', '<' ) ) {
-		trigger_error( 'Beans Unit Tests require PHP 5.6 or higher.', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- Valid use case for our testing suite.
+		trigger_error( 'WP Rocket Unit Tests require PHP 5.6 or higher.', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- Valid use case for our testing suite.
 	}
 
 	if ( ! file_exists( dirname( __DIR__ ) . '/vendor/autoload.php' ) ) {

--- a/tests/boostrap-functions.php
+++ b/tests/boostrap-functions.php
@@ -2,7 +2,7 @@
 /**
  * Common bootstrap functionality.
  *
- * @package WP_Rocket\Tests\Unit
+ * @package WP_Rocket\Tests
  */
 
 namespace WP_Rocket\Tests;


### PR DESCRIPTION
This PR includes the following improvements for bootstrapping the test suites:

- Loads Patchwork first before anything else runs, ie to ensure it's ready before any user-defined (WP, 3rd, or WP Rocket) functions are loaded into memory. This change avoids wonky, weird behaviors that can happen when mocking functions.
- Centralizes bootstrapping tasks (by moving them into a common functions file that's called from each test suite's bootstrap file)
- Adds a new composer script to run all the tests: `composer run-tests`
- Changes the inheritance test case inheritance by:
     - adding a new `TestCase`
     - extending that class off of `WP_UnitTestCase`
     - The new inheritance chain is: `WP_Rocket\Tests\Integration\TestCase` -> `WP_UnitTestCase` -> `WP_UnitTestCase_Base` -> `PHPUnit\Framework\TestCase`

Some other minor things it does:
- Moves the unit test's phpunit.xml file in with the unit tests folder
- Adds namespacing to the bootstrap files