### PR TITLE
Fix #2464 - CPCSS Allow <style> tag in fallback input field

### DIFF
--- a/inc/classes/admin/settings/class-settings.php
+++ b/inc/classes/admin/settings/class-settings.php
@@ -312,7 +312,7 @@ class Settings {
 		$input['async_css'] = ! empty( $input['async_css'] ) ? 1 : 0;
 
 		// Option: Critical CSS.
-		$input['critical_css'] = ! empty( $input['critical_css'] ) ? str_replace( [ '<style>', '</style>' ], '', wp_strip_all_tags( $input['critical_css'], [ "\'", '\"' ] ) ) : '';
+		$input['critical_css'] = ! empty( $input['critical_css'] ) ? wp_strip_all_tags( str_replace( [ '<style>', '</style>' ], '', $input['critical_css'] ), [ "\'", '\"' ] ) : '';
 
 		// Database options.
 		$input['database_revisions']          = ! empty( $input['database_revisions'] ) ? 1 : 0;

--- a/tests/Fixtures/inc/classes/admin/settings/Settings/sanitizeCallback.php
+++ b/tests/Fixtures/inc/classes/admin/settings/Settings/sanitizeCallback.php
@@ -51,4 +51,32 @@ return [
 			'critical_css' => 'body>a{ background-color: lightblue; } h1 { color: white; text-align: center; } p { font-family: verdana; font-size: 20px; }',
 		],
 	],
+
+	// Test Critical CSS without > child selector & <style> tag
+	[
+		[
+			'critical_css' => '<style>body { background-color: lightblue; } h1 { color: white; text-align: center; } p { font-family: verdana; font-size: 20px; } b</style>',
+		],
+		[
+			'critical_css' => 'body { background-color: lightblue; } h1 { color: white; text-align: center; } p { font-family: verdana; font-size: 20px; } b',
+		],
+	],
+	// Test Critical CSS with > child selector & <style> tag
+	[
+		[
+			'critical_css' => '<style>body > a { background-color: lightblue; } h1 { color: white; text-align: center; } p { font-family: verdana; font-size: 20px; } b</style>',
+		],
+		[
+			'critical_css' => 'body > a { background-color: lightblue; } h1 { color: white; text-align: center; } p { font-family: verdana; font-size: 20px; } b',
+		],
+	],
+	// Test Critical CSS with > child selector & XSS & <style> tag
+	[
+		[
+			'critical_css' => '<script>alert("a");</script><style>body > a { background-color: lightblue; } h1 { color: white; text-align: center; } p { font-family: verdana; font-size: 20px; } b</style>',
+		],
+		[
+			'critical_css' => 'body > a { background-color: lightblue; } h1 { color: white; text-align: center; } p { font-family: verdana; font-size: 20px; } b',
+		],
+	],
 ];


### PR DESCRIPTION
Closes #2468.

**Identify the root cause** ✅ 
The root cause is related to the order of the operations on this line:
https://github.com/wp-media/wp-rocket/blob/26e4ef22eb690577b5c46f180927af8e6e807742/inc/classes/admin/settings/class-settings.php#L315


**Scope a solution** ✅ 
The solution will be to first remove the <style> </style> tags and then to run wp_strip_all_tags:

`$input['critical_css'] = ! empty( $input['critical_css'] ) ? wp_strip_all_tags( str_replace( [ '<style>', '</style>' ], '', $input['critical_css'] ), [ "\'", '\"' ] ) : '';`


**Estimate the effort** ✅ 
Effort [XS]

- [x] Automated tests
- [x] QA tests