### PR TITLE
Load constants.php early to prevent fatal error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules/
 /vendor/*
+/tests/env/local/

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,6 @@ matrix:
     env: WP_VERSION=latest
   - php: 7.2
     env: WP_VERSION=latest
-  - php: 7.1
-    env: WP_VERSION=latest
-  - php: 7.0
-    env: WP_VERSION=latest
   - php: 5.6
     env: WP_VERSION=4.9.11
   - php: 5.6

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -11,8 +11,17 @@ use Brain\Monkey;
 use WP_Rocket\Tests\TestCaseTrait;
 use WP_UnitTestCase;
 
-class TestCase extends WP_UnitTestCase {
+abstract class TestCase extends WP_UnitTestCase {
 	use TestCaseTrait;
+
+	/**
+	 * Name of the API credentials config file, if applicable. Set in the test or new TestCase.
+	 *
+	 * For example: rocketcdn.php or cloudflare.php.
+	 *
+	 * @var string
+	 */
+	protected static $api_credentials_config_file;
 
 	/**
 	 * Prepares the test environment before each test.
@@ -28,5 +37,34 @@ class TestCase extends WP_UnitTestCase {
 	public function tearDown() {
 		Monkey\tearDown();
 		parent::tearDown();
+	}
+
+	/**
+	 * Gets the credential's value from either an environment variable (stored locally on the machine or CI) or from a local constant defined in `tests/env/local/cloudflare.php`.
+	 *
+	 * @param string $name Name of the environment variable or constant to find.
+	 *
+	 * @return string returns the value if available; else an empty string.
+	 */
+	protected static function getApiCredential( $name ) {
+		$var = getenv( $name );
+		if ( ! empty( $var ) ) {
+			return $var;
+		}
+
+		if ( ! self::$api_credentials_config_file ) {
+			return '';
+		}
+
+		$config_file = dirname( __DIR__ ) . '/env/local/' . self::$api_credentials_config_file;
+
+		if ( ! is_readable( $config_file ) ) {
+			return '';
+		}
+
+		// This file is local to the developer's machine and not stored in the repo.
+		require_once $config_file;
+
+		return rocket_get_constant( $name, '' );
 	}
 }

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 use Brain\Monkey;
 use WP_Rocket\Tests\TestCaseTrait;
 
-class TestCase extends PHPUnitTestCase {
+abstract class TestCase extends PHPUnitTestCase {
 	use \Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 	use TestCaseTrait;
 

--- a/tests/Unit/bootstrap.php
+++ b/tests/Unit/bootstrap.php
@@ -18,3 +18,22 @@ define( 'DAY_IN_SECONDS', 24 * HOUR_IN_SECONDS );
 define( 'WEEK_IN_SECONDS', 7 * DAY_IN_SECONDS );
 define( 'MONTH_IN_SECONDS', 30 * DAY_IN_SECONDS );
 define( 'YEAR_IN_SECONDS', 365 * DAY_IN_SECONDS );
+
+/**
+ * The original files need to loaded into memory before we mock them with Patchwork. Add files here before the unit tests start.
+ *
+ * @since 1.0.0
+ */
+function load_original_functions_before_mocking() {
+	$originals = [
+		'rocket_get_constant' => require_once WP_ROCKET_PLUGIN_ROOT . 'inc/constants.php',
+	];
+
+	foreach ( $originals as $function_name => $file ) {
+		if ( ! function_exists( $function_name ) ) {
+			require_once $file;
+		}
+	}
+}
+
+load_original_functions_before_mocking();


### PR DESCRIPTION
`Fatal error: Cannot redeclare rocket_get_constant() (previously declared in /home/travis/build/wp-media/wp-rocket/vendor/brain/monkey/src/Expectation/FunctionStub.php(52) : eval()'d code:2) in /home/travis/build/wp-media/wp-rocket/inc/constants.php on line 32`

Picked from https://github.com/wp-media/wp-rocket/pull/2249/commits/6a5bbe228d0bebc3d1b7685d872653eba6677c1c

This is needed to prevent the error everytime we use `when` or `expect` for `rocket_get_constant` in the unit tests
