### PR TITLE
Fix #2159 - Don't clear the cache when preload option is changed

### DIFF
--- a/inc/admin/options.php
+++ b/inc/admin/options.php
@@ -54,7 +54,6 @@ function rocket_after_save_options( $oldvalue, $value ) {
 		'sucury_waf_cache_sync'       => true,
 		'sucury_waf_api_key'          => true,
 		'manual_preload'              => true,
-		'sitemap_preload'             => true,
 	];
 
 	// Create 2 arrays to compare.

--- a/inc/admin/options.php
+++ b/inc/admin/options.php
@@ -53,6 +53,8 @@ function rocket_after_save_options( $oldvalue, $value ) {
 		'analytics_enabled'           => true,
 		'sucury_waf_cache_sync'       => true,
 		'sucury_waf_api_key'          => true,
+		'manual_preload'              => true,
+		'sitemap_preload'             => true,
 	];
 
 	// Create 2 arrays to compare.


### PR DESCRIPTION
Fix #2159 - Don't clear the cache when preload option is changed

When you turn on or off the preload option, the cache is cleared, but there's no benefit to or need for doing that.