### PR TITLE
Fix #2134 - Improve "Separate cache files for mobile devices" help text

### DIFF
--- a/inc/classes/admin/settings/class-page.php
+++ b/inc/classes/admin/settings/class-page.php
@@ -516,7 +516,7 @@ class Page {
 					'type'              => 'checkbox',
 					'label'             => __( 'Separate cache files for mobile devices', 'rocket' ),
 					// translators: %1$s = opening <a> tag, %2$s = closing </a> tag.
-					'description'       => sprintf( __( '%1$sMobile cache%2$s works safest with both options enabled. When in doubt, keep both.', 'rocket' ), '<a href="' . esc_url( $mobile_cache_beacon['url'] ) . '" data-beacon-article="' . esc_attr( $mobile_cache_beacon['id'] ) . '" target="_blank">', '</a>' ),
+					'description'       => sprintf( __( 'Most modern themes are responsive and should work without a separate cache. Enable this only if you have a dedicated mobile theme or plugin. %1$sMore info%2$s', 'rocket' ), '<a href="' . esc_url( $mobile_cache_beacon['url'] ) . '" data-beacon-article="' . esc_attr( $mobile_cache_beacon['id'] ) . '" target="_blank">', '</a>' ),
 					'container_class'   => [
 						rocket_is_mobile_plugin_active() ? 'wpr-isDisabled' : '',
 						'wpr-field--children',


### PR DESCRIPTION
Changed text to:
Most modern themes are responsive and should work without a separate cache. Enable this only if you have a dedicated mobile theme or plugin. More info

More info links to https://docs.wp-rocket.me/article/708-mobile-caching/?utm_source=wp_plugin&utm_medium=wp_rocket (This link https://jmp.sh/5qe7CW3)

Reference Issue ticket #2134 