### PR TITLE
Tests: Switches to use wp-media/phpunit v1.1.6

### DIFF
--- a/tests/Integration/ApiTestCase.php
+++ b/tests/Integration/ApiTestCase.php
@@ -41,6 +41,6 @@ abstract class ApiTestCase extends WPMediaRESTfulTestCase {
 			];
 		}
 
-		return $this->doRestRequest( $body_params, '/wp-rocket/v1/rocketcdn/enable' );
+		return $this->doRestPut( '/wp-rocket/v1/rocketcdn/enable', $body_params );
 	}
 }

--- a/tests/Integration/ApiTestCase.php
+++ b/tests/Integration/ApiTestCase.php
@@ -22,7 +22,7 @@ abstract class ApiTestCase extends WPMediaRESTfulTestCase {
 			];
 		}
 
-		return $this->doRestRequest( $body_params, '/wp-rocket/v1/rocketcdn/disable' );
+		return $this->doRestPut( '/wp-rocket/v1/rocketcdn/disable', $body_params );
 	}
 
 	/**

--- a/tests/Integration/RESTVfsTestCase.php
+++ b/tests/Integration/RESTVfsTestCase.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration;
+
+use Brain\Monkey\Functions;
+use WPMedia\PHPUnit\Integration\RESTVfsTestCase as BaseTestCase;
+
+abstract class RESTVfsTestCase extends BaseTestCase {
+
+	public function setUp() {
+		parent::setUp();
+
+		// Redefine rocket_direct_filesystem() to use the virtual filesystem.
+		Functions\when( 'rocket_direct_filesystem' )->justReturn( $this->filesystem );
+	}
+
+	public function getPathToFixturesDir() {
+		return WP_ROCKET_TESTS_FIXTURES_DIR;
+	}
+
+	public function getDefaultVfs() {
+		return [
+			'wp-admin'      => [],
+			'wp-content'    => [
+				'cache'            => [
+					'busting'      => [
+						1 => [],
+					],
+					'critical-css' => [],
+					'min'          => [],
+					'wp-rocket'    => [
+						'index.html' => '',
+					],
+				],
+				'mu-plugins'       => [],
+				'plugins'          => [
+					'wp-rocket' => [],
+				],
+				'themes'           => [
+					'twentytwenty' => [],
+				],
+				'uploads'          => [],
+				'wp-rocket-config' => [],
+			],
+			'wp-includes'   => [],
+			'wp-config.php' => '',
+		];
+	}
+}


### PR DESCRIPTION
Switches to use the new version of `wp-media/phpunit`:

- Adds `RESTVfsTestCase` for Rocket integration tests to use
- Changes the `ApiTestCase` to use the new `WPMedia\PHPUnit\Integration\RESTfulTestCase::doRestPut()` method