### PR TITLE
Excluded Dynamic Inline JS

### DIFF
--- a/inc/classes/optimization/JS/class-combine.php
+++ b/inc/classes/optimization/JS/class-combine.php
@@ -840,6 +840,7 @@ class Combine extends Abstract_JS_Optimization {
 			'tdbMenuItem',
 			'tdbSearchItem',
 			'best_seller_badge',
+			'wp_post_blocks_vars.listed_posts=[',
 		];
 
 		/**


### PR DESCRIPTION
Excluded Dynamic Inline JS:
wp_post_blocks_vars.listed_posts=[

https://www.diffchecker.com/nXuEVYpQ