### PR TITLE
Format code added to wp-config.php to match WPCS

### DIFF
--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -382,7 +382,7 @@ function set_rocket_wp_cache_define( $turn_it_on ) {
 	$is_wp_cache_exist = false;
 
 	// Get WP_CACHE constant define.
-	$constant = "define('WP_CACHE', $turn_it_on); // Added by WP Rocket" . "\r\n";
+	$constant = "define( 'WP_CACHE', $turn_it_on );    // Added by WP Rocket." . "\r\n";
 
 	foreach ( $config_file as &$line ) {
 		if ( ! preg_match( '/^define\(\s*\'([A-Z_]+)\',(.*)\)/', $line, $match ) ) {


### PR DESCRIPTION
Format the code added by WP Rocket to wp-config.php according to the WordPress Coding Standards.
Thank you, Vasilis, for indulging me!
