### PR TITLE
Hide RocketCDN on local/staging sites

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,9 +65,6 @@
 			"inc/vendors/classes/class-rocket-mobile-detect.php",
 			"inc/classes/class-wp-rocket-requirements-check.php"
 		],
-		"files": [
-			"inc/functions/api.php"
-		],
 		"psr-4": {
 			"WPMedia\\Cloudflare\\": "inc/Addons/Cloudflare"
 		}

--- a/inc/classes/subscriber/CDN/RocketCDN/AdminPageSubscriber.php
+++ b/inc/classes/subscriber/CDN/RocketCDN/AdminPageSubscriber.php
@@ -75,10 +75,6 @@ class AdminPageSubscriber extends Abstract_Render implements Subscriber_Interfac
 	 * @return void
 	 */
 	public function display_rocketcdn_status() {
-		if ( ! rocket_is_live_site() ) {
-			return;
-		}
-
 		$subscription_data = $this->api_client->get_subscription_data();
 
 		if ( 'running' === $subscription_data['subscription_status'] ) {
@@ -96,6 +92,7 @@ class AdminPageSubscriber extends Abstract_Render implements Subscriber_Interfac
 		}
 
 		$data = [
+			'is_live_site'    => rocket_is_live_site(),
 			'container_class' => $container_class,
 			'label'           => $label,
 			'status_class'    => $status_class,

--- a/inc/classes/subscriber/CDN/RocketCDN/AdminPageSubscriber.php
+++ b/inc/classes/subscriber/CDN/RocketCDN/AdminPageSubscriber.php
@@ -75,6 +75,10 @@ class AdminPageSubscriber extends Abstract_Render implements Subscriber_Interfac
 	 * @return void
 	 */
 	public function display_rocketcdn_status() {
+		if ( ! rocket_is_live_site() ) {
+			return;
+		}
+
 		$subscription_data = $this->api_client->get_subscription_data();
 
 		if ( 'running' === $subscription_data['subscription_status'] ) {
@@ -161,6 +165,10 @@ class AdminPageSubscriber extends Abstract_Render implements Subscriber_Interfac
 	 * @return void
 	 */
 	public function display_manage_subscription() {
+		if ( ! rocket_is_live_site() ) {
+			return;
+		}
+
 		$subscription_data = $this->api_client->get_subscription_data();
 
 		if ( 'running' !== $subscription_data['subscription_status'] ) {
@@ -206,6 +214,10 @@ class AdminPageSubscriber extends Abstract_Render implements Subscriber_Interfac
 	 * @return void
 	 */
 	public function add_subscription_modal() {
+		if ( ! rocket_is_live_site() ) {
+			return;
+		}
+
 		$base_url   = rocket_get_constant( 'WP_ROCKET_DEBUG', false )
 			? 'https://dave.wp-rocket.me/'
 			: rocket_get_constant( 'WP_ROCKET_WEB_MAIN' );

--- a/inc/classes/subscriber/CDN/RocketCDN/NoticesSubscriber.php
+++ b/inc/classes/subscriber/CDN/RocketCDN/NoticesSubscriber.php
@@ -56,6 +56,10 @@ class NoticesSubscriber extends Abstract_Render implements Subscriber_Interface 
 	 * @return void
 	 */
 	public function promote_rocketcdn_notice() {
+		if ( ! rocket_is_live_site() ) {
+			return;
+		}
+
 		if ( ! $this->should_display_notice() ) {
 			return;
 		}
@@ -72,6 +76,10 @@ class NoticesSubscriber extends Abstract_Render implements Subscriber_Interface 
 	 * @return void
 	 */
 	public function add_dismiss_script() {
+		if ( ! rocket_is_live_site() ) {
+			return;
+		}
+
 		if ( ! $this->should_display_notice() ) {
 			return;
 		}
@@ -152,6 +160,10 @@ class NoticesSubscriber extends Abstract_Render implements Subscriber_Interface 
 	 * @return void
 	 */
 	public function display_rocketcdn_cta() {
+		if ( ! rocket_is_live_site() ) {
+			return;
+		}
+
 		$subscription_data = $this->api_client->get_subscription_data();
 
 		if ( 'running' === $subscription_data['subscription_status'] ) {

--- a/inc/functions/api.php
+++ b/inc/functions/api.php
@@ -73,3 +73,75 @@ function get_rocket_cdn_cnames( $zone = 'all' ) { // phpcs:ignore WordPress.Nami
 
 	return $hosts;
 }
+
+/**
+ * Check if the current URL is for a live site (not local, not staging)
+ *
+ * @since 3.5
+ * @author Remy Perona
+ *
+ * @return bool True if live, false otherwise.
+ */
+function rocket_is_live_site() {
+	if ( rocket_get_constant( 'WP_ROCKET_DEBUG' ) ) {
+		return true;
+	}
+
+	$host = wp_parse_url( home_url(), PHP_URL_HOST );
+
+	if ( ! $host ) {
+		return false;
+	}
+
+	$localhost = [
+		'127.0.0.1',
+		'localhost',
+	];
+
+	if ( in_array( $host, $localhost, true ) ) {
+		return false;
+	}
+
+	$tld           = pathinfo( $host, PATHINFO_EXTENSION );
+	$excluded_tlds = [
+		'localhost',
+		'local',
+		'dev',
+		'test',
+		'docksal',
+	];
+
+	if ( in_array( $tld, $excluded_tlds, true ) ) {
+		return false;
+	}
+
+	if ( '.dev.cc' === substr( $host, -7 ) ) {
+		return false;
+	}
+
+	if ( '.lndo.site' === substr( $host, -10 ) ) {
+		return false;
+	}
+
+	$staging = [
+		'.wpengine.com',
+		'.pantheonsite.io',
+		'.flywheelsites.com',
+		'.flywheelstaging.com',
+		'.kinsta.com',
+		'.kinsta.cloud',
+		'.cloudwaysapps.com',
+		'.azurewebsites.net',
+		'.wpserveur.net',
+		'-liquidwebsites.com',
+		'.myftpupload.com',
+	];
+
+	foreach ( $staging as $domain ) {
+		if ( strpos( $host, $domain ) ) {
+			return false;
+		}
+	}
+
+	return true;
+}

--- a/inc/functions/api.php
+++ b/inc/functions/api.php
@@ -137,8 +137,8 @@ function rocket_is_live_site() {
 		'.myftpupload.com',
 	];
 
-	foreach ( $staging as $domain ) {
-		if ( strpos( $host, $domain ) ) {
+	foreach ( $staging as $partial_host ) {
+		if ( strpos( $host, $partial_host ) ) {
 			return false;
 		}
 	}

--- a/inc/main.php
+++ b/inc/main.php
@@ -40,6 +40,7 @@ function rocket_init() {
 	$wp_rocket->load();
 
 	// Call defines and functions.
+	require_once WP_ROCKET_FUNCTIONS_PATH . 'api.php';
 	require WP_ROCKET_FUNCTIONS_PATH . 'files.php';
 	require WP_ROCKET_FUNCTIONS_PATH . 'posts.php';
 	require WP_ROCKET_FUNCTIONS_PATH . 'admin.php';

--- a/tests/Integration/Functions/rocketIsLiveSite.php
+++ b/tests/Integration/Functions/rocketIsLiveSite.php
@@ -1,0 +1,75 @@
+<?php
+namespace WP_Rocket\Tests\Integration\Functions\Options;
+
+use WPMedia\PHPUnit\Integration\TestCase;
+use Brain\Monkey\Functions;
+
+/**
+ * @covers rocket_is_live_site()
+ * @group Functions
+ * @group API
+ */
+class Test_RocketIsLiveSite extends TestCase {
+	public function testShouldReturnTrueWhenWPROCKETDEBUG() {
+		Functions\when( 'rocket_get_constant' )->justReturn( true );
+
+		$this->assertTrue( rocket_is_live_site() );
+	}
+
+	public function testShouldReturnFalseWhenNoHost() {
+		Functions\when( 'rocket_get_constant' )->justReturn( false );
+
+		$callback = function() {
+			return 'http://';
+		};
+
+		add_filter( 'home_url', $callback );
+
+		$this->assertFalse( rocket_is_live_site() );
+
+		remove_filter( 'home_url', $callback );
+	}
+
+	public function testShouldReturnFalseWhenLocalOrStaging() {
+		Functions\when( 'rocket_get_constant' )->justReturn( false );
+
+		$local_staging = [
+			'127.0.0.1',
+			'localhost',
+			'example.localhost',
+			'example.local',
+			'example.dev',
+			'example.test',
+			'example.docksal',
+			'example.dev.cc',
+			'example.lndo.site',
+			'example.wpengine.com',
+			'example.pantheonsite.io',
+			'example.flywheelsites.com',
+			'example.flywheelstaging.com',
+			'example.kinsta.com',
+			'example.kinsta.cloud',
+			'example.cloudwaysapps.com',
+			'example.azurewebsites.net',
+			'example.wpserveur.net',
+			'example-liquidwebsites.com',
+			'example.myftpupload.com'
+		];
+
+		foreach ( $local_staging as $domain ) {
+			$callback = function() use ( $domain ) {
+				return 'http://' . $domain;
+			};
+
+			add_filter( 'home_url', $callback );
+			$this->assertFalse( rocket_is_live_site() );
+			remove_filter( 'home_url', $callback );
+		}
+	}
+
+	public function testShouldReturnTrueWhenLiveSite() {
+		Functions\when( 'rocket_get_constant' )->justReturn( false );
+
+		$this->assertTrue( rocket_is_live_site() );
+	}
+}

--- a/tests/Integration/Subscriber/CDN/RocketCDN/AdminPageSubscriber/addSubscriptionModal.php
+++ b/tests/Integration/Subscriber/CDN/RocketCDN/AdminPageSubscriber/addSubscriptionModal.php
@@ -25,9 +25,18 @@ class Test_AddSubscriptionModal extends TestCase {
 		return $this->format_the_html( ob_get_clean() );
 	}
 
-	/**
-	 * Test should display the modal HTML with the production URL in the iframe.
-	 */
+	public function testShouldDisplayNothingWhenNotLiveSite() {
+		$callback = function() {
+			return 'http://localhost';
+		};
+
+		add_filter( 'home_url', $callback );
+
+		$this->assertEmpty( $this->getActualHtml() );
+
+		remove_filter( 'home_url', $callback );
+	}
+
 	public function testShouldDisplayModalWithProductionURL() {
 		$expected = <<<HTML
 <div class="wpr-rocketcdn-modal" id="wpr-rocketcdn-modal" aria-hidden="true">
@@ -44,9 +53,6 @@ HTML;
 		$this->assertSame( $this->format_the_html( $expected ), $this->getActualHtml() );
 	}
 
-	/**
-	 * Test should display the modal HTML with the development URL in the iframe.
-	 */
 	public function testShouldDisplayModalWithDevURL() {
 		Functions\expect( 'rocket_get_constant' )
 			->once()

--- a/tests/Integration/Subscriber/CDN/RocketCDN/AdminPageSubscriber/displayManageSubscription.php
+++ b/tests/Integration/Subscriber/CDN/RocketCDN/AdminPageSubscriber/displayManageSubscription.php
@@ -30,6 +30,18 @@ class Test_DisplayManageSubscription extends TestCase {
 		return $this->format_the_html( ob_get_clean() );
 	}
 
+	public function testShouldDisplayNothingWhenNotLiveSite() {
+		$callback = function() {
+			return 'http://localhost';
+		};
+
+		add_filter( 'home_url', $callback );
+
+		$this->assertEmpty( $this->getActualHtml() );
+
+		remove_filter( 'home_url', $callback );
+	}
+
 	/**
 	 * Test should return not render the HTML when the subscription is inactive.
 	 */

--- a/tests/Integration/Subscriber/CDN/RocketCDN/AdminPageSubscriber/displayRocketcdnStatus.php
+++ b/tests/Integration/Subscriber/CDN/RocketCDN/AdminPageSubscriber/displayRocketcdnStatus.php
@@ -36,9 +36,18 @@ class Test_DisplayRocketcdnStatus extends TestCase {
 		return $this->format_the_html( ob_get_clean() );
 	}
 
-	/**
-	 * Test should render the "no subscription" HTML when the subscription status is "cancelled."
-	 */
+	public function testShouldDisplayNothingWhenNotLiveSite() {
+		$callback = function() {
+			return 'http://localhost';
+		};
+
+		add_filter( 'home_url', $callback );
+
+		$this->assertEmpty( $this->getActualHtml() );
+
+		remove_filter( 'home_url', $callback );
+	}
+
 	public function testShouldRenderNoSubscriptionHTMLWhenCancelled() {
 		set_transient(
 			'rocketcdn_status',
@@ -70,9 +79,6 @@ HTML;
 		$this->assertSame( $this->format_the_html( $expected ), $this->getActualHtml() );
 	}
 
-	/**
-	 * Test should render HTML when the subscription status is "running".
-	 */
 	public function testShouldRenderHTMLWhenSubscriptionIsRunning() {
 		set_transient(
 			'rocketcdn_status',

--- a/tests/Integration/Subscriber/CDN/RocketCDN/AdminPageSubscriber/displayRocketcdnStatus.php
+++ b/tests/Integration/Subscriber/CDN/RocketCDN/AdminPageSubscriber/displayRocketcdnStatus.php
@@ -37,13 +37,32 @@ class Test_DisplayRocketcdnStatus extends TestCase {
 	}
 
 	public function testShouldDisplayNothingWhenNotLiveSite() {
+		set_transient(
+			'rocketcdn_status',
+			[
+				'is_active'                     => false,
+				'subscription_status'           => 'cancelled',
+				'subscription_next_date_update' => '2020-01-01',
+			],
+			MINUTE_IN_SECONDS
+		);
+
 		$callback = function() {
 			return 'http://localhost';
 		};
 
+		$expected = <<<HTML
+<div class="wpr-optionHeader">
+	<h3 class="wpr-title2">RocketCDN</h3>
+</div>
+<div class="wpr-field wpr-field-account">
+	<span class="wpr-infoAccount wpr-isInvalid">RocketCDN is unavailable on local domains and staging sites.</span>
+</div>
+HTML;
+
 		add_filter( 'home_url', $callback );
 
-		$this->assertEmpty( $this->getActualHtml() );
+		$this->assertSame( $this->format_the_html( $expected ), $this->getActualHtml() );
 
 		remove_filter( 'home_url', $callback );
 	}

--- a/tests/Integration/Subscriber/CDN/RocketCDN/NoticesSubscriber/addDismissScript.php
+++ b/tests/Integration/Subscriber/CDN/RocketCDN/NoticesSubscriber/addDismissScript.php
@@ -38,9 +38,18 @@ class Test_AddDismissScript extends TestCase {
 		return $this->format_the_html( ob_get_clean() );
 	}
 
-	/**
-	 * Test should not add script when user doesn't have the capability to use it
-	 */
+	public function testShouldDisplayNothingWhenNotLiveSite() {
+		$callback = function() {
+			return 'http://localhost';
+		};
+
+		add_filter( 'home_url', $callback );
+
+		$this->assertNotContains( $this->get_script( wp_create_nonce( 'rocketcdn_dismiss_notice' ) ), $this->getActualHtml() );
+
+		remove_filter( 'home_url', $callback );
+	}
+
 	public function testShouldNotAddScriptWhenNoCapability() {
 		$user_id = self::factory()->user->create( [ 'role' => 'editor' ] );
 
@@ -49,9 +58,6 @@ class Test_AddDismissScript extends TestCase {
 		$this->assertNotContains( $this->get_script( wp_create_nonce( 'rocketcdn_dismiss_notice' ) ), $this->getActualHtml() );
 	}
 
-	/**
-	 * Test should not add script when not on WP Rocket settings page
-	 */
 	public function testShouldNotAddScriptWhenNotRocketPage() {
 		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
 
@@ -61,9 +67,6 @@ class Test_AddDismissScript extends TestCase {
 		$this->assertNotContains( $this->get_script( wp_create_nonce( 'rocketcdn_dismiss_notice' ) ), $this->getActualHtml() );
 	}
 
-	/**
-	 * Test should not add script when the notice has been dismissed
-	 */
 	public function testShouldNotAddScriptWhenDismissed() {
 		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
 
@@ -75,9 +78,6 @@ class Test_AddDismissScript extends TestCase {
 		$this->assertNotContains( $this->get_script( wp_create_nonce( 'rocketcdn_dismiss_notice' ) ), $this->getActualHtml() );
 	}
 
-	/**
-	 * Test should not add script when RocketCDN is active
-	 */
 	public function testShouldNotAddScriptWhenActive() {
 		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
 
@@ -89,9 +89,6 @@ class Test_AddDismissScript extends TestCase {
 		$this->assertNotContains( $this->get_script( wp_create_nonce( 'rocketcdn_dismiss_notice' ) ), $this->getActualHtml() );
 	}
 
-	/**
-	 * Test should add script when RocketCDN is inactive
-	 */
 	public function testShouldAddScriptWhenNotActive() {
 		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
 

--- a/tests/Integration/Subscriber/CDN/RocketCDN/NoticesSubscriber/displayRocketcdnCta.php
+++ b/tests/Integration/Subscriber/CDN/RocketCDN/NoticesSubscriber/displayRocketcdnCta.php
@@ -18,9 +18,52 @@ class Test_DisplayRocketcdnCta extends TestCase {
 		return $this->format_the_html( ob_get_clean() );
 	}
 
-	/**
-	 * Test should not display notice when RocketCDN is active
-	 */
+	public function testShouldDisplayNothingWhenNotLiveSite() {
+		$callback = function() {
+			return 'http://localhost';
+		};
+	
+		$not_expected = $this->format_the_html( '<div class="wpr-rocketcdn-cta-small notice-alt notice-warning wpr-isHidden" id="wpr-rocketcdn-cta-small">
+			<div class="wpr-flex">
+				<section>
+					<h3 class="notice-title">Speed up your website with RocketCDN, WP Rocket’s Content Delivery Network.</strong></h3>
+				</section>
+				<div>
+					<button class="wpr-button" id="wpr-rocketcdn-open-cta">Learn More</button>
+				</div>
+			</div>
+		</div>
+		<div class="wpr-rocketcdn-cta " id="wpr-rocketcdn-cta">
+			<section class="wpr-rocketcdn-cta-content--no-promo">
+				<h3 class="wpr-title2">RocketCDN</h3>
+				<p class="wpr-rocketcdn-cta-subtitle">Speed up your website thanks to:</p>
+				<div class="wpr-flex">
+					<ul class="wpr-rocketcdn-features">
+						<li class="wpr-rocketcdn-feature wpr-rocketcdn-bandwidth">High performance Content Delivery Network (CDN) with <strong>unlimited bandwith</strong></li>
+						<li class="wpr-rocketcdn-feature wpr-rocketcdn-configuration">Easy configuration: the <strong>best CDN settings</strong> are automatically applied</li>
+						<li class="wpr-rocketcdn-feature wpr-rocketcdn-automatic">WP Rocket integration: the CDN option is <strong>automatically configured</strong> in our plugin</li>
+					</ul>
+					<div class="wpr-rocketcdn-pricing">
+						<h4 class="wpr-rocketcdn-pricing-current"><span class="wpr-title1">$7.99</span> / month</h4>
+						<button class="wpr-button wpr-rocketcdn-open" data-micromodal-trigger="wpr-rocketcdn-modal">Get Started</button>
+					</div>
+				</div>
+			</section>
+			<div class="wpr-rocketcdn-cta-footer">
+				<a href="https://go.wp-rocket.me/rocket-cdn" target="_blank" rel="noopener noreferrer">Learn more about RocketCDN</a>
+			</div>
+			<button class="wpr-rocketcdn-cta-close--no-promo" id="wpr-rocketcdn-close-cta">
+				<span class="screen-reader-text">Reduce this banner</span>
+			</button>
+		</div>' );
+
+		add_filter( 'home_url', $callback );
+
+		$this->assertNotContains( $not_expected, $this->getActualHtml() );
+
+		remove_filter( 'home_url', $callback );
+	}
+
 	public function testShouldNotDisplayNoticeWhenActive() {
 		set_transient( 'rocketcdn_status', [ 'subscription_status' => 'running' ], MINUTE_IN_SECONDS );
 
@@ -61,9 +104,6 @@ class Test_DisplayRocketcdnCta extends TestCase {
 		$this->assertNotContains( $not_expected, $this->getActualHtml() );
 	}
 
-	/**
-	 * Test should display the big CTA, small CTA hidden, and no promo
-	 */
 	public function testShouldDisplayBigCTANoPromoWhenDefault() {
 		set_transient( 'rocketcdn_status', [ 'subscription_status' => 'cancelled' ], MINUTE_IN_SECONDS );
 		set_transient(
@@ -117,9 +157,6 @@ class Test_DisplayRocketcdnCta extends TestCase {
 		$this->assertContains( $expected, $this->getActualHtml() );
 	}
 
-	/**
-	 * Test should display the small CTA, the big CTA hidden
-	 */
 	public function testShouldDisplaySmallCTAWhenBigHidden() {
 		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
 
@@ -179,9 +216,6 @@ class Test_DisplayRocketcdnCta extends TestCase {
 		$this->assertContains( $expected, $this->getActualHtml() );
 	}
 
-	/**
-	 * Test should display the big CTA with the promo when active
-	 */
 	public function testShouldDisplayBigCTAPromoWhenPromoActive() {
 		set_transient( 'rocketcdn_status', [ 'subscription_status' => 'cancelled' ], MINUTE_IN_SECONDS );
 		set_transient(
@@ -241,9 +275,6 @@ class Test_DisplayRocketcdnCta extends TestCase {
 		$this->assertContains( $expected, $this->getActualHtml() );
 	}
 
-	/**
-	 * Test should have an error message instead of pricing when the pricing API is not available
-	 */
 	public function testShouldDisplayErrorMessageWhenPricingAPINotAvailable() {
 		set_transient( 'rocketcdn_status', [ 'subscription_status' => 'cancelled' ], MINUTE_IN_SECONDS );
 		set_transient( 'rocketcdn_pricing', new WP_Error( 'rocketcdn_error', 'RocketCDN is not available at the moment. Please retry later' ), MINUTE_IN_SECONDS );

--- a/tests/Integration/Subscriber/CDN/RocketCDN/NoticesSubscriber/promoteRocketcdnNotice.php
+++ b/tests/Integration/Subscriber/CDN/RocketCDN/NoticesSubscriber/promoteRocketcdnNotice.php
@@ -25,9 +25,18 @@ class Test_PromoteRocketcdnNotice extends TestCase {
 	</div>' );
 	}
 
-	/**
-	 * Test should not display the notice when current user doesn't have the capability
-	 */
+	public function testShouldDisplayNothingWhenNotLiveSite() {
+		$callback = function() {
+			return 'http://localhost';
+		};
+
+		add_filter( 'home_url', $callback );
+
+		$this->assertNotContains( $this->get_notice(), $this->getActualHtml() );
+
+		remove_filter( 'home_url', $callback );
+	}
+
 	public function testShouldNotDisplayNoticeWhenNoCapability() {
 		$user_id = self::factory()->user->create( [ 'role' => 'editor' ] );
 
@@ -36,9 +45,6 @@ class Test_PromoteRocketcdnNotice extends TestCase {
 		$this->assertNotContains( $this->get_notice(), $this->getActualHtml() );
 	}
 
-	/**
-	 * Test should not display the notice when not on WP Rocket settings page
-	 */
 	public function testShouldNotDisplayNoticeWhenNotRocketPage() {
 		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
 
@@ -48,9 +54,6 @@ class Test_PromoteRocketcdnNotice extends TestCase {
 		$this->assertNotContains( $this->get_notice(), $this->getActualHtml() );
 	}
 
-	/**
-	 * Test should not display the notice when the notice has been dismissed
-	 */
 	public function testShouldNotDisplayNoticeWhenDismissed() {
 		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
 
@@ -62,9 +65,6 @@ class Test_PromoteRocketcdnNotice extends TestCase {
 		$this->assertNotContains( $this->get_notice(), $this->getActualHtml() );
 	}
 
-	/**
-	 * Test should not display the notice when RocketCDN is active
-	 */
 	public function testShouldNotDisplayNoticeWhenActive() {
 		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
 
@@ -76,9 +76,6 @@ class Test_PromoteRocketcdnNotice extends TestCase {
 		$this->assertNotContains( $this->get_notice(), $this->getActualHtml() );
 	}
 
-	/**
-	 * Test should display the notice when RocketCDN is inactive
-	 */
 	public function testShouldDisplayNoticeWhenNotActive() {
 		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
 

--- a/tests/Unit/Functions/rocketIsLiveSite.php
+++ b/tests/Unit/Functions/rocketIsLiveSite.php
@@ -1,0 +1,74 @@
+<?php
+namespace WP_Rocket\Tests\Unit\Functions\Options;
+
+use WPMedia\PHPUnit\Unit\TestCase;
+use Brain\Monkey\Functions;
+
+/**
+ * @covers rocket_is_live_site()
+ * @group Functions
+ * @group API
+ */
+class Test_RocketIsLiveSite extends TestCase {
+	public function setUp() {
+		parent::setUp();
+
+		require_once WP_ROCKET_PLUGIN_ROOT . 'inc/functions/api.php';
+	}
+
+	public function testShouldReturnTrueWhenWPROCKETDEBUG() {
+		Functions\when( 'rocket_get_constant' )->justReturn( true );
+
+		$this->assertTrue( rocket_is_live_site() );
+	}
+
+	public function testShouldReturnFalseWhenNoHost() {
+		Functions\when( 'rocket_get_constant' )->justReturn( false );
+		Functions\when( 'home_url' )->justReturn( 'http://example.org' );
+		Functions\when( 'wp_parse_url' )->justReturn( null );
+
+		$this->assertFalse( rocket_is_live_site() );
+	}
+
+	public function testShouldReturnFalseWhenLocalOrStaging() {
+		Functions\when( 'rocket_get_constant' )->justReturn( false );
+		Functions\when( 'home_url' )->justReturn( 'http://example.org' );
+
+		$local_staging = [
+			'127.0.0.1',
+			'localhost',
+			'example.localhost',
+			'example.local',
+			'example.dev',
+			'example.test',
+			'example.docksal',
+			'example.dev.cc',
+			'example.lndo.site',
+			'example.wpengine.com',
+			'example.pantheonsite.io',
+			'example.flywheelsites.com',
+			'example.flywheelstaging.com',
+			'example.kinsta.com',
+			'example.kinsta.cloud',
+			'example.cloudwaysapps.com',
+			'example.azurewebsites.net',
+			'example.wpserveur.net',
+			'example-liquidwebsites.com',
+			'example.myftpupload.com'
+		];
+
+		foreach ( $local_staging as $domain ) {
+			Functions\when( 'wp_parse_url' )->justReturn( $domain );
+
+			$this->assertFalse( rocket_is_live_site() );
+		}
+	}
+
+	public function testShouldReturnTrueWhenLiveSite() {
+		Functions\when( 'rocket_get_constant' )->justReturn( false );
+		Functions\when( 'home_url' )->justReturn( 'http://example.org' );
+		Functions\when( 'wp_parse_url' )->justReturn( 'example.org' );
+
+		$this->assertTrue( rocket_is_live_site() );
+	}
+}

--- a/tests/Unit/Subscriber/CDN/RocketCDN/AdminPageSubscriber/addSubscriptionModal.php
+++ b/tests/Unit/Subscriber/CDN/RocketCDN/AdminPageSubscriber/addSubscriptionModal.php
@@ -20,6 +20,13 @@ class Test_AddSubscriptionModal extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
+		Functions\stubs(
+			[
+				'home_url'      => 'http://example.org',
+				'rest_url'      => 'http://example.org/wp-json/',
+			]
+		);
+
 		$this->page = new AdminPageSubscriber(
 			$this->createMock( APIClient::class ),
 			$this->createMock( Options_Data::class ),
@@ -43,6 +50,7 @@ class Test_AddSubscriptionModal extends TestCase {
 
 	public function testShouldDisplayModalWithProductionURL() {
 		Functions\when( 'rocket_is_live_site' )->justReturn( true );
+		Functions\when( 'add_query_arg' )->justReturn( 'https://wp-rocket.me/cdn/iframe?website=http://example.org&callback=http://example.org/wp-json/wp-rocket/v1/rocketcdn/');
 		Functions\expect( 'rocket_get_constant' )
 			->ordered()
 			->once()
@@ -52,14 +60,6 @@ class Test_AddSubscriptionModal extends TestCase {
 			->once()
 			->with( 'WP_ROCKET_WEB_MAIN' )
 			->andReturn( 'https://wp-rocket.me' );
-
-		Functions\stubs(
-			[
-				'add_query_arg' => 'https://wp-rocket.me/cdn/iframe?website=http://example.org&callback=http://example.org/wp-json/wp-rocket/v1/rocketcdn/',
-				'home_url'      => 'http://example.org',
-				'rest_url'      => 'http://example.org/wp-json/',
-			]
-		);
 
 		$expected = <<<HTML
 <div class="wpr-rocketcdn-modal" id="wpr-rocketcdn-modal" aria-hidden="true">
@@ -78,18 +78,11 @@ HTML;
 
 	public function testShouldDisplayModalWithDevURL() {
 		Functions\when( 'rocket_is_live_site' )->justReturn( true );
+		Functions\when( 'add_query_arg' )->justReturn( 'https://dave.wp-rocket.me/cdn/iframe?website=http://example.org&callback=http://example.org/wp-json/wp-rocket/v1/rocketcdn/' );
 		Functions\expect( 'rocket_get_constant' )
 			->once()
 			->with( 'WP_ROCKET_DEBUG', false )
 			->andReturn( true );
-
-		Functions\stubs(
-			[
-				'add_query_arg' => 'https://dave.wp-rocket.me/cdn/iframe?website=http://example.org&callback=http://example.org/wp-json/wp-rocket/v1/rocketcdn/',
-				'home_url'      => 'http://example.org',
-				'rest_url'      => 'http://example.org/wp-json/',
-			]
-		);
 
 		$expected = <<<HTML
 <div class="wpr-rocketcdn-modal" id="wpr-rocketcdn-modal" aria-hidden="true">

--- a/tests/Unit/Subscriber/CDN/RocketCDN/AdminPageSubscriber/addSubscriptionModal.php
+++ b/tests/Unit/Subscriber/CDN/RocketCDN/AdminPageSubscriber/addSubscriptionModal.php
@@ -4,6 +4,9 @@ namespace WP_Rocket\Tests\Unit\Subscriber\CDN\RocketCDN;
 
 use Brain\Monkey\Functions;
 use WPMedia\PHPUnit\Unit\TestCase;
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Admin\Settings\Beacon;
+use WP_Rocket\CDN\RocketCDN\APIClient;
 use WP_Rocket\Subscriber\CDN\RocketCDN\AdminPageSubscriber;
 
 /**
@@ -18,10 +21,10 @@ class Test_AddSubscriptionModal extends TestCase {
 		parent::setUp();
 
 		$this->page = new AdminPageSubscriber(
-			$this->createMock( 'WP_Rocket\CDN\RocketCDN\APIClient' ),
-			$this->createMock( 'WP_Rocket\Admin\Options_Data' ),
-			$this->createMock( 'WP_Rocket\Admin\Settings\Beacon' ),
-			''
+			$this->createMock( APIClient::class ),
+			$this->createMock( Options_Data::class ),
+			$this->createMock( Beacon::class ),
+			'views/settings/rocketcdn'
 		);
 	}
 
@@ -32,9 +35,12 @@ class Test_AddSubscriptionModal extends TestCase {
 		return $this->format_the_html( ob_get_clean() );
 	}
 
-	/**
-	 * Test should display the modal HTML with the production URL in the iframe
-	 */
+	public function testShouldDisplayNothingWhenNotLiveSite() {
+		Functions\when( 'rocket_is_live_site' )->justReturn( false );
+
+		$this->assertNull( $this->page->add_subscription_modal() );
+	}
+
 	public function testShouldDisplayModalWithProductionURL() {
 		Functions\when( 'rocket_is_live_site' )->justReturn( true );
 		Functions\expect( 'rocket_get_constant' )
@@ -70,9 +76,6 @@ HTML;
 		$this->assertSame( $this->format_the_html( $expected ), $this->getActualHtml() );
 	}
 
-	/**
-	 * Test should display the modal HTML with the development URL in the iframe
-	 */
 	public function testShouldDisplayModalWithDevURL() {
 		Functions\when( 'rocket_is_live_site' )->justReturn( true );
 		Functions\expect( 'rocket_get_constant' )

--- a/tests/Unit/Subscriber/CDN/RocketCDN/AdminPageSubscriber/addSubscriptionModal.php
+++ b/tests/Unit/Subscriber/CDN/RocketCDN/AdminPageSubscriber/addSubscriptionModal.php
@@ -36,6 +36,7 @@ class Test_AddSubscriptionModal extends TestCase {
 	 * Test should display the modal HTML with the production URL in the iframe
 	 */
 	public function testShouldDisplayModalWithProductionURL() {
+		Functions\when( 'rocket_is_live_site' )->justReturn( true );
 		Functions\expect( 'rocket_get_constant' )
 			->ordered()
 			->once()
@@ -73,6 +74,7 @@ HTML;
 	 * Test should display the modal HTML with the development URL in the iframe
 	 */
 	public function testShouldDisplayModalWithDevURL() {
+		Functions\when( 'rocket_is_live_site' )->justReturn( true );
 		Functions\expect( 'rocket_get_constant' )
 			->once()
 			->with( 'WP_ROCKET_DEBUG', false )

--- a/tests/Unit/Subscriber/CDN/RocketCDN/AdminPageSubscriber/displayManageSubscription.php
+++ b/tests/Unit/Subscriber/CDN/RocketCDN/AdminPageSubscriber/displayManageSubscription.php
@@ -4,6 +4,7 @@ namespace WP_Rocket\Tests\Unit\Subscriber\CDN\RocketCDN;
 
 use WPMedia\PHPUnit\Unit\TestCase;
 use WP_Rocket\Subscriber\CDN\RocketCDN\AdminPageSubscriber;
+use Brain\Monkey\Functions;
 
 /**
  * @covers \WP_Rocket\Subscriber\CDN\RocketCDN\AdminPageSubscriber::display_manage_subscription
@@ -35,6 +36,7 @@ class Test_DisplayManageSubscription extends TestCase {
 	 * Test should return not render the HTML when the subscription is inactive.
 	 */
 	public function testShouldNotRenderButtonHTMLWhenSubscriptionInactive() {
+		Functions\when( 'rocket_is_live_site' )->justReturn( true );
 		$this->api_client->expects( $this->once() )
 		                 ->method( 'get_subscription_data' )
 		                 ->willReturn( ['subscription_status' => 'cancelled' ] );
@@ -45,6 +47,7 @@ class Test_DisplayManageSubscription extends TestCase {
 	 * Test should render the manage subscription button HTML when the subscription is active.
 	 */
 	public function testShouldRenderButtonHTMLWhenSubscriptionActive() {
+		Functions\when( 'rocket_is_live_site' )->justReturn( true );
 		$this->mockCommonWpFunctions();
 
 		$this->api_client->expects( $this->once() )

--- a/tests/Unit/Subscriber/CDN/RocketCDN/AdminPageSubscriber/displayRocketcdnStatus.php
+++ b/tests/Unit/Subscriber/CDN/RocketCDN/AdminPageSubscriber/displayRocketcdnStatus.php
@@ -49,6 +49,7 @@ class Test_DisplayRocketcdnStatus extends FilesystemTestCase {
 	 * Test should output HTML for an inactive subscription
 	 */
 	public function testShouldOutputNoSubscriptionWhenInactive() {
+		Functions\when( 'rocket_is_live_site' )->justReturn( true );
 		$this->api_client->method( 'get_subscription_data' )
 		                 ->willReturn(
 			                 [
@@ -81,6 +82,7 @@ HTML;
 	}
 
 	public function testShouldOutputSubscriptionDataWhenActive() {
+		Functions\when( 'rocket_is_live_site' )->justReturn( true );
 		$this->api_client->method( 'get_subscription_data' )
 		                 ->willReturn(
 			                 [

--- a/tests/Unit/Subscriber/CDN/RocketCDN/AdminPageSubscriber/displayRocketcdnStatus.php
+++ b/tests/Unit/Subscriber/CDN/RocketCDN/AdminPageSubscriber/displayRocketcdnStatus.php
@@ -3,8 +3,11 @@
 namespace WP_Rocket\Tests\Unit\Subscriber\CDN\RocketCDN\AdminPageSubscriber;
 
 use Brain\Monkey\Functions;
-use WP_Rocket\Tests\Unit\FilesystemTestCase;
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Admin\Settings\Beacon;
+use WP_Rocket\CDN\RocketCDN\APIClient;
 use WP_Rocket\Subscriber\CDN\RocketCDN\AdminPageSubscriber;
+use WP_Rocket\Tests\Unit\FilesystemTestCase;
 
 /**
  * @covers AdminPageSubscriber::display_rocketcdn_status
@@ -15,28 +18,28 @@ class Test_DisplayRocketcdnStatus extends FilesystemTestCase {
 	private $api_client;
 	private $page;
 	protected $rootVirtualDir = 'wp-rocket';
-	protected $structure = [
-			'views' => [
-				'settings' => [
-					'rocketcdn' => [
-						'dashboard-status.php' => ''
-					]
-				]
-			]
+	protected $structure      = [
+		'views' => [
+			'settings' => [
+				'rocketcdn' => [
+					'dashboard-status.php' => '',
+				],
+			],
+		],
 	];
 
 	public function setUp() {
 		parent::setUp();
 
-		$this->api_client = $this->createMock( 'WP_Rocket\CDN\RocketCDN\APIClient' );
+		$this->api_client = $this->createMock( APIClient::class );
 		$this->page       = new AdminPageSubscriber(
 			$this->api_client,
-			$this->createMock( 'WP_Rocket\Admin\Options_Data' ),
-			$this->createMock( 'WP_Rocket\Admin\Settings\Beacon' ),
+			$this->createMock( Options_Data::class ),
+			$this->createMock( Beacon::class ),
 			'views/settings/rocketcdn'
 		);
 
-		Functions\When( 'rocket_direct_filesystem' )->justReturn( $this->filesystem );
+		Functions\when( 'rocket_direct_filesystem' )->justReturn( $this->filesystem );
 	}
 
 	private function getActualHtml() {
@@ -45,21 +48,25 @@ class Test_DisplayRocketcdnStatus extends FilesystemTestCase {
 		return $this->format_the_html( ob_get_clean() );
 	}
 
-	/**
-	 * Test should output HTML for an inactive subscription
-	 */
+	public function testShouldDisplayNothingWhenNotLiveSite() {
+		Functions\when( 'rocket_is_live_site' )->justReturn( false );
+
+		$this->assertNull( $this->page->display_rocketcdn_status() );
+	}
+
 	public function testShouldOutputNoSubscriptionWhenInactive() {
 		Functions\when( 'rocket_is_live_site' )->justReturn( true );
-		$this->api_client->method( 'get_subscription_data' )
-		                 ->willReturn(
-			                 [
-				                 'is_active'                     => false,
-				                 'subscription_status'           => 'cancelled',
-				                 'subscription_next_date_update' => '2020-01-01',
-			                 ]
-		                 );
 		Functions\expect( 'get_option' )->never();
 		Functions\expect( 'date_i18n' )->never();
+
+		$this->api_client->method( 'get_subscription_data' )
+			->willReturn(
+				[
+					'is_active'           => false,
+					'subscription_status' => 'cancelled',
+					'subscription_next_date_update' => '2020-01-01',
+				]
+			);
 
 		$expected = <<<HTML
 <div class="wpr-optionHeader">
@@ -83,16 +90,17 @@ HTML;
 
 	public function testShouldOutputSubscriptionDataWhenActive() {
 		Functions\when( 'rocket_is_live_site' )->justReturn( true );
-		$this->api_client->method( 'get_subscription_data' )
-		                 ->willReturn(
-			                 [
-				                 'is_active'                     => true,
-				                 'subscription_status'           => 'running',
-				                 'subscription_next_date_update' => '2020-01-01',
-			                 ]
-		                 );
 		Functions\when( 'get_option' )->justReturn( 'Y-m-d' );
 		Functions\when( 'date_i18n' )->justReturn( '2020-01-01' );
+
+		$this->api_client->method( 'get_subscription_data' )
+			->willReturn(
+					[
+						'is_active'           => true,
+						'subscription_status' => 'running',
+						'subscription_next_date_update' => '2020-01-01',
+					]
+				);
 
 		$expected = <<<HTML
 <div class="wpr-optionHeader">

--- a/tests/Unit/Subscriber/CDN/RocketCDN/AdminPageSubscriber/displayRocketcdnStatus.php
+++ b/tests/Unit/Subscriber/CDN/RocketCDN/AdminPageSubscriber/displayRocketcdnStatus.php
@@ -51,7 +51,25 @@ class Test_DisplayRocketcdnStatus extends FilesystemTestCase {
 	public function testShouldDisplayNothingWhenNotLiveSite() {
 		Functions\when( 'rocket_is_live_site' )->justReturn( false );
 
-		$this->assertNull( $this->page->display_rocketcdn_status() );
+		$this->api_client->method( 'get_subscription_data' )
+			->willReturn(
+				[
+					'is_active'           => false,
+					'subscription_status' => 'cancelled',
+					'subscription_next_date_update' => '2020-01-01',
+				]
+		);
+
+		$expected = <<<HTML
+<div class="wpr-optionHeader">
+	<h3 class="wpr-title2">RocketCDN</h3>
+</div>
+<div class="wpr-field wpr-field-account">
+	<span class="wpr-infoAccount wpr-isInvalid">RocketCDN is unavailable on local domains and staging sites.</span>
+</div>
+HTML;
+
+		$this->assertSame( $this->format_the_html( $expected ), $this->getActualHtml() );
 	}
 
 	public function testShouldOutputNoSubscriptionWhenInactive() {
@@ -66,7 +84,7 @@ class Test_DisplayRocketcdnStatus extends FilesystemTestCase {
 					'subscription_status' => 'cancelled',
 					'subscription_next_date_update' => '2020-01-01',
 				]
-			);
+		);
 
 		$expected = <<<HTML
 <div class="wpr-optionHeader">

--- a/tests/Unit/Subscriber/CDN/RocketCDN/NoticesSubscriber/addDismissScript.php
+++ b/tests/Unit/Subscriber/CDN/RocketCDN/NoticesSubscriber/addDismissScript.php
@@ -22,6 +22,7 @@ class Test_AddDismissScript extends TestCase {
 	 * Test should not add script when user doesn't have the capability to use it
 	 */
 	public function testShouldNotAddScriptWhenNoCapability() {
+		Functions\when( 'rocket_is_live_site' )->justReturn( true );
 		Functions\when('current_user_can')->justReturn(false);
 
 		$page = new NoticesSubscriber( $this->api_client, 'views/settings/rocketcdn');
@@ -33,6 +34,7 @@ class Test_AddDismissScript extends TestCase {
 	 * Test should not add script when not on WP Rocket settings page
 	 */
 	public function testShouldNotAddScriptWhenNotRocketPage() {
+		Functions\when( 'rocket_is_live_site' )->justReturn( true );
 		Functions\when('current_user_can')->justReturn(true);
 		Functions\when('get_current_screen')->alias(function() {
 			return (object) [ 'id' => 'general' ];
@@ -47,6 +49,7 @@ class Test_AddDismissScript extends TestCase {
 	 * Test should not add script when the notice has been dismissed
 	 */
 	public function testShouldNotAddScriptWhenDismissed() {
+		Functions\when( 'rocket_is_live_site' )->justReturn( true );
 		Functions\when('current_user_can')->justReturn(true);
 		Functions\when('get_current_screen')->alias(function() {
 			return (object) [ 'id' => 'settings_page_wprocket' ];
@@ -63,6 +66,7 @@ class Test_AddDismissScript extends TestCase {
 	 * Test should not add script when RocketCDN is active
 	 */
 	public function testShouldNotAddScriptWhenActive() {
+		Functions\when( 'rocket_is_live_site' )->justReturn( true );
 		Functions\when('current_user_can')->justReturn(true);
 		Functions\when('get_current_screen')->alias(function() {
 			return (object) [ 'id' => 'settings_page_wprocket' ];
@@ -82,6 +86,7 @@ class Test_AddDismissScript extends TestCase {
 	 * Test should add script when RocketCDN is inactive
 	 */
 	public function testShouldAddScriptWhenNotActive() {
+		Functions\when( 'rocket_is_live_site' )->justReturn( true );
 		$this->mockCommonWpFunctions();
 
 		Functions\when('current_user_can')->justReturn(true);

--- a/tests/Unit/Subscriber/CDN/RocketCDN/NoticesSubscriber/addDismissScript.php
+++ b/tests/Unit/Subscriber/CDN/RocketCDN/NoticesSubscriber/addDismissScript.php
@@ -42,7 +42,7 @@ class Test_AddDismissScript extends TestCase {
 			function() {
 				return (object) [ 'id' => 'general' ];
 			}
-			);
+		);
 
 		$this->assertNull( $this->notices->add_dismiss_script() );
 	}
@@ -54,7 +54,7 @@ class Test_AddDismissScript extends TestCase {
 			function() {
 				return (object) [ 'id' => 'settings_page_wprocket' ];
 			}
-			);
+		);
 		Functions\when( 'get_current_user_id' )->justReturn( 1 );
 		Functions\when( 'get_user_meta' )->justReturn( true );
 
@@ -68,7 +68,7 @@ class Test_AddDismissScript extends TestCase {
 			function() {
 				return (object) [ 'id' => 'settings_page_wprocket' ];
 			}
-			);
+		);
 		Functions\when( 'get_current_user_id' )->justReturn( 1 );
 		Functions\when( 'get_user_meta' )->justReturn( false );
 
@@ -86,21 +86,20 @@ class Test_AddDismissScript extends TestCase {
 			function() {
 				return (object) [ 'id' => 'settings_page_wprocket' ];
 			}
-			);
+		);
 		Functions\when( 'get_current_user_id' )->justReturn( 1 );
 		Functions\when( 'get_user_meta' )->justReturn( false );
+		Functions\when( 'wp_create_nonce' )->justReturn( '123456' );
+		Functions\when( 'admin_url' )->justReturn( 'https://example.org/wp-admin/admin-ajax.php' );
 
 		$this->api_client->method( 'get_subscription_data' )
 			->willReturn( [ 'subscription_status' => 'cancelled' ] );
-
-		Functions\when( 'wp_create_nonce' )->justReturn( '123456' );
-		Functions\when( 'admin_url' )->justReturn( 'https://example.org/wp-admin/admin-ajax.php' );
 
 		$this->setOutputCallback(
 			function( $output ) {
 				return trim( $output );
 			}
-			);
+		);
 		$this->expectOutputString(
 			"<script>
 		window.addEventListener( 'load', function() {

--- a/tests/Unit/Subscriber/CDN/RocketCDN/NoticesSubscriber/displayRocketcdnCta.php
+++ b/tests/Unit/Subscriber/CDN/RocketCDN/NoticesSubscriber/displayRocketcdnCta.php
@@ -1,211 +1,198 @@
 <?php
 namespace WP_Rocket\Tests\Unit\Subscriber\CDN\RocketCDN;
 
-use WPMedia\PHPUnit\Unit\TestCase;
-use WP_Rocket\Subscriber\CDN\RocketCDN\NoticesSubscriber;
 use Brain\Monkey\Functions;
+use WP_Rocket\CDN\RocketCDN\APIClient;
+use WP_Rocket\Subscriber\CDN\RocketCDN\NoticesSubscriber;
+use WP_Rocket\Tests\Unit\FilesystemTestCase;
 
 /**
  * @covers \WP_Rocket\Subscriber\CDN\RocketCDN\NoticesSubscriber::display_rocketcdn_cta
  * @group RocketCDN
  */
-class Test_DisplayRocketcdnCta extends TestCase {
+class Test_DisplayRocketcdnCta extends FilesystemTestCase {
+	protected static $mockCommonWpFunctionsInSetUp = true;
 	private $api_client;
-	private $filesystem;
+	private $notices;
+	protected $rootVirtualDir = 'wp-rocket';
+	protected $structure      = [
+		'views' => [
+			'settings' => [
+				'rocketcdn' => [
+					'cta-big.php'   => '',
+					'cta-small.php' => '',
+				],
+			],
+		],
+	];
 
 	public function setUp() {
 		parent::setUp();
 
-		$this->api_client = $this->createMock( 'WP_Rocket\CDN\RocketCDN\APIClient' );
-		$this->filesystem = $this->getMockBuilder( 'WP_Filesystem_Direct' )
-							->setMethods( [
-								'is_readable',
-							])
-							->getMock();
-		$this->filesystem->method('is_readable')->will($this->returnCallback('is_readable'));
-    }
+		$this->api_client = $this->createMock( APIClient::class );
+		$this->notices    = new NoticesSubscriber( $this->api_client, 'views/settings/rocketcdn' );
 
-	/**
-	 * Test should return null when RocketCDN is active
-	 */
+		Functions\when( 'rocket_direct_filesystem' )->justReturn( $this->filesystem );
+	}
+
+	public function testShouldDisplayNothingWhenNotLiveSite() {
+		Functions\when( 'rocket_is_live_site' )->justReturn( false );
+
+		$this->assertNull( $this->notices->display_rocketcdn_cta() );
+	}
+
 	public function testShouldReturnNullWhenActive() {
 		Functions\when( 'rocket_is_live_site' )->justReturn( true );
-		$this->api_client->method('get_subscription_data')
+
+		$this->api_client->method( 'get_subscription_data' )
 			->willReturn(
 			[
 				'subscription_status' => 'running',
 			]
 		);
 
-		$page = new NoticesSubscriber( $this->api_client, 'views/settings/rocketcdn');
-		$this->assertNull($page->display_rocketcdn_cta());
+		$this->assertNull( $this->notices->display_rocketcdn_cta() );
 	}
 
-	/**
-	 * test should display the big CTA without promo
-	 */
 	public function testShouldDisplayBigCTANoPromoWhenDefault() {
 		Functions\when( 'rocket_is_live_site' )->justReturn( true );
-		$this->mockCommonWpFunctions();
+		Functions\when( 'get_option' )->justReturn( 'Y-m-d' );
+		Functions\when( 'date_i18n' )->justReturn( '2020-01-01' );
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_user_meta' )->justReturn( false );
+		Functions\when( 'number_format_i18n' )->returnArg();
 
-		$this->api_client->method('get_subscription_data')
+		$this->api_client->method( 'get_subscription_data' )
 			->willReturn(
 			[
 				'subscription_status' => 'cancelled',
 			]
 		);
 
-		$this->api_client->method('get_pricing_data')
+		$this->api_client->method( 'get_pricing_data' )
 			->willReturn(
 				[
-					'monthly_price' => 7.99,
-					'is_discount_active' => false,
-					'discount_campaign_name' => '',
-					'end_date' => 0,
+					'monthly_price'            => 7.99,
+					'is_discount_active'       => false,
+					'discount_campaign_name'   => '',
+					'end_date'                 => 0,
 					'discounted_price_monthly' => 6.9,
 				]
 		);
 
-		Functions\when('get_option')->justReturn('Y-m-d');
-		Functions\when('date_i18n')->justReturn('2020-01-01');
-		Functions\when('get_current_user_id')->justReturn(1);
-		Functions\when('get_user_meta')->justReturn(false);
-		Functions\When( 'rocket_direct_filesystem')->alias( function() {
-			return $this->filesystem;
-		});
-		Functions\when('number_format_i18n')->returnArg();
-
-		$page = new NoticesSubscriber( $this->api_client, 'views/settings/rocketcdn');
-
-		$this->setOutputCallback(function($output) {
-			return preg_replace("/\r|\n|\t/", '', $output);
-		});
-		$this->expectOutputString('<div class="wpr-rocketcdn-cta-small notice-alt notice-warning wpr-isHidden" id="wpr-rocketcdn-cta-small"><div class="wpr-flex"><section><h3 class="notice-title">Speed up your website with RocketCDN, WP Rocket’s Content Delivery Network.</strong></h3></section><div><button class="wpr-button" id="wpr-rocketcdn-open-cta">Learn More</button></div></div></div><div class="wpr-rocketcdn-cta " id="wpr-rocketcdn-cta"><section class="wpr-rocketcdn-cta-content--no-promo"><h3 class="wpr-title2">RocketCDN</h3><p class="wpr-rocketcdn-cta-subtitle">Speed up your website thanks to:</p><div class="wpr-flex"><ul class="wpr-rocketcdn-features"><li class="wpr-rocketcdn-feature wpr-rocketcdn-bandwidth">High performance Content Delivery Network (CDN) with <strong>unlimited bandwith</strong></li><li class="wpr-rocketcdn-feature wpr-rocketcdn-configuration">Easy configuration: the <strong>best CDN settings</strong> are automatically applied</li><li class="wpr-rocketcdn-feature wpr-rocketcdn-automatic">WP Rocket integration: the CDN option is <strong>automatically configured</strong> in our plugin</li></ul><div class="wpr-rocketcdn-pricing"><h4 class="wpr-rocketcdn-pricing-current"><span class="wpr-title1">$7.99</span> / month</h4><button class="wpr-button wpr-rocketcdn-open" data-micromodal-trigger="wpr-rocketcdn-modal">Get Started</button></div></div></section><div class="wpr-rocketcdn-cta-footer"><a href="https://go.wp-rocket.me/rocket-cdn" target="_blank" rel="noopener noreferrer">Learn more about RocketCDN</a></div><button class="wpr-rocketcdn-cta-close--no-promo" id="wpr-rocketcdn-close-cta"><span class="screen-reader-text">Reduce this banner</span></button></div>',
-			$page->display_rocketcdn_cta()
+		$this->setOutputCallback(
+				function( $output ) {
+					return preg_replace( "/\r|\n|\t/", '', $output );
+				}
+			);
+		$this->expectOutputString(
+			'<div class="wpr-rocketcdn-cta-small notice-alt notice-warning wpr-isHidden" id="wpr-rocketcdn-cta-small"><div class="wpr-flex"><section><h3 class="notice-title">Speed up your website with RocketCDN, WP Rocket’s Content Delivery Network.</strong></h3></section><div><button class="wpr-button" id="wpr-rocketcdn-open-cta">Learn More</button></div></div></div><div class="wpr-rocketcdn-cta " id="wpr-rocketcdn-cta"><section class="wpr-rocketcdn-cta-content--no-promo"><h3 class="wpr-title2">RocketCDN</h3><p class="wpr-rocketcdn-cta-subtitle">Speed up your website thanks to:</p><div class="wpr-flex"><ul class="wpr-rocketcdn-features"><li class="wpr-rocketcdn-feature wpr-rocketcdn-bandwidth">High performance Content Delivery Network (CDN) with <strong>unlimited bandwith</strong></li><li class="wpr-rocketcdn-feature wpr-rocketcdn-configuration">Easy configuration: the <strong>best CDN settings</strong> are automatically applied</li><li class="wpr-rocketcdn-feature wpr-rocketcdn-automatic">WP Rocket integration: the CDN option is <strong>automatically configured</strong> in our plugin</li></ul><div class="wpr-rocketcdn-pricing"><h4 class="wpr-rocketcdn-pricing-current"><span class="wpr-title1">$7.99</span> / month</h4><button class="wpr-button wpr-rocketcdn-open" data-micromodal-trigger="wpr-rocketcdn-modal">Get Started</button></div></div></section><div class="wpr-rocketcdn-cta-footer"><a href="https://go.wp-rocket.me/rocket-cdn" target="_blank" rel="noopener noreferrer">Learn more about RocketCDN</a></div><button class="wpr-rocketcdn-cta-close--no-promo" id="wpr-rocketcdn-close-cta"><span class="screen-reader-text">Reduce this banner</span></button></div>',
+			$this->notices->display_rocketcdn_cta()
 		);
 	}
 
-	/**
-	 * Test should display the small CTA when the big one is hidden
-	 */
 	public function testShouldDisplaySmallCTAWhenBigHidden() {
 		Functions\when( 'rocket_is_live_site' )->justReturn( true );
-		$this->mockCommonWpFunctions();
+		Functions\when( 'get_option' )->justReturn( 'Y-m-d' );
+		Functions\when( 'date_i18n' )->justReturn( '2020-01-01' );
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_user_meta' )->justReturn( true );
+		Functions\when( 'number_format_i18n' )->returnArg();
 
-		$this->api_client->method('get_subscription_data')
+		$this->api_client->method( 'get_subscription_data' )
 			->willReturn(
 			[
 				'subscription_status' => 'cancelled',
 			]
 		);
 
-		$this->api_client->method('get_pricing_data')
+		$this->api_client->method( 'get_pricing_data' )
 			->willReturn(
 				[
-					'monthly_price' => 7.99,
-					'is_discount_active' => false,
-					'discount_campaign_name' => '',
-					'end_date' => 0,
+					'monthly_price'            => 7.99,
+					'is_discount_active'       => false,
+					'discount_campaign_name'   => '',
+					'end_date'                 => 0,
 					'discounted_price_monthly' => 6.9,
 				]
 		);
 
-		Functions\when('get_option')->justReturn('Y-m-d');
-		Functions\when('date_i18n')->justReturn('2020-01-01');
-		Functions\when('get_current_user_id')->justReturn(1);
-		Functions\when('get_user_meta')->justReturn(true);
-		Functions\When( 'rocket_direct_filesystem')->alias( function() {
-			return $this->filesystem;
-		});
-		Functions\when('number_format_i18n')->returnArg();
-
-		$page = new NoticesSubscriber( $this->api_client, 'views/settings/rocketcdn');
-
-		$this->setOutputCallback(function($output) {
-			return preg_replace("/\r|\n|\t/", '', $output);
-		});
-		$this->expectOutputString('<div class="wpr-rocketcdn-cta-small notice-alt notice-warning " id="wpr-rocketcdn-cta-small"><div class="wpr-flex"><section><h3 class="notice-title">Speed up your website with RocketCDN, WP Rocket’s Content Delivery Network.</strong></h3></section><div><button class="wpr-button" id="wpr-rocketcdn-open-cta">Learn More</button></div></div></div><div class="wpr-rocketcdn-cta wpr-isHidden" id="wpr-rocketcdn-cta"><section class="wpr-rocketcdn-cta-content--no-promo"><h3 class="wpr-title2">RocketCDN</h3><p class="wpr-rocketcdn-cta-subtitle">Speed up your website thanks to:</p><div class="wpr-flex"><ul class="wpr-rocketcdn-features"><li class="wpr-rocketcdn-feature wpr-rocketcdn-bandwidth">High performance Content Delivery Network (CDN) with <strong>unlimited bandwith</strong></li><li class="wpr-rocketcdn-feature wpr-rocketcdn-configuration">Easy configuration: the <strong>best CDN settings</strong> are automatically applied</li><li class="wpr-rocketcdn-feature wpr-rocketcdn-automatic">WP Rocket integration: the CDN option is <strong>automatically configured</strong> in our plugin</li></ul><div class="wpr-rocketcdn-pricing"><h4 class="wpr-rocketcdn-pricing-current"><span class="wpr-title1">$7.99</span> / month</h4><button class="wpr-button wpr-rocketcdn-open" data-micromodal-trigger="wpr-rocketcdn-modal">Get Started</button></div></div></section><div class="wpr-rocketcdn-cta-footer"><a href="https://go.wp-rocket.me/rocket-cdn" target="_blank" rel="noopener noreferrer">Learn more about RocketCDN</a></div><button class="wpr-rocketcdn-cta-close--no-promo" id="wpr-rocketcdn-close-cta"><span class="screen-reader-text">Reduce this banner</span></button></div>',
-			$page->display_rocketcdn_cta()
+		$this->setOutputCallback(
+			function( $output ) {
+				return preg_replace( "/\r|\n|\t/", '', $output );
+			}
+			);
+		$this->expectOutputString(
+			'<div class="wpr-rocketcdn-cta-small notice-alt notice-warning " id="wpr-rocketcdn-cta-small"><div class="wpr-flex"><section><h3 class="notice-title">Speed up your website with RocketCDN, WP Rocket’s Content Delivery Network.</strong></h3></section><div><button class="wpr-button" id="wpr-rocketcdn-open-cta">Learn More</button></div></div></div><div class="wpr-rocketcdn-cta wpr-isHidden" id="wpr-rocketcdn-cta"><section class="wpr-rocketcdn-cta-content--no-promo"><h3 class="wpr-title2">RocketCDN</h3><p class="wpr-rocketcdn-cta-subtitle">Speed up your website thanks to:</p><div class="wpr-flex"><ul class="wpr-rocketcdn-features"><li class="wpr-rocketcdn-feature wpr-rocketcdn-bandwidth">High performance Content Delivery Network (CDN) with <strong>unlimited bandwith</strong></li><li class="wpr-rocketcdn-feature wpr-rocketcdn-configuration">Easy configuration: the <strong>best CDN settings</strong> are automatically applied</li><li class="wpr-rocketcdn-feature wpr-rocketcdn-automatic">WP Rocket integration: the CDN option is <strong>automatically configured</strong> in our plugin</li></ul><div class="wpr-rocketcdn-pricing"><h4 class="wpr-rocketcdn-pricing-current"><span class="wpr-title1">$7.99</span> / month</h4><button class="wpr-button wpr-rocketcdn-open" data-micromodal-trigger="wpr-rocketcdn-modal">Get Started</button></div></div></section><div class="wpr-rocketcdn-cta-footer"><a href="https://go.wp-rocket.me/rocket-cdn" target="_blank" rel="noopener noreferrer">Learn more about RocketCDN</a></div><button class="wpr-rocketcdn-cta-close--no-promo" id="wpr-rocketcdn-close-cta"><span class="screen-reader-text">Reduce this banner</span></button></div>',
+			$this->notices->display_rocketcdn_cta()
 		);
 	}
 
-	/**
-	 * Test should display the big CTA with the promo when active
-	 */
 	public function testShouldDisplayBigCTAPromoWhenPromoActive() {
 		Functions\when( 'rocket_is_live_site' )->justReturn( true );
-		$this->mockCommonWpFunctions();
+		Functions\when( 'get_option' )->justReturn( 'Y-m-d' );
+		Functions\when( 'date_i18n' )->justReturn( '2020-01-01' );
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_user_meta' )->justReturn( false );
+		Functions\when( 'number_format_i18n' )->returnArg();
 
-		$this->api_client->method('get_subscription_data')
+		$this->api_client->method( 'get_subscription_data' )
 			->willReturn(
 			[
 				'subscription_status' => 'cancelled',
 			]
 		);
 
-		$this->api_client->method('get_pricing_data')
+		$this->api_client->method( 'get_pricing_data' )
 			->willReturn(
 				[
-					'monthly_price' => 7.99,
-					'is_discount_active' => true,
-					'discount_campaign_name' => 'Launch',
-					'end_date' => '2020-01-01',
+					'monthly_price'            => 7.99,
+					'is_discount_active'       => true,
+					'discount_campaign_name'   => 'Launch',
+					'end_date'                 => '2020-01-01',
 					'discounted_price_monthly' => 6.90,
 				]
 		);
 
-		Functions\when('get_option')->justReturn('Y-m-d');
-		Functions\when('date_i18n')->justReturn('2020-01-01');
-		Functions\when('get_current_user_id')->justReturn(1);
-		Functions\when('get_user_meta')->justReturn(false);
-		Functions\When( 'rocket_direct_filesystem')->alias( function() {
-			return $this->filesystem;
-		});
-		Functions\when('number_format_i18n')->returnArg();
-
-		$page = new NoticesSubscriber( $this->api_client, 'views/settings/rocketcdn');
-
-		$this->setOutputCallback(function($output) {
-			return preg_replace("/\r|\n|\t/", '', $output);
-		});
-		$this->expectOutputString('<div class="wpr-rocketcdn-cta-small notice-alt notice-warning wpr-isHidden" id="wpr-rocketcdn-cta-small"><div class="wpr-flex"><section><h3 class="notice-title">Speed up your website with RocketCDN, WP Rocket’s Content Delivery Network.</strong></h3></section><div><button class="wpr-button" id="wpr-rocketcdn-open-cta">Learn More</button></div></div></div><div class="wpr-rocketcdn-cta " id="wpr-rocketcdn-cta"><div class="wpr-flex wpr-rocketcdn-promo"><h3 class="wpr-title1">Launch</h3><p class="wpr-title2 wpr-rocketcdn-promo-date">Valid until 2020-01-01 only!</p></div><section class="wpr-rocketcdn-cta-content"><h3 class="wpr-title2">RocketCDN</h3><p class="wpr-rocketcdn-cta-subtitle">Speed up your website thanks to:</p><div class="wpr-flex"><ul class="wpr-rocketcdn-features"><li class="wpr-rocketcdn-feature wpr-rocketcdn-bandwidth">High performance Content Delivery Network (CDN) with <strong>unlimited bandwith</strong></li><li class="wpr-rocketcdn-feature wpr-rocketcdn-configuration">Easy configuration: the <strong>best CDN settings</strong> are automatically applied</li><li class="wpr-rocketcdn-feature wpr-rocketcdn-automatic">WP Rocket integration: the CDN option is <strong>automatically configured</strong> in our plugin</li></ul><div class="wpr-rocketcdn-pricing"><h4 class="wpr-title2 wpr-rocketcdn-pricing-regular"><del>$7.99</del></h4><h4 class="wpr-rocketcdn-pricing-current"><span class="wpr-title1">$6.9*</span> / month</h4><button class="wpr-button wpr-rocketcdn-open" data-micromodal-trigger="wpr-rocketcdn-modal">Get Started</button></div></div></section><div class="wpr-rocketcdn-cta-footer"><a href="https://go.wp-rocket.me/rocket-cdn" target="_blank" rel="noopener noreferrer">Learn more about RocketCDN</a></div><button class="wpr-rocketcdn-cta-close" id="wpr-rocketcdn-close-cta"><span class="screen-reader-text">Reduce this banner</span></button><p>* $6.9/month for 12 months then $7.99/month. You can cancel your subscription at any time.</p></div>',
-			$page->display_rocketcdn_cta()
+		$this->setOutputCallback(
+				function( $output ) {
+					return preg_replace( "/\r|\n|\t/", '', $output );
+				}
+			);
+		$this->expectOutputString(
+			'<div class="wpr-rocketcdn-cta-small notice-alt notice-warning wpr-isHidden" id="wpr-rocketcdn-cta-small"><div class="wpr-flex"><section><h3 class="notice-title">Speed up your website with RocketCDN, WP Rocket’s Content Delivery Network.</strong></h3></section><div><button class="wpr-button" id="wpr-rocketcdn-open-cta">Learn More</button></div></div></div><div class="wpr-rocketcdn-cta " id="wpr-rocketcdn-cta"><div class="wpr-flex wpr-rocketcdn-promo"><h3 class="wpr-title1">Launch</h3><p class="wpr-title2 wpr-rocketcdn-promo-date">Valid until 2020-01-01 only!</p></div><section class="wpr-rocketcdn-cta-content"><h3 class="wpr-title2">RocketCDN</h3><p class="wpr-rocketcdn-cta-subtitle">Speed up your website thanks to:</p><div class="wpr-flex"><ul class="wpr-rocketcdn-features"><li class="wpr-rocketcdn-feature wpr-rocketcdn-bandwidth">High performance Content Delivery Network (CDN) with <strong>unlimited bandwith</strong></li><li class="wpr-rocketcdn-feature wpr-rocketcdn-configuration">Easy configuration: the <strong>best CDN settings</strong> are automatically applied</li><li class="wpr-rocketcdn-feature wpr-rocketcdn-automatic">WP Rocket integration: the CDN option is <strong>automatically configured</strong> in our plugin</li></ul><div class="wpr-rocketcdn-pricing"><h4 class="wpr-title2 wpr-rocketcdn-pricing-regular"><del>$7.99</del></h4><h4 class="wpr-rocketcdn-pricing-current"><span class="wpr-title1">$6.9*</span> / month</h4><button class="wpr-button wpr-rocketcdn-open" data-micromodal-trigger="wpr-rocketcdn-modal">Get Started</button></div></div></section><div class="wpr-rocketcdn-cta-footer"><a href="https://go.wp-rocket.me/rocket-cdn" target="_blank" rel="noopener noreferrer">Learn more about RocketCDN</a></div><button class="wpr-rocketcdn-cta-close" id="wpr-rocketcdn-close-cta"><span class="screen-reader-text">Reduce this banner</span></button><p>* $6.9/month for 12 months then $7.99/month. You can cancel your subscription at any time.</p></div>',
+			$this->notices->display_rocketcdn_cta()
 		);
 	}
 
-	/**
-	 * Test should have an error message instead of pricing when the pricing API is not available
-	 */
 	public function testShouldDisplayErrorMessageWhenPricingAPINotAvailable() {
 		Functions\when( 'rocket_is_live_site' )->justReturn( true );
-		$this->mockCommonWpFunctions();
+		Functions\when( 'is_wp_error' )->justReturn( true );
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_user_meta' )->justReturn( false );
 
-		$this->api_client->method('get_subscription_data')
+		$this->api_client->method( 'get_subscription_data' )
 			->willReturn(
 			[
 				'subscription_status' => 'cancelled',
 			]
 		);
 
-		$wp_error   = \Mockery::mock( \WP_Error::class );
-		$wp_error->shouldReceive('get_error_message')->andReturn( 'RocketCDN is not available at the moment. Please retry later' );
+		$wp_error = \Mockery::mock( \WP_Error::class );
+		$wp_error->shouldReceive( 'get_error_message' )
+			->andReturn( 'RocketCDN is not available at the moment. Please retry later' );
 
-		$this->api_client->method('get_pricing_data')
+		$this->api_client->method( 'get_pricing_data' )
 			->willReturn( $wp_error );
 
-		Functions\when('is_wp_error')->justReturn(true);
-		Functions\when('get_current_user_id')->justReturn(1);
-		Functions\when('get_user_meta')->justReturn(false);
-		Functions\When( 'rocket_direct_filesystem')->alias( function() {
-			return $this->filesystem;
-		});
-
-		$page = new NoticesSubscriber( $this->api_client, 'views/settings/rocketcdn');
-		$this->setOutputCallback(function($output) {
-			return preg_replace("/\r|\n|\t/", '', $output);
-		});
-		$this->expectOutputString('<div class="wpr-rocketcdn-cta-small notice-alt notice-warning wpr-isHidden" id="wpr-rocketcdn-cta-small"><div class="wpr-flex"><section><h3 class="notice-title">Speed up your website with RocketCDN, WP Rocket’s Content Delivery Network.</strong></h3></section><div><button class="wpr-button" id="wpr-rocketcdn-open-cta">Learn More</button></div></div></div><div class="wpr-rocketcdn-cta " id="wpr-rocketcdn-cta"><section class="wpr-rocketcdn-cta-content--no-promo"><h3 class="wpr-title2">RocketCDN</h3><p class="wpr-rocketcdn-cta-subtitle">Speed up your website thanks to:</p><div class="wpr-flex"><ul class="wpr-rocketcdn-features"><li class="wpr-rocketcdn-feature wpr-rocketcdn-bandwidth">High performance Content Delivery Network (CDN) with <strong>unlimited bandwith</strong></li><li class="wpr-rocketcdn-feature wpr-rocketcdn-configuration">Easy configuration: the <strong>best CDN settings</strong> are automatically applied</li><li class="wpr-rocketcdn-feature wpr-rocketcdn-automatic">WP Rocket integration: the CDN option is <strong>automatically configured</strong> in our plugin</li></ul><div class="wpr-rocketcdn-pricing"><p>RocketCDN is not available at the moment. Please retry later</p></div></div></section><div class="wpr-rocketcdn-cta-footer"><a href="https://go.wp-rocket.me/rocket-cdn" target="_blank" rel="noopener noreferrer">Learn more about RocketCDN</a></div><button class="wpr-rocketcdn-cta-close--no-promo" id="wpr-rocketcdn-close-cta"><span class="screen-reader-text">Reduce this banner</span></button></div>',
-			$page->display_rocketcdn_cta()
+		$this->setOutputCallback(
+				function( $output ) {
+					return preg_replace( "/\r|\n|\t/", '', $output );
+				}
+			);
+		$this->expectOutputString(
+			'<div class="wpr-rocketcdn-cta-small notice-alt notice-warning wpr-isHidden" id="wpr-rocketcdn-cta-small"><div class="wpr-flex"><section><h3 class="notice-title">Speed up your website with RocketCDN, WP Rocket’s Content Delivery Network.</strong></h3></section><div><button class="wpr-button" id="wpr-rocketcdn-open-cta">Learn More</button></div></div></div><div class="wpr-rocketcdn-cta " id="wpr-rocketcdn-cta"><section class="wpr-rocketcdn-cta-content--no-promo"><h3 class="wpr-title2">RocketCDN</h3><p class="wpr-rocketcdn-cta-subtitle">Speed up your website thanks to:</p><div class="wpr-flex"><ul class="wpr-rocketcdn-features"><li class="wpr-rocketcdn-feature wpr-rocketcdn-bandwidth">High performance Content Delivery Network (CDN) with <strong>unlimited bandwith</strong></li><li class="wpr-rocketcdn-feature wpr-rocketcdn-configuration">Easy configuration: the <strong>best CDN settings</strong> are automatically applied</li><li class="wpr-rocketcdn-feature wpr-rocketcdn-automatic">WP Rocket integration: the CDN option is <strong>automatically configured</strong> in our plugin</li></ul><div class="wpr-rocketcdn-pricing"><p>RocketCDN is not available at the moment. Please retry later</p></div></div></section><div class="wpr-rocketcdn-cta-footer"><a href="https://go.wp-rocket.me/rocket-cdn" target="_blank" rel="noopener noreferrer">Learn more about RocketCDN</a></div><button class="wpr-rocketcdn-cta-close--no-promo" id="wpr-rocketcdn-close-cta"><span class="screen-reader-text">Reduce this banner</span></button></div>',
+			$this->notices->display_rocketcdn_cta()
 		);
 	}
 }

--- a/tests/Unit/Subscriber/CDN/RocketCDN/NoticesSubscriber/displayRocketcdnCta.php
+++ b/tests/Unit/Subscriber/CDN/RocketCDN/NoticesSubscriber/displayRocketcdnCta.php
@@ -81,10 +81,10 @@ class Test_DisplayRocketcdnCta extends FilesystemTestCase {
 		);
 
 		$this->setOutputCallback(
-				function( $output ) {
-					return preg_replace( "/\r|\n|\t/", '', $output );
-				}
-			);
+			function( $output ) {
+				return preg_replace( "/\r|\n|\t/", '', $output );
+			}
+		);
 		$this->expectOutputString(
 			'<div class="wpr-rocketcdn-cta-small notice-alt notice-warning wpr-isHidden" id="wpr-rocketcdn-cta-small"><div class="wpr-flex"><section><h3 class="notice-title">Speed up your website with RocketCDN, WP Rocket’s Content Delivery Network.</strong></h3></section><div><button class="wpr-button" id="wpr-rocketcdn-open-cta">Learn More</button></div></div></div><div class="wpr-rocketcdn-cta " id="wpr-rocketcdn-cta"><section class="wpr-rocketcdn-cta-content--no-promo"><h3 class="wpr-title2">RocketCDN</h3><p class="wpr-rocketcdn-cta-subtitle">Speed up your website thanks to:</p><div class="wpr-flex"><ul class="wpr-rocketcdn-features"><li class="wpr-rocketcdn-feature wpr-rocketcdn-bandwidth">High performance Content Delivery Network (CDN) with <strong>unlimited bandwith</strong></li><li class="wpr-rocketcdn-feature wpr-rocketcdn-configuration">Easy configuration: the <strong>best CDN settings</strong> are automatically applied</li><li class="wpr-rocketcdn-feature wpr-rocketcdn-automatic">WP Rocket integration: the CDN option is <strong>automatically configured</strong> in our plugin</li></ul><div class="wpr-rocketcdn-pricing"><h4 class="wpr-rocketcdn-pricing-current"><span class="wpr-title1">$7.99</span> / month</h4><button class="wpr-button wpr-rocketcdn-open" data-micromodal-trigger="wpr-rocketcdn-modal">Get Started</button></div></div></section><div class="wpr-rocketcdn-cta-footer"><a href="https://go.wp-rocket.me/rocket-cdn" target="_blank" rel="noopener noreferrer">Learn more about RocketCDN</a></div><button class="wpr-rocketcdn-cta-close--no-promo" id="wpr-rocketcdn-close-cta"><span class="screen-reader-text">Reduce this banner</span></button></div>',
 			$this->notices->display_rocketcdn_cta()
@@ -121,7 +121,7 @@ class Test_DisplayRocketcdnCta extends FilesystemTestCase {
 			function( $output ) {
 				return preg_replace( "/\r|\n|\t/", '', $output );
 			}
-			);
+		);
 		$this->expectOutputString(
 			'<div class="wpr-rocketcdn-cta-small notice-alt notice-warning " id="wpr-rocketcdn-cta-small"><div class="wpr-flex"><section><h3 class="notice-title">Speed up your website with RocketCDN, WP Rocket’s Content Delivery Network.</strong></h3></section><div><button class="wpr-button" id="wpr-rocketcdn-open-cta">Learn More</button></div></div></div><div class="wpr-rocketcdn-cta wpr-isHidden" id="wpr-rocketcdn-cta"><section class="wpr-rocketcdn-cta-content--no-promo"><h3 class="wpr-title2">RocketCDN</h3><p class="wpr-rocketcdn-cta-subtitle">Speed up your website thanks to:</p><div class="wpr-flex"><ul class="wpr-rocketcdn-features"><li class="wpr-rocketcdn-feature wpr-rocketcdn-bandwidth">High performance Content Delivery Network (CDN) with <strong>unlimited bandwith</strong></li><li class="wpr-rocketcdn-feature wpr-rocketcdn-configuration">Easy configuration: the <strong>best CDN settings</strong> are automatically applied</li><li class="wpr-rocketcdn-feature wpr-rocketcdn-automatic">WP Rocket integration: the CDN option is <strong>automatically configured</strong> in our plugin</li></ul><div class="wpr-rocketcdn-pricing"><h4 class="wpr-rocketcdn-pricing-current"><span class="wpr-title1">$7.99</span> / month</h4><button class="wpr-button wpr-rocketcdn-open" data-micromodal-trigger="wpr-rocketcdn-modal">Get Started</button></div></div></section><div class="wpr-rocketcdn-cta-footer"><a href="https://go.wp-rocket.me/rocket-cdn" target="_blank" rel="noopener noreferrer">Learn more about RocketCDN</a></div><button class="wpr-rocketcdn-cta-close--no-promo" id="wpr-rocketcdn-close-cta"><span class="screen-reader-text">Reduce this banner</span></button></div>',
 			$this->notices->display_rocketcdn_cta()
@@ -155,10 +155,10 @@ class Test_DisplayRocketcdnCta extends FilesystemTestCase {
 		);
 
 		$this->setOutputCallback(
-				function( $output ) {
-					return preg_replace( "/\r|\n|\t/", '', $output );
-				}
-			);
+			function( $output ) {
+				return preg_replace( "/\r|\n|\t/", '', $output );
+			}
+		);
 		$this->expectOutputString(
 			'<div class="wpr-rocketcdn-cta-small notice-alt notice-warning wpr-isHidden" id="wpr-rocketcdn-cta-small"><div class="wpr-flex"><section><h3 class="notice-title">Speed up your website with RocketCDN, WP Rocket’s Content Delivery Network.</strong></h3></section><div><button class="wpr-button" id="wpr-rocketcdn-open-cta">Learn More</button></div></div></div><div class="wpr-rocketcdn-cta " id="wpr-rocketcdn-cta"><div class="wpr-flex wpr-rocketcdn-promo"><h3 class="wpr-title1">Launch</h3><p class="wpr-title2 wpr-rocketcdn-promo-date">Valid until 2020-01-01 only!</p></div><section class="wpr-rocketcdn-cta-content"><h3 class="wpr-title2">RocketCDN</h3><p class="wpr-rocketcdn-cta-subtitle">Speed up your website thanks to:</p><div class="wpr-flex"><ul class="wpr-rocketcdn-features"><li class="wpr-rocketcdn-feature wpr-rocketcdn-bandwidth">High performance Content Delivery Network (CDN) with <strong>unlimited bandwith</strong></li><li class="wpr-rocketcdn-feature wpr-rocketcdn-configuration">Easy configuration: the <strong>best CDN settings</strong> are automatically applied</li><li class="wpr-rocketcdn-feature wpr-rocketcdn-automatic">WP Rocket integration: the CDN option is <strong>automatically configured</strong> in our plugin</li></ul><div class="wpr-rocketcdn-pricing"><h4 class="wpr-title2 wpr-rocketcdn-pricing-regular"><del>$7.99</del></h4><h4 class="wpr-rocketcdn-pricing-current"><span class="wpr-title1">$6.9*</span> / month</h4><button class="wpr-button wpr-rocketcdn-open" data-micromodal-trigger="wpr-rocketcdn-modal">Get Started</button></div></div></section><div class="wpr-rocketcdn-cta-footer"><a href="https://go.wp-rocket.me/rocket-cdn" target="_blank" rel="noopener noreferrer">Learn more about RocketCDN</a></div><button class="wpr-rocketcdn-cta-close" id="wpr-rocketcdn-close-cta"><span class="screen-reader-text">Reduce this banner</span></button><p>* $6.9/month for 12 months then $7.99/month. You can cancel your subscription at any time.</p></div>',
 			$this->notices->display_rocketcdn_cta()

--- a/tests/Unit/Subscriber/CDN/RocketCDN/NoticesSubscriber/displayRocketcdnCta.php
+++ b/tests/Unit/Subscriber/CDN/RocketCDN/NoticesSubscriber/displayRocketcdnCta.php
@@ -29,6 +29,7 @@ class Test_DisplayRocketcdnCta extends TestCase {
 	 * Test should return null when RocketCDN is active
 	 */
 	public function testShouldReturnNullWhenActive() {
+		Functions\when( 'rocket_is_live_site' )->justReturn( true );
 		$this->api_client->method('get_subscription_data')
 			->willReturn(
 			[
@@ -44,6 +45,7 @@ class Test_DisplayRocketcdnCta extends TestCase {
 	 * test should display the big CTA without promo
 	 */
 	public function testShouldDisplayBigCTANoPromoWhenDefault() {
+		Functions\when( 'rocket_is_live_site' )->justReturn( true );
 		$this->mockCommonWpFunctions();
 
 		$this->api_client->method('get_subscription_data')
@@ -87,6 +89,7 @@ class Test_DisplayRocketcdnCta extends TestCase {
 	 * Test should display the small CTA when the big one is hidden
 	 */
 	public function testShouldDisplaySmallCTAWhenBigHidden() {
+		Functions\when( 'rocket_is_live_site' )->justReturn( true );
 		$this->mockCommonWpFunctions();
 
 		$this->api_client->method('get_subscription_data')
@@ -130,6 +133,7 @@ class Test_DisplayRocketcdnCta extends TestCase {
 	 * Test should display the big CTA with the promo when active
 	 */
 	public function testShouldDisplayBigCTAPromoWhenPromoActive() {
+		Functions\when( 'rocket_is_live_site' )->justReturn( true );
 		$this->mockCommonWpFunctions();
 
 		$this->api_client->method('get_subscription_data')
@@ -173,6 +177,7 @@ class Test_DisplayRocketcdnCta extends TestCase {
 	 * Test should have an error message instead of pricing when the pricing API is not available
 	 */
 	public function testShouldDisplayErrorMessageWhenPricingAPINotAvailable() {
+		Functions\when( 'rocket_is_live_site' )->justReturn( true );
 		$this->mockCommonWpFunctions();
 
 		$this->api_client->method('get_subscription_data')

--- a/tests/Unit/Subscriber/CDN/RocketCDN/NoticesSubscriber/promoteRocketcdnNotice.php
+++ b/tests/Unit/Subscriber/CDN/RocketCDN/NoticesSubscriber/promoteRocketcdnNotice.php
@@ -29,6 +29,7 @@ class Test_PromoteRocketcdnNotice extends TestCase {
 	 * Test should return null when current user doesn't have the capability
 	 */
 	public function testShouldReturnNullWhenNoCapability() {
+		Functions\when( 'rocket_is_live_site' )->justReturn( true );
 		Functions\when('current_user_can')->justReturn(false);
 
 		$page = new NoticesSubscriber( $this->api_client, 'views/settings/rocketcdn');
@@ -40,6 +41,7 @@ class Test_PromoteRocketcdnNotice extends TestCase {
 	 * Test should return null when not on WP Rocket settings page
 	 */
 	public function testShouldReturnNullWhenNotRocketPage() {
+		Functions\when( 'rocket_is_live_site' )->justReturn( true );
 		Functions\when('current_user_can')->justReturn(true);
 		Functions\when('get_current_screen')->alias(function() {
 			return (object) [ 'id' => 'general' ];
@@ -54,6 +56,7 @@ class Test_PromoteRocketcdnNotice extends TestCase {
 	 * Test should return null when the notice was dismissed
 	 */
 	public function testShouldReturNullWhenDismissed() {
+		Functions\when( 'rocket_is_live_site' )->justReturn( true );
 		Functions\when('current_user_can')->justReturn(true);
 		Functions\when('get_current_screen')->alias(function() {
 			return (object) [ 'id' => 'settings_page_wprocket' ];
@@ -70,6 +73,7 @@ class Test_PromoteRocketcdnNotice extends TestCase {
 	 * Test should return null when RocketCDN is active
 	 */
 	public function testShouldReturnNullWhenActive() {
+		Functions\when( 'rocket_is_live_site' )->justReturn( true );
 		Functions\when('current_user_can')->justReturn(true);
 		Functions\when('get_current_screen')->alias(function() {
 			return (object) [ 'id' => 'settings_page_wprocket' ];
@@ -89,6 +93,7 @@ class Test_PromoteRocketcdnNotice extends TestCase {
 	 * Test should display the notice when RocketCDN is inactive
 	 */
 	public function testShoulDisplayNoticeWhenNotActive() {
+		Functions\when( 'rocket_is_live_site' )->justReturn( true );
 		$this->mockCommonWpFunctions();
 
 		Functions\when('current_user_can')->justReturn(true);

--- a/tests/Unit/Subscriber/CDN/RocketCDN/NoticesSubscriber/promoteRocketcdnNotice.php
+++ b/tests/Unit/Subscriber/CDN/RocketCDN/NoticesSubscriber/promoteRocketcdnNotice.php
@@ -50,10 +50,10 @@ class Test_PromoteRocketcdnNotice extends FilesystemTestCase {
 		Functions\when( 'rocket_is_live_site' )->justReturn( true );
 		Functions\when( 'current_user_can' )->justReturn( true );
 		Functions\when( 'get_current_screen' )->alias(
-				function() {
-					return (object) [ 'id' => 'general' ];
-				}
-			);
+			function() {
+				return (object) [ 'id' => 'general' ];
+			}
+		);
 
 		$this->assertNull( $this->notices->promote_rocketcdn_notice() );
 	}
@@ -62,10 +62,10 @@ class Test_PromoteRocketcdnNotice extends FilesystemTestCase {
 		Functions\when( 'rocket_is_live_site' )->justReturn( true );
 		Functions\when( 'current_user_can' )->justReturn( true );
 		Functions\when( 'get_current_screen' )->alias(
-				function() {
-					return (object) [ 'id' => 'settings_page_wprocket' ];
-				}
-			);
+			function() {
+				return (object) [ 'id' => 'settings_page_wprocket' ];
+			}
+		);
 		Functions\when( 'get_current_user_id' )->justReturn( 1 );
 		Functions\when( 'get_user_meta' )->justReturn( true );
 
@@ -79,7 +79,7 @@ class Test_PromoteRocketcdnNotice extends FilesystemTestCase {
 			function() {
 				return (object) [ 'id' => 'settings_page_wprocket' ];
 			}
-			);
+		);
 		Functions\when( 'get_current_user_id' )->justReturn( 1 );
 		Functions\when( 'get_user_meta' )->justReturn( false );
 
@@ -91,14 +91,12 @@ class Test_PromoteRocketcdnNotice extends FilesystemTestCase {
 
 	public function testShoulDisplayNoticeWhenNotActive() {
 		Functions\when( 'rocket_is_live_site' )->justReturn( true );
-		$this->mockCommonWpFunctions();
-
 		Functions\when( 'current_user_can' )->justReturn( true );
 		Functions\when( 'get_current_screen' )->alias(
 			function() {
 				return (object) [ 'id' => 'settings_page_wprocket' ];
 			}
-			);
+		);
 		Functions\when( 'get_current_user_id' )->justReturn( 1 );
 		Functions\when( 'get_user_meta' )->justReturn( false );
 

--- a/tests/Unit/Subscriber/CDN/RocketCDN/NoticesSubscriber/promoteRocketcdnNotice.php
+++ b/tests/Unit/Subscriber/CDN/RocketCDN/NoticesSubscriber/promoteRocketcdnNotice.php
@@ -1,122 +1,117 @@
 <?php
 namespace WP_Rocket\Tests\Unit\Subscriber\CDN\RocketCDN;
 
-use WPMedia\PHPUnit\Unit\TestCase;
-use WP_Rocket\Subscriber\CDN\RocketCDN\NoticesSubscriber;
 use Brain\Monkey\Functions;
+use WP_Rocket\CDN\RocketCDN\APIClient;
+use WP_Rocket\Subscriber\CDN\RocketCDN\NoticesSubscriber;
+use WP_Rocket\Tests\Unit\FilesystemTestCase;
 
 /**
  * @covers \WP_Rocket\Subscriber\CDN\RocketCDN\NoticesSubscriber::promote_rocketcdn_notice
  * @group RocketCDN
  */
-class Test_PromoteRocketcdnNotice extends TestCase {
+class Test_PromoteRocketcdnNotice extends FilesystemTestCase {
+	protected static $mockCommonWpFunctionsInSetUp = true;
 	private $api_client;
-	private $filesystem;
+	private $notices;
+	protected $structure = [
+		'views' => [
+			'settings' => [
+				'rocketcdn' => [
+					'promote-notice.php' => '',
+				],
+			],
+		],
+	];
 
 	public function setUp() {
 		parent::setUp();
 
-		$this->api_client = $this->createMock( 'WP_Rocket\CDN\RocketCDN\APIClient' );
-		$this->filesystem = $this->getMockBuilder( 'WP_Filesystem_Direct' )
-							->setMethods( [
-								'is_readable',
-							])
-							->getMock();
-		$this->filesystem->method('is_readable')->will($this->returnCallback('is_readable'));
-    }
+		$this->api_client = $this->createMock( APIClient::class );
+		$this->notices    = new NoticesSubscriber( $this->api_client, 'views/settings/rocketcdn' );
 
-	/**
-	 * Test should return null when current user doesn't have the capability
-	 */
+		Functions\when( 'rocket_direct_filesystem' )->justReturn( $this->filesystem );
+	}
+
+	public function testShouldDisplayNothingWhenNotLiveSite() {
+		Functions\when( 'rocket_is_live_site' )->justReturn( false );
+
+		$this->assertNull( $this->notices->promote_rocketcdn_notice() );
+	}
+
 	public function testShouldReturnNullWhenNoCapability() {
 		Functions\when( 'rocket_is_live_site' )->justReturn( true );
-		Functions\when('current_user_can')->justReturn(false);
+		Functions\when( 'current_user_can' )->justReturn( false );
 
-		$page = new NoticesSubscriber( $this->api_client, 'views/settings/rocketcdn');
-
-		$this->assertNull($page->promote_rocketcdn_notice());
+		$this->assertNull( $this->notices->promote_rocketcdn_notice() );
 	}
 
-	/**
-	 * Test should return null when not on WP Rocket settings page
-	 */
 	public function testShouldReturnNullWhenNotRocketPage() {
 		Functions\when( 'rocket_is_live_site' )->justReturn( true );
-		Functions\when('current_user_can')->justReturn(true);
-		Functions\when('get_current_screen')->alias(function() {
-			return (object) [ 'id' => 'general' ];
-		});
+		Functions\when( 'current_user_can' )->justReturn( true );
+		Functions\when( 'get_current_screen' )->alias(
+				function() {
+					return (object) [ 'id' => 'general' ];
+				}
+			);
 
-		$page = new NoticesSubscriber( $this->api_client, 'views/settings/rocketcdn');
-
-		$this->assertNull($page->promote_rocketcdn_notice());
+		$this->assertNull( $this->notices->promote_rocketcdn_notice() );
 	}
 
-	/**
-	 * Test should return null when the notice was dismissed
-	 */
 	public function testShouldReturNullWhenDismissed() {
 		Functions\when( 'rocket_is_live_site' )->justReturn( true );
-		Functions\when('current_user_can')->justReturn(true);
-		Functions\when('get_current_screen')->alias(function() {
-			return (object) [ 'id' => 'settings_page_wprocket' ];
-		});
-		Functions\when('get_current_user_id')->justReturn(1);
-		Functions\when('get_user_meta')->justReturn(true);
+		Functions\when( 'current_user_can' )->justReturn( true );
+		Functions\when( 'get_current_screen' )->alias(
+				function() {
+					return (object) [ 'id' => 'settings_page_wprocket' ];
+				}
+			);
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_user_meta' )->justReturn( true );
 
-		$page = new NoticesSubscriber( $this->api_client, 'views/settings/rocketcdn');
-
-		$this->assertNull($page->promote_rocketcdn_notice());
+		$this->assertNull( $this->notices->promote_rocketcdn_notice() );
 	}
 
-	/**
-	 * Test should return null when RocketCDN is active
-	 */
 	public function testShouldReturnNullWhenActive() {
 		Functions\when( 'rocket_is_live_site' )->justReturn( true );
-		Functions\when('current_user_can')->justReturn(true);
-		Functions\when('get_current_screen')->alias(function() {
-			return (object) [ 'id' => 'settings_page_wprocket' ];
-		});
-		Functions\when('get_current_user_id')->justReturn(1);
-		Functions\when('get_user_meta')->justReturn(false);
+		Functions\when( 'current_user_can' )->justReturn( true );
+		Functions\when( 'get_current_screen' )->alias(
+			function() {
+				return (object) [ 'id' => 'settings_page_wprocket' ];
+			}
+			);
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_user_meta' )->justReturn( false );
 
-		$this->api_client->method('get_subscription_data')
-			->willReturn(['subscription_status' => 'running']);
+		$this->api_client->method( 'get_subscription_data' )
+			->willReturn( [ 'subscription_status' => 'running' ] );
 
-		$page = new NoticesSubscriber( $this->api_client, 'views/settings/rocketcdn');
-
-		$this->assertNull($page->promote_rocketcdn_notice());
+		$this->assertNull( $this->notices->promote_rocketcdn_notice() );
 	}
 
-	/**
-	 * Test should display the notice when RocketCDN is inactive
-	 */
 	public function testShoulDisplayNoticeWhenNotActive() {
 		Functions\when( 'rocket_is_live_site' )->justReturn( true );
 		$this->mockCommonWpFunctions();
 
-		Functions\when('current_user_can')->justReturn(true);
-		Functions\when('get_current_screen')->alias(function() {
-			return (object) [ 'id' => 'settings_page_wprocket' ];
-		});
-		Functions\when('get_current_user_id')->justReturn(1);
-		Functions\when('get_user_meta')->justReturn(false);
+		Functions\when( 'current_user_can' )->justReturn( true );
+		Functions\when( 'get_current_screen' )->alias(
+			function() {
+				return (object) [ 'id' => 'settings_page_wprocket' ];
+			}
+			);
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_user_meta' )->justReturn( false );
 
-		$this->api_client->method('get_subscription_data')
-			->willReturn(['subscription_status' => 'cancelled']);
+		$this->api_client->method( 'get_subscription_data' )
+			->willReturn( [ 'subscription_status' => 'cancelled' ] );
 
-		Functions\When( 'rocket_direct_filesystem')->alias( function() {
-			return $this->filesystem;
-		});
-
-		$page = new NoticesSubscriber( $this->api_client, 'views/settings/rocketcdn');
-
-		$this->expectOutputString('<div class="notice notice-alt notice-warning is-dismissible" id="rocketcdn-promote-notice">
+		$this->expectOutputString(
+			'<div class="notice notice-alt notice-warning is-dismissible" id="rocketcdn-promote-notice">
 	<h2 class="notice-title">New!</h2>
 	<p>Speed up your website with RocketCDN, WP Rocket’s Content Delivery Network!</p>
 	<p><a href="#page_cdn" class="wpr-button" id="rocketcdn-learn-more-dismiss">Learn More</a></p>
-</div>');
-		$page->promote_rocketcdn_notice();
+</div>'
+			);
+		$this->notices->promote_rocketcdn_notice();
 	}
 }

--- a/views/settings/rocketcdn/dashboard-status.php
+++ b/views/settings/rocketcdn/dashboard-status.php
@@ -5,11 +5,12 @@
  * @since 3.5
  *
  * @param array $data {
- *      @type string $container_class Flex container CSS class.
- *      @type string $label Content label.
- *      @type string $status_class CSS Class to display the status.
- *      @type string $status_text Text to display the subscription status.
- *      @type bool   $is_active Boolean identifying the activation status.
+ *    @type bool   $is_live_site    Identifies if the current website is a live or local/staging one
+ *    @type string $container_class Flex container CSS class.
+ *    @type string $label           Content label.
+ *    @type string $status_class    CSS Class to display the status.
+ *    @type string $status_text     Text to display the subscription status.
+ *    @type bool   $is_active       Boolean identifying the activation status.
  * }
  */
 
@@ -18,6 +19,9 @@
 	<h3 class="wpr-title2">RocketCDN</h3>
 </div>
 <div class="wpr-field wpr-field-account">
+	<?php if ( ! $data['is_live_site'] ) : ?>
+	<span class="wpr-infoAccount wpr-isInvalid"><?php esc_html_e( 'RocketCDN is unavailable on local domains and staging sites.', 'rocket' ); ?></span>
+	<?php else : ?>
 	<div class="wpr-flex<?php echo esc_attr( $data['container_class'] ); ?>">
 		<div>
 			<span class="wpr-title3"><?php echo esc_html( $data['label'] ); ?></span>
@@ -29,4 +33,5 @@
 		</div>
 		<?php endif; ?>
 	</div>
+	<?php endif; ?>
 </div>


### PR DESCRIPTION
We don't want users to signup for RocketCDN on localhost or staging sites. This PR adds:
- a function `rocket_is_live_site()` to check if the current URL corresponds to localhost or known staging domains
- Checks in method displaying content related to RocketCDN on the settings page
- Updated unit & integration tests

**To-Do**
- [x] Add new tests for when `rocket_is_live_site()` is false
- [x] Test on live staging site. Done. Tested on our Dev live staging site. Works as expected.