### PR TITLE
Fix undefined constant WP_ROCKET_CONFIG_PATH

### DIFF
--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -19,6 +19,10 @@ function get_rocket_advanced_cache_file() {
 	// Add a constant to be sure this is our file.
 	$buffer .= "define( 'WP_ROCKET_ADVANCED_CACHE', true );\n\n";
 
+	$buffer .= "if ( ! defined( 'WP_ROCKET_CONFIG_PATH' ) ) {\n";
+	$buffer .= "\tdefine( 'WP_ROCKET_CONFIG_PATH',       WP_CONTENT_DIR . '/wp-rocket-config/' );\n";
+	$buffer .= "}\n\n";
+
 	// Include the Mobile Detect class if we have to create a different caching file for mobile.
 	if ( is_rocket_generate_caching_mobile_files() ) {
 		$buffer .= "if ( file_exists( '" . WP_ROCKET_VENDORS_PATH . "classes/class-rocket-mobile-detect.php' ) && ! class_exists( 'Rocket_Mobile_Detect' ) ) {\n";


### PR DESCRIPTION
Fixes:

`Notice: Use of undefined constant WP_ROCKET_CONFIG_PATH - assumed 'WP_ROCKET_CONFIG_PATH' in /home/alfonsoc/public_html/rocket/wp-content/plugins/wp-rocket/inc/classes/logger/class-logger.php on line 236`

```

# | Time | Memory | Function | Location
-- | -- | -- | -- | --
1 | 0.0042 | 435704 | {main}( ) | .../index.php:0
2 | 0.0088 | 479232 | require_once( '/app/public/wp-admin/admin.php' ) | .../index.php:10
3 | 0.0110 | 493856 | require_once( '/app/public/wp-load.php' ) | .../admin.php:34
4 | 0.0134 | 505496 | require_once( '/app/public/wp-config.php' ) | .../wp-load.php:37
5 | 0.0163 | 591072 | require_once( '/app/public/wp-settings.php' ) | .../wp-config.php:109
6 | 0.0622 | 1367712 | include( '/app/public/wp-content/advanced-cache.php' ) | .../wp-settings.php:95
7 | 0.0964 | 1699928 | WP_Rocket\Buffer\Cache->__construct( ) | .../advanced-cache.php:63
8 | 0.0965 | 1699992 | WP_Rocket\Buffer\Cache->log( ) | .../class-cache.php:69
9 | 0.1045 | 1759904 | WP_Rocket\Logger\Logger::info( ) | .../class-abstract-buffer.php:120
10 | 0.1045 | 1759904 | WP_Rocket\Logger\Logger::get_logger( ) | .../class-logger.php:82
11 | 0.1789 | 2008264 | WP_Rocket\Logger\Logger::get_log_file_path( ) | .../class-logger.php:196


```

