### PR TITLE
Fixes `rocket rrmdir` directories to preserve checks

### DIFF
--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -1100,7 +1100,7 @@ function rocket_rrmdir( $dir, $dirs_to_preserve = '' ) {
 		if ( ! $entry->isDir() ) {
 			$filesystem->delete( $path );
 		} else {
-			\WP_Rocket\Tests\Integration\inc\functions\rocket_rrmdir( $path, $dirs_to_preserve );
+			rocket_rrmdir( $path, $dirs_to_preserve );
 		}
 	}
 

--- a/tests/Fixtures/inc/functions/rocketRrmdir.php
+++ b/tests/Fixtures/inc/functions/rocketRrmdir.php
@@ -195,8 +195,8 @@ return [
 		'shouldBailOutWhenRootDirIsPreserved_fr' => [
 			'to_delete'   => 'wp-content/cache/wp-rocket/example.org/fr',
 			'to_preserve' => [
-				'vfs://public/wp-content/cache/wp-rocket/example.org/de',
-				'vfs://public/wp-content/cache/wp-rocket/example.org/fr',
+				'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/de',
+				'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/fr',
 			],
 			'expected'    => [
 				'before_rocket_rrmdir' => 0,
@@ -207,8 +207,8 @@ return [
 		'shouldBailOutWhenRootDirIsPreserved_de' => [
 			'to_delete'   => 'wp-content/cache/wp-rocket/example.org/de',
 			'to_preserve' => [
-				'vfs://public/wp-content/cache/wp-rocket/example.org/de',
-				'vfs://public/wp-content/cache/wp-rocket/example.org/fr',
+				'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/de',
+				'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/fr',
 			],
 			'expected'    => [
 				'before_rocket_rrmdir' => 0,
@@ -220,7 +220,7 @@ return [
 		'shouldDeleteAllExceptDEentries'                => [
 			'to_delete'   => 'wp-content/cache/wp-rocket/example.org',
 			'to_preserve' => [
-				'vfs://public/wp-content/cache/wp-rocket/example.org/de',
+				'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/de',
 			],
 			'expected'    => [
 				'before_rocket_rrmdir' => 6,
@@ -250,8 +250,8 @@ return [
 		'shouldDeleteAllExceptFEandDE'                  => [
 			'to_delete'                           => 'wp-content/cache/wp-rocket/example.org',
 			'to_preserve'                         => [
-				'vfs://public/wp-content/cache/wp-rocket/example.org/de',
-				'vfs://public/wp-content/cache/wp-rocket/example.org/fr',
+				'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/de',
+				'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/fr',
 			],
 			'expected'                            => [
 				'before_rocket_rrmdir' => 5,
@@ -277,7 +277,7 @@ return [
 			'shouldDeleteAllWhenLangNotPreserved' => [
 				'to_delete'   => 'wp-content/cache/wp-rocket/example.org/',
 				'to_preserve' => [
-					'vfs://public/wp-content/cache/wp-rocket/example.org/nl', // doesn't have files in the cache.
+					'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/nl', // doesn't have files in the cache.
 				],
 				'expected'    => [
 					'before_rocket_rrmdir' => 7,
@@ -312,8 +312,8 @@ return [
 			'shouldDeleteAllWhenLangNotPreserved' => [
 				'to_delete'   => 'wp-content/cache/wp-rocket/',
 				'to_preserve' => [
-					'vfs://public/wp-content/cache/wp-rocket/example.org/de',
-					'vfs://public/wp-content/cache/wp-rocket/example.org/fr',
+					'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/de',
+					'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/fr',
 				],
 				'expected'    => [
 					'before_rocket_rrmdir' => 7,

--- a/tests/Integration/inc/functions/rocketMkdirP.php
+++ b/tests/Integration/inc/functions/rocketMkdirP.php
@@ -7,6 +7,7 @@ use WP_Rocket\Tests\Integration\FilesystemTestCase;
 /**
  * @covers ::rocket_mkdir_p
  * @uses  ::rocket_is_stream
+ * @uses  ::rocket_direct_filesystem
  *
  * @group Functions
  * @group Files

--- a/tests/Integration/inc/functions/rocketMkdirP.php
+++ b/tests/Integration/inc/functions/rocketMkdirP.php
@@ -7,6 +7,7 @@ use WP_Rocket\Tests\Integration\FilesystemTestCase;
 /**
  * @covers ::rocket_mkdir_p
  * @uses  ::rocket_is_stream
+ *
  * @group Functions
  * @group Files
  * @group vfs

--- a/tests/Integration/inc/functions/rocketRrmdir.php
+++ b/tests/Integration/inc/functions/rocketRrmdir.php
@@ -6,7 +6,6 @@ use WP_Rocket\Tests\Integration\FilesystemTestCase;
 
 /**
  * @covers ::rocket_rrmdir
- * @uses  ::rocket_is_stream
  * @uses  ::rocket_direct_filesystem
  * @uses  ::_rocket_preserve_directory
  *

--- a/tests/Integration/inc/functions/rocketRrmdir.php
+++ b/tests/Integration/inc/functions/rocketRrmdir.php
@@ -6,7 +6,10 @@ use WP_Rocket\Tests\Integration\FilesystemTestCase;
 
 /**
  * @covers ::rocket_rrmdir
+ * @uses  ::rocket_is_stream
  * @uses  ::rocket_direct_filesystem
+ * @uses  ::_rocket_preserve_directory
+ *
  * @group Functions
  * @group Files
  * @group vfs

--- a/tests/Unit/inc/functions/rocketMkdirP.php
+++ b/tests/Unit/inc/functions/rocketMkdirP.php
@@ -9,7 +9,6 @@ use WP_Rocket\Tests\Unit\FilesystemTestCase;
  * @covers ::rocket_mkdir_p
  * @uses  ::rocket_is_stream
  * @uses  ::rocket_direct_filesystem
- * @uses  ::_rocket_preserve_directory
  *
  * @group Functions
  * @group Files

--- a/tests/Unit/inc/functions/rocketMkdirP.php
+++ b/tests/Unit/inc/functions/rocketMkdirP.php
@@ -8,6 +8,9 @@ use WP_Rocket\Tests\Unit\FilesystemTestCase;
 /**
  * @covers ::rocket_mkdir_p
  * @uses  ::rocket_is_stream
+ * @uses  ::rocket_direct_filesystem
+ * @uses  ::_rocket_preserve_directory
+ *
  * @group Functions
  * @group Files
  * @group vfs

--- a/tests/Unit/inc/functions/rocketRrmdir.php
+++ b/tests/Unit/inc/functions/rocketRrmdir.php
@@ -8,6 +8,8 @@ use WP_Rocket\Tests\Unit\FilesystemTestCase;
 /**
  * @covers ::rocket_rrmdir
  * @uses  ::rocket_direct_filesystem
+ * @uses  ::_rocket_preserve_directory
+ *
  * @group Functions
  * @group Files
  * @group vfs


### PR DESCRIPTION
PR #2522 broke the check for directories to preserve. How? The directories include regex pattern. For example, PR 2522 did not process:

```
[
	'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/fr',
	'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/de',
]
```

This PR does the following:

- Converts the array of directories to preserve into an OR string and then escapes the `/` for regex
- Adds a private internal function for checking if the given file/dir should be preserved or not
- Uses the original code as a guide