### PR TITLE
rocket rrmdir() - Optimizes, replaces glob, and provides full code coverage

### DIFF
--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -1040,6 +1040,11 @@ function rocket_rrmdir( $dir, $dirs_to_preserve = [] ) {
 	$dir        = untrailingslashit( $dir );
 	$filesystem = rocket_direct_filesystem();
 
+	// Bail out if the given directory is in the list of directories to preserve.
+	if ( ! empty( $dirs_to_preserve ) && $filesystem->is_dir( $dir ) ) {
+		return;
+	}
+
 	/**
 	 * Fires before a file/directory cache is deleted
 	 *

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -1037,7 +1037,8 @@ function rocket_clean_cache_dir() {
  * @return void
  */
 function rocket_rrmdir( $dir, $dirs_to_preserve = [] ) {
-	$dir = untrailingslashit( $dir );
+	$dir        = untrailingslashit( $dir );
+	$filesystem = rocket_direct_filesystem();
 
 	/**
 	 * Fires before a file/directory cache is deleted
@@ -1052,19 +1053,19 @@ function rocket_rrmdir( $dir, $dirs_to_preserve = [] ) {
 	// Remove the hidden empty file for mobile detection on NGINX with the Rocket NGINX configuration.
 	$nginx_mobile_detect_file = $dir . '/.mobile-active';
 
-	if ( rocket_direct_filesystem()->is_dir( $dir ) && rocket_direct_filesystem()->exists( $nginx_mobile_detect_file ) ) {
-		rocket_direct_filesystem()->delete( $nginx_mobile_detect_file );
+	if ( $filesystem->is_dir( $dir ) && $filesystem->exists( $nginx_mobile_detect_file ) ) {
+		$filesystem->delete( $nginx_mobile_detect_file );
 	}
 
 	// Remove the hidden empty file for webp.
 	$nowebp_detect_file = $dir . '/.no-webp';
 
-	if ( rocket_direct_filesystem()->is_dir( $dir ) && rocket_direct_filesystem()->exists( $nowebp_detect_file ) ) {
-		rocket_direct_filesystem()->delete( $nowebp_detect_file );
+	if ( $filesystem->is_dir( $dir ) && $filesystem->exists( $nowebp_detect_file ) ) {
+		$filesystem->delete( $nowebp_detect_file );
 	}
 
-	if ( ! rocket_direct_filesystem()->is_dir( $dir ) ) {
-		rocket_direct_filesystem()->delete( $dir );
+	if ( ! $filesystem->is_dir( $dir ) ) {
+		$filesystem->delete( $dir );
 		return;
 	};
 
@@ -1079,15 +1080,15 @@ function rocket_rrmdir( $dir, $dirs_to_preserve = [] ) {
 
 		$dirs = array_diff( $dirs, array_filter( $keys ) );
 		foreach ( $dirs as $dir ) {
-			if ( rocket_direct_filesystem()->is_dir( $dir ) ) {
+			if ( $filesystem->is_dir( $dir ) ) {
 				rocket_rrmdir( $dir, $dirs_to_preserve );
 			} else {
-				rocket_direct_filesystem()->delete( $dir );
+				$filesystem->delete( $dir );
 			}
 		}
 	}
 
-	rocket_direct_filesystem()->delete( $dir );
+	$filesystem->delete( $dir );
 
 	/**
 	 * Fires after a file/directory cache was deleted

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -1033,11 +1033,10 @@ function rocket_clean_cache_dir() {
  * @since 1.0
  * @since 3.5.3 Bails if given dir should be preserved; replaces glob; optimizes.
  *
- * @param string $dir File/Directory to delete.
+ * @param string $dir              File/Directory to delete.
  * @param array  $dirs_to_preserve (default: array()) Dirs that should not be deleted.
- * @return void
  */
-function rocket_rrmdir( $dir, $dirs_to_preserve = [] ) {
+function rocket_rrmdir( $dir, array $dirs_to_preserve = [] ) {
 	$dir        = untrailingslashit( $dir );
 	$filesystem = rocket_direct_filesystem();
 
@@ -1051,9 +1050,9 @@ function rocket_rrmdir( $dir, $dirs_to_preserve = [] ) {
 	 *
 	 * @since 1.1.0
 	 *
-	 * @param string $dir File/Directory to delete.
-	 * @param array $dirs_to_preserve Directories that should not be deleted.
-	*/
+	 * @param string $dir              File/Directory to delete.
+	 * @param array  $dirs_to_preserve Directories that should not be deleted.
+	 */
 	do_action( 'before_rocket_rrmdir', $dir, $dirs_to_preserve ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
 
 	// Remove the hidden empty file for mobile detection on NGINX with the Rocket NGINX configuration.
@@ -1072,17 +1071,18 @@ function rocket_rrmdir( $dir, $dirs_to_preserve = [] ) {
 
 	if ( ! $filesystem->is_dir( $dir ) ) {
 		$filesystem->delete( $dir );
+
 		return;
 	}
 
 	// Get the directory entries.
 	try {
 		$entries = new FilesystemIterator( $dir, FilesystemIterator::SKIP_DOTS );
-	} catch( Exception $e ) {
+	} catch ( Exception $e ) {
 		$entries = [];
 	}
 
-	foreach( $entries as $entry ) {
+	foreach ( $entries as $entry ) {
 		$path = $entry->getPathname();
 
 		// If not a directory, delete it.
@@ -1104,9 +1104,9 @@ function rocket_rrmdir( $dir, $dirs_to_preserve = [] ) {
 	 *
 	 * @since 1.1.0
 	 *
-	 * @param string $dir File/Directory to delete.
-	 * @param array $dirs_to_preserve Dirs that should not be deleted.
-	*/
+	 * @param string $dir              File/Directory to delete.
+	 * @param array  $dirs_to_preserve Dirs that should not be deleted.
+	 */
 	do_action( 'after_rocket_rrmdir', $dir, $dirs_to_preserve ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
 }
 

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -1042,7 +1042,7 @@ function rocket_rrmdir( $dir, $dirs_to_preserve = [] ) {
 	$filesystem = rocket_direct_filesystem();
 
 	// Bail out if the given directory is in the list of directories to preserve.
-	if ( ! empty( $dirs_to_preserve ) && $filesystem->is_dir( $dir ) ) {
+	if ( ! empty( $dirs_to_preserve ) && $filesystem->is_dir( $dir ) && in_array( $dir, $dirs_to_preserve, true ) ) {
 		return;
 	}
 

--- a/tests/Fixtures/inc/functions/rocketRrmdir.php
+++ b/tests/Fixtures/inc/functions/rocketRrmdir.php
@@ -11,9 +11,17 @@ return [
 					'example.org'                 => [
 						'index.html'      => '',
 						'index.html_gzip' => '',
+						'de'              => [
+							'index.html'      => '',
+							'index.html_gzip' => '',
+						],
+						'fr'              => [
+							'index.html'      => '',
+							'index.html_gzip' => '',
+						],
 						'hidden-files'    => [
-							'.mobile-active'  => '',
-							'.no-webp'        => '',
+							'.mobile-active' => '',
+							'.no-webp'       => '',
 						],
 						'lorem-ipsum'     => [
 							'index.html'      => '',
@@ -75,18 +83,7 @@ return [
 
 	// Test data.
 	'test_data' => [
-		'shouldHandleSingleFile' => [
-			'to_delete'   => 'example.org/lorem-ipsum/index.html',
-			'to_preserve' => [],
-			'expected'    => [
-				'before_rocket_rrmdir' => 1,
-				'after_rocket_rrmdir'  => 0,
-				'deleted'              => [
-					'example.org/lorem-ipsum/index.html',
-				],
-			],
-		],
-		'shouldDeleteHiddenFiles' => [
+		'shouldHandleSingleFile'                      => [
 			'to_delete'   => 'example.org/hidden-files/',
 			'to_preserve' => [],
 			'expected'    => [
@@ -97,6 +94,31 @@ return [
 					'example.org/hidden-files/.no-webp',
 					'example.org/hidden-files/',
 				],
+			],
+		],
+		'shouldDeleteHiddenFiles'                     => [
+			'to_delete'   => 'example.org/hidden-files/',
+			'to_preserve' => [],
+			'expected'    => [
+				'before_rocket_rrmdir' => 1,
+				'after_rocket_rrmdir'  => 1,
+				'deleted'              => [
+					'example.org/hidden-files/.mobile-active',
+					'example.org/hidden-files/.no-webp',
+					'example.org/hidden-files/',
+				],
+			],
+		],
+		'shouldBailOutWhenDirectoryShouldBePreserved' => [
+			'to_delete'   => 'example.org/fr',
+			'to_preserve' => [
+				'vfs://public/wp-content/cache/wp-rocket/example.org/de',
+				'vfs://public/wp-content/cache/wp-rocket/example.org/fr',
+			],
+			'expected'    => [
+				'before_rocket_rrmdir' => 0,
+				'after_rocket_rrmdir'  => 0,
+				'deleted'              => [],
 			],
 		],
 

--- a/tests/Fixtures/inc/functions/rocketRrmdir.php
+++ b/tests/Fixtures/inc/functions/rocketRrmdir.php
@@ -1,0 +1,117 @@
+<?php
+
+return [
+	'vfs_dir'   => 'wp-content/cache/wp-rocket/',
+
+	// Virtual filesystem structure.
+	'structure' => [
+		'wp-content' => [
+			'cache'            => [
+				'wp-rocket'    => [
+					'example.org'                 => [
+						'index.html'      => '',
+						'index.html_gzip' => '',
+						'hidden-files'    => [
+							'.mobile-active'  => '',
+							'.no-webp'        => '',
+						],
+						'lorem-ipsum'     => [
+							'index.html'      => '',
+							'index.html_gzip' => '',
+						],
+						'nec-ullamcorper' => [
+							'enim-nunc-faucibus' => [
+								'index.html'      => '',
+								'index.html_gzip' => '',
+							],
+							'index.html'         => '',
+							'index.html_gzip'    => '',
+						],
+					],
+					'example.org-wpmedia-123456'  => [
+						'index.html'      => '',
+						'index.html_gzip' => '',
+						'lorem-ipsum'     => [
+							'index.html'      => '',
+							'index.html_gzip' => '',
+						],
+					],
+					'example.org-wpmedia1-123456' => [
+						'index.html'      => '',
+						'index.html_gzip' => '',
+						'nec-ullamcorper' => [
+							'enim-nunc-faucibus' => [
+								'index.html'      => '',
+								'index.html_gzip' => '',
+							],
+							'index.html'         => '',
+							'index.html_gzip'    => '',
+						],
+					],
+				],
+				'min'          => [
+					'1' => [
+						'123456.css' => '',
+						'123456.js'  => '',
+					],
+				],
+				'busting'      => [
+					'1' => [
+						'ga-123456.js' => '',
+					],
+				],
+				'critical-css' => [
+					'1' => [
+						'front-page.php' => '',
+						'blog.php'       => '',
+					],
+				],
+			],
+			'wp-rocket-config' => [
+				'example.org.php' => 'test',
+			],
+		],
+	],
+
+	// Test data.
+	'test_data' => [
+		'shouldHandleSingleFile' => [
+			'to_delete'   => 'example.org/lorem-ipsum/index.html',
+			'to_preserve' => [],
+			'expected'    => [
+				'before_rocket_rrmdir' => 1,
+				'after_rocket_rrmdir'  => 0,
+				'deleted'              => [
+					'example.org/lorem-ipsum/index.html',
+				],
+			],
+		],
+		'shouldDeleteHiddenFiles' => [
+			'to_delete'   => 'example.org/hidden-files/',
+			'to_preserve' => [],
+			'expected'    => [
+				'before_rocket_rrmdir' => 1,
+				'after_rocket_rrmdir'  => 1,
+				'deleted'              => [
+					'example.org/hidden-files/.mobile-active',
+					'example.org/hidden-files/.no-webp',
+					'example.org/hidden-files/',
+				],
+			],
+		],
+
+//		[
+//			'to_delete'   => 'example.org/lorem-ipsum/',
+//			'to_preserve' => [],
+//			'expected'    => [
+//				'before_rocket_rrmdir' => 1,
+//				'after_rocket_rrmdir'  => 1,
+//				'deleted'              => [
+//					'example.org/lorem-ipsum/index.html',
+//					'example.org/lorem-ipsum/index.html_gzip',
+//					'example.org/lorem-ipsum/',
+//				],
+//			],
+//		],
+	],
+];

--- a/tests/Fixtures/inc/functions/rocketRrmdir.php
+++ b/tests/Fixtures/inc/functions/rocketRrmdir.php
@@ -83,8 +83,8 @@ return [
 
 	// Test data.
 	'test_data' => [
-		'shouldHandleSingleFile'                        => [
-			'to_delete'   => 'example.org/lorem-ipsum/index.html',
+		'shouldDeleteOnlyASingleFile'                        => [
+			'to_delete'   => 'wp-content/cache/wp-rocket/example.org/lorem-ipsum/index.html',
 			'to_preserve' => [],
 			'expected'    => [
 				'before_rocket_rrmdir' => 1,
@@ -95,7 +95,7 @@ return [
 			],
 		],
 		'shouldDeleteHiddenFiles'                       => [
-			'to_delete'   => 'example.org/hidden-files/',
+			'to_delete'   => 'wp-content/cache/wp-rocket/example.org/hidden-files/',
 			'to_preserve' => [],
 			'expected'    => [
 				'before_rocket_rrmdir' => 1,
@@ -110,7 +110,7 @@ return [
 
 		// Should delete the directory and all of its entries.
 		'shouldDeleteSingleDir'                         => [
-			'to_delete'   => 'example.org/lorem-ipsum/',
+			'to_delete'   => 'wp-content/cache/wp-rocket/example.org/lorem-ipsum/',
 			'to_preserve' => [],
 			'expected'    => [
 				'before_rocket_rrmdir' => 1,
@@ -122,8 +122,8 @@ return [
 				],
 			],
 		],
-		[
-			'to_delete'   => 'example.org/nec-ullamcorper/',
+		'shouldDeleteSingleDirWithChildDirs' => [
+			'to_delete'   => 'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/',
 			'to_preserve' => [],
 			'expected'    => [
 				'before_rocket_rrmdir' => 2,
@@ -139,7 +139,7 @@ return [
 			],
 		],
 		'shouldDeleteAllOf_example.org-wpmedia1-123456' => [
-			'to_delete'   => 'example.org-wpmedia1-123456',
+			'to_delete'   => 'wp-content/cache/wp-rocket/example.org-wpmedia1-123456',
 			'to_preserve' => [],
 			'expected'    => [
 				'before_rocket_rrmdir' => 3,
@@ -158,7 +158,7 @@ return [
 			],
 		],
 		'shouldDeleteAllOf_example.org'                 => [
-			'to_delete'   => 'example.org/',
+			'to_delete'   => 'wp-content/cache/wp-rocket/example.org/',
 			'to_preserve' => [],
 			'expected'    => [
 				'before_rocket_rrmdir' => 7,
@@ -189,9 +189,11 @@ return [
 			],
 		],
 
-		// Should not delete directories or its entries when marked as preserved.
-		'shouldBailOutWhenDirectoryShouldBePreserved' => [
-			'to_delete'   => 'example.org/fr',
+		/**
+		 * Should not delete directories or its entries when marked as preserved.
+		 */
+		'shouldBailOutWhenRootDirIsPreserved_fr' => [
+			'to_delete'   => 'wp-content/cache/wp-rocket/example.org/fr',
 			'to_preserve' => [
 				'vfs://public/wp-content/cache/wp-rocket/example.org/de',
 				'vfs://public/wp-content/cache/wp-rocket/example.org/fr',
@@ -199,35 +201,159 @@ return [
 			'expected'    => [
 				'before_rocket_rrmdir' => 0,
 				'after_rocket_rrmdir'  => 0,
-				'deleted' => []
+				'deleted'              => [],
 			],
 		],
-//		'shouldBailOutWhenDirectoryShouldBePreserved' => [
-//			'to_delete'   => 'example.org',
-//			'to_preserve' => [
-//				'vfs://public/wp-content/cache/wp-rocket/example.org/de',
-//				'vfs://public/wp-content/cache/wp-rocket/example.org/fr',
-//			],
-//			'expected'    => [
-//				'before_rocket_rrmdir' => 0,
-//				'after_rocket_rrmdir'  => 0,
-//				'deleted' => [
-//					'wp-content/cache/wp-rocket/example.org/index.html',
-//					'wp-content/cache/wp-rocket/example.org/index.html_gzip',
-//					'wp-content/cache/wp-rocket/example.org/hidden-files',
-//					'wp-content/cache/wp-rocket/example.org/hidden-files/.mobile-active',
-//					'wp-content/cache/wp-rocket/example.org/hidden-files/.no-webp',
-//					'wp-content/cache/wp-rocket/example.org/lorem-ipsum',
-//					'wp-content/cache/wp-rocket/example.org/lorem-ipsum/index.html',
-//					'wp-content/cache/wp-rocket/example.org/lorem-ipsum/index.html_gzip',
-//					'wp-content/cache/wp-rocket/example.org/nec-ullamcorper',
-//					'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/enim-nunc-faucibus',
-//					'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/enim-nunc-faucibus/index.html',
-//					'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/enim-nunc-faucibus/index.html_gzip',
-//					'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/index.html',
-//					'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/index.html_gzip',
-//				]
-//			],
-//		],
+		'shouldBailOutWhenRootDirIsPreserved_de' => [
+			'to_delete'   => 'wp-content/cache/wp-rocket/example.org/de',
+			'to_preserve' => [
+				'vfs://public/wp-content/cache/wp-rocket/example.org/de',
+				'vfs://public/wp-content/cache/wp-rocket/example.org/fr',
+			],
+			'expected'    => [
+				'before_rocket_rrmdir' => 0,
+				'after_rocket_rrmdir'  => 0,
+				'deleted'              => [],
+			],
+		],
+		// Delete all except the de directory/files.
+		'shouldDeleteAllExceptDEentries'                => [
+			'to_delete'   => 'wp-content/cache/wp-rocket/example.org',
+			'to_preserve' => [
+				'vfs://public/wp-content/cache/wp-rocket/example.org/de',
+			],
+			'expected'    => [
+				'before_rocket_rrmdir' => 6,
+				'after_rocket_rrmdir'  => 6,
+				'deleted'              => [
+					'wp-content/cache/wp-rocket/example.org/index.html',
+					'wp-content/cache/wp-rocket/example.org/index.html_gzip',
+					'wp-content/cache/wp-rocket/example.org/fr',
+					'wp-content/cache/wp-rocket/example.org/fr/index.html',
+					'wp-content/cache/wp-rocket/example.org/fr/index.html_gzip',
+					'wp-content/cache/wp-rocket/example.org/hidden-files',
+					'wp-content/cache/wp-rocket/example.org/hidden-files/.mobile-active',
+					'wp-content/cache/wp-rocket/example.org/hidden-files/.no-webp',
+					'wp-content/cache/wp-rocket/example.org/lorem-ipsum',
+					'wp-content/cache/wp-rocket/example.org/lorem-ipsum/index.html',
+					'wp-content/cache/wp-rocket/example.org/lorem-ipsum/index.html_gzip',
+					'wp-content/cache/wp-rocket/example.org/nec-ullamcorper',
+					'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/enim-nunc-faucibus',
+					'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/enim-nunc-faucibus/index.html',
+					'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/enim-nunc-faucibus/index.html_gzip',
+					'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/index.html',
+					'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/index.html_gzip',
+				],
+			],
+		],
+		// Should delete all except fr and de directories and files.
+		'shouldDeleteAllExceptFEandDE'                  => [
+			'to_delete'                           => 'wp-content/cache/wp-rocket/example.org',
+			'to_preserve'                         => [
+				'vfs://public/wp-content/cache/wp-rocket/example.org/de',
+				'vfs://public/wp-content/cache/wp-rocket/example.org/fr',
+			],
+			'expected'                            => [
+				'before_rocket_rrmdir' => 5,
+				'after_rocket_rrmdir'  => 5,
+				'deleted'              => [
+					'wp-content/cache/wp-rocket/example.org/index.html',
+					'wp-content/cache/wp-rocket/example.org/index.html_gzip',
+					'wp-content/cache/wp-rocket/example.org/hidden-files',
+					'wp-content/cache/wp-rocket/example.org/hidden-files/.mobile-active',
+					'wp-content/cache/wp-rocket/example.org/hidden-files/.no-webp',
+					'wp-content/cache/wp-rocket/example.org/lorem-ipsum',
+					'wp-content/cache/wp-rocket/example.org/lorem-ipsum/index.html',
+					'wp-content/cache/wp-rocket/example.org/lorem-ipsum/index.html_gzip',
+					'wp-content/cache/wp-rocket/example.org/nec-ullamcorper',
+					'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/enim-nunc-faucibus',
+					'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/enim-nunc-faucibus/index.html',
+					'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/enim-nunc-faucibus/index.html_gzip',
+					'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/index.html',
+					'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/index.html_gzip',
+				],
+			],
+			// Should delete all in the example.org directory _when_ the preserved language does not exist in the cache.
+			'shouldDeleteAllWhenLangNotPreserved' => [
+				'to_delete'   => 'wp-content/cache/wp-rocket/example.org/',
+				'to_preserve' => [
+					'vfs://public/wp-content/cache/wp-rocket/example.org/nl', // doesn't have files in the cache.
+				],
+				'expected'    => [
+					'before_rocket_rrmdir' => 7,
+					'after_rocket_rrmdir'  => 7,
+					'deleted'              => [
+						'wp-content/cache/wp-rocket/example.org',
+						'wp-content/cache/wp-rocket/example.org/index.html',
+						'wp-content/cache/wp-rocket/example.org/index.html_gzip',
+						'wp-content/cache/wp-rocket/example.org/de',
+						'wp-content/cache/wp-rocket/example.org/de/index.html',
+						'wp-content/cache/wp-rocket/example.org/de/index.html_gzip',
+						'wp-content/cache/wp-rocket/example.org/fr',
+						'wp-content/cache/wp-rocket/example.org/fr/index.html',
+						'wp-content/cache/wp-rocket/example.org/fr/index.html_gzip',
+						'wp-content/cache/wp-rocket/example.org/hidden-files',
+						'wp-content/cache/wp-rocket/example.org/hidden-files/.mobile-active',
+						'wp-content/cache/wp-rocket/example.org/hidden-files/.no-webp',
+						'wp-content/cache/wp-rocket/example.org/lorem-ipsum',
+						'wp-content/cache/wp-rocket/example.org/lorem-ipsum/index.html',
+						'wp-content/cache/wp-rocket/example.org/lorem-ipsum/index.html_gzip',
+						'wp-content/cache/wp-rocket/example.org/nec-ullamcorper',
+						'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/enim-nunc-faucibus',
+						'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/enim-nunc-faucibus/index.html',
+						'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/enim-nunc-faucibus/index.html_gzip',
+						'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/index.html',
+						'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/index.html_gzip',
+					],
+				],
+			],
+
+			// Should delete everything in the wp-content/cache/wp-rocket/ directory except for example.org/de and example.org/fr
+			'shouldDeleteAllWhenLangNotPreserved' => [
+				'to_delete'   => 'wp-content/cache/wp-rocket/',
+				'to_preserve' => [
+					'vfs://public/wp-content/cache/wp-rocket/example.org/de',
+					'vfs://public/wp-content/cache/wp-rocket/example.org/fr',
+				],
+				'expected'    => [
+					'before_rocket_rrmdir' => 7,
+					'after_rocket_rrmdir'  => 7,
+					'deleted'              => [
+						// example.org
+						'wp-content/cache/wp-rocket/example.org/index.html',
+						'wp-content/cache/wp-rocket/example.org/index.html_gzip',
+						'wp-content/cache/wp-rocket/example.org/hidden-files',
+						'wp-content/cache/wp-rocket/example.org/hidden-files/.mobile-active',
+						'wp-content/cache/wp-rocket/example.org/hidden-files/.no-webp',
+						'wp-content/cache/wp-rocket/example.org/lorem-ipsum',
+						'wp-content/cache/wp-rocket/example.org/lorem-ipsum/index.html',
+						'wp-content/cache/wp-rocket/example.org/lorem-ipsum/index.html_gzip',
+						'wp-content/cache/wp-rocket/example.org/nec-ullamcorper',
+						'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/enim-nunc-faucibus',
+						'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/enim-nunc-faucibus/index.html',
+						'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/enim-nunc-faucibus/index.html_gzip',
+						'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/index.html',
+						'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/index.html_gzip',
+						// example.org-wpmedia-123456
+						'wp-content/cache/wp-rocket/example.org-wpmedia-123456',
+						'wp-content/cache/wp-rocket/example.org-wpmedia-123456/index.html',
+						'wp-content/cache/wp-rocket/example.org-wpmedia-123456/index.html_gzip',
+						'wp-content/cache/wp-rocket/example.org-wpmedia-123456/lorem-ipsum',
+						'wp-content/cache/wp-rocket/example.org-wpmedia-123456/lorem-ipsum/index.html',
+						'wp-content/cache/wp-rocket/example.org-wpmedia-123456/lorem-ipsum/index.html_gzip',
+						// example.org-wpmedia1-123456
+						'wp-content/cache/wp-rocket/example.org-wpmedia1-123456',
+						'wp-content/cache/wp-rocket/example.org-wpmedia1-123456/index.html',
+						'wp-content/cache/wp-rocket/example.org-wpmedia1-123456/index.html_gzip',
+						'wp-content/cache/wp-rocket/example.org-wpmedia1-123456/nec-ullamcorper',
+						'wp-content/cache/wp-rocket/example.org-wpmedia1-123456/nec-ullamcorper/enim-nunc-faucibus',
+						'wp-content/cache/wp-rocket/example.org-wpmedia1-123456/nec-ullamcorper/enim-nunc-faucibus/index.html',
+						'wp-content/cache/wp-rocket/example.org-wpmedia1-123456/nec-ullamcorper/enim-nunc-faucibus/index.html_gzip',
+						'wp-content/cache/wp-rocket/example.org-wpmedia1-123456/nec-ullamcorper/index.html',
+						'wp-content/cache/wp-rocket/example.org-wpmedia1-123456/nec-ullamcorper/index.html_gzip',
+					],
+				],
+			],
+		],
 	],
 ];

--- a/tests/Fixtures/inc/functions/rocketRrmdir.php
+++ b/tests/Fixtures/inc/functions/rocketRrmdir.php
@@ -83,41 +83,43 @@ return [
 
 	// Test data.
 	'test_data' => [
-		'shouldHandleSingleFile'  => [
+		'shouldHandleSingleFile'                        => [
 			'to_delete'   => 'example.org/lorem-ipsum/index.html',
 			'to_preserve' => [],
 			'expected'    => [
 				'before_rocket_rrmdir' => 1,
 				'after_rocket_rrmdir'  => 0,
+				'deleted'              => [
+					'wp-content/cache/wp-rocket/example.org/lorem-ipsum/index.html',
+				],
 			],
 		],
-		'shouldDeleteHiddenFiles' => [
+		'shouldDeleteHiddenFiles'                       => [
 			'to_delete'   => 'example.org/hidden-files/',
 			'to_preserve' => [],
 			'expected'    => [
 				'before_rocket_rrmdir' => 1,
 				'after_rocket_rrmdir'  => 1,
+				'deleted'              => [
+					'wp-content/cache/wp-rocket/example.org/hidden-files',
+					'wp-content/cache/wp-rocket/example.org/hidden-files/.mobile-active',
+					'wp-content/cache/wp-rocket/example.org/hidden-files/.no-webp',
+				],
 			],
 		],
-//		'shouldBailOutWhenDirectoryShouldBePreserved' => [
-//			'to_delete'   => 'example.org/fr',
-//			'to_preserve' => [
-//				'vfs://public/wp-content/cache/wp-rocket/example.org/de',
-//				'vfs://public/wp-content/cache/wp-rocket/example.org/fr',
-//			],
-//			'expected'    => [
-//				'before_rocket_rrmdir' => 0,
-//				'after_rocket_rrmdir'  => 0,
-//			],
-//		],
 
 		// Should delete the directory and all of its entries.
-		'shouldDeleteSingleDir'   => [
+		'shouldDeleteSingleDir'                         => [
 			'to_delete'   => 'example.org/lorem-ipsum/',
 			'to_preserve' => [],
 			'expected'    => [
 				'before_rocket_rrmdir' => 1,
 				'after_rocket_rrmdir'  => 1,
+				'deleted'              => [
+					'wp-content/cache/wp-rocket/example.org/lorem-ipsum',
+					'wp-content/cache/wp-rocket/example.org/lorem-ipsum/index.html',
+					'wp-content/cache/wp-rocket/example.org/lorem-ipsum/index.html_gzip',
+				],
 			],
 		],
 		[
@@ -126,15 +128,106 @@ return [
 			'expected'    => [
 				'before_rocket_rrmdir' => 2,
 				'after_rocket_rrmdir'  => 2,
+				'deleted'              => [
+					'wp-content/cache/wp-rocket/example.org/nec-ullamcorper',
+					'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/enim-nunc-faucibus',
+					'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/enim-nunc-faucibus/index.html',
+					'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/enim-nunc-faucibus/index.html_gzip',
+					'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/index.html',
+					'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/index.html_gzip',
+				],
 			],
 		],
-		[
+		'shouldDeleteAllOf_example.org-wpmedia1-123456' => [
 			'to_delete'   => 'example.org-wpmedia1-123456',
 			'to_preserve' => [],
 			'expected'    => [
 				'before_rocket_rrmdir' => 3,
 				'after_rocket_rrmdir'  => 3,
+				'deleted'              => [
+					'wp-content/cache/wp-rocket/example.org-wpmedia1-123456',
+					'wp-content/cache/wp-rocket/example.org-wpmedia1-123456/index.html',
+					'wp-content/cache/wp-rocket/example.org-wpmedia1-123456/index.html_gzip',
+					'wp-content/cache/wp-rocket/example.org-wpmedia1-123456/nec-ullamcorper',
+					'wp-content/cache/wp-rocket/example.org-wpmedia1-123456/nec-ullamcorper/enim-nunc-faucibus',
+					'wp-content/cache/wp-rocket/example.org-wpmedia1-123456/nec-ullamcorper/enim-nunc-faucibus/index.html',
+					'wp-content/cache/wp-rocket/example.org-wpmedia1-123456/nec-ullamcorper/enim-nunc-faucibus/index.html_gzip',
+					'wp-content/cache/wp-rocket/example.org-wpmedia1-123456/nec-ullamcorper/index.html',
+					'wp-content/cache/wp-rocket/example.org-wpmedia1-123456/nec-ullamcorper/index.html_gzip',
+				],
 			],
 		],
+		'shouldDeleteAllOf_example.org'                 => [
+			'to_delete'   => 'example.org/',
+			'to_preserve' => [],
+			'expected'    => [
+				'before_rocket_rrmdir' => 7,
+				'after_rocket_rrmdir'  => 7,
+				'deleted'              => [
+					'wp-content/cache/wp-rocket/example.org',
+					'wp-content/cache/wp-rocket/example.org/index.html',
+					'wp-content/cache/wp-rocket/example.org/index.html_gzip',
+					'wp-content/cache/wp-rocket/example.org/de',
+					'wp-content/cache/wp-rocket/example.org/de/index.html',
+					'wp-content/cache/wp-rocket/example.org/de/index.html_gzip',
+					'wp-content/cache/wp-rocket/example.org/fr',
+					'wp-content/cache/wp-rocket/example.org/fr/index.html',
+					'wp-content/cache/wp-rocket/example.org/fr/index.html_gzip',
+					'wp-content/cache/wp-rocket/example.org/hidden-files',
+					'wp-content/cache/wp-rocket/example.org/hidden-files/.mobile-active',
+					'wp-content/cache/wp-rocket/example.org/hidden-files/.no-webp',
+					'wp-content/cache/wp-rocket/example.org/lorem-ipsum',
+					'wp-content/cache/wp-rocket/example.org/lorem-ipsum/index.html',
+					'wp-content/cache/wp-rocket/example.org/lorem-ipsum/index.html_gzip',
+					'wp-content/cache/wp-rocket/example.org/nec-ullamcorper',
+					'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/enim-nunc-faucibus',
+					'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/enim-nunc-faucibus/index.html',
+					'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/enim-nunc-faucibus/index.html_gzip',
+					'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/index.html',
+					'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/index.html_gzip',
+				],
+			],
+		],
+
+		// Should not delete directories or its entries when marked as preserved.
+		'shouldBailOutWhenDirectoryShouldBePreserved' => [
+			'to_delete'   => 'example.org/fr',
+			'to_preserve' => [
+				'vfs://public/wp-content/cache/wp-rocket/example.org/de',
+				'vfs://public/wp-content/cache/wp-rocket/example.org/fr',
+			],
+			'expected'    => [
+				'before_rocket_rrmdir' => 0,
+				'after_rocket_rrmdir'  => 0,
+				'deleted' => []
+			],
+		],
+//		'shouldBailOutWhenDirectoryShouldBePreserved' => [
+//			'to_delete'   => 'example.org',
+//			'to_preserve' => [
+//				'vfs://public/wp-content/cache/wp-rocket/example.org/de',
+//				'vfs://public/wp-content/cache/wp-rocket/example.org/fr',
+//			],
+//			'expected'    => [
+//				'before_rocket_rrmdir' => 0,
+//				'after_rocket_rrmdir'  => 0,
+//				'deleted' => [
+//					'wp-content/cache/wp-rocket/example.org/index.html',
+//					'wp-content/cache/wp-rocket/example.org/index.html_gzip',
+//					'wp-content/cache/wp-rocket/example.org/hidden-files',
+//					'wp-content/cache/wp-rocket/example.org/hidden-files/.mobile-active',
+//					'wp-content/cache/wp-rocket/example.org/hidden-files/.no-webp',
+//					'wp-content/cache/wp-rocket/example.org/lorem-ipsum',
+//					'wp-content/cache/wp-rocket/example.org/lorem-ipsum/index.html',
+//					'wp-content/cache/wp-rocket/example.org/lorem-ipsum/index.html_gzip',
+//					'wp-content/cache/wp-rocket/example.org/nec-ullamcorper',
+//					'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/enim-nunc-faucibus',
+//					'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/enim-nunc-faucibus/index.html',
+//					'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/enim-nunc-faucibus/index.html_gzip',
+//					'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/index.html',
+//					'wp-content/cache/wp-rocket/example.org/nec-ullamcorper/index.html_gzip',
+//				]
+//			],
+//		],
 	],
 ];

--- a/tests/Fixtures/inc/functions/rocketRrmdir.php
+++ b/tests/Fixtures/inc/functions/rocketRrmdir.php
@@ -83,57 +83,58 @@ return [
 
 	// Test data.
 	'test_data' => [
-		'shouldHandleSingleFile'                      => [
-			'to_delete'   => 'example.org/hidden-files/',
+		'shouldHandleSingleFile'  => [
+			'to_delete'   => 'example.org/lorem-ipsum/index.html',
 			'to_preserve' => [],
 			'expected'    => [
 				'before_rocket_rrmdir' => 1,
-				'after_rocket_rrmdir'  => 1,
-				'deleted'              => [
-					'example.org/hidden-files/.mobile-active',
-					'example.org/hidden-files/.no-webp',
-					'example.org/hidden-files/',
-				],
-			],
-		],
-		'shouldDeleteHiddenFiles'                     => [
-			'to_delete'   => 'example.org/hidden-files/',
-			'to_preserve' => [],
-			'expected'    => [
-				'before_rocket_rrmdir' => 1,
-				'after_rocket_rrmdir'  => 1,
-				'deleted'              => [
-					'example.org/hidden-files/.mobile-active',
-					'example.org/hidden-files/.no-webp',
-					'example.org/hidden-files/',
-				],
-			],
-		],
-		'shouldBailOutWhenDirectoryShouldBePreserved' => [
-			'to_delete'   => 'example.org/fr',
-			'to_preserve' => [
-				'vfs://public/wp-content/cache/wp-rocket/example.org/de',
-				'vfs://public/wp-content/cache/wp-rocket/example.org/fr',
-			],
-			'expected'    => [
-				'before_rocket_rrmdir' => 0,
 				'after_rocket_rrmdir'  => 0,
-				'deleted'              => [],
 			],
 		],
-
-//		[
-//			'to_delete'   => 'example.org/lorem-ipsum/',
-//			'to_preserve' => [],
+		'shouldDeleteHiddenFiles' => [
+			'to_delete'   => 'example.org/hidden-files/',
+			'to_preserve' => [],
+			'expected'    => [
+				'before_rocket_rrmdir' => 1,
+				'after_rocket_rrmdir'  => 1,
+			],
+		],
+//		'shouldBailOutWhenDirectoryShouldBePreserved' => [
+//			'to_delete'   => 'example.org/fr',
+//			'to_preserve' => [
+//				'vfs://public/wp-content/cache/wp-rocket/example.org/de',
+//				'vfs://public/wp-content/cache/wp-rocket/example.org/fr',
+//			],
 //			'expected'    => [
-//				'before_rocket_rrmdir' => 1,
-//				'after_rocket_rrmdir'  => 1,
-//				'deleted'              => [
-//					'example.org/lorem-ipsum/index.html',
-//					'example.org/lorem-ipsum/index.html_gzip',
-//					'example.org/lorem-ipsum/',
-//				],
+//				'before_rocket_rrmdir' => 0,
+//				'after_rocket_rrmdir'  => 0,
 //			],
 //		],
+
+		// Should delete the directory and all of its entries.
+		'shouldDeleteSingleDir'   => [
+			'to_delete'   => 'example.org/lorem-ipsum/',
+			'to_preserve' => [],
+			'expected'    => [
+				'before_rocket_rrmdir' => 1,
+				'after_rocket_rrmdir'  => 1,
+			],
+		],
+		[
+			'to_delete'   => 'example.org/nec-ullamcorper/',
+			'to_preserve' => [],
+			'expected'    => [
+				'before_rocket_rrmdir' => 2,
+				'after_rocket_rrmdir'  => 2,
+			],
+		],
+		[
+			'to_delete'   => 'example.org-wpmedia1-123456',
+			'to_preserve' => [],
+			'expected'    => [
+				'before_rocket_rrmdir' => 3,
+				'after_rocket_rrmdir'  => 3,
+			],
+		],
 	],
 ];

--- a/tests/Integration/FilesystemTestCase.php
+++ b/tests/Integration/FilesystemTestCase.php
@@ -3,6 +3,7 @@
 namespace WP_Rocket\Tests\Integration;
 
 use Brain\Monkey\Functions;
+use org\bovigo\vfs\vfsStream;
 use WPMedia\PHPUnit\Integration\VirtualFilesystemTestCase;
 
 abstract class FilesystemTestCase extends VirtualFilesystemTestCase {
@@ -54,11 +55,10 @@ abstract class FilesystemTestCase extends VirtualFilesystemTestCase {
 		sort( $this->original_entries );
 	}
 
-	protected function startsWith( $string, $match ) {
-		return substr( $string, 0, strlen( $match ) ) === $match;
-	}
-
 	protected function stripVfsRoot( $path ) {
-		return str_replace( vfsStream::SCHEME . "://{$this->rootVirtualDir}", '', $path );
+		$search = vfsStream::SCHEME . "://{$this->rootVirtualDir}";
+		$search = rtrim( $search, '/\\' ) . '/';
+
+		return str_replace( $search, '', $path );
 	}
 }

--- a/tests/Integration/FilesystemTestCase.php
+++ b/tests/Integration/FilesystemTestCase.php
@@ -6,6 +6,7 @@ use Brain\Monkey\Functions;
 use WPMedia\PHPUnit\Integration\VirtualFilesystemTestCase;
 
 abstract class FilesystemTestCase extends VirtualFilesystemTestCase {
+	protected $original_entries = [];
 
 	public function setUp() {
 		parent::setUp();
@@ -45,5 +46,19 @@ abstract class FilesystemTestCase extends VirtualFilesystemTestCase {
 			'wp-includes'   => [],
 			'wp-config.php' => '',
 		];
+	}
+
+	protected function setUpOriginalEntries() {
+		$this->original_entries = array_merge( $this->original_files, $this->original_dirs );
+		$this->original_entries = array_filter( $this->original_entries );
+		sort( $this->original_entries );
+	}
+
+	protected function startsWith( $string, $match ) {
+		return substr( $string, 0, strlen( $match ) ) === $match;
+	}
+
+	protected function stripVfsRoot( $path ) {
+		return str_replace( vfsStream::SCHEME . "://{$this->rootVirtualDir}", '', $path );
 	}
 }

--- a/tests/Integration/inc/functions/rocketRrmdir.php
+++ b/tests/Integration/inc/functions/rocketRrmdir.php
@@ -15,12 +15,10 @@ use WP_Rocket\Tests\Integration\FilesystemTestCase;
 class Test_RocketRrmdir extends FilesystemTestCase {
 	protected $path_to_test_data = '/inc/functions/rocketRrmdir.php';
 	private $stats;
-	private $to_preserve;
 
 	public function setUp() {
 		parent::setUp();
 
-		$this->to_preserve = [];
 		$this->stats       = [
 			'before_rocket_rrmdir' => did_action( 'before_rocket_rrmdir' ),
 			'after_rocket_rrmdir'  => did_action( 'after_rocket_rrmdir' ),
@@ -36,8 +34,6 @@ class Test_RocketRrmdir extends FilesystemTestCase {
 		$to_delete      = rtrim( $to_delete, '/\\' );
 		$to_delete_path = $this->config['vfs_dir'] . $to_delete;
 		$to_delete      = $this->filesystem->getUrl( $to_delete_path );
-		$is_file        = $this->filesystem->is_file( $to_delete );
-		$this->initPreserve( $to_preserve );
 
 		// Run it.
 		rocket_rrmdir( $to_delete, $to_preserve );
@@ -52,34 +48,15 @@ class Test_RocketRrmdir extends FilesystemTestCase {
 			did_action( 'after_rocket_rrmdir' ) - $this->stats['after_rocket_rrmdir']
 		);
 
-		foreach ( $this->original_entries as $entry ) {
-			if ( $is_file ) {
-				$exists = $entry !== $to_delete_path;
-				$this->assertSame( $exists, $this->filesystem->exists( $entry ) );
-				continue;
-			}
-
-			$exists = ! (
-				$this->startsWith( $entry, $to_delete_path )
-				&&
-				! $this->shouldPreserve( $entry )
-			);
-
-			$this->assertSame( $exists, $this->filesystem->exists( $entry ) );
+		// Check the "deleted" files/directories no longer exist, i.e. were deleted.
+		foreach( $expected['deleted'] as $entry ) {
+			$this->assertFalse( $this->filesystem->exists( $entry ));
 		}
-	}
 
-	private function shouldPreserve( $entry ) {
-		return (
-			! empty( $to_preserve )
-			&&
-			in_array( $entry, $to_preserve, true )
-		);
-	}
-
-	private function initPreserve( $to_preserve ) {
-		if ( ! empty( $to_preserve ) ) {
-			$this->to_preserve = array_map( [ $this, 'stripVfsRoot' ], $to_preserve );
+		// Check the non-deleted files/directories still exist, i.e. were not deleted.
+		$should_exist = array_diff( $this->original_entries, $expected['deleted'] );
+		foreach( $should_exist as $entry ) {
+			$this->assertTrue( $this->filesystem->exists( $entry ) );
 		}
 	}
 }

--- a/tests/Integration/inc/functions/rocketRrmdir.php
+++ b/tests/Integration/inc/functions/rocketRrmdir.php
@@ -47,5 +47,31 @@ class Test_RocketRrmdir extends FilesystemTestCase {
 		foreach ( $expected['deleted'] as $path ) {
 			$this->assertFalse( $this->filesystem->exists( $this->config['vfs_dir'] . $path ) );
 		}
+
+		if ( empty( $to_preserve ) ) {
+			return;
+		}
+
+		foreach( $this->getOriginalPreservedFiles( $to_preserve ) as $path ) {
+			$this->assertTrue( $this->filesystem->exists( $path ) );
+		}
+	}
+
+	private function getOriginalPreservedFiles( $to_preserve ) {
+		$preserves = [];
+		foreach( $to_preserve as $dir ) {
+			$preserves[] = str_replace( 'vfs://public/', '', $dir );
+		}
+
+		$preserve_files = [];
+		foreach( $this->original_files as $file ) {
+			foreach( $preserves as $dir ) {
+				if ( substr( $file, 0, strlen( $dir ) ) === $dir ) {
+					$preserve_files[] = $file;
+				}
+			}
+		}
+
+		return $preserve_files;
 	}
 }

--- a/tests/Integration/inc/functions/rocketRrmdir.php
+++ b/tests/Integration/inc/functions/rocketRrmdir.php
@@ -15,22 +15,31 @@ use WP_Rocket\Tests\Integration\FilesystemTestCase;
 class Test_RocketRrmdir extends FilesystemTestCase {
 	protected $path_to_test_data = '/inc/functions/rocketRrmdir.php';
 	private $stats;
+	private $to_preserve;
 
 	public function setUp() {
 		parent::setUp();
 
-		$this->stats = [
+		$this->to_preserve = [];
+		$this->stats       = [
 			'before_rocket_rrmdir' => did_action( 'before_rocket_rrmdir' ),
 			'after_rocket_rrmdir'  => did_action( 'after_rocket_rrmdir' ),
 		];
+
+		$this->setUpOriginalEntries();
 	}
 
 	/**
 	 * @dataProvider providerTestData
 	 */
 	public function testShouldRecursivelyRemoveFilesAndDirectories( $to_delete, $to_preserve, $expected ) {
-		$to_delete = $this->filesystem->getUrl( $this->config['vfs_dir'] . $to_delete );
+		$to_delete      = rtrim( $to_delete, '/\\' );
+		$to_delete_path = $this->config['vfs_dir'] . $to_delete;
+		$to_delete      = $this->filesystem->getUrl( $to_delete_path );
+		$is_file        = $this->filesystem->is_file( $to_delete );
+		$this->initPreserve( $to_preserve );
 
+		// Run it.
 		rocket_rrmdir( $to_delete, $to_preserve );
 
 		// Check the action events.
@@ -43,35 +52,34 @@ class Test_RocketRrmdir extends FilesystemTestCase {
 			did_action( 'after_rocket_rrmdir' ) - $this->stats['after_rocket_rrmdir']
 		);
 
-		// Check that the expected files/directories were actually deleted.
-		foreach ( $expected['deleted'] as $path ) {
-			$this->assertFalse( $this->filesystem->exists( $this->config['vfs_dir'] . $path ) );
-		}
+		foreach ( $this->original_entries as $entry ) {
+			if ( $is_file ) {
+				$exists = $entry !== $to_delete_path;
+				$this->assertSame( $exists, $this->filesystem->exists( $entry ) );
+				continue;
+			}
 
-		if ( empty( $to_preserve ) ) {
-			return;
-		}
+			$exists = ! (
+				$this->startsWith( $entry, $to_delete_path )
+				&&
+				! $this->shouldPreserve( $entry )
+			);
 
-		foreach( $this->getOriginalPreservedFiles( $to_preserve ) as $path ) {
-			$this->assertTrue( $this->filesystem->exists( $path ) );
+			$this->assertSame( $exists, $this->filesystem->exists( $entry ) );
 		}
 	}
 
-	private function getOriginalPreservedFiles( $to_preserve ) {
-		$preserves = [];
-		foreach( $to_preserve as $dir ) {
-			$preserves[] = str_replace( 'vfs://public/', '', $dir );
-		}
+	private function shouldPreserve( $entry ) {
+		return (
+			! empty( $to_preserve )
+			&&
+			in_array( $entry, $to_preserve, true )
+		);
+	}
 
-		$preserve_files = [];
-		foreach( $this->original_files as $file ) {
-			foreach( $preserves as $dir ) {
-				if ( substr( $file, 0, strlen( $dir ) ) === $dir ) {
-					$preserve_files[] = $file;
-				}
-			}
+	private function initPreserve( $to_preserve ) {
+		if ( ! empty( $to_preserve ) ) {
+			$this->to_preserve = array_map( [ $this, 'stripVfsRoot' ], $to_preserve );
 		}
-
-		return $preserve_files;
 	}
 }

--- a/tests/Integration/inc/functions/rocketRrmdir.php
+++ b/tests/Integration/inc/functions/rocketRrmdir.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\functions;
+
+use WP_Rocket\Tests\Integration\FilesystemTestCase;
+
+/**
+ * @covers ::rocket_rrmdir
+ * @uses  ::rocket_direct_filesystem
+ * @group Functions
+ * @group Files
+ * @group vfs
+ * @group thisone
+ */
+class Test_RocketRrmdir extends FilesystemTestCase {
+	protected $path_to_test_data = '/inc/functions/rocketRrmdir.php';
+	private $stats;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->stats = [
+			'before_rocket_rrmdir' => did_action( 'before_rocket_rrmdir' ),
+			'after_rocket_rrmdir'  => did_action( 'after_rocket_rrmdir' ),
+		];
+	}
+
+	/**
+	 * @dataProvider providerTestData
+	 */
+	public function testShouldRecursivelyRemoveFilesAndDirectories( $to_delete, $to_preserve, $expected ) {
+		$to_delete = $this->filesystem->getUrl( $this->config['vfs_dir'] . $to_delete );
+
+		rocket_rrmdir( $to_delete, $to_preserve );
+
+		// Check the action events.
+		$this->assertEquals(
+			$expected['before_rocket_rrmdir'],
+			did_action( 'before_rocket_rrmdir' ) - $this->stats['before_rocket_rrmdir']
+		);
+		$this->assertEquals(
+			$expected['after_rocket_rrmdir'],
+			did_action( 'after_rocket_rrmdir' ) - $this->stats['after_rocket_rrmdir']
+		);
+
+		// Check that the expected files/directories were actually deleted.
+		foreach ( $expected['deleted'] as $path ) {
+			$this->assertFalse( $this->filesystem->exists( $this->config['vfs_dir'] . $path ) );
+		}
+	}
+}

--- a/tests/Integration/inc/functions/rocketRrmdir.php
+++ b/tests/Integration/inc/functions/rocketRrmdir.php
@@ -10,7 +10,6 @@ use WP_Rocket\Tests\Integration\FilesystemTestCase;
  * @group Functions
  * @group Files
  * @group vfs
- * @group thisone
  */
 class Test_RocketRrmdir extends FilesystemTestCase {
 	protected $path_to_test_data = '/inc/functions/rocketRrmdir.php';
@@ -19,7 +18,7 @@ class Test_RocketRrmdir extends FilesystemTestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->stats       = [
+		$this->stats = [
 			'before_rocket_rrmdir' => did_action( 'before_rocket_rrmdir' ),
 			'after_rocket_rrmdir'  => did_action( 'after_rocket_rrmdir' ),
 		];
@@ -31,9 +30,7 @@ class Test_RocketRrmdir extends FilesystemTestCase {
 	 * @dataProvider providerTestData
 	 */
 	public function testShouldRecursivelyRemoveFilesAndDirectories( $to_delete, $to_preserve, $expected ) {
-		$to_delete      = rtrim( $to_delete, '/\\' );
-		$to_delete_path = $this->config['vfs_dir'] . $to_delete;
-		$to_delete      = $this->filesystem->getUrl( $to_delete_path );
+		$to_delete = $this->filesystem->getUrl( untrailingslashit( $to_delete ) );
 
 		// Run it.
 		rocket_rrmdir( $to_delete, $to_preserve );
@@ -49,13 +46,13 @@ class Test_RocketRrmdir extends FilesystemTestCase {
 		);
 
 		// Check the "deleted" files/directories no longer exist, i.e. were deleted.
-		foreach( $expected['deleted'] as $entry ) {
-			$this->assertFalse( $this->filesystem->exists( $entry ));
+		foreach ( $expected['deleted'] as $entry ) {
+			$this->assertFalse( $this->filesystem->exists( $entry ) );
 		}
 
 		// Check the non-deleted files/directories still exist, i.e. were not deleted.
 		$should_exist = array_diff( $this->original_entries, $expected['deleted'] );
-		foreach( $should_exist as $entry ) {
+		foreach ( $should_exist as $entry ) {
 			$this->assertTrue( $this->filesystem->exists( $entry ) );
 		}
 	}

--- a/tests/Unit/FilesystemTestCase.php
+++ b/tests/Unit/FilesystemTestCase.php
@@ -3,9 +3,11 @@
 namespace WP_Rocket\Tests\Unit;
 
 use Brain\Monkey\Functions;
+use org\bovigo\vfs\vfsStream;
 use WPMedia\PHPUnit\Unit\VirtualFilesystemTestCase;
 
 abstract class FilesystemTestCase extends VirtualFilesystemTestCase {
+	protected $original_entries;
 
 	public function setUp() {
 		parent::setUp();
@@ -45,5 +47,19 @@ abstract class FilesystemTestCase extends VirtualFilesystemTestCase {
 			'wp-includes'   => [],
 			'wp-config.php' => '',
 		];
+	}
+
+	protected function setUpOriginalEntries() {
+		$this->original_entries = array_merge( $this->original_files, $this->original_dirs );
+		$this->original_entries = array_filter( $this->original_entries );
+		sort( $this->original_entries );
+	}
+
+	protected function startsWith( $string, $match ) {
+		return substr( $string, 0, strlen( $match ) ) === $match;
+	}
+
+	protected function stripVfsRoot( $path ) {
+		return str_replace( vfsStream::SCHEME . "://{$this->rootVirtualDir}", '', $path );
 	}
 }

--- a/tests/Unit/FilesystemTestCase.php
+++ b/tests/Unit/FilesystemTestCase.php
@@ -55,11 +55,10 @@ abstract class FilesystemTestCase extends VirtualFilesystemTestCase {
 		sort( $this->original_entries );
 	}
 
-	protected function startsWith( $string, $match ) {
-		return substr( $string, 0, strlen( $match ) ) === $match;
-	}
-
 	protected function stripVfsRoot( $path ) {
-		return str_replace( vfsStream::SCHEME . "://{$this->rootVirtualDir}", '', $path );
+		$search = vfsStream::SCHEME . "://{$this->rootVirtualDir}";
+		$search = rtrim( $search, '/\\' ) . '/';
+
+		return str_replace( $search, '', $path );
 	}
 }

--- a/tests/Unit/inc/functions/rocketRrmdir.php
+++ b/tests/Unit/inc/functions/rocketRrmdir.php
@@ -15,53 +15,59 @@ use WP_Rocket\Tests\Unit\FilesystemTestCase;
  */
 class Test_RocketRrmdir extends FilesystemTestCase {
 	protected $path_to_test_data = '/inc/functions/rocketRrmdir.php';
+	private $to_preserve;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->setUpOriginalEntries();
+		$this->to_preserve = [];
+	}
 
 	/**
 	 * @dataProvider providerTestData
 	 */
 	public function testShouldRecursivelyRemoveFilesAndDirectories( $to_delete, $to_preserve, $expected ) {
-		$to_delete = $this->filesystem->getUrl( $this->config['vfs_dir'] . $to_delete );
+		$to_delete      = rtrim( $to_delete, '/\\' );
+		$to_delete_path = $this->config['vfs_dir'] . $to_delete;
+		$to_delete      = $this->filesystem->getUrl( $to_delete_path );
+		$is_file        = $this->filesystem->is_file( $to_delete );
+		$this->initPreserve( $to_preserve );
 
 		// Check the action events.
-		$dir = rtrim( $to_delete, '/\\' );
-		Actions\expectDone( 'before_rocket_rrmdir' )
-			->times( $expected['before_rocket_rrmdir'] )
-			->with( $dir, $to_preserve );
-		Actions\expectDone( 'after_rocket_rrmdir' )
-			->times( $expected['after_rocket_rrmdir'] )
-			->with( $dir, $to_preserve );
+		Actions\expectDone( 'before_rocket_rrmdir' )->times( $expected['before_rocket_rrmdir'] );
+		Actions\expectDone( 'after_rocket_rrmdir' )->times( $expected['after_rocket_rrmdir'] );
 
 		rocket_rrmdir( $to_delete, $to_preserve );
 
-		// Check that the expected files/directories were actually deleted.
-		foreach ( $expected['deleted'] as $path ) {
-			$this->assertFalse( $this->filesystem->exists( $this->config['vfs_dir'] . $path ) );
-		}
+		foreach ( $this->original_entries as $entry ) {
+			if ( $is_file ) {
+				$exists = $entry !== $to_delete_path;
+				$this->assertSame( $exists, $this->filesystem->exists( $entry ) );
+				continue;
+			}
 
-		if ( empty( $to_preserve ) ) {
-			return;
-		}
+			$exists = ! (
+				$this->startsWith( $entry, $to_delete_path )
+				&&
+				! $this->shouldPreserve( $entry )
+			);
 
-		foreach( $this->getOriginalPreservedFiles( $to_preserve ) as $path ) {
-			$this->assertTrue( $this->filesystem->exists( $path ) );
+			$this->assertSame( $exists, $this->filesystem->exists( $entry ) );
 		}
 	}
 
-	private function getOriginalPreservedFiles( $to_preserve ) {
-		$preserves = [];
-		foreach( $to_preserve as $dir ) {
-			$preserves[] = str_replace( 'vfs://public/', '', $dir );
-		}
+	private function shouldPreserve( $entry ) {
+		return (
+			! empty( $to_preserve )
+			&&
+			in_array( $entry, $to_preserve, true )
+		);
+	}
 
-		$preserve_files = [];
-		foreach( $this->original_files as $file ) {
-			foreach( $preserves as $dir ) {
-				if ( substr( $file, 0, strlen( $dir ) ) === $dir ) {
-					$preserve_files[] = $file;
-				}
-			}
+	private function initPreserve( $to_preserve ) {
+		if ( ! empty( $to_preserve ) ) {
+			$this->to_preserve = array_map( [ $this, 'stripVfsRoot' ], $to_preserve );
 		}
-
-		return $preserve_files;
 	}
 }

--- a/tests/Unit/inc/functions/rocketRrmdir.php
+++ b/tests/Unit/inc/functions/rocketRrmdir.php
@@ -25,7 +25,7 @@ class Test_RocketRrmdir extends FilesystemTestCase {
 	 * @dataProvider providerTestData
 	 */
 	public function testShouldRecursivelyRemoveFilesAndDirectories( $to_delete, $to_preserve, $expected ) {
-		$to_delete      = $this->filesystem->getUrl( untrailingslashit( $to_delete ) );
+		$to_delete = $this->filesystem->getUrl( untrailingslashit( $to_delete ) );
 
 		// Check the action events.
 		Actions\expectDone( 'before_rocket_rrmdir' )->times( $expected['before_rocket_rrmdir'] );
@@ -35,13 +35,13 @@ class Test_RocketRrmdir extends FilesystemTestCase {
 		rocket_rrmdir( $to_delete, $to_preserve );
 
 		// Check the "deleted" files/directories no longer exist, i.e. were deleted.
-		foreach( $expected['deleted'] as $entry ) {
-			$this->assertFalse( $this->filesystem->exists( $entry ));
+		foreach ( $expected['deleted'] as $entry ) {
+			$this->assertFalse( $this->filesystem->exists( $entry ) );
 		}
 
 		// Check the non-deleted files/directories still exist, i.e. were not deleted.
 		$should_exist = array_diff( $this->original_entries, $expected['deleted'] );
-		foreach( $should_exist as $entry ) {
+		foreach ( $should_exist as $entry ) {
 			$this->assertTrue( $this->filesystem->exists( $entry ) );
 		}
 	}

--- a/tests/Unit/inc/functions/rocketRrmdir.php
+++ b/tests/Unit/inc/functions/rocketRrmdir.php
@@ -37,5 +37,31 @@ class Test_RocketRrmdir extends FilesystemTestCase {
 		foreach ( $expected['deleted'] as $path ) {
 			$this->assertFalse( $this->filesystem->exists( $this->config['vfs_dir'] . $path ) );
 		}
+
+		if ( empty( $to_preserve ) ) {
+			return;
+		}
+
+		foreach( $this->getOriginalPreservedFiles( $to_preserve ) as $path ) {
+			$this->assertTrue( $this->filesystem->exists( $path ) );
+		}
+	}
+
+	private function getOriginalPreservedFiles( $to_preserve ) {
+		$preserves = [];
+		foreach( $to_preserve as $dir ) {
+			$preserves[] = str_replace( 'vfs://public/', '', $dir );
+		}
+
+		$preserve_files = [];
+		foreach( $this->original_files as $file ) {
+			foreach( $preserves as $dir ) {
+				if ( substr( $file, 0, strlen( $dir ) ) === $dir ) {
+					$preserve_files[] = $file;
+				}
+			}
+		}
+
+		return $preserve_files;
 	}
 }

--- a/tests/Unit/inc/functions/rocketRrmdir.php
+++ b/tests/Unit/inc/functions/rocketRrmdir.php
@@ -11,7 +11,6 @@ use WP_Rocket\Tests\Unit\FilesystemTestCase;
  * @group Functions
  * @group Files
  * @group vfs
- * @group thisone
  */
 class Test_RocketRrmdir extends FilesystemTestCase {
 	protected $path_to_test_data = '/inc/functions/rocketRrmdir.php';
@@ -20,17 +19,13 @@ class Test_RocketRrmdir extends FilesystemTestCase {
 		parent::setUp();
 
 		$this->setUpOriginalEntries();
-		$this->to_preserve = [];
 	}
 
 	/**
 	 * @dataProvider providerTestData
 	 */
 	public function testShouldRecursivelyRemoveFilesAndDirectories( $to_delete, $to_preserve, $expected ) {
-		$to_delete      = untrailingslashit( $to_delete );
-		$to_delete_path = $this->config['vfs_dir'] . $to_delete;
-		$to_delete      = $this->filesystem->getUrl( $to_delete_path );
-		$this->initPreserve( $to_preserve );
+		$to_delete      = $this->filesystem->getUrl( untrailingslashit( $to_delete ) );
 
 		// Check the action events.
 		Actions\expectDone( 'before_rocket_rrmdir' )->times( $expected['before_rocket_rrmdir'] );
@@ -48,12 +43,6 @@ class Test_RocketRrmdir extends FilesystemTestCase {
 		$should_exist = array_diff( $this->original_entries, $expected['deleted'] );
 		foreach( $should_exist as $entry ) {
 			$this->assertTrue( $this->filesystem->exists( $entry ) );
-		}
-	}
-
-	private function initPreserve( $to_preserve ) {
-		if ( ! empty( $to_preserve ) ) {
-			$this->to_preserve = array_map( [ $this, 'stripVfsRoot' ], $to_preserve );
 		}
 	}
 }

--- a/tests/Unit/inc/functions/rocketRrmdir.php
+++ b/tests/Unit/inc/functions/rocketRrmdir.php
@@ -15,7 +15,6 @@ use WP_Rocket\Tests\Unit\FilesystemTestCase;
  */
 class Test_RocketRrmdir extends FilesystemTestCase {
 	protected $path_to_test_data = '/inc/functions/rocketRrmdir.php';
-	private $to_preserve;
 
 	public function setUp() {
 		parent::setUp();
@@ -28,41 +27,28 @@ class Test_RocketRrmdir extends FilesystemTestCase {
 	 * @dataProvider providerTestData
 	 */
 	public function testShouldRecursivelyRemoveFilesAndDirectories( $to_delete, $to_preserve, $expected ) {
-		$to_delete      = rtrim( $to_delete, '/\\' );
+		$to_delete      = untrailingslashit( $to_delete );
 		$to_delete_path = $this->config['vfs_dir'] . $to_delete;
 		$to_delete      = $this->filesystem->getUrl( $to_delete_path );
-		$is_file        = $this->filesystem->is_file( $to_delete );
 		$this->initPreserve( $to_preserve );
 
 		// Check the action events.
 		Actions\expectDone( 'before_rocket_rrmdir' )->times( $expected['before_rocket_rrmdir'] );
 		Actions\expectDone( 'after_rocket_rrmdir' )->times( $expected['after_rocket_rrmdir'] );
 
+		// Run it.
 		rocket_rrmdir( $to_delete, $to_preserve );
 
-		foreach ( $this->original_entries as $entry ) {
-			if ( $is_file ) {
-				$exists = $entry !== $to_delete_path;
-				$this->assertSame( $exists, $this->filesystem->exists( $entry ) );
-				continue;
-			}
-
-			$exists = ! (
-				$this->startsWith( $entry, $to_delete_path )
-				&&
-				! $this->shouldPreserve( $entry )
-			);
-
-			$this->assertSame( $exists, $this->filesystem->exists( $entry ) );
+		// Check the "deleted" files/directories no longer exist, i.e. were deleted.
+		foreach( $expected['deleted'] as $entry ) {
+			$this->assertFalse( $this->filesystem->exists( $entry ));
 		}
-	}
 
-	private function shouldPreserve( $entry ) {
-		return (
-			! empty( $to_preserve )
-			&&
-			in_array( $entry, $to_preserve, true )
-		);
+		// Check the non-deleted files/directories still exist, i.e. were not deleted.
+		$should_exist = array_diff( $this->original_entries, $expected['deleted'] );
+		foreach( $should_exist as $entry ) {
+			$this->assertTrue( $this->filesystem->exists( $entry ) );
+		}
 	}
 
 	private function initPreserve( $to_preserve ) {

--- a/tests/Unit/inc/functions/rocketRrmdir.php
+++ b/tests/Unit/inc/functions/rocketRrmdir.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\functions;
+
+use Brain\Monkey\Actions;
+use WP_Rocket\Tests\Unit\FilesystemTestCase;
+
+/**
+ * @covers ::rocket_rrmdir
+ * @uses  ::rocket_direct_filesystem
+ * @group Functions
+ * @group Files
+ * @group vfs
+ * @group thisone
+ */
+class Test_RocketRrmdir extends FilesystemTestCase {
+	protected $path_to_test_data = '/inc/functions/rocketRrmdir.php';
+
+	/**
+	 * @dataProvider providerTestData
+	 */
+	public function testShouldRecursivelyRemoveFilesAndDirectories( $to_delete, $to_preserve, $expected ) {
+		$to_delete = $this->filesystem->getUrl( $this->config['vfs_dir'] . $to_delete );
+
+		// Check the action events.
+		$dir = rtrim( $to_delete, '/\\' );
+		Actions\expectDone( 'before_rocket_rrmdir' )
+			->times( $expected['before_rocket_rrmdir'] )
+			->with( $dir, $to_preserve );
+		Actions\expectDone( 'after_rocket_rrmdir' )
+			->times( $expected['after_rocket_rrmdir'] )
+			->with( $dir, $to_preserve );
+
+		rocket_rrmdir( $to_delete, $to_preserve );
+
+		// Check that the expected files/directories were actually deleted.
+		foreach ( $expected['deleted'] as $path ) {
+			$this->assertFalse( $this->filesystem->exists( $this->config['vfs_dir'] . $path ) );
+		}
+	}
+}


### PR DESCRIPTION
`rocket_rrmdir()` is an original filesystem function that has not been optimized nor does it have tests. This PR gives it some love as it's a critical part of Rocket.

This PR does the following:

- 🏁 Adds tests
- 🚀 Optimizes by calling `rocket_direct_filesystem()` 1x instead of 11x
- 🚀 Checks if the given directory is in the list of preserves _before_ doing anything else
- 🚀 Optimizes the check for directory in preserves list
- 🏁 Replaces `glob()` with SPL

👉 Needed to move PR #2510 forward.

## TODO

- [x] Validate glob behavior
- [x] Add unit and integration tests
- [x] Optimize
- [x] Replace `glob`
- [ ] QA 👈 needed because the source code did change.