### PR TITLE
Improves the integration test with reflection, @group, and overload valid key.

### DIFF
--- a/tests/Integration/Buffer/Tests/TestIsSpeedTool.php
+++ b/tests/Integration/Buffer/Tests/TestIsSpeedTool.php
@@ -5,6 +5,9 @@ use WP_Rocket\Tests\Integration\TestCase;
 use WP_Rocket\Buffer\Tests;
 use WP_Rocket\Buffer\Config;
 
+/**
+ * @group Buffer
+ */
 class TestIsSpeedTool extends TestCase {
      /**
      * @covers ::is_speed_tool

--- a/tests/Integration/Buffer/Tests/TestIsSpeedTool.php
+++ b/tests/Integration/Buffer/Tests/TestIsSpeedTool.php
@@ -11,7 +11,12 @@ class TestIsSpeedTool extends TestCase {
      * @author Remy Perona
      */
     public function testShouldReturnTrueWhenLighthouse() {
-        $config = new Config(
+    	// Grab the current Config::$config_dir_path value. We'll restore it when we're done.
+	    $config_dir_path = $this->get_reflective_property( 'config_dir_path', 'WP_Rocket\Buffer\Config' );
+	    // Set the Config::$config_dir_path value to `null`.
+	    $this->set_reflective_property( null, 'config_dir_path', 'WP_Rocket\Buffer\Config' );
+
+	    $config = new Config(
             [
                 'config_dir_path' => 'wp-content/wp-rocket/config',
                 'server'          => [
@@ -22,8 +27,9 @@ class TestIsSpeedTool extends TestCase {
 
         $tests = new Tests( $config );
 
-        $this->assertTrue(
-            $tests->is_speed_tool()
-        );
+        $this->assertTrue( $tests->is_speed_tool() );
+
+        // Restore the Config::$config_dir_path.
+	    $this->set_reflective_property( $config_dir_path, 'config_dir_path', 'WP_Rocket\Buffer\Config' );
     }
 }

--- a/tests/Integration/Functions/Options/TestExcludeDeferJS.php
+++ b/tests/Integration/Functions/Options/TestExcludeDeferJS.php
@@ -3,6 +3,10 @@ namespace WP_Rocket\Tests\Integration\Functions\Options;
 
 use WP_Rocket\Tests\Integration\TestCase;
 
+/**
+ * @group Functions
+ * @group Options
+ */
 class TestExcludeDeferJS extends TestCase {
     public function testShouldReturnExcludeDeferJSArray() {
         $exclude_defer_js = [

--- a/tests/Integration/Optimization/CSS/Combine/TestInsertCombinedCSS.php
+++ b/tests/Integration/Optimization/CSS/Combine/TestInsertCombinedCSS.php
@@ -7,6 +7,9 @@ use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Admin\Options;
 use MatthiasMullie\Minify\CSS;
 
+/**
+ * @group Optimize
+ */
 class TestInsertCombinedCSS extends TestCase {
     public function testShouldInsertCombinedCSS() {
         $combine      = new Combine( new Options_Data( (new Options( 'wp_rocket_'))->get( 'settings' ) ), new CSS() );

--- a/tests/Integration/Optimization/CSS/CombineGoogleFonts/TestOptimize.php
+++ b/tests/Integration/Optimization/CSS/CombineGoogleFonts/TestOptimize.php
@@ -4,6 +4,9 @@ namespace WP_Rocket\Tests\Integration\Optimize\CSS\CombineGoogleFonts;
 use WP_Rocket\Tests\Integration\TestCase;
 use WP_Rocket\Optimization\CSS\Combine_Google_Fonts;
 
+/**
+ * @group Optimize
+ */
 class TestOptimize extends TestCase {
     public function testShouldCombineGoogleFontsWhenSubset() {
         $combine = new Combine_Google_Fonts();

--- a/tests/Integration/Subscriber/CDNSubscriber/TestGetCDNHosts.php
+++ b/tests/Integration/Subscriber/CDNSubscriber/TestGetCDNHosts.php
@@ -7,6 +7,9 @@ use WP_Rocket\Admin\Options;
 use WP_Rocket\CDN\CDN;
 use WP_Rocket\Subscriber\CDN\CDNSubscriber;
 
+/**
+ * @group Subscriber
+ */
 class TestRewriteGetCDNHosts extends TestCase {
     public function testShouldReturnCDNHosts() {
         update_option(

--- a/tests/Integration/Subscriber/CDNSubscriber/TestGetSubscribedEvents.php
+++ b/tests/Integration/Subscriber/CDNSubscriber/TestGetSubscribedEvents.php
@@ -4,6 +4,9 @@ namespace WP_Rocket\Tests\Integration\Subscriber\CDNSubscriber;
 use WP_Rocket\Tests\Integration\TestCase;
 use WP_Rocket\Subscriber\CDN\CDNSubscriber;
 
+/**
+ * @group Subscriber
+ */
 class TestGetSubscribedEvents extends TestCase {
     public function testShouldReturnSubscribedEventsArray() {
         $events = [

--- a/tests/Integration/Subscriber/CDNSubscriber/TestRewrite.php
+++ b/tests/Integration/Subscriber/CDNSubscriber/TestRewrite.php
@@ -7,6 +7,9 @@ use WP_Rocket\Admin\Options;
 use WP_Rocket\CDN\CDN;
 use WP_Rocket\Subscriber\CDN\CDNSubscriber;
 
+/**
+ * @group Subscriber
+ */
 class TestRewrite extends TestCase {
     public function testShouldRewriteURL() {
         update_option(

--- a/tests/Integration/Subscriber/CDNSubscriber/TestRewriteCSSProperties.php
+++ b/tests/Integration/Subscriber/CDNSubscriber/TestRewriteCSSProperties.php
@@ -7,6 +7,9 @@ use WP_Rocket\Admin\Options;
 use WP_Rocket\CDN\CDN;
 use WP_Rocket\Subscriber\CDN\CDNSubscriber;
 
+/**
+ * @group Subscriber
+ */
 class TestRewriteCSSProperties extends TestCase {
     public function testShouldRewriteCSSProperties() {
         update_option(

--- a/tests/Integration/Subscriber/CDNSubscriber/TestRewriteSrcset.php
+++ b/tests/Integration/Subscriber/CDNSubscriber/TestRewriteSrcset.php
@@ -7,6 +7,9 @@ use WP_Rocket\Admin\Options;
 use WP_Rocket\CDN\CDN;
 use WP_Rocket\Subscriber\CDN\CDNSubscriber;
 
+/**
+ * @group Subscriber
+ */
 class TestRewriteSrcset extends TestCase {
     /**
      * @runInSeparateProcess

--- a/tests/Integration/Subscriber/ExpiredCachePurgeSubscriber/TestGetCacheLifespan.php
+++ b/tests/Integration/Subscriber/ExpiredCachePurgeSubscriber/TestGetCacheLifespan.php
@@ -7,6 +7,9 @@ use WP_Rocket\Admin\Options;
 use WP_Rocket\Cache\Expired_Cache_Purge;
 use WP_Rocket\Subscriber\Cache\Expired_Cache_Purge_Subscriber;
 
+/**
+ * @group Subscriber
+ */
 class TestGetCacheLifespan extends TestCase {
 	public function testShouldReturnLifespan() {
 		update_option(

--- a/tests/Integration/Subscriber/ExpiredCachePurgeSubscriber/TestGetSubscribedEvents.php
+++ b/tests/Integration/Subscriber/ExpiredCachePurgeSubscriber/TestGetSubscribedEvents.php
@@ -4,6 +4,9 @@ namespace WP_Rocket\Tests\Integration\Subscriber\ExpiredCachePurgeSubscriber;
 use WP_Rocket\Tests\Integration\TestCase;
 use WP_Rocket\Subscriber\Cache\Expired_Cache_Purge_Subscriber;
 
+/**
+ * @group Subscriber
+ */
 class TestGetSubscribedEvents extends TestCase {
 	public function testShouldReturnSubscribedEventsArray() {
 		$events = [

--- a/tests/Integration/Subscriber/ExpiredCachePurgeSubscriber/TestScheduleEvent.php
+++ b/tests/Integration/Subscriber/ExpiredCachePurgeSubscriber/TestScheduleEvent.php
@@ -7,6 +7,9 @@ use WP_Rocket\Admin\Options;
 use WP_Rocket\Cache\Expired_Cache_Purge;
 use WP_Rocket\Subscriber\Cache\Expired_Cache_Purge_Subscriber;
 
+/**
+ * @group Subscriber
+ */
 class TestScheduleEvent extends TestCase {
 	public function testShouldScheduleEvent() {
 		update_option(

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -8,9 +8,12 @@
 namespace WP_Rocket\Tests\Integration;
 
 use Brain\Monkey;
+use WP_Rocket\Tests\TestCaseTrait;
 use WP_UnitTestCase;
 
 class TestCase extends WP_UnitTestCase {
+	use TestCaseTrait;
+
 	/**
 	 * Prepares the test environment before each test.
 	 */

--- a/tests/Integration/bootstrap.php
+++ b/tests/Integration/bootstrap.php
@@ -52,6 +52,10 @@ function bootstrap_integration_suite( $wp_tests_dir ) {
 	tests_add_filter(
 		'muplugins_loaded',
 		function() {
+			// Overload the license key for testing.
+			\Patchwork\redefine( 'rocket_valid_key', '__return_true' );
+
+			// Load the plugin.
 			require WP_ROCKET_PLUGIN_ROOT . '/wp-rocket.php';
 		}
 	);

--- a/tests/TestCaseTrait.php
+++ b/tests/TestCaseTrait.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Common functionality for all PHP test cases.
+ *
+ * @package WP_Rocket\Tests
+ */
+
+namespace WP_Rocket\Tests;
+
+trait TestCaseTrait {
+	/**
+	 * Get reflective access to the private/protected method.
+	 *
+	 * @param string $method_name Method name for which to gain access.
+	 * @param string $class_name  Name of the target class.
+	 *
+	 * @return \ReflectionMethod
+	 * @throws \ReflectionException Throws an exception if method does not exist.
+	 */
+	protected function get_reflective_method( $method_name, $class_name ) {
+		$class  = new \ReflectionClass( $class_name );
+		$method = $class->getMethod( $method_name );
+		$method->setAccessible( true );
+
+		return $method;
+	}
+
+	/**
+	 * Get reflective access to the private/protected property.
+	 *
+	 * @param string       $property Property name for which to gain access.
+	 * @param string|mixed $class    Class name or instance.
+	 *
+	 * @return \ReflectionProperty|string
+	 * @throws \ReflectionException Throws an exception if property does not exist.
+	 */
+	protected function get_reflective_property( $property, $class ) {
+		$class    = new \ReflectionClass( $class );
+		$property = $class->getProperty( $property );
+		$property->setAccessible( true );
+
+		return $property;
+	}
+
+	/**
+	 * Set the value of a property or private property.
+	 *
+	 * @param mixed  $value    The value to set for the property.
+	 * @param string $property Property name for which to gain access.
+	 * @param mixed  $instance Instance of the target object.
+	 *
+	 * @return \ReflectionProperty|string
+	 * @throws \ReflectionException Throws an exception if property does not exist.
+	 */
+	protected function set_reflective_property( $value, $property, $instance ) {
+		$property = $this->get_reflective_property( $property, $instance );
+		$property->setValue( $instance, $value );
+		$property->setAccessible( false );
+
+		return $property;
+	}
+}

--- a/tests/Unit/Buffer/Tests/TestIsSpeedTool.php
+++ b/tests/Unit/Buffer/Tests/TestIsSpeedTool.php
@@ -4,6 +4,9 @@ namespace WP_Rocket\Tests\Unit\Buffer\Tests;
 use PHPUnit\Framework\TestCase;
 use WP_Rocket\Buffer\Tests;
 
+/**
+ * @group Buffer
+ */
 class TestIsSpeedTool extends TestCase {
     /**
      * @covers ::is_speed_tool

--- a/tests/Unit/CDN/TestRewrite.php
+++ b/tests/Unit/CDN/TestRewrite.php
@@ -5,6 +5,9 @@ use WP_Rocket\CDN\CDN;
 use WP_Rocket\Tests\Unit\TestCase;
 use Brain\Monkey\Functions;
 
+/**
+ * @group CDN
+ */
 class TestRewrite extends TestCase {
     public function testShouldRewriteURLToCDN() {
         $options = $this->createMock('WP_Rocket\Admin\Options_Data');

--- a/tests/Unit/CDN/TestRewriteCSSProperties.php
+++ b/tests/Unit/CDN/TestRewriteCSSProperties.php
@@ -5,6 +5,9 @@ use WP_Rocket\CDN\CDN;
 use WP_Rocket\Tests\Unit\TestCase;
 use Brain\Monkey\Functions;
 
+/**
+ * @group CDN
+ */
 class TestRewriteCSSProperties extends TestCase {
     public function testShouldRewriteCSSProperties() {
         $options = $this->createMock('WP_Rocket\Admin\Options_Data');

--- a/tests/Unit/CDN/TestRewriteSrcset.php
+++ b/tests/Unit/CDN/TestRewriteSrcset.php
@@ -5,6 +5,9 @@ use WP_Rocket\CDN\CDN;
 use WP_Rocket\Tests\Unit\TestCase;
 use Brain\Monkey\Functions;
 
+/**
+ * @group CDN
+ */
 class TestRewriteSrcset extends TestCase {
     public function testShouldRewriteURLToCDN() {
         $options = $this->createMock('WP_Rocket\Admin\Options_Data');

--- a/tests/Unit/CDN/TestRewriteURL.php
+++ b/tests/Unit/CDN/TestRewriteURL.php
@@ -5,6 +5,9 @@ use WP_Rocket\CDN\CDN;
 use WP_Rocket\Tests\Unit\TestCase;
 use Brain\Monkey\Functions;
 
+/**
+ * @group CDN
+ */
 class TestRewriteURL extends TestCase {
     /**
      * @dataProvider rewriteURLProvider

--- a/tests/Unit/Cache/TestPurgeExpiredFiles.php
+++ b/tests/Unit/Cache/TestPurgeExpiredFiles.php
@@ -7,6 +7,9 @@ use Brain\Monkey\Functions;
 use org\bovigo\vfs\vfsStream,
 	org\bovigo\vfs\vfsStreamDirectory;
 
+/**
+ * @group Cache
+ */
 class TestPurgeExpiredFiles extends TestCase {
 	private $cache_path;
 	private $mock_fs;

--- a/tests/Unit/Functions/Options/TestExcludeDeferJS.php
+++ b/tests/Unit/Functions/Options/TestExcludeDeferJS.php
@@ -6,6 +6,8 @@ use Brain\Monkey\Functions;
 
 /**
  * @runTestsInSeparateProcesses
+ * @group Functions
+ * @group Options
  */
 class TestExcludeDeferJS extends TestCase {
     protected function setUp() {

--- a/tests/Unit/Optimization/CSS/Combine/TestInsertCombinedCSS.php
+++ b/tests/Unit/Optimization/CSS/Combine/TestInsertCombinedCSS.php
@@ -5,6 +5,9 @@ use WP_Rocket\Tests\Unit\TestCase;
 use WP_Rocket\Optimization\CSS\Combine;
 use Brain\Monkey\Functions;
 
+/**
+ * @group Optimize
+ */
 class TestInsertCombinedCSS extends TestCase {
     public function testShouldInsertCombinedCSS() {
         Functions\when('create_rocket_uniqid')->justReturn('1234');

--- a/tests/Unit/Optimization/CSS/CombineGoogleFonts/TestOptimize.php
+++ b/tests/Unit/Optimization/CSS/CombineGoogleFonts/TestOptimize.php
@@ -5,6 +5,9 @@ use WP_Rocket\Tests\Unit\TestCase;
 use WP_Rocket\Optimization\CSS\Combine_Google_Fonts;
 use Brain\Monkey\Functions;
 
+/**
+ * @group Optimize
+ */
 class TestOptimize extends TestCase {
     public function testShouldCombineGoogleFontsWhenSubset() {
         Functions\when('rocket_extract_url_component')->alias( function($url, $component ) {

--- a/tests/Unit/Subscriber/Media/WebpSubscriber/TestConvertToWebp.php
+++ b/tests/Unit/Subscriber/Media/WebpSubscriber/TestConvertToWebp.php
@@ -6,6 +6,9 @@ use WP_Rocket\Tests\Unit\TestCase;
 use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
 
+/**
+ * @group Subscriber
+ */
 class TestConvertToWebp extends TestCase {
 	/**
 	 * Test Webp_Subscriber->convert_to_webp() should return the identical HTML when separate cache is disabled via the option.

--- a/tests/Unit/Subscriber/Media/WebpSubscriber/TestMaybeDisableSettingField.php
+++ b/tests/Unit/Subscriber/Media/WebpSubscriber/TestMaybeDisableSettingField.php
@@ -6,6 +6,9 @@ use WP_Rocket\Tests\Unit\TestCase;
 use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
 
+/**
+ * @group Subscriber
+ */
 class TestMaybeDisableSettingField extends TestCase {
 	/**
 	 * Test Webp_Subscriber->maybe_disable_setting_field() should return the identical array when webp cache is enabled.

--- a/tests/Unit/Subscriber/Media/WebpSubscriber/TestMaybeDisableWebpCache.php
+++ b/tests/Unit/Subscriber/Media/WebpSubscriber/TestMaybeDisableWebpCache.php
@@ -6,6 +6,9 @@ use WP_Rocket\Tests\Unit\TestCase;
 use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
 
+/**
+ * @group Subscriber
+ */
 class TestMaybeDisableWebpCache extends TestCase {
 	/**
 	 * Test Webp_Subscriber->maybe_disable_webp_cache() should return true when webp cache is already disabled.

--- a/tests/Unit/Subscriber/Media/WebpSubscriber/TestSyncWebpCacheWithThirdPartyPlugins.php
+++ b/tests/Unit/Subscriber/Media/WebpSubscriber/TestSyncWebpCacheWithThirdPartyPlugins.php
@@ -6,6 +6,9 @@ use WP_Rocket\Tests\Unit\TestCase;
 use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
 
+/**
+ * @group Subscriber
+ */
 class TestSyncWebpCacheWithThirdPartyPlugins extends TestCase {
 	/**
 	 * Test Webp_Subscriber->sync_webp_cache_with_third_party_plugins() should not disable the webp cache option when not enabled.

--- a/tests/Unit/Subscriber/Media/WebpSubscriber/TestWebpSectionDescription.php
+++ b/tests/Unit/Subscriber/Media/WebpSubscriber/TestWebpSectionDescription.php
@@ -6,6 +6,9 @@ use WP_Rocket\Tests\Unit\TestCase;
 use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
 
+/**
+ * @group Subscriber
+ */
 class TestWebpSectionDescription extends TestCase {
 	/**
 	 * Test Webp_Subscriber->webp_section_description() should return specific text when no webp plugin is available and cache option is disabled.

--- a/tests/Unit/Subscriber/Tools/TestDetectMissingTags.php
+++ b/tests/Unit/Subscriber/Tools/TestDetectMissingTags.php
@@ -5,6 +5,9 @@ use WP_Rocket\Subscriber\Tools\Detect_Missing_Tags_Subscriber;
 use WP_Rocket\Tests\Unit\TestCase;
 use Brain\Monkey\Functions;
 
+/**
+ * @group Subscriber
+ */
 class TestDetectMissingTags extends TestCase {
 
 	use \Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -9,8 +9,11 @@ namespace WP_Rocket\Tests\Unit;
 
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 use Brain\Monkey;
+use WP_Rocket\Tests\TestCaseTrait;
 
 class TestCase extends PHPUnitTestCase {
+	use TestCaseTrait;
+
 	/**
 	 * Prepares the test environment before each test.
 	 */

--- a/tests/Unit/ThirdParty/Plugins/Images/Webp/EwwwSubscriber/TestGetBasename.php
+++ b/tests/Unit/ThirdParty/Plugins/Images/Webp/EwwwSubscriber/TestGetBasename.php
@@ -5,6 +5,9 @@ use WP_Rocket\Subscriber\Third_Party\Plugins\Images\Webp\EWWW_Subscriber;
 use WP_Rocket\Tests\Unit\TestCase;
 use Brain\Monkey\Functions;
 
+/**
+ * @group ThirdParty
+ */
 class TestGetBasename extends TestCase {
 	/**
 	 * Test EWWW_Subscriber->get_basename() should return a plugin basename when EWWW not enabled.

--- a/tests/Unit/ThirdParty/Plugins/Images/Webp/EwwwSubscriber/TestIsConvertingToWebp.php
+++ b/tests/Unit/ThirdParty/Plugins/Images/Webp/EwwwSubscriber/TestIsConvertingToWebp.php
@@ -5,6 +5,9 @@ use WP_Rocket\Subscriber\Third_Party\Plugins\Images\Webp\EWWW_Subscriber;
 use WP_Rocket\Tests\Unit\TestCase;
 use Brain\Monkey\Functions;
 
+/**
+ * @group ThirdParty
+ */
 class TestIsConvertingToWebp extends TestCase {
 	/**
 	 * Test EWWW_Subscriber->is_converting_to_webp() should return false when EWWW option not enabled.

--- a/tests/Unit/ThirdParty/Plugins/Images/Webp/EwwwSubscriber/TestIsServingWebp.php
+++ b/tests/Unit/ThirdParty/Plugins/Images/Webp/EwwwSubscriber/TestIsServingWebp.php
@@ -6,6 +6,9 @@ use WP_Rocket\Tests\Unit\TestCase;
 use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
 
+/**
+ * @group ThirdParty
+ */
 class TestIsServingWebp extends TestCase {
 	/**
 	 * Test EWWW_Subscriber->is_serving_webp() should return true when ExactDN is enabled.

--- a/tests/Unit/ThirdParty/Plugins/Images/Webp/EwwwSubscriber/TestIsServingWebpCompatibleWithCdn.php
+++ b/tests/Unit/ThirdParty/Plugins/Images/Webp/EwwwSubscriber/TestIsServingWebpCompatibleWithCdn.php
@@ -6,6 +6,9 @@ use WP_Rocket\Tests\Unit\TestCase;
 use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
 
+/**
+ * @group ThirdParty
+ */
 class TestIsServingWebpCompatibleWithCdn extends TestCase {
 	/**
 	 * Test EWWW_Subscriber->is_serving_webp() should return true when ExactDN is enabled.

--- a/tests/Unit/ThirdParty/Plugins/Images/Webp/EwwwSubscriber/TestLoadHooks.php
+++ b/tests/Unit/ThirdParty/Plugins/Images/Webp/EwwwSubscriber/TestLoadHooks.php
@@ -7,6 +7,9 @@ namespace WP_Rocket\Tests\Unit\ThirdParty\Plugins\Images\Webp\EwwwSubscriber {
 	use Brain\Monkey\Filters;
 	use Brain\Monkey\Functions;
 
+	/**
+	 * @group ThirdParty
+	 */
 	class TestLoadHooks extends TestCase {
 		/**
 		 * Test EWWW_Subscriber->load_hooks() should not register hooks when separate cache is disabled via the option.
@@ -92,7 +95,7 @@ namespace WP_Rocket\Tests\Unit\ThirdParty\Plugins\Images\Webp\EwwwSubscriber {
 			$subscriber
 				->expects( $this->once() )
 				->method( 'plugin_deactivation' );
-			
+
 			Functions\When( 'plugin_basename')->justReturn('ewww-image-optimizer/ewww-image-optimizer.php');
 			Functions\When( 'is_multisite')->justReturn( false );
 

--- a/tests/Unit/ThirdParty/Plugins/Images/Webp/EwwwSubscriber/TestMaybeRemoveImagesCnames.php
+++ b/tests/Unit/ThirdParty/Plugins/Images/Webp/EwwwSubscriber/TestMaybeRemoveImagesCnames.php
@@ -6,6 +6,9 @@ use WP_Rocket\Tests\Unit\TestCase;
 use Brain\Monkey\Functions;
 use SebastianBergmann\Exporter\Exporter;
 
+/**
+ * @group ThirdParty
+ */
 class TestMaybeRemoveImagesCnames extends TestCase {
 	/**
 	 * Test EWWW_Subscriber->maybe_remove_images_cnames() should return identical when not using ExactDN.

--- a/tests/Unit/ThirdParty/Plugins/Images/Webp/EwwwSubscriber/TestMaybeRemoveImagesFromCdnDropdown.php
+++ b/tests/Unit/ThirdParty/Plugins/Images/Webp/EwwwSubscriber/TestMaybeRemoveImagesFromCdnDropdown.php
@@ -5,6 +5,9 @@ use WP_Rocket\Subscriber\Third_Party\Plugins\Images\Webp\EWWW_Subscriber;
 use WP_Rocket\Tests\Unit\TestCase;
 use Brain\Monkey\Functions;
 
+/**
+ * @group ThirdParty
+ */
 class TestMaybeRemoveImagesFromCdnDropdown extends TestCase {
 	/**
 	 * Test EWWW_Subscriber->maybe_remove_images_from_cdn_dropdown() should return identical when not using ExactDN.

--- a/tests/Unit/ThirdParty/Plugins/Images/Webp/ImagifySubscriber/TestGetBasename.php
+++ b/tests/Unit/ThirdParty/Plugins/Images/Webp/ImagifySubscriber/TestGetBasename.php
@@ -5,6 +5,9 @@ use WP_Rocket\Subscriber\Third_Party\Plugins\Images\Webp\Imagify_Subscriber;
 use WP_Rocket\Tests\Unit\TestCase;
 use Brain\Monkey\Functions;
 
+/**
+ * @group ThirdParty
+ */
 class TestGetBasename extends TestCase {
 	/**
 	 * Test Imagify_Subscriber->get_basename() should return a plugin basename when Imagify not enabled.

--- a/tests/Unit/ThirdParty/Plugins/Images/Webp/ImagifySubscriber/TestIsConvertingToWebp.php
+++ b/tests/Unit/ThirdParty/Plugins/Images/Webp/ImagifySubscriber/TestIsConvertingToWebp.php
@@ -5,6 +5,9 @@ use WP_Rocket\Subscriber\Third_Party\Plugins\Images\Webp\Imagify_Subscriber;
 use WP_Rocket\Tests\Unit\TestCase;
 use Brain\Monkey\Functions;
 
+/**
+ * @group ThirdParty
+ */
 class TestIsConvertingToWebp extends TestCase {
 	/**
 	 * Test Imagify_Subscriber->is_converting_to_webp() should return false when Imagify option not enabled.

--- a/tests/Unit/ThirdParty/Plugins/Images/Webp/ImagifySubscriber/TestIsServingWebp.php
+++ b/tests/Unit/ThirdParty/Plugins/Images/Webp/ImagifySubscriber/TestIsServingWebp.php
@@ -6,6 +6,9 @@ use WP_Rocket\Tests\Unit\TestCase;
 use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
 
+/**
+ * @group ThirdParty
+ */
 class TestIsServingWebp extends TestCase {
 	/**
 	 * Test Imagify_Subscriber->is_serving_webp() should return false when Imagify option not enabled.

--- a/tests/Unit/ThirdParty/Plugins/Images/Webp/ImagifySubscriber/TestIsServingWebpCompatibleWithCdn.php
+++ b/tests/Unit/ThirdParty/Plugins/Images/Webp/ImagifySubscriber/TestIsServingWebpCompatibleWithCdn.php
@@ -6,6 +6,9 @@ use WP_Rocket\Tests\Unit\TestCase;
 use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
 
+/**
+ * @group ThirdParty
+ */
 class TestIsServingWebpCompatibleWithCdn extends TestCase {
 	/**
 	 * Test Imagify_Subscriber->is_serving_webp_compatible_with_cdn() should return false when Imagify is not enabled.

--- a/tests/Unit/ThirdParty/Plugins/Images/Webp/ImagifySubscriber/TestLoadHooks.php
+++ b/tests/Unit/ThirdParty/Plugins/Images/Webp/ImagifySubscriber/TestLoadHooks.php
@@ -7,6 +7,9 @@ use Brain\Monkey\Actions;
 use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
 
+/**
+ * @group ThirdParty
+ */
 class TestLoadHooks extends TestCase {
 	/**
 	 * Test Imagify_Subscriber->load_hooks() should not register hooks when separate cache is disabled via the option.

--- a/tests/Unit/ThirdParty/Plugins/Images/Webp/ImagifySubscriber/TestSyncOnNetworkOptionAdd.php
+++ b/tests/Unit/ThirdParty/Plugins/Images/Webp/ImagifySubscriber/TestSyncOnNetworkOptionAdd.php
@@ -7,6 +7,9 @@ use Brain\Monkey\Actions;
 use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
 
+/**
+ * @group ThirdParty
+ */
 class TestSyncOnNetworkOptionAdd extends TestCase {
 	/**
 	 * Test Imagify_Subscriber->sync_on_network_option_add() should trigger a hook when the "display webp" option is enabled on option creation.

--- a/tests/Unit/ThirdParty/Plugins/Images/Webp/ImagifySubscriber/TestSyncOnNetworkOptionDelete.php
+++ b/tests/Unit/ThirdParty/Plugins/Images/Webp/ImagifySubscriber/TestSyncOnNetworkOptionDelete.php
@@ -7,6 +7,9 @@ use Brain\Monkey\Actions;
 use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
 
+/**
+ * @group ThirdParty
+ */
 class TestSyncOnNetworkOptionDelete extends TestCase {
 	/**
 	 * Test Imagify_Subscriber->sync_on_network_option_delete() should sync when on the same network and serving webp.

--- a/tests/Unit/ThirdParty/Plugins/Images/Webp/ImagifySubscriber/TestSyncOnNetworkOptionUpdate.php
+++ b/tests/Unit/ThirdParty/Plugins/Images/Webp/ImagifySubscriber/TestSyncOnNetworkOptionUpdate.php
@@ -7,6 +7,9 @@ use Brain\Monkey\Actions;
 use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
 
+/**
+ * @group ThirdParty
+ */
 class TestSyncOnNetworkOptionUpdate extends TestCase {
 	/**
 	 * Test Imagify_Subscriber->sync_on_network_option_update() should sync when on the same network.

--- a/tests/Unit/ThirdParty/Plugins/Images/Webp/ImagifySubscriber/TestSyncOnOptionAdd.php
+++ b/tests/Unit/ThirdParty/Plugins/Images/Webp/ImagifySubscriber/TestSyncOnOptionAdd.php
@@ -7,6 +7,9 @@ use Brain\Monkey\Actions;
 use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
 
+/**
+ * @group ThirdParty
+ */
 class TestSyncOnOptionAdd extends TestCase {
 	/**
 	 * Test Imagify_Subscriber->sync_on_option_add() should trigger a hook when the "display webp" option is enabled on option creation.

--- a/tests/Unit/ThirdParty/Plugins/Images/Webp/ImagifySubscriber/TestSyncOnOptionDelete.php
+++ b/tests/Unit/ThirdParty/Plugins/Images/Webp/ImagifySubscriber/TestSyncOnOptionDelete.php
@@ -7,6 +7,9 @@ use Brain\Monkey\Actions;
 use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
 
+/**
+ * @group ThirdParty
+ */
 class TestSyncOnOptionDelete extends TestCase {
 	/**
 	 * Test Imagify_Subscriber->sync_on_option_delete() should sync when serving webp.

--- a/tests/Unit/ThirdParty/Plugins/Images/Webp/ImagifySubscriber/TestSyncOnOptionUpdate.php
+++ b/tests/Unit/ThirdParty/Plugins/Images/Webp/ImagifySubscriber/TestSyncOnOptionUpdate.php
@@ -7,6 +7,9 @@ use Brain\Monkey\Actions;
 use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
 
+/**
+ * @group ThirdParty
+ */
 class TestSyncOnOptionUpdate extends TestCase {
 	/**
 	 * Test Imagify_Subscriber->sync_on_option_update() should sync when the plugin’s webp options change.

--- a/tests/Unit/ThirdParty/Plugins/Images/Webp/WebpCommon/TestPluginActivation.php
+++ b/tests/Unit/ThirdParty/Plugins/Images/Webp/WebpCommon/TestPluginActivation.php
@@ -4,6 +4,9 @@ namespace WP_Rocket\Tests\Unit\ThirdParty\Plugins\Images\Webp\WebpCommon;
 use WP_Rocket\Subscriber\Third_Party\Plugins\Images\Webp\Webp_Common;
 use WP_Rocket\Tests\Unit\TestCase;
 
+/**
+ * @group ThirdParty
+ */
 class TestPluginActivation extends TestCase {
 	/**
 	 * Test Webp_Common->plugin_activation() should trigger a hook when serving webp.

--- a/tests/Unit/ThirdParty/Plugins/Images/Webp/WebpCommon/TestPluginDectivation.php
+++ b/tests/Unit/ThirdParty/Plugins/Images/Webp/WebpCommon/TestPluginDectivation.php
@@ -4,6 +4,9 @@ namespace WP_Rocket\Tests\Unit\ThirdParty\Plugins\Images\Webp\WebpCommon;
 use WP_Rocket\Subscriber\Third_Party\Plugins\Images\Webp\Webp_Common;
 use WP_Rocket\Tests\Unit\TestCase;
 
+/**
+ * @group ThirdParty
+ */
 class TestPluginDeactivation extends TestCase {
 	/**
 	 * Test Webp_Common->plugin_deactivation() should trigger a hook when serving webp.

--- a/tests/Unit/ThirdParty/Plugins/Images/Webp/WebpCommon/TestRegister.php
+++ b/tests/Unit/ThirdParty/Plugins/Images/Webp/WebpCommon/TestRegister.php
@@ -4,6 +4,9 @@ namespace WP_Rocket\Tests\Unit\ThirdParty\Plugins\Images\Webp\WebpCommon;
 use WP_Rocket\Subscriber\Third_Party\Plugins\Images\Webp\Webp_Common;
 use WP_Rocket\Tests\Unit\TestCase;
 
+/**
+ * @group ThirdParty
+ */
 class TestRegister extends TestCase {
 	/**
 	 * Test Webp_Common->register() should add a reference of itself to the given list.

--- a/tests/Unit/ThirdParty/Plugins/Images/Webp/WebpCommon/TestTriggerWebpChange.php
+++ b/tests/Unit/ThirdParty/Plugins/Images/Webp/WebpCommon/TestTriggerWebpChange.php
@@ -5,6 +5,9 @@ use WP_Rocket\Subscriber\Third_Party\Plugins\Images\Webp\Webp_Common;
 use WP_Rocket\Tests\Unit\TestCase;
 use Brain\Monkey\Actions;
 
+/**
+ * @group ThirdParty
+ */
 class TestTriggerWebpChange extends TestCase {
 	/**
 	 * Test Webp_Common->trigger_webp_change() should trigger a hook.

--- a/tests/Unit/ThirdParty/Plugins/Smush.php
+++ b/tests/Unit/ThirdParty/Plugins/Smush.php
@@ -1,24 +1,26 @@
 <?php
+
 namespace WP_Rocket\Tests\Unit\ThirdParty\Plugins\Smush;
 
 use WP_Rocket\Subscriber\Third_Party\Plugins\Smush_Subscriber;
 use WP_Rocket\Tests\Unit\TestCase;
 use Brain\Monkey\Functions;
 
-class Smush extends TestCase
-{
+/**
+ * @group ThirdParty
+ */
+class Smush extends TestCase {
 	use \Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 
 	/**
 	 * Setup constants required by Smush plugin & include the smush.php
 	 *
-	 * @since 3.4.2
+	 * @since  3.4.2
+	 * @return void
 	 * @author Soponar Cristina
 	 *
-	 * @return void
 	 */
-	protected function setUp()
-	{
+	protected function setUp() {
 		parent::setUp();
 
 		if ( ! defined( 'WP_SMUSH_VERSION' ) ) {
@@ -32,15 +34,14 @@ class Smush extends TestCase
 	/**
 	 * Test should disable WP Rocket lazy load functionality when Smush lazyload is enabled
 	 *
-	 * @since 3.4.2
+	 * @since  3.4.2
 	 * @author Soponar Cristina
 	 *
 	 */
-	public function testShouldDisableWPRocketLazyLoad()
-	{
+	public function testShouldDisableWPRocketLazyLoad() {
 		$this->mockCommonWpFunctions();
 
-		$subscriber  = new Smush_Subscriber();
+		$subscriber = new Smush_Subscriber();
 
 		Functions\expect( 'get_option' )
 			->once() // called once
@@ -50,19 +51,18 @@ class Smush extends TestCase
 	}
 
 	/**
-	  * Test should not disable WP Rocket lazy load functionality when Smush lazyload is disabled
+	 * Test should not disable WP Rocket lazy load functionality when Smush lazyload is disabled
 	 *
-	 * @since 3.4.2
+	 * @since  3.4.2
 	 * @author Soponar Cristina
 	 *
 	 */
-	public function testShouldNotDisableWPRocketLazyLoad()
-	{
-		$subscriber  = new Smush_Subscriber();
+	public function testShouldNotDisableWPRocketLazyLoad() {
+		$subscriber = new Smush_Subscriber();
 
 		Functions\expect( 'get_option' )
 			->once() // called once
-			->andReturn( [ ] );
+			->andReturn( [] );
 
 		$this->assertEmpty( $subscriber->is_smush_lazyload_active( [] ) );
 	}
@@ -70,13 +70,12 @@ class Smush extends TestCase
 	/**
 	 * Test should not disable WP Rocket lazy load functionality when Smush lazyload is disabled
 	 *
-	 * @since 3.4.2
+	 * @since  3.4.2
 	 * @author Soponar Cristina
 	 *
 	 */
-	public function testShouldNotMaybeDeactivateLazyload()
-	{
-		$subscriber  = new Smush_Subscriber();
+	public function testShouldNotMaybeDeactivateLazyload() {
+		$subscriber = new Smush_Subscriber();
 
 		Functions\expect( 'get_option' )
 			->once() // called once
@@ -93,13 +92,12 @@ class Smush extends TestCase
 	/**
 	 * Test should disable WP Rocket lazy load functionality when Smush lazyload is enabled
 	 *
-	 * @since 3.4.2
+	 * @since  3.4.2
 	 * @author Soponar Cristina
 	 *
 	 */
-	public function testShouldMaybeDeactivateLazyload()
-	{
-		$subscriber  = new Smush_Subscriber();
+	public function testShouldMaybeDeactivateLazyload() {
+		$subscriber = new Smush_Subscriber();
 
 		Functions\expect( 'get_option' )
 			->once() // called once
@@ -107,7 +105,7 @@ class Smush extends TestCase
 
 		Functions\expect( 'update_rocket_option' )
 			->once()
-			->with('lazyload', '0');
+			->with( 'lazyload', '0' );
 
 		$subscriber->maybe_deactivate_rocket_lazyload();
 

--- a/tests/boostrap-functions.php
+++ b/tests/boostrap-functions.php
@@ -19,6 +19,7 @@ function init_test_suite( $test_suite = 'Unit' ) {
 
 	// Load the Composer autoloader.
 	require_once WP_ROCKET_PLUGIN_ROOT . '/vendor/autoload.php';
+	require_once __DIR__ . '/TestCaseTrait.php';
 
 	// Load Patchwork before everything else in order to allow us to redefine WordPress, 3rd party, and WP Rocket functions.
 	require_once WP_ROCKET_PLUGIN_ROOT . '/vendor/antecedent/patchwork/Patchwork.php';


### PR DESCRIPTION
This PR improves primarily the integration test suite by:

1. Adding reflection to provide granular control when you need to access a private or protected property or method within a test. Very handy.
2. Adds `@group` for targeted test runs.
3. Overloads the `rocket_valid_key()` to ensure all files are loaded when the plugin boots up for testing.
4. Fixes `TestIsSpeedTool` test using reflection to ensure `Config::$config_dir_path` is `null` when doing the test.