### PR TITLE
Fixes 2376 Prevent PHP Fatal Error in process.php

### DIFF
--- a/inc/admin/upgrader.php
+++ b/inc/admin/upgrader.php
@@ -254,8 +254,6 @@ add_action( 'wp_rocket_first_install', 'rocket_first_install' );
  */
 function rocket_new_upgrade( $wp_rocket_version, $actual_version ) {
 	if ( version_compare( $actual_version, '2.4.1', '<' ) ) {
-		// Regenerate advanced-cache.php file.
-		rocket_generate_advanced_cache_file();
 		delete_transient( 'rocket_ask_for_update' );
 	}
 
@@ -270,13 +268,9 @@ function rocket_new_upgrade( $wp_rocket_version, $actual_version ) {
 
 		update_option( WP_ROCKET_SLUG, $options );
 
-		// Regenerate advanced-cache.php file.
-		rocket_generate_advanced_cache_file();
 	}
 
 	if ( version_compare( $actual_version, '2.7', '<' ) ) {
-		// Regenerate advanced-cache.php file.
-		rocket_generate_advanced_cache_file();
 
 		// Regenerate config file.
 		rocket_generate_config_file();
@@ -334,7 +328,6 @@ function rocket_new_upgrade( $wp_rocket_version, $actual_version ) {
 		rocket_clean_domain();
 		rocket_clean_minify();
 		rocket_clean_cache_busting();
-		rocket_generate_advanced_cache_file();
 	}
 
 	if ( version_compare( $actual_version, '3.0.3', '<' ) ) {
@@ -347,10 +340,6 @@ function rocket_new_upgrade( $wp_rocket_version, $actual_version ) {
 
 	if ( version_compare( $actual_version, '3.1.1', '<' ) ) {
 		rocket_generate_config_file();
-	}
-
-	if ( version_compare( $actual_version, '3.1.4', '<' ) ) {
-		rocket_generate_advanced_cache_file();
 	}
 
 	if ( version_compare( $actual_version, '3.2', '<' ) ) {
@@ -366,7 +355,6 @@ function rocket_new_upgrade( $wp_rocket_version, $actual_version ) {
 
 		update_option( WP_ROCKET_SLUG, $options );
 		rocket_generate_config_file();
-		rocket_generate_advanced_cache_file();
 
 		// Create a .htaccess file in the log folder.
 		$handler = Logger::get_stream_handler();
@@ -409,13 +397,11 @@ function rocket_new_upgrade( $wp_rocket_version, $actual_version ) {
 	}
 
 	if ( version_compare( $actual_version, '3.3', '<' ) ) {
-		rocket_generate_advanced_cache_file();
 		rocket_generate_config_file();
 		rocket_clean_domain();
 	}
 
 	if ( version_compare( $actual_version, '3.3.2', '<' ) ) {
-		rocket_generate_advanced_cache_file();
 		flush_rocket_htaccess();
 		rocket_generate_config_file();
 		rocket_clean_domain();
@@ -446,6 +432,10 @@ function rocket_new_upgrade( $wp_rocket_version, $actual_version ) {
 
 	if ( version_compare( $actual_version, '3.4.0.1', '<' ) ) {
 		( new WP_Rocket\Subscriber\Plugin\Capabilities_Subscriber() )->add_rocket_capabilities();
+	}
+
+	if ( version_compare( $actual_version, '3.5.1', '<' ) ) {
+		rocket_generate_advanced_cache_file();
 	}
 }
 add_action( 'wp_rocket_upgrade', 'rocket_new_upgrade', 10, 2 );

--- a/inc/admin/upgrader.php
+++ b/inc/admin/upgrader.php
@@ -1,5 +1,6 @@
 <?php
 use WP_Rocket\Logger\Logger;
+use WP_Rocket\Subscriber\Plugin\Capabilities_Subscriber;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -269,11 +270,6 @@ function rocket_new_upgrade( $wp_rocket_version, $actual_version ) {
 		update_option( WP_ROCKET_SLUG, $options );
 	}
 
-	if ( version_compare( $actual_version, '2.7', '<' ) ) {
-		// Regenerate config file.
-		rocket_generate_config_file();
-	}
-
 	if ( version_compare( $actual_version, '2.8', '<' ) ) {
 		$options                              = get_option( WP_ROCKET_SLUG );
 		$options['manual_preload']            = 1;
@@ -323,21 +319,8 @@ function rocket_new_upgrade( $wp_rocket_version, $actual_version ) {
 	}
 
 	if ( version_compare( $actual_version, '2.11', '<' ) ) {
-		rocket_clean_domain();
 		rocket_clean_minify();
 		rocket_clean_cache_busting();
-	}
-
-	if ( version_compare( $actual_version, '3.0.3', '<' ) ) {
-		if ( rocket_is_ssl_website() ) {
-			update_rocket_option( 'cache_ssl', 1 );
-		}
-
-		rocket_generate_config_file();
-	}
-
-	if ( version_compare( $actual_version, '3.1.1', '<' ) ) {
-		rocket_generate_config_file();
 	}
 
 	if ( version_compare( $actual_version, '3.2', '<' ) ) {
@@ -371,38 +354,11 @@ function rocket_new_upgrade( $wp_rocket_version, $actual_version ) {
 	}
 
 	if ( version_compare( $actual_version, '3.2.0.1', '<' ) ) {
-		flush_rocket_htaccess();
 		wp_safe_remote_get( esc_url( home_url() ) );
 	}
 
-	if ( version_compare( $actual_version, '3.2.1', '<' ) ) {
-		flush_rocket_htaccess();
-		rocket_generate_config_file();
-		rocket_clean_domain();
-	}
-
-	if ( version_compare( $actual_version, '3.2.1.1', '<' ) ) {
-		rocket_generate_config_file();
-	}
-
-	if ( version_compare( $actual_version, '3.2.2', '<' ) ) {
-		flush_rocket_htaccess();
-	}
-
-	if ( version_compare( $actual_version, '3.2.4', '<' ) ) {
-		flush_rocket_htaccess();
-		rocket_generate_config_file();
-	}
-
-	if ( version_compare( $actual_version, '3.3', '<' ) ) {
-		rocket_generate_config_file();
-		rocket_clean_domain();
-	}
-
 	if ( version_compare( $actual_version, '3.3.2', '<' ) ) {
-		flush_rocket_htaccess();
 		rocket_generate_config_file();
-		rocket_clean_domain();
 	}
 
 	if ( version_compare( $actual_version, '3.3.6', '<' ) ) {
@@ -429,7 +385,7 @@ function rocket_new_upgrade( $wp_rocket_version, $actual_version ) {
 	}
 
 	if ( version_compare( $actual_version, '3.4.0.1', '<' ) ) {
-		( new WP_Rocket\Subscriber\Plugin\Capabilities_Subscriber() )->add_rocket_capabilities();
+		( new Capabilities_Subscriber() )->add_rocket_capabilities();
 	}
 
 	if ( version_compare( $actual_version, '3.5.1', '<' ) ) {

--- a/inc/admin/upgrader.php
+++ b/inc/admin/upgrader.php
@@ -267,11 +267,9 @@ function rocket_new_upgrade( $wp_rocket_version, $actual_version ) {
 		}
 
 		update_option( WP_ROCKET_SLUG, $options );
-
 	}
 
 	if ( version_compare( $actual_version, '2.7', '<' ) ) {
-
 		// Regenerate config file.
 		rocket_generate_config_file();
 	}

--- a/inc/front/process.php
+++ b/inc/front/process.php
@@ -1,19 +1,19 @@
 <?php
-
+// phpcs:ignoreFile
 defined( 'ABSPATH' ) || exit;
 
 // Don't cache robots.txt && .htaccess directory (it's happened sometimes with weird server configuration).
-if ( isset( $_SERVER['REQUEST_URI'] ) && ( strstr( wp_unslash( $_SERVER['REQUEST_URI'] ), 'robots.txt' ) || strstr( wp_unslash( $_SERVER['REQUEST_URI'] ), '.htaccess' ) ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+if ( isset( $_SERVER['REQUEST_URI'] ) && ( strstr( $_SERVER['REQUEST_URI'], 'robots.txt' ) || strstr( $_SERVER['REQUEST_URI'], '.htaccess' ) ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 	rocket_define_donotoptimize_constant( true );
 
 	return;
 }
 
-$rocket_request_uri = explode( '?', wp_unslash( $_SERVER['REQUEST_URI'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+$rocket_request_uri = explode( '?', $_SERVER['REQUEST_URI'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 $rocket_request_uri = reset( $rocket_request_uri );
 
 // Don't cache disallowed extensions.
-if ( strtolower( wp_unslash( $_SERVER['REQUEST_URI'] ) ) !== '/index.php' && in_array( pathinfo( $rocket_request_uri, PATHINFO_EXTENSION ), [ 'php', 'xml', 'xsl' ], true ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+if ( strtolower( $_SERVER['REQUEST_URI'] ) !== '/index.php' && in_array( pathinfo( $rocket_request_uri, PATHINFO_EXTENSION ), [ 'php', 'xml', 'xsl' ], true ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 	rocket_define_donotoptimize_constant( true );
 
 	return;

--- a/inc/front/process.php
+++ b/inc/front/process.php
@@ -284,7 +284,7 @@ $request_uri_path = preg_replace_callback( '/%[0-9A-F]{2}/', 'rocket_urlencode_l
 // Directories in Windows can't contain question marks.
 $request_uri_path = str_replace( '?', '_', $request_uri_path ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
 
-$rocket_cache_filepath = $request_uri_path . '/' . $filename . '.html';
+$rocket_cache_filepath = $request_uri_path . '/' . $rocket_filename . '.html';
 
 
 // Serve the cache file if exist.

--- a/tests/Integration/inc/admin/rocketNewUpgrade.php
+++ b/tests/Integration/inc/admin/rocketNewUpgrade.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\Inc\admin;
+
+use Brain\Monkey\Functions;
+use WPMedia\PHPUnit\Integration\TestCase;
+
+/**
+ * @covers ::rocket_new_upgrade
+ * @group admin
+ * @group upgrade
+ * @group AdminOnly
+ */
+class Test_RocketNewUpgrade extends TestCase {
+	public function testShouldRegenerateAdvancedCacheFile() {
+		Functions\expect( 'rocket_generate_advanced_cache_file' )
+			->once();
+
+		do_action( 'wp_rocket_upgrade', '3.5.1', '3.4.4' );
+	}
+}

--- a/tests/Unit/inc/admin/rocketNewUpgrade.php
+++ b/tests/Unit/inc/admin/rocketNewUpgrade.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\admin;
+
+use Brain\Monkey\Functions;
+use WPMedia\PHPUnit\Unit\TestCase;
+
+/**
+ * @covers ::rocket_new_upgrade
+ * @group admin
+ * @group upgrade
+ */
+class Test_RocketNewUpgrade extends TestCase {
+	public function setUp() {
+		parent::setUp();
+
+		require_once WP_ROCKET_PLUGIN_ROOT . 'inc/admin/upgrader.php';
+	}
+
+	public function testShouldRegenerateAdvancedCacheFile() {
+		Functions\when( 'rocket_is_ssl_website' )->justReturn( false );
+		Functions\expect( 'rocket_generate_advanced_cache_file' )
+			->once();
+
+		rocket_new_upgrade( '3.5.1', '3.4.4' );
+	}
+}


### PR DESCRIPTION
- Remove calls to `wp_unslash()`, WP is not fully loaded at that point
- Regenerate the `advanced-cache.php` file on next plugin update

Closes #2376 

## TODO

- [x] Review the [Acceptance Criteria](https://github.com/wp-media/wp-rocket/issues/2376#issuecomment-596566555)
- [x] Review the ["What if" scenarios](https://github.com/wp-media/wp-rocket/issues/2376#issuecomment-596566555)
- [x] Unit tests
- [x] Integration tests
- [x] QA