### PR TITLE
Fixes #2341: Preload count in admin notice is inaccurate

### DIFF
--- a/inc/classes/ServiceProvider/class-preload-subscribers.php
+++ b/inc/classes/ServiceProvider/class-preload-subscribers.php
@@ -47,6 +47,7 @@ class Preload_Subscribers extends AbstractServiceProvider {
 			->withArgument( $this->getContainer()->get( 'full_preload_process' ) );
 		$this->getContainer()->share( 'preload_subscriber', 'WP_Rocket\Subscriber\Preload\Preload_Subscriber' )
 			->withArgument( $this->getContainer()->get( 'homepage_preload' ) )
+			->withArgument( $this->getContainer()->get( 'sitemap_preload' ) )
 			->withArgument( $this->getContainer()->get( 'options' ) );
 		$this->getContainer()->share( 'sitemap_preload_subscriber', 'WP_Rocket\Subscriber\Preload\Sitemap_Preload_Subscriber' )
 			->withArgument( $this->getContainer()->get( 'sitemap_preload' ) )

--- a/inc/classes/subscriber/preload/class-preload-subscriber.php
+++ b/inc/classes/subscriber/preload/class-preload-subscriber.php
@@ -5,6 +5,7 @@ use WP_Rocket\Logger\Logger;
 use WP_Rocket\Event_Management\Subscriber_Interface;
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Preload\Homepage;
+use WP_Rocket\Preload\Sitemap;
 
 /**
  * Preload Subscriber
@@ -24,6 +25,16 @@ class Preload_Subscriber implements Subscriber_Interface {
 	private $homepage_preloader;
 
 	/**
+	 * Sitemap Preload instance.
+	 *
+	 * @since  3.5.0.2
+	 * @author Grégory Viguier
+	 *
+	 * @var Sitemap
+	 */
+	private $sitemap_preloader;
+
+	/**
 	 * WP Rocket Options instance.
 	 *
 	 * @since 3.2
@@ -40,10 +51,12 @@ class Preload_Subscriber implements Subscriber_Interface {
 	 * @author Remy Perona
 	 *
 	 * @param Homepage     $homepage_preloader Homepage Preload instance.
+	 * @param Sitemap      $sitemap_preloader  Sitemap Preload instance.
 	 * @param Options_Data $options            WP Rocket Options instance.
 	 */
-	public function __construct( Homepage $homepage_preloader, Options_Data $options ) {
+	public function __construct( Homepage $homepage_preloader, Sitemap $sitemap_preloader, Options_Data $options ) {
 		$this->homepage_preloader = $homepage_preloader;
+		$this->sitemap_preloader  = $sitemap_preloader;
 		$this->options            = $options;
 	}
 
@@ -126,7 +139,7 @@ class Preload_Subscriber implements Subscriber_Interface {
 	}
 
 	/**
-	 * Launches the preload if the option is activated
+	 * Launches the homepage preload if the option is activated.
 	 *
 	 * @since 3.2
 	 * @author Remy Perona
@@ -270,13 +283,15 @@ class Preload_Subscriber implements Subscriber_Interface {
 			return;
 		}
 
-		$running = $this->homepage_preloader->get_number_of_preloaded_items();
+		$homepage_count = $this->homepage_preloader->get_number_of_preloaded_items();
+		$sitemap_count  = $this->sitemap_preloader->get_number_of_preloaded_items();
 
-		if ( false === $running ) {
+		if ( false === $homepage_count && false === $sitemap_count ) {
 			return;
 		}
 
-		$status = 'info';
+		$running = $homepage_count + $sitemap_count;
+		$status  = 'info';
 		// translators: %1$s = Number of pages preloaded.
 		$message  = '<p>' . sprintf( _n( 'Preload: %1$s uncached page has now been preloaded. (refresh to see progress)', 'Preload: %1$s uncached pages have now been preloaded. (refresh to see progress)', $running, 'rocket' ), number_format_i18n( $running ) );
 		$message .= ' <em> - (' . date_i18n( get_option( 'date_format' ) ) . ' @ ' . date_i18n( get_option( 'time_format' ) ) . ') </em></p>';

--- a/inc/classes/subscriber/preload/class-preload-subscriber.php
+++ b/inc/classes/subscriber/preload/class-preload-subscriber.php
@@ -27,7 +27,7 @@ class Preload_Subscriber implements Subscriber_Interface {
 	/**
 	 * Sitemap Preload instance.
 	 *
-	 * @since  3.5.0.2
+	 * @since  3.5.0.3
 	 * @author Grégory Viguier
 	 *
 	 * @var Sitemap

--- a/tests/Unit/inc/classes/subscriber/preload/Preload_Subscriber/maybePreloadMobileHomepage.php
+++ b/tests/Unit/inc/classes/subscriber/preload/Preload_Subscriber/maybePreloadMobileHomepage.php
@@ -7,6 +7,7 @@ use WPMedia\PHPUnit\Unit\TestCase;
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Preload\Full_Process;
 use WP_Rocket\Preload\Homepage;
+use WP_Rocket\Preload\Sitemap;
 use WP_Rocket\Subscriber\Preload\Preload_Subscriber;
 
 /**
@@ -20,6 +21,7 @@ class Test_MaybePreloadMobileHomepage extends TestCase {
 
 	public function testShouldUseMobilePrefixWhenMobilePreloadIsEnabled() {
 		$options            = $this->createMock( Options_Data::class );
+		$sitemap_preloader  = $this->createMock( Sitemap::class );
 		$homepage_preloader = $this->createMock( Homepage::class );
 		$homepage_preloader
 			->expects( $this->once() )
@@ -39,13 +41,14 @@ class Test_MaybePreloadMobileHomepage extends TestCase {
 				]
 			);
 
-		$subscriber = new Preload_Subscriber( $homepage_preloader, $options );
+		$subscriber = new Preload_Subscriber( $homepage_preloader, $sitemap_preloader, $options );
 
 		$subscriber->maybe_preload_mobile_homepage( $this->home_url, 'whatever', [] );
 	}
 
 	public function testShouldNotUseMobilePrefixWhenMobilePreloadIsNotEnabled() {
 		$options            = $this->createMock( Options_Data::class );
+		$sitemap_preloader  = $this->createMock( Sitemap::class );
 		$homepage_preloader = $this->createMock( Homepage::class );
 		$homepage_preloader
 			->expects( $this->once() )
@@ -58,7 +61,7 @@ class Test_MaybePreloadMobileHomepage extends TestCase {
 		Functions\expect( 'wp_safe_remote_get' )
 			->never();
 
-		$subscriber = new Preload_Subscriber( $homepage_preloader, $options );
+		$subscriber = new Preload_Subscriber( $homepage_preloader, $sitemap_preloader, $options );
 
 		$subscriber->maybe_preload_mobile_homepage( $this->home_url, 'whatever', [] );
 	}


### PR DESCRIPTION
This fixes again the number of preloaded pages displayed in the admin notice.
The notice was displaying the homepage preload count only, missing the sitemap preload count.

At some point we will need to rethink some things in this `Preload_Subscriber` class, as it should deal only with homepage preload (as the `Sitemap_Preload_Subscriber` deals with sitemap preload), but ends up also dealing with the admin notice, and so, with the sitemap preload.
Imho, this class should be the reunion of all preload types, and a class `Homepage_Preload_Subscriber` (similar to `Sitemap_Preload_Subscriber`, and both using a common interface) should be created. The hidden advantage of this class would be its name being more understandable (it was a challenge for me to understand the role of each class, especially since the roles are mixed in this one).

Closes #2341.