### PR TITLE
Remove trailingslash before sending data

### DIFF
--- a/inc/admin/ui/enqueue.php
+++ b/inc/admin/ui/enqueue.php
@@ -16,7 +16,7 @@ function rocket_add_admin_css_js() {
 		'rocket_ajax_data',
 		[
 			'nonce'      => wp_create_nonce( 'rocket-ajax' ),
-			'origin_url' => rocket_get_constant( 'WP_ROCKET_WEB_MAIN' ),
+			'origin_url' => untrailingslashit( rocket_get_constant( 'WP_ROCKET_WEB_MAIN' ) ),
 		]
 	);
 


### PR DESCRIPTION
`WP_ROCKET_WEB_MAIN` value is `https://wp-rocket.me/`, and the iframe origin is `https://wp-rocket.me`. This was causing an issue in the Javascript because the 2 didn't exactly match.