### PR TITLE
Prevent errors caused by use of WP_Filesystem() for license-data.php require

### DIFF
--- a/wp-rocket.php
+++ b/wp-rocket.php
@@ -77,14 +77,12 @@ if ( ! defined( 'WP_ROCKET_LASTVERSION' ) ) {
 	define( 'WP_ROCKET_LASTVERSION', '3.4.4' );
 }
 
-if ( ! function_exists( 'WP_Filesystem' ) ) {
-	require ABSPATH . 'wp-admin/includes/file.php';
-}
-
-WP_Filesystem();
-global $wp_filesystem;
-
-if ( $wp_filesystem->exists( WP_ROCKET_PATH . 'licence-data.php' ) ) {
+/**
+ * We use is_readable() with @ silencing as WP_Filesystem() can use different methods to access the filesystem.
+ *
+ * This is more performant and more compatible. It allows us to work around file permissions and missing credentials.
+ */
+if ( @is_readable( WP_ROCKET_PATH . 'licence-data.php' ) ) { //phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 	require WP_ROCKET_PATH . 'licence-data.php';
 }
 


### PR DESCRIPTION
Closes #2455 

It's currently not possible to write automated tests for this, so we will be relying on QA test and live test on customers websites to confirm it works as expected.

@arunbasillal @vmanthos @piotrbak If you can check this change on tickets which reported the following problems:
- Errors in the log related to wp-filesystem, like `ftp_pwd()` related
- License validation issues where email & api key fields are blank

- [x] QA tests
- [x] Live tests