### PR TITLE
Tests: get_rocket_advanced_cache_file()

### DIFF
--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -25,21 +25,22 @@ function get_rocket_advanced_cache_file() { // phpcs:ignore WordPress.NamingConv
 
 	// Include the Mobile Detect class if we have to create a different caching file for mobile.
 	if ( is_rocket_generate_caching_mobile_files() ) {
-		$buffer .= "if ( file_exists( '" . WP_ROCKET_VENDORS_PATH . "classes/class-rocket-mobile-detect.php' ) && ! class_exists( 'Rocket_Mobile_Detect' ) ) {\n";
-		$buffer .= "\tinclude_once '" . WP_ROCKET_VENDORS_PATH . "classes/class-rocket-mobile-detect.php';\n";
+		$vendor_path = rocket_get_constant( 'WP_ROCKET_VENDORS_PATH' );
+		$buffer .= "if ( file_exists( '" . $vendor_path . "classes/class-rocket-mobile-detect.php' ) && ! class_exists( 'Rocket_Mobile_Detect' ) ) {\n";
+		$buffer .= "\tinclude_once '" . $vendor_path . "classes/class-rocket-mobile-detect.php';\n";
 		$buffer .= "}\n\n";
 	}
 
 	// Register a class autoloader and include the process file.
-	$buffer .= "if ( version_compare( phpversion(), '" . WP_ROCKET_PHP_VERSION . "' ) >= 0 ) {\n\n";
+	$buffer .= "if ( version_compare( phpversion(), '" . rocket_get_constant( 'WP_ROCKET_PHP_VERSION' ) . "' ) >= 0 ) {\n\n";
 
 	// Class autoloader.
-	$autoloader = rocket_direct_filesystem()->get_contents( WP_ROCKET_INC_PATH . 'process-autoloader.php' );
+	$autoloader = rocket_direct_filesystem()->get_contents( rocket_get_constant( 'WP_ROCKET_INC_PATH' ) . 'process-autoloader.php' );
 
 	if ( $autoloader ) {
 		$autoloader = preg_replace( '@^<\?php\s*@', '', $autoloader );
 		$autoloader = str_replace( [ "\n", "\n\t\n" ], [ "\n\t", "\n\n" ], trim( $autoloader ) );
-		$autoloader = str_replace( 'WP_ROCKET_PATH', "'" . WP_ROCKET_PATH . "'", $autoloader );
+		$autoloader = str_replace( 'WP_ROCKET_PATH', "'" . rocket_get_constant( 'WP_ROCKET_PATH' ) . "'", $autoloader );
 
 		$buffer .= "\t$autoloader\n\n";
 	}
@@ -54,7 +55,7 @@ function get_rocket_advanced_cache_file() { // phpcs:ignore WordPress.NamingConv
 
 	$rocket_config_class = new \WP_Rocket\Buffer\Config(
 		[
-			\'config_dir_path\' => \'' . WP_ROCKET_CONFIG_PATH . '\',
+			\'config_dir_path\' => \'' . rocket_get_constant( 'WP_ROCKET_CONFIG_PATH' ) . '\',
 		]
 	);
 
@@ -64,7 +65,7 @@ function get_rocket_advanced_cache_file() { // phpcs:ignore WordPress.NamingConv
 		),
 		$rocket_config_class,
 		[
-			\'cache_dir_path\' => \'' . WP_ROCKET_CACHE_PATH . '\',
+			\'cache_dir_path\' => \'' . rocket_get_constant( 'WP_ROCKET_CACHE_PATH' ) . '\',
 		]
 	) )->maybe_init_process();' . "\n";
 	$buffer .= "} else {\n";

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -80,9 +80,7 @@ function get_rocket_advanced_cache_file() { // phpcs:ignore WordPress.NamingConv
 	 *
 	 * @param string $buffer The content that will be printed in advanced-cache.php.
 	*/
-	$buffer = apply_filters( 'rocket_advanced_cache_file', $buffer );
-
-	return $buffer;
+	return (string) apply_filters( 'rocket_advanced_cache_file', $buffer );
 }
 
 /**

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -5,9 +5,10 @@ use WP_Rocket\Logger\Logger;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Generate the content of advanced-cache.php file
+ * Generate the content of advanced-cache.php file.
  *
- * @since 2.1   Add filter rocket_advanced_cache_file
+ * @since 3.5.5 Uses rocket_get_constant() for constants.
+ * @since 2.1   Add filter rocket_advanced_cache_file.
  * @since 2.0.3
  *
  * @return  string  $buffer The content of avanced-cache.php file
@@ -26,6 +27,7 @@ function get_rocket_advanced_cache_file() { // phpcs:ignore WordPress.NamingConv
 	// Include the Mobile Detect class if we have to create a different caching file for mobile.
 	if ( is_rocket_generate_caching_mobile_files() ) {
 		$vendor_path = rocket_get_constant( 'WP_ROCKET_VENDORS_PATH' );
+
 		$buffer .= "if ( file_exists( '" . $vendor_path . "classes/class-rocket-mobile-detect.php' ) && ! class_exists( 'Rocket_Mobile_Detect' ) ) {\n";
 		$buffer .= "\tinclude_once '" . $vendor_path . "classes/class-rocket-mobile-detect.php';\n";
 		$buffer .= "}\n\n";
@@ -74,7 +76,7 @@ function get_rocket_advanced_cache_file() { // phpcs:ignore WordPress.NamingConv
 	$buffer .= "}\n";
 
 	/**
-	 * Filter the content of advanced-cache.php file
+	 * Filter the content of advanced-cache.php file.
 	 *
 	 * @since 2.1
 	 *

--- a/tests/Fixtures/inc/functions/getRocketAdvancedCacheFile.php
+++ b/tests/Fixtures/inc/functions/getRocketAdvancedCacheFile.php
@@ -14,8 +14,8 @@ if ( ! defined( 'WP_ROCKET_CONFIG_PATH' ) ) {
 STARTING_CONTENTS;
 
 $mobile = <<<MOBILE_CONTENTS
-if ( file_exists( 'classes/class-rocket-mobile-detect.php' ) && ! class_exists( 'Rocket_Mobile_Detect' ) ) {
-	include_once 'classes/class-rocket-mobile-detect.php';
+if ( file_exists( 'vfs://public/wp-content/plugins/wp-rocket/inc/vendors/classes/class-rocket-mobile-detect.php' ) && ! class_exists( 'Rocket_Mobile_Detect' ) ) {
+	include_once 'vfs://public/wp-content/plugins/wp-rocket/inc/vendors/classes/class-rocket-mobile-detect.php';
 }
 
 
@@ -85,6 +85,27 @@ ENDING_CONTENTS;
 $default = $starting . $ending;
 
 return [
+	// Use in tests when the test data starts in this directory.
+	'vfs_dir' => 'wp-content/',
+
+	'structure' => [
+		'wp-content'       => [
+			'plugins' => [
+				'wp-rocket' => [
+					'inc'              => [
+						'process-autoloader.php' => file_get_contents( WP_ROCKET_PLUGIN_ROOT . 'inc/process-autoloader.php' ),
+					],
+					'licence-data.php' => '',
+				],
+			],
+		],
+		'wp-rocket-config' => [
+			'example.org.php' => '<?php $var = "Some contents.";',
+		],
+
+		'advanced-cache.php' => '<?php $var = "Some contents.";',
+	],
+
 	'settings' => [
 		'cache_mobile'            => 0,
 		'do_caching_mobile_files' => 0,
@@ -92,27 +113,31 @@ return [
 
 	'test_data' => [
 		[
-			'settings' => [],
-			'expected' => $default,
+			'settings'                                => [],
+			'expected'                                => $default,
+			'is_rocket_generate_caching_mobile_files' => false,
 		],
 		[
-			'settings' => [
+			'settings'                                => [
 				'cache_mobile' => 1,
 			],
-			'expected' => $default,
+			'expected'                                => $default,
+			'is_rocket_generate_caching_mobile_files' => false,
 		],
 		[
-			'settings' => [
+			'settings'                                => [
 				'do_caching_mobile_files' => 1,
 			],
-			'expected' => $default,
+			'expected'                                => $default,
+			'is_rocket_generate_caching_mobile_files' => false,
 		],
 		[
-			'settings' => [
+			'settings'                                => [
 				'cache_mobile'            => 1,
 				'do_caching_mobile_files' => 1,
 			],
-			'expected' => $starting . $mobile . $ending,
+			'expected'                                => $starting . $mobile . $ending,
+			'is_rocket_generate_caching_mobile_files' => true,
 		],
 	],
 ];

--- a/tests/Fixtures/inc/functions/getRocketAdvancedCacheFile.php
+++ b/tests/Fixtures/inc/functions/getRocketAdvancedCacheFile.php
@@ -1,0 +1,118 @@
+<?php
+
+$starting = <<<STARTING_CONTENTS
+<?php
+defined( 'ABSPATH' ) || exit;
+
+define( 'WP_ROCKET_ADVANCED_CACHE', true );
+
+if ( ! defined( 'WP_ROCKET_CONFIG_PATH' ) ) {
+	define( 'WP_ROCKET_CONFIG_PATH',       WP_CONTENT_DIR . '/wp-rocket-config/' );
+}
+
+
+STARTING_CONTENTS;
+
+$mobile = <<<MOBILE_CONTENTS
+if ( file_exists( 'classes/class-rocket-mobile-detect.php' ) && ! class_exists( 'Rocket_Mobile_Detect' ) ) {
+	include_once 'classes/class-rocket-mobile-detect.php';
+}
+
+
+MOBILE_CONTENTS;
+
+$ending = <<<ENDING_CONTENTS
+if ( version_compare( phpversion(), '5.6' ) >= 0 ) {
+
+	spl_autoload_register(
+		function( \$class ) {
+			\$rocket_path    = 'vfs://public/wp-content/plugins/wp-rocket/';
+			\$rocket_classes = [
+				'WP_Rocket\\\Buffer\\\Abstract_Buffer' => \$rocket_path . 'inc/classes/Buffer/class-abstract-buffer.php',
+				'WP_Rocket\\\Buffer\\\Cache'           => \$rocket_path . 'inc/classes/Buffer/class-cache.php',
+				'WP_Rocket\\\Buffer\\\Tests'           => \$rocket_path . 'inc/classes/Buffer/class-tests.php',
+				'WP_Rocket\\\Buffer\\\Config'          => \$rocket_path . 'inc/classes/Buffer/class-config.php',
+				'WP_Rocket\\\Logger\\\HTML_Formatter'  => \$rocket_path . 'inc/classes/logger/class-html-formatter.php',
+				'WP_Rocket\\\Logger\\\Logger'          => \$rocket_path . 'inc/classes/logger/class-logger.php',
+				'WP_Rocket\\\Logger\\\Stream_Handler'  => \$rocket_path . 'inc/classes/logger/class-stream-handler.php',
+				'WP_Rocket\\\Traits\\\Memoize'         => \$rocket_path . 'inc/classes/traits/trait-memoize.php',
+			];
+
+			if ( isset( \$rocket_classes[ \$class ] ) ) {
+				\$file = \$rocket_classes[ \$class ];
+			} elseif ( strpos( \$class, 'Monolog\\\' ) === 0 ) {
+				\$file = \$rocket_path . 'vendor/monolog/monolog/src/' . str_replace( '\\\', '/', \$class ) . '.php';
+			} elseif ( strpos( \$class, 'Psr\\\Log\\\' ) === 0 ) {
+				\$file = \$rocket_path . 'vendor/psr/log/' . str_replace( '\\\', '/', \$class ) . '.php';
+			} else {
+				return;
+			}
+
+			if ( file_exists( \$file ) ) {
+				require \$file;
+			}
+		}
+	);
+
+	if ( ! class_exists( '\WP_Rocket\Buffer\Cache' ) ) {
+		if ( ! defined( 'DONOTROCKETOPTIMIZE' ) ) {
+			define( 'DONOTROCKETOPTIMIZE', true ); // WPCS: prefix ok.
+		}
+		return;
+	}
+
+	\$rocket_config_class = new \WP_Rocket\Buffer\Config(
+		[
+			'config_dir_path' => 'vfs://public/wp-content/wp-rocket-config/',
+		]
+	);
+
+	( new \WP_Rocket\Buffer\Cache(
+		new \WP_Rocket\Buffer\Tests(
+			\$rocket_config_class
+		),
+		\$rocket_config_class,
+		[
+			'cache_dir_path' => 'vfs://public/wp-content/cache/wp-rocket/',
+		]
+	) )->maybe_init_process();
+} else {
+	define( 'WP_ROCKET_ADVANCED_CACHE_PROBLEM', true );
+}
+
+ENDING_CONTENTS;
+
+$default = $starting . $ending;
+
+return [
+	'settings' => [
+		'cache_mobile'            => 0,
+		'do_caching_mobile_files' => 0,
+	],
+
+	'test_data' => [
+		[
+			'settings' => [],
+			'expected' => $default,
+		],
+		[
+			'settings' => [
+				'cache_mobile' => 1,
+			],
+			'expected' => $default,
+		],
+		[
+			'settings' => [
+				'do_caching_mobile_files' => 1,
+			],
+			'expected' => $default,
+		],
+		[
+			'settings' => [
+				'cache_mobile'            => 1,
+				'do_caching_mobile_files' => 1,
+			],
+			'expected' => $starting . $mobile . $ending,
+		],
+	],
+];

--- a/tests/Integration/inc/functions/getRocketAdvancedCacheFile.php
+++ b/tests/Integration/inc/functions/getRocketAdvancedCacheFile.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\functions;
+
+use Brain\Monkey\Functions;
+use WPMedia\PHPUnit\Integration\TestCase;
+
+/**
+ * @covers ::get_rocket_advanced_cache_file
+ * @uses   ::is_rocket_generate_caching_mobile_files
+ * @uses   ::rocket_get_constant
+ * @uses   ::rocket_direct_filesystem
+ *
+ * @group  Files
+ */
+class Test_IsRocketGenerateCachingMobileFiles extends TestCase {
+	private $config;
+	private $original_settings;
+
+	public function setUp() {
+		parent::setUp();
+
+		if ( empty( $this->config ) ) {
+			$this->loadConfig();
+		}
+
+		$this->original_settings = get_option( 'wp_rocket_settings', [] );
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+
+		if ( empty( $this->original_settings ) ) {
+			delete_option( 'wp_rocket_settings' );
+		} else {
+			update_option( 'wp_rocket_settings', $this->original_settings );
+		}
+	}
+
+	/**
+	 * @dataProvider providerTestData
+	 */
+	public function testShouldReturnExpectedOptionValue( $settings, $expected ) {
+		update_option(
+			'wp_rocket_settings',
+			array_merge( $this->original_settings, $this->config['settings'], $settings )
+		);
+
+		Functions\expect( 'rocket_get_constant' )
+			->once()->with( 'WP_ROCKET_PHP_VERSION' )->andReturn( '5.6' )
+			->andAlsoExpectIt()
+			->once()->with( 'WP_ROCKET_INC_PATH' )->andReturn( WP_ROCKET_PLUGIN_ROOT . '/inc/' )
+			->andAlsoExpectIt()
+			->once()->with( 'WP_ROCKET_PATH' )->andReturn( 'vfs://public/wp-content/plugins/wp-rocket/' )
+			->andAlsoExpectIt()
+			->once()->with( 'WP_ROCKET_CONFIG_PATH' )->andReturn( 'vfs://public/wp-content/wp-rocket-config/' )
+			->andAlsoExpectIt()
+			->once()->with( 'WP_ROCKET_CACHE_PATH' )->andReturn( 'vfs://public/wp-content/cache/wp-rocket/' );
+
+		$this->assertSame( $expected, get_rocket_advanced_cache_file() );
+	}
+
+	public function providerTestData() {
+		if ( empty( $this->config ) ) {
+			$this->loadConfig();
+		}
+
+		return $this->config['test_data'];
+	}
+
+	private function loadConfig() {
+		$this->config = $this->getTestData( __DIR__, basename( __FILE__, '.php' ) );
+	}
+}

--- a/tests/Unit/inc/functions/getRocketAdvancedCacheFile.php
+++ b/tests/Unit/inc/functions/getRocketAdvancedCacheFile.php
@@ -1,9 +1,10 @@
 <?php
 
-namespace WP_Rocket\Tests\Integration\inc\functions;
+namespace WP_Rocket\Tests\Unit\inc\functions;
 
 use Brain\Monkey\Functions;
-use WP_Rocket\Tests\Integration\FilesystemTestCase;
+use WP_Rocket\Tests\Unit\FilesystemTestCase;
+use WPMedia\PHPUnit\Unit\TestCase;
 
 /**
  * @covers ::get_rocket_advanced_cache_file
@@ -15,32 +16,15 @@ use WP_Rocket\Tests\Integration\FilesystemTestCase;
  */
 class Test_GetRocketAdvancedCacheFile extends FilesystemTestCase {
 	protected $path_to_test_data = '/inc/functions/getRocketAdvancedCacheFile.php';
-	private $original_settings;
-
-	public function setUp() {
-		parent::setUp();
-
-		$this->original_settings = get_option( 'wp_rocket_settings', [] );
-	}
-
-	public function tearDown() {
-		parent::tearDown();
-
-		if ( empty( $this->original_settings ) ) {
-			delete_option( 'wp_rocket_settings' );
-		} else {
-			update_option( 'wp_rocket_settings', $this->original_settings );
-		}
-	}
 
 	/**
 	 * @dataProvider providerTestData
 	 */
 	public function testShouldReturnExpectedContent( $settings, $expected, $is_rocket_generate_caching_mobile_files ) {
-		update_option(
-			'wp_rocket_settings',
-			array_merge( $this->original_settings, $this->config['settings'], $settings )
-		);
+
+		Functions\expect( 'is_rocket_generate_caching_mobile_files' )
+			->once()
+			->andReturn( $is_rocket_generate_caching_mobile_files );
 
 		Functions\expect( 'rocket_get_constant' )
 			->once()->with( 'WP_ROCKET_PHP_VERSION' )->andReturn( '5.6' )


### PR DESCRIPTION
- Adds tests for `get_rocket_advanced_cache_file()`
- Micro-optimization: returns filtered content instead of assigning to variable and then returning
- Adds `rocket_get_constant()` to constants to make code testable