### PR TITLE
Add customer status to Beacon identify

### DIFF
--- a/inc/classes/admin/settings/class-beacon.php
+++ b/inc/classes/admin/settings/class-beacon.php
@@ -139,10 +139,17 @@ class Beacon {
 	 * @return array
 	 */
 	private function identify_data() {
-		return [
+		$identify_data = [
 			'email'   => $this->options->get( 'consumer_email' ),
 			'Website' => home_url(),
 		];
+		$customer_data = get_transient( 'wp_rocket_customer_data' );
+
+		if ( false !== $customer_data && isset( $customer_data->status ) ) {
+			$identify_data['status'] = $customer_data->status;
+		}
+
+		return $identify_data;
 	}
 
 	/**


### PR DESCRIPTION
This will be used to send messages in Beacon, with specific targetting depending on the customer status (new/active/expired).

The status is fetched from the API, and stored in the `wp_rocket_customer_data` transient. The fetch and cache of the data is done in `WP_Rocket\Admin\Settings\Page`.

Ideally I would need to do some decoupling there and make sure I always have a value for the `status`, but as it's non-critical data and we're already in the testing phase for 3.4.3, I went for the easiest solution (for now).