### PR TITLE
Fixed: Cloudflare Auto Purge By Url add home and feed urls to purge urls list

### DIFF
--- a/inc/classes/subscriber/Addons/Cloudflare/CloudflareSubscriber.php
+++ b/inc/classes/subscriber/Addons/Cloudflare/CloudflareSubscriber.php
@@ -203,12 +203,7 @@ class CloudflareSubscriber implements Subscriber_Interface {
 		$feed_urls[]  = get_feed_link();
 		$feed_urls[]  = get_feed_link( 'comments_' );
 
-		/**
-		 * Filter the home feeds urls
-		 *
-		 * @since 2.7
-		 * @param array     $urls The urls of the home feeds.
-		*/
+		// this filter is documented in inc/functions/files.php.
 		$feed_urls  = apply_filters( 'rocket_clean_home_feeds', $feed_urls );
 		$purge_urls = array_unique( array_merge( $purge_urls, $feed_urls ) );
 

--- a/inc/classes/subscriber/Addons/Cloudflare/CloudflareSubscriber.php
+++ b/inc/classes/subscriber/Addons/Cloudflare/CloudflareSubscriber.php
@@ -196,6 +196,21 @@ class CloudflareSubscriber implements Subscriber_Interface {
 		if ( is_wp_error( $cf_cache_everything ) || ! $cf_cache_everything ) {
 			return;
 		}
+		// Add home URL and feeds URLs to Cloudflare clean cache URLs list.
+		$home_url     = get_rocket_i18n_home_url( $lang );
+		$purge_urls[] = $home_url;
+		$feed_urls    = [];
+		$feed_urls[]  = get_feed_link();
+		$feed_urls[]  = get_feed_link( 'comments_' );
+
+		/**
+		 * Filter the home feeds urls
+		 *
+		 * @since 2.7
+		 * @param array     $urls The urls of the home feeds.
+		*/
+		$feed_urls  = apply_filters( 'rocket_clean_home_feeds', $feed_urls );
+		$purge_urls = array_unique( array_merge( $purge_urls, $feed_urls ) );
 
 		// Purge CloudFlare.
 		$cf_purge = $this->cloudflare->purge_by_url( $post, $purge_urls, $lang );

--- a/inc/classes/subscriber/Addons/Cloudflare/CloudflareSubscriber.php
+++ b/inc/classes/subscriber/Addons/Cloudflare/CloudflareSubscriber.php
@@ -159,21 +159,6 @@ class CloudflareSubscriber implements Subscriber_Interface {
 
 		// Purge CloudFlare.
 		$cf_purge = $this->cloudflare->purge_cloudflare();
-
-		if ( is_wp_error( $cf_purge ) ) {
-			$cf_purge_result = [
-				'result'  => 'error',
-				// translators: %s = CloudFare API return message.
-				'message' => sprintf( __( '<strong>WP Rocket:</strong> %s', 'rocket' ), $cf_purge->get_error_message() ),
-			];
-		} else {
-			$cf_purge_result = [
-				'result'  => 'success',
-				'message' => __( '<strong>WP Rocket:</strong> Cloudflare cache successfully purged.', 'rocket' ),
-			];
-		}
-
-		set_transient( get_current_user_id() . '_cloudflare_purge_result', $cf_purge_result );
 	}
 
 	/**
@@ -197,8 +182,7 @@ class CloudflareSubscriber implements Subscriber_Interface {
 			return;
 		}
 		// Add home URL and feeds URLs to Cloudflare clean cache URLs list.
-		$home_url     = get_rocket_i18n_home_url( $lang );
-		$purge_urls[] = $home_url;
+		$purge_urls[] = get_rocket_i18n_home_url( $lang );
 		$feed_urls    = [];
 		$feed_urls[]  = get_feed_link();
 		$feed_urls[]  = get_feed_link( 'comments_' );

--- a/tests/Unit/Subscriber/Addons/CloudflareSubscriber/TestAutoPurge.php
+++ b/tests/Unit/Subscriber/Addons/CloudflareSubscriber/TestAutoPurge.php
@@ -80,16 +80,6 @@ class TestAutoPurge extends TestCase {
 		$cloudflare->shouldReceive('has_page_rule')->andReturn( true );
 		$cloudflare->shouldReceive('purge_cloudflare')->andReturn( $wp_error );
 
-		$cf_purge_result = [
-			'result'  => 'error',
-			// translators: %s = CloudFare API return message.
-			'message' => sprintf( __( '<strong>WP Rocket:</strong> %s', 'rocket' ), 'Error!' ),
-		];
-
-		Functions\expect( 'set_transient' )
-			->once()
-			->with('1_cloudflare_purge_result', $cf_purge_result );
-
 		$cloudflare_subscriber = new CloudflareSubscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
 		$cloudflare_subscriber->auto_purge();
 	}
@@ -106,15 +96,6 @@ class TestAutoPurge extends TestCase {
 		$cloudflare = \Mockery::mock( \WP_Rocket\Addons\Cloudflare\Cloudflare::class );
 		$cloudflare->shouldReceive('has_page_rule')->andReturn( true );
 		$cloudflare->shouldReceive('purge_cloudflare')->andReturn( true );
-
-		$cf_purge_result = [
-			'result'  => 'success',
-			'message' => __( '<strong>WP Rocket:</strong> Cloudflare cache successfully purged.', 'rocket' ),
-		];
-
-		Functions\expect( 'set_transient' )
-			->once()
-			->with('1_cloudflare_purge_result', $cf_purge_result );
 
 		$cloudflare_subscriber = new CloudflareSubscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
 		$cloudflare_subscriber->auto_purge();

--- a/tests/Unit/Subscriber/Addons/CloudflareSubscriber/TestAutoPurgeByUrl.php
+++ b/tests/Unit/Subscriber/Addons/CloudflareSubscriber/TestAutoPurgeByUrl.php
@@ -75,8 +75,8 @@ class TestAutoPurgeByUrl extends TestCase {
 		$mocks = $this->getConstructorMocks( 1, '', '', '' );
 		Functions\when( 'current_user_can' )->justReturn( true );
 		Functions\when( 'get_current_user_id' )->justReturn( 1 );
-		Functions\when( 'get_rocket_i18n_home_url' )->justReturn( 'http://local.com/' );
-		Functions\when( 'get_feed_link' )->justReturn( 'http://local.com/feed/' );
+		Functions\expect( 'get_rocket_i18n_home_url' )->once()->andReturn( 'http://example.org/' );
+		Functions\expect( 'get_feed_link' )->twice()->andReturn( 'http://example.org/feed/', 'http://example.org/feed/comments' );
 
 		$wp_error   = \Mockery::mock( \WP_Error::class );
 		$wp_error->shouldReceive('get_error_message')->andReturn( 'Error!' );
@@ -97,8 +97,8 @@ class TestAutoPurgeByUrl extends TestCase {
 		Functions\when( 'current_user_can' )->justReturn( true );
 		Functions\when( 'get_current_user_id' )->justReturn( 1 );
 		Functions\when( 'is_wp_error' )->justReturn( false );
-		Functions\when( 'get_rocket_i18n_home_url' )->justReturn( 'http://local.com/' );
-		Functions\when( 'get_feed_link' )->justReturn( 'http://local.com/feed/' );
+		Functions\expect( 'get_rocket_i18n_home_url' )->once()->andReturn( 'http://example.org/' );
+		Functions\expect( 'get_feed_link' )->twice()->andReturn( 'http://example.org/feed/', 'http://example.org/feed/comments' );
 
 		$wp_error   = \Mockery::mock( \WP_Error::class );
 		$cloudflare = \Mockery::mock( \WP_Rocket\Addons\Cloudflare\Cloudflare::class );

--- a/tests/Unit/Subscriber/Addons/CloudflareSubscriber/TestAutoPurgeByUrl.php
+++ b/tests/Unit/Subscriber/Addons/CloudflareSubscriber/TestAutoPurgeByUrl.php
@@ -75,6 +75,8 @@ class TestAutoPurgeByUrl extends TestCase {
 		$mocks = $this->getConstructorMocks( 1, '', '', '' );
 		Functions\when( 'current_user_can' )->justReturn( true );
 		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_rocket_i18n_home_url' )->justReturn( 'http://local.com/' );
+		Functions\when( 'get_feed_link' )->justReturn( 'http://local.com/feed/' );
 
 		$wp_error   = \Mockery::mock( \WP_Error::class );
 		$wp_error->shouldReceive('get_error_message')->andReturn( 'Error!' );
@@ -95,6 +97,8 @@ class TestAutoPurgeByUrl extends TestCase {
 		Functions\when( 'current_user_can' )->justReturn( true );
 		Functions\when( 'get_current_user_id' )->justReturn( 1 );
 		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'get_rocket_i18n_home_url' )->justReturn( 'http://local.com/' );
+		Functions\when( 'get_feed_link' )->justReturn( 'http://local.com/feed/' );
 
 		$wp_error   = \Mockery::mock( \WP_Error::class );
 		$cloudflare = \Mockery::mock( \WP_Rocket\Addons\Cloudflare\Cloudflare::class );

--- a/tests/Unit/Subscriber/Addons/CloudflareSubscriber/TestAutoPurgeByUrl.php
+++ b/tests/Unit/Subscriber/Addons/CloudflareSubscriber/TestAutoPurgeByUrl.php
@@ -75,15 +75,17 @@ class TestAutoPurgeByUrl extends TestCase {
 		$mocks = $this->getConstructorMocks( 1, '', '', '' );
 		Functions\when( 'current_user_can' )->justReturn( true );
 		Functions\when( 'get_current_user_id' )->justReturn( 1 );
-		Functions\expect( 'get_rocket_i18n_home_url' )->once()->andReturn( 'http://example.org/' );
+		Functions\expect( 'get_rocket_i18n_home_url' )->once()->with( '' )->andReturn( 'http://example.org/' );
 		Functions\expect( 'get_feed_link' )->twice()->andReturn( 'http://example.org/feed/', 'http://example.org/feed/comments' );
 
 		$wp_error   = \Mockery::mock( \WP_Error::class );
 		$wp_error->shouldReceive('get_error_message')->andReturn( 'Error!' );
 
 		$cloudflare = \Mockery::mock( \WP_Rocket\Addons\Cloudflare\Cloudflare::class );
-		$cloudflare->shouldReceive('has_page_rule')->andReturn( true );
-		$cloudflare->shouldReceive('purge_by_url')->andReturn( $wp_error );
+		$cloudflare->shouldReceive('has_page_rule')->with( 'cache_everything' )->andReturn( true );
+		$cloudflare->shouldReceive('purge_by_url')
+		           ->with( 1, [ '/hello-world', 'http://example.org/', 'http://example.org/feed/', 'http://example.org/feed/comments' ], '' )
+		           ->andReturn( $wp_error );
 
 		$cloudflare_subscriber = new CloudflareSubscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
 		$cloudflare_subscriber->auto_purge_by_url( 1, [ '/hello-world' ], '' );
@@ -97,13 +99,14 @@ class TestAutoPurgeByUrl extends TestCase {
 		Functions\when( 'current_user_can' )->justReturn( true );
 		Functions\when( 'get_current_user_id' )->justReturn( 1 );
 		Functions\when( 'is_wp_error' )->justReturn( false );
-		Functions\expect( 'get_rocket_i18n_home_url' )->once()->andReturn( 'http://example.org/' );
+		Functions\expect( 'get_rocket_i18n_home_url' )->once()->with( '' )->andReturn( 'http://example.org/' );
 		Functions\expect( 'get_feed_link' )->twice()->andReturn( 'http://example.org/feed/', 'http://example.org/feed/comments' );
 
-		$wp_error   = \Mockery::mock( \WP_Error::class );
 		$cloudflare = \Mockery::mock( \WP_Rocket\Addons\Cloudflare\Cloudflare::class );
-		$cloudflare->shouldReceive('has_page_rule')->andReturn( true );
-		$cloudflare->shouldReceive('purge_by_url')->andReturn( true );
+		$cloudflare->shouldReceive('has_page_rule')->with( 'cache_everything' )->andReturn( true );
+		$cloudflare->shouldReceive('purge_by_url')
+		           ->with( 1, [ '/hello-world', 'http://example.org/', 'http://example.org/feed/', 'http://example.org/feed/comments' ], '' )
+		           ->andReturn( true );
 
 		$cloudflare_subscriber = new CloudflareSubscriber( $cloudflare, $mocks['options_data'], $mocks['options'] );
 		$cloudflare_subscriber->auto_purge_by_url( 1, [ '/hello-world' ], '' );


### PR DESCRIPTION
Cleaning Cloudflare cache when a post cache is cleaned needed also the home URL and the feeds URLs

## TODO
- [x] Potentially remove notices (because there is a report for some notice which still appears :)). Waiting on feedback from Lucy/Arun.