### PR TITLE
Improves test bootstrapping

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -88,13 +88,13 @@
 		"wp-media/cloudflare": "self.version"
 	},
 	"scripts": {
-		"test-unit": "\"vendor/bin/wpmedia-phpunit\" unit path=tests/Unit",
-		"test-integration": "\"vendor/bin/wpmedia-phpunit\" integration path=tests/Integration --exclude-group AdminOnly",
-		"test-integration-admin": "\"vendor/bin/wpmedia-phpunit\" integration path=tests/Integration --group AdminOnly",
+		"test-unit": "\"vendor/bin/phpunit\" --testsuite unit --colors=always --configuration tests/Unit/phpunit.xml.dist",
+		"test-integration": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --exclude-group AdminOnly",
+		"test-integration-adminonly": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group AdminOnly",
 		"run-tests": [
 			"@test-unit",
 			"@test-integration",
-			"@test-integration-admin"
+			"@test-integration-adminonly"
 		],
 		"run-stan":"vendor/bin/phpstan analyze --memory-limit=2G --no-progress",
 		"install-codestandards": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",

--- a/composer.json
+++ b/composer.json
@@ -89,12 +89,14 @@
 	},
 	"scripts": {
 		"test-unit": "\"vendor/bin/phpunit\" --testsuite unit --colors=always --configuration tests/Unit/phpunit.xml.dist",
-		"test-integration": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --exclude-group AdminOnly",
+		"test-integration": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --exclude-group AdminOnly,WithWoo",
 		"test-integration-adminonly": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group AdminOnly",
+		"test-integration-withwoo": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group WithWoo",
 		"run-tests": [
 			"@test-unit",
 			"@test-integration",
-			"@test-integration-adminonly"
+			"@test-integration-adminonly",
+			"@test-integration-withwoo"
 		],
 		"run-stan":"vendor/bin/phpstan analyze --memory-limit=2G --no-progress",
 		"install-codestandards": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",

--- a/composer.lock
+++ b/composer.lock
@@ -2029,12 +2029,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "0365bf26eddd4a8be9980d7dabf05ceb2aba2f02"
+                "reference": "1df6b9d09d2b074fd3f0f10a7696d9f797d4772c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/0365bf26eddd4a8be9980d7dabf05ceb2aba2f02",
-                "reference": "0365bf26eddd4a8be9980d7dabf05ceb2aba2f02",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/1df6b9d09d2b074fd3f0f10a7696d9f797d4772c",
+                "reference": "1df6b9d09d2b074fd3f0f10a7696d9f797d4772c",
                 "shasum": ""
             },
             "conflict": {
@@ -2053,6 +2053,7 @@
                 "cakephp/cakephp": ">=1.3,<1.3.18|>=2,<2.4.99|>=2.5,<2.5.99|>=2.6,<2.6.12|>=2.7,<2.7.6|>=3,<3.5.18|>=3.6,<3.6.15|>=3.7,<3.7.7",
                 "cart2quote/module-quotation": ">=4.1.6,<=4.4.5|>=5,<5.4.4",
                 "cartalyst/sentry": "<=2.1.6",
+                "centreon/centreon": "<18.10.8|>=19,<19.4.5",
                 "cesnet/simplesamlphp-module-proxystatistics": "<3.1",
                 "codeigniter/framework": "<=3.0.6",
                 "composer/composer": "<=1-alpha.11",
@@ -2119,7 +2120,7 @@
                 "monolog/monolog": ">=1.8,<1.12",
                 "namshi/jose": "<2.2",
                 "onelogin/php-saml": "<2.10.4",
-                "oneup/uploader-bundle": ">=1,<1.9.3|>=2,<2.1.5",
+                "oneup/uploader-bundle": "<1.9.3|>=2,<2.1.5",
                 "openid/php-openid": "<2.3",
                 "oro/crm": ">=1.7,<1.7.4",
                 "oro/platform": ">=1.7,<1.7.4",
@@ -2155,7 +2156,7 @@
                 "silverstripe/cms": "<4.3.6|>=4.4,<4.4.4",
                 "silverstripe/comments": ">=1.3,<1.9.99|>=2,<2.9.99|>=3,<3.1.1",
                 "silverstripe/forum": "<=0.6.1|>=0.7,<=0.7.3",
-                "silverstripe/framework": "<4.4.4",
+                "silverstripe/framework": "<4.4.5|>=4.5,<4.5.2",
                 "silverstripe/graphql": ">=2,<2.0.5|>=3,<3.1.2",
                 "silverstripe/registry": ">=2.1,<2.1.2|>=2.2,<2.2.1",
                 "silverstripe/restfulserver": ">=1,<1.0.9|>=2,<2.0.4",
@@ -2279,7 +2280,7 @@
                 }
             ],
             "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
-            "time": "2020-02-10T16:13:40+00:00"
+            "time": "2020-02-19T06:23:50+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -3354,12 +3355,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-media/phpunit.git",
-                "reference": "36a126eb75bcf758f0a17d92a75b4dbdebe0de55"
+                "reference": "4d2ee892c7ab13fd58bd5535b948b658283b40cd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-media/phpunit/zipball/36a126eb75bcf758f0a17d92a75b4dbdebe0de55",
-                "reference": "36a126eb75bcf758f0a17d92a75b4dbdebe0de55",
+                "url": "https://api.github.com/repos/wp-media/phpunit/zipball/4d2ee892c7ab13fd58bd5535b948b658283b40cd",
+                "reference": "4d2ee892c7ab13fd58bd5535b948b658283b40cd",
                 "shasum": ""
             },
             "require": {
@@ -3390,7 +3391,7 @@
             ],
             "description": "PHPUnit extender for bootstrapping unit and WordPress integration test suites.",
             "homepage": "https://github.com/wp-media/phpunit",
-            "time": "2020-02-14T03:13:42+00:00"
+            "time": "2020-02-20T15:23:12+00:00"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -1650,16 +1650,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.10",
+            "version": "0.12.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "39004edc7fc308752f625b89b70ad1710708f45e"
+                "reference": "ca5f2b7cf81c6d8fba74f9576970399c5817e03b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/39004edc7fc308752f625b89b70ad1710708f45e",
-                "reference": "39004edc7fc308752f625b89b70ad1710708f45e",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ca5f2b7cf81c6d8fba74f9576970399c5817e03b",
+                "reference": "ca5f2b7cf81c6d8fba74f9576970399c5817e03b",
                 "shasum": ""
             },
             "require": {
@@ -1685,7 +1685,7 @@
                 "MIT"
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
-            "time": "2020-02-12T22:03:42+00:00"
+            "time": "2020-02-16T14:00:29+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3214,7 +3214,7 @@
             ],
             "description": "An eCommerce toolkit that helps you sell anything. Beautifully.",
             "homepage": "https://woocommerce.com/",
-            "time": "2020-02-13T15:13:27+00:00"
+            "time": "2020-02-13T16:18:48+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",

--- a/tests/Integration/Subscriber/ThirdParty/Plugins/Ecommerce/WooCommerce/TestNonceUserLoggedOut.php
+++ b/tests/Integration/Subscriber/ThirdParty/Plugins/Ecommerce/WooCommerce/TestNonceUserLoggedOut.php
@@ -7,6 +7,7 @@ use WPMedia\PHPUnit\Integration\TestCase;
 
 /**
  * @group  Subscriber_TestNonce
+ * @group  WithWoo
  */
 class TestNonceUserLoggedOut extends TestCase {
 

--- a/tests/Integration/bootstrap.php
+++ b/tests/Integration/bootstrap.php
@@ -14,10 +14,9 @@ tests_add_filter(
 	'muplugins_loaded',
 	function() {
 		// Load WooCommerce.
-		require WP_ROCKET_PLUGIN_ROOT . '/vendor/woocommerce/woocommerce/includes/class-wc-install.php';
-		WC_Install::install();
-
 		require WP_ROCKET_PLUGIN_ROOT . '/vendor/woocommerce/woocommerce/woocommerce.php';
+		\WC_Install::install();
+
 
 		// Overload the license key for testing.
 		redefine( 'rocket_valid_key', '__return_true' );

--- a/tests/Integration/bootstrap.php
+++ b/tests/Integration/bootstrap.php
@@ -2,6 +2,8 @@
 
 namespace WP_Rocket\Tests\Integration;
 
+use WC_Install;
+use WPMedia\PHPUnit\BootstrapManager;
 use function Patchwork\redefine;
 
 define( 'WP_ROCKET_PLUGIN_ROOT', dirname( dirname( __DIR__ ) ) . DIRECTORY_SEPARATOR );
@@ -13,11 +15,13 @@ define( 'WP_ROCKET_IS_TESTING', true );
 tests_add_filter(
 	'muplugins_loaded',
 	function() {
-		// Load WooCommerce.
-		define( 'WC_TAX_ROUNDING_MODE', 'auto' );
-		define( 'WC_USE_TRANSACTIONS', false );
-		require WP_ROCKET_PLUGIN_ROOT . '/vendor/woocommerce/woocommerce/woocommerce.php';
 
+		if ( BootstrapManager::isGroup( 'WithWoo' ) ) {
+			// Load WooCommerce.
+			define( 'WC_TAX_ROUNDING_MODE', 'auto' );
+			define( 'WC_USE_TRANSACTIONS', false );
+			require WP_ROCKET_PLUGIN_ROOT . '/vendor/woocommerce/woocommerce/woocommerce.php';
+		}
 
 		// Overload the license key for testing.
 		redefine( 'rocket_valid_key', '__return_true' );
@@ -32,12 +36,15 @@ tests_add_filter(
 tests_add_filter(
 	'setup_theme',
 	function() {
+		if ( ! BootstrapManager::isGroup( 'WithWoo' ) ) {
+			return;
+		}
 		// Clean existing install first.
 		define( 'WP_UNINSTALL_PLUGIN', true );
 		define( 'WC_REMOVE_ALL_DATA', true );
 		include WP_ROCKET_PLUGIN_ROOT . '/vendor/woocommerce/woocommerce/uninstall.php';
 
-		\WC_Install::install();
+		WC_Install::install();
 
 		// Reload capabilities after install, see https://core.trac.wordpress.org/ticket/28374.
 		if ( version_compare( $GLOBALS['wp_version'], '4.7', '<' ) ) {

--- a/tests/Integration/bootstrap.php
+++ b/tests/Integration/bootstrap.php
@@ -8,7 +8,6 @@ define( 'WP_ROCKET_PLUGIN_ROOT', dirname( dirname( __DIR__ ) ) . DIRECTORY_SEPAR
 define( 'WP_ROCKET_TESTS_FIXTURES_DIR', dirname( __DIR__ ) . '/Fixtures' );
 define( 'WP_ROCKET_TESTS_DIR', __DIR__ );
 define( 'WP_ROCKET_IS_TESTING', true );
-define( 'WPMEDIA_IS_TESTING', true ); // Used by wp-media/{package}.
 
 // Manually load the plugin being tested.
 tests_add_filter(

--- a/tests/Integration/bootstrap.php
+++ b/tests/Integration/bootstrap.php
@@ -14,8 +14,9 @@ tests_add_filter(
 	'muplugins_loaded',
 	function() {
 		// Load WooCommerce.
+		define( 'WC_TAX_ROUNDING_MODE', 'auto' );
+		define( 'WC_USE_TRANSACTIONS', false );
 		require WP_ROCKET_PLUGIN_ROOT . '/vendor/woocommerce/woocommerce/woocommerce.php';
-		\WC_Install::install();
 
 
 		// Overload the license key for testing.
@@ -23,5 +24,29 @@ tests_add_filter(
 
 		// Load the plugin.
 		require WP_ROCKET_PLUGIN_ROOT . '/wp-rocket.php';
+	}
+);
+
+
+// install WC.
+tests_add_filter(
+	'setup_theme',
+	function() {
+		// Clean existing install first.
+		define( 'WP_UNINSTALL_PLUGIN', true );
+		define( 'WC_REMOVE_ALL_DATA', true );
+		include WP_ROCKET_PLUGIN_ROOT . '/vendor/woocommerce/woocommerce/uninstall.php';
+
+		\WC_Install::install();
+
+		// Reload capabilities after install, see https://core.trac.wordpress.org/ticket/28374.
+		if ( version_compare( $GLOBALS['wp_version'], '4.7', '<' ) ) {
+			$GLOBALS['wp_roles']->reinit();
+		} else {
+			$GLOBALS['wp_roles'] = null; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			wp_roles();
+		}
+
+		echo esc_html( 'Installing WooCommerce...' . PHP_EOL );
 	}
 );

--- a/tests/Integration/bootstrap.php
+++ b/tests/Integration/bootstrap.php
@@ -14,6 +14,9 @@ tests_add_filter(
 	'muplugins_loaded',
 	function() {
 		// Load WooCommerce.
+		require WP_ROCKET_PLUGIN_ROOT . '/vendor/woocommerce/woocommerce/includes/class-wc-install.php';
+		WC_Install::install();
+
 		require WP_ROCKET_PLUGIN_ROOT . '/vendor/woocommerce/woocommerce/woocommerce.php';
 
 		// Overload the license key for testing.

--- a/tests/Integration/init-tests.php
+++ b/tests/Integration/init-tests.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Initializes the wp-media/phpunit handler, which then calls the rocket integration test suite.
+ */
+
+define( 'WPMEDIA_PHPUNIT_ROOT_DIR', dirname( dirname( __DIR__ ) ) . DIRECTORY_SEPARATOR );
+define( 'WPMEDIA_PHPUNIT_ROOT_TEST_DIR', __DIR__ );
+
+require_once WPMEDIA_PHPUNIT_ROOT_DIR . 'vendor/wp-media/phpunit/Integration/bootstrap.php';
+
+define( 'WPMEDIA_IS_TESTING', true ); // Used by wp-media/{package}.

--- a/tests/Integration/phpunit.xml.dist
+++ b/tests/Integration/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.3/phpunit.xsd"
-		 bootstrap="../../vendor/wp-media/phpunit/Integration/bootstrap.php"
+		 bootstrap="init-tests.php"
 		 backupGlobals="false"
 		 colors="true"
 		 beStrictAboutCoversAnnotation="true"

--- a/tests/Unit/init-tests.php
+++ b/tests/Unit/init-tests.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Initializes the wp-media/phpunit handler, which then calls the rocket unit test suite.
+ */
+
+define( 'WPMEDIA_PHPUNIT_ROOT_DIR', dirname( dirname( __DIR__ ) ) . DIRECTORY_SEPARATOR );
+define( 'WPMEDIA_PHPUNIT_ROOT_TEST_DIR', __DIR__ );
+
+require_once WPMEDIA_PHPUNIT_ROOT_DIR . 'vendor/wp-media/phpunit/Unit/bootstrap.php';
+
+define( 'WPMEDIA_IS_TESTING', true ); // Used by wp-media/{package}.

--- a/tests/Unit/phpunit.xml.dist
+++ b/tests/Unit/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.3/phpunit.xsd"
-         bootstrap="../../vendor/wp-media/phpunit/Unit/bootstrap.php"
+         bootstrap="init-tests.php"
          backupGlobals="false"
          colors="true"
          beStrictAboutCoversAnnotation="true"


### PR DESCRIPTION
This PR does the following:

- Changes the composer test scripts to run `phpunit` directly
- Changes to make Rocket first and then it loads `wp-media/phpunit` bootstrap files
- Solves the integration test database error problem. Credit @crystinutzaa 
- Moves WooCommerce tests to a separate group and composer script