### PR TITLE
Fixed: decreased integration tests running time

### DIFF
--- a/inc/classes/subscriber/CDN/CDNSubscriber.php
+++ b/inc/classes/subscriber/CDN/CDNSubscriber.php
@@ -197,7 +197,7 @@ class CDNSubscriber implements Subscriber_Interface {
 	 * @return boolean
 	 */
 	private function is_allowed() {
-		if ( defined( 'DONOTROCKETOPTIMIZE' ) && DONOTROCKETOPTIMIZE ) {
+		if ( rocket_has_constant( 'DONOTROCKETOPTIMIZE' ) && rocket_get_constant( 'DONOTROCKETOPTIMIZE' ) ) {
 			return false;
 		}
 

--- a/tests/Integration/Subscriber/CDNSubscriber/TestRewrite.php
+++ b/tests/Integration/Subscriber/CDNSubscriber/TestRewrite.php
@@ -6,6 +6,7 @@ use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Admin\Options;
 use WP_Rocket\CDN\CDN;
 use WP_Rocket\Subscriber\CDN\CDNSubscriber;
+use Brain\Monkey;
 
 /**
  * @group Subscriber
@@ -64,10 +65,6 @@ class TestRewrite extends TestCase {
         );
     }
 
-	/**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     */
     public function testShouldReturnOriginalWhenDONOTROCKETOPTIMIZE() {
         update_option(
             'wp_rocket_settings',
@@ -83,7 +80,13 @@ class TestRewrite extends TestCase {
             ]
         );
 
-        define( 'DONOTROCKETOPTIMIZE', true );
+		// Mock DONOTROCKETOPTIMIZE constant.
+		Monkey\Functions\expect( 'rocket_has_constant' )
+			->with( 'DONOTROCKETOPTIMIZE' )
+			->andReturn( true );
+		Monkey\Functions\expect( 'rocket_get_constant' )
+			->with( 'DONOTROCKETOPTIMIZE' )
+			->andReturn( true );
 
         $options        = new Options_Data( (new Options( 'wp_rocket_'))->get( 'settings' ) );
         $cdn_subscriber = new CDNSubscriber( $options, new CDN( $options ) );

--- a/tests/Integration/Subscriber/CDNSubscriber/TestRewrite.php
+++ b/tests/Integration/Subscriber/CDNSubscriber/TestRewrite.php
@@ -64,6 +64,10 @@ class TestRewrite extends TestCase {
         );
     }
 
+	/**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
     public function testShouldReturnOriginalWhenDONOTROCKETOPTIMIZE() {
         update_option(
             'wp_rocket_settings',
@@ -92,10 +96,6 @@ class TestRewrite extends TestCase {
         );
     }
 
-    /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     */
     public function testShouldReturnOriginalWhenNoCNAME() {
         update_option(
             'wp_rocket_settings',

--- a/tests/Integration/Subscriber/CDNSubscriber/TestRewriteSrcset.php
+++ b/tests/Integration/Subscriber/CDNSubscriber/TestRewriteSrcset.php
@@ -11,10 +11,7 @@ use WP_Rocket\Subscriber\CDN\CDNSubscriber;
  * @group Subscriber
  */
 class TestRewriteSrcset extends TestCase {
-    /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     */
+
     public function testShouldRewriteSrcsetURLs() {
         update_option(
             'wp_rocket_settings',
@@ -42,10 +39,6 @@ class TestRewriteSrcset extends TestCase {
         );
     }
 
-    /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     */
     public function testShouldReturnOriginalWhenCDNDisabled() {
         update_option(
             'wp_rocket_settings',
@@ -72,10 +65,6 @@ class TestRewriteSrcset extends TestCase {
         );
     }
 
-    /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     */
     public function testShouldReturnOriginalWhenNoCNAME() {
         update_option(
             'wp_rocket_settings',


### PR DESCRIPTION
Integration tests take a long time to run due to :
```
/**
     * @runInSeparateProcess
     * @preserveGlobalState disabled
     */
```
I inverted the @runInSeparateProcess to be available only for the function which defines the constant and it decreased the running time to 1.1s all integration tests (before it was about 9minutes)