### PR TITLE
Restores class_alias arguments order in 3.5 deprecated

### DIFF
--- a/inc/deprecated/3.5.php
+++ b/inc/deprecated/3.5.php
@@ -6,18 +6,18 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Class aliases.
  */
-class_alias( '\WP_Rocket\Optimization\CSS\Combine_Google_Fonts', '\WP_Rocket\Engine\Optimization\GoogleFonts\Combine' );
-class_alias( '\WP_Rocket\Preload\Abstract_Preload', '\WP_Rocket\Engine\Preload\AbstractPreload' );
-class_alias( '\WP_Rocket\Preload\Full_Process', '\WP_Rocket\Engine\Preload\FullProcess' );
-class_alias( '\WP_Rocket\Preload\Homepage', '\WP_Rocket\Engine\Preload\Homepage' );
-class_alias( '\WP_Rocket\Preload\Partial_Process', '\WP_Rocket\Engine\Preload\PartialProcess' );
-class_alias( '\WP_Rocket\Preload\Process', '\WP_Rocket\Engine\Preload\AbstractProcess' );
-class_alias( '\WP_Rocket\Preload\Sitemap', '\WP_Rocket\Engine\Preload\Sitemap' );
-class_alias( '\WP_Rocket\ServiceProvider\Preload_Subscribers', '\WP_Rocket\Engine\Preload\ServiceProvider' );
-class_alias( '\WP_Rocket\Subscriber\Optimization\Combine_Google_Fonts_Subscriber', '\WP_Rocket\Engine\Optimization\GoogleFonts\Subscriber' );
-class_alias( '\WP_Rocket\Subscriber\Preload\Partial_Preload_Subscriber', '\WP_Rocket\Engine\Preload\PartialPreloadSubscriber' );
-class_alias( '\WP_Rocket\Subscriber\Preload\Preload_Subscriber', '\WP_Rocket\Engine\Preload\PreloadSubscriber' );
-class_alias( '\WP_Rocket\Subscriber\Preload\Sitemap_Preload_Subscriber', '\WP_Rocket\Engine\Preload\SitemapPreloadSubscriber' );
+class_alias( '\WP_Rocket\Engine\Preload\AbstractPreload', '\WP_Rocket\Preload\Abstract_Preload' );
+class_alias( '\WP_Rocket\Engine\Preload\AbstractProcess', '\WP_Rocket\Preload\Process' );
+class_alias( '\WP_Rocket\Engine\Preload\FullProcess', '\WP_Rocket\Preload\Full_Process' );
+class_alias( '\WP_Rocket\Engine\Preload\Homepage', '\WP_Rocket\Preload\Homepage' );
+class_alias( '\WP_Rocket\Engine\Preload\PartialPreloadSubscriber', '\WP_Rocket\Subscriber\Preload\Partial_Preload_Subscriber' );
+class_alias( '\WP_Rocket\Engine\Preload\PartialProcess', '\WP_Rocket\Preload\Partial_Process' );
+class_alias( '\WP_Rocket\Engine\Preload\PreloadSubscriber', '\WP_Rocket\Subscriber\Preload\Preload_Subscriber' );
+class_alias( '\WP_Rocket\Engine\Preload\ServiceProvider', '\WP_Rocket\ServiceProvider\Preload_Subscribers' );
+class_alias( '\WP_Rocket\Engine\Preload\Sitemap', '\WP_Rocket\Preload\Sitemap' );
+class_alias( '\WP_Rocket\Engine\Preload\SitemapPreloadSubscriber', '\WP_Rocket\Subscriber\Preload\Sitemap_Preload_Subscriber' );
+class_alias( '\WP_Rocket\Engine\Optimization\GoogleFonts\Combine', '\WP_Rocket\Optimization\CSS\Combine_Google_Fonts' );
+class_alias( '\WP_Rocket\Engine\Optimization\GoogleFonts\Subscriber', '\WP_Rocket\Subscriber\Optimization\Combine_Google_Fonts_Subscriber' );
 
 /**
  * Removes Minification, DNS Prefetch, LazyLoad, Defer JS when on an AMP version of a post with the AMP for WordPress plugin from Auttomatic


### PR DESCRIPTION
Fixes my mistake in PR #2596 for 3.5 deprecated file:

- restores the `class_alias()` arguments. Doh.
- orders the `class_alias()` lines alphabetically to make it easier to find the one you are looking for.