### PR TITLE
Auto exclude attachement_category taxonomy from CPCSS

### DIFF
--- a/inc/classes/optimization/CSS/class-critical-css.php
+++ b/inc/classes/optimization/CSS/class-critical-css.php
@@ -251,6 +251,7 @@ class Critical_CSS {
 				'truethemes-gallery-category',
 				'coupon_campaign',
 				'element_category',
+				'attachment_category',
 			]
 		);
 


### PR DESCRIPTION
This PR auto-excludes the `attachment_category` taxonomy from CPCSS which is generated by Media Library Assistant.

This taxonomy allows to categorize the media only in the admin. No public URL exist.

Related ticket:
https://secure.helpscout.net/conversation/1042714840/138497?folderId=273768