### PR TITLE
[WIP] Fixes Too Few Arguments in pre_post_update hook

### DIFF
--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -283,7 +283,7 @@ add_action( 'wp_update_comment_count', 'rocket_clean_post' );
  * @param int   $post_id   The post ID.
  * @param array $post_data Array of unslashed post data.
  */
-function rocket_clean_post_cache_on_status_change( $post_id, $post_data ) {
+function rocket_clean_post_cache_on_status_change( $post_id, $post_data = null ) {
 	if ( 'publish' !== get_post_field( 'post_status', $post_id ) || 'draft' !== $post_data['post_status'] ) {
 		return;
 	}
@@ -623,7 +623,7 @@ function rocket_clean_cache_theme_update( $wp_upgrader, $hook_extra ) {
  * @param int   $post_id   The post ID.
  * @param array $post_data Array of unslashed post data.
  */
-function rocket_clean_post_cache_on_slug_change( $post_id, $post_data ) {
+function rocket_clean_post_cache_on_slug_change( $post_id, $post_data = null ) {
 	// Bail out if the post status is draft, pending or auto-draft.
 	if ( in_array( get_post_field( 'post_status', $post_id ), [ 'draft', 'pending', 'auto-draft' ], true ) ) {
 		return;


### PR DESCRIPTION
Fixes Fatal Error: Too few arguments on pre_post_update hook calls.

It seems the second parameter is not defined while saving products in drafts. I tried to recreate it on my local (WP + WOO) but I could not recreate it, so I assume is a plugin affecting this one.

Ticket:
https://secure.helpscout.net/conversation/1088587705/147100?folderId=3083222