### PR TITLE
Tests: Adds integration tests to get_rocket_option().

### DIFF
--- a/tests/Fixtures/inc/functions/getRocketOption.php
+++ b/tests/Fixtures/inc/functions/getRocketOption.php
@@ -1,0 +1,58 @@
+<?php
+
+return [
+	'settings' => [
+		'automatic_cleanup_frequency' => 'weekly',
+		'cdn'                         => 1,
+		'cdn_cnames'                  => [ 'https://rocketcdn.me' ],
+		'cdn_zone'                    => [ 'all' ],
+		'do_cloudflare'               => 1,
+		'purge_cron_interval'         => 10,
+		'purge_cron_unit'             => 'HOUR_IN_SECONDS',
+	],
+
+	'test_data' => [
+		[
+			'option'   => 'automatic_cleanup_frequency',
+			'default'  => 'daily',
+			'expected' => 'weekly',
+		],
+		[
+			'option'   => 'cdn',
+			'default'  => 0,
+			'expected' => 1,
+		],
+		[
+			'option'   => 'cdn_cnames',
+			'default'  => [],
+			'expected' => [ 'https://rocketcdn.me' ],
+		],
+		[
+			'option'   => 'cdn_zone',
+			'default'  => [],
+			'expected' => [ 'all' ],
+		],
+		[
+			'option'   => 'do_cloudflare',
+			'default'  => 0,
+			'expected' => 1,
+		],
+
+		// These don't exist.
+		[
+			'option'   => 'doesnotexist',
+			'default'  => false,
+			'expected' => false,
+		],
+		[
+			'option'   => 'control_heartbeat',
+			'default'  => 0,
+			'expected' => 0,
+		],
+		[
+			'option'   => 'heartbeat_site_behavior',
+			'default'  => 'reduce_periodicity',
+			'expected' => 'reduce_periodicity',
+		],
+	],
+];

--- a/tests/Integration/inc/functions/getRocketOption.php
+++ b/tests/Integration/inc/functions/getRocketOption.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\functions;
+
+use WPMedia\PHPUnit\Integration\TestCase;
+
+/**
+ * @covers ::get_rocket_option
+ * @uses   \WP_Rocket\Admin\Options\
+ * @uses   \WP_Rocket\Admin\Options_Data\
+ * @group  Options
+ * @group  Functions
+ */
+class Test_GetRocketOption extends TestCase {
+	private $config;
+	private $original_settings;
+
+	public function setUp() {
+		parent::setUp();
+
+		if ( empty( $this->config ) ) {
+			$this->loadConfig();
+		}
+
+		$this->original_settings = get_option( 'wp_rocket_settings', [] );
+
+		update_option(
+			'wp_rocket_settings',
+			array_merge( $this->original_settings, $this->config['settings'] )
+		);
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+
+		if ( empty( $this->original_settings ) ) {
+			delete_option( 'wp_rocket_settings' );
+		} else {
+			update_option( 'wp_rocket_settings', $this->original_settings );
+		}
+	}
+
+	/**
+	 * @dataProvider providerTestData
+	 */
+	public function testShouldReturnExpectedOptionValue( $option, $default, $expected ) {
+		$this->assertSame( $expected, get_rocket_option( $option, $default ) );
+	}
+
+	public function providerTestData() {
+		if ( empty( $this->config ) ) {
+			$this->loadConfig();
+		}
+
+		return $this->config['test_data'];
+	}
+
+	private function loadConfig() {
+		$this->config = $this->getTestData( __DIR__, basename( __FILE__, '.php' ) );
+	}
+}


### PR DESCRIPTION
Adds integration tests to get_rocket_option().

As the function instantiates objects within it, it is not capable of having unit tests.

No QA is required as the source code is not changed.