### PR TITLE
Tests: Adds and improves tests for WP_Rocket\Subscriber\Optimization\Critical_CSS_Subscriber::generate_critical_css_on_activation

### DIFF
--- a/inc/classes/subscriber/Optimization/class-critical-css-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-critical-css-subscriber.php
@@ -17,8 +17,23 @@ defined( 'ABSPATH' ) || exit;
  * @author Remy Perona
  */
 class Critical_CSS_Subscriber implements Subscriber_Interface {
+
 	/**
-	 * Constructor
+	 * Instance of Critical CSS.
+	 *
+	 * @var Critical_CSS
+	 */
+	protected $critical_css;
+
+	/**
+	 * Instance of options.
+	 *
+	 * @var Options_Data
+	 */
+	protected $options;
+
+	/**
+	 * Creates an instance of the Critical CSS Subscriber.
 	 *
 	 * @param Critical_CSS $critical_css Critical CSS instance.
 	 * @param Options_Data $options      WP Rocket options.

--- a/tests/Fixtures/inc/classes/subscriber/Optimization/class-critical-css-subscriber/generateCriticalCssOnActivation.php
+++ b/tests/Fixtures/inc/classes/subscriber/Optimization/class-critical-css-subscriber/generateCriticalCssOnActivation.php
@@ -8,9 +8,12 @@ return [
 		'wp-content' => [
 			'cache' => [
 				'critical-css' => [
-					'2' => [
+					'1' => [
 						'.'            => '',
 						'..'           => '',
+						'critical.css' => 'body { font-family: Helvetica, Arial, sans-serif; text-align: center;}',
+					],
+					'2' => [
 						'critical.css' => 'body { font-family: Helvetica, Arial, sans-serif; text-align: center;}',
 					],
 				],
@@ -20,23 +23,48 @@ return [
 
 	// Test data.
 	'test_data' => [
-		'testShouldBailOutWhenCriticalCssPathIsNotEmpty'           => [
-			[
-				'path' => 'wp-content/cache/critical-css/2/',
+		'non_multisite' => [
+			'testShouldBailOutWhenCriticalCSSOptionIsFalse'  => [
+				'values'         => [
+					'old' => [ 'async_css' => 0 ],
+					'new' => [ 'async_css' => 0 ],
+				],
+				'shouldGenerate' => false,
 			],
-			// Old Value.
-			[ 'async_css' => 0 ],
-			// New Value.
-			[ 'async_css' => 1 ],
+			'testShouldBailOutWhenCriticalCssPathIsNotEmpty' => [
+				'values'         => [
+					'old' => [ 'async_css' => 0 ],
+					'new' => [ 'async_css' => 1 ],
+				],
+				'shouldGenerate' => false,
+			],
 		],
-		'testShouldInvokeProcessHandlerWhenCriticalCssPathIsEmpty' => [
+
+		'multisite' => [
 			[
-				'path' => 'wp-content/cache/critical-css/1/',
+				'values'          => [
+					'old' => [ 'async_css' => 0 ],
+					'new' => [ 'async_css' => 0 ],
+				],
+				'blog_id'         => 2,
+				'should_generate' => false,
 			],
-			// Old Value.
-			[ 'async_css' => 0 ],
-			// New Value.
-			[ 'async_css' => 1 ],
+			[
+				'values'          => [
+					'old' => [ 'async_css' => 0 ],
+					'new' => [ 'async_css' => 1 ],
+				],
+				'blog_id'         => 2,
+				'should_generate' => false,
+			],
+			[
+				'values'          => [
+					'old' => [ 'async_css' => 0 ],
+					'new' => [ 'async_css' => 1 ],
+				],
+				'site_id'         => 3,
+				'should_generate' => true,
+			],
 		],
 	],
 ];

--- a/tests/Fixtures/inc/classes/subscriber/Optimization/class-critical-css-subscriber/generateCriticalCssOnActivation.php
+++ b/tests/Fixtures/inc/classes/subscriber/Optimization/class-critical-css-subscriber/generateCriticalCssOnActivation.php
@@ -24,16 +24,30 @@ return [
 	// Test data.
 	'test_data' => [
 		'non_multisite' => [
-			'testShouldBailOutWhenCriticalCSSOptionIsFalse'  => [
+			[
 				'values'         => [
 					'old' => [ 'async_css' => 0 ],
 					'new' => [ 'async_css' => 0 ],
 				],
 				'shouldGenerate' => false,
 			],
-			'testShouldBailOutWhenCriticalCssPathIsNotEmpty' => [
+			[
+				'values'         => [
+					'old' => [ 'async_css' => 1 ],
+					'new' => [ 'async_css' => 0 ],
+				],
+				'shouldGenerate' => false,
+			],
+			[
 				'values'         => [
 					'old' => [ 'async_css' => 0 ],
+					'new' => [ 'async_css' => 1 ],
+				],
+				'shouldGenerate' => false,
+			],
+			[
+				'values'         => [
+					'old' => [ 'async_css' => 1 ],
 					'new' => [ 'async_css' => 1 ],
 				],
 				'shouldGenerate' => false,
@@ -62,7 +76,31 @@ return [
 					'old' => [ 'async_css' => 0 ],
 					'new' => [ 'async_css' => 1 ],
 				],
+				'blog_id'         => 2,
+				'should_generate' => false,
+			],
+			[
+				'values'          => [
+					'old' => [ 'async_css' => 1 ],
+					'new' => [ 'async_css' => 1 ],
+				],
+				'blog_id'         => 2,
+				'should_generate' => false,
+			],
+			[
+				'values'          => [
+					'old' => [ 'async_css' => 0 ],
+					'new' => [ 'async_css' => 1 ],
+				],
 				'site_id'         => 3,
+				'should_generate' => true,
+			],
+			[
+				'values'          => [
+					'old' => [ 'async_css' => 0 ],
+					'new' => [ 'async_css' => 1 ],
+				],
+				'site_id'         => 4,
 				'should_generate' => true,
 			],
 		],

--- a/tests/Integration/inc/classes/subscriber/Optimization/class-critical-css-subscriber/generateCriticalCssOnActivation.php
+++ b/tests/Integration/inc/classes/subscriber/Optimization/class-critical-css-subscriber/generateCriticalCssOnActivation.php
@@ -1,8 +1,10 @@
 <?php
+
 namespace WP_Rocket\Tests\Integration\inc\classes\subscriber\Optimization\Critical_CSS_Subscriber;
 
 use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
+use WP_Rocket\Subscriber\Optimization\Critical_CSS_Subscriber;
 use WP_Rocket\Tests\Integration\FilesystemTestCase;
 
 /**
@@ -14,38 +16,148 @@ use WP_Rocket\Tests\Integration\FilesystemTestCase;
 class Test_GenerateCriticalCssOnActivation extends FilesystemTestCase {
 	protected $path_to_test_data = '/inc/classes/subscriber/Optimization/class-critical-css-subscriber/generateCriticalCssOnActivation.php';
 	private static $container;
+	private static $user_id;
 	private $subscriber;
+	private $switchedBlog = false;
+	private $did_filter;
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$user_id   = $factory->user->create(
+			[
+				'role'          => 'adminstrator',
+				'user_nicename' => 'rocket_tester',
+			]
+		);
 		self::$container = apply_filters( 'rocket_container', null );
 	}
 
 	public function setUp() {
 		parent::setUp();
 
-		$this->subscriber = self::$container->get( 'critical_css_subscriber' );
+		$this->switchedBlog = false;
+		$this->did_filter   = [
+			'do_rocket_critical_css_generation' => 0,
+		];
+		$this->subscriber   = self::$container->get( 'critical_css_subscriber' );
+		delete_transient( 'rocket_critical_css_generation_process_running' );
 	}
 
-	public function testShouldBailOutWhenCriticalCSSOptionIsFalse() {
-		$this->assertEquals( 0, Filters\applied( 'do_rocket_critical_css_generation' ) );
-		Functions\expect( 'get_transient' )->with( 'rocket_critical_css_generation_process_running' )->never();
+	public function tearDown() {
+		parent::tearDown();
 
-		$this->subscriber->generate_critical_css_on_activation( [ 'async_css' => 0 ], [ 'async_css' => 0 ] );
-	}
+		delete_transient( 'rocket_critical_css_generation_process_running' );
 
-	public function testShouldBailOutWhenCriticalCssPathIsValid() {
-		$this->assertEquals( 0, Filters\applied( 'do_rocket_critical_css_generation' ) );
-		Functions\expect( 'get_transient' )->with( 'rocket_critical_css_generation_process_running' )->never();
-
-		$this->subscriber->generate_critical_css_on_activation( [ 'async_css' => 0 ], [ 'async_css' => 1 ] );
+		if ( $this->switchedBlog ) {
+			restore_current_blog();
+			$this->switchedBlog = false;
+		}
 	}
 
 	/**
-	 * @dataProvider providerTestData
+	 * @dataProvider nonMultisiteTestData
 	 */
-	public function testShouldGenerateCriticalCss( $old_value, $new_value ) {
-		$this->assertTrue( true );
-		// TODO: Add test data and the tests here.
+	public function testShouldProcessNonMultisite( $values ) {
+		$this->assertEquals( 0, Filters\applied( 'do_rocket_critical_css_generation' ) );
+		Functions\expect( 'get_transient' )->with( 'rocket_critical_css_generation_process_running' )->never();
+
+		$this->assertTrue( $this->filesystem->is_dir( $this->config['vfs_dir'] . '1/' ) );
+
+		// Run it.
+		$this->subscriber->generate_critical_css_on_activation( $values['old'], $values['new'] );
+	}
+
+	/**
+	 * @dataProvider multisiteTestData
+	 * @group        Multisite
+	 */
+	public function testShouldProcessMultisite( $values, $site_id, $should_generate ) {
+		if ( get_current_blog_id() !== $site_id ) {
+			$this->createSite( $site_id );
+		}
+
+		$critical_css_path = $this->config['vfs_dir'] . "{$site_id}/";
+		$this->assertSame( get_current_blog_id(), $site_id );
+		$this->setCriticalCssPath( $site_id );
+
+		if ( $should_generate ) {
+			add_filter( 'do_rocket_critical_css_generation', [ $this, 'do_rocket_critical_css_generation_cb' ] );
+			$this->assertFalse( $this->filesystem->is_dir( $critical_css_path ) );
+		}
+
+		// Temporary hack until we make `rocket_mkdir_p()` work with `vfs://`.
+		Functions\expect( 'rocket_mkdir_p' )
+			->with( $critical_css_path )
+			->andReturnUsing(
+				function ( $target ) {
+					if ( ! $this->filesystem->exists( $target ) ) {
+						$this->filesystem->mkdir( $target );
+					}
+
+					return $this->filesystem->is_dir( $target );
+				}
+			);
+
+		$this->assertFalse( get_transient( 'rocket_critical_css_generation_process_running' ) );
+
+		// Run it.
+		$this->subscriber->generate_critical_css_on_activation( $values['old'], $values['new'] );
+
+		$this->assertTrue( $this->filesystem->is_dir( $critical_css_path ) );
+
+		if ( $should_generate ) {
+			$this->assertEquals( 1, $this->did_filter['do_rocket_critical_css_generation'] );
+			$value = get_transient( 'rocket_critical_css_generation_process_running' );
+			$this->assertSame( [ 'generated', 'total', 'items' ], array_keys( $value ) );
+		} else {
+			$this->assertEquals( 0, $this->did_filter['do_rocket_critical_css_generation'] );
+			$this->assertFalse( get_transient( 'rocket_critical_css_generation_process_running' ) );
+		}
+	}
+
+	public function nonMultisiteTestData() {
+		if ( empty( $this->config ) ) {
+			$this->loadConfig();
+		}
+
+		return $this->config['test_data']['non_multisite'];
+	}
+
+	public function multisiteTestData() {
+		if ( empty( $this->config ) ) {
+			$this->loadConfig();
+		}
+
+		return $this->config['test_data']['multisite'];
+	}
+
+	private function createSite( $site_id ) {
+		if ( empty( get_blogaddress_by_id( $site_id ) ) ) {
+			$this->factory->blog->create(
+				[
+					'network_id' => $site_id,
+					'user_id'    => self::$user_id,
+				]
+			);
+		}
+
+		switch_to_blog( $site_id );
+		$this->switchedBlog = true;
+	}
+
+	private function setCriticalCssPath( $site_id ) {
+		$property     = $this->get_reflective_property( 'critical_css', Critical_CSS_Subscriber::class );
+		$critical_css = $property->getValue( $this->subscriber );
+
+		$this->set_reflective_property(
+			rocket_get_constant( 'WP_ROCKET_CRITICAL_CSS_PATH' ) . $site_id . '/',
+			'critical_css_path',
+			$critical_css
+		);
+	}
+
+	public function do_rocket_critical_css_generation_cb( $value ) {
+		$this->did_filter['do_rocket_critical_css_generation'] ++;
+
+		return $value;
 	}
 }

--- a/tests/Unit/inc/classes/subscriber/Optimization/class-critical-css-subscriber/generateCriticalCssOnActivation.php
+++ b/tests/Unit/inc/classes/subscriber/Optimization/class-critical-css-subscriber/generateCriticalCssOnActivation.php
@@ -3,6 +3,7 @@
 namespace WP_Rocket\Tests\Unit\inc\classes\subscriber\Optimization\Critical_CSS_Subscriber;
 
 use Brain\Monkey\Functions;
+use FilesystemIterator;
 use Mockery;
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Optimization\CSS\Critical_CSS;
@@ -35,32 +36,83 @@ class Test_GenerateCriticalCssOnActivation extends FilesystemTestCase {
 		);
 	}
 
-	public function testShouldBailOutWhenCriticalCSSOptionIsFalse() {
+	/**
+	 * @dataProvider nonMultisiteTestData
+	 */
+	public function testShouldGenerateCriticalCss( $values ) {
+		$critical_css_path = $this->config['vfs_dir'] . '1/';
+
+		$this->assertTrue( $this->filesystem->is_dir( $critical_css_path ) );
+		Functions\expect( 'rocket_mkdir_p' )->with( $critical_css_path )->never();
 		$this->critical_css->shouldReceive( 'process_handler' )->never();
 
-		$this->subscriber->generate_critical_css_on_activation( [ 'async_css' => 0 ], [ 'async_css' => 0 ] );
-	}
+		if ( $values['old']['async_css'] !== $values['new']['async_css'] && 1 === (int) $values['new']['async_css'] ) {
+			$this->critical_css->shouldReceive( 'get_critical_css_path' )->once()->andReturn( $critical_css_path );
+		} else {
+			$this->critical_css->shouldReceive( 'get_critical_css_path' )->never();
+		}
 
-	public function testShouldBailOutWhenCriticalCssPathIsInvalid() {
-		$this->critical_css->shouldReceive( 'process_handler' )->never();
-		$this->critical_css->shouldReceive( 'get_critical_css_path' )->once()->andReturn( 'invalid' );
-
-		$this->subscriber->generate_critical_css_on_activation( [ 'async_css' => 0 ], [ 'async_css' => 1 ] );
+		// Run it.
+		$this->subscriber->generate_critical_css_on_activation( $values['old'], $values['new'] );
 	}
 
 	/**
-	 * @dataProvider providerTestData
+	 * @dataProvider multisiteTestData
 	 */
-	public function testShouldGenerateCriticalCss( $critical_css_path, $old_value, $new_value ) {
-		$dirs = $this->filesystem->getDirsListing( $this->config['vfs_dir'] );
-		if ( ! in_array( $critical_css_path['path'], $dirs, true ) ) {
+	public function testShouldProcessMultisite( $values, $site_id, $should_generate ) {
+		$critical_css_path = $this->filesystem->getUrl( $this->config['vfs_dir'] . "{$site_id}/" );
+
+		$will_bailout = (
+			$values['old']['async_css'] === $values['new']['async_css']
+			||
+			1 !== (int) $values['new']['async_css']
+		);
+
+		if ( $will_bailout ) {
+			$this->critical_css->shouldReceive( 'get_critical_css_path' )->never();
 			$this->critical_css->shouldReceive( 'process_handler' )->never();
 		} else {
-			$this->critical_css->shouldReceive( 'process_handler' )->once()->andReturn();
+			$this->critical_css->shouldReceive( 'get_critical_css_path' )->once()->andReturn( $critical_css_path );
+
+			if ( $should_generate ) {
+				$this->assertFalse( $this->filesystem->is_dir( $critical_css_path ) );
+				Functions\expect( 'rocket_mkdir_p' )
+					->with( $critical_css_path )
+					->andReturnUsing(
+						function ( $target ) {
+							$this->filesystem->mkdir( $target );
+							$this->assertTrue( $this->filesystem->is_dir( $target ) );
+
+							return true;
+						}
+					);
+				$this->critical_css->shouldReceive( 'process_handler' )->once()->andReturn();
+
+			} else {
+				$this->critical_css->shouldReceive( 'process_handler' )->never();
+				Functions\expect( 'rocket_mkdir_p' )->with( $critical_css_path )->never();
+			}
 		}
 
-		$this->critical_css->shouldReceive( 'get_critical_css_path' )->once()->andReturn( $critical_css_path['path'] );
+		// Run it.
+		$this->subscriber->generate_critical_css_on_activation( $values['old'], $values['new'] );
 
-		$this->subscriber->generate_critical_css_on_activation( $old_value, $new_value );
+		$this->assertTrue( $this->filesystem->is_dir( $critical_css_path ) );
+	}
+
+	public function nonMultisiteTestData() {
+		if ( empty( $this->config ) ) {
+			$this->loadConfig();
+		}
+
+		return $this->config['test_data']['non_multisite'];
+	}
+
+	public function multisiteTestData() {
+		if ( empty( $this->config ) ) {
+			$this->loadConfig();
+		}
+
+		return $this->config['test_data']['multisite'];
 	}
 }


### PR DESCRIPTION
- Adds and improves tests for `WP_Rocket\Subscriber\Optimization\Critical_CSS_Subscriber::generate_critical_css_on_activation`.
- Defines `Critical_CSS_Subscriber ` properties (which are assigned in `__construct()`).

QA is not required for this PR.