### PR TITLE
Overwrite destination cache file if it already exists

### DIFF
--- a/inc/classes/Buffer/class-cache.php
+++ b/inc/classes/Buffer/class-cache.php
@@ -349,7 +349,7 @@ class Cache extends Abstract_Buffer {
 
 		// Save the cache file.
 		rocket_put_content( $temp_filepath, $content );
-		rocket_direct_filesystem()->move( $temp_filepath, $cache_filepath );
+		rocket_direct_filesystem()->move( $temp_filepath, $cache_filepath, true );
 
 		if ( function_exists( 'gzencode' ) ) {
 			/**
@@ -360,7 +360,7 @@ class Cache extends Abstract_Buffer {
 			$compression_level = apply_filters( 'rocket_gzencode_level_compression', 3 );
 
 			rocket_put_content( $temp_gzip_filepath, gzencode( $content, $compression_level ) );
-			rocket_direct_filesystem()->move( $temp_gzip_filepath, $gzip_filepath );
+			rocket_direct_filesystem()->move( $temp_gzip_filepath, $gzip_filepath, true );
 		}
 	}
 


### PR DESCRIPTION
If the destination file defined in `move()` already exists, the method bails out early, and the temp file remains.

By using the 3rd parameter, an overwrite of the existing file is forced, preventing the issue.