### PR TITLE
[WIP] Prevent multiple calls to Cloudflare IPs API call

### DIFF
--- a/inc/functions/cloudflare.php
+++ b/inc/functions/cloudflare.php
@@ -518,53 +518,68 @@ function rocket_get_cloudflare_ips() {
 	}
 
 	$cf_ips = get_transient( 'rocket_cloudflare_ips' );
+
 	if ( false === $cf_ips ) {
 		try {
 			$cf_ips_instance = new Cloudflare\IPs( $cf_instance );
 			$cf_ips          = $cf_ips_instance->ips();
-
 			if ( ! isset( $cf_ips->success ) || ! $cf_ips->success ) {
-				throw new Exception( 'Error connecting to Cloudflare' );
+				$cf_ips = rocket_get_default_cloudflare_ips();
 			}
 
 			set_transient( 'rocket_cloudflare_ips', $cf_ips, 2 * WEEK_IN_SECONDS );
 		} catch ( Exception $e ) {
-			$cf_ips = (object) [
-				'success' => true,
-				'result'  => (object) [],
-			];
-
-			$cf_ips->result->ipv4_cidrs = [
-				'103.21.244.0/22',
-				'103.22.200.0/22',
-				'103.31.4.0/22',
-				'104.16.0.0/12',
-				'108.162.192.0/18',
-				'131.0.72.0/22',
-				'141.101.64.0/18',
-				'162.158.0.0/15',
-				'172.64.0.0/13',
-				'173.245.48.0/20',
-				'188.114.96.0/20',
-				'190.93.240.0/20',
-				'197.234.240.0/22',
-				'198.41.128.0/17',
-			];
-
-			$cf_ips->result->ipv6_cidrs = [
-				'2400:cb00::/32',
-				'2405:8100::/32',
-				'2405:b500::/32',
-				'2606:4700::/32',
-				'2803:f800::/32',
-				'2c0f:f248::/32',
-				'2a06:98c0::/29',
-			];
+			$cf_ips = rocket_get_default_cloudflare_ips();
 
 			set_transient( 'rocket_cloudflare_ips', $cf_ips, 2 * WEEK_IN_SECONDS );
 			return $cf_ips;
 		}
 	}
+
+	return $cf_ips;
+}
+
+/**
+ * Get Cloudflare default IPs.
+ *
+ * @since 3.4.3
+ *
+ * @author Soponar Cristina
+ *
+ * @return Object $cf_ips Default Cloudflare IPs
+ */
+function rocket_get_default_cloudflare_ips() {
+	$cf_ips = (object) [
+		'success' => true,
+		'result'  => (object) [],
+	];
+
+	$cf_ips->result->ipv4_cidrs = [
+		'103.21.244.0/22',
+		'103.22.200.0/22',
+		'103.31.4.0/22',
+		'104.16.0.0/12',
+		'108.162.192.0/18',
+		'131.0.72.0/22',
+		'141.101.64.0/18',
+		'162.158.0.0/15',
+		'172.64.0.0/13',
+		'173.245.48.0/20',
+		'188.114.96.0/20',
+		'190.93.240.0/20',
+		'197.234.240.0/22',
+		'198.41.128.0/17',
+	];
+
+	$cf_ips->result->ipv6_cidrs = [
+		'2400:cb00::/32',
+		'2405:8100::/32',
+		'2405:b500::/32',
+		'2606:4700::/32',
+		'2803:f800::/32',
+		'2c0f:f248::/32',
+		'2a06:98c0::/29',
+	];
 
 	return $cf_ips;
 }


### PR DESCRIPTION
Prevent WP Rocket to make multiple calls to Cloudflare IPs API call.
If the call to /ips did not received success then an Exception was thrown. 
Instead it should return the default ips from Cloudflare and set the transient.