### PR TITLE
Tests: rocket_get_filesystem_perms()

### DIFF
--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -1263,13 +1263,16 @@ function rocket_put_content( $file, $content ) {
  * `substr( sprintf( '%o', $perm & 0777 ), -4 )` | string | '644'  | '755'  |
  *
  * @since  3.2.4
- * @author Grégory Viguier
  *
  * @param  string $type The type: 'dir' or 'file'.
  * @return int          Octal integer.
  */
 function rocket_get_filesystem_perms( $type ) {
 	static $perms = [];
+
+	if ( rocket_get_constant( 'WP_ROCKET_IS_TESTING', false ) ) {
+		$perms = [];
+	}
 
 	// Allow variants.
 	switch ( $type ) {
@@ -1296,18 +1299,20 @@ function rocket_get_filesystem_perms( $type ) {
 	// If the constants are not defined, use fileperms() like WordPress does.
 	switch ( $type ) {
 		case 'dir':
-			if ( defined( 'FS_CHMOD_DIR' ) ) {
-				$perms[ $type ] = FS_CHMOD_DIR;
+			$fs_chmod_dir = (int) rocket_get_constant( 'FS_CHMOD_DIR', 0 );
+			if ( $fs_chmod_dir > 0 ) {
+				$perms[ $type ] = $fs_chmod_dir;
 			} else {
-				$perms[ $type ] = fileperms( ABSPATH ) & 0777 | 0755;
+				$perms[ $type ] = fileperms( rocket_get_constant( 'ABSPATH' ) ) & 0777 | 0755;
 			}
 			break;
 
 		case 'file':
-			if ( defined( 'FS_CHMOD_FILE' ) ) {
-				$perms[ $type ] = FS_CHMOD_FILE;
+			$fs_chmod_file = (int) rocket_get_constant( 'FS_CHMOD_FILE', 0 );
+			if ( $fs_chmod_file > 0 ) {
+				$perms[ $type ] = $fs_chmod_file;
 			} else {
-				$perms[ $type ] = fileperms( ABSPATH . 'index.php' ) & 0777 | 0644;
+				$perms[ $type ] = fileperms( rocket_get_constant( 'ABSPATH' ) . 'index.php' ) & 0777 | 0644;
 			}
 	}
 

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -1306,7 +1306,7 @@ function rocket_get_filesystem_perms( $type ) {
 	} else {
 		$fs_chmod_file  = (int) rocket_get_constant( 'FS_CHMOD_FILE', 0 );
 		$perms[ $type ] = $fs_chmod_file > 0
-			? $perms[ $type ] = $fs_chmod_file
+			? $fs_chmod_file
 			: fileperms( rocket_get_constant( 'ABSPATH' ) . 'index.php' ) & 0777 | 0644;
 	}
 

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -1265,6 +1265,7 @@ function rocket_put_content( $file, $content ) {
  * @since  3.2.4
  *
  * @param  string $type The type: 'dir' or 'file'.
+ *
  * @return int          Octal integer.
  */
 function rocket_get_filesystem_perms( $type ) {
@@ -1297,23 +1298,16 @@ function rocket_get_filesystem_perms( $type ) {
 	}
 
 	// If the constants are not defined, use fileperms() like WordPress does.
-	switch ( $type ) {
-		case 'dir':
-			$fs_chmod_dir = (int) rocket_get_constant( 'FS_CHMOD_DIR', 0 );
-			if ( $fs_chmod_dir > 0 ) {
-				$perms[ $type ] = $fs_chmod_dir;
-			} else {
-				$perms[ $type ] = fileperms( rocket_get_constant( 'ABSPATH' ) ) & 0777 | 0755;
-			}
-			break;
-
-		case 'file':
-			$fs_chmod_file = (int) rocket_get_constant( 'FS_CHMOD_FILE', 0 );
-			if ( $fs_chmod_file > 0 ) {
-				$perms[ $type ] = $fs_chmod_file;
-			} else {
-				$perms[ $type ] = fileperms( rocket_get_constant( 'ABSPATH' ) . 'index.php' ) & 0777 | 0644;
-			}
+	if ( 'dir' === $type ) {
+		$fs_chmod_dir   = (int) rocket_get_constant( 'FS_CHMOD_DIR', 0 );
+		$perms[ $type ] = $fs_chmod_dir > 0
+			? $fs_chmod_dir
+			: fileperms( rocket_get_constant( 'ABSPATH' ) ) & 0777 | 0755;
+	} else {
+		$fs_chmod_file  = (int) rocket_get_constant( 'FS_CHMOD_FILE', 0 );
+		$perms[ $type ] = $fs_chmod_file > 0
+			? $perms[ $type ] = $fs_chmod_file
+			: fileperms( rocket_get_constant( 'ABSPATH' ) . 'index.php' ) & 0777 | 0644;
 	}
 
 	return $perms[ $type ];

--- a/tests/Fixtures/inc/functions/rocketGetFilesystemPerms.php
+++ b/tests/Fixtures/inc/functions/rocketGetFilesystemPerms.php
@@ -1,0 +1,54 @@
+<?php
+
+return [
+	'vfs_dir' => 'wp-content/',
+
+	'test_data' => [
+		[
+			'type'     => 'invalid',
+			'constant' => false,
+			'expected' => 0755,
+		],
+		[
+			'type'     => 'dir',
+			'constant' => false,
+			'expected' => 0777,
+		],
+		[
+			'type'     => 'dirs',
+			'constant' => false,
+			'expected' => 0777,
+		],
+		[
+			'type'     => 'folder',
+			'constant' => false,
+			'expected' => 0777,
+		],
+		[
+			'type'     => 'folders',
+			'constant' => false,
+			'expected' => 0777,
+		],
+		[
+			'type'     => 'dir',
+			'constant' => 'FS_CHMOD_DIR',
+			'expected' => 0777,
+		],
+
+		[
+			'type'     => 'file',
+			'constant' => false,
+			'expected' => 0666,
+		],
+		[
+			'type'     => 'files',
+			'constant' => false,
+			'expected' => 0666,
+		],
+		[
+			'type'     => 'file',
+			'constant' => 'FS_CHMOD_FILE',
+			'expected' => 0666,
+		],
+	],
+];

--- a/tests/Unit/inc/functions/rocketGetFilesystemPerms.php
+++ b/tests/Unit/inc/functions/rocketGetFilesystemPerms.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\functions;
+
+use Brain\Monkey\Functions;
+use WP_Rocket\Tests\Unit\FilesystemTestCase;
+
+/**
+ * @covers ::rocket_get_filesystem_perms
+ *
+ * @group  Files
+ * @group  Functions
+ * @group  thisone
+ */
+class Test_RocketGetFilesystemPerms extends FilesystemTestCase {
+	protected $path_to_test_data = '/inc/functions/rocketGetFilesystemPerms.php';
+
+	/**
+	 * @dataProvider providerTestData
+	 */
+	public function testShouldReturnPerms( $type, $constant, $expected ) {
+		if ( empty( $constant ) ) {
+			Functions\expect( 'rocket_get_constant' )->with( 'ABSPATH' )->andReturn( 'vfs://public/' );
+		} else {
+			Functions\expect( 'rocket_get_constant' )->with( $constant, 0 )->andReturn( $expected );
+		}
+
+		$actual = rocket_get_filesystem_perms( $type );
+		$this->assertSame( $expected, $actual );
+	}
+}

--- a/tests/VirtualFilesystemTrait.php
+++ b/tests/VirtualFilesystemTrait.php
@@ -138,6 +138,7 @@ trait VirtualFilesystemTrait {
 			],
 			'wp-includes'   => [],
 			'wp-config.php' => '',
+			'index.php'     => '',
 		];
 	}
 }


### PR DESCRIPTION
- Adds unit tests for `rocket_get_filesystem_perms()`
- Adds `rocket_get_constant()` to make the code testable
- Resets  the static variable to an empty array when testing
- Micro-optimization by switching to if/else instead of `switch/case/breaks` - with only 2 possibilities, if/else is faster and else code
