### PR TITLE
Fixes integration bootstrap and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,10 @@ before_install:
   # Unless we need XDebug, disable it for improved performance.
   - phpenv config-rm xdebug.ini || return 0
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
-  - rm composer.lock
+  - |
+    if [[ -f composer.lock ]] ; then
+      rm composer.lock
+    fi
   - composer remove --dev phpstan/phpstan szepeviktor/phpstan-wordpress
 install:
   - composer install --prefer-dist --no-interaction

--- a/tests/Integration/bootstrap.php
+++ b/tests/Integration/bootstrap.php
@@ -36,10 +36,6 @@ tests_add_filter(
 		define( 'WP_ROCKET_CACHE_ROOT_PATH', 'vfs://public/wp-content/cache/' );
 		define( 'WP_ROCKET_CACHE_ROOT_URL', 'vfs://public/wp-content/cache/' );
 
-		// Set the path and URL to our virtual filesystem.
-		define( 'WP_ROCKET_CACHE_ROOT_PATH', 'vfs://public/wp-content/cache/' );
-		define( 'WP_ROCKET_CACHE_ROOT_URL', 'vfs://public/wp-content/cache/' );
-
 		if ( BootstrapManager::isGroup( 'WithWoo' ) ) {
 			// Load WooCommerce.
 			define( 'WC_TAX_ROUNDING_MODE', 'auto' );


### PR DESCRIPTION
Fixes the integration bootstrap by removing the duplicate constant definitions.

Fixes Travis by first checking if the `composer.lock` file exists. If yes, remove it.

No QA is needed for this one, as no source code is changed.