### PR TITLE
Auto-exclude Klaviyo JS script from Combine JS

### DIFF
--- a/inc/classes/optimization/JS/class-combine.php
+++ b/inc/classes/optimization/JS/class-combine.php
@@ -661,6 +661,7 @@ class Combine extends Abstract_JS_Optimization {
 			'embed-cdn.gettyimages.com/widgets.js',
 			'app.mailerlite.com',
 			'ck.page',
+			'static.klaviyo.com/onsite/js/klaviyo.js',
 		];
 
 		$excluded_external = array_merge( $defaults, $this->options->get( 'exclude_js', [] ) );

--- a/tests/Unit/Cache/TestPurgeExpiredFiles.php
+++ b/tests/Unit/Cache/TestPurgeExpiredFiles.php
@@ -156,47 +156,4 @@ class TestPurgeExpiredFiles extends TestCase {
 			$this->cache_path->getChild('wp-rocket')->getChild('example.org')->getChild('en')->hasChild('index.html')
 		);
 	}
-
-	public function testShouldNotDeleteCacheFilesWhenCachingIsDisabled() {
-		Functions\When( 'get_rocket_i18n_uri' )->justReturn(
-			[
-				'http://example.org/'
-			]
-		);
-
-		Functions\When( 'rocket_direct_filesystem' )
-			->alias( function() {
-				return $this->mock_fs;
-			} );
-
-		Filters\expectApplied( 'do_rocket_generate_caching_files' )
-			->once()
-			->andReturn( false ); // Simulate a filter.
-
-		Functions\expect( 'get_rocket_parse_url' )
-			->never()
-			->andReturnUsing( function( $value ) {
-				return parse_url( $value );
-			} );
-
-		$expired_cache_purge = new Expired_Cache_Purge( $this->cache_path->getChild( 'wp-rocket' )->url() );
-
-		$expired_cache_purge->purge_expired_files( 36000 );
-
-		$this->assertTrue(
-			$this->cache_path->getChild( 'wp-rocket' )->getChild( 'example.org' )->getChild( 'about' )->hasChild( 'index.html' )
-		);
-		$this->assertTrue(
-			$this->cache_path->getChild( 'wp-rocket' )->getChild( 'example.org' )->getChild( 'category' )->getChild( 'wordpress' )->hasChild( 'index.html' )
-		);
-		$this->assertTrue(
-			$this->cache_path->getChild( 'wp-rocket' )->getChild( 'example.org' )->getChild( 'blog' )->hasChild( 'index.html' )
-		);
-		$this->assertTrue(
-			$this->cache_path->getChild( 'wp-rocket' )->getChild( 'example.org' )->getChild( 'en' )->hasChild( 'index.html' )
-		);
-		$this->assertTrue(
-			$this->cache_path->getChild( 'wp-rocket' )->getChild( 'example.org-Greg-594d03f6ae698691165999' )->hasChild( 'index.html' )
-		);
-	}
 }


### PR DESCRIPTION
Klaviyo has a JS file to use their API. To work, this file must not be combined. A check is required to use their JS API and Klaviyo is checking that this file is loaded on the website.

If we combine the Klaviyo JS file, then Klaviyo isn't able to find it and can't validate the account to use the JS API.

e.g we had to exclude the Klaviyo JS file on our own website to be validated.

I decided to make a PR as we had our first ticket issue about that few days ago:
https://secure.helpscout.net/conversation/1036927375/137413/