### PR TITLE
Closes #2478 Preload fetches wrong WPML Urls

### DIFF
--- a/inc/Engine/Preload/PartialPreloadSubscriber.php
+++ b/inc/Engine/Preload/PartialPreloadSubscriber.php
@@ -140,9 +140,11 @@ class PartialPreloadSubscriber implements Subscriber_Interface {
 					// URL with query string.
 					$file_path = preg_replace( '/#/', '?', $file_path, 1 );
 				} else {
-					$file_path = untrailingslashit( $file_path );
+					$file_path         = untrailingslashit( $file_path );
+					$data['home_path'] = untrailingslashit( $data['home_path'] );
 					if ( '/' === substr( get_option( 'permalink_structure' ), -1 ) ) {
-						$file_path .= '/';
+						$file_path         .= '/';
+						$data['home_path'] .= '/';
 					}
 				}
 

--- a/tests/Fixtures/inc/Engine/Preload/PartialPreloadSubscriber/preloadAfterAutomaticCachePurge.php
+++ b/tests/Fixtures/inc/Engine/Preload/PartialPreloadSubscriber/preloadAfterAutomaticCachePurge.php
@@ -1,0 +1,155 @@
+<?php
+return [
+	'bailoutNoManualPreload' => [
+		'/%postname%/',
+		false,
+		[],
+		[],
+	],
+	'bailoutNoDeleted' => [
+		'/%postname%/',
+		true,
+		[],
+		[],
+	],
+	'bailoutAllUrlsHaveLoggedIn' => [
+		'/%postname%/',
+		true,
+		[
+			[
+				'home_url'  => 'http://example.com/home1',
+				'home_path' => '/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home1',
+				'logged_in' => true,
+				'files'     => [
+					'/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home1/how-to-prank-your-coworkers',
+					'/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home1/best-source-of-gifs',
+				],
+			],
+		],
+		[],
+	],
+	'preloadUrlsSlashedPermalink' => [
+		'/%postname%/',
+		true,
+		[
+			[
+				'home_url'  => 'http://example.com/home1',
+				'home_path' => '/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home1',
+				'logged_in' => false,
+				'files'     => [
+					'/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home1',
+				],
+			],
+			[
+				'home_url'  => 'http://example.com/home2/',
+				'home_path' => '/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home2',
+				'logged_in' => false,
+				'files'     => [
+					'/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home2',
+				],
+			],
+			[
+				'home_url'  => 'http://example.com/home3/',
+				'home_path' => '/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home3/',
+				'logged_in' => false,
+				'files'     => [
+					'/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home3',
+				],
+			],
+			[
+				'home_url'  => 'http://example.com/home4/',
+				'home_path' => '/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home4/',
+				'logged_in' => false,
+				'files'     => [
+					'/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home4/',
+				],
+			],
+			[
+				'home_url'  => 'http://example.com/home5/',
+				'home_path' => '/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home5',
+				'logged_in' => false,
+				'files'     => [
+					'/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home5/',
+				],
+			],
+			[
+				'home_url'  => 'http://example.com/home6',
+				'home_path' => '/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home6/',
+				'logged_in' => false,
+				'files'     => [
+					'/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home6/',
+				],
+			],
+		],
+		[
+			'http://example.com/home1',
+			'http://example.com/home2/',
+			'http://example.com/home3/',
+			'http://example.com/home4/',
+			'http://example.com/home5/',
+			'http://example.com/home6',
+		],
+	],
+	'preloadUrlsUnSlashedPermalink' => [
+		'/%postname%',
+		true,
+		[
+			[
+				'home_url'  => 'http://example.com/home1',
+				'home_path' => '/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home1',
+				'logged_in' => false,
+				'files'     => [
+					'/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home1',
+				],
+			],
+			[
+				'home_url'  => 'http://example.com/home2/',
+				'home_path' => '/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home2',
+				'logged_in' => false,
+				'files'     => [
+					'/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home2',
+				],
+			],
+			[
+				'home_url'  => 'http://example.com/home3/',
+				'home_path' => '/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home3/',
+				'logged_in' => false,
+				'files'     => [
+					'/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home3',
+				],
+			],
+			[
+				'home_url'  => 'http://example.com/home4/',
+				'home_path' => '/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home4/',
+				'logged_in' => false,
+				'files'     => [
+					'/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home4/',
+				],
+			],
+			[
+				'home_url'  => 'http://example.com/home5/',
+				'home_path' => '/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home5',
+				'logged_in' => false,
+				'files'     => [
+					'/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home5/',
+				],
+			],
+			[
+				'home_url'  => 'http://example.com/home6',
+				'home_path' => '/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home6/',
+				'logged_in' => false,
+				'files'     => [
+					'/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home6/',
+				],
+			],
+		],
+		[
+			'http://example.com/home1',
+			'http://example.com/home2/',
+			'http://example.com/home3/',
+			'http://example.com/home4/',
+			'http://example.com/home5/',
+			'http://example.com/home6',
+		],
+	],
+];

--- a/tests/Integration/inc/Engine/Preload/PartialPreloadSubscriber/preloadAfterAutomaticCachePurge.php
+++ b/tests/Integration/inc/Engine/Preload/PartialPreloadSubscriber/preloadAfterAutomaticCachePurge.php
@@ -29,8 +29,8 @@ class Test_PreloadAfterAutomaticCachePurge extends TestCase {
 		parent::tearDown();
 
 		$this->subscriber = null;
-		$this->property->setAccessible( false );
 		$this->property->setValue( $this->subscriber, [] );
+		$this->property->setAccessible( false );
 	}
 
 	/**

--- a/tests/Integration/inc/Engine/Preload/PartialPreloadSubscriber/preloadAfterAutomaticCachePurge.php
+++ b/tests/Integration/inc/Engine/Preload/PartialPreloadSubscriber/preloadAfterAutomaticCachePurge.php
@@ -30,6 +30,9 @@ class Test_PreloadAfterAutomaticCachePurge extends TestCase {
 
 		$this->property->setValue( $this->subscriber, [] );
 		$this->property->setAccessible( false );
+
+		remove_filter( 'pre_get_rocket_option_manual_preload', [ $this, 'manual_preload_filter' ] );
+		remove_filter( 'pre_option_permalink_structure', [ $this, 'permalink_structure_filter' ] );
 	}
 
 	/**
@@ -54,9 +57,6 @@ class Test_PreloadAfterAutomaticCachePurge extends TestCase {
 		foreach ( $expected as $url ) {
 			$this->assertContains( $url, $this->urls );
 		}
-
-		remove_filter( 'pre_get_rocket_option_manual_preload', [ $this, 'manual_preload_filter' ] );
-		remove_filter( 'pre_option_permalink_structure', [ $this, 'permalink_structure_filter' ] );
 	}
 
 	public function manual_preload_filter() {

--- a/tests/Integration/inc/Engine/Preload/PartialPreloadSubscriber/preloadAfterAutomaticCachePurge.php
+++ b/tests/Integration/inc/Engine/Preload/PartialPreloadSubscriber/preloadAfterAutomaticCachePurge.php
@@ -28,7 +28,6 @@ class Test_PreloadAfterAutomaticCachePurge extends TestCase {
 	public function tearDown() {
 		parent::tearDown();
 
-		$this->subscriber = null;
 		$this->property->setValue( $this->subscriber, [] );
 		$this->property->setAccessible( false );
 	}

--- a/tests/Integration/inc/Engine/Preload/PartialPreloadSubscriber/preloadAfterAutomaticCachePurge.php
+++ b/tests/Integration/inc/Engine/Preload/PartialPreloadSubscriber/preloadAfterAutomaticCachePurge.php
@@ -22,6 +22,7 @@ class Test_PreloadAfterAutomaticCachePurge extends TestCase {
 		$this->subscriber = $container->get( 'partial_preload_subscriber' );
 		$this->property   = $this->get_reflective_property( 'urls', $this->subscriber );
 		$this->property->setAccessible( true );
+		$this->property->setValue( $this->subscriber, [] );
 	}
 
 	public function tearDown() {
@@ -29,6 +30,7 @@ class Test_PreloadAfterAutomaticCachePurge extends TestCase {
 
 		$this->subscriber = null;
 		$this->property->setAccessible( false );
+		$this->property->setValue( $this->subscriber, [] );
 	}
 
 	/**

--- a/tests/Integration/inc/Engine/Preload/PartialPreloadSubscriber/preloadAfterAutomaticCachePurge.php
+++ b/tests/Integration/inc/Engine/Preload/PartialPreloadSubscriber/preloadAfterAutomaticCachePurge.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\Preload\PartialPreloadSubscriber;
+
+use WPMedia\PHPUnit\Integration\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Preload\PartialPreloadSubscriber::preload_after_automatic_cache_purge
+ * @group  Preload
+ */
+class Test_PreloadAfterAutomaticCachePurge extends TestCase {
+	private $urls;
+	private $subscriber;
+	private $property;
+	private $permalink_structure;
+	private $manual_preload;
+
+	public function setUp() {
+		parent::setUp();
+
+		$container        = apply_filters( 'rocket_container', null );
+		$this->subscriber = $container->get( 'partial_preload_subscriber' );
+		$this->property   = $this->get_reflective_property( 'urls', $this->subscriber );
+		$this->property->setAccessible( true );
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+
+		$this->subscriber = null;
+		$this->property->setAccessible( false );
+	}
+
+	/**
+	 * @dataProvider providerTestData
+	 */
+	public function testShouldDoExpectedWithSlashedUrl( $permalink_structure, $option_value, $deleted, $expected ) {
+		$this->permalink_structure = $permalink_structure;
+		$this->manual_preload      = $option_value;
+
+		add_filter( 'pre_get_rocket_option_manual_preload', [ $this, 'manual_preload_filter' ] );
+		add_filter( 'pre_option_permalink_structure', [ $this, 'permalink_structure_filter' ] );
+
+		do_action( 'rocket_after_automatic_cache_purge', $deleted );
+
+		$this->property = $this->get_reflective_property( 'urls', $this->subscriber );
+		$this->urls     = $this->property->getValue( $this->subscriber );
+
+		if ( ! $expected ) {
+			$this->assertEmpty( $this->urls );
+		}
+
+		foreach ( $expected as $url ) {
+			$this->assertContains( $url, $this->urls );
+		}
+
+		remove_filter( 'pre_get_rocket_option_manual_preload', [ $this, 'manual_preload_filter' ] );
+		remove_filter( 'pre_option_permalink_structure', [ $this, 'permalink_structure_filter' ] );
+	}
+
+	public function manual_preload_filter() {
+		return $this->manual_preload;
+	}
+
+	public function permalink_structure_filter() {
+		return $this->permalink_structure;
+	}
+
+	public function providerTestData() {
+		return $this->getTestData( __DIR__, 'preloadAfterAutomaticCachePurge' );
+	}
+}

--- a/tests/Unit/inc/Engine/Preload/PartialPreloadSubscriber/preloadAfterAutomaticCachePurge.php
+++ b/tests/Unit/inc/Engine/Preload/PartialPreloadSubscriber/preloadAfterAutomaticCachePurge.php
@@ -2,7 +2,7 @@
 
 namespace WP_Rocket\Tests\Unit\inc\Engine\Preload\PartialPreloadSubscriber;
 
-
+use Mockery;
 use Brain\Monkey\Functions;
 use WPMedia\PHPUnit\Unit\TestCase;
 use WP_Rocket\Admin\Options_Data;
@@ -21,8 +21,8 @@ class Test_PreloadAfterAutomaticCachePurge extends TestCase {
 	private $property;
 
 	public function setUp() {
-		$this->options         = $this->createMock( Options_Data::class );
-		$this->partial_process = $this->createMock( PartialProcess::class );
+		$this->options         = Mockery::mock( Options_Data::class );
+		$this->partial_process = Mockery::mock( PartialProcess::class );
 		$this->subscriber      = new PartialPreloadSubscriber( $this->partial_process, $this->options );
 		$this->property        = $this->get_reflective_property( 'urls', $this->subscriber );
 		$this->property->setAccessible( true );
@@ -43,10 +43,7 @@ class Test_PreloadAfterAutomaticCachePurge extends TestCase {
 	 */
 	public function testShouldDoExpected( $permalink_structure, $option_value, $deleted, $expected ) {
 		if ( $deleted ) {
-			$this->options
-				->expects( $this->once() )
-				->method( 'get' )
-				->willReturn( $option_value );
+			$this->options->shouldReceive( 'get' )->andReturn( $option_value );
 		}
 
 		Functions\when( 'get_option' )->justReturn( $permalink_structure );

--- a/tests/Unit/inc/Engine/Preload/PartialPreloadSubscriber/preloadAfterAutomaticCachePurge.php
+++ b/tests/Unit/inc/Engine/Preload/PartialPreloadSubscriber/preloadAfterAutomaticCachePurge.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\Preload\PartialPreloadSubscriber;
+
+
+use Brain\Monkey\Functions;
+use WPMedia\PHPUnit\Unit\TestCase;
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Engine\Preload\PartialPreloadSubscriber;
+use WP_Rocket\Engine\Preload\PartialProcess;
+
+/**
+ * @covers \WP_Rocket\Engine\Preload\PartialPreloadSubscriber::preload_after_automatic_cache_purge
+ * @group  PreloadQ
+ */
+class Test_PreloadAfterAutomaticCachePurge extends TestCase {
+	private $urls = [];
+	private $options;
+	private $partial_process;
+	private $subscriber;
+	private $property;
+
+	public function setUp() {
+		$this->options         = $this->createMock( Options_Data::class );
+		$this->partial_process = $this->createMock( PartialProcess::class );
+		$this->subscriber      = new PartialPreloadSubscriber( $this->partial_process, $this->options );
+		$this->property        = $this->get_reflective_property( 'urls', $this->subscriber );
+		$this->property->setAccessible( true );
+
+		Functions\when( 'untrailingslashit' )->alias( function( $string ) {
+			return rtrim( $string, '/\\' );
+		} );
+	}
+
+	protected function tearDown() {
+		parent::tearDown();
+		$this->urls = [];
+		$this->property->setAccessible( false );
+	}
+
+	/**
+	 * @dataProvider providerTestData
+	 */
+	public function testShouldDoExpected( $permalink_structure, $option_value, $deleted, $expected ) {
+		if ( $deleted ) {
+			$this->options
+				->expects( $this->once() )
+				->method( 'get' )
+				->willReturn( $option_value );
+		}
+
+		Functions\when( 'get_option' )->justReturn( $permalink_structure );
+
+		$this->subscriber->preload_after_automatic_cache_purge( $deleted );
+
+		$this->property = $this->get_reflective_property( 'urls', $this->subscriber );
+		$this->urls     = $this->property->getValue( $this->subscriber );
+
+		if ( ! $expected ) {
+			$this->assertEmpty( $this->urls );
+		}
+
+		foreach ( $expected as $url ) {
+			$this->assertContains( $url, $this->urls );
+		}
+	}
+
+	public function providerTestData() {
+		return $this->getTestData( __DIR__, 'preloadAfterAutomaticCachePurge' );
+	}
+}

--- a/tests/Unit/inc/Engine/Preload/PartialPreloadSubscriber/preloadAfterAutomaticCachePurge.php
+++ b/tests/Unit/inc/Engine/Preload/PartialPreloadSubscriber/preloadAfterAutomaticCachePurge.php
@@ -11,7 +11,7 @@ use WP_Rocket\Engine\Preload\PartialProcess;
 
 /**
  * @covers \WP_Rocket\Engine\Preload\PartialPreloadSubscriber::preload_after_automatic_cache_purge
- * @group  PreloadQ
+ * @group  Preload
  */
 class Test_PreloadAfterAutomaticCachePurge extends TestCase {
 	private $urls = [];


### PR DESCRIPTION
**Reproduce the issue** ✅ 
Reproduced on mega website.

**Identify the root cause** ✅ 
The root cause is related to `$data['home_path']` which has the missing / at the end, so the str_replace() will have double // .
`home_path` trims the `/` in here:
https://github.com/wp-media/wp-rocket/blob/0bdcd1d0f9897541af2b589731d04af166ba1504/inc/classes/Cache/class-expired-cache-purge.php#L117-L118


**Scope a solution** ✅ 
The solution is to add back the '/' in `home_path` if the permalink_structure has the trailing slash:
```
$file_path = untrailingslashit( $file_path );
$data['home_path'] = untrailingslashit( $data['home_path'] );
if ( '/' === substr( get_option( 'permalink_structure' ), -1 ) ) {
		$file_path .= '/';
		$data['home_path'] .= '/';
}
```


**Estimate the effort** ✅ 
Effort [S] - All the effort should go in writing Unit & Integration tests for `preload_after_automatic_cache_purge()` function


**To Do**
- [x] Unit tests for `preload_after_automatic_cache_purge()` function
- [x] Integration tests for `preload_after_automatic_cache_purge()` function
- [x] QA