### PR TITLE
Update TravisCI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,9 @@ branches:
 cache:
   directories:
   - vendor
-  - "$HOME/.composer/cache"
+  - $HOME/.composer/cache
 matrix:
+  fast_finish: true
   include:
   - php: 7.4
     env: WP_VERSION=latest
@@ -24,28 +25,35 @@ matrix:
     env: WP_VERSION=latest
   - php: 7.2
     env: WP_VERSION=latest
-  - php: 7.1
-    env: WP_VERSION=latest
-  - php: 7.0
-    env: WP_VERSION=latest
   - php: 5.6
+    env: WP_VERSION=latest
+  - name: Legacy
+    php: 5.6
     env: WP_VERSION=4.9.11
-  - php: 5.6
-    env: WP_VERSION=latest
+  - name: Coding Standards
+    php: 7.3
+    env: WP_TRAVISCI=phpcs
+before_install:
+  # Unless we need XDebug, disable it for improved performance.
+  - phpenv config-rm xdebug.ini || return 0
+  - export PATH="$HOME/.composer/vendor/bin:$PATH"
+install:
+  - composer install --prefer-dist --no-interaction
+  # Install an older version of PHPUnit if we're still running PHP 5.6.
+  - |
+    if [[ "$TRAVIS_PHP_VERSION" == "5.6" ]]; then
+      wget -O ./vendor/bin/phpunit https://phar.phpunit.de/phpunit-5.phar
+      chmod +x ./vendor/bin/phpunit
+    fi
 before_script:
-- rm composer.lock
-- export PATH="$HOME/.composer/vendor/bin:$PATH"
-- composer install --no-progress
-- |
-  if [ -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini ]; then
-    phpenv config-rm xdebug.ini
-  else
-    echo "xdebug.ini does not exist"
-  fi
 - |
   if [[ ! -z "$WP_VERSION" ]] ; then
     bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
   fi
 script:
-- composer run-tests
-- composer phpcs
+- |
+  if [[ "$WP_TRAVISCI" == "phpcs" ]]; then
+    composer phpcs
+  else
+    composer run-tests
+  fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,15 +36,10 @@ matrix:
 before_install:
   # Unless we need XDebug, disable it for improved performance.
   - phpenv config-rm xdebug.ini || return 0
+  - rm composer.lock
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
 install:
   - composer install --prefer-dist --no-interaction
-  # Install an older version of PHPUnit if we're still running PHP 5.6.
-  - |
-    if [[ "$TRAVIS_PHP_VERSION" == "5.6" ]]; then
-      wget -O ./vendor/bin/phpunit https://phar.phpunit.de/phpunit-5.phar
-      chmod +x ./vendor/bin/phpunit
-    fi
 before_script:
 - |
   if [[ ! -z "$WP_VERSION" ]] ; then


### PR DESCRIPTION
- Remove PHP 7 & 7.1
- Name Legacy build running PHP 5.6 & WP 4.9
- Add specific build for coding standards
- Move some commands from `before_script` to `before_install`
- Run composer on `install step`
- Run PHP CS only on coding standards build