### PR TITLE
Add API Credential Handling to Tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules/
 /vendor/*
+/tests/env/local/

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -8,11 +8,10 @@
 namespace WP_Rocket\Tests\Integration;
 
 use Brain\Monkey;
-use Kint\Parser\Plugin;
 use WP_Rocket\Tests\TestCaseTrait;
 use WP_UnitTestCase;
 
-class TestCase extends WP_UnitTestCase {
+abstract class TestCase extends WP_UnitTestCase {
 	use TestCaseTrait;
 
 	/**

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -8,11 +8,21 @@
 namespace WP_Rocket\Tests\Integration;
 
 use Brain\Monkey;
+use Kint\Parser\Plugin;
 use WP_Rocket\Tests\TestCaseTrait;
 use WP_UnitTestCase;
 
 class TestCase extends WP_UnitTestCase {
 	use TestCaseTrait;
+
+	/**
+	 * Name of the API credentials config file, if applicable. Set in the test or new TestCase.
+	 *
+	 * For example: rocketcdn.php or cloudflare.php.
+	 *
+	 * @var string
+	 */
+	protected static $api_credentials_config_file;
 
 	/**
 	 * Prepares the test environment before each test.
@@ -28,5 +38,34 @@ class TestCase extends WP_UnitTestCase {
 	public function tearDown() {
 		Monkey\tearDown();
 		parent::tearDown();
+	}
+
+	/**
+	 * Gets the credential's value from either an environment variable (stored locally on the machine or CI) or from a local constant defined in `tests/env/local/cloudflare.php`.
+	 *
+	 * @param string $name Name of the environment variable or constant to find.
+	 *
+	 * @return string returns the value if available; else an empty string.
+	 */
+	protected static function getApiCredential( $name ) {
+		$var = getenv( $name );
+		if ( ! empty( $var ) ) {
+			return $var;
+		}
+
+		if ( ! self::$api_credentials_config_file ) {
+			return '';
+		}
+
+		$config_file = dirname( __DIR__ ) . '/env/local/' . self::$api_credentials_config_file;
+
+		if ( ! is_readable( $config_file ) ) {
+			return '';
+		}
+
+		// This file is local to the developer's machine and not stored in the repo.
+		require_once $config_file;
+
+		return rocket_get_constant( $name, '' );
 	}
 }

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 use Brain\Monkey;
 use WP_Rocket\Tests\TestCaseTrait;
 
-class TestCase extends PHPUnitTestCase {
+abstract class TestCase extends PHPUnitTestCase {
 	use \Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 	use TestCaseTrait;
 


### PR DESCRIPTION
Adds the ability to load private API credentials from:

- local machine's env var
- local machine's config file, i.e. located in `tests/env/local/`.
- via Travis in an encrypted env var
