### PR TITLE
Use filter_var instead of filter_input to validate REMOTE_ADDR

### DIFF
--- a/inc/common/cloudflare-flexible-ssl.php
+++ b/inc/common/cloudflare-flexible-ssl.php
@@ -31,7 +31,7 @@ function rocket_is_cloudflare() {
  * @return bool
  */
 function rocket_is_cf_ip() {
-	if ( ! isset( $_SERVER['REMOTE_ADDR'] ) ) {
+	if ( empty( $_SERVER['REMOTE_ADDR'] ) ) {
 		return false;
 	}
 

--- a/inc/common/cloudflare-flexible-ssl.php
+++ b/inc/common/cloudflare-flexible-ssl.php
@@ -38,7 +38,7 @@ function rocket_is_cf_ip() {
 	// Store original remote address in $original_ip.
 	$original_ip = filter_var( wp_unslash( $_SERVER['REMOTE_ADDR'] ), FILTER_VALIDATE_IP );
 
-	if ( ! isset( $original_ip ) ) {
+	if ( empty( $original_ip ) ) {
 		return false;
 	}
 

--- a/inc/common/cloudflare-flexible-ssl.php
+++ b/inc/common/cloudflare-flexible-ssl.php
@@ -31,8 +31,13 @@ function rocket_is_cloudflare() {
  * @return bool
  */
 function rocket_is_cf_ip() {
+	if ( ! isset( $_SERVER['REMOTE_ADDR'] ) ) {
+		return false;
+	}
+
 	// Store original remote address in $original_ip.
-	$original_ip = filter_input( INPUT_SERVER, 'REMOTE_ADDR', FILTER_VALIDATE_IP );
+	$original_ip = filter_var( wp_unslash( $_SERVER['REMOTE_ADDR'] ), FILTER_VALIDATE_IP );
+
 	if ( ! isset( $original_ip ) ) {
 		return false;
 	}


### PR DESCRIPTION
Customer website was in a redirect loop after update to 3.5.

NOTE (added by Tonya): The code in question is from 3.4.1.

After digging, I found out that `filter_input` was returning a `NULL` value instead of the IP when we check for it in the Cloudflare flexible SSL code.

There seems to be a bug with `filter_input` and FastCGI, so that would impact some setups: https://www.php.net/manual/en/function.filter-input.php#115960

Using `filter_var` with the global SERVER variable directly solves the issue. Confirmed on the customer website.

Closes #2421 