### PR TITLE
Fix #2416 - Fatal error: Uncaught Error: Class 'WPaas\Plugin' not found

### DIFF
--- a/inc/3rd-party/hosting/godaddy.php
+++ b/inc/3rd-party/hosting/godaddy.php
@@ -101,6 +101,9 @@ add_action( 'before_rocket_clean_home', 'rocket_clean_home_godaddy', 10, 2 );
  * @return void
  */
 function rocket_godaddy_request( $method, $url = null ) {
+	if ( ! method_exists( 'WPass\Plugin', 'vip' ) ) {
+		return;
+	}
 	if ( empty( $url ) ) {
 		$url = home_url();
 	}

--- a/inc/main.php
+++ b/inc/main.php
@@ -189,9 +189,16 @@ function rocket_activation() {
 	require WP_ROCKET_FUNCTIONS_PATH . 'formatting.php';
 	require WP_ROCKET_FUNCTIONS_PATH . 'i18n.php';
 	require WP_ROCKET_FUNCTIONS_PATH . 'htaccess.php';
-	require WP_ROCKET_3RD_PARTY_PATH . 'hosting/godaddy.php';
-	require WP_ROCKET_3RD_PARTY_PATH . 'hosting/o2switch.php';
-	require WP_ROCKET_3RD_PARTY_PATH . 'hosting/wpengine.php';
+
+	if ( class_exists( 'WPaaS\Plugin' ) ) {
+		require WP_ROCKET_3RD_PARTY_PATH . 'hosting/godaddy.php';
+	}
+	if ( defined( 'O2SWITCH_VARNISH_PURGE_KEY' ) ) {
+		require WP_ROCKET_3RD_PARTY_PATH . 'hosting/o2switch.php';
+	}
+	if ( class_exists( 'WpeCommon' ) && function_exists( 'wpe_param' ) ) {
+		require WP_ROCKET_3RD_PARTY_PATH . 'hosting/wpengine.php';
+	}
 
 	if ( rocket_valid_key() ) {
 		// Add All WP Rocket rules of the .htaccess file.

--- a/tests/Integration/inc/main/rocketActivation.php
+++ b/tests/Integration/inc/main/rocketActivation.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\main;
+
+use Brain\Monkey\Functions;
+use WPMedia\PHPUnit\Integration\TestCase;
+
+/**
+ * @covers ::rocket_activation
+ * @group AdminOnly
+ * @group Activation
+ */
+class Test_RocketActivation extends TestCase {
+	private static $included_files;
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		Functions\expect( 'rocket_get_constant' )
+			->with( 'O2SWITCH_VARNISH_PURGE_KEY' )
+			->andReturn( 'varnish_key' );
+
+		self::$included_files = get_included_files();
+	}
+
+	public function testShouldNotLoadHostingGoDaddyWPEngine() {
+		$this->assertFalse( in_array( WP_ROCKET_3RD_PARTY_PATH . 'hosting/godaddy.php', self::$included_files ) );
+		$this->assertFalse( in_array( WP_ROCKET_3RD_PARTY_PATH . 'hosting/wpengine.php', self::$included_files ) );
+	}
+
+	public function testShouldLoadoHostingO2SWITCH() {
+		$this->assertTrue( in_array( WP_ROCKET_3RD_PARTY_PATH . 'hosting/o2switch.php', self::$included_files ) );
+	}
+
+}


### PR DESCRIPTION
Warning: count(): Parameter must be an array or an object that implements Countable in /wp-content/plugins/wp-rocket/inc/functions/files.php on line 266
Fatal error: Uncaught Error: Class 'WPaas\Plugin' not found in //wp-content/plugins/wp-rocket/inc/3rd-party/hosting/godaddy.php:108 Stack trace: #0 /wp-content/plugins/wp-rocket/inc/3rd-party/hosting/godaddy.php(58): rocket_godaddy_request('BAN')
#1 /wp-includes/class-wp-hook.php(290): rocket_clean_domain_godaddy('/home/C4011/web...') #2 /wp-includes/class-wp-hook.php(312): WP_Hook->apply_filters('', Array)
#3 /wp-includes/plugin.php(478): WP_Hook->do_action(Array)
#4 /wp-content/plugins/wp-rocket/inc/functions/files.php(840): do_action('before_rocket_c...', '/home/C4011/web...', '', 'https://progros...')
#5 /wp-content/plugins/webtoffee-gdpr-cookie-consent/third-party/scripts/wp-rocket/wp-rocket.php(72): rocket_clean_domain()
#6 /hom in/wp-content/plugins/wp-rocket/inc/3rd-party/hosting/godaddy.php on line 108