### PR TITLE
Optimize Travis by removing PHP 7.0 and 7.1 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,6 @@ matrix:
     env: WP_VERSION=latest
   - php: 7.2
     env: WP_VERSION=latest
-  - php: 7.1
-    env: WP_VERSION=latest
-  - php: 7.0
-    env: WP_VERSION=latest
   - php: 5.6
     env: WP_VERSION=4.9.11
   - php: 5.6


### PR DESCRIPTION
Why? Speed up the builds.

What about version differences?
We are not using the new PHP 7 features. For us, there's no difference between PHP 7.0, 7.1, or 7.2. In other words, the builds on 7.0 and 7.1 are redundant and unnecessary for us.

Note:
This change has no impact on the product or our customers. This impacts dev only.