### PR TITLE
Fix the number of preloaded pages in the admin notice

### DIFF
--- a/inc/classes/preload/class-abstract-preload.php
+++ b/inc/classes/preload/class-abstract-preload.php
@@ -58,11 +58,9 @@ abstract class Abstract_Preload {
 	 * @return void
 	 */
 	public function cancel_preload() {
-		delete_transient( 'rocket_preload_running' );
+		delete_transient( $this->get_running_transient_name() );
 
-		if ( \method_exists( $this->preload_process, 'cancel_process' ) ) {
-			$this->preload_process->cancel_process();
-		}
+		$this->preload_process->cancel_process();
 	}
 
 	/**
@@ -75,6 +73,24 @@ abstract class Abstract_Preload {
 	 */
 	public function is_process_running() {
 		return $this->preload_process->is_process_running();
+	}
+
+	/**
+	 * Get the number of preloaded URLs.
+	 *
+	 * @since  3.5
+	 * @author Grégory Viguier
+	 *
+	 * @return int|bool The number of preloaded URLs. False if the process is not running.
+	 */
+	public function get_number_of_preloaded_items() {
+		$nbr = get_transient( $this->get_running_transient_name() );
+
+		if ( false === $nbr ) {
+			return false;
+		}
+
+		return absint( $nbr );
 	}
 
 	/**
@@ -109,5 +125,17 @@ abstract class Abstract_Preload {
 		$query_array = array_merge( $this->cache_query_strings, $query_array );
 
 		return $path . '?' . http_build_query( $query_array );
+	}
+
+	/**
+	 * Get the name of the transient that stores the number of preloaded URLs.
+	 *
+	 * @since  3.5
+	 * @author Grégory Viguier
+	 *
+	 * @return string
+	 */
+	protected function get_running_transient_name() {
+		return sprintf( 'rocket_%s_preload_running', static::PRELOAD_ID );
 	}
 }

--- a/inc/classes/preload/class-abstract-process.php
+++ b/inc/classes/preload/class-abstract-process.php
@@ -52,10 +52,10 @@ abstract class Process extends WP_Background_Process {
 			return [];
 		}
 
-		$source = is_string( $source ) ? $source : '';
-
 		$item['mobile'] = ! empty( $item['mobile'] );
-		$item['source'] = ! empty( $item['source'] ) ? $item['source'] : $source;
+		if ( empty( $item['source'] ) ) {
+			$item['source'] = is_string( $source ) ? $source : '';
+		}
 
 		return $item;
 	}

--- a/inc/classes/preload/class-partial-process.php
+++ b/inc/classes/preload/class-partial-process.php
@@ -31,11 +31,13 @@ class Partial_Process extends Process {
 	 *     A string is allowed for backward compatibility (for the URL).
 	 *
 	 *     @type string $url    The URL to preload.
-	 *     @type bool   $mobile True when we want to send a "mobile" user agent with the request. Optional.
+	 *     @type bool   $mobile True when we want to send a "mobile" user agent with the request.
+	 *     @type string $source An identifier related to the source of the preload (e.g. RELOAD_ID).
 	 * }
 	 * @return bool False.
 	 */
 	protected function task( $item ) {
-		return $this->maybe_preload( $item );
+		$this->maybe_preload( $item );
+		return false;
 	}
 }

--- a/inc/classes/subscriber/preload/class-preload-subscriber.php
+++ b/inc/classes/subscriber/preload/class-preload-subscriber.php
@@ -243,7 +243,7 @@ class Preload_Subscriber implements Subscriber_Interface {
 			return;
 		}
 
-		$running = get_transient( 'rocket_preload_running' );
+		$running = $this->homepage_preloader->get_number_of_preloaded_items();
 
 		if ( false === $running ) {
 			return;

--- a/tests/Integration/inc/classes/preload/Full_Process/isMobilePreloadEnabled.php
+++ b/tests/Integration/inc/classes/preload/Full_Process/isMobilePreloadEnabled.php
@@ -1,14 +1,13 @@
 <?php
 namespace WP_Rocket\Tests\Integration\inc\classes\preload\Full_Process;
 
-use WP_Rocket\Tests\Integration\PreloadTestCase as TestCase;
-use WP_Rocket\Preload\Full_Process;
+use WP_Rocket\Tests\Integration\inc\classes\preload\PreloadTestCase;
 
 /**
  * @covers \WP_Rocket\Preload\Full_Process::is_mobile_preload_enabled
  * @group Preload
  */
-class Test_isMobilePreloadEnabled extends TestCase {
+class Test_isMobilePreloadEnabled extends PreloadTestCase {
 
 	public function testShouldReturnTrueWhenOptionsEnabled() {
 		add_filter( $this->option_hook_prefix . 'manual_preload', [ $this, 'return_1' ] );

--- a/tests/Integration/inc/classes/preload/Homepage/preload.php
+++ b/tests/Integration/inc/classes/preload/Homepage/preload.php
@@ -1,14 +1,17 @@
 <?php
+
 namespace WP_Rocket\Tests\Integration\inc\classes\preload\Homepage;
 
-use WP_Rocket\Tests\Integration\PreloadTestCase as TestCase;
 use WP_Rocket\Preload\Homepage;
+use WP_Rocket\Tests\Integration\inc\classes\preload\PreloadTestCase;
 
 /**
  * @covers \WP_Rocket\Preload\Homepage::preload
- * @group Preload
+ * @group  Preload
  */
-class Test_Preload extends TestCase {
+class Test_Preload extends PreloadTestCase {
+	protected $setUpFilters = true;
+	protected $tearDownFilters = true;
 
 	public function testShouldPreloadWhenValidUrls() {
 		$home_urls = [
@@ -16,13 +19,6 @@ class Test_Preload extends TestCase {
 			[ 'url' => "{$this->site_url}/2020/02/18/mobile-preload-post-tester/" ],
 			[ 'url' => "{$this->site_url}/category/mobile-preload/", 'mobile' => 1 ],
 		];
-
-		add_filter( $this->option_hook_prefix . 'manual_preload', [ $this, 'return_1' ] );
-		add_filter( $this->option_hook_prefix . 'cache_mobile', [ $this, 'return_1' ] );
-		add_filter( $this->option_hook_prefix . 'do_caching_mobile_files', [ $this, 'return_1' ] );
-		add_filter( $this->option_hook_prefix . 'cache_reject_uri', [ $this, 'return_empty_array' ] );
-
-		delete_transient( 'rocket_preload_errors' );
 
 		( new Homepage( $this->process ) )->preload( $home_urls );
 
@@ -33,13 +29,30 @@ class Test_Preload extends TestCase {
 		$queue = get_site_option( $key );
 		delete_site_option( $key );
 
-		// This one is excluded when requesting "{$this->site_url}/mobile-preload-homepage/", but included when requesting "{$this->site_url}/2020/02/18/mobile-preload-post-tester/" and "{$this->site_url}/category/mobile-preload/".
-		$this->assertContains( "{$this->site_url}/mobile-preload-homepage/", $queue );
-		$this->assertContains( "{$this->site_url}/mobile-preload-homepage/fr", $queue );
-		$this->assertContains( "{$this->site_url}/mobile-preload-homepage/es", $queue );
-		$this->assertContains( [ 'url' => "{$this->site_url}/mobile-preload-homepage/", 'mobile' => true ], $queue );
-		$this->assertContains( [ 'url' => "{$this->site_url}/mobile-preload-homepage/fr", 'mobile' => true ], $queue );
-		$this->assertContains( [ 'url' => "{$this->site_url}/mobile-preload-homepage/es", 'mobile' => true ], $queue );
+		$this->assertContains(
+			[ 'url' => "{$this->site_url}/mobile-preload-homepage/", 'mobile' => false, 'source' => 'homepage' ],
+			$queue
+		);
+		$this->assertContains(
+			[ 'url' => "{$this->site_url}/mobile-preload-homepage/fr", 'mobile' => false, 'source' => 'homepage' ],
+			$queue
+		);
+		$this->assertContains(
+			[ 'url' => "{$this->site_url}/mobile-preload-homepage/es", 'mobile' => false, 'source' => 'homepage' ],
+			$queue
+		);
+		$this->assertContains(
+			[ 'url' => "{$this->site_url}/mobile-preload-homepage/", 'mobile' => true, 'source' => 'homepage' ],
+			$queue
+		);
+		$this->assertContains(
+			[ 'url' => "{$this->site_url}/mobile-preload-homepage/fr", 'mobile' => true, 'source' => 'homepage' ],
+			$queue
+		);
+		$this->assertContains(
+			[ 'url' => "{$this->site_url}/mobile-preload-homepage/es", 'mobile' => true, 'source' => 'homepage' ],
+			$queue
+		);
 		$this->assertNotContains( 'https://toto.org', $queue );
 	}
 }

--- a/tests/Integration/inc/classes/preload/Homepage/preload.php
+++ b/tests/Integration/inc/classes/preload/Homepage/preload.php
@@ -10,7 +10,7 @@ use WP_Rocket\Tests\Integration\inc\classes\preload\PreloadTestCase;
  * @group  Preload
  */
 class Test_Preload extends PreloadTestCase {
-	protected $setUpFilters = true;
+	protected $setUpFilters    = true;
 	protected $tearDownFilters = true;
 
 	public function testShouldPreloadWhenValidUrls() {

--- a/tests/Integration/inc/classes/preload/PreloadTestCase.php
+++ b/tests/Integration/inc/classes/preload/PreloadTestCase.php
@@ -1,16 +1,19 @@
 <?php
-namespace WP_Rocket\Tests\Integration;
 
-use WPMedia\PHPUnit\Integration\TestCase;
+namespace WP_Rocket\Tests\Integration\inc\classes\preload;
+
 use WP_Rocket\Tests\Integration\Fixtures\Preload\Process_Wrapper;
+use WPMedia\PHPUnit\Integration\TestCase;
 
-abstract class PreloadTestCase extends TestCase {
-	protected $site_url           = 'https://smashingcoding.com';
-	protected $identifier         = 'rocket_preload';
+class PreloadTestCase extends TestCase {
+	protected $site_url = 'https://smashingcoding.com';
+	protected $identifier = 'rocket_preload';
 	protected $option_hook_prefix = 'pre_get_rocket_option_';
 	protected $preloadErrorsTransient;
 	protected $preloadRunningTransient;
 	protected $process;
+	protected $setUpFilters = false;
+	protected $tearDownFilters = false;
 
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
@@ -26,6 +29,10 @@ abstract class PreloadTestCase extends TestCase {
 		$this->preloadErrorsTransient  = get_transient( 'rocket_preload_errors' );
 		$this->preloadRunningTransient = get_transient( 'rocket_preload_running' );
 		$this->process                 = new Process_Wrapper();
+
+		if ( $this->setUpFilters ) {
+			$this->setUpFilters();
+		}
 	}
 
 	public function setSiteUrl() {
@@ -59,5 +66,28 @@ abstract class PreloadTestCase extends TestCase {
 		$this->preloadErrorsTransient  = null;
 		$this->preloadRunningTransient = null;
 		$this->process                 = null;
+
+
+		if ( $this->tearDownFilters ) {
+			$this->tearDownFilters();
+		}
+	}
+
+	protected function setUpFilters() {
+		add_filter( $this->option_hook_prefix . 'manual_preload', [ $this, 'return_1' ] );
+		add_filter( $this->option_hook_prefix . 'cache_mobile', [ $this, 'return_1' ] );
+		add_filter( $this->option_hook_prefix . 'do_caching_mobile_files', [ $this, 'return_1' ] );
+		add_filter( $this->option_hook_prefix . 'cache_reject_uri', [ $this, 'return_empty_array' ] );
+
+		delete_transient( 'rocket_preload_errors' );
+	}
+
+	protected function tearDownFilters() {
+		remove_filter( $this->option_hook_prefix . 'manual_preload', [ $this, 'return_1' ] );
+		remove_filter( $this->option_hook_prefix . 'cache_mobile', [ $this, 'return_1' ] );
+		remove_filter( $this->option_hook_prefix . 'do_caching_mobile_files', [ $this, 'return_1' ] );
+		remove_filter( $this->option_hook_prefix . 'cache_reject_uri', [ $this, 'return_empty_array' ] );
+
+		delete_transient( 'rocket_preload_errors' );
 	}
 }

--- a/tests/Integration/inc/classes/preload/PreloadTestCase.php
+++ b/tests/Integration/inc/classes/preload/PreloadTestCase.php
@@ -6,14 +6,14 @@ use WP_Rocket\Tests\Integration\Fixtures\Preload\Process_Wrapper;
 use WPMedia\PHPUnit\Integration\TestCase;
 
 class PreloadTestCase extends TestCase {
-	protected $site_url = 'https://smashingcoding.com';
-	protected $identifier = 'rocket_preload';
+	protected $site_url           = 'https://smashingcoding.com';
+	protected $identifier         = 'rocket_preload';
 	protected $option_hook_prefix = 'pre_get_rocket_option_';
 	protected $preloadErrorsTransient;
 	protected $preloadRunningTransient;
 	protected $process;
-	protected $setUpFilters = false;
-	protected $tearDownFilters = false;
+	protected $setUpFilters       = false;
+	protected $tearDownFilters    = false;
 
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();

--- a/tests/Integration/inc/classes/preload/Sitemap/runPreload.php
+++ b/tests/Integration/inc/classes/preload/Sitemap/runPreload.php
@@ -11,7 +11,7 @@ use WP_Rocket\Tests\Integration\inc\classes\preload\PreloadTestCase;
  */
 class Test_RunPreload extends PreloadTestCase {
 	protected $post_id;
-	protected $setUpFilters = true;
+	protected $setUpFilters    = true;
 	protected $tearDownFilters = true;
 
 	public function tearDown() {

--- a/tests/Integration/inc/classes/preload/Sitemap/runPreload.php
+++ b/tests/Integration/inc/classes/preload/Sitemap/runPreload.php
@@ -2,15 +2,17 @@
 namespace WP_Rocket\Tests\Integration\inc\classes\preload\Sitemap;
 
 use Brain\Monkey\Actions;
-use WP_Rocket\Tests\Integration\PreloadTestCase as TestCase;
 use WP_Rocket\Preload\Sitemap;
+use WP_Rocket\Tests\Integration\inc\classes\preload\PreloadTestCase;
 
 /**
  * @covers \WP_Rocket\Preload\Sitemap::run_preload
  * @group Preload
  */
-class Test_RunPreload extends TestCase {
+class Test_RunPreload extends PreloadTestCase {
 	protected $post_id;
+	protected $setUpFilters = true;
+	protected $tearDownFilters = true;
 
 	public function tearDown() {
 		parent::tearDown();
@@ -31,12 +33,7 @@ class Test_RunPreload extends TestCase {
 			"{$this->site_url}/mobile-preload-sitemap-mobile.xml",
 		];
 
-		add_filter( $this->option_hook_prefix . 'manual_preload', [ $this, 'return_1' ] );
-		add_filter( $this->option_hook_prefix . 'cache_mobile', [ $this, 'return_1' ] );
-		add_filter( $this->option_hook_prefix . 'do_caching_mobile_files', [ $this, 'return_1' ] );
-		add_filter( $this->option_hook_prefix . 'cache_reject_uri', [ $this, 'return_empty_array' ] );
-
-		delete_transient( 'rocket_preload_errors' );
+		$this->setUpFilters();
 
 		( new Sitemap( $this->process ) )->run_preload( $sitemaps );
 
@@ -47,11 +44,15 @@ class Test_RunPreload extends TestCase {
 		$queue = get_site_option( $key );
 		delete_site_option( $key );
 
-		$this->assertContains( "{$this->site_url}/mobile-preload-homepage/", $queue );
-		$this->assertContains( "{$this->site_url}/2020/02/18/mobile-preload-post-tester/", $queue );
-		$this->assertContains( [ 'url' => "{$this->site_url}/mobile-preload-homepage/", 'mobile' => true ], $queue );
-		$this->assertContains( [ 'url' => "{$this->site_url}/2020/02/18/mobile-preload-post-tester/", 'mobile' => true ], $queue );
-		$this->assertContains( [ 'url' => "{$this->site_url}/category/mobile-preload/", 'mobile' => true ], $queue );
+		$expected = [
+			[ 'url' => "{$this->site_url}/mobile-preload-homepage/", 'mobile' => false, 'source' => 'sitemap' ],
+			[ 'url' => "{$this->site_url}/mobile-preload-homepage/", 'mobile' => true, 'source' => 'sitemap' ],
+			[ 'url' => "{$this->site_url}/2020/02/18/mobile-preload-post-tester/", 'mobile' => false, 'source' => 'sitemap' ],
+			[ 'url' => "{$this->site_url}/2020/02/18/mobile-preload-post-tester/", 'mobile' => true, 'source' => 'sitemap' ],
+			[ 'url' => "{$this->site_url}/category/mobile-preload/", 'mobile' => true, 'source' => 'sitemap' ],
+		];
+
+		$this->assertSame( $expected, $queue );
 		$this->assertCount( 5, $queue );
 	}
 
@@ -83,12 +84,7 @@ class Test_RunPreload extends TestCase {
 
 		$this->assertNotFalse( $permalink );
 
-		add_filter( $this->option_hook_prefix . 'manual_preload', [ $this, 'return_1' ] );
-		add_filter( $this->option_hook_prefix . 'cache_mobile', [ $this, 'return_1' ] );
-		add_filter( $this->option_hook_prefix . 'do_caching_mobile_files', [ $this, 'return_1' ] );
-		add_filter( $this->option_hook_prefix . 'cache_reject_uri', [ $this, 'return_empty_array' ] );
-
-		delete_transient( 'rocket_preload_errors' );
+		$this->setUpFilters();
 
 		( new Sitemap( $this->process ) )->run_preload( $sitemaps );
 
@@ -99,12 +95,16 @@ class Test_RunPreload extends TestCase {
 		$queue = get_site_option( $key );
 		delete_site_option( $key );
 
-		$this->assertContains( "{$this->site_url}/mobile-preload-homepage/", $queue );
-		$this->assertContains( "{$this->site_url}/2020/02/18/mobile-preload-post-tester/", $queue );
-		$this->assertContains( [ 'url' => "{$this->site_url}/mobile-preload-homepage/", 'mobile' => true ], $queue );
-		$this->assertContains( [ 'url' => "{$this->site_url}/2020/02/18/mobile-preload-post-tester/", 'mobile' => true ], $queue );
-		$this->assertContains( "{$this->site_url}/category/mobile-preload/", $queue );
-		$this->assertContains( [ 'url' => "{$this->site_url}/category/mobile-preload/", 'mobile' => true ], $queue );
+		$expected = [
+			[ 'url' => "{$this->site_url}/mobile-preload-homepage/", 'mobile' => false, 'source' => 'sitemap' ],
+			[ 'url' => "{$this->site_url}/mobile-preload-homepage/", 'mobile' => true, 'source' => 'sitemap' ],
+			[ 'url' => "{$this->site_url}/2020/02/18/mobile-preload-post-tester/", 'mobile' => false, 'source' => 'sitemap' ],
+			[ 'url' => "{$this->site_url}/2020/02/18/mobile-preload-post-tester/", 'mobile' => true, 'source' => 'sitemap' ],
+			[ 'url' => "{$this->site_url}/category/mobile-preload/", 'mobile' => false, 'source' => 'sitemap' ],
+			[ 'url' => "{$this->site_url}/category/mobile-preload/", 'mobile' => true, 'source' => 'sitemap' ],
+		];
+
+		$this->assertSame( $expected, $queue );
 		$this->assertCount( 6, $queue );
 
 		wp_delete_post( $this->post_id, true );


### PR DESCRIPTION
About the way the pages are count:
- Do not count mobile pages.
- Count only pages successfully preloaded (request not blocked internally). We can't know about the request status (200) since the requests are non blocking, we have no answer.
- For the homepage preload, take also the homepage itself into account: since it is requested to grab its URLs, it is preloaded at the same time.
- Use 2 transients for each "source" (mobile and sitemap): this prevents the second source to reset the previous source’s count. So there is no `'rocket_preload_running'` transient anymore, but 2: `'rocket_homepage_preload_running'` and `'rocket_sitemap_preload_running'`. The admin notice shows the addition of both. Note: we could use a single transient containing an array of counts, but async calls + same (cached) storage source are never a good idea.

Tweak: the abstract class `WP_Rocket\Preload\Process` now has a `cancel_process()`, so we're sure it always has this method, even if we're extending an old version of `WP_Background_Process`.

Since we are so close of the beta version:
- No unit nor integration tests.
- With the way preload is built, I couldn't find a proper way to separate concerns (preload vs process), it’s quick and dirty.

Fixes #2341.