### PR TITLE
Fixed: clean expired cache scheduled event when cron unit is set to minutes

### DIFF
--- a/tests/Integration/Subscriber/ExpiredCachePurgeSubscriber/TestCleanCacheScheduledEvent.php
+++ b/tests/Integration/Subscriber/ExpiredCachePurgeSubscriber/TestCleanCacheScheduledEvent.php
@@ -77,4 +77,51 @@ class TestCleanCacheScheduledEvent extends TestCase {
 
 		$this->assertTrue( true ); // Prevent "risky" warning.
 	}
+
+	public function testShouldNotCleanScheduledEventWhenUnitIsMinutesAndIntervalIsNotChanged() {
+		Functions\expect( 'wp_clear_scheduled_hook' )->never();
+
+		update_option(
+			'wp_rocket_settings',
+			[
+				'purge_cron_interval' => 20,
+				'purge_cron_unit'     => 'MINUTE_IN_SECONDS',
+			]
+		);
+
+		update_option(
+			'wp_rocket_settings',
+			[
+				'purge_cron_interval' => 20,
+				'purge_cron_unit'     => 'MINUTE_IN_SECONDS',
+			]
+		);
+
+		$this->assertTrue( true ); // Prevent "risky" warning.
+	}
+
+	public function testShouldCleanScheduledEventWhenUnitIsMinutesAndIntervalIsChanged() {
+		Functions\expect( 'wp_clear_scheduled_hook' )
+			->once()
+			->with( Expired_Cache_Purge_Subscriber::EVENT_NAME )
+			->andReturnNull(); // No need to run it.
+
+		update_option(
+			'wp_rocket_settings',
+			[
+				'purge_cron_interval' => 20,
+				'purge_cron_unit'     => 'MINUTE_IN_SECONDS',
+			]
+		);
+
+		update_option(
+			'wp_rocket_settings',
+			[
+				'purge_cron_interval' => 45,
+				'purge_cron_unit'     => 'MINUTE_IN_SECONDS',
+			]
+		);
+
+		$this->assertTrue( true ); // Prevent "risky" warning.
+	}
 }


### PR DESCRIPTION
Cleaning the scheduled event from clean expired cache when cron unit is set to minutes.
For hours & days the scheduled event should be set to 1 hour, but for minutes should be set to those exact minutes.

My latest changes got removed from the last PR #2180

Arun pointed out that when changing from Minutes to Minutes and if the interval is changes the scheduled event should be cleaned. Added the code + Integration tests for it.