### PR TITLE
Fix #2216 - Add Reader mode in query strings to provide compatibility with AMP

### DIFF
--- a/inc/ThirdParty/Plugins/Optimization/AMP.php
+++ b/inc/ThirdParty/Plugins/Optimization/AMP.php
@@ -57,7 +57,7 @@ class AMP implements Subscriber_Interface {
 	 * @since  3.5.2
 	 * @author Soponar Cristina
 	 */
-	public function generate_config_file() {
+	public function generate_config_file( $val ) {
 		rocket_generate_config_file();
 	}
 

--- a/inc/ThirdParty/Plugins/Optimization/AMP.php
+++ b/inc/ThirdParty/Plugins/Optimization/AMP.php
@@ -57,7 +57,7 @@ class AMP implements Subscriber_Interface {
 	 * @since  3.5.2
 	 * @author Soponar Cristina
 	 */
-	public function generate_config_file( $val ) {
+	public function generate_config_file() {
 		rocket_generate_config_file();
 	}
 

--- a/inc/ThirdParty/Plugins/Optimization/AMP.php
+++ b/inc/ThirdParty/Plugins/Optimization/AMP.php
@@ -78,7 +78,7 @@ class AMP implements Subscriber_Interface {
 			return $query_strings;
 		}
 
-		if ( 'transitional' === $options['theme_support'] ) {
+		if ( in_array( $options['theme_support'], [ 'transitional', 'reader' ], true ) ) {
 			$query_strings[] = static::QUERY;
 		}
 

--- a/tests/Integration/inc/ThirdParty/Plugins/Optimization/AMP/isAmpCompatibleCallback.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Optimization/AMP/isAmpCompatibleCallback.php
@@ -18,6 +18,12 @@ class Test_IsAmpCompatibleCallback extends TestCase {
 		$this->assertContains( 'amp', apply_filters( 'rocket_cache_query_strings', [] ) );
 	}
 
+	public function testShouldAddAmpWhenThemeSupportIsReader() {
+		Functions\expect( 'rocket_generate_config_file' )->once();
+		$this->setSettings( 'theme_support', 'reader' );
+		$this->assertContains( 'amp', apply_filters( 'rocket_cache_query_strings', [] ) );
+	}
+
 	public function testShouldNotAddAmpWhenThemeSupportIsNotTransitional() {
 		Functions\expect( 'rocket_generate_config_file' )->once();
 		$this->setSettings( 'theme_support', 'standard' );

--- a/tests/Integration/inc/ThirdParty/Plugins/Optimization/AMP/isAmpCompatibleCallback.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Optimization/AMP/isAmpCompatibleCallback.php
@@ -19,7 +19,7 @@ class Test_IsAmpCompatibleCallback extends TestCase {
 	}
 
 	public function testShouldAddAmpWhenThemeSupportIsReader() {
-		Functions\expect( 'rocket_generate_config_file' )->once();
+		// Default value is reader, so rocket_generate_config_file will not be called because update_option is not called.
 		$this->setSettings( 'theme_support', 'reader' );
 		$this->assertContains( 'amp', apply_filters( 'rocket_cache_query_strings', [] ) );
 	}

--- a/tests/Unit/inc/ThirdParty/Plugins/Optimization/AMP/isAmpCompatibleCallback.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/Optimization/AMP/isAmpCompatibleCallback.php
@@ -58,4 +58,13 @@ class Test_IsAmpCompatibleCallback extends TestCase {
 		$this->assertContains( 'amp', $this->amp->is_amp_compatible_callback( [] ) );
 	}
 
+	public function testShouldAddAmpWhenThemeSupportIsReader() {
+		Functions\expect( 'get_option' )
+			->once()
+			->with( 'amp-options', [] )
+			->andReturn( [ 'theme_support' => 'reader' ] );
+
+		$this->assertContains( 'amp', $this->amp->is_amp_compatible_callback( [] ) );
+	}
+
 }


### PR DESCRIPTION
AMP plugin compatibility with Reader Mode.

It seems that in Reader Mode  I have URLs with /amp/ for posts, but URLs with ?amp for the rest.