### PR TITLE
Automatic mobile preload after cache purge

### DIFF
--- a/inc/classes/preload/class-abstract-preload.php
+++ b/inc/classes/preload/class-abstract-preload.php
@@ -76,6 +76,18 @@ abstract class Abstract_Preload {
 	}
 
 	/**
+	 * Tell if mobile preload is enabled.
+	 *
+	 * @since  3.5
+	 * @author Grégory Viguier
+	 *
+	 * @return bool
+	 */
+	public function is_mobile_preload_enabled() {
+		return $this->preload_process->is_mobile_preload_enabled();
+	}
+
+	/**
 	 * Get the number of preloaded URLs.
 	 *
 	 * @since  3.5

--- a/inc/classes/subscriber/preload/class-preload-subscriber.php
+++ b/inc/classes/subscriber/preload/class-preload-subscriber.php
@@ -57,16 +57,19 @@ class Preload_Subscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events() {
 		return [
-			'admin_notices'                   => [
+			'admin_notices'                          => [
 				[ 'notice_preload_triggered' ],
 				[ 'notice_preload_running' ],
 				[ 'notice_preload_complete' ],
 			],
-			'admin_post_rocket_stop_preload'  => [ 'do_admin_post_stop_preload' ],
-			'pagely_cache_purge_after'        => [ 'run_preload', 11 ],
-			'update_option_' . WP_ROCKET_SLUG => [
+			'admin_post_rocket_stop_preload'         => [ 'do_admin_post_stop_preload' ],
+			'pagely_cache_purge_after'               => [ 'run_preload', 11 ],
+			'update_option_' . WP_ROCKET_SLUG        => [
 				[ 'maybe_launch_preload', 11, 2 ],
 				[ 'maybe_cancel_preload', 10, 2 ],
+			],
+			'rocket_after_preload_after_purge_cache' => [
+				[ 'maybe_preload_mobile_homepage', 10, 3 ],
 			],
 		];
 	}
@@ -182,6 +185,30 @@ class Preload_Subscriber implements Subscriber_Interface {
 		if ( isset( $value['manual_preload'] ) && 1 === (int) $value['manual_preload'] ) {
 			$this->preload();
 		}
+	}
+
+	/**
+	 * After automatically preloading the homepage (after purging the cache), also preload the homepage for mobile.
+	 *
+	 * @since  3.5
+	 * @author Grégory Viguier
+	 *
+	 * @param string $home_url URL to the homepage being preloaded.
+	 * @param string $lang     The lang of the homepage.
+	 * @param array  $args     Arguments used for the preload request.
+	 */
+	public function maybe_preload_mobile_homepage( $home_url, $lang, $args ) {
+		if ( ! $this->homepage_preloader->is_mobile_preload_enabled() ) {
+			return;
+		}
+
+		if ( empty( $args['user-agent'] ) ) {
+			$args['user-agent'] = 'WP Rocket/Homepage_Preload_After_Purge_Cache';
+		}
+
+		$args['user-agent'] .= ' iPhone';
+
+		wp_safe_remote_get( $home_url, $args );
 	}
 
 	/**

--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -462,6 +462,8 @@ function do_admin_post_rocket_purge_cache() { // phpcs:ignore WordPress.NamingCo
 				}
 
 				if ( get_rocket_option( 'manual_preload' ) && ( ! defined( 'WP_ROCKET_DEBUG' ) || ! WP_ROCKET_DEBUG ) ) {
+					$home_url = home_url( $lang );
+
 					/**
 					 * Filters the arguments for the preload request being triggered after clearing the cache.
 					 *
@@ -470,7 +472,7 @@ function do_admin_post_rocket_purge_cache() { // phpcs:ignore WordPress.NamingCo
 					 *
 					 * @param array $args Request arguments.
 					 */
-					$args = apply_filters(
+					$args = (array) apply_filters(
 						'rocket_preload_after_purge_cache_request_args',
 						[
 							'blocking'   => false,
@@ -479,10 +481,20 @@ function do_admin_post_rocket_purge_cache() { // phpcs:ignore WordPress.NamingCo
 							'sslverify'  => apply_filters( 'https_local_ssl_verify', false ), // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
 						]
 					);
-					wp_safe_remote_get(
-						home_url( $lang ),
-						$args
-					);
+
+					wp_safe_remote_get( $home_url, $args );
+
+					$preload_process = new WP_Rocket\Preload\Full_Process();
+
+					if ( $preload_process->is_mobile_preload_enabled() ) {
+						if ( empty( $args['user-agent'] ) ) {
+							$args['user-agent'] = $preload_process->get_item_user_agent( [ 'mobile' => true ] );
+						} else {
+							$args['user-agent'] .= ' iPhone';
+						}
+
+						wp_safe_remote_get( $home_url, $args );
+					}
 				}
 
 				rocket_dismiss_box( 'rocket_warning_plugin_modification' );

--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -462,7 +462,7 @@ function do_admin_post_rocket_purge_cache() { // phpcs:ignore WordPress.NamingCo
 				}
 
 				if ( get_rocket_option( 'manual_preload' ) && ( ! defined( 'WP_ROCKET_DEBUG' ) || ! WP_ROCKET_DEBUG ) ) {
-					$home_url = home_url( $lang );
+					$home_url = get_rocket_i18n_home_url( $lang );
 
 					/**
 					 * Filters the arguments for the preload request being triggered after clearing the cache.
@@ -484,17 +484,17 @@ function do_admin_post_rocket_purge_cache() { // phpcs:ignore WordPress.NamingCo
 
 					wp_safe_remote_get( $home_url, $args );
 
-					$preload_process = new WP_Rocket\Preload\Full_Process();
-
-					if ( $preload_process->is_mobile_preload_enabled() ) {
-						if ( empty( $args['user-agent'] ) ) {
-							$args['user-agent'] = $preload_process->get_item_user_agent( [ 'mobile' => true ] );
-						} else {
-							$args['user-agent'] .= ' iPhone';
-						}
-
-						wp_safe_remote_get( $home_url, $args );
-					}
+					/**
+					 * Fires after automatically preloading the homepage, which occurs after purging the cache.
+					 *
+					 * @since  3.5
+					 * @author Grégory Viguier
+					 *
+					 * @param string $home_url URL to the homepage being preloaded.
+					 * @param string $lang     The lang of the homepage.
+					 * @param array  $args     Arguments used for the preload request.
+					 */
+					do_action( 'rocket_after_preload_after_purge_cache', $home_url, $lang, $args );
 				}
 
 				rocket_dismiss_box( 'rocket_warning_plugin_modification' );


### PR DESCRIPTION
After purging the cache, the homepage is automatically preloaded. Now it is also preloaded for mobile if the separate mobile cache is enabled.

Closes #2349.