### PR TITLE
Fixes regex and optimizes rocket_clean_minify()

### DIFF
--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -430,9 +430,10 @@ function set_rocket_wp_cache_define( $turn_it_on ) { // phpcs:ignore WordPress.N
  */
 function rocket_clean_minify( $extensions = [ 'js', 'css' ] ) {
 	$extensions = is_string( $extensions ) ? (array) $extensions : $extensions;
+	$cache_path = rocket_get_constant( 'WP_ROCKET_MINIFY_CACHE_PATH' );
 
 	try {
-		$dir = new RecursiveDirectoryIterator( WP_ROCKET_MINIFY_CACHE_PATH . get_current_blog_id(), FilesystemIterator::SKIP_DOTS );
+		$dir = new RecursiveDirectoryIterator( $cache_path . get_current_blog_id(), FilesystemIterator::SKIP_DOTS );
 	} catch ( \UnexpectedValueException $e ) {
 		// No logging yet.
 		return;
@@ -482,7 +483,7 @@ function rocket_clean_minify( $extensions = [ 'js', 'css' ] ) {
 		}
 	}
 
-	$third_party = WP_ROCKET_MINIFY_CACHE_PATH . '3rd-party';
+	$third_party =  "{$cache_path}3rd-party";
 
 	try {
 		$files = new FilesystemIterator( $third_party );

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -430,19 +430,11 @@ function set_rocket_wp_cache_define( $turn_it_on ) { // phpcs:ignore WordPress.N
  */
 function rocket_clean_minify( $extensions = [ 'js', 'css' ] ) {
 	$extensions = is_string( $extensions ) ? (array) $extensions : $extensions;
-	$cache_path = rocket_get_constant( 'WP_ROCKET_MINIFY_CACHE_PATH' );
+	$min_cache_path = rocket_get_constant( 'WP_ROCKET_MINIFY_CACHE_PATH' );
 
-	try {
-		$dir = new RecursiveDirectoryIterator( $cache_path . get_current_blog_id(), FilesystemIterator::SKIP_DOTS );
-	} catch ( \UnexpectedValueException $e ) {
-		// No logging yet.
-		return;
-	}
-
-	try {
-		$iterator = new RecursiveIteratorIterator( $dir, RecursiveIteratorIterator::CHILD_FIRST );
-	} catch ( \Exception $e ) {
-		// No logging yet.
+	$min_path = $min_cache_path . get_current_blog_id();
+	$iterator   = _rocket_get_cache_path_iterator( $min_path );
+	if ( false === $iterator ) {
 		return;
 	}
 
@@ -483,10 +475,8 @@ function rocket_clean_minify( $extensions = [ 'js', 'css' ] ) {
 		}
 	}
 
-	$third_party =  "{$cache_path}3rd-party";
-
 	try {
-		$files = new FilesystemIterator( $third_party );
+		$files = new FilesystemIterator( "{$min_cache_path}3rd-party" );
 
 		foreach ( $files as $file ) {
 			if ( rocket_direct_filesystem()->is_file( $file ) ) {

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -432,12 +432,13 @@ function rocket_clean_minify( $extensions = [ 'js', 'css' ] ) {
 	$extensions = is_string( $extensions ) ? (array) $extensions : $extensions;
 	$min_cache_path = rocket_get_constant( 'WP_ROCKET_MINIFY_CACHE_PATH' );
 
-	$min_path = $min_cache_path . get_current_blog_id();
+	$min_path = $min_cache_path . get_current_blog_id() . '/';
 	$iterator   = _rocket_get_cache_path_iterator( $min_path );
 	if ( false === $iterator ) {
 		return;
 	}
 
+	$min_path_regex = str_replace( '/', '\/', $min_path );
 	foreach ( $extensions as $ext ) {
 		/**
 		 * Fires before the minify cache files are deleted
@@ -449,9 +450,8 @@ function rocket_clean_minify( $extensions = [ 'js', 'css' ] ) {
 		do_action( 'before_rocket_clean_minify', $ext ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
 
 		try {
-			$entries = new RegexIterator( $iterator, "/.*\.{$ext}/" );
-		} catch ( \InvalidArgumentException $e ) {
-			// No logging yet.
+			$entries = new RegexIterator( $iterator, "/{$min_path_regex}.*\.{$ext}/" );
+		} catch ( Exception $e ) {
 			return;
 		}
 

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -429,6 +429,11 @@ function set_rocket_wp_cache_define( $turn_it_on ) { // phpcs:ignore WordPress.N
  * @param  string|array $extensions Optional. File extensions to minify. Default: js and css.
  */
 function rocket_clean_minify( $extensions = [ 'js', 'css' ] ) {
+	// Bails out if there are no extensions to target.
+	if ( empty( $extensions ) ) {
+		return;
+	}
+
 	if ( is_string( $extensions ) ) {
 		$extensions = (array) $extensions;
 	}

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -438,6 +438,7 @@ function rocket_clean_minify( $extensions = [ 'js', 'css' ] ) {
 		return;
 	}
 
+	$filesystem = rocket_direct_filesystem();
 	$min_path_regex = str_replace( '/', '\/', $min_path );
 	foreach ( $extensions as $ext ) {
 		/**
@@ -456,7 +457,7 @@ function rocket_clean_minify( $extensions = [ 'js', 'css' ] ) {
 		}
 
 		foreach ( $entries as $entry ) {
-			rocket_direct_filesystem()->delete( $entry->getPathname() );
+			$filesystem->delete( $entry->getPathname() );
 		}
 
 		/**
@@ -470,8 +471,8 @@ function rocket_clean_minify( $extensions = [ 'js', 'css' ] ) {
 	}
 
 	foreach ( $iterator as $item ) {
-		if ( rocket_direct_filesystem()->is_dir( $item ) ) {
-			rocket_direct_filesystem()->delete( $item );
+		if ( $filesystem->is_dir( $item ) ) {
+			$filesystem->delete( $item );
 		}
 	}
 
@@ -479,8 +480,8 @@ function rocket_clean_minify( $extensions = [ 'js', 'css' ] ) {
 		$files = new FilesystemIterator( "{$min_cache_path}3rd-party" );
 
 		foreach ( $files as $file ) {
-			if ( rocket_direct_filesystem()->is_file( $file ) ) {
-				rocket_direct_filesystem()->delete( $file );
+			if ( $filesystem->is_file( $file ) ) {
+				$filesystem->delete( $file );
 			}
 		}
 	} catch ( \UnexpectedValueException $e ) {

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -494,7 +494,7 @@ function rocket_clean_minify( $extensions = [ 'js', 'css' ] ) {
 				$filesystem->delete( $file );
 			}
 		}
-	} catch ( \UnexpectedValueException $e ) {
+	} catch ( UnexpectedValueException $e ) {
 		// No logging yet.
 		return;
 	}

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -421,17 +421,19 @@ function set_rocket_wp_cache_define( $turn_it_on ) { // phpcs:ignore WordPress.N
 }
 
 /**
- * Delete all minify cache files
+ * Delete all minify cache files.
  *
+ * @since 3.5.4 Optimizes and replaces glob.
  * @since 2.1
  *
- * @param  string|array $extensions (default: array('js','css') File extensions to minify.
- * @return void
+ * @param  string|array $extensions Optional. File extensions to minify. Default: js and css.
  */
 function rocket_clean_minify( $extensions = [ 'js', 'css' ] ) {
-	$extensions = is_string( $extensions ) ? (array) $extensions : $extensions;
-	$min_cache_path = rocket_get_constant( 'WP_ROCKET_MINIFY_CACHE_PATH' );
+	if ( is_string( $extensions ) ) {
+		$extensions = (array) $extensions;
+	}
 
+	$min_cache_path = rocket_get_constant( 'WP_ROCKET_MINIFY_CACHE_PATH' );
 	$min_path = $min_cache_path . get_current_blog_id() . '/';
 	$iterator   = _rocket_get_cache_path_iterator( $min_path );
 	if ( false === $iterator ) {

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -423,10 +423,10 @@ function set_rocket_wp_cache_define( $turn_it_on ) { // phpcs:ignore WordPress.N
 /**
  * Delete all minify cache files.
  *
- * @since 3.5.4 Optimizes and replaces glob.
+ * @since 3.5.3 Replaces glob.
  * @since 2.1
  *
- * @param  string|array $extensions Optional. File extensions to minify. Default: js and css.
+ * @param string|array $extensions Optional. File extensions to minify. Default: js and css.
  */
 function rocket_clean_minify( $extensions = [ 'js', 'css' ] ) {
 	// Bails out if there are no extensions to target.
@@ -439,22 +439,23 @@ function rocket_clean_minify( $extensions = [ 'js', 'css' ] ) {
 	}
 
 	$min_cache_path = rocket_get_constant( 'WP_ROCKET_MINIFY_CACHE_PATH' );
-	$min_path = $min_cache_path . get_current_blog_id() . '/';
-	$iterator   = _rocket_get_cache_path_iterator( $min_path );
+	$min_path       = $min_cache_path . get_current_blog_id() . '/';
+	$iterator       = _rocket_get_cache_path_iterator( $min_path );
 	if ( false === $iterator ) {
 		return;
 	}
 
-	$filesystem = rocket_direct_filesystem();
+	$filesystem     = rocket_direct_filesystem();
 	$min_path_regex = str_replace( '/', '\/', $min_path );
+
 	foreach ( $extensions as $ext ) {
 		/**
-		 * Fires before the minify cache files are deleted
+		 * Fires before the minify cache files are deleted.
 		 *
 		 * @since 2.1
 		 *
 		 * @param string $ext File extensions to minify.
-		*/
+		 */
 		do_action( 'before_rocket_clean_minify', $ext ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
 
 		try {
@@ -468,21 +469,23 @@ function rocket_clean_minify( $extensions = [ 'js', 'css' ] ) {
 		}
 
 		/**
-		 * Fires after the minify cache files was deleted
+		 * Fires after the minify cache files was deleted.
 		 *
 		 * @since 2.1
 		 *
 		 * @param string $ext File extensions to minify.
-		*/
+		 */
 		do_action( 'after_rocket_clean_minify', $ext ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
 	}
 
+	// Delete any directories.
 	foreach ( $iterator as $item ) {
 		if ( $filesystem->is_dir( $item ) ) {
 			$filesystem->delete( $item );
 		}
 	}
 
+	// Clean the cache/min/3rd-party items.
 	try {
 		$files = new FilesystemIterator( "{$min_cache_path}3rd-party" );
 

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -456,13 +456,14 @@ function rocket_clean_minify( $extensions = [ 'js', 'css' ] ) {
 		do_action( 'before_rocket_clean_minify', $ext ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
 
 		try {
-			$files = new RegexIterator( $iterator, '#.*\.' . $ext . '#', RegexIterator::GET_MATCH );
-			foreach ( $files as $file ) {
-				rocket_direct_filesystem()->delete( $file[0] );
-			}
+			$entries = new RegexIterator( $iterator, "/.*\.{$ext}/" );
 		} catch ( \InvalidArgumentException $e ) {
 			// No logging yet.
 			return;
+		}
+
+		foreach ( $entries as $entry ) {
+			rocket_direct_filesystem()->delete( $entry->getPathname() );
 		}
 
 		/**

--- a/tests/Fixtures/inc/functions/rocketCleanMinify.php
+++ b/tests/Fixtures/inc/functions/rocketCleanMinify.php
@@ -29,7 +29,7 @@ return [
 				],
 			],
 		],
-		'shouldCleanCssFiles'                     => [
+		'shouldClean_css'                         => [
 			'extensions' => 'css',
 			'expected'   => [
 				'cleaned'     => [
@@ -52,7 +52,29 @@ return [
 				],
 			],
 		],
-		'shouldCleanJsFiles'                      => [
+		'shouldClean_css.gz'                      => [
+			'extensions' => 'css.gz',
+			'expected'   => [
+				'cleaned'     => [
+					'vfs://public/wp-content/cache/min/1/fa2965d41f1515951de523cecb81f85e.css.gz'         => null,
+					'vfs://public/wp-content/cache/min/3rd-party/2n7x3vd41f1515951de523cecb81f85e.css.gz' => null,
+				],
+				'non_cleaned' => [
+					'vfs://public/wp-content/cache/min/1/'                                       => false,
+					'vfs://public/wp-content/cache/min/1/fa2965d41f1515951de523cecb81f85e.css'   => false,
+					'vfs://public/wp-content/cache/min/1/5c795b0e3a1884eec34a989485f863ff.js'    => false,
+					'vfs://public/wp-content/cache/min/1/5c795b0e3a1884eec34a989485f863ff.js.gz' => false,
+
+					'vfs://public/wp-content/cache/min/2/' => true,
+
+					'vfs://public/wp-content/cache/min/3rd-party/'                                       => false,
+					'vfs://public/wp-content/cache/min/3rd-party/2n7x3vd41f1515951de523cecb81f85e.css'   => false,
+					'vfs://public/wp-content/cache/min/3rd-party/bt937b0e3a1884eec34a989485f863ff.js'    => false,
+					'vfs://public/wp-content/cache/min/3rd-party/bt937b0e3a1884eec34a989485f863ff.js.gz' => false,
+				],
+			],
+		],
+		'shouldClean_js'                          => [
 			'extensions' => 'js',
 			'expected'   => [
 				'cleaned'     => [
@@ -70,6 +92,28 @@ return [
 					'vfs://public/wp-content/cache/min/2/' => true,
 
 					'vfs://public/wp-content/cache/min/3rd-party/'                                        => false,
+					'vfs://public/wp-content/cache/min/3rd-party/2n7x3vd41f1515951de523cecb81f85e.css'    => false,
+					'vfs://public/wp-content/cache/min/3rd-party/2n7x3vd41f1515951de523cecb81f85e.css.gz' => false,
+				],
+			],
+		],
+		'shouldClean_js.gz'                       => [
+			'extensions' => 'js.gz',
+			'expected'   => [
+				'cleaned'     => [
+					'vfs://public/wp-content/cache/min/1/5c795b0e3a1884eec34a989485f863ff.js.gz'         => null,
+					'vfs://public/wp-content/cache/min/3rd-party/bt937b0e3a1884eec34a989485f863ff.js.gz' => null,
+				],
+				'non_cleaned' => [
+					'vfs://public/wp-content/cache/min/1/'                                        => false,
+					'vfs://public/wp-content/cache/min/1/5c795b0e3a1884eec34a989485f863ff.js'     => false,
+					'vfs://public/wp-content/cache/min/1/fa2965d41f1515951de523cecb81f85e.css'    => false,
+					'vfs://public/wp-content/cache/min/1/fa2965d41f1515951de523cecb81f85e.css.gz' => false,
+
+					'vfs://public/wp-content/cache/min/2/' => true,
+
+					'vfs://public/wp-content/cache/min/3rd-party/'                                        => false,
+					'vfs://public/wp-content/cache/min/3rd-party/bt937b0e3a1884eec34a989485f863ff.js'     => false,
 					'vfs://public/wp-content/cache/min/3rd-party/2n7x3vd41f1515951de523cecb81f85e.css'    => false,
 					'vfs://public/wp-content/cache/min/3rd-party/2n7x3vd41f1515951de523cecb81f85e.css.gz' => false,
 				],
@@ -93,6 +137,28 @@ return [
 					'vfs://public/wp-content/cache/min/1/'         => false,
 					'vfs://public/wp-content/cache/min/2/'         => true,
 					'vfs://public/wp-content/cache/min/3rd-party/' => false,
+				],
+			],
+		],
+		'shouldClean_.gz'                         => [
+			'extensions' => 'gz',
+			'expected'   => [
+				'cleaned'     => [
+					'vfs://public/wp-content/cache/min/1/fa2965d41f1515951de523cecb81f85e.css.gz'         => null,
+					'vfs://public/wp-content/cache/min/1/5c795b0e3a1884eec34a989485f863ff.js.gz'          => null,
+					'vfs://public/wp-content/cache/min/3rd-party/2n7x3vd41f1515951de523cecb81f85e.css.gz' => null,
+					'vfs://public/wp-content/cache/min/3rd-party/bt937b0e3a1884eec34a989485f863ff.js.gz'  => null,
+				],
+				'non_cleaned' => [
+					'vfs://public/wp-content/cache/min/1/'                                     => false,
+					'vfs://public/wp-content/cache/min/1/5c795b0e3a1884eec34a989485f863ff.js'  => false,
+					'vfs://public/wp-content/cache/min/1/fa2965d41f1515951de523cecb81f85e.css' => false,
+
+					'vfs://public/wp-content/cache/min/2/' => true,
+
+					'vfs://public/wp-content/cache/min/3rd-party/'                                     => false,
+					'vfs://public/wp-content/cache/min/3rd-party/bt937b0e3a1884eec34a989485f863ff.js'  => false,
+					'vfs://public/wp-content/cache/min/3rd-party/2n7x3vd41f1515951de523cecb81f85e.css' => false,
 				],
 			],
 		],

--- a/tests/Fixtures/inc/functions/rocketCleanMinify.php
+++ b/tests/Fixtures/inc/functions/rocketCleanMinify.php
@@ -1,67 +1,100 @@
 <?php
 
 return [
-	'vfs_dir'   => 'wp-content/cache/min/',
+	'vfs_dir' => 'wp-content/cache/min/',
 
-	// Virtual filesystem structure.
-	'structure' => [
-		'wp-content' => [
-			'cache' => [
-				'min' => [
-					'1'         => [
-						'5c795b0e3a1884eec34a989485f863ff.js'     => '',
-						'5c795b0e3a1884eec34a989485f863ff.js.gz'  => '',
-						'fa2965d41f1515951de523cecb81f85e.css'    => '',
-						'fa2965d41f1515951de523cecb81f85e.css.gz' => '',
-					],
-					'3rd-party' => [
-						'2n7x3vd41f1515951de523cecb81f85e.css'    => '',
-						'2n7x3vd41f1515951de523cecb81f85e.css.gz' => '',
-						'bt937b0e3a1884eec34a989485f863ff.js'     => '',
-						'bt937b0e3a1884eec34a989485f863ff.js.gz'  => '',
-					],
+	'structure' => require WP_ROCKET_TESTS_FIXTURES_DIR . '/vfs-structure/default.php',
+
+	// Test data.
+	'test_data' => [
+		'shouldNotCleanWhenNoExtensionsGiven'     => [
+			'extensions' => '',
+			'expected'   => [
+				'cleaned'     => [],
+				'non_cleaned' => [
+					'vfs://public/wp-content/cache/min/1/'         => true,
+					'vfs://public/wp-content/cache/min/2/'         => true,
+					'vfs://public/wp-content/cache/min/3rd-party/' => true,
 				],
 			],
 		],
-	],
+		'shouldNotCleanWhenExtensionDoesNotExist' => [
+			'extensions' => [ 'php', 'html' ],
+			'expected'   => [
+				'cleaned'     => [],
+				'non_cleaned' => [
+					'vfs://public/wp-content/cache/min/1/'         => true,
+					'vfs://public/wp-content/cache/min/2/'         => true,
+					'vfs://public/wp-content/cache/min/3rd-party/' => true,
+				],
+			],
+		],
+		'shouldCleanCssFiles'                     => [
+			'extensions' => 'css',
+			'expected'   => [
+				'cleaned'     => [
+					'vfs://public/wp-content/cache/min/1/fa2965d41f1515951de523cecb81f85e.css'    => null,
+					'vfs://public/wp-content/cache/min/1/fa2965d41f1515951de523cecb81f85e.css.gz' => null,
 
-	// Test data.
-	// The virtual filesystem does not work with glob. Therefore, we have to specify all of the file extensions.
-	'test_data' => [
-		[
-			[ 'css', 'css.gz' ],
-			[
-				'wp-content/cache/min/1/fa2965d41f1515951de523cecb81f85e.css',
-				'wp-content/cache/min/1/fa2965d41f1515951de523cecb81f85e.css.gz',
-				'wp-content/cache/min/3rd-party/2n7x3vd41f1515951de523cecb81f85e.css',
-				'wp-content/cache/min/3rd-party/2n7x3vd41f1515951de523cecb81f85e.css.gz',
-				'wp-content/cache/min/3rd-party/bt937b0e3a1884eec34a989485f863ff.js',
-				'wp-content/cache/min/3rd-party/bt937b0e3a1884eec34a989485f863ff.js.gz',
-			]
+					'vfs://public/wp-content/cache/min/3rd-party/2n7x3vd41f1515951de523cecb81f85e.css'    => null,
+					'vfs://public/wp-content/cache/min/3rd-party/2n7x3vd41f1515951de523cecb81f85e.css.gz' => null,
+				],
+				'non_cleaned' => [
+					'vfs://public/wp-content/cache/min/1/'                                       => false,
+					'vfs://public/wp-content/cache/min/1/5c795b0e3a1884eec34a989485f863ff.js'    => false,
+					'vfs://public/wp-content/cache/min/1/5c795b0e3a1884eec34a989485f863ff.js.gz' => false,
+
+					'vfs://public/wp-content/cache/min/2/' => true,
+
+					'vfs://public/wp-content/cache/min/3rd-party/'                                       => false,
+					'vfs://public/wp-content/cache/min/3rd-party/bt937b0e3a1884eec34a989485f863ff.js'    => false,
+					'vfs://public/wp-content/cache/min/3rd-party/bt937b0e3a1884eec34a989485f863ff.js.gz' => false,
+				],
+			],
 		],
-		[
-			[ 'js', 'js.gz' ],
-			[
-				'wp-content/cache/min/1/5c795b0e3a1884eec34a989485f863ff.js',
-				'wp-content/cache/min/1/5c795b0e3a1884eec34a989485f863ff.js.gz',
-				'wp-content/cache/min/3rd-party/2n7x3vd41f1515951de523cecb81f85e.css',
-				'wp-content/cache/min/3rd-party/2n7x3vd41f1515951de523cecb81f85e.css.gz',
-				'wp-content/cache/min/3rd-party/bt937b0e3a1884eec34a989485f863ff.js',
-				'wp-content/cache/min/3rd-party/bt937b0e3a1884eec34a989485f863ff.js.gz',
-			]
+		'shouldCleanJsFiles'                      => [
+			'extensions' => 'js',
+			'expected'   => [
+				'cleaned'     => [
+					'vfs://public/wp-content/cache/min/1/5c795b0e3a1884eec34a989485f863ff.js'    => null,
+					'vfs://public/wp-content/cache/min/1/5c795b0e3a1884eec34a989485f863ff.js.gz' => null,
+
+					'vfs://public/wp-content/cache/min/3rd-party/bt937b0e3a1884eec34a989485f863ff.js'    => null,
+					'vfs://public/wp-content/cache/min/3rd-party/bt937b0e3a1884eec34a989485f863ff.js.gz' => null,
+				],
+				'non_cleaned' => [
+					'vfs://public/wp-content/cache/min/1/'                                        => false,
+					'vfs://public/wp-content/cache/min/1/fa2965d41f1515951de523cecb81f85e.css'    => false,
+					'vfs://public/wp-content/cache/min/1/fa2965d41f1515951de523cecb81f85e.css.gz' => false,
+
+					'vfs://public/wp-content/cache/min/2/' => true,
+
+					'vfs://public/wp-content/cache/min/3rd-party/'                                        => false,
+					'vfs://public/wp-content/cache/min/3rd-party/2n7x3vd41f1515951de523cecb81f85e.css'    => false,
+					'vfs://public/wp-content/cache/min/3rd-party/2n7x3vd41f1515951de523cecb81f85e.css.gz' => false,
+				],
+			],
 		],
-		[
-			[ 'css', 'css.gz', 'js', 'js.gz' ],
-			[
-				'wp-content/cache/min/1/fa2965d41f1515951de523cecb81f85e.css',
-				'wp-content/cache/min/1/fa2965d41f1515951de523cecb81f85e.css.gz',
-				'wp-content/cache/min/1/5c795b0e3a1884eec34a989485f863ff.js',
-				'wp-content/cache/min/1/5c795b0e3a1884eec34a989485f863ff.js.gz',
-				'wp-content/cache/min/3rd-party/2n7x3vd41f1515951de523cecb81f85e.css',
-				'wp-content/cache/min/3rd-party/2n7x3vd41f1515951de523cecb81f85e.css.gz',
-				'wp-content/cache/min/3rd-party/bt937b0e3a1884eec34a989485f863ff.js',
-				'wp-content/cache/min/3rd-party/bt937b0e3a1884eec34a989485f863ff.js.gz',
-			]
+		'shouldCleanCssAndJs'                     => [
+			'extensions' => [ 'css', 'js' ],
+			'expected'   => [
+				'cleaned'     => [
+					'vfs://public/wp-content/cache/min/1/5c795b0e3a1884eec34a989485f863ff.js'     => null,
+					'vfs://public/wp-content/cache/min/1/5c795b0e3a1884eec34a989485f863ff.js.gz'  => null,
+					'vfs://public/wp-content/cache/min/1/fa2965d41f1515951de523cecb81f85e.css'    => null,
+					'vfs://public/wp-content/cache/min/1/fa2965d41f1515951de523cecb81f85e.css.gz' => null,
+
+					'vfs://public/wp-content/cache/min/3rd-party/bt937b0e3a1884eec34a989485f863ff.js'     => null,
+					'vfs://public/wp-content/cache/min/3rd-party/bt937b0e3a1884eec34a989485f863ff.js.gz'  => null,
+					'vfs://public/wp-content/cache/min/3rd-party/2n7x3vd41f1515951de523cecb81f85e.css'    => null,
+					'vfs://public/wp-content/cache/min/3rd-party/2n7x3vd41f1515951de523cecb81f85e.css.gz' => null,
+				],
+				'non_cleaned' => [
+					'vfs://public/wp-content/cache/min/1/'         => false,
+					'vfs://public/wp-content/cache/min/2/'         => true,
+					'vfs://public/wp-content/cache/min/3rd-party/' => false,
+				],
+			],
 		],
 	],
 ];

--- a/tests/Fixtures/inc/functions/rocketRrmdir.php
+++ b/tests/Fixtures/inc/functions/rocketRrmdir.php
@@ -327,8 +327,8 @@ return [
 				'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/fr',
 			],
 			'expected'    => [
-				'before_rocket_rrmdir' => 19,
-				'after_rocket_rrmdir'  => 19,
+				'before_rocket_rrmdir' => 21,
+				'after_rocket_rrmdir'  => 21,
 				'removed'              => [
 					'vfs://public/wp-content/cache/min/'                                                 => null,
 					'vfs://public/wp-content/cache/busting'                                              => null,

--- a/tests/Fixtures/vfs-structure/default.php
+++ b/tests/Fixtures/vfs-structure/default.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-	'wp-content'  => [
+	'wp-content' => [
 		'cache'            => [
 			'wp-rocket'    => [
 				'index.html'                 => '',
@@ -81,9 +81,23 @@ return [
 				],
 			],
 			'min'          => [
-				'1' => [
-					'123456.css' => '',
-					'123456.js'  => '',
+				'1'         => [
+					'5c795b0e3a1884eec34a989485f863ff.js'     => '',
+					'5c795b0e3a1884eec34a989485f863ff.js.gz'  => '',
+					'fa2965d41f1515951de523cecb81f85e.css'    => '',
+					'fa2965d41f1515951de523cecb81f85e.css.gz' => '',
+				],
+				'2'         => [
+					'34a989485f863ff5c795b0e3a1884eec.js'     => '',
+					'34a989485f863ff5c795b0e3a1884eec.js.gz'  => '',
+					'523cecb81f85efa2965d41f1515951de.css'    => '',
+					'523cecb81f85efa2965d41f1515951de.css.gz' => '',
+				],
+				'3rd-party' => [
+					'2n7x3vd41f1515951de523cecb81f85e.css'    => '',
+					'2n7x3vd41f1515951de523cecb81f85e.css.gz' => '',
+					'bt937b0e3a1884eec34a989485f863ff.js'     => '',
+					'bt937b0e3a1884eec34a989485f863ff.js.gz'  => '',
 				],
 			],
 			'busting'      => [

--- a/tests/Integration/FilesystemTestCase.php
+++ b/tests/Integration/FilesystemTestCase.php
@@ -17,39 +17,6 @@ abstract class FilesystemTestCase extends VirtualFilesystemTestCase {
 		Functions\when( 'rocket_direct_filesystem' )->justReturn( $this->filesystem );
 	}
 
-	public function getPathToFixturesDir() {
-		return WP_ROCKET_TESTS_FIXTURES_DIR;
-	}
-
-	public function getDefaultVfs() {
-		return [
-			'wp-admin'      => [],
-			'wp-content'    => [
-				'cache'            => [
-					'busting'      => [
-						1 => [],
-					],
-					'critical-css' => [],
-					'min'          => [],
-					'wp-rocket'    => [
-						'index.html' => '',
-					],
-				],
-				'mu-plugins'       => [],
-				'plugins'          => [
-					'wp-rocket' => [],
-				],
-				'themes'           => [
-					'twentytwenty' => [],
-				],
-				'uploads'          => [],
-				'wp-rocket-config' => [],
-			],
-			'wp-includes'   => [],
-			'wp-config.php' => '',
-		];
-	}
-
 	protected function setUpOriginalEntries() {
 		$this->original_entries = array_merge( $this->original_files, $this->original_dirs );
 		$this->original_entries = array_filter( $this->original_entries );
@@ -93,5 +60,38 @@ abstract class FilesystemTestCase extends VirtualFilesystemTestCase {
 			var_dump( $actual );
 		}
 		$this->assertEmpty( $actual );
+	}
+
+	public function getPathToFixturesDir() {
+		return WP_ROCKET_TESTS_FIXTURES_DIR;
+	}
+
+	public function getDefaultVfs() {
+		return [
+			'wp-admin'      => [],
+			'wp-content'    => [
+				'cache'            => [
+					'busting'      => [
+						1 => [],
+					],
+					'critical-css' => [],
+					'min'          => [],
+					'wp-rocket'    => [
+						'index.html' => '',
+					],
+				],
+				'mu-plugins'       => [],
+				'plugins'          => [
+					'wp-rocket' => [],
+				],
+				'themes'           => [
+					'twentytwenty' => [],
+				],
+				'uploads'          => [],
+				'wp-rocket-config' => [],
+			],
+			'wp-includes'   => [],
+			'wp-config.php' => '',
+		];
 	}
 }

--- a/tests/Integration/inc/functions/rocketCleanMinify.php
+++ b/tests/Integration/inc/functions/rocketCleanMinify.php
@@ -11,6 +11,7 @@ use WP_Rocket\Tests\Integration\FilesystemTestCase;
  * @group Functions
  * @group Files
  * @group vfs
+ * @group thisone
  */
 class Test_RocketCleanMinify extends FilesystemTestCase {
 	protected $path_to_test_data = '/inc/functions/rocketCleanMinify.php';

--- a/tests/Integration/inc/functions/rocketCleanMinify.php
+++ b/tests/Integration/inc/functions/rocketCleanMinify.php
@@ -11,7 +11,6 @@ use WP_Rocket\Tests\Integration\FilesystemTestCase;
  * @group Functions
  * @group Files
  * @group vfs
- * @group thisone
  */
 class Test_RocketCleanMinify extends FilesystemTestCase {
 	protected $path_to_test_data = '/inc/functions/rocketCleanMinify.php';

--- a/tests/Integration/inc/functions/rocketCleanMinify.php
+++ b/tests/Integration/inc/functions/rocketCleanMinify.php
@@ -6,6 +6,8 @@ use WP_Rocket\Tests\Integration\FilesystemTestCase;
 
 /**
  * @covers ::rocket_clean_minify
+ * @uses  ::rocket_direct_filesystem
+ *
  * @group Functions
  * @group Files
  * @group vfs
@@ -13,58 +15,15 @@ use WP_Rocket\Tests\Integration\FilesystemTestCase;
 class Test_RocketCleanMinify extends FilesystemTestCase {
 	protected $path_to_test_data = '/inc/functions/rocketCleanMinify.php';
 
-	public function tearDown() {
-		delete_option( 'wp_rocket_settings' );
-
-		parent::tearDown();
-	}
-
-	public function testPath() {
-		$this->assertSame( 'vfs://public/wp-content/cache/min/', WP_ROCKET_MINIFY_CACHE_PATH );
-	}
-
-	public function testShouldFireEventsForEachExt() {
-		rocket_clean_minify( [ 'css' ] );
-
-		$expected = 1;
-		$this->assertEquals( $expected, did_action( 'before_rocket_clean_minify' ) );
-		$this->assertEquals( $expected, did_action( 'after_rocket_clean_minify' ) );
-
-		rocket_clean_minify( [ 'css', 'js' ] );
-
-		$expected += 2;
-		$this->assertEquals( $expected, did_action( 'before_rocket_clean_minify' ) );
-		$this->assertEquals( $expected, did_action( 'after_rocket_clean_minify' ) );
-	}
-
 	/**
 	 * @dataProvider providerTestData
 	 */
-	public function testShouldCleanMinified( $config, $filesToClean ) {
-		$cache = $this->stripRoot( $this->filesystem->getFilesListing( 'wp-content/cache/min' ) );
+	public function testShouldCleanMinified( $extensions, $expected ) {
+		$this->getShouldNotCleanEntries( $expected['non_cleaned'] );
 
-		// Check files before cleaning.
-		$this->assertSame( $this->original_files, $cache );
+		rocket_clean_minify( $extensions );
 
-		rocket_clean_minify( $config );
-
-		$after_cache = $this->stripRoot( $this->filesystem->getFilesListing( 'wp-content/cache/min' ) );
-
-		// Check the "cleaned" files were deleted.
-		$this->assertEquals( $filesToClean, array_intersect( $filesToClean, $cache ) );
-		$this->assertEquals( $filesToClean, array_diff( $filesToClean, $after_cache ) );
-		$this->assertNotContains( $filesToClean, $after_cache );
-
-		// Check that non-cleaned files still exists, i.e. were not deleted.
-		$this->assertEquals( $after_cache, array_intersect( $after_cache, $cache ) );
-	}
-
-	private function stripRoot( $files ) {
-		return array_map(
-			function( $file ) {
-				return str_replace( 'vfs://public/', '', $file );
-			},
-			$files
-		);
+		$this->checkCleanedIsDeleted( $expected['cleaned'] );
+		$this->checkNonCleanedExist( isset( $expected['dump_results'] ) );
 	}
 }

--- a/tests/Unit/FilesystemTestCase.php
+++ b/tests/Unit/FilesystemTestCase.php
@@ -7,13 +7,63 @@ use org\bovigo\vfs\vfsStream;
 use WPMedia\PHPUnit\Unit\VirtualFilesystemTestCase;
 
 abstract class FilesystemTestCase extends VirtualFilesystemTestCase {
-	protected $original_entries;
+	protected $original_entries = [];
+	protected $shouldNotClean   = [];
 
 	public function setUp() {
 		parent::setUp();
 
 		// Redefine rocket_direct_filesystem() to use the virtual filesystem.
 		Functions\when( 'rocket_direct_filesystem' )->justReturn( $this->filesystem );
+	}
+
+	protected function setUpOriginalEntries() {
+		$this->original_entries = array_merge( $this->original_files, $this->original_dirs );
+		$this->original_entries = array_filter( $this->original_entries );
+		sort( $this->original_entries );
+	}
+
+	protected function stripVfsRoot( $path ) {
+		$search = vfsStream::SCHEME . "://{$this->rootVirtualDir}";
+		$search = rtrim( $search, '/\\' ) . '/';
+
+		return str_replace( $search, '', $path );
+	}
+
+	protected function getShouldNotCleanEntries( array $shouldNotClean ) {
+		$this->shouldNotClean = [];
+		foreach ( $shouldNotClean as $entry => $scanDir ) {
+			$this->shouldNotClean[] = $entry;
+			if ( $scanDir && $this->filesystem->is_dir( $entry ) ) {
+				$this->shouldNotClean = array_merge( $this->shouldNotClean, $this->filesystem->getListing( $entry ) );
+			}
+		}
+	}
+
+	protected function checkCleanedIsDeleted( array $shouldClean ) {
+		foreach ( $shouldClean as $dir => $contents ) {
+			// Deleted.
+			if ( is_null( $contents ) ) {
+				if ( false !== $this->filesystem->exists( $dir ) ) {
+					echo "\n {$dir} \n";
+				}
+				$this->assertFalse( $this->filesystem->exists( $dir ) );
+
+			} else {
+				$this->shouldNotClean[] = trailingslashit( $dir );
+				// Emptied, but not deleted.
+				$this->assertSame( $contents, $this->filesystem->getFilesListing( $dir ) );
+			}
+		}
+	}
+
+	protected function checkNonCleanedExist( $dump_results = false ) {
+		$entriesAfterCleaning = $this->filesystem->getListing( $this->filesystem->getUrl( $this->config['vfs_dir'] ) );
+		$actual               = array_diff( $entriesAfterCleaning, $this->shouldNotClean );
+		if ( $dump_results ) {
+			var_dump( $actual );
+		}
+		$this->assertEmpty( $actual );
 	}
 
 	public function getPathToFixturesDir() {
@@ -47,18 +97,5 @@ abstract class FilesystemTestCase extends VirtualFilesystemTestCase {
 			'wp-includes'   => [],
 			'wp-config.php' => '',
 		];
-	}
-
-	protected function setUpOriginalEntries() {
-		$this->original_entries = array_merge( $this->original_files, $this->original_dirs );
-		$this->original_entries = array_filter( $this->original_entries );
-		sort( $this->original_entries );
-	}
-
-	protected function stripVfsRoot( $path ) {
-		$search = vfsStream::SCHEME . "://{$this->rootVirtualDir}";
-		$search = rtrim( $search, '/\\' ) . '/';
-
-		return str_replace( $search, '', $path );
 	}
 }

--- a/tests/Unit/inc/functions/rocketCleanMinify.php
+++ b/tests/Unit/inc/functions/rocketCleanMinify.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\functions;
+
+use Brain\Monkey\Actions;
+use Brain\Monkey\Functions;
+use WP_Rocket\Tests\Unit\FilesystemTestCase;
+
+/**
+ * @covers ::rocket_clean_minify
+ * @uses  ::rocket_direct_filesystem
+ *
+ * @group Functions
+ * @group Files
+ * @group vfs
+ * @group thisone
+ */
+class Test_RocketCleanMinify extends FilesystemTestCase {
+	protected $path_to_test_data = '/inc/functions/rocketCleanMinify.php';
+	private   $valid_extensions  = [ 'css', 'css.gz', 'js', 'js.gz' ];
+
+	public function setUp() {
+		parent::setUp();
+
+		Functions\when( 'get_current_blog_id' )->justReturn( 1 );
+		Functions\expect( 'rocket_get_constant' )->with( 'WP_ROCKET_MINIFY_CACHE_PATH' )->andReturn( 'vfs://public/wp-content/cache/min/' );
+	}
+
+	/**
+	 * @dataProvider providerTestData
+	 */
+	public function testShouldCleanMinified( $extensions, $expected ) {
+		$this->getShouldNotCleanEntries( $expected['non_cleaned'] );
+
+		foreach ( (array) $extensions as $ext ) {
+			if ( ! in_array( $ext, $this->valid_extensions, true ) ) {
+				continue;
+			}
+			Actions\expectDone( 'before_rocket_clean_minify' )->once()->with( $ext );
+			Actions\expectDone( 'after_rocket_clean_minify' )->once()->with( $ext );
+		}
+
+		rocket_clean_minify( $extensions );
+
+		$this->checkCleanedIsDeleted( $expected['cleaned'] );
+		$this->checkNonCleanedExist( isset( $expected['dump_results'] ) );
+	}
+}

--- a/tests/Unit/inc/functions/rocketCleanMinify.php
+++ b/tests/Unit/inc/functions/rocketCleanMinify.php
@@ -13,7 +13,6 @@ use WP_Rocket\Tests\Unit\FilesystemTestCase;
  * @group Functions
  * @group Files
  * @group vfs
- * @group thisone
  */
 class Test_RocketCleanMinify extends FilesystemTestCase {
 	protected $path_to_test_data = '/inc/functions/rocketCleanMinify.php';


### PR DESCRIPTION
## Risk of potential bug 🐛 

It's possible for a given extension to be part of the absolute path to the minify cache directory. For example, it could be part of the user account or domain name, such as `kb.css.example.org` or account name `foo.css`. As we learned in PR #2571, we need to prefix the regex with absolute path to the `cache/min` directory to avoid the potential risk of this problem.

In addition, this PR:

- Optimizes the function:
     - Bails out if there's no extension to clean
     - Calls `rocket_direct_filesystem()` 1x instead of 5x
     - Only updates the extensions variable if a string was passed into the function
- Makes it consistent with the other clean functions
- Makes the tests consistent with the other clean functions
- Adds unit tests

## TODO

- [x] Make consistent
- [x] Optimize
- [x] Update the integration tests
- [x] Add unit tests
- [x] QA