### PR TITLE
Fixed #1550 Update Wordpress Compatibility

### DIFF
--- a/inc/classes/subscriber/Plugin/class-updater-subscriber.php
+++ b/inc/classes/subscriber/Plugin/class-updater-subscriber.php
@@ -366,6 +366,7 @@ class Updater_Subscriber implements Subscriber_Interface {
 		$obj->new_version = $match['user_version'];
 		$obj->url         = $this->vendor_url;
 		$obj->package     = $match['package'];
+		$obj->tested      = WP_ROCKET_WP_VERSION_TESTED;
 
 		if ( $this->icons && ! empty( $this->icons['1x'] ) ) {
 			$obj->icons = $this->icons;

--- a/wp-rocket.php
+++ b/wp-rocket.php
@@ -20,6 +20,7 @@ defined( 'ABSPATH' ) || die( 'Cheatin&#8217; uh?' );
 // Rocket defines.
 define( 'WP_ROCKET_VERSION',               '3.5-alpha1' );
 define( 'WP_ROCKET_WP_VERSION',            '4.9' );
+define( 'WP_ROCKET_WP_VERSION_TESTED',     '5.3.2' );
 define( 'WP_ROCKET_PHP_VERSION',           '5.6' );
 define( 'WP_ROCKET_PRIVATE_KEY',           false );
 define( 'WP_ROCKET_SLUG',                  'wp_rocket_settings' );


### PR DESCRIPTION
Updated Wordpress Compatibility

I added a new constant: `WP_ROCKET_WP_VERSION_TESTED` which includes the latest version of Wordpress and how it displays like this: https://www.screencast.com/t/y3gCQ5ZOpG6R

This can also be fetched from update API or directly from Wordpress with `get_core_updates()` function. 

Reference Issue #1550 

**Which should be the best approach?**