### PR TITLE
Fixes 2416 By conditioning loading of hosting files upon plugin activation

### DIFF
--- a/inc/3rd-party/hosting/godaddy.php
+++ b/inc/3rd-party/hosting/godaddy.php
@@ -101,9 +101,14 @@ add_action( 'before_rocket_clean_home', 'rocket_clean_home_godaddy', 10, 2 );
  * @return void
  */
 function rocket_godaddy_request( $method, $url = null ) {
+	if ( ! method_exists( 'WPass\Plugin', 'vip' ) ) {
+		return;
+	}
+
 	if ( empty( $url ) ) {
 		$url = home_url();
 	}
+
 	$host = rocket_extract_url_component( $url, PHP_URL_HOST );
 	$url  = set_url_scheme( str_replace( $host, WPaas\Plugin::vip(), $url ), 'http' );
 

--- a/inc/main.php
+++ b/inc/main.php
@@ -189,9 +189,16 @@ function rocket_activation() {
 	require WP_ROCKET_FUNCTIONS_PATH . 'formatting.php';
 	require WP_ROCKET_FUNCTIONS_PATH . 'i18n.php';
 	require WP_ROCKET_FUNCTIONS_PATH . 'htaccess.php';
-	require WP_ROCKET_3RD_PARTY_PATH . 'hosting/godaddy.php';
-	require WP_ROCKET_3RD_PARTY_PATH . 'hosting/o2switch.php';
-	require WP_ROCKET_3RD_PARTY_PATH . 'hosting/wpengine.php';
+
+	if ( class_exists( 'WPaaS\Plugin' ) ) {
+		require WP_ROCKET_3RD_PARTY_PATH . 'hosting/godaddy.php';
+	}
+	if ( defined( 'O2SWITCH_VARNISH_PURGE_KEY' ) ) {
+		require WP_ROCKET_3RD_PARTY_PATH . 'hosting/o2switch.php';
+	}
+	if ( class_exists( 'WpeCommon' ) && function_exists( 'wpe_param' ) ) {
+		require WP_ROCKET_3RD_PARTY_PATH . 'hosting/wpengine.php';
+	}
 
 	if ( rocket_valid_key() ) {
 		// Add All WP Rocket rules of the .htaccess file.

--- a/tests/Integration/inc/ThirdParty/thirdParty.php
+++ b/tests/Integration/inc/ThirdParty/thirdParty.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\ThirdParty;
+
+use WPMedia\PHPUnit\Integration\TestCase;
+
+/**
+ * @group ThirdParty
+ */
+class Test_ThirdParty extends TestCase {
+	private static $included_files;
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		self::$included_files = get_included_files();
+	}
+
+	public function testShouldNotLoadHostingFilesWhenNotPresent() {
+		$this->assertNotContains( WP_ROCKET_3RD_PARTY_PATH . 'hosting/godaddy.php', self::$included_files );
+		$this->assertNotContains( WP_ROCKET_3RD_PARTY_PATH . 'hosting/wpengine.php', self::$included_files );
+		$this->assertNotContains( WP_ROCKET_3RD_PARTY_PATH . 'hosting/o2switch.php', self::$included_files );
+		$this->assertNotContains( WP_ROCKET_3RD_PARTY_PATH . 'hosting/flywheel.php', self::$included_files );
+		$this->assertNotContains( WP_ROCKET_3RD_PARTY_PATH . 'hosting/siteground.php', self::$included_files );
+	}
+}

--- a/tests/Integration/inc/rocketActivation.php
+++ b/tests/Integration/inc/rocketActivation.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc;
+
+use Brain\Monkey\Functions;
+use WPMedia\PHPUnit\Integration\TestCase;
+
+/**
+ * @covers ::rocket_activation
+ * @group AdminOnly
+ * @group Activation
+ */
+class Test_RocketActivation extends TestCase {
+
+	public function testShouldNotLoadoHostingFilesWhenNotInActivation() {
+		Functions\expect( 'rocket_get_constant' )
+			->with( 'O2SWITCH_VARNISH_PURGE_KEY' )
+			->andReturn( 'varnish_key' );
+
+		$included_files = get_included_files();
+
+		$this->assertNotContains( WP_ROCKET_3RD_PARTY_PATH . 'hosting/godaddy.php', $included_files );
+		$this->assertNotContains( WP_ROCKET_3RD_PARTY_PATH . 'hosting/wpengine.php', $included_files );
+		$this->assertNotContains( WP_ROCKET_3RD_PARTY_PATH . 'hosting/o2switch.php', $included_files );
+	}
+}


### PR DESCRIPTION
Closes #2416 

- Conditions loading the 3rd party hosting files upon plugin activation
- Checks if class and `vip` method exists. If no, bails out.

Recreates PR #2419 to base off of `master` instead of `develop`.