### PR TITLE
Fix #2241 - Add display swap param for single Google font

### DIFF
--- a/inc/classes/optimization/CSS/class-combine-google-fonts.php
+++ b/inc/classes/optimization/CSS/class-combine-google-fonts.php
@@ -205,11 +205,6 @@ class Combine_Google_Fonts extends Abstract_Optimization {
 			return $font_url . '&display=' . $display;
 		}
 
-		if ( isset( $allowed_values[ $parsed_font['display'] ] ) ) {
-			// Font display exists and is valid.
-			return $font_url;
-		}
-
 		$font_url = str_replace( '&display=' . $parsed_font['display'], '', $font_url );
 		return $font_url . '&display=' . $display;
 	}

--- a/tests/Fixtures/inc/classes/optimization/CSS/Combine_Google_Fonts/optimize.php
+++ b/tests/Fixtures/inc/classes/optimization/CSS/Combine_Google_Fonts/optimize.php
@@ -118,4 +118,88 @@ return [
 			'</body>' .
 		'</html>',
 	],
+	// Single Font no Display param
+	[
+		// Test Data: Original HTML.
+		'<html>' .
+			'<head>' .
+				'<title>Sample Page</title>' .
+				'<link href="https://fonts.googleapis.com/css?family=Josefin+Sans:300" rel="stylesheet" property="stylesheet" type"text/css" media="all">' .
+			'</head>' .
+			'<body>' .
+			'</body>' .
+		'</html>',
+		// Expected: Combined HTML.
+		'<html>' .
+			'<head>' .
+				'<title>Sample Page</title>' .
+				'<link href="https://fonts.googleapis.com/css?family=Josefin+Sans:300&display=swap" rel="stylesheet" property="stylesheet" type"text/css" media="all">' .
+			'</head>' .
+			'<body>' .
+			'</body>' .
+		'</html>',
+	],
+	// Single Font Display param
+	[
+		// Test Data: Original HTML.
+		'<html>' .
+			'<head>' .
+				'<title>Sample Page</title>' .
+				'<link href="https://fonts.googleapis.com/css?family=Josefin+Sans:300&display=auto" rel="stylesheet" property="stylesheet" type"text/css" media="all">' .
+			'</head>' .
+			'<body>' .
+			'</body>' .
+		'</html>',
+		// Expected: Combined HTML.
+		'<html>' .
+			'<head>' .
+				'<title>Sample Page</title>' .
+				'<link href="https://fonts.googleapis.com/css?family=Josefin+Sans:300&display=auto" rel="stylesheet" property="stylesheet" type"text/css" media="all">' .
+			'</head>' .
+			'<body>' .
+			'</body>' .
+		'</html>',
+	],
+	// Single Font Invalid Display param
+	[
+		// Test Data: Original HTML.
+		'<html>' .
+			'<head>' .
+				'<title>Sample Page</title>' .
+				'<link href="https://fonts.googleapis.com/css?family=Josefin+Sans:300&display=invalid" rel="stylesheet" property="stylesheet" type"text/css" media="all">' .
+			'</head>' .
+			'<body>' .
+			'</body>' .
+		'</html>',
+		// Expected: Combined HTML.
+		'<html>' .
+			'<head>' .
+				'<title>Sample Page</title>' .
+				'<link href="https://fonts.googleapis.com/css?family=Josefin+Sans:300&display=swap" rel="stylesheet" property="stylesheet" type"text/css" media="all">' .
+			'</head>' .
+			'<body>' .
+			'</body>' .
+		'</html>',
+	],
+	// Single Font with decode
+	[
+		// Test Data: Original HTML.
+		'<html>' .
+			'<head>' .
+				'<title>Sample Page</title>' .
+				'<link rel="stylesheet" id="dt-web-fonts-css"  href="//fonts.googleapis.com/css?family=Josefin+Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica+One%3A400%2C600%2C700&#038;ver=7.3.2" type="text/css" media="all" />' .
+			'</head>' .
+			'<body>' .
+			'</body>' .
+		'</html>',
+		// Expected: Combined HTML.
+		'<html>' .
+			'<head>' .
+				'<title>Sample Page</title>' .
+				'<link rel="stylesheet" id="dt-web-fonts-css"  href="//fonts.googleapis.com/css?family=Josefin+Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica+One%3A400%2C600%2C700&ver=7.3.2&display=swap" type="text/css" media="all" />' .
+			'</head>' .
+			'<body>' .
+			'</body>' .
+		'</html>',
+	],
 ];

--- a/tests/Fixtures/inc/classes/optimization/CSS/Combine_Google_Fonts/optimize.php
+++ b/tests/Fixtures/inc/classes/optimization/CSS/Combine_Google_Fonts/optimize.php
@@ -20,7 +20,7 @@ return [
 		// Expected: Combined HTML.
 		'<html>' .
 			'<head>' .
-				'<title>Sample Page</title><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&display=swap" />' .
+				'<title>Sample Page</title><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=swap" />' .
 			'</head>' .
 			'<body>' .
 			'</body>' .
@@ -43,7 +43,7 @@ return [
 		// Expected: Combined HTML.
 		'<html>' .
 			'<head>' .
-				'<title>Sample Page</title><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato%3A100%2C300%2C400%2C600%2C700%2C900%7COpen%20Sans%3A700%2C300%2C600%2C400%7CRaleway%3A900%7CPlayfair%20Display%7COpen%20Sans%7CJockey%20One%3A400%7CAbril%20Fatface%3Aregular&subset=latin&display=swap" />' .
+				'<title>Sample Page</title><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato%3A100%2C300%2C400%2C600%2C700%2C900%7COpen%20Sans%3A700%2C300%2C600%2C400%7CRaleway%3A900%7CPlayfair%20Display%7COpen%20Sans%7CJockey%20One%3A400%7CAbril%20Fatface%3Aregular&#038;subset=latin&#038;display=swap" />' .
 			'</head>' .
 			'<body>' .
 			'</body>' .
@@ -65,7 +65,7 @@ return [
 		// Expected: Combined HTML.
 		'<html>' .
 			'<head>' .
-				'<title>Sample Page</title><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&display=swap" />' .
+				'<title>Sample Page</title><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=swap" />' .
 			'</head>' .
 			'<body>' .
 			'</body>' .
@@ -87,7 +87,7 @@ return [
 		// Expected: Combined HTML.
 		'<html>' .
 			'<head>' .
-				'<title>Sample Page</title><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3Aregular%2C300%7CLato%3Aregular%2C300&display=swap" />' .
+				'<title>Sample Page</title><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3Aregular%2C300%7CLato%3Aregular%2C300&#038;display=swap" />' .
 			'</head>' .
 			'<body>' .
 			'</body>' .
@@ -133,7 +133,7 @@ return [
 		'<html>' .
 			'<head>' .
 				'<title>Sample Page</title>' .
-				'<link href="https://fonts.googleapis.com/css?family=Josefin+Sans:300&display=swap" rel="stylesheet" property="stylesheet" type"text/css" media="all">' .
+				'<link href="https://fonts.googleapis.com/css?family=Josefin+Sans:300&#038;display=swap" rel="stylesheet" property="stylesheet" type"text/css" media="all">' .
 			'</head>' .
 			'<body>' .
 			'</body>' .
@@ -145,7 +145,7 @@ return [
 		'<html>' .
 			'<head>' .
 				'<title>Sample Page</title>' .
-				'<link href="https://fonts.googleapis.com/css?family=Josefin+Sans:300&display=auto" rel="stylesheet" property="stylesheet" type"text/css" media="all">' .
+				'<link href="https://fonts.googleapis.com/css?family=Josefin+Sans:300&#038;display=auto" rel="stylesheet" property="stylesheet" type"text/css" media="all">' .
 			'</head>' .
 			'<body>' .
 			'</body>' .
@@ -154,7 +154,7 @@ return [
 		'<html>' .
 			'<head>' .
 				'<title>Sample Page</title>' .
-				'<link href="https://fonts.googleapis.com/css?family=Josefin+Sans:300&display=swap" rel="stylesheet" property="stylesheet" type"text/css" media="all">' .
+				'<link href="https://fonts.googleapis.com/css?family=Josefin+Sans:300&#038;display=swap" rel="stylesheet" property="stylesheet" type"text/css" media="all">' .
 			'</head>' .
 			'<body>' .
 			'</body>' .
@@ -175,7 +175,7 @@ return [
 		'<html>' .
 			'<head>' .
 				'<title>Sample Page</title>' .
-				'<link href="https://fonts.googleapis.com/css?family=Josefin+Sans:300&display=swap" rel="stylesheet" property="stylesheet" type"text/css" media="all">' .
+				'<link href="https://fonts.googleapis.com/css?family=Josefin+Sans:300&#038;display=swap" rel="stylesheet" property="stylesheet" type"text/css" media="all">' .
 			'</head>' .
 			'<body>' .
 			'</body>' .
@@ -196,7 +196,7 @@ return [
 		'<html>' .
 			'<head>' .
 				'<title>Sample Page</title>' .
-				'<link rel="stylesheet" id="dt-web-fonts-css"  href="//fonts.googleapis.com/css?family=Josefin+Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica+One%3A400%2C600%2C700&ver=7.3.2&display=swap" type="text/css" media="all" />' .
+				'<link rel="stylesheet" id="dt-web-fonts-css"  href="//fonts.googleapis.com/css?family=Josefin+Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica+One%3A400%2C600%2C700&#038;ver=7.3.2&#038;display=swap" type="text/css" media="all" />' .
 			'</head>' .
 			'<body>' .
 			'</body>' .

--- a/tests/Fixtures/inc/classes/optimization/CSS/Combine_Google_Fonts/optimize.php
+++ b/tests/Fixtures/inc/classes/optimization/CSS/Combine_Google_Fonts/optimize.php
@@ -154,7 +154,7 @@ return [
 		'<html>' .
 			'<head>' .
 				'<title>Sample Page</title>' .
-				'<link href="https://fonts.googleapis.com/css?family=Josefin+Sans:300&display=auto" rel="stylesheet" property="stylesheet" type"text/css" media="all">' .
+				'<link href="https://fonts.googleapis.com/css?family=Josefin+Sans:300&display=swap" rel="stylesheet" property="stylesheet" type"text/css" media="all">' .
 			'</head>' .
 			'<body>' .
 			'</body>' .

--- a/tests/Unit/inc/classes/optimization/CSS/Combine_Google_Fonts/optimize.php
+++ b/tests/Unit/inc/classes/optimization/CSS/Combine_Google_Fonts/optimize.php
@@ -16,13 +16,16 @@ class Test_Optimize extends TestCase {
 	 * @dataProvider addDataProvider
 	 */
 	public function testShouldCombineGoogleFonts( $original, $combined ) {
-		Functions\when( 'rocket_extract_url_component' )->alias( function( $url, $component ) {
+		Functions\when( 'wp_parse_url' )->alias( function( $url, $component ) {
 			return parse_url( $url, $component );
 		} );
 		Functions\when( 'wp_parse_args' )->alias( function( $value ) {
 			parse_str( $value, $r );
 
 			return $r;
+		} );
+		Functions\when( 'esc_url' )->alias( function( $url ) {
+			return str_replace( [ '&amp;', '&' ], '&#038;', $url );
 		} );
 
 		$combine = new Combine_Google_Fonts();


### PR DESCRIPTION
Closes #2241 

**Reproduce the problem** ✅ 
Reproduced on local site

**Identify the root cause** ✅ 
Vasilis did a great job alredy at highlighting what was causing this 👍 

We currently stop the process if there is zero or one Google font on the page

**Scope a solution** ✅ 
There is multiple steps to achieve this:
- Stop the process only if there is no Google fonts on the page
- Add a new condition for the case when there is only one. We don't want to go through the whole parsing and rewriting in this case, we only want to add the display parameter to it. Faster code
- Create a new method to check if the display parameter is already present in the URL
- If no, add it with the `swap` value by default, filtered with the exisiting filter `rocket_combined_google_fonts_display`
- If yes, check its value. If it's not `swap`,  force the value, still using the filter above

**Estimate the effort** ✅ 

`Effort: [S]`

S task, we already have some unit & integration tests in place here, we will have to write additional ones for the one Google font case