### PR TITLE
Fixed Declared function at compile time, moved bailout condition before require

### DIFF
--- a/inc/3rd-party/3rd-party.php
+++ b/inc/3rd-party/3rd-party.php
@@ -34,7 +34,7 @@ if ( defined( 'O2SWITCH_VARNISH_PURGE_KEY' ) ) {
 	require WP_ROCKET_3RD_PARTY_PATH . 'hosting/o2switch.php';
 }
 
-if ( defined( 'PL_INSTANCE_REF' ) && class_exists( '\Presslabs\Cache\CacheHandler' ) ) {
+if ( defined( 'PL_INSTANCE_REF' ) && class_exists( '\Presslabs\Cache\CacheHandler' ) && file_exists( WP_CONTENT_DIR . '/advanced-cache.php' ) ) {
 	require WP_ROCKET_3RD_PARTY_PATH . 'hosting/presslabs.php';
 }
 

--- a/inc/3rd-party/3rd-party.php
+++ b/inc/3rd-party/3rd-party.php
@@ -2,18 +2,45 @@
 
 defined( 'ABSPATH' ) || exit;
 
-require WP_ROCKET_3RD_PARTY_PATH . 'hosting/wpengine.php';
-require WP_ROCKET_3RD_PARTY_PATH . 'hosting/flywheel.php';
-require WP_ROCKET_3RD_PARTY_PATH . 'hosting/wp-serveur.php';
+if ( class_exists( 'WpeCommon' ) && function_exists( 'wpe_param' ) ) {
+	require WP_ROCKET_3RD_PARTY_PATH . 'hosting/wpengine.php';
+}
+
+if ( class_exists( 'FlywheelNginxCompat' ) ) {
+	require WP_ROCKET_3RD_PARTY_PATH . 'hosting/flywheel.php';
+}
+
+if ( defined( 'DB_HOST' ) && strpos( DB_HOST, '.wpserveur.net' ) !== false ) {
+	require WP_ROCKET_3RD_PARTY_PATH . 'hosting/wp-serveur.php';
+}
+
+if ( rocket_is_plugin_active( 'sg-cachepress/sg-cachepress.php' ) ) {
+	require WP_ROCKET_3RD_PARTY_PATH . 'hosting/siteground.php';
+}
+
+if ( class_exists( '\\Savvii\\CacheFlusherPlugin' ) & class_exists( '\\Savvii\\Options' ) ) {
+	require WP_ROCKET_3RD_PARTY_PATH . 'hosting/savvii.php';
+}
+
+if ( class_exists( 'WPaaS\Plugin' ) ) {
+	require WP_ROCKET_3RD_PARTY_PATH . 'hosting/godaddy.php';
+}
+
+if ( isset( $_SERVER['KINSTA_CACHE_ZONE'] ) ) {
+	require WP_ROCKET_3RD_PARTY_PATH . 'hosting/kinsta.php';
+}
+
+if ( defined( 'O2SWITCH_VARNISH_PURGE_KEY' ) ) {
+	require WP_ROCKET_3RD_PARTY_PATH . 'hosting/o2switch.php';
+}
+
+if ( defined( 'PL_INSTANCE_REF' ) && class_exists( '\Presslabs\Cache\CacheHandler' ) ) {
+	require WP_ROCKET_3RD_PARTY_PATH . 'hosting/presslabs.php';
+}
+
 require WP_ROCKET_3RD_PARTY_PATH . 'hosting/pagely.php';
 require WP_ROCKET_3RD_PARTY_PATH . 'hosting/nginx.php';
-require WP_ROCKET_3RD_PARTY_PATH . 'hosting/siteground.php';
 require WP_ROCKET_3RD_PARTY_PATH . 'hosting/pressidium.php';
-require WP_ROCKET_3RD_PARTY_PATH . 'hosting/savvii.php';
-require WP_ROCKET_3RD_PARTY_PATH . 'hosting/godaddy.php';
-require WP_ROCKET_3RD_PARTY_PATH . 'hosting/kinsta.php';
-require WP_ROCKET_3RD_PARTY_PATH . 'hosting/o2switch.php';
-require WP_ROCKET_3RD_PARTY_PATH . 'hosting/presslabs.php';
 
 require WP_ROCKET_3RD_PARTY_PATH . 'plugins/geotargetingwp.php';
 require WP_ROCKET_3RD_PARTY_PATH . 'plugins/slider/revslider.php';

--- a/inc/3rd-party/hosting/flywheel.php
+++ b/inc/3rd-party/hosting/flywheel.php
@@ -2,10 +2,6 @@
 
 defined( 'ABSPATH' ) || exit;
 
-if ( ! class_exists( 'FlywheelNginxCompat' ) ) {
-	return;
-}
-
 /**
  * Changes the text on the Varnish one-click block.
  *

--- a/inc/3rd-party/hosting/godaddy.php
+++ b/inc/3rd-party/hosting/godaddy.php
@@ -2,10 +2,6 @@
 
 defined( 'ABSPATH' ) || exit;
 
-if ( ! class_exists( 'WPaaS\Plugin' ) ) {
-	return;
-}
-
 /**
  * Changes the text on the Varnish one-click block.
  *

--- a/inc/3rd-party/hosting/kinsta.php
+++ b/inc/3rd-party/hosting/kinsta.php
@@ -2,10 +2,6 @@
 
 defined( 'ABSPATH' ) || exit;
 
-if ( ! isset( $_SERVER['KINSTA_CACHE_ZONE'] ) ) {
-	return;
-}
-
 add_filter( 'do_rocket_generate_caching_files', '__return_false', PHP_INT_MAX );
 add_filter( 'rocket_display_varnish_options_tab', '__return_false' );
 // Prevent mandatory cookies on hosting with server cache.

--- a/inc/3rd-party/hosting/o2switch.php
+++ b/inc/3rd-party/hosting/o2switch.php
@@ -2,10 +2,6 @@
 
 defined( 'ABSPATH' ) || exit;
 
-if ( ! defined( 'O2SWITCH_VARNISH_PURGE_KEY' ) ) {
-	return;
-}
-
 /**
  * Changes the text on the Varnish one-click block.
  *

--- a/inc/3rd-party/hosting/presslabs.php
+++ b/inc/3rd-party/hosting/presslabs.php
@@ -2,10 +2,6 @@
 
 defined( 'ABSPATH' ) || exit;
 
-if ( ! defined( 'PL_INSTANCE_REF' ) || ! class_exists( '\Presslabs\Cache\CacheHandler' ) ) {
-	return;
-}
-
 if ( ! file_exists( WP_CONTENT_DIR . '/advanced-cache.php' ) ) {
 	return;
 }

--- a/inc/3rd-party/hosting/presslabs.php
+++ b/inc/3rd-party/hosting/presslabs.php
@@ -2,10 +2,6 @@
 
 defined( 'ABSPATH' ) || exit;
 
-if ( ! file_exists( WP_CONTENT_DIR . '/advanced-cache.php' ) ) {
-	return;
-}
-
 require_once WP_CONTENT_DIR . '/advanced-cache.php';
 
 add_action( 'pl_pre_cache_refresh', 'rocket_clean_files', 0 );

--- a/inc/3rd-party/hosting/savvii.php
+++ b/inc/3rd-party/hosting/savvii.php
@@ -2,10 +2,6 @@
 
 defined( 'ABSPATH' ) || exit;
 
-if ( ! class_exists( '\\Savvii\\CacheFlusherPlugin' ) || ! class_exists( '\\Savvii\\Options' ) ) {
-	return;
-}
-
 /**
  * Changes the text on the Varnish one-click block.
  *

--- a/inc/3rd-party/hosting/siteground.php
+++ b/inc/3rd-party/hosting/siteground.php
@@ -2,10 +2,6 @@
 
 defined( 'ABSPATH' ) || exit;
 
-if ( ! rocket_is_plugin_active( 'sg-cachepress/sg-cachepress.php' ) ) {
-	return;
-}
-
 /**
  * Returns the current version of the SG Optimizer plugin.
  *

--- a/inc/3rd-party/hosting/wp-serveur.php
+++ b/inc/3rd-party/hosting/wp-serveur.php
@@ -2,10 +2,6 @@
 
 defined( 'ABSPATH' ) || exit;
 
-if ( ! ( defined( 'DB_HOST' ) && strpos( DB_HOST, '.wpserveur.net' ) !== false ) ) {
-	return;
-}
-
 /**
  * Allow to purge Varnish on WP Serveur websites.
  *

--- a/inc/3rd-party/hosting/wpengine.php
+++ b/inc/3rd-party/hosting/wpengine.php
@@ -2,10 +2,6 @@
 
 defined( 'ABSPATH' ) || exit;
 
-if ( ! ( class_exists( 'WpeCommon' ) && function_exists( 'wpe_param' ) ) ) {
-	return;
-}
-
 /**
  * Changes the text on the Varnish one-click block.
  *


### PR DESCRIPTION
Fixes:
Fatal error: Cannot redeclare rocket_remove_partial_purge_hooks() (previously declared in /wp-content/plugins/wp-rocket/inc/3rd-party/hosting/kinsta.php:107) in /wp-content/plugins/wp-rocket/inc/3rd-party/hosting/presslabs.php on line 72

In this case a function name (`rocket_remove_partial_purge_hooks`) is used in 2 placed and PHP functions defined inside IF conditions are declared at runtime and functions declared outside if conditions are declared at compile time. So the bailout will not work in this case and it worked in the previous version (it was inside if condition).

Solution:
Move the bailout condition before require. 

This will decrease also a little bit the number of files loaded by WP Rocket. 

https://secure.helpscout.net/conversation/1101455078/149590?folderId=3083222
Tested on the client staging server and is working fine.