### PR TITLE
Exclude combination of jQuery served from c0.wp.com

### DIFF
--- a/inc/classes/optimization/JS/class-combine.php
+++ b/inc/classes/optimization/JS/class-combine.php
@@ -731,6 +731,7 @@ class Combine extends Abstract_JS_Optimization {
 			'ck.page',
 			'cdn.jsdelivr.net/gh/AmauriC/',
 			'static.klaviyo.com/onsite/js/klaviyo.js',
+			'c0.wp.com/c/' . get_bloginfo( 'version' ) . '/wp-includes/js/jquery/jquery.js',
 		];
 
 		$excluded_external = array_merge( $defaults, $this->options->get( 'exclude_js', [] ) );


### PR DESCRIPTION
The exclusion is done in a dynamic way, taking into consideration WordPress's version. `c0.wp.com`.

I'll close the older PR about this:
https://github.com/wp-media/wp-rocket/pull/1869
