### PR TITLE
Fix #2217 CDN + Optimize CSS delivery - assets are not rewritten because of priority

### DIFF
--- a/inc/classes/subscriber/Optimization/class-critical-css-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-critical-css-subscriber.php
@@ -43,7 +43,7 @@ class Critical_CSS_Subscriber implements Subscriber_Interface {
 			],
 			'wp_head'                                 => [ 'insert_load_css', PHP_INT_MAX ],
 			'rocket_buffer'                           => [
-				[ 'insert_critical_css_buffer', 29 ],
+				[ 'insert_critical_css_buffer', 19 ],
 				[ 'async_css', 32 ],
 			],
 			'switch_theme'                            => 'maybe_regenerate_cpcss',


### PR DESCRIPTION
In 3.4.3 the CDN feature is not rewriting asset paths in critical path CSS due to high priority in here:

https://github.com/wp-media/wp-rocket/blob/master/inc/classes/subscriber/Optimization/class-critical-css-subscriber.php#L46