### PR TITLE
Tests: rocket_widget_update_callback()

### DIFF
--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -20,12 +20,12 @@ add_action( 'update_option_theme_mods_' . get_option( 'stylesheet' ), 'rocket_cl
 add_action( 'upgrader_process_complete', 'rocket_clean_cache_theme_update', 10, 2 );  // When a theme is updated.
 
 /**
- * Purge cache When a widget is updated
+ * Purge cache When a widget is updated.
  *
  * @since 1.1.1
  *
  * @param object $instance Widget instance.
- * @return object Widget instance
+ * @return object Widget instance.
  */
 function rocket_widget_update_callback( $instance ) {
 	rocket_clean_domain();

--- a/tests/Fixtures/inc/common/rocketWidgetUpdateCallback.php
+++ b/tests/Fixtures/inc/common/rocketWidgetUpdateCallback.php
@@ -1,0 +1,55 @@
+<?php
+
+$expected = [
+	'rocket_clean_domain_urls' => [ 'http://example.org' ],
+	'cleaned'                  => [
+		'vfs://public/wp-content/cache/wp-rocket/example.org'                => null,
+		'vfs://public/wp-content/cache/wp-rocket/example.org-wpmedia-123456' => null,
+		'vfs://public/wp-content/cache/wp-rocket/example.org-tester-987654'  => null,
+		'vfs://public/wp-content/cache/wp-rocket/dots.example.org'           => [],
+	],
+	'non_cleaned'              => [
+		// fs entry => should scan the directory and get the file listings.
+		'vfs://public/wp-content/cache/min/'                 => true,
+		'vfs://public/wp-content/cache/busting/'             => true,
+		'vfs://public/wp-content/cache/critical-css/'        => true,
+		'vfs://public/wp-content/cache/wp-rocket/'           => false,
+		'vfs://public/wp-content/cache/wp-rocket/index.html' => false,
+	],
+];
+
+return [
+	// Use in tests when the test data starts in this directory.
+	'vfs_dir'   => 'wp-content/cache/',
+
+	// Virtual filesystem structure.
+	'structure' => require WP_ROCKET_TESTS_FIXTURES_DIR . '/vfs-structure/default.php',
+
+	// Test data.
+	'test_data' => [
+
+		'shouldCleanDomainWhenWidgetUpdateWithTitleOnly' => [
+			'widget'   => [
+				'title' => 'Duis aute irure',
+				'text'  => '',
+			],
+			'expected' => $expected,
+		],
+
+		'shouldCleanDomainWhenWidgetUpdateWithTextOnly' => [
+			'widget'   => [
+				'title' => '',
+				'text'  => 'Ut enim ad minim veniam',
+			],
+			'expected' => $expected,
+		],
+
+		'shouldCleanDomainWhenWidgetUpdateWithTitleAndText' => [
+			'widget'   => [
+				'title' => 'Lorem ipsum',
+				'text'  => 'Ut enim ad minim veniam',
+			],
+			'expected' => $expected,
+		],
+	],
+];

--- a/tests/Integration/inc/common/rocketWidgetUpdateCallback.php
+++ b/tests/Integration/inc/common/rocketWidgetUpdateCallback.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\common;
+
+use WP_Widget_Text;
+use WP_Rocket\Tests\Integration\FilesystemTestCase;
+
+/**
+ * @covers ::rocket_widget_update_callback
+ * @uses   ::rocket_clean_domain
+ *
+ * @group  Common
+ * @group  Purge
+ * @group  vfs
+ */
+class Test_RocketWidgetUpdateCallback extends FilesystemTestCase {
+	protected $path_to_test_data = '/inc/common/rocketWidgetUpdateCallback.php';
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		wp_set_current_user( $factory->user->create( [ 'role' => 'administrator' ] ) );
+	}
+
+	public function testCallbackIsRegistered() {
+		$this->assertEquals( 10, has_filter( 'widget_update_callback', 'rocket_widget_update_callback' ) );
+	}
+
+	/**
+	 * @dataProvider providerTestData
+	 */
+	public function testShouldInvokeRocketCleanDomainOnWidgetUpdate( $instance, $expected ) {
+		$widget                             = new WP_Widget_Text();
+		$_POST["widget-{$widget->id_base}"] = $instance;
+
+		$shouldNotClean = $this->getNonCleaned( $expected['non_cleaned'] );
+
+		// Update it.
+		$widget->update_callback();
+
+		// Check the "cleaned" directories.
+		foreach ( $expected['cleaned'] as $dir => $contents ) {
+			// Deleted.
+			if ( is_null( $contents ) ) {
+				$this->assertFalse( $this->filesystem->exists( $dir ) );
+			} else {
+				$shouldNotClean[] = trailingslashit( $dir );
+				// Emptied, but not deleted.
+				$this->assertSame( $contents, $this->filesystem->getFilesListing( $dir ) );
+			}
+		}
+
+		// Check the non-cleaned files/directories still exist.
+		$entriesAfterCleaning = $this->filesystem->getListing( $this->filesystem->getUrl( $this->config['vfs_dir'] ) );
+		$actual = array_diff( $entriesAfterCleaning, $shouldNotClean );
+		if ( ! empty( $expected['test_it'] ) ) {
+			var_dump( $actual );
+		} else {
+			$this->assertEmpty( $actual );
+		}
+	}
+
+	private function getNonCleaned( $config ) {
+		$entries = [];
+		foreach( $config as $entry => $scanDir ) {
+			$entries[] = $entry;
+			if ( $scanDir && $this->filesystem->is_dir( $entry ) ) {
+				$entries = array_merge( $entries, $this->filesystem->getListing( $entry ) );
+			}
+		}
+		return $entries;
+	}
+}

--- a/tests/Unit/inc/common/rocketWidgetUpdateCallback.php
+++ b/tests/Unit/inc/common/rocketWidgetUpdateCallback.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\common;
+
+use Brain\Monkey\Functions;
+use WPMedia\PHPUnit\Unit\TestCase;
+
+/**
+ * @covers ::rocket_widget_update_callback
+ * @uses   ::rocket_clean_domain
+ *
+ * @group  Common
+ * @group  Purge
+ * @group  vfs
+ */
+class Test_RocketWidgetUpdateCallback extends TestCase {
+
+	public function setUp() {
+		parent::setUp();
+
+		Functions\when( 'get_option' )->justReturn( '' );
+
+		require_once WP_ROCKET_PLUGIN_ROOT . 'inc/common/purge.php';
+	}
+
+	/**
+	 * @dataProvider providerTestData
+	 */
+	public function testShouldInvokeRocketCleanDomainOnWidgetUpdate( $instance ) {
+		Functions\expect( 'rocket_clean_domain' )->once()->andReturnNull();
+
+		$this->assertSame( $instance, rocket_widget_update_callback( $instance ) );
+	}
+
+	public function providerTestData() {
+		$config = require_once WP_ROCKET_TESTS_FIXTURES_DIR . '/inc/common/rocketWidgetUpdateCallback.php';
+
+		return $config['test_data'];
+	}
+}

--- a/tests/Unit/inc/common/rocketWidgetUpdateCallback.php
+++ b/tests/Unit/inc/common/rocketWidgetUpdateCallback.php
@@ -11,7 +11,6 @@ use WPMedia\PHPUnit\Unit\TestCase;
  *
  * @group  Common
  * @group  Purge
- * @group  vfs
  */
 class Test_RocketWidgetUpdateCallback extends TestCase {
 


### PR DESCRIPTION
Adds integration and unit tests for `rocket_widget_update_callback()` in the `purge.file`. 

No QA is needed, as the source code is not touched in this PR.
