### PR TITLE
Fixes #2383: Conflict between WP Rocket mobile preload and wp_is_mobile()

### DIFF
--- a/inc/classes/preload/class-abstract-preload.php
+++ b/inc/classes/preload/class-abstract-preload.php
@@ -88,6 +88,18 @@ abstract class Abstract_Preload {
 	}
 
 	/**
+	 * Get the prefix to prepend to the user agent used for preload to make a HTTP request detected as a mobile device.
+	 *
+	 * @since  3.5.0.2
+	 * @author Grégory Viguier
+	 *
+	 * @return string
+	 */
+	public function get_mobile_user_agent_prefix() {
+		return $this->preload_process->get_mobile_user_agent_prefix();
+	}
+
+	/**
 	 * Get the number of preloaded URLs.
 	 *
 	 * @since  3.5

--- a/inc/classes/preload/class-abstract-process.php
+++ b/inc/classes/preload/class-abstract-process.php
@@ -99,10 +99,38 @@ abstract class Process extends WP_Background_Process {
 	 */
 	public function get_item_user_agent( array $item ) {
 		if ( $item['mobile'] ) {
-			return 'WP Rocket/Preload iPhone';
+			return $this->get_mobile_user_agent_prefix() . ' WP Rocket/Preload';
 		}
 
 		return 'WP Rocket/Preload';
+	}
+
+	/**
+	 * Get the prefix to prepend to the user agent used for preload to make a HTTP request detected as a mobile device.
+	 *
+	 * @since  3.5.0.2
+	 * @author Grégory Viguier
+	 *
+	 * @return string
+	 */
+	public function get_mobile_user_agent_prefix() {
+		$prefix = 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1';
+
+		/**
+		 * Filter the prefix to prepend to the user agent used for preload to make a HTTP request detected as a mobile device.
+		 *
+		 * @since  3.5.0.2
+		 * @author Grégory Viguier
+		 *
+		 * @param string $prefix The prefix.
+		 */
+		$new_prefix = apply_filters( 'rocket_mobile_preload_user_agent_prefix', $prefix );
+
+		if ( empty( $new_prefix ) || ! is_string( $new_prefix ) ) {
+			return $prefix;
+		}
+
+		return $new_prefix;
 	}
 
 	/**

--- a/inc/classes/subscriber/preload/class-preload-subscriber.php
+++ b/inc/classes/subscriber/preload/class-preload-subscriber.php
@@ -206,7 +206,7 @@ class Preload_Subscriber implements Subscriber_Interface {
 			$args['user-agent'] = 'WP Rocket/Homepage_Preload_After_Purge_Cache';
 		}
 
-		$args['user-agent'] .= ' iPhone';
+		$args['user-agent'] = $this->homepage_preloader->get_mobile_user_agent_prefix() . ' ' . $args['user-agent'];
 
 		wp_safe_remote_get( $home_url, $args );
 	}

--- a/tests/Integration/inc/classes/preload/Full_Process/getItemUserAgent.php
+++ b/tests/Integration/inc/classes/preload/Full_Process/getItemUserAgent.php
@@ -1,0 +1,29 @@
+<?php
+namespace WP_Rocket\Tests\Integration\inc\classes\preload\Full_Process;
+
+use WP_Rocket\Tests\Integration\inc\classes\preload\PreloadTestCase;
+
+/**
+ * @covers \WP_Rocket\Preload\Full_Process::get_item_user_agent
+ * @group  Preload
+ */
+class Test_GetItemUserAgent extends PreloadTestCase {
+
+	public function testShouldBeDetectedAsMobileByWordPressWhenMobileItem() {
+		$previous_ua                = ! empty( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : null;
+		$_SERVER['HTTP_USER_AGENT'] = $this->process->get_item_user_agent( [ 'mobile' => 1 ] );
+
+		$this->assertTrue( wp_is_mobile() );
+
+		$_SERVER['HTTP_USER_AGENT'] = $previous_ua;
+	}
+
+	public function testShouldNotBeDetectedAsMobileByWordPressWhenNotMobileItem() {
+		$previous_ua                = ! empty( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : null;
+		$_SERVER['HTTP_USER_AGENT'] = $this->process->get_item_user_agent( [ 'mobile' => 0 ] );
+
+		$this->assertFalse( wp_is_mobile() );
+
+		$_SERVER['HTTP_USER_AGENT'] = $previous_ua;
+	}
+}

--- a/tests/Unit/inc/classes/preload/Process/getItemUserAgent.php
+++ b/tests/Unit/inc/classes/preload/Process/getItemUserAgent.php
@@ -9,16 +9,20 @@ use WP_Rocket\Preload\Process;
  * @group Preload
  */
 class Test_GetItemUserAgent extends TestCase {
+	private $user_agent = 'WP Rocket/Preload';
+	private $prefix     = 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1';
 
 	public function testShouldReturnMobileUaWhenMobileItem() {
-		$stub = $this->getMockForAbstractClass( Process::class );
+		$expected = $this->prefix . ' ' . $this->user_agent;
+		$stub     = $this->getMockForAbstractClass( Process::class );
 
-		$this->assertContains( 'iPhone', $stub->get_item_user_agent( [ 'mobile' => 1 ] ) );
+		$this->assertSame( $expected, $stub->get_item_user_agent( [ 'mobile' => 1 ] ) );
 	}
 
 	public function testShouldNotReturnMobileUaWhenNotMobileItem() {
-		$stub = $this->getMockForAbstractClass( Process::class );
+		$expected = $this->user_agent;
+		$stub     = $this->getMockForAbstractClass( Process::class );
 
-		$this->assertNotContains( 'iPhone', $stub->get_item_user_agent( [ 'mobile' => 0 ] ) );
+		$this->assertSame( $expected, $stub->get_item_user_agent( [ 'mobile' => 0 ] ) );
 	}
 }

--- a/tests/Unit/inc/classes/preload/Process/getMobileUserAgentPrefix.php
+++ b/tests/Unit/inc/classes/preload/Process/getMobileUserAgentPrefix.php
@@ -1,0 +1,43 @@
+<?php
+namespace WP_Rocket\Tests\Unit\inc\classes\preload\Process;
+
+use Brain\Monkey\Filters;
+use WPMedia\PHPUnit\Unit\TestCase;
+use WP_Rocket\Preload\Process;
+
+/**
+ * @covers \WP_Rocket\Preload\Process::get_mobile_user_agent_prefix
+ * @group Preload
+ */
+class Test_GetMobileUserAgentPrefix extends TestCase {
+	private $prefix = 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1';
+
+	public function testShouldReturnMobilePrefixWhenNotFiltered() {
+		$stub = $this->getMockForAbstractClass( Process::class );
+
+		$this->assertSame( $this->prefix, $stub->get_mobile_user_agent_prefix() );
+	}
+
+	public function testShouldReturnMobilePrefixWhenFilteredWithWrongValue() {
+		$stub = $this->getMockForAbstractClass( Process::class );
+
+		Filters\expectApplied( 'rocket_mobile_preload_user_agent_prefix' )
+			->andReturn( '' ); // Simulate a filter.
+
+		$this->assertSame( $this->prefix, $stub->get_mobile_user_agent_prefix() );
+
+		Filters\expectApplied( 'rocket_mobile_preload_user_agent_prefix' )
+			->andReturn( [ 'ho ho ho' ] ); // Simulate a filter.
+
+		$this->assertSame( $this->prefix, $stub->get_mobile_user_agent_prefix() );
+	}
+
+	public function testShouldNotReturnMobilePrefixWhenFilteredWithValidValue() {
+		$stub = $this->getMockForAbstractClass( Process::class );
+
+		Filters\expectApplied( 'rocket_mobile_preload_user_agent_prefix' )
+			->andReturn( 'Internet Explorer' ); // Simulate a filter.
+
+		$this->assertSame( 'Internet Explorer', $stub->get_mobile_user_agent_prefix() );
+	}
+}

--- a/tests/Unit/inc/classes/subscriber/preload/Preload_Subscriber/maybePreloadMobileHomepage.php
+++ b/tests/Unit/inc/classes/subscriber/preload/Preload_Subscriber/maybePreloadMobileHomepage.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\classes\subscriber\preload\Preload_Subscriber;
+
+use Brain\Monkey\Functions;
+use WPMedia\PHPUnit\Unit\TestCase;
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Preload\Full_Process;
+use WP_Rocket\Preload\Homepage;
+use WP_Rocket\Subscriber\Preload\Preload_Subscriber;
+
+/**
+ * @covers \WP_Rocket\Subscriber\Preload::maybe_preload_mobile_homepage
+ * @group  Preload
+ */
+class Test_MaybePreloadMobileHomepage extends TestCase {
+	private $home_url   = 'https://example.org/';
+	private $user_agent = 'WP Rocket/Homepage_Preload_After_Purge_Cache';
+	private $prefix     = 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1';
+
+	public function testShouldUseMobilePrefixWhenMobilePreloadIsEnabled() {
+		$options            = $this->createMock( Options_Data::class );
+		$homepage_preloader = $this->createMock( Homepage::class );
+		$homepage_preloader
+			->expects( $this->once() )
+			->method( 'is_mobile_preload_enabled' )
+			->willReturn( true );
+		$homepage_preloader
+			->expects( $this->once() )
+			->method( 'get_mobile_user_agent_prefix' )
+			->willReturn( $this->prefix );
+
+		Functions\expect( 'wp_safe_remote_get' )
+			->once()
+			->with(
+				$this->home_url,
+				[
+					'user-agent' => $this->prefix . ' ' . $this->user_agent,
+				]
+			);
+
+		$subscriber = new Preload_Subscriber( $homepage_preloader, $options );
+
+		$subscriber->maybe_preload_mobile_homepage( $this->home_url, 'whatever', [] );
+	}
+
+	public function testShouldNotUseMobilePrefixWhenMobilePreloadIsNotEnabled() {
+		$options            = $this->createMock( Options_Data::class );
+		$homepage_preloader = $this->createMock( Homepage::class );
+		$homepage_preloader
+			->expects( $this->once() )
+			->method( 'is_mobile_preload_enabled' )
+			->willReturn( false );
+		$homepage_preloader
+			->expects( $this->never() )
+			->method( 'get_mobile_user_agent_prefix' );
+
+		Functions\expect( 'wp_safe_remote_get' )
+			->never();
+
+		$subscriber = new Preload_Subscriber( $homepage_preloader, $options );
+
+		$subscriber->maybe_preload_mobile_homepage( $this->home_url, 'whatever', [] );
+	}
+}


### PR DESCRIPTION
Make the user agent used to preload mobile pages detected as mobile by `wp_is_mobile()`.
We use now a more complex user agent, closer to a real one, that uses `iPhone` (for WPR mobile detect) and `Mobile` (for `wp_is_mobile()`).
Also, this new string is prepended to the custom user agent instead of being happened.

Fixes #2383.