### PR TITLE
Closes #2399: Partial Preloading doesn't create a mobile file

### DIFF
--- a/inc/Engine/Preload/PartialPreloadSubscriber.php
+++ b/inc/Engine/Preload/PartialPreloadSubscriber.php
@@ -201,16 +201,27 @@ class PartialPreloadSubscriber implements Subscriber_Interface {
 		 *
 		 * @param int $limit Maximum number of URLs to preload at once.
 		 */
-		$limit = (int) apply_filters( 'rocket_preload_limit_number', 100 );
-		$count = 0;
+		$limit  = (int) apply_filters( 'rocket_preload_limit_number', 100 );
+		$count  = 0;
+		$mobile = $this->partial_preload->is_mobile_preload_enabled();
 
 		foreach ( $this->urls as $url ) {
 			$path = wp_parse_url( $url, PHP_URL_PATH );
+
 			if ( isset( $path ) && preg_match( '#^(' . \get_rocket_cache_reject_uri() . ')$#', $path ) ) {
 				continue;
 			}
 
 			$this->partial_preload->push_to_queue( $url );
+
+			if ( $mobile ) {
+				$this->partial_preload->push_to_queue(
+					[
+						'url'    => $url,
+						'mobile' => true,
+					]
+				);
+			}
 
 			++$count;
 

--- a/tests/Fixtures/inc/Engine/Preload/PartialProcess_Wrapper.php
+++ b/tests/Fixtures/inc/Engine/Preload/PartialProcess_Wrapper.php
@@ -1,0 +1,29 @@
+<?php
+// phpcs:ignoreFile
+namespace WP_Rocket\Tests\Fixtures\inc\Engine\Preload;
+
+use WP_Rocket\Engine\Preload\PartialProcess;
+
+/**
+ * Wrapper class used to test the results.
+ */
+class PartialProcess_Wrapper extends PartialProcess {
+	private $generatedKey;
+
+	public function save() {
+		$key = $this->generate_key();
+
+		if ( ! empty( $this->data ) ) {
+			update_site_option( $key, $this->data );
+			$this->generatedKey = $key;
+		} else {
+			$this->generatedKey = null;
+		}
+
+		return $this;
+	}
+
+	public function getGeneratedKey() {
+		return $this->generatedKey;
+	}
+}

--- a/tests/Integration/inc/Engine/Preload/PartialPreloadSubscriber/maybeDispatch.php
+++ b/tests/Integration/inc/Engine/Preload/PartialPreloadSubscriber/maybeDispatch.php
@@ -62,9 +62,6 @@ class Test_MaybeDispatch extends TestCase {
 		do_action( 'after_rocket_clean_post', $post, $purge_urls, 'en' );
 		do_action( 'shutdown' );
 
-		//$this->subscriber->preload_after_clean_post( $post, $purge_urls, 'en' );
-		//$this->subscriber->maybe_dispatch();
-
 		$key = $this->process_wrapper->getGeneratedKey();
 
 		$this->assertNotNull( $key );

--- a/tests/Integration/inc/Engine/Preload/PartialPreloadSubscriber/maybeDispatch.php
+++ b/tests/Integration/inc/Engine/Preload/PartialPreloadSubscriber/maybeDispatch.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\Preload\PartialPreloadSubscriber;
+
+use WP_Rocket\Tests\Fixtures\inc\Engine\Preload\PartialProcess_Wrapper;
+use WPMedia\PHPUnit\Integration\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Preload\PartialPreloadSubscriber::maybeDispatch
+ * @group  Preload
+ */
+class Test_MaybeDispatch extends TestCase {
+	private static $post_id;
+	private $subscriber;
+	private $process;
+	private $process_wrapper;
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$post_id = $factory->post->create();
+	}
+
+	public function setUp() {
+		parent::setUp();
+
+		add_filter( 'pre_get_rocket_option_manual_preload', [ $this, 'return_true' ] );
+		add_filter( 'pre_get_rocket_option_cache_mobile', [ $this, 'return_true' ] );
+		add_filter( 'pre_option_permalink_structure', [ $this, 'permalink_structure_filter' ] );
+		remove_action( 'shutdown', 'wp_ob_end_flush_all', 1 );
+
+		$container             = apply_filters( 'rocket_container', null );
+		$this->subscriber      = $container->get( 'partial_preload_subscriber' );
+		$process_ref           = $this->get_reflective_property( 'partial_preload', $this->subscriber );
+		$this->process         = $process_ref->getValue( $this->subscriber );
+		$this->process_wrapper = new PartialProcess_Wrapper();
+
+		$process_ref->setValue( $this->subscriber, $this->process_wrapper );
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+
+		remove_filter( 'pre_get_rocket_option_manual_preload', [ $this, 'return_true' ] );
+		remove_filter( 'pre_get_rocket_option_cache_mobile', [ $this, 'return_true' ] );
+		remove_filter( 'pre_get_rocket_option_do_caching_mobile_files', [ $this, 'return_true' ] );
+		remove_filter( 'pre_get_rocket_option_do_caching_mobile_files', [ $this, 'return_false' ] );
+		remove_filter( 'pre_option_permalink_structure', [ $this, 'permalink_structure_filter' ] );
+		add_action( 'shutdown', 'wp_ob_end_flush_all', 1 );
+
+		$this->set_reflective_property( $this->process, 'partial_preload', $this->subscriber );
+
+		$this->subscriber      = null;
+		$this->process         = null;
+		$this->process_wrapper = null;
+	}
+
+	public function testShouldDispatchWhenUrlsAndNoMobilePreload() {
+		add_filter( 'pre_get_rocket_option_do_caching_mobile_files', [ $this, 'return_false' ] );
+
+		$post       = get_post( self::$post_id );
+		$purge_urls = rocket_get_purge_urls( self::$post_id, $post );
+
+		do_action( 'after_rocket_clean_post', $post, $purge_urls, 'en' );
+		do_action( 'shutdown' );
+
+		//$this->subscriber->preload_after_clean_post( $post, $purge_urls, 'en' );
+		//$this->subscriber->maybe_dispatch();
+
+		$key = $this->process_wrapper->getGeneratedKey();
+
+		$this->assertNotNull( $key );
+
+		$queue    = get_site_option( $key );
+		$post_url = get_permalink( $post );
+		$home_url = get_rocket_i18n_home_url( 'en' );
+		delete_site_option( $key );
+
+		// Only desktop items.
+		$this->assertContains( $post_url, $queue );
+		$this->assertNotContains( [ 'url' => $post_url, 'mobile' => true ], $queue );
+		$this->assertContains( $home_url, $queue );
+		$this->assertNotContains( [ 'url' => $home_url, 'mobile' => true ], $queue );
+	}
+
+	public function testShouldDispatchWhenUrlsAndMobilePreload() {
+		add_filter( 'pre_get_rocket_option_do_caching_mobile_files', [ $this, 'return_true' ] );
+
+		$post       = get_post( self::$post_id );
+		$purge_urls = rocket_get_purge_urls( self::$post_id, $post );
+
+		do_action( 'after_rocket_clean_post', $post, $purge_urls, 'en' );
+		do_action( 'shutdown' );
+
+		$key = $this->process_wrapper->getGeneratedKey();
+
+		$this->assertNotNull( $key );
+
+		$queue    = get_site_option( $key );
+		$post_url = get_permalink( $post );
+		$home_url = get_rocket_i18n_home_url( 'en' );
+		delete_site_option( $key );
+
+		// Desktop and mobile items.
+		$this->assertContains( $post_url, $queue );
+		$this->assertContains( [ 'url' => $post_url, 'mobile' => true ], $queue );
+		$this->assertContains( $home_url, $queue );
+		$this->assertContains( [ 'url' => $home_url, 'mobile' => true ], $queue );
+	}
+
+	public function permalink_structure_filter() {
+		return '/%postname%/';
+	}
+}

--- a/tests/Integration/inc/Engine/Preload/PartialPreloadSubscriber/maybeDispatch.php
+++ b/tests/Integration/inc/Engine/Preload/PartialPreloadSubscriber/maybeDispatch.php
@@ -6,7 +6,7 @@ use WP_Rocket\Tests\Fixtures\inc\Engine\Preload\PartialProcess_Wrapper;
 use WPMedia\PHPUnit\Integration\TestCase;
 
 /**
- * @covers \WP_Rocket\Engine\Preload\PartialPreloadSubscriber::maybeDispatch
+ * @covers \WP_Rocket\Engine\Preload\PartialPreloadSubscriber::maybe_dispatch
  * @group  Preload
  */
 class Test_MaybeDispatch extends TestCase {

--- a/tests/Unit/inc/Engine/Preload/PartialPreloadSubscriber/maybeDispatch.php
+++ b/tests/Unit/inc/Engine/Preload/PartialPreloadSubscriber/maybeDispatch.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace WP_Rocket\Tests\Unit\inc\Engine\Preload\PartialPreloadSubscriber;
 
 use Brain\Monkey\Functions;

--- a/tests/Unit/inc/Engine/Preload/PartialPreloadSubscriber/maybeDispatch.php
+++ b/tests/Unit/inc/Engine/Preload/PartialPreloadSubscriber/maybeDispatch.php
@@ -1,0 +1,135 @@
+<?php
+namespace WP_Rocket\Tests\Unit\inc\Engine\Preload\PartialPreloadSubscriber;
+
+use Brain\Monkey\Functions;
+use WPMedia\PHPUnit\Unit\TestCase;
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Engine\Preload\PartialPreloadSubscriber;
+use WP_Rocket\Engine\Preload\PartialProcess;
+
+/**
+ * @covers \WP_Rocket\Engine\Preload\PartialPreloadSubscriber::maybe_dispatch
+ * @group  Preload
+ */
+class Test_MaybePreloadMobileHomepage extends TestCase {
+
+	public function testShouldNotDispatchWhenNoUrls() {
+		$options         = $this->createMock( Options_Data::class );
+		$partial_process = $this->createMock( PartialProcess::class );
+		$partial_process
+			->expects( $this->never() )
+			->method( 'is_mobile_preload_enabled' );
+
+		Functions\when( 'wp_doing_ajax' )
+			->justReturn( false );
+
+		$subscriber = new PartialPreloadSubscriber( $partial_process, $options );
+
+		$subscriber->maybe_dispatch();
+	}
+
+	public function testShouldDispatchWhenUrlsAndNoMobilePreload() {
+		$queue           = [];
+		$urls            = [
+			'https://example.org/',
+			'https://example.org/test/',
+		];
+		$options         = $this->createMock( Options_Data::class );
+		$partial_process = $this->getMockBuilder( PartialProcess::class )
+		                        ->setMethods( [ 'is_mobile_preload_enabled', 'push_to_queue', 'save', 'dispatch' ] )
+		                        ->getMock();
+		$partial_process
+			->expects( $this->once() )
+			->method( 'is_mobile_preload_enabled' )
+			->willReturn( false );
+		$partial_process
+			->expects( $this->exactly( 2 ) )
+			->method( 'push_to_queue' )
+			->will( $this->returnCallback( function( $item ) use ( &$queue ) {
+				$queue[] = $item;
+			} ) );
+		$partial_process
+			->expects( $this->once() )
+			->method( 'save' )
+			->willReturnSelf();
+		$partial_process
+			->expects( $this->once() )
+			->method( 'dispatch' )
+			->willReturn( null );
+
+		Functions\when( 'wp_doing_ajax' )
+			->justReturn( false );
+
+		Functions\when( 'wp_parse_url' )->alias( function( $url, $component = -1 ) {
+			return parse_url( $url, $component );
+		} );
+
+		Functions\when( 'get_rocket_cache_reject_uri' )
+			->justReturn( '/foo/|/bar/|/(?:.+/)?embed/' );
+
+		$subscriber = new PartialPreloadSubscriber( $partial_process, $options );
+
+		$this->set_reflective_property( $urls, 'urls', $subscriber );
+
+		$subscriber->maybe_dispatch();
+
+		$this->assertSame( $urls, $queue );
+		$this->assertCount( 2, $queue );
+	}
+
+	public function testShouldDispatchWhenUrlsAndMobilePreload() {
+		$queue           = [];
+		$urls            = [
+			'https://example.org/',
+			'https://example.org/test/',
+		];
+		$options         = $this->createMock( Options_Data::class );
+		$partial_process = $this->getMockBuilder( PartialProcess::class )
+		                        ->setMethods( [ 'is_mobile_preload_enabled', 'push_to_queue', 'save', 'dispatch' ] )
+		                        ->getMock();
+		$partial_process
+			->expects( $this->once() )
+			->method( 'is_mobile_preload_enabled' )
+			->willReturn( true );
+		$partial_process
+			->expects( $this->exactly( 4 ) )
+			->method( 'push_to_queue' )
+			->will( $this->returnCallback( function( $item ) use ( &$queue ) {
+				$queue[] = $item;
+			} ) );
+		$partial_process
+			->expects( $this->once() )
+			->method( 'save' )
+			->willReturnSelf();
+		$partial_process
+			->expects( $this->once() )
+			->method( 'dispatch' )
+			->willReturn( null );
+
+		Functions\when( 'wp_doing_ajax' )
+			->justReturn( false );
+
+		Functions\when( 'wp_parse_url' )->alias( function( $url, $component = -1 ) {
+			return parse_url( $url, $component );
+		} );
+
+		Functions\when( 'get_rocket_cache_reject_uri' )
+			->justReturn( '/foo/|/bar/|/(?:.+/)?embed/' );
+
+		$subscriber = new PartialPreloadSubscriber( $partial_process, $options );
+
+		$this->set_reflective_property( $urls, 'urls', $subscriber );
+
+		$subscriber->maybe_dispatch();
+
+		$expected = [
+			'https://example.org/',
+			[ 'url' => 'https://example.org/', 'mobile' => true ],
+			'https://example.org/test/',
+			[ 'url' => 'https://example.org/test/', 'mobile' => true ],
+		];
+
+		$this->assertSame( $expected, $queue );
+		$this->assertCount( 4, $queue );
+	}
+}

--- a/tests/Unit/inc/Engine/Preload/PartialPreloadSubscriber/maybeDispatch.php
+++ b/tests/Unit/inc/Engine/Preload/PartialPreloadSubscriber/maybeDispatch.php
@@ -12,6 +12,12 @@ use WP_Rocket\Engine\Preload\PartialProcess;
  * @group  Preload
  */
 class Test_MaybePreloadMobileHomepage extends TestCase {
+	private $queue = [];
+
+	protected function tearDown() {
+		parent::tearDown();
+		$this->queue = [];
+	}
 
 	public function testShouldNotDispatchWhenNoUrls() {
 		$options         = $this->createMock( Options_Data::class );
@@ -26,102 +32,29 @@ class Test_MaybePreloadMobileHomepage extends TestCase {
 		$subscriber = new PartialPreloadSubscriber( $partial_process, $options );
 
 		$subscriber->maybe_dispatch();
+
+		$this->assertEmpty( $this->queue );
 	}
 
 	public function testShouldDispatchWhenUrlsAndNoMobilePreload() {
-		$queue           = [];
-		$urls            = [
+		$urls = [
 			'https://example.org/',
 			'https://example.org/test/',
 		];
-		$options         = $this->createMock( Options_Data::class );
-		$partial_process = $this->getMockBuilder( PartialProcess::class )
-		                        ->setMethods( [ 'is_mobile_preload_enabled', 'push_to_queue', 'save', 'dispatch' ] )
-		                        ->getMock();
-		$partial_process
-			->expects( $this->once() )
-			->method( 'is_mobile_preload_enabled' )
-			->willReturn( false );
-		$partial_process
-			->expects( $this->exactly( 2 ) )
-			->method( 'push_to_queue' )
-			->will( $this->returnCallback( function( $item ) use ( &$queue ) {
-				$queue[] = $item;
-			} ) );
-		$partial_process
-			->expects( $this->once() )
-			->method( 'save' )
-			->willReturnSelf();
-		$partial_process
-			->expects( $this->once() )
-			->method( 'dispatch' )
-			->willReturn( null );
 
-		Functions\when( 'wp_doing_ajax' )
-			->justReturn( false );
+		$this->getSubscriber( $urls, false )->maybe_dispatch();
 
-		Functions\when( 'wp_parse_url' )->alias( function( $url, $component = -1 ) {
-			return parse_url( $url, $component );
-		} );
-
-		Functions\when( 'get_rocket_cache_reject_uri' )
-			->justReturn( '/foo/|/bar/|/(?:.+/)?embed/' );
-
-		$subscriber = new PartialPreloadSubscriber( $partial_process, $options );
-
-		$this->set_reflective_property( $urls, 'urls', $subscriber );
-
-		$subscriber->maybe_dispatch();
-
-		$this->assertSame( $urls, $queue );
-		$this->assertCount( 2, $queue );
+		foreach ( $urls as $url ) {
+			$this->assertContains( $url, $this->queue );
+		}
+		$this->assertCount( 2, $this->queue );
 	}
 
 	public function testShouldDispatchWhenUrlsAndMobilePreload() {
-		$queue           = [];
-		$urls            = [
+		$urls     = [
 			'https://example.org/',
 			'https://example.org/test/',
 		];
-		$options         = $this->createMock( Options_Data::class );
-		$partial_process = $this->getMockBuilder( PartialProcess::class )
-		                        ->setMethods( [ 'is_mobile_preload_enabled', 'push_to_queue', 'save', 'dispatch' ] )
-		                        ->getMock();
-		$partial_process
-			->expects( $this->once() )
-			->method( 'is_mobile_preload_enabled' )
-			->willReturn( true );
-		$partial_process
-			->expects( $this->exactly( 4 ) )
-			->method( 'push_to_queue' )
-			->will( $this->returnCallback( function( $item ) use ( &$queue ) {
-				$queue[] = $item;
-			} ) );
-		$partial_process
-			->expects( $this->once() )
-			->method( 'save' )
-			->willReturnSelf();
-		$partial_process
-			->expects( $this->once() )
-			->method( 'dispatch' )
-			->willReturn( null );
-
-		Functions\when( 'wp_doing_ajax' )
-			->justReturn( false );
-
-		Functions\when( 'wp_parse_url' )->alias( function( $url, $component = -1 ) {
-			return parse_url( $url, $component );
-		} );
-
-		Functions\when( 'get_rocket_cache_reject_uri' )
-			->justReturn( '/foo/|/bar/|/(?:.+/)?embed/' );
-
-		$subscriber = new PartialPreloadSubscriber( $partial_process, $options );
-
-		$this->set_reflective_property( $urls, 'urls', $subscriber );
-
-		$subscriber->maybe_dispatch();
-
 		$expected = [
 			'https://example.org/',
 			[ 'url' => 'https://example.org/', 'mobile' => true ],
@@ -129,7 +62,54 @@ class Test_MaybePreloadMobileHomepage extends TestCase {
 			[ 'url' => 'https://example.org/test/', 'mobile' => true ],
 		];
 
-		$this->assertSame( $expected, $queue );
-		$this->assertCount( 4, $queue );
+		$this->getSubscriber( $urls, true )->maybe_dispatch();
+
+		foreach ( $expected as $url ) {
+			$this->assertContains( $url, $this->queue );
+		}
+		$this->assertCount( 4, $this->queue );
+	}
+
+	private function getSubscriber( array $urls, $mobile_preload_enabled ) {
+		$nbr_items_in_queue = $mobile_preload_enabled ? 4 : 2;
+		$this->queue        = [];
+		$options            = $this->createMock( Options_Data::class );
+		$partial_process    = $this->getMockBuilder( PartialProcess::class )
+		                           ->setMethods( [ 'is_mobile_preload_enabled', 'push_to_queue', 'save', 'dispatch' ] )
+		                           ->getMock();
+		$partial_process
+			->expects( $this->once() )
+			->method( 'is_mobile_preload_enabled' )
+			->willReturn( $mobile_preload_enabled );
+		$partial_process
+			->expects( $this->exactly( $nbr_items_in_queue ) )
+			->method( 'push_to_queue' )
+			->will( $this->returnCallback( function( $item ) {
+				$this->queue[] = $item;
+			} ) );
+		$partial_process
+			->expects( $this->once() )
+			->method( 'save' )
+			->willReturnSelf();
+		$partial_process
+			->expects( $this->once() )
+			->method( 'dispatch' )
+			->willReturn( null );
+
+		Functions\when( 'wp_doing_ajax' )
+			->justReturn( false );
+
+		Functions\when( 'wp_parse_url' )->alias( function( $url, $component = -1 ) {
+			return parse_url( $url, $component );
+		} );
+
+		Functions\when( 'get_rocket_cache_reject_uri' )
+			->justReturn( '/foo/|/bar/|/(?:.+/)?embed/' );
+
+		$subscriber = new PartialPreloadSubscriber( $partial_process, $options );
+
+		$this->set_reflective_property( $urls, 'urls', $subscriber );
+
+		return $subscriber;
 	}
 }


### PR DESCRIPTION
This allows to preload (also) the mobile version of the URLs after:
- clearing a post cache,
- clearing a term cache,
- clearing automatically expired cache files.

Closes #2399.

- [ ] QA tests