### PR TITLE
Fixes #2302 CPCSS is not always automatically generated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,6 +85,7 @@
 		"test-integration-adminonly": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group AdminOnly",
 		"test-integration-docloudflare": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group DoCloudflare",
 		"test-integration-withwoo": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group WithWoo",
+		"test-integration-cpcss": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group CriticalCss",
 		"run-tests": [
 			"@test-unit",
 			"@test-integration",

--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,6 @@
 		"test-integration-adminonly": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group AdminOnly",
 		"test-integration-docloudflare": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group DoCloudflare",
 		"test-integration-withwoo": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group WithWoo",
-		"test-integration-cpcss": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group CriticalCss",
 		"run-tests": [
 			"@test-unit",
 			"@test-integration",

--- a/inc/classes/optimization/CSS/class-critical-css.php
+++ b/inc/classes/optimization/CSS/class-critical-css.php
@@ -52,7 +52,7 @@ class Critical_CSS {
 			'url'  => home_url( '/' ),
 		];
 
-		$this->critical_css_path = WP_ROCKET_CRITICAL_CSS_PATH . get_current_blog_id() . '/';
+		$this->critical_css_path = rocket_get_constant( 'WP_ROCKET_CRITICAL_CSS_PATH' ) . get_current_blog_id() . '/';
 	}
 
 	/**

--- a/inc/classes/subscriber/Optimization/class-critical-css-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-critical-css-subscriber.php
@@ -41,7 +41,7 @@ class Critical_CSS_Subscriber implements Subscriber_Interface {
 
 		return [
 			'admin_post_rocket_generate_critical_css' => 'init_critical_css_generation',
-			'update_option_' . $slug         => [
+			'update_option_' . $slug                  => [
 				[ 'generate_critical_css_on_activation', 11, 2 ],
 				[ 'stop_process_on_deactivation', 11, 2 ],
 			],

--- a/inc/classes/subscriber/Optimization/class-critical-css-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-critical-css-subscriber.php
@@ -138,27 +138,29 @@ class Critical_CSS_Subscriber implements Subscriber_Interface {
 	 * @param array $value     New values for WP Rocket settings.
 	 */
 	public function generate_critical_css_on_activation( $old_value, $value ) {
-		if ( isset( $old_value['async_css'], $value['async_css'] ) && ( $old_value['async_css'] !== $value['async_css'] ) && 1 === (int) $value['async_css'] ) {
-			$critical_css_path = $this->critical_css->get_critical_css_path();
+		if ( ! isset( $old_value['async_css'], $value['async_css'] ) || ( $old_value['async_css'] === $value['async_css'] ) || 1 !== (int) $value['async_css'] ) {
+			return;
+		}
 
-			// Check if the CPCSS path exists and create it.
-			if ( ! rocket_direct_filesystem()->is_dir( $critical_css_path ) ) {
-				rocket_mkdir_p( $critical_css_path );
-			}
+		$critical_css_path = $this->critical_css->get_critical_css_path();
 
-			try {
-				if ( ( new FilesystemIterator( $critical_css_path, FilesystemIterator::SKIP_DOTS ) )->valid() ) {
-					// Bail out if the folder is not empty.
-					return;
-				}
-			} catch ( UnexpectedValueException $e ) {
-				// Bail out when folder is invalid.
+		// Check if the CPCSS path exists and create it.
+		if ( ! rocket_direct_filesystem()->is_dir( $critical_css_path ) ) {
+			rocket_mkdir_p( $critical_css_path );
+		}
+
+		try {
+			if ( ( new FilesystemIterator( $critical_css_path, FilesystemIterator::SKIP_DOTS ) )->valid() ) {
+				// Bail out if the folder is not empty.
 				return;
 			}
-
-			// Generate the CPCSS files.
-			$this->critical_css->process_handler();
+		} catch ( UnexpectedValueException $e ) {
+			// Bail out when folder is invalid.
+			return;
 		}
+
+		// Generate the CPCSS files.
+		$this->critical_css->process_handler();
 	}
 
 	/**

--- a/inc/classes/subscriber/Optimization/class-critical-css-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-critical-css-subscriber.php
@@ -4,6 +4,9 @@ namespace WP_Rocket\Subscriber\Optimization;
 use WP_Rocket\Event_Management\Subscriber_Interface;
 use WP_Rocket\Optimization\CSS\Critical_CSS;
 use WP_Rocket\Admin\Options_Data;
+use FilesystemIterator;
+use UnexpectedValueException;
+
 
 defined( 'ABSPATH' ) || exit;
 
@@ -34,9 +37,11 @@ class Critical_CSS_Subscriber implements Subscriber_Interface {
 	 * @return array
 	 */
 	public static function get_subscribed_events() {
+		$slug = rocket_get_constant( 'WP_ROCKET_SLUG' );
+
 		return [
 			'admin_post_rocket_generate_critical_css' => 'init_critical_css_generation',
-			'update_option_' . WP_ROCKET_SLUG         => [
+			'update_option_' . $slug         => [
 				[ 'generate_critical_css_on_activation', 11, 2 ],
 				[ 'stop_process_on_deactivation', 11, 2 ],
 			],
@@ -134,14 +139,24 @@ class Critical_CSS_Subscriber implements Subscriber_Interface {
 	 */
 	public function generate_critical_css_on_activation( $old_value, $value ) {
 		if ( isset( $old_value['async_css'], $value['async_css'] ) && ( $old_value['async_css'] !== $value['async_css'] ) && 1 === (int) $value['async_css'] ) {
+			$critical_css_path = $this->critical_css->get_critical_css_path();
+
+			// Check if the CPCSS path exists and create it.
+			if ( ! rocket_direct_filesystem()->is_dir( $critical_css_path ) ) {
+				rocket_mkdir_p( $critical_css_path );
+			}
+
 			try {
-				if ( ( new \FilesystemIterator( $this->critical_css->get_critical_css_path(), \FilesystemIterator::SKIP_DOTS ) )->valid() ) {
+				if ( ( new FilesystemIterator( $critical_css_path, FilesystemIterator::SKIP_DOTS ) )->valid() ) {
+					// Bail out if the folder is not empty.
 					return;
 				}
-			} catch ( \UnexpectedValueException $e ) {
+			} catch ( UnexpectedValueException $e ) {
+				// Bail out when folder is invalid.
 				return;
 			}
 
+			// Generate the CPCSS files.
 			$this->critical_css->process_handler();
 		}
 	}

--- a/tests/Integration/inc/classes/subscriber/Optimization/class-critical-css-subscriber/generateCriticalCssOnActivation.php
+++ b/tests/Integration/inc/classes/subscriber/Optimization/class-critical-css-subscriber/generateCriticalCssOnActivation.php
@@ -1,0 +1,55 @@
+<?php
+namespace WP_Rocket\Tests\Integration\inc\classes\subscriber\Optimization\Critical_CSS_Subscriber;
+
+use FilesystemIterator;
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+use WP_Rocket\Tests\Integration\FilesystemTestCase;
+
+/**
+ * @covers \WP_Rocket\Subscriber\Optimization\Critical_CSS_Subscriber::generate_critical_css_on_activation
+ * @group  Subscribers
+ * @group  CriticalCss
+ */
+class Test_GenerateCriticalCssOnActivation extends FilesystemTestCase {
+
+	protected $structure = [
+		'critical-css' => [
+			'1' => [
+				'.'            => '',
+				'..'           => '',
+				'critical.css' => 'css content',
+			],
+		],
+	];
+
+	private static $container;
+	private $subscriber;
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		self::$container = apply_filters( 'rocket_container', null );
+	}
+
+	public function setUp() {
+		parent::setUp();
+
+		Functions\expect( 'rocket_get_constant' )->atLeast( 1 )->with( 'WP_ROCKET_CRITICAL_CSS_PATH' )->andReturn( $this->filesystem->getUrl( 'cache/critical-css/' ) );
+		$this->subscriber = self::$container->get( 'critical_css_subscriber' );
+	}
+
+	public function testShouldBailOutWhenCriticalCSSOptionIsFalse() {
+		$this->assertEquals( 0, Filters\applied( 'do_rocket_critical_css_generation' ) );
+		Functions\expect( 'get_transient' )->with( 'rocket_critical_css_generation_process_running' )->never();
+
+		$this->subscriber->generate_critical_css_on_activation( [ 'async_css' => 0 ], [ 'async_css' => 0 ] );
+	}
+
+	public function testShouldBailOutWhenCriticalCssPathIsValid() {
+		$this->assertEquals( 0, Filters\applied( 'do_rocket_critical_css_generation' ) );
+		Functions\expect( 'get_transient' )->with( 'rocket_critical_css_generation_process_running' )->never();
+
+		$this->subscriber->generate_critical_css_on_activation( [ 'async_css' => 0 ], [ 'async_css' => 1 ] );
+	}
+
+}

--- a/tests/Integration/inc/classes/subscriber/Optimization/class-critical-css-subscriber/generateCriticalCssOnActivation.php
+++ b/tests/Integration/inc/classes/subscriber/Optimization/class-critical-css-subscriber/generateCriticalCssOnActivation.php
@@ -18,7 +18,7 @@ class Test_GenerateCriticalCssOnActivation extends FilesystemTestCase {
 			'1' => [
 				'.'            => '',
 				'..'           => '',
-				'critical.css' => 'css content',
+				'critical.css' => 'body { font-family: Helvetica, Arial, sans-serif; text-align: center;}',
 			],
 		],
 	];

--- a/tests/Unit/inc/classes/subscriber/Optimization/class-critical-css-subscriber/generateCriticalCssOnActivation.php
+++ b/tests/Unit/inc/classes/subscriber/Optimization/class-critical-css-subscriber/generateCriticalCssOnActivation.php
@@ -1,0 +1,81 @@
+<?php
+namespace WP_Rocket\Tests\Unit\inc\classes\subscriber\Optimization\Critical_CSS_Subscriber;
+
+use FilesystemIterator;
+use Brain\Monkey\Functions;
+use Mockery;
+use UnexpectedValueException;
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Optimization\CSS\Critical_CSS;
+use WP_Rocket\Optimization\CSS\Critical_CSS_Generation;
+use WP_Rocket\Subscriber\Optimization\Critical_CSS_Subscriber;
+use WP_Rocket\Tests\Unit\FilesystemTestCase;
+
+/**
+ * @covers \WP_Rocket\Subscriber\Optimization\Critical_CSS_Subscriber::generate_critical_css_on_activation
+ * @group  Subscribers
+ * @group  CriticalCss
+ */
+class Test_GenerateCriticalCssOnActivation extends FilesystemTestCase {
+
+	protected $structure = [
+		'critical-css' => [
+			'1' => [
+				'.'            => '',
+				'..'           => '',
+				'critical.css' => 'css content',
+			],
+			// This one is empty.
+			'2' => [
+				'.'  => '',
+				'..' => '',
+			],
+		],
+	];
+
+	private $critical_css;
+	private $subscriber;
+
+	public function setUp() {
+		parent::setUp();
+
+		Functions\expect( 'rocket_get_constant' )->atLeast( 1 )->with( 'WP_ROCKET_CRITICAL_CSS_PATH' )->andReturn( $this->filesystem->getUrl( 'cache/critical-css/' ) );
+		Functions\when( 'get_current_blog_id' )->justReturn( 1 );
+		Functions\expect( 'home_url' )->once()->with( '/' )->andReturn( 'http://example.com' );
+
+		$this->critical_css = Mockery::mock( Critical_CSS::class, [ $this->createMock( Critical_CSS_Generation::class ) ] );
+		$this->subscriber   = new Critical_CSS_Subscriber(
+			$this->critical_css,
+			$this->createMock( Options_Data::class )
+		);
+	}
+
+	public function testShouldBailOutWhenCriticalCSSOptionIsFalse() {
+		$this->critical_css->shouldReceive( 'process_handler' )->never();
+
+		$this->subscriber->generate_critical_css_on_activation( [ 'async_css' => 0 ], [ 'async_css' => 0 ] );
+	}
+
+	public function testShouldBailOutWhenCriticalCssPathIsInvalid() {
+		$this->critical_css->shouldReceive( 'process_handler' )->never();
+		$this->critical_css->shouldReceive( 'get_critical_css_path' )->once()->andReturn( 'invalid' );
+
+		$this->subscriber->generate_critical_css_on_activation( [ 'async_css' => 0 ], [ 'async_css' => 1 ] );
+	}
+
+
+	public function testShouldBailOutWhenCriticalCssPathIsNotEmpty() {
+		$this->critical_css->shouldReceive( 'process_handler' )->never();
+		$this->critical_css->shouldReceive( 'get_critical_css_path' )->once()->andReturn( 'vfs://cache/critical-css/1/' );
+
+		$this->subscriber->generate_critical_css_on_activation( [ 'async_css' => 0 ], [ 'async_css' => 1 ] );
+	}
+
+	public function testShouldInvokeProcessHandlerWhenCriticalCssPathIsEmpty() {
+		$this->critical_css->shouldReceive( 'process_handler' )->once()->andReturn();
+		$this->critical_css->shouldReceive( 'get_critical_css_path' )->once()->andReturn( 'vfs://cache/critical-css/2/' );
+
+		$this->subscriber->generate_critical_css_on_activation( [ 'async_css' => 0 ], [ 'async_css' => 1 ] );
+	}
+
+}

--- a/tests/Unit/inc/classes/subscriber/Optimization/class-critical-css-subscriber/generateCriticalCssOnActivation.php
+++ b/tests/Unit/inc/classes/subscriber/Optimization/class-critical-css-subscriber/generateCriticalCssOnActivation.php
@@ -23,7 +23,7 @@ class Test_GenerateCriticalCssOnActivation extends FilesystemTestCase {
 			'1' => [
 				'.'            => '',
 				'..'           => '',
-				'critical.css' => 'css content',
+				'critical.css' => 'body { font-family: Helvetica, Arial, sans-serif; text-align: center;}',
 			],
 			// This one is empty.
 			'2' => [


### PR DESCRIPTION
The issue is that critical css is saved in the folder /wp-content/cache/critical-css/1, however on a first activation of Critical CSS this folder does not exist, so there will be an error and a return which will not allow to create the critical CSS.

Scope a solution ✅
The solution should be to check before if the folder structure exists otherwise create it and allow to run the process_handler() function.

Closes #2302 

**TODO**
- [x] Unit tests
- [x] Integration tests
- [x] QA live tests