### PR TITLE
Revert to http as default scheme for Varnish request

### DIFF
--- a/inc/Addon/Varnish/Varnish.php
+++ b/inc/Addon/Varnish/Varnish.php
@@ -68,7 +68,7 @@ class Varnish {
 		 * @since 2.7.3
 		 * @param string $scheme The HTTP protocol
 		 */
-		$scheme = apply_filters( 'rocket_varnish_http_purge_scheme', $parse_url['scheme'] );
+		$scheme = apply_filters( 'rocket_varnish_http_purge_scheme', 'http' );
 
 		/**
 		 * Filters the headers to send with the Varnish purge request


### PR DESCRIPTION
After QA testing and discussing with Piotr, we agreed that reverting the default scheme to `http` when doing the Varnish purge request was the best way to go:
- We didn't get many tickets related to this specific topic
- Changing the behaviour could lead to more tickets, as for example Cloudways Varnish uses `http` only even for a website with SSL
- A filter is available to change the scheme if our users need to