### PR TITLE
Update priorities to prevent wrong insertion order

### DIFF
--- a/inc/classes/subscriber/Optimization/class-combine-google-fonts-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-combine-google-fonts-subscriber.php
@@ -21,7 +21,7 @@ class Combine_Google_Fonts_Subscriber extends Minify_Subscriber {
 	 */
 	public static function get_subscribed_events() {
 		return [
-			'rocket_buffer' => [ 'process', 28 ],
+			'rocket_buffer' => [ 'process', 18 ],
 		];
 	}
 

--- a/inc/classes/subscriber/Optimization/class-minify-css-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-minify-css-subscriber.php
@@ -26,7 +26,7 @@ class Minify_CSS_Subscriber extends Minify_Subscriber {
 				[ 'fix_ssl_minify' ],
 				[ 'i18n_multidomain_url' ],
 			],
-			'rocket_buffer'  => [ 'process', 26 ],
+			'rocket_buffer'  => [ 'process', 16 ],
 		];
 
 		return $events;


### PR DESCRIPTION
Combine CSS and Google Fonts need to be inserted after the CPCSS in the page.

Reference:

- [HS Ticket](https://secure.helpscout.net/conversation/1101451982/149588?folderId=273768)
- Related to PR #2239 

Notes on the issue from Slack thread:

>the combined CSS process is happening on priority 26, so after the critical CSS insertion (19), and they both use the <title> as an anchor, so it ends up above instead of below

- test on customer website: changed priority for combined CSS and Google fonts to 16 and 18 respectively, display is correct ✅ 
- did the same test on my local site ✅ 