### PR TITLE
Prevent licence-data.php file deletion on multisite

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,12 +85,14 @@
 		"test-integration-adminonly": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group AdminOnly",
 		"test-integration-docloudflare": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group DoCloudflare",
 		"test-integration-withwoo": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group WithWoo",
+		"test-integration-multisite": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group Multisite",
 		"run-tests": [
 			"@test-unit",
 			"@test-integration",
 			"@test-integration-adminonly",
 			"@test-integration-docloudflare",
-			"@test-integration-withwoo"
+			"@test-integration-withwoo",
+			"@test-integration-multisite"
 		],
 		"run-stan":"vendor/bin/phpstan analyze --memory-limit=2G --no-progress",
 		"install-codestandards": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",

--- a/inc/functions/options.php
+++ b/inc/functions/options.php
@@ -639,6 +639,10 @@ function rocket_check_key() {
  * @return void
  */
 function rocket_delete_licence_data_file() {
+	if ( is_multisite() ) {
+		return;
+	}
+
 	$rocket_path = rocket_get_constant( 'WP_ROCKET_PATH' );
 
 	if ( ! rocket_direct_filesystem()->exists( $rocket_path . 'licence-data.php' ) ) {

--- a/tests/Integration/bootstrap.php
+++ b/tests/Integration/bootstrap.php
@@ -23,6 +23,10 @@ tests_add_filter(
 			require WP_ROCKET_PLUGIN_ROOT . '/vendor/woocommerce/woocommerce/woocommerce.php';
 		}
 
+		if ( BootstrapManager::isGroup( 'Multisite' ) ) {
+			define( 'MULTISITE', true );
+		}
+
 		// Overload the license key for testing.
 		redefine( 'rocket_valid_key', '__return_true' );
 

--- a/tests/Integration/inc/functions/rocketDeleteLicenceDataFile.php
+++ b/tests/Integration/inc/functions/rocketDeleteLicenceDataFile.php
@@ -28,4 +28,15 @@ class Test_RocketDeleteLicenceDataFile extends FilesystemTestCase {
 
 		$this->assertFalse( $this->filesystem->exists( 'licence-data.php' ) );
 	}
+
+	/**
+	 * @group Multisite
+	 */
+	public function testShouldDoNothingWhenMultisite() {
+		$this->assertTrue( $this->filesystem->exists( 'wp-rocket/licence-data.php' ) );
+
+		rocket_delete_licence_data_file();
+
+		$this->assertTrue( $this->filesystem->exists( 'wp-rocket/licence-data.php' ) );
+	}
 }

--- a/tests/Unit/inc/functions/rocketDeleteLicenceDataFile.php
+++ b/tests/Unit/inc/functions/rocketDeleteLicenceDataFile.php
@@ -24,6 +24,7 @@ class Test_RocketDeleteLicenceDataFile extends FilesystemTestCase {
 	}
 
 	public function testShouldDeleteLicenceDataFileWhenExists() {
+		Functions\when( 'is_multisite' )->justReturn( false );
 		Functions\expect( 'rocket_get_constant' )
 			->once()
 			->with( 'WP_ROCKET_PATH' )
@@ -34,5 +35,15 @@ class Test_RocketDeleteLicenceDataFile extends FilesystemTestCase {
 		rocket_delete_licence_data_file();
 
 		$this->assertFalse( $this->filesystem->exists( 'wp-rocket/licence-data.php' ) );
+	}
+
+	public function testShouldDoNothingWhenMultisite() {
+		Functions\when( 'is_multisite' )->justReturn( true );
+
+		$this->assertTrue( $this->filesystem->exists( 'wp-rocket/licence-data.php' ) );
+
+		rocket_delete_licence_data_file();
+
+		$this->assertTrue( $this->filesystem->exists( 'wp-rocket/licence-data.php' ) );
 	}
 }


### PR DESCRIPTION
On multisite we need to preserve the `licence-data.php` file for other sub-sites to be able to validate the license too

Closes #2411 