### PR TITLE
Tests and optimizes: rocket_add_url_protocol()

### DIFF
--- a/inc/functions/formatting.php
+++ b/inc/functions/formatting.php
@@ -259,22 +259,29 @@ function rocket_remove_url_protocol( $url, $no_dots = false ) {
 }
 
 /**
- * Add HTTP protocol to an url that does not have
+ * Add HTTP protocol to an url that does not have.
  *
  * @since 2.2.1
  *
  * @param string $url The URL to parse.
- * @return string $url The URL with protocol
+ *
+ * @return string $url The URL with protocol.
  */
 function rocket_add_url_protocol( $url ) {
-
-	if ( strpos( $url, 'http://' ) === false && strpos( $url, 'https://' ) === false ) {
-		if ( substr( $url, 0, 2 ) !== '//' ) {
-			$url = '//' . $url;
-		}
-		$url = set_url_scheme( $url );
+	// Bail out if the URL starts with http:// or https://.
+	if (
+		strpos( $url, 'http://' ) !== false
+		||
+		strpos( $url, 'https://' ) !== false
+	) {
+		return $url;
 	}
-	return $url;
+
+	if ( substr( $url, 0, 2 ) !== '//' ) {
+		$url = '//' . $url;
+	}
+
+	return set_url_scheme( $url );
 }
 
 /**

--- a/inc/functions/formatting.php
+++ b/inc/functions/formatting.php
@@ -259,7 +259,7 @@ function rocket_remove_url_protocol( $url, $no_dots = false ) {
 }
 
 /**
- * Add HTTP protocol to an url that does not have.
+ * Add HTTP protocol to an url that does not have it.
  *
  * @since 2.2.1
  *

--- a/tests/Fixtures/inc/functions/rocketAddUrlProtocol.php
+++ b/tests/Fixtures/inc/functions/rocketAddUrlProtocol.php
@@ -1,0 +1,42 @@
+<?php
+
+return [
+	[
+		'url'       => 'http://example.org',
+		'expected'  => 'http://example.org',
+	],
+	[
+		'url'       => 'http://example.org?p=10',
+		'expected'  => 'http://example.org?p=10',
+	],
+	[
+		'url'       => 'https://example.org/lorem-ipsum/',
+		'expected'  => 'https://example.org/lorem-ipsum/',
+	],
+
+	[
+		'url'       => '//example.org',
+		'expected'  => 'http://example.org',
+	],
+	[
+		'url'       => '//example.org?p=10',
+		'expected'  => 'http://example.org?p=10',
+	],
+	[
+		'url'       => '//example.org/lorem-ipsum/',
+		'expected'  => 'http://example.org/lorem-ipsum/',
+	],
+
+	[
+		'url'       => 'example.org',
+		'expected'  => 'http://example.org',
+	],
+	[
+		'url'       => 'example.org?p=10',
+		'expected'  => 'http://example.org?p=10',
+	],
+	[
+		'url'       => 'example.org/lorem-ipsum/',
+		'expected'  => 'http://example.org/lorem-ipsum/',
+	],
+];

--- a/tests/Integration/inc/functions/rocketAddUrlProtocol.php
+++ b/tests/Integration/inc/functions/rocketAddUrlProtocol.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\functions;
+
+use WPMedia\PHPUnit\Integration\TestCase;
+
+/**
+ * @covers ::rocket_add_url_protocol
+ * @group  Functions
+ * @group  Formatting
+ */
+class Test_RocketAddUrlProtocol extends TestCase {
+
+	/**
+	 * @dataProvider providerTestData
+	 */
+	public function testShouldReturnExpectedParsedUrl( $url, $expected ) {
+		$this->assertSame( $expected, rocket_add_url_protocol( $url ) );
+	}
+
+	public function providerTestData() {
+		return $this->getTestData( __DIR__, 'rocketAddUrlProtocol' );
+	}
+}

--- a/tests/Unit/inc/functions/rocketAddUrlProtocol.php
+++ b/tests/Unit/inc/functions/rocketAddUrlProtocol.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\functions;
+
+use Brain\Monkey\Functions;
+use WPMedia\PHPUnit\Unit\TestCase;
+
+/**
+ * @covers ::rocket_add_url_protocol
+ * @group  Functions
+ * @group  Formatting
+ */
+class Test_RocketAddUrlProtocol extends TestCase {
+
+	/**
+	 * @dataProvider providerTestData
+	 */
+	public function testShouldReturnExpectedParsedUrl( $url, $expected ) {
+		if ( strpos( $url, 'http' ) === false ) {
+			Functions\expect( 'set_url_scheme' )
+				->once()
+				->andReturnUsing(
+					function ( $url ) {
+						return "http:{$url}";
+					}
+				);
+		} else {
+			Functions\expect( 'set_url_scheme' )->never();
+		}
+		$this->assertSame( $expected, rocket_add_url_protocol( $url ) );
+	}
+
+	public function providerTestData() {
+		return $this->getTestData( __DIR__, 'rocketAddUrlProtocol' );
+	}
+}


### PR DESCRIPTION
`rocket_add_url_protocol()`:

- Adds unit tests
- Adds integration tests
- Optimizes by:
    - flipping http/https checks into guard clause
    - returning URL from `set_url_scheme()` instead of assigning to variable and then returning

Tests were done _before_ the code was optimized to ensure the changes did not change the behavior.