### PR TITLE
Exclude inline JavaScript keyword -- cache directory size

### DIFF
--- a/inc/classes/optimization/JS/class-combine.php
+++ b/inc/classes/optimization/JS/class-combine.php
@@ -585,6 +585,7 @@ class Combine extends Abstract_JS_Optimization {
 			'window.broadstreetKeywords',
 			'window.wc_ga_pro.available_gateways',
 			'xa.prototype',
+			'var blockClass',
 		];
 
 		$excluded_inline = array_merge( $defaults, $this->options->get( 'exclude_inline_js', [] ) );


### PR DESCRIPTION
Exclude inline JavaScript keyword to prevent cache directory size issue related to TagDiv Cloud Library: https://cloud.tagdiv.com/#/load/All

See ticket: https://secure.helpscout.net/conversation/1053324383/140499