### PR TITLE
Fixes AMP::is_amp_compatible_callback() tests.

### DIFF
--- a/tests/Fixtures/inc/ThirdParty/Plugins/Optimization/AMP/isAmpCompatibleCallback.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/Optimization/AMP/isAmpCompatibleCallback.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+	'testShouldAddAmpWhenThemeSupportIsReader'             => [
+		'theme_support' => 'transitional',
+		'expected'      => [ 'amp' ],
+	],
+	'testShouldAddAmpWhenThemeSupportIsReader'             => [
+		'theme_support' => 'reader',
+		'expected'      => [ 'amp' ],
+	],
+	'testShouldNotAddAmpWhenThemeSupportIsNotTransitional' => [
+		'theme_support' => 'standard',
+		'expected'      => [],
+	],
+	'testShouldNotAddAmpWhenThemeSupportIsNotSet'          => [
+		'theme_support' => null,
+		'expected'      => [],
+	],
+];

--- a/tests/Fixtures/inc/ThirdParty/Plugins/Optimization/AMP/isAmpCompatibleCallback.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/Optimization/AMP/isAmpCompatibleCallback.php
@@ -1,20 +1,24 @@
 <?php
 
 return [
-	'testShouldAddAmpWhenThemeSupportIsReader'             => [
-		'theme_support' => 'transitional',
-		'expected'      => [ 'amp' ],
+	'testShouldBailoutIfAmpThemeOptionsAreNull'      => [
+		'setting'  => null,
+		'expected' => [],
 	],
-	'testShouldAddAmpWhenThemeSupportIsReader'             => [
-		'theme_support' => 'reader',
-		'expected'      => [ 'amp' ],
+	'testShouldBailoutIfAmpThemeSupportIsNull'       => [
+		'setting'  => [ 'theme_support' => null ],
+		'expected' => [],
 	],
-	'testShouldNotAddAmpWhenThemeSupportIsNotTransitional' => [
-		'theme_support' => 'standard',
-		'expected'      => [],
+	'testShouldBailoutIfAmpIsNotTransitional'        => [
+		'setting'  => [ 'theme_support' => 'standard' ],
+		'expected' => [],
 	],
-	'testShouldNotAddAmpWhenThemeSupportIsNotSet'          => [
-		'theme_support' => null,
-		'expected'      => [],
+	'testShouldAddAmpWhenThemeSupportIsTransitional' => [
+		'setting'  => [ 'theme_support' => 'transitional' ],
+		'expected' => [ 'amp' ],
+	],
+	'testShouldAddAmpWhenThemeSupportIsReader'       => [
+		'setting'  => [ 'theme_support' => 'reader' ],
+		'expected' => [ 'amp' ],
 	],
 ];

--- a/tests/Integration/inc/ThirdParty/Plugins/Optimization/AMP/TestCase.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Optimization/AMP/TestCase.php
@@ -6,7 +6,13 @@ use AMP_Options_Manager;
 use WPMedia\PHPUnit\Integration\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase {
+	protected $path_to_test_data;
+
 	protected function setSettings( $option, $value ) {
 		AMP_Options_Manager::update_option( $option, $value);
+	}
+
+	public function ampDataProvider() {
+		return require_once WP_ROCKET_TESTS_FIXTURES_DIR . "/inc/ThirdParty/Plugins/Optimization/AMP/{$this->path_to_test_data}";
 	}
 }

--- a/tests/Integration/inc/ThirdParty/Plugins/Optimization/AMP/isAmpCompatibleCallback.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Optimization/AMP/isAmpCompatibleCallback.php
@@ -23,11 +23,11 @@ class Test_IsAmpCompatibleCallback extends TestCase {
 	/**
 	 * @dataProvider ampDataProvider
 	 */
-	public function testShouldReturnExpected( $theme_support, $expected ) {
+	public function testShouldReturnExpected( $setting, $expected ) {
 		// Set and then check the AMP theme support setting.
-		$this->setSettings( 'theme_support', $theme_support );
+		$this->setSettings( 'theme_support', $setting['theme_support'] );
 		$options = get_option( AMP_Options_Manager::OPTION_NAME );
-		$this->assertEquals( $theme_support, $options['theme_support'] );
+		$this->assertEquals( $setting['theme_support'], $options['theme_support'] );
 
 		$this->assertSame( $expected, apply_filters( 'rocket_cache_query_strings', [] ) );
 	}

--- a/tests/Integration/inc/ThirdParty/Plugins/Optimization/AMP/isAmpCompatibleCallback.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Optimization/AMP/isAmpCompatibleCallback.php
@@ -25,9 +25,13 @@ class Test_IsAmpCompatibleCallback extends TestCase {
 	 */
 	public function testShouldReturnExpected( $setting, $expected ) {
 		// Set and then check the AMP theme support setting.
-		$this->setSettings( 'theme_support', $setting['theme_support'] );
-		$options = get_option( AMP_Options_Manager::OPTION_NAME );
-		$this->assertEquals( $setting['theme_support'], $options['theme_support'] );
+		if ( ! is_null( $setting ) ) {
+			$this->setSettings( 'theme_support', $setting['theme_support'] );
+			$options = get_option( AMP_Options_Manager::OPTION_NAME );
+			$this->assertEquals( $setting['theme_support'], $options['theme_support'] );
+		} else {
+			delete_option( AMP_Options_Manager::OPTION_NAME );
+		}
 
 		$this->assertSame( $expected, apply_filters( 'rocket_cache_query_strings', [] ) );
 	}

--- a/tests/Integration/inc/ThirdParty/Plugins/Optimization/AMP/isAmpCompatibleCallback.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Optimization/AMP/isAmpCompatibleCallback.php
@@ -3,36 +3,32 @@
 namespace WP_Rocket\Tests\Integration\inc\ThirdParty\Plugins\Optimization\AMP;
 
 use Brain\Monkey\Functions;
+use AMP_Options_Manager;
 
 /**
  * @covers \WP_Rocket\ThirdParty\Plugins\Optimization\AMP::is_amp_compatible_callback
- * @covers \WP_Rocket\ThirdParty\Plugins\Optimization\AMP::generate_config_file
- * @group ThirdParty
- * @group WithAmp
+ * @group  ThirdParty
+ * @group  WithAmp
  */
 class Test_IsAmpCompatibleCallback extends TestCase {
+	protected $path_to_test_data = 'isAmpCompatibleCallback.php';
 
-	public function testShouldAddAmpWhenThemeSupportIsTransitional() {
-		Functions\expect( 'rocket_generate_config_file' )->once();
-		$this->setSettings( 'theme_support', 'transitional' );
-		$this->assertContains( 'amp', apply_filters( 'rocket_cache_query_strings', [] ) );
+	public function setUp() {
+		parent::setUp();
+
+		// Updating the AMP settings will trigger this to run.
+		Functions\when( 'rocket_generate_config_file' )->justReturn();
 	}
 
-	public function testShouldAddAmpWhenThemeSupportIsReader() {
-		// Default value is reader, so rocket_generate_config_file will not be called because update_option is not called.
-		$this->setSettings( 'theme_support', 'reader' );
-		$this->assertContains( 'amp', apply_filters( 'rocket_cache_query_strings', [] ) );
-	}
+	/**
+	 * @dataProvider ampDataProvider
+	 */
+	public function testShouldReturnExpected( $theme_support, $expected ) {
+		// Set and then check the AMP theme support setting.
+		$this->setSettings( 'theme_support', $theme_support );
+		$options = get_option( AMP_Options_Manager::OPTION_NAME );
+		$this->assertEquals( $theme_support, $options['theme_support'] );
 
-	public function testShouldNotAddAmpWhenThemeSupportIsNotTransitional() {
-		Functions\expect( 'rocket_generate_config_file' )->once();
-		$this->setSettings( 'theme_support', 'standard' );
-		$this->assertEquals( [], apply_filters( 'rocket_cache_query_strings', [] ) );
-	}
-
-	public function testShouldNotAddAmpWhenThemeSupportIsNotSet() {
-		Functions\expect( 'rocket_generate_config_file' )->once();
-		$this->setSettings( 'theme_support', null );
-		$this->assertEquals( [], apply_filters( 'rocket_cache_query_strings', [] ) );
+		$this->assertSame( $expected, apply_filters( 'rocket_cache_query_strings', [] ) );
 	}
 }

--- a/tests/Unit/inc/ThirdParty/Plugins/Optimization/AMP/isAmpCompatibleCallback.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/Optimization/AMP/isAmpCompatibleCallback.php
@@ -3,14 +3,15 @@
 namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\Optimization\AMP;
 
 use Brain\Monkey\Functions;
+use Mockery;
 use WPMedia\PHPUnit\Unit\TestCase;
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\ThirdParty\Plugins\Optimization\AMP;
 
 /**
  * @covers \WP_Rocket\ThirdParty\Plugins\Optimization\AMP::is_amp_compatible_callback
- * @group ThirdParty
- * @group WithAmp
+ * @group  ThirdParty
+ * @group  WithAmp
  */
 class Test_IsAmpCompatibleCallback extends TestCase {
 	private $amp;
@@ -18,53 +19,22 @@ class Test_IsAmpCompatibleCallback extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->amp = new AMP( $this->createMock( Options_Data::class ) );
+		$this->amp = new AMP( Mockery::mock( Options_Data::class ) );
 	}
 
-	public function testShouldBailoutIfAmpThemeOptionsAreNull() {
+	/**
+	 * @dataProvider ampDataProvider
+	 */
+	public function testShouldReturnExpected( $theme_support, $expected ) {
 		Functions\expect( 'get_option' )
 			->once()
 			->with( 'amp-options', [] )
-			->andReturn( null );
+			->andReturn( $theme_support );
 
-		$this->assertEquals( [], $this->amp->is_amp_compatible_callback( [] ) );
+		$this->assertSame( $expected, $this->amp->is_amp_compatible_callback( [] ) );
 	}
 
-	public function testShouldBailoutIfAmpThemeSupportIsNull() {
-		Functions\expect( 'get_option' )
-			->once()
-			->with( 'amp-options', [] )
-			->andReturn( [ 'theme_support' => null ] );
-
-		$this->assertEquals( [], $this->amp->is_amp_compatible_callback( [] ) );
+	public function ampDataProvider() {
+		return require_once WP_ROCKET_TESTS_FIXTURES_DIR . '/inc/ThirdParty/Plugins/Optimization/AMP/isAmpCompatibleCallback.php';
 	}
-
-
-	public function testShouldBailoutIfAmpIsNotTransitional() {
-		Functions\expect( 'get_option' )
-			->once()
-			->with( 'amp-options', [] )
-			->andReturn( [ 'theme_support' => 'standard' ] );
-
-		$this->assertEquals( [], $this->amp->is_amp_compatible_callback( [] ) );
-	}
-
-	public function testShouldAddAmpWhenThemeSupportIsTransitional() {
-		Functions\expect( 'get_option' )
-			->once()
-			->with( 'amp-options', [] )
-			->andReturn( [ 'theme_support' => 'transitional' ] );
-
-		$this->assertContains( 'amp', $this->amp->is_amp_compatible_callback( [] ) );
-	}
-
-	public function testShouldAddAmpWhenThemeSupportIsReader() {
-		Functions\expect( 'get_option' )
-			->once()
-			->with( 'amp-options', [] )
-			->andReturn( [ 'theme_support' => 'reader' ] );
-
-		$this->assertContains( 'amp', $this->amp->is_amp_compatible_callback( [] ) );
-	}
-
 }


### PR DESCRIPTION
The AMP integration tests are failing due to `rocket_generate_config_file()` expectations. This function is called when the AMP options are updated. However, that doesn't happen when the filter `'rocket_cache_query_strings'` is fired.

This PR:

- removes the `rocket_generate_config_file()` assertion
- moves the test data to fixture

No QA is required as the source code remains untouched.

Errors prior to this PR:

```
"vendor/bin/phpunit" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group WithAmp
Installing...
Running as single site... To run multisite, use -c tests/phpunit/multisite.xml
Not running ajax tests. To execute these, use --group ajax.
Not running ms-files tests. To execute these, use --group ms-files.
Not running external-http tests. To execute these, use --group external-http.
PHPUnit 7.5.20 by Sebastian Bergmann and contributors.
Runtime:       PHP 7.4.4
Configuration: /home/travis/build/wp-media/wp-rocket/tests/Integration/phpunit.xml.dist
..E.EE                                                              6 / 6 (100%)

Time: 3.03 seconds, Memory: 96.52 MB

There were 3 errors:

1) WP_Rocket\Tests\Integration\inc\ThirdParty\Plugins\Optimization\AMP\Test_IsAmpCompatibleCallback::testShouldAddAmpWhenThemeSupportIsTransitional
Mockery\Exception\InvalidCountException: Method rocket_generate_config_file(<Any Arguments>) from Mockery_0 should be called
 exactly 1 times but called 0 times.

/home/travis/build/wp-media/wp-rocket/vendor/mockery/mockery/library/Mockery/CountValidator/Exact.php:38
/home/travis/build/wp-media/wp-rocket/vendor/mockery/mockery/library/Mockery/Expectation.php:312
/home/travis/build/wp-media/wp-rocket/vendor/mockery/mockery/library/Mockery/ExpectationDirector.php:119
/home/travis/build/wp-media/wp-rocket/vendor/mockery/mockery/library/Mockery/Container.php:309
/home/travis/build/wp-media/wp-rocket/vendor/mockery/mockery/library/Mockery/Container.php:294
/home/travis/build/wp-media/wp-rocket/vendor/mockery/mockery/library/Mockery.php:205
/home/travis/build/wp-media/wp-rocket/vendor/mockery/mockery/library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegration.php:74
/home/travis/build/wp-media/wp-rocket/vendor/mockery/mockery/library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegration.php:49
/home/travis/build/wp-media/wp-rocket/vendor/mockery/mockery/library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegrationAssertPostConditionsForV7AndPrevious.php:27

2) WP_Rocket\Tests\Integration\inc\ThirdParty\Plugins\Optimization\AMP\Test_IsAmpCompatibleCallback::testShouldNotAddAmpWhenThemeSupportIsNotTransitional
Mockery\Exception\InvalidCountException: Method rocket_generate_config_file(<Any Arguments>) from Mockery_0 should be called
 exactly 1 times but called 0 times.

/home/travis/build/wp-media/wp-rocket/vendor/mockery/mockery/library/Mockery/CountValidator/Exact.php:38
/home/travis/build/wp-media/wp-rocket/vendor/mockery/mockery/library/Mockery/Expectation.php:312
/home/travis/build/wp-media/wp-rocket/vendor/mockery/mockery/library/Mockery/ExpectationDirector.php:119
/home/travis/build/wp-media/wp-rocket/vendor/mockery/mockery/library/Mockery/Container.php:309
/home/travis/build/wp-media/wp-rocket/vendor/mockery/mockery/library/Mockery/Container.php:294
/home/travis/build/wp-media/wp-rocket/vendor/mockery/mockery/library/Mockery.php:205
/home/travis/build/wp-media/wp-rocket/vendor/mockery/mockery/library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegration.php:74
/home/travis/build/wp-media/wp-rocket/vendor/mockery/mockery/library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegration.php:49
/home/travis/build/wp-media/wp-rocket/vendor/mockery/mockery/library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegrationAssertPostConditionsForV7AndPrevious.php:27

3) WP_Rocket\Tests\Integration\inc\ThirdParty\Plugins\Optimization\AMP\Test_IsAmpCompatibleCallback::testShouldNotAddAmpWhenThemeSupportIsNotSet
Mockery\Exception\InvalidCountException: Method rocket_generate_config_file(<Any Arguments>) from Mockery_0 should be called
 exactly 1 times but called 0 times.

/home/travis/build/wp-media/wp-rocket/vendor/mockery/mockery/library/Mockery/CountValidator/Exact.php:38
/home/travis/build/wp-media/wp-rocket/vendor/mockery/mockery/library/Mockery/Expectation.php:312
/home/travis/build/wp-media/wp-rocket/vendor/mockery/mockery/library/Mockery/ExpectationDirector.php:119
/home/travis/build/wp-media/wp-rocket/vendor/mockery/mockery/library/Mockery/Container.php:309
/home/travis/build/wp-media/wp-rocket/vendor/mockery/mockery/library/Mockery/Container.php:294
/home/travis/build/wp-media/wp-rocket/vendor/mockery/mockery/library/Mockery.php:205
/home/travis/build/wp-media/wp-rocket/vendor/mockery/mockery/library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegration.php:74
/home/travis/build/wp-media/wp-rocket/vendor/mockery/mockery/library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegration.php:49
/home/travis/build/wp-media/wp-rocket/vendor/mockery/mockery/library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegrationAssertPostConditionsForV7AndPrevious.php:27

ERRORS!
Tests: 6, Assertions: 15, Errors: 3.
```