### PR TITLE
Fix #2121 - Exclude fwp-loop comment from stripping for FacetWP

### DIFF
--- a/inc/vendors/classes/class-minify-html.php
+++ b/inc/vendors/classes/class-minify-html.php
@@ -176,7 +176,7 @@ class Minify_HTML
 
     protected function _commentCB($m)
     {
-        return (false !== strpos($m[1], 'ngg_resource_manager_marker') || 0 === strpos($m[1], '[') || false !== strpos($m[1], '<![') || 0 === strpos($m[1], 'esi') || 0 === strpos($m[1], 'noindex') || 0 === strpos($m[1], '/noindex') || 0 === strpos($m[1], 'start_content') || 0 === strpos($m[1], 'end_content'))
+        return (false !== strpos($m[1], 'fwp-loop') || false !== strpos($m[1], 'ngg_resource_manager_marker') || 0 === strpos($m[1], '[') || false !== strpos($m[1], '<![') || 0 === strpos($m[1], 'esi') || 0 === strpos($m[1], 'noindex') || 0 === strpos($m[1], '/noindex') || 0 === strpos($m[1], 'start_content') || 0 === strpos($m[1], 'end_content'))
             ? $m[0]
             : '';
     }


### PR DESCRIPTION
Keep the comment to preserve compatibility with FacetWP

```html
<!--fwp-loop-->
```

Reference issue #2121 