### PR TITLE
Adds a filter to rocket_is_live_site() for dev TLDs to be live prod site.

### DIFF
--- a/inc/functions/api.php
+++ b/inc/functions/api.php
@@ -106,7 +106,6 @@ function rocket_is_live_site() {
 	$excluded_tlds = [
 		'localhost',
 		'local',
-		'dev',
 		'test',
 		'docksal',
 	];
@@ -115,8 +114,15 @@ function rocket_is_live_site() {
 		return false;
 	}
 
-	if ( '.dev.cc' === substr( $host, -7 ) ) {
-		return false;
+	if ( 'dev' === $tld || '.dev.cc' === substr( $host, -7 ) ) {
+		/**
+		 * Indicates if this website's .dev TLD is the real live production website, i.e. not staging or local dev.
+		 *
+		 * @since 3.5
+		 *
+		 * @param bool True indicates .dev is the real live PROD website.
+		 */
+		return (bool) apply_filters( 'rocket_tld_is_live_prod_site', false );
 	}
 
 	if ( '.lndo.site' === substr( $host, -10 ) ) {

--- a/tests/Integration/Functions/rocketIsLiveSite.php
+++ b/tests/Integration/Functions/rocketIsLiveSite.php
@@ -10,6 +10,7 @@ use Brain\Monkey\Functions;
  * @group API
  */
 class Test_RocketIsLiveSite extends TestCase {
+
 	public function testShouldReturnTrueWhenWPROCKETDEBUG() {
 		Functions\when( 'rocket_get_constant' )->justReturn( true );
 
@@ -33,15 +34,50 @@ class Test_RocketIsLiveSite extends TestCase {
 	public function testShouldReturnFalseWhenLocalOrStaging() {
 		Functions\when( 'rocket_get_constant' )->justReturn( false );
 
-		$local_staging = [
+		$urls   = $this->getLocalStagingSites();
+		$urls[] = 'example.dev';
+		$urls[] = 'example.dev.cc';
+		foreach ( $urls as $domain ) {
+			$callback = function() use ( $domain ) {
+				return 'http://' . $domain;
+			};
+
+			add_filter( 'home_url', $callback );
+			$this->assertFalse( rocket_is_live_site() );
+			remove_filter( 'home_url', $callback );
+		}
+	}
+
+	public function testShouldReturnTrueWhenDevTLDIsLiveSite() {
+		Functions\expect( 'rocket_get_constant' )->with( 'WP_ROCKET_DEBUG' )->andReturn( false );
+
+		add_filter( 'rocket_tld_is_live_prod_site', [ $this, 'return_true' ] );
+		foreach ( [ 'example.dev', 'example.dev.css' ] as $domain ) {
+			$callback = function() use ( $domain ) {
+				return 'http://' . $domain;
+			};
+
+			add_filter( 'home_url', $callback );
+			$this->assertTrue( rocket_is_live_site() );
+			remove_filter( 'home_url', $callback );
+		}
+		remove_filter( 'rocket_tld_is_live_prod_site', [ $this, 'return_true' ] );
+	}
+
+	public function testShouldReturnTrueWhenLiveSite() {
+		Functions\when( 'rocket_get_constant' )->justReturn( false );
+
+		$this->assertTrue( rocket_is_live_site() );
+	}
+
+	private function getLocalStagingSites() {
+		return [
 			'127.0.0.1',
 			'localhost',
 			'example.localhost',
 			'example.local',
-			'example.dev',
 			'example.test',
 			'example.docksal',
-			'example.dev.cc',
 			'example.lndo.site',
 			'example.wpengine.com',
 			'example.pantheonsite.io',
@@ -53,23 +89,7 @@ class Test_RocketIsLiveSite extends TestCase {
 			'example.azurewebsites.net',
 			'example.wpserveur.net',
 			'example-liquidwebsites.com',
-			'example.myftpupload.com'
+			'example.myftpupload.com',
 		];
-
-		foreach ( $local_staging as $domain ) {
-			$callback = function() use ( $domain ) {
-				return 'http://' . $domain;
-			};
-
-			add_filter( 'home_url', $callback );
-			$this->assertFalse( rocket_is_live_site() );
-			remove_filter( 'home_url', $callback );
-		}
-	}
-
-	public function testShouldReturnTrueWhenLiveSite() {
-		Functions\when( 'rocket_get_constant' )->justReturn( false );
-
-		$this->assertTrue( rocket_is_live_site() );
 	}
 }

--- a/tests/Unit/Functions/rocketIsLiveSite.php
+++ b/tests/Unit/Functions/rocketIsLiveSite.php
@@ -1,13 +1,15 @@
 <?php
+
 namespace WP_Rocket\Tests\Unit\Functions\Options;
 
-use WPMedia\PHPUnit\Unit\TestCase;
+use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
+use WPMedia\PHPUnit\Unit\TestCase;
 
 /**
  * @covers rocket_is_live_site()
- * @group Functions
- * @group API
+ * @group  Functions
+ * @group  API
  */
 class Test_RocketIsLiveSite extends TestCase {
 	public function setUp() {
@@ -34,15 +36,60 @@ class Test_RocketIsLiveSite extends TestCase {
 		Functions\when( 'rocket_get_constant' )->justReturn( false );
 		Functions\when( 'home_url' )->justReturn( 'http://example.org' );
 
-		$local_staging = [
+		$urls   = $this->getLocalStagingSites();
+		$urls[] = 'example.dev';
+		$urls[] = 'example.dev.cc';
+		foreach ( $urls as $domain ) {
+			Functions\when( 'wp_parse_url' )->justReturn( $domain );
+
+			$this->assertFalse( rocket_is_live_site() );
+		}
+	}
+
+	public function testShouldReturnFalseWhenIsLiveProdSiteFilterOnButLocalOrStaging() {
+		Functions\when( 'rocket_get_constant' )->justReturn( false );
+		Functions\when( 'home_url' )->justReturn( 'http://example.org' );
+
+		add_filter( 'rocket_tld_is_live_prod_site', '__return_true' );
+		foreach ( $this->getLocalStagingSites() as $domain ) {
+			Functions\when( 'wp_parse_url' )->justReturn( $domain );
+
+			$this->assertFalse( rocket_is_live_site() );
+		}
+		remove_filter( 'rocket_tld_is_live_prod_site', '__return_false' );
+	}
+
+	public function testShouldReturnTrueWhenDevTLDIsLiveSite() {
+		Functions\when( 'rocket_get_constant' )->justReturn( false );
+		Functions\when( 'home_url' )->justReturn( 'http://example.org' );
+
+		foreach ( [ 'example.dev', 'example.dev.cc' ] as $domain ) {
+			Functions\when( 'wp_parse_url' )->justReturn( $domain );
+			Filters\expectApplied( 'rocket_tld_is_live_prod_site' )
+				->once()
+				->with( false )
+				->andReturn( true );
+
+			$this->assertTrue( rocket_is_live_site() );
+		}
+	}
+
+	public function testShouldReturnTrueWhenLiveSite() {
+		Functions\when( 'rocket_get_constant' )->justReturn( false );
+		Functions\when( 'home_url' )->justReturn( 'http://example.org' );
+		Functions\when( 'wp_parse_url' )->justReturn( 'example.org' );
+
+		$this->assertTrue( rocket_is_live_site() );
+	}
+
+	private function getLocalStagingSites() {
+		return [
 			'127.0.0.1',
 			'localhost',
 			'example.localhost',
 			'example.local',
-			'example.dev',
 			'example.test',
 			'example.docksal',
-			'example.dev.cc',
 			'example.lndo.site',
 			'example.wpengine.com',
 			'example.pantheonsite.io',
@@ -54,21 +101,7 @@ class Test_RocketIsLiveSite extends TestCase {
 			'example.azurewebsites.net',
 			'example.wpserveur.net',
 			'example-liquidwebsites.com',
-			'example.myftpupload.com'
+			'example.myftpupload.com',
 		];
-
-		foreach ( $local_staging as $domain ) {
-			Functions\when( 'wp_parse_url' )->justReturn( $domain );
-
-			$this->assertFalse( rocket_is_live_site() );
-		}
-	}
-
-	public function testShouldReturnTrueWhenLiveSite() {
-		Functions\when( 'rocket_get_constant' )->justReturn( false );
-		Functions\when( 'home_url' )->justReturn( 'http://example.org' );
-		Functions\when( 'wp_parse_url' )->justReturn( 'example.org' );
-
-		$this->assertTrue( rocket_is_live_site() );
 	}
 }


### PR DESCRIPTION
This PR adds a filter `'rocket_tld_is_live_prod_site'` for `.dev` and `.dev.cc` TLDs. 

- By default, these TLDs are considered development purposes only. 
- A customer or dev can register a `__return_true` callback to indicate that their `.dev` or `.dev.cc` TLD is the real live PROD website (and not for local or development site).

Why? We currently have over 4,500 customers with dev TLDs. This filter gives them a way to use RocketCDN.