### PR TITLE
Fix #2369 Cloudflare Addon change curl to wp-remote-get

### DIFF
--- a/inc/Addon/Cloudflare/composer.json
+++ b/inc/Addon/Cloudflare/composer.json
@@ -37,7 +37,7 @@
 		"exclude-from-classmap": [ "/Tests/" ]
 	},
 	"autoload-dev": {
-		"psr-4": { "WPMedia\\Cloudflare\\Tests\\": "Tests/"	}
+		"psr-4": { "WPMedia\\Cloudflare\\Tests\\": "Tests/" }
 	},
 	"scripts": {
 		"test-unit": "\"vendor/bin/wpmedia-phpunit\" unit path=Tests/Unit",


### PR DESCRIPTION
Fix: #2369 - PHP Notice: Undefined property: stdClass::$error in wp-rocket\inc\Addon\Cloudflare\Cloudflare.php on line 131

Changes Cloudflare API requests from curl to wp_remote_get().

Includes the latest package of WP-Media/Cloudflare which includes = Save development mode and optimal settings when CF credentials are valid.

TO DO
- [x] QA