### PR TITLE
Fix #2107 CDN srcset rewrites

### DIFF
--- a/inc/classes/CDN/CDN.php
+++ b/inc/classes/CDN/CDN.php
@@ -61,11 +61,18 @@ class CDN {
 		if ( ! preg_match_all( $pattern, $html, $srcsets, PREG_SET_ORDER ) ) {
 			return $html;
 		}
-
 		foreach ( $srcsets as $srcset ) {
 			$sources    = explode( ',', $srcset['sources'] );
+			$sources    =
+				array_unique(
+					array_map(
+						function( $source ) {
+							return trim( $source );
+						},
+						$sources
+					)
+				);
 			$cdn_srcset = $srcset['sources'];
-
 			foreach ( $sources as $source ) {
 				$url        = \preg_split( '#\s+#', trim( $source ) );
 				$cdn_srcset = str_replace( $url[0], $this->rewrite_url( $url[0] ), $cdn_srcset );

--- a/inc/classes/CDN/CDN.php
+++ b/inc/classes/CDN/CDN.php
@@ -63,15 +63,7 @@ class CDN {
 		}
 		foreach ( $srcsets as $srcset ) {
 			$sources    = explode( ',', $srcset['sources'] );
-			$sources    =
-				array_unique(
-					array_map(
-						function( $source ) {
-							return trim( $source );
-						},
-						$sources
-					)
-				);
+			$sources    = array_unique( array_map( 'trim', $sources ) );
 			$cdn_srcset = $srcset['sources'];
 			foreach ( $sources as $source ) {
 				$url        = \preg_split( '#\s+#', trim( $source ) );

--- a/tests/Fixtures/CDN/original.html
+++ b/tests/Fixtures/CDN/original.html
@@ -515,6 +515,9 @@ img.emoji {
 <figure class="post-thumbnail">
 	<img width="1568" height="1046" src="http://example.org/wp-content/uploads/2018/03/sticker-mule-189122-unsplash-1568x1046.jpg" class="attachment-post-thumbnail size-post-thumbnail wp-post-image" alt="" srcset="http://example.org/wp-content/uploads/2018/03/sticker-mule-189122-unsplash-1568x1046.jpg 1568w, http://example.org/wp-content/uploads/2018/03/sticker-mule-189122-unsplash-300x200.jpg 300w, http://example.org/wp-content/uploads/2018/03/sticker-mule-189122-unsplash-768x513.jpg 768w, http://example.org/wp-content/uploads/2018/03/sticker-mule-189122-unsplash-1024x683.jpg 1024w" sizes="(max-width: 1568px) 100vw, 1568px" />
 </figure>
+<figure class="post-thumbnail">
+	<img width="1568" height="1046" src="http://example.org/wp-content/uploads/2018/03/sticker-mule-189122-unsplash-1568x1046.jpg" class="attachment-post-thumbnail size-post-thumbnail wp-post-image" alt="" srcset="http://example.org/wp-content/uploads/2018/03/sticker-mule-189122-unsplash-1568x1046.jpg 1568w, http://example.org/wp-content/uploads/2018/03/sticker-mule-189122-unsplash-300x200.jpg 300w, http://example.org/wp-content/uploads/2018/03/sticker-mule-189122-unsplash-768x513.jpg 768w, http://example.org/wp-content/uploads/2018/03/sticker-mule-189122-unsplash-1024x683.jpg 1024w, http://example.org/wp-content/uploads/2018/03/sticker-mule-189122-unsplash-1568x1046.jpg 1568w" sizes="(max-width: 1568px) 100vw, 1568px" />
+</figure>
 <picture>
 	<source srcset="/images/site/logo/logo-acommeassure.webp" type="image/webp">
 	<source srcset="/images/site/logo/logo-acommeassure.png 100w" type="image/png">

--- a/tests/Fixtures/CDN/rewrite.html
+++ b/tests/Fixtures/CDN/rewrite.html
@@ -515,6 +515,9 @@ img.emoji {
 <figure class="post-thumbnail">
 	<img width="1568" height="1046" src="http://cdn.example.org/wp-content/uploads/2018/03/sticker-mule-189122-unsplash-1568x1046.jpg" class="attachment-post-thumbnail size-post-thumbnail wp-post-image" alt="" srcset="http://example.org/wp-content/uploads/2018/03/sticker-mule-189122-unsplash-1568x1046.jpg 1568w, http://example.org/wp-content/uploads/2018/03/sticker-mule-189122-unsplash-300x200.jpg 300w, http://example.org/wp-content/uploads/2018/03/sticker-mule-189122-unsplash-768x513.jpg 768w, http://example.org/wp-content/uploads/2018/03/sticker-mule-189122-unsplash-1024x683.jpg 1024w" sizes="(max-width: 1568px) 100vw, 1568px" />
 </figure>
+<figure class="post-thumbnail">
+	<img width="1568" height="1046" src="http://cdn.example.org/wp-content/uploads/2018/03/sticker-mule-189122-unsplash-1568x1046.jpg" class="attachment-post-thumbnail size-post-thumbnail wp-post-image" alt="" srcset="http://example.org/wp-content/uploads/2018/03/sticker-mule-189122-unsplash-1568x1046.jpg 1568w, http://example.org/wp-content/uploads/2018/03/sticker-mule-189122-unsplash-300x200.jpg 300w, http://example.org/wp-content/uploads/2018/03/sticker-mule-189122-unsplash-768x513.jpg 768w, http://example.org/wp-content/uploads/2018/03/sticker-mule-189122-unsplash-1024x683.jpg 1024w, http://example.org/wp-content/uploads/2018/03/sticker-mule-189122-unsplash-1568x1046.jpg 1568w" sizes="(max-width: 1568px) 100vw, 1568px" />
+</figure>
 <picture>
 	<source srcset="http://cdn.example.org/images/site/logo/logo-acommeassure.webp" type="image/webp">
 	<source srcset="/images/site/logo/logo-acommeassure.png 100w" type="image/png">

--- a/tests/Fixtures/CDN/srcset/rewrite.html
+++ b/tests/Fixtures/CDN/srcset/rewrite.html
@@ -515,6 +515,9 @@ img.emoji {
 <figure class="post-thumbnail">
 	<img width="1568" height="1046" src="http://example.org/wp-content/uploads/2018/03/sticker-mule-189122-unsplash-1568x1046.jpg" class="attachment-post-thumbnail size-post-thumbnail wp-post-image" alt="" srcset="http://cdn.example.org/wp-content/uploads/2018/03/sticker-mule-189122-unsplash-1568x1046.jpg 1568w, http://cdn.example.org/wp-content/uploads/2018/03/sticker-mule-189122-unsplash-300x200.jpg 300w, http://cdn.example.org/wp-content/uploads/2018/03/sticker-mule-189122-unsplash-768x513.jpg 768w, http://cdn.example.org/wp-content/uploads/2018/03/sticker-mule-189122-unsplash-1024x683.jpg 1024w" sizes="(max-width: 1568px) 100vw, 1568px" />
 </figure>
+<figure class="post-thumbnail">
+	<img width="1568" height="1046" src="http://example.org/wp-content/uploads/2018/03/sticker-mule-189122-unsplash-1568x1046.jpg" class="attachment-post-thumbnail size-post-thumbnail wp-post-image" alt="" srcset="http://cdn.example.org/wp-content/uploads/2018/03/sticker-mule-189122-unsplash-1568x1046.jpg 1568w, http://cdn.example.org/wp-content/uploads/2018/03/sticker-mule-189122-unsplash-300x200.jpg 300w, http://cdn.example.org/wp-content/uploads/2018/03/sticker-mule-189122-unsplash-768x513.jpg 768w, http://cdn.example.org/wp-content/uploads/2018/03/sticker-mule-189122-unsplash-1024x683.jpg 1024w, http://cdn.example.org/wp-content/uploads/2018/03/sticker-mule-189122-unsplash-1568x1046.jpg 1568w" sizes="(max-width: 1568px) 100vw, 1568px" />
+</figure>
 <picture>
 	<source srcset="http://cdn.example.org/images/site/logo/logo-acommeassure.webp" type="image/webp">
 	<source srcset="http://cdn.example.org/images/site/logo/logo-acommeassure.png 100w" type="image/png">


### PR DESCRIPTION
Fixes multiple CDN url replacement on srcset rewrites.

Applied array_unique() after I made a trim() on the sources array.