### PR TITLE
Tests: Adds tests for get_rocket_parse_url().

### DIFF
--- a/inc/functions/formatting.php
+++ b/inc/functions/formatting.php
@@ -361,7 +361,7 @@ function get_rocket_parse_url( $url ) { // phpcs:ignore WordPress.NamingConventi
 	 *
 	 * @param array Components of an URL
 	*/
-	return apply_filters(
+	return (array) apply_filters(
 		'rocket_parse_url',
 		[
 			'host'     => $host,

--- a/tests/Fixtures/inc/functions/getRocketParseUrl.php
+++ b/tests/Fixtures/inc/functions/getRocketParseUrl.php
@@ -1,0 +1,78 @@
+<?php
+
+return [
+	'shouldBailOutWhenNotAString' => [
+		'url'       => false,
+		'expected'  => null,
+	],
+	[
+		'url'      => 'https://example.org/lorem-ipsum/',
+		'expected' => [
+			'host'     => 'example.org',
+			'path'     => '/lorem-ipsum/',
+			'scheme'   => 'https',
+			'query'    => '',
+			'fragment' => '',
+		],
+	],
+	[
+		'url'      => 'http://example.org/lorem-ipsum/',
+		'expected' => [
+			'host'     => 'example.org',
+			'path'     => '/lorem-ipsum/',
+			'scheme'   => 'http',
+			'query'    => '',
+			'fragment' => '',
+		],
+	],
+	[
+		'url'      => 'http://example.org/lorem-ipsum',
+		'expected' => [
+			'host'     => 'example.org',
+			'path'     => '/lorem-ipsum',
+			'scheme'   => 'http',
+			'query'    => '',
+			'fragment' => '',
+		],
+	],
+	[
+		'url'      => 'http://example.org/lorem-ipsum?amp',
+		'expected' => [
+			'host'     => 'example.org',
+			'path'     => '/lorem-ipsum',
+			'scheme'   => 'http',
+			'query'    => 'amp',
+			'fragment' => '',
+		],
+	],
+	[
+		'url'      => 'http://example.org/2020/03/lorem-ipsum/',
+		'expected' => [
+			'host'     => 'example.org',
+			'path'     => '/2020/03/lorem-ipsum/',
+			'scheme'   => 'http',
+			'query'    => '',
+			'fragment' => '',
+		],
+	],
+	[
+		'url'      => 'https://Example.org/lorem-ipsum/nec-ullamcorper',
+		'expected' => [
+			'host'     => 'example.org',
+			'path'     => '/lorem-ipsum/nec-ullamcorper',
+			'scheme'   => 'https',
+			'query'    => '',
+			'fragment' => '',
+		],
+	],
+	[
+		'url'      => 'https://Example.org/lorem-ipsum/nec-ullamcorper?foo=bar#baz',
+		'expected' => [
+			'host'     => 'example.org',
+			'path'     => '/lorem-ipsum/nec-ullamcorper',
+			'scheme'   => 'https',
+			'query'    => 'foo=bar',
+			'fragment' => 'baz',
+		],
+	],
+];

--- a/tests/Integration/inc/functions/getRocketParseUrl.php
+++ b/tests/Integration/inc/functions/getRocketParseUrl.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\functions;
+
+use WPMedia\PHPUnit\Integration\TestCase;
+
+/**
+ * @covers ::get_rocket_parse_url
+ * @group  Functions
+ * @group  Posts
+ */
+class Test_GetRocketParseUrls extends TestCase {
+
+	/**
+	 * @dataProvider providerTestData
+	 */
+	public function testShouldReturnExpectedParsedUrl( $url, $expected ) {
+		$this->assertSame( $expected, get_rocket_parse_url( $url ) );
+	}
+
+	public function providerTestData() {
+		return $this->getTestData( __DIR__, 'getRocketParseUrl' );
+	}
+}

--- a/tests/Unit/inc/functions/getRocketParseUrl.php
+++ b/tests/Unit/inc/functions/getRocketParseUrl.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\functions;
+
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+use WPMedia\PHPUnit\Unit\TestCase;
+
+/**
+ * @covers ::get_rocket_parse_url
+ * @group  Functions
+ * @group  Posts
+ */
+class Test_GetRocketParseUrls extends TestCase {
+
+	/**
+	 * @dataProvider providerTestData
+	 */
+	public function testShouldReturnExpectedParsedUrl( $url, $expected ) {
+		if ( is_string( $url ) ) {
+			Functions\expect( 'wp_parse_url' )
+				->once()
+				->with( $url )
+				->andReturnUsing( function( $url ) {
+					return parse_url( $url );
+			} );
+			Filters\expectApplied( 'rocket_parse_url' )
+				->once()
+				->with( $expected )
+				->andReturn( $expected );
+		} else {
+			Functions\expect( 'wp_parse_url' )->never();
+			Filters\expectApplied( 'rocket_parse_url' )->never();
+		}
+
+		$this->assertSame( $expected, get_rocket_parse_url( $url ) );
+	}
+
+	public function providerTestData() {
+		return $this->getTestData( __DIR__, 'getRocketParseUrl' );
+	}
+}


### PR DESCRIPTION
- Adds tests for `get_rocket_parse_url()`.
- And ensures the filtered value is always an array data type. Why? We can't trust that callbacks will return an array.