### PR TITLE
Remove RocketCDN debug to dave

### DIFF
--- a/inc/admin/ui/enqueue.php
+++ b/inc/admin/ui/enqueue.php
@@ -16,7 +16,7 @@ function rocket_add_admin_css_js() {
 		'rocket_ajax_data',
 		[
 			'nonce'      => wp_create_nonce( 'rocket-ajax' ),
-			'origin_url' => rocket_get_constant( 'WP_ROCKET_DEBUG', false ) ? 'https://dave.wp-rocket.me' : rocket_get_constant( 'WP_ROCKET_WEB_MAIN' ),
+			'origin_url' => rocket_get_constant( 'WP_ROCKET_WEB_MAIN' ),
 		]
 	);
 

--- a/inc/classes/subscriber/CDN/RocketCDN/AdminPageSubscriber.php
+++ b/inc/classes/subscriber/CDN/RocketCDN/AdminPageSubscriber.php
@@ -215,15 +215,12 @@ class AdminPageSubscriber extends Abstract_Render implements Subscriber_Interfac
 			return;
 		}
 
-		$base_url   = rocket_get_constant( 'WP_ROCKET_DEBUG', false )
-			? 'https://dave.wp-rocket.me/'
-			: rocket_get_constant( 'WP_ROCKET_WEB_MAIN' );
 		$iframe_src = add_query_arg(
 			[
 				'website'  => home_url(),
 				'callback' => rest_url( 'wp-rocket/v1/rocketcdn/' ),
 			],
-			$base_url . 'cdn/iframe'
+			rocket_get_constant( 'WP_ROCKET_WEB_MAIN' ) . 'cdn/iframe'
 		);
 		?>
 		<div class="wpr-rocketcdn-modal" id="wpr-rocketcdn-modal" aria-hidden="true">

--- a/tests/Integration/Subscriber/CDN/RocketCDN/AdminPageSubscriber/addSubscriptionModal.php
+++ b/tests/Integration/Subscriber/CDN/RocketCDN/AdminPageSubscriber/addSubscriptionModal.php
@@ -2,7 +2,6 @@
 
 namespace WP_Rocket\Tests\Integration\Subscriber\CDN\RocketCDN;
 
-use Brain\Monkey\Functions;
 use WPMedia\PHPUnit\Integration\TestCase;
 
 /**
@@ -44,27 +43,6 @@ class Test_AddSubscriptionModal extends TestCase {
 		<div class="wpr-rocketcdn-modal__container" role="dialog" aria-modal="true" aria-labelledby="wpr-rocketcdn-modal-title">
 			<div id="wpr-rocketcdn-modal-content">
 				<iframe id="rocketcdn-iframe" src="https://wp-rocket.me/cdn/iframe?website=http://example.org&#038;callback=http://example.org/index.php?rest_route=/wp-rocket/v1/rocketcdn/" width="674" height="425"></iframe>
-			</div>
-		</div>
-	</div>
-</div>
-HTML;
-
-		$this->assertSame( $this->format_the_html( $expected ), $this->getActualHtml() );
-	}
-
-	public function testShouldDisplayModalWithDevURL() {
-		Functions\expect( 'rocket_get_constant' )
-			->once()
-			->with( 'WP_ROCKET_DEBUG', false )
-			->andReturn( true );
-
-		$expected = <<<HTML
-<div class="wpr-rocketcdn-modal" id="wpr-rocketcdn-modal" aria-hidden="true">
-	<div class="wpr-rocketcdn-modal__overlay" tabindex="-1">
-		<div class="wpr-rocketcdn-modal__container" role="dialog" aria-modal="true" aria-labelledby="wpr-rocketcdn-modal-title">
-			<div id="wpr-rocketcdn-modal-content">
-				<iframe id="rocketcdn-iframe" src="https://dave.wp-rocket.me/cdn/iframe?website=http://example.org&#038;callback=http://example.org/index.php?rest_route=/wp-rocket/v1/rocketcdn/" width="674" height="425"></iframe>
 			</div>
 		</div>
 	</div>

--- a/tests/Unit/Subscriber/CDN/RocketCDN/AdminPageSubscriber/addSubscriptionModal.php
+++ b/tests/Unit/Subscriber/CDN/RocketCDN/AdminPageSubscriber/addSubscriptionModal.php
@@ -52,11 +52,6 @@ class Test_AddSubscriptionModal extends TestCase {
 		Functions\when( 'rocket_is_live_site' )->justReturn( true );
 		Functions\when( 'add_query_arg' )->justReturn( 'https://wp-rocket.me/cdn/iframe?website=http://example.org&callback=http://example.org/wp-json/wp-rocket/v1/rocketcdn/');
 		Functions\expect( 'rocket_get_constant' )
-			->ordered()
-			->once()
-			->with( 'WP_ROCKET_DEBUG', false )
-			->andReturn( false )
-			->andAlsoExpectIt()
 			->once()
 			->with( 'WP_ROCKET_WEB_MAIN' )
 			->andReturn( 'https://wp-rocket.me' );
@@ -67,29 +62,6 @@ class Test_AddSubscriptionModal extends TestCase {
 		<div class="wpr-rocketcdn-modal__container" role="dialog" aria-modal="true" aria-labelledby="wpr-rocketcdn-modal-title">
 			<div id="wpr-rocketcdn-modal-content">
 				<iframe id="rocketcdn-iframe" src="https://wp-rocket.me/cdn/iframe?website=http://example.org&callback=http://example.org/wp-json/wp-rocket/v1/rocketcdn/" width="674" height="425"></iframe>
-			</div>
-		</div>
-	</div>
-</div>
-HTML;
-
-		$this->assertSame( $this->format_the_html( $expected ), $this->getActualHtml() );
-	}
-
-	public function testShouldDisplayModalWithDevURL() {
-		Functions\when( 'rocket_is_live_site' )->justReturn( true );
-		Functions\when( 'add_query_arg' )->justReturn( 'https://dave.wp-rocket.me/cdn/iframe?website=http://example.org&callback=http://example.org/wp-json/wp-rocket/v1/rocketcdn/' );
-		Functions\expect( 'rocket_get_constant' )
-			->once()
-			->with( 'WP_ROCKET_DEBUG', false )
-			->andReturn( true );
-
-		$expected = <<<HTML
-<div class="wpr-rocketcdn-modal" id="wpr-rocketcdn-modal" aria-hidden="true">
-	<div class="wpr-rocketcdn-modal__overlay" tabindex="-1">
-		<div class="wpr-rocketcdn-modal__container" role="dialog" aria-modal="true" aria-labelledby="wpr-rocketcdn-modal-title">
-			<div id="wpr-rocketcdn-modal-content">
-				<iframe id="rocketcdn-iframe" src="https://dave.wp-rocket.me/cdn/iframe?website=http://example.org&callback=http://example.org/wp-json/wp-rocket/v1/rocketcdn/" width="674" height="425"></iframe>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
Remove the use of the dave site for RocketCDN when `WP_ROCKET_DEBUG` is enabled