### PR TITLE
Fix #2167 - After clearing Autoptimize cache, rocket_clean_domain is not being called

### DIFF
--- a/inc/3rd-party/plugins/autoptimize.php
+++ b/inc/3rd-party/plugins/autoptimize.php
@@ -1,7 +1,7 @@
 <?php
 defined( 'ABSPATH' ) || die( 'Cheatin&#8217; uh?' );
 
-if ( function_exists( 'autoptimize_do_cachepurged_action' ) ) :
+if ( class_exists( 'autoptimizeCache' ) ) :
 	/**
 	 * Improvement with Autoptimize: clear the cache when Autoptimize's cache is cleared
 	 *


### PR DESCRIPTION
Cleaning Autoptimize cache with the menu bar link, will not clean WP Rocket cache and will cause 404 errors related to JS and CSS files.

The menu bar link is triggered with admin-ajax.php and at that point the function `autoptimize_do_cachepurged_action` is not defined. I've modified it to `class_exists( 'autoptimizeCache' )`

Reference issue #2167 