### PR TITLE
Makes .dev a live site. Reverts filter. Adds .docksal.site as local.

### DIFF
--- a/inc/functions/api.php
+++ b/inc/functions/api.php
@@ -75,7 +75,7 @@ function get_rocket_cdn_cnames( $zone = 'all' ) { // phpcs:ignore WordPress.Nami
 }
 
 /**
- * Check if the current URL is for a live site (not local, not staging)
+ * Check if the current URL is for a live site (not local, not staging).
  *
  * @since 3.5
  * @author Remy Perona
@@ -114,15 +114,8 @@ function rocket_is_live_site() {
 		return false;
 	}
 
-	if ( 'dev' === $tld || '.dev.cc' === substr( $host, -7 ) ) {
-		/**
-		 * Indicates if this website's .dev TLD is the real live production website, i.e. not staging or local dev.
-		 *
-		 * @since 3.5
-		 *
-		 * @param bool True indicates .dev is the real live PROD website.
-		 */
-		return (bool) apply_filters( 'rocket_tld_is_live_prod_site', false );
+	if ( '.dev.cc' === substr( $host, -7 ) ) {
+		return false;
 	}
 
 	if ( '.lndo.site' === substr( $host, -10 ) ) {

--- a/inc/functions/api.php
+++ b/inc/functions/api.php
@@ -101,7 +101,7 @@ function rocket_is_live_site() {
 		'.docksal',
 		'.docksal.site',
 		'.dev.cc',
-		'.lndo.site'
+		'.lndo.site',
 	];
 	foreach ( $local_tlds as $local_tld ) {
 		if ( $host === $local_tld ) {

--- a/inc/functions/api.php
+++ b/inc/functions/api.php
@@ -88,40 +88,32 @@ function rocket_is_live_site() {
 	}
 
 	$host = wp_parse_url( home_url(), PHP_URL_HOST );
-
 	if ( ! $host ) {
 		return false;
 	}
 
-	$localhost = [
+	// Check for local development sites.
+	$local_tlds = [
 		'127.0.0.1',
 		'localhost',
+		'.local',
+		'.test',
+		'.docksal',
+		'.dev.cc',
+		'.lndo.site'
 	];
+	foreach ( $local_tlds as $local_tld ) {
+		if ( $host === $local_tld ) {
+			return false;
+		}
 
-	if ( in_array( $host, $localhost, true ) ) {
-		return false;
+		// Check the TLD.
+		if ( substr( $host, -strlen( $local_tld ) ) === $local_tld ) {
+			return false;
+		}
 	}
 
-	$tld           = pathinfo( $host, PATHINFO_EXTENSION );
-	$excluded_tlds = [
-		'localhost',
-		'local',
-		'test',
-		'docksal',
-	];
-
-	if ( in_array( $tld, $excluded_tlds, true ) ) {
-		return false;
-	}
-
-	if ( '.dev.cc' === substr( $host, -7 ) ) {
-		return false;
-	}
-
-	if ( '.lndo.site' === substr( $host, -10 ) ) {
-		return false;
-	}
-
+	// Check for staging sites.
 	$staging = [
 		'.wpengine.com',
 		'.pantheonsite.io',
@@ -135,7 +127,6 @@ function rocket_is_live_site() {
 		'-liquidwebsites.com',
 		'.myftpupload.com',
 	];
-
 	foreach ( $staging as $partial_host ) {
 		if ( strpos( $host, $partial_host ) ) {
 			return false;

--- a/inc/functions/api.php
+++ b/inc/functions/api.php
@@ -99,6 +99,7 @@ function rocket_is_live_site() {
 		'.local',
 		'.test',
 		'.docksal',
+		'.docksal.site',
 		'.dev.cc',
 		'.lndo.site'
 	];

--- a/tests/Integration/Functions/rocketIsLiveSite.php
+++ b/tests/Integration/Functions/rocketIsLiveSite.php
@@ -77,6 +77,7 @@ class Test_RocketIsLiveSite extends TestCase {
 			'example.test',
 			'example.dev.cc',
 			'example.docksal',
+			'example.docksal.site',
 			'example.lndo.site',
 			'example.wpengine.com',
 			'example.pantheonsite.io',

--- a/tests/Integration/Functions/rocketIsLiveSite.php
+++ b/tests/Integration/Functions/rocketIsLiveSite.php
@@ -34,10 +34,7 @@ class Test_RocketIsLiveSite extends TestCase {
 	public function testShouldReturnFalseWhenLocalOrStaging() {
 		Functions\when( 'rocket_get_constant' )->justReturn( false );
 
-		$urls   = $this->getLocalStagingSites();
-		$urls[] = 'example.dev';
-		$urls[] = 'example.dev.cc';
-		foreach ( $urls as $domain ) {
+		foreach ( $this->getLocalStagingSites() as $domain ) {
 			$callback = function() use ( $domain ) {
 				return 'http://' . $domain;
 			};
@@ -48,26 +45,27 @@ class Test_RocketIsLiveSite extends TestCase {
 		}
 	}
 
-	public function testShouldReturnTrueWhenDevTLDIsLiveSite() {
-		Functions\expect( 'rocket_get_constant' )->with( 'WP_ROCKET_DEBUG' )->andReturn( false );
+	public function testShouldReturnTrueWhenLiveSite() {
+		Functions\when( 'rocket_get_constant' )->justReturn( false );
 
-		add_filter( 'rocket_tld_is_live_prod_site', [ $this, 'return_true' ] );
-		foreach ( [ 'example.dev', 'example.dev.css' ] as $domain ) {
-			$callback = function() use ( $domain ) {
-				return 'http://' . $domain;
+		$live_tlds = [
+			'.org',
+			'.org.uk',
+			'.com',
+			'.co.uk',
+			'.dev',
+			'.me',
+			'.me.uk',
+		];
+		foreach ( $live_tlds as $tld ) {
+			$callback = function() use ( $tld ) {
+				return "http://example{$tld}";
 			};
 
 			add_filter( 'home_url', $callback );
 			$this->assertTrue( rocket_is_live_site() );
 			remove_filter( 'home_url', $callback );
 		}
-		remove_filter( 'rocket_tld_is_live_prod_site', [ $this, 'return_true' ] );
-	}
-
-	public function testShouldReturnTrueWhenLiveSite() {
-		Functions\when( 'rocket_get_constant' )->justReturn( false );
-
-		$this->assertTrue( rocket_is_live_site() );
 	}
 
 	private function getLocalStagingSites() {
@@ -77,6 +75,7 @@ class Test_RocketIsLiveSite extends TestCase {
 			'example.localhost',
 			'example.local',
 			'example.test',
+			'example.dev.cc',
 			'example.docksal',
 			'example.lndo.site',
 			'example.wpengine.com',

--- a/tests/Unit/Functions/rocketIsLiveSite.php
+++ b/tests/Unit/Functions/rocketIsLiveSite.php
@@ -74,6 +74,7 @@ class Test_RocketIsLiveSite extends TestCase {
 			'example.test',
 			'example.dev.cc',
 			'example.docksal',
+			'example.docksal.site',
 			'example.lndo.site',
 			'example.wpengine.com',
 			'example.pantheonsite.io',


### PR DESCRIPTION
- Reverts the filter, as it's not needed, per PR #2339.
- Allows `.dev`TLD as a real public TLD, i.e. live site.
- Refactors code for readability and performance.
- Adds `.docksal.site`, as it's coming in [1.4.0](https://github.com/docksal/docksal/issues/1215).