### PR TITLE
Update hook name to delete_user

### DIFF
--- a/inc/classes/subscriber/Cache/PurgeActionsSubscriber.php
+++ b/inc/classes/subscriber/Cache/PurgeActionsSubscriber.php
@@ -33,7 +33,7 @@ class PurgeActionsSubscriber implements Subscriber_Interface {
 	public static function get_subscribed_events() {
 		return [
 			'profile_update' => 'purge_user_cache',
-			'deleted_user'   => 'purge_user_cache',
+			'delete_user'    => 'purge_user_cache',
 		];
 	}
 


### PR DESCRIPTION
deleted_user is too late, the user was already deleted, preventing the user ID from being accessed, and the cache directory form being removed.