### PR TITLE
Disable WP 5.4 core lazyload when WPR images lazyload is enabled

### DIFF
--- a/inc/classes/subscriber/Optimization/class-lazyload-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-lazyload-subscriber.php
@@ -437,11 +437,11 @@ class Lazyload_Subscriber implements Subscriber_Interface {
 	 * @return bool
 	 */
 	public function maybe_disable_core_lazyload( $value ) {
-		if ( $this->can_lazyload_images() ) {
-			return false;
+		if ( false === $value ) {
+			return $value;
 		}
 
-		return $value;
+		return ! (bool) $this->can_lazyload_images();
 	}
 
 	/**

--- a/inc/classes/subscriber/Optimization/class-lazyload-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-lazyload-subscriber.php
@@ -89,16 +89,17 @@ class Lazyload_Subscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events() {
 		return [
-			'wp_footer'            => [
+			'wp_footer'               => [
 				[ 'insert_lazyload_script', PHP_INT_MAX ],
 				[ 'insert_youtube_thumbnail_script', PHP_INT_MAX ],
 			],
-			'wp_head'              => [ 'insert_nojs_style', PHP_INT_MAX ],
-			'wp_enqueue_scripts'   => [ 'insert_youtube_thumbnail_style', PHP_INT_MAX ],
-			'rocket_buffer'        => [ 'lazyload', 18 ],
-			'rocket_lazyload_html' => 'lazyload_responsive',
-			'init'                 => 'lazyload_smilies',
-			'wp'                   => 'deactivate_lazyload_on_specific_posts',
+			'wp_head'                 => [ 'insert_nojs_style', PHP_INT_MAX ],
+			'wp_enqueue_scripts'      => [ 'insert_youtube_thumbnail_style', PHP_INT_MAX ],
+			'rocket_buffer'           => [ 'lazyload', 18 ],
+			'rocket_lazyload_html'    => 'lazyload_responsive',
+			'init'                    => 'lazyload_smilies',
+			'wp'                      => 'deactivate_lazyload_on_specific_posts',
+			'wp_lazy_loading_enabled' => 'maybe_disable_core_lazyload',
 		];
 	}
 
@@ -424,6 +425,22 @@ class Lazyload_Subscriber implements Subscriber_Interface {
 		if ( is_rocket_post_excluded_option( 'lazyload_iframes' ) ) {
 			add_filter( 'do_rocket_lazyload_iframes', '__return_false' );
 		}
+	}
+
+	/**
+	 * Disable WP core lazyload if our images lazyload is active
+	 *
+	 * @since 3.5
+	 * @author Remy Perona
+	 *
+	 * @return bool
+	 */
+	public function maybe_disable_core_lazyload() {
+		if ( $this->can_lazyload_images() ) {
+			return false;
+		}
+
+		return true;
 	}
 
 	/**

--- a/inc/classes/subscriber/Optimization/class-lazyload-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-lazyload-subscriber.php
@@ -433,14 +433,15 @@ class Lazyload_Subscriber implements Subscriber_Interface {
 	 * @since 3.5
 	 * @author Remy Perona
 	 *
+	 * @param bool $value Current value for the enabling variable.
 	 * @return bool
 	 */
-	public function maybe_disable_core_lazyload() {
+	public function maybe_disable_core_lazyload( $value ) {
 		if ( $this->can_lazyload_images() ) {
 			return false;
 		}
 
-		return true;
+		return $value;
 	}
 
 	/**


### PR DESCRIPTION
The feature is not merged yet in core, but to be ahead, we decide to handle this in the plugin using the provided filter `wp_lazy_loading_enabled`.

We will disable core lazyload when our images lazyload is enabled in WP Rocket settings.