### PR TITLE
Adds unit tests for rocket_has_i18n().

### DIFF
--- a/tests/Fixtures/SitePress.php
+++ b/tests/Fixtures/SitePress.php
@@ -1,0 +1,13 @@
+<?php
+// phpcs:ignoreFile
+
+if ( ! class_exists( 'SitePress') ) {
+
+	class SitePress {
+
+		/**
+		 * See https://github.com/wpml/sitepress-multilingual-cms/blob/develop/sitepress.class.php#L1204
+		 */
+		public function get_active_languages() {}
+	}
+}

--- a/tests/Unit/inc/Addon/Varnish/Subscriber/cleanHome.php
+++ b/tests/Unit/inc/Addon/Varnish/Subscriber/cleanHome.php
@@ -16,6 +16,12 @@ use WP_Rocket\Addon\Varnish\Varnish;
  */
 class Test_CleanHome extends TestCase {
 
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		require_once WP_ROCKET_PLUGIN_ROOT . 'inc/functions/i18n.php';
+	}
+
 	public function testShouldDoNothingWhenVarnishDisabled() {
 		$options = $this->createMock( 'WP_Rocket\Admin\Options_Data' );
 		$map     = [

--- a/tests/Unit/inc/classes/Cache/Expired_Cache_Purge/purgeExpiredFiles.php
+++ b/tests/Unit/inc/classes/Cache/Expired_Cache_Purge/purgeExpiredFiles.php
@@ -16,6 +16,12 @@ use WP_Rocket\Tests\Unit\FilesystemTestCase;
 class Test_PurgeExpiredFiles extends FilesystemTestCase {
 	protected $path_to_test_data = '/inc/classes/Cache/Expired_Cache_Purge/purgeExpiredFiles.php';
 
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		require_once WP_ROCKET_PLUGIN_ROOT . 'inc/functions/i18n.php';
+	}
+
 	public function testShouldReturnNullWhenNoLifespan() {
 		Functions\expect( 'get_rocket_i18n_uri' )->never();
 		Functions\expect( 'rocket_direct_filesystem' )->never();

--- a/tests/Unit/inc/functions/rocketHasI18n.php
+++ b/tests/Unit/inc/functions/rocketHasI18n.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\functions;
+
+use Brain\Monkey\Functions;
+use SitePress;
+use stdClass;
+use WPMedia\PHPUnit\Unit\TestCase;
+
+/**
+ * @covers ::rocket_has_i18n
+ * @group Functions
+ * @group i18n
+ */
+class Test_RocketHasI18n extends TestCase {
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		require_once WP_ROCKET_PLUGIN_ROOT . 'inc/functions/i18n.php';
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+
+		unset( $GLOBALS['sitepress'], $GLOBALS['q_config'], $GLOBALS['polylang'] );
+	}
+
+	public function testShouldReturnFalseWhenNoneFound() {
+		$this->assertFalse( rocket_has_i18n() );
+	}
+
+	public function testShouldReturnFalseWhenSitePressButNotObject() {
+		// Not an object.
+		$GLOBALS['sitepress'] = 'not object';
+		$this->assertFalse( rocket_has_i18n() );
+
+		// Method doesn't exist.
+		$GLOBALS['sitepress'] = new stdClass();
+		$this->assertFalse( rocket_has_i18n() );
+	}
+
+	public function testShouldReturnWPMLWhenSitePress() {
+		require_once WP_ROCKET_TESTS_FIXTURES_DIR . '/SitePress.php';
+		$GLOBALS['sitepress'] = new SitePress();
+
+		$this->assertSame( 'wpml', rocket_has_i18n() );
+	}
+
+	public function testShouldReturnPolylangWhenPll() {
+		$GLOBALS['polylang'] = 'en';
+		$this->assertFalse( rocket_has_i18n() );
+
+		Functions\expect( 'pll_languages_list' )->andReturn( [ 'en' ] );
+		$this->assertSame( 'polylang', rocket_has_i18n() );
+	}
+
+	public function testShouldReturnFalseWhenQConfigNotArray() {
+		$GLOBALS['q_config'] = 'not-array';
+		$this->assertFalse( rocket_has_i18n() );
+	}
+
+	public function testShouldReturnFalseWhenQConfigFunctionsNotExist() {
+		$GLOBALS['q_config'] = [ 'en' ];
+		$this->assertFalse( rocket_has_i18n() );
+	}
+
+
+	public function testShouldReturnQTranslateWhenQConfigFunctionExists() {
+		$GLOBALS['q_config'] = [ 'en' ];
+
+		Functions\expect( 'qtrans_convertURL' )->never();
+		$this->assertTrue( function_exists( 'qtrans_convertURL' ) );
+		$this->assertFalse( function_exists( 'qtranxf_convertURL' ) );
+		$this->assertSame( 'qtranslate', rocket_has_i18n() );
+
+		Functions\expect( 'qtranxf_convertURL' )->never();
+		$this->assertTrue( function_exists( 'qtranxf_convertURL' ) );
+		$this->assertSame( 'qtranslate-x', rocket_has_i18n() );
+	}
+}


### PR DESCRIPTION
Adds unit tests for `rocket_has_i18n()`.

No source code changes. No QA is needed.