### PR TITLE
Tests: Adds tests for rocket_is_plugin_active() and rocket_is_plugin_active_for_network()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,7 @@
 	},
 	"scripts": {
 		"test-unit": "\"vendor/bin/phpunit\" --testsuite unit --colors=always --configuration tests/Unit/phpunit.xml.dist",
-		"test-integration": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --exclude-group AdminOnly,WithWoo,WithAmp,WithAmpAndCloudflare,DoCloudflare",
+		"test-integration": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --exclude-group AdminOnly,WithWoo,WithAmp,WithAmpAndCloudflare,DoCloudflare,Multisite",
 		"test-integration-adminonly": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group AdminOnly",
 		"test-integration-docloudflare": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group DoCloudflare",
 		"test-integration-withwoo": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group WithWoo",

--- a/inc/functions/options.php
+++ b/inc/functions/options.php
@@ -61,6 +61,8 @@ function rocket_is_plugin_active( $plugin ) {
  * @source wp-admin/includes/plugin.php
  *
  * @param string $plugin Plugin folder/main file.
+ *
+ * @return bool true if multisite and plugin is active for network; else, false.
  */
 function rocket_is_plugin_active_for_network( $plugin ) {
 	if ( ! is_multisite() ) {

--- a/inc/functions/options.php
+++ b/inc/functions/options.php
@@ -48,9 +48,15 @@ function update_rocket_option( $key, $value ) { // phpcs:ignore WordPress.Naming
  * @source wp-admin/includes/plugin.php
  *
  * @param string $plugin Plugin folder/main file.
+ *
+ * @return boolean true when plugin is active; else false.
  */
 function rocket_is_plugin_active( $plugin ) {
-	return in_array( $plugin, (array) get_option( 'active_plugins', [] ), true ) || rocket_is_plugin_active_for_network( $plugin );
+	return (
+		in_array( $plugin, (array) get_option( 'active_plugins', [] ), true )
+		||
+		rocket_is_plugin_active_for_network( $plugin )
+	);
 }
 
 /**

--- a/inc/functions/options.php
+++ b/inc/functions/options.php
@@ -76,7 +76,7 @@ function rocket_is_plugin_active_for_network( $plugin ) {
 	}
 
 	$plugins = get_site_option( 'active_sitewide_plugins' );
-	return ( isset( $plugins[ $plugin ] ) );
+	return isset( $plugins[ $plugin ] );
 }
 
 /**

--- a/inc/functions/options.php
+++ b/inc/functions/options.php
@@ -68,11 +68,7 @@ function rocket_is_plugin_active_for_network( $plugin ) {
 	}
 
 	$plugins = get_site_option( 'active_sitewide_plugins' );
-	if ( isset( $plugins[ $plugin ] ) ) {
-		return true;
-	}
-
-	return false;
+	return ( isset( $plugins[ $plugin ] ) );
 }
 
 /**

--- a/tests/Fixtures/inc/functions/rocketIsPluginActive.php
+++ b/tests/Fixtures/inc/functions/rocketIsPluginActive.php
@@ -1,0 +1,123 @@
+<?php
+
+return [
+	'active_plugins'          => [
+		'akismet/akismet.php',
+		'imagify/imagify.php',
+		'woocommerce/woocommerce.php',
+		'wp-rocket/wp-rocket.php',
+	],
+	'active_sitewide_plugins' => [
+		'bbpress/bbpress.php'         => 1,
+		'ninja-forms/ninja-forms.php' => 1,
+		'wordpress-seo/wp-seo.php'    => 1,
+	],
+
+	'test_data' => [
+
+		'non_multisite' => [
+			[
+				'akismet/akismet.php',
+				true,
+			],
+			[
+				'imagify/imagify.php',
+				true,
+			],
+			[
+				'woocommerce/woocommerce.php',
+				true,
+			],
+			[
+				'wp-rocket/wp-rocket.php',
+				true,
+			],
+
+			// Multisite.
+			[
+				'bbpress/bbpress.php',
+				false,
+			],
+			[
+				'ninja-forms/ninja-forms.php',
+				false,
+			],
+			[
+				'wordpress-seo/wp-seo.php',
+				false,
+			],
+
+			// These don't exist.
+			[
+				'classic-editor/classic-editor.php',
+				false,
+			],
+			[
+				'gravity-forms/gravity-forms.php',
+				false,
+			],
+			[
+				'jetpack/jetpack.php',
+				false,
+			],
+			[
+				'wpforms-lites/wpforms.php',
+				false,
+			],
+		],
+
+		'multisite' => [
+			[
+				'akismet/akismet.php',
+				true,
+			],
+			[
+				'imagify/imagify.php',
+				true,
+			],
+			[
+				'woocommerce/woocommerce.php',
+				true,
+			],
+			[
+				'wp-rocket/wp-rocket.php',
+				true,
+			],
+
+			// Multisite.
+			[
+				'bbpress/bbpress.php',
+				true,
+				'is_multisite_active' => true,
+			],
+			[
+				'ninja-forms/ninja-forms.php',
+				true,
+				'is_multisite_active' => true,
+			],
+			[
+				'wordpress-seo/wp-seo.php',
+				true,
+				'is_multisite_active' => true,
+			],
+
+			// These don't exist.
+			[
+				'classic-editor/classic-editor.php',
+				false,
+			],
+			[
+				'gravity-forms/gravity-forms.php',
+				false,
+			],
+			[
+				'jetpack/jetpack.php',
+				false,
+			],
+			[
+				'wpforms-lites/wpforms.php',
+				false,
+			],
+		],
+	],
+];

--- a/tests/Fixtures/inc/functions/rocketIsPluginActiveForNetwork.php
+++ b/tests/Fixtures/inc/functions/rocketIsPluginActiveForNetwork.php
@@ -2,10 +2,10 @@
 
 return [
 	'active_sitewide_plugins' => [
-		'bbpress/bbpress.php' => 1,
+		'bbpress/bbpress.php'         => 1,
 		'ninja-forms/ninja-forms.php' => 1,
-		'wordpress-seo/wp-seo.php' => 1,
-		'wp-rocket/wp-rocket.php' => 1,
+		'wordpress-seo/wp-seo.php'    => 1,
+		'wp-rocket/wp-rocket.php'     => 1,
 	],
 
 	'test_data' => [

--- a/tests/Fixtures/inc/functions/rocketIsPluginActiveForNetwork.php
+++ b/tests/Fixtures/inc/functions/rocketIsPluginActiveForNetwork.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+	'active_sitewide_plugins' => [
+		'bbpress/bbpress.php' => 1,
+		'ninja-forms/ninja-forms.php' => 1,
+		'wordpress-seo/wp-seo.php' => 1,
+		'wp-rocket/wp-rocket.php' => 1,
+	],
+
+	'test_data' => [
+		[
+			'wp-rocket/wp-rocket.php',
+			true,
+		],
+		[
+			'imagify/imagify.php',
+			false,
+		],
+		[
+			'gravity-forms/gravity-forms.php',
+			false,
+		],
+		[
+			'ninja-forms/ninja-forms.php',
+			true,
+		],
+		[
+			'wpforms-lites/wpforms.php',
+			false,
+		],
+		[
+			'woocommerce/woocommerce.php',
+			false,
+		],
+		[
+			'bbpress/bbpress.php',
+			true,
+		],
+		[
+			'wordpress-seo/wp-seo.php',
+			true,
+		],
+	],
+];

--- a/tests/Integration/inc/functions/rocketIsPluginActive.php
+++ b/tests/Integration/inc/functions/rocketIsPluginActive.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\functions;
+
+use WPMedia\PHPUnit\Integration\TestCase;
+
+/**
+ * @covers ::rocket_is_plugin_active
+ * @uses   ::rocket_is_plugin_active_for_network
+ * @group  Options
+ * @group  Functions
+ */
+class Test_RocketIsPluginActive extends TestCase {
+	private $config;
+
+	public function setUp() {
+		parent::setUp();
+
+		if ( empty( $this->config ) ) {
+			$this->loadConfig();
+		}
+
+		update_option( 'active_plugins', $this->config['active_plugins'] );
+	}
+
+	/**
+	 * @dataProvider nonMultisiteTestData
+	 */
+	public function testShouldReturnCorrectStateWhenNotMultisite( $plugin, $expected ) {
+		$this->assertSame( $expected, rocket_is_plugin_active( $plugin ) );
+	}
+
+	/**
+	 * @dataProvider multisiteTestData
+	 * @group        Multisite
+	 */
+	public function testShouldReturnCorrectStateWhenMultisite( $plugin, $expected ) {
+		update_site_option( 'active_sitewide_plugins', $this->config['active_sitewide_plugins'] );
+
+		$this->assertSame( $this->config['active_sitewide_plugins'], get_site_option( 'active_sitewide_plugins' ) );
+		$this->assertSame( $expected, rocket_is_plugin_active( $plugin ) );
+	}
+
+	public function nonMultisiteTestData() {
+		if ( empty( $this->config ) ) {
+			$this->loadConfig();
+		}
+
+		return $this->config['test_data']['non_multisite'];
+	}
+
+	public function multisiteTestData() {
+		if ( empty( $this->config ) ) {
+			$this->loadConfig();
+		}
+
+		return $this->config['test_data']['multisite'];
+	}
+
+	private function loadConfig() {
+		$this->config = $this->getTestData( __DIR__, 'rocketIsPluginActive' );
+	}
+}

--- a/tests/Integration/inc/functions/rocketIsPluginActiveForNetwork.php
+++ b/tests/Integration/inc/functions/rocketIsPluginActiveForNetwork.php
@@ -2,15 +2,12 @@
 
 namespace WP_Rocket\Tests\Integration\inc\functions;
 
-use Brain\Monkey\Functions;
 use WPMedia\PHPUnit\Integration\TestCase;
 
 /**
  * @covers ::rocket_is_plugin_active_for_network
  * @group  Options
  * @group  Functions
- * @group  Multisite
- * @group  thisone
  */
 class Test_RocketIsPluginActiveForNetwork extends TestCase {
 	private $config;
@@ -25,8 +22,13 @@ class Test_RocketIsPluginActiveForNetwork extends TestCase {
 		update_site_option( 'active_sitewide_plugins', $this->config['active_sitewide_plugins'] );
 	}
 
+	public function testShouldReturnFalseWhenNotMultisite() {
+		$this->assertFalse( rocket_is_plugin_active_for_network( 'wp-rocket/wp-rocket.php' ) );
+	}
+
 	/**
 	 * @dataProvider providerTestData
+	 * @group        Multisite
 	 */
 	public function testShouldReturnCorrectState( $plugin, $expected ) {
 		$this->assertSame( $this->config['active_sitewide_plugins'], get_site_option( 'active_sitewide_plugins' ) );

--- a/tests/Integration/inc/functions/rocketIsPluginActiveForNetwork.php
+++ b/tests/Integration/inc/functions/rocketIsPluginActiveForNetwork.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\functions;
+
+use Brain\Monkey\Functions;
+use WPMedia\PHPUnit\Integration\TestCase;
+
+/**
+ * @covers ::rocket_is_plugin_active_for_network
+ * @group  Options
+ * @group  Functions
+ * @group  Multisite
+ * @group  thisone
+ */
+class Test_RocketIsPluginActiveForNetwork extends TestCase {
+	private $config;
+
+	public function setUp() {
+		parent::setUp();
+
+		if ( empty( $this->config ) ) {
+			$this->loadConfig();
+		}
+
+		update_site_option( 'active_sitewide_plugins', $this->config['active_sitewide_plugins'] );
+	}
+
+	/**
+	 * @dataProvider providerTestData
+	 */
+	public function testShouldReturnCorrectState( $plugin, $expected ) {
+		$this->assertSame( $this->config['active_sitewide_plugins'], get_site_option( 'active_sitewide_plugins' ) );
+		$this->assertSame( $expected, rocket_is_plugin_active_for_network( $plugin ) );
+	}
+
+	public function providerTestData() {
+		if ( empty( $this->config ) ) {
+			$this->loadConfig();
+		}
+
+		return $this->config['test_data'];
+	}
+
+	private function loadConfig() {
+		$this->config = $this->getTestData( __DIR__, 'rocketIsPluginActiveForNetwork' );
+	}
+}

--- a/tests/Unit/inc/functions/rocketIsPluginActive.php
+++ b/tests/Unit/inc/functions/rocketIsPluginActive.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\functions;
+
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+use WPMedia\PHPUnit\Unit\TestCase;
+
+/**
+ * @covers ::rocket_is_plugin_active
+ * @group  Options
+ * @group  Functions
+ */
+class Test_RocketIsPluginActive extends TestCase {
+	private $config;
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		require_once WP_ROCKET_PLUGIN_ROOT . 'inc/functions/options.php';
+	}
+
+	public function setUp() {
+		parent::setUp();
+
+		if ( empty( $this->config ) ) {
+			$this->loadConfig();
+		}
+
+		Functions\expect( 'get_option' )
+			->once()
+			->with( 'active_plugins', [] )
+			->andReturn( $this->config['active_plugins'] );
+	}
+
+	/**
+	 * @dataProvider nonMultisiteTestData
+	 */
+	public function testShouldReturnCorrectStateWhenNotMultisite( $plugin, $expected ) {
+		Functions\when( 'rocket_is_plugin_active_for_network' )->justReturn( false );
+
+		$this->assertSame( $expected, rocket_is_plugin_active( $plugin ) );
+	}
+
+	/**
+	 * @dataProvider multisiteTestData
+	 * @group        Multisite
+	 */
+	public function testShouldReturnCorrectStateWhenMultisite( $plugin, $expected, $is_multisite_active = false ) {
+		Functions\when( 'rocket_is_plugin_active_for_network' )->justReturn( $is_multisite_active );
+
+		$this->assertSame( $expected, rocket_is_plugin_active( $plugin ) );
+	}
+
+	public function nonMultisiteTestData() {
+		if ( empty( $this->config ) ) {
+			$this->loadConfig();
+		}
+
+		return $this->config['test_data']['non_multisite'];
+	}
+
+	public function multisiteTestData() {
+		if ( empty( $this->config ) ) {
+			$this->loadConfig();
+		}
+
+		return $this->config['test_data']['multisite'];
+	}
+
+	private function loadConfig() {
+		$this->config = $this->getTestData( __DIR__, 'rocketIsPluginActive' );
+	}
+}

--- a/tests/Unit/inc/functions/rocketIsPluginActiveForNetwork.php
+++ b/tests/Unit/inc/functions/rocketIsPluginActiveForNetwork.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\functions;
+
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+use WPMedia\PHPUnit\Unit\TestCase;
+
+/**
+ * @covers ::rocket_is_plugin_active_for_network
+ * @group  Options
+ * @group  Functions
+ */
+class Test_RocketIsPluginActiveForNetwork extends TestCase {
+	private $config;
+
+	protected function setUp() {
+		parent::setUp();
+
+		if ( empty( $this->config ) ) {
+			$this->loadConfig();
+		}
+	}
+
+	/**
+	 * @dataProvider providerTestData
+	 */
+	public function testShouldReturnCorrectState( $plugin, $expected ) {
+		Functions\expect( 'is_multisite' )->once()->andReturn( true );
+		Functions\expect( 'get_site_option' )
+			->once()
+			->with( 'active_sitewide_plugins' )
+			->andReturn( $this->config['active_sitewide_plugins'] );
+
+		$this->assertSame( $expected, rocket_is_plugin_active_for_network( $plugin ) );
+	}
+
+	public function providerTestData() {
+		if ( empty( $this->config ) ) {
+			$this->loadConfig();
+		}
+
+		return $this->config['test_data'];
+	}
+
+	private function loadConfig() {
+		$this->config = $this->getTestData( __DIR__, 'rocketIsPluginActiveForNetwork' );
+	}
+}


### PR DESCRIPTION
Adds unit and integration tests for both `rocket_is_plugin_active()` and `rocket_is_plugin_active_for_network()`.

Additional changes:

- Adds `@return` to the functions' DocBlocks
- Minor micro-optimizations
- Minor reformatting
- Excludes the `Multisite` group from the `test-integration` script
