### PR TITLE
Auto-exclude FeedbackCompany JS file

### DIFF
--- a/inc/Engine/Optimization/Minify/JS/Combine.php
+++ b/inc/Engine/Optimization/Minify/JS/Combine.php
@@ -638,6 +638,7 @@ class Combine extends AbstractJSOptimization {
 			'wpvq_ans89733',
 			'_isp_version',
 			'price_range_data',
+			'window.FeedbackCompanyWidgets',
 		];
 
 		$excluded_inline = array_merge( $defaults, $this->options->get( 'exclude_inline_js', [] ) );
@@ -727,6 +728,7 @@ class Combine extends AbstractJSOptimization {
 			'static.klaviyo.com/onsite/js/klaviyo.js',
 			'a.omappapi.com/app/js/api.min.js',
 			'static.zdassets.com',
+			'feedbackcompany.com/widgets/feedback-company-widget.min.js',
 		];
 
 		$excluded_external = array_merge( $defaults, $this->options->get( 'exclude_js', [] ) );


### PR DESCRIPTION
This PR does an automatic compatibility with FeedbackCompany widget by auto-excluding the JS file and inline JS from our combine JS process.