### PR TITLE
Improves the virtual filesystem fixtures and tests

### DIFF
--- a/tests/Fixtures/content/advancedCacheContent.php
+++ b/tests/Fixtures/content/advancedCacheContent.php
@@ -1,7 +1,6 @@
 <?php
 
-return [
-	'starting' => <<<STARTING_CONTENTS
+$start = <<<STARTING_CONTENTS
 <?php
 defined( 'ABSPATH' ) || exit;
 
@@ -12,17 +11,17 @@ if ( ! defined( 'WP_ROCKET_CONFIG_PATH' ) ) {
 }
 
 
-STARTING_CONTENTS
-	,
-	'mobile'   => <<<MOBILE_CONTENTS
+STARTING_CONTENTS;
+
+$mobile = <<<MOBILE_CONTENTS
 if ( file_exists( 'vfs://public/wp-content/plugins/wp-rocket/inc/vendors/classes/class-rocket-mobile-detect.php' ) && ! class_exists( 'Rocket_Mobile_Detect' ) ) {
 	include_once 'vfs://public/wp-content/plugins/wp-rocket/inc/vendors/classes/class-rocket-mobile-detect.php';
 }
 
 
-MOBILE_CONTENTS
-	,
-	'ending'   => <<<ENDING_CONTENTS
+MOBILE_CONTENTS;
+
+$end = <<<ENDING_CONTENTS
 if ( version_compare( phpversion(), '5.6' ) >= 0 ) {
 
 	spl_autoload_register(
@@ -81,6 +80,9 @@ if ( version_compare( phpversion(), '5.6' ) >= 0 ) {
 	define( 'WP_ROCKET_ADVANCED_CACHE_PROBLEM', true );
 }
 
-ENDING_CONTENTS
-	,
+ENDING_CONTENTS;
+
+return [
+	'non_mobile' => "{$start}{$end}",
+	'mobile'     => "{$start}{$mobile}{$end}",
 ];

--- a/tests/Fixtures/inc/functions/getRocketAdvancedCacheFile.php
+++ b/tests/Fixtures/inc/functions/getRocketAdvancedCacheFile.php
@@ -1,6 +1,6 @@
 <?php
 
-$content = require __DIR__ . '/advancedCacheContent.php';
+$content = require WP_ROCKET_TESTS_FIXTURES_DIR . '/content/advancedCacheContent.php';
 
 return [
 	// Use in tests when the test data starts in this directory.
@@ -32,21 +32,21 @@ return [
 	'test_data' => [
 		[
 			'settings'                                => [],
-			'expected'                                => $content['starting'] . $content['ending'],
+			'expected'                                => $content['non_mobile'],
 			'is_rocket_generate_caching_mobile_files' => false,
 		],
 		[
 			'settings'                                => [
 				'cache_mobile' => 1,
 			],
-			'expected'                                => $content['starting'] . $content['ending'],
+			'expected'                                => $content['non_mobile'],
 			'is_rocket_generate_caching_mobile_files' => false,
 		],
 		[
 			'settings'                                => [
 				'do_caching_mobile_files' => 1,
 			],
-			'expected'                                => $content['starting'] . $content['ending'],
+			'expected'                                => $content['non_mobile'],
 			'is_rocket_generate_caching_mobile_files' => false,
 		],
 		[
@@ -54,7 +54,7 @@ return [
 				'cache_mobile'            => 1,
 				'do_caching_mobile_files' => 1,
 			],
-			'expected'                                => $content['starting'] . $content['mobile'] . $content['ending'],
+			'expected'                                => $content['mobile'],
 			'is_rocket_generate_caching_mobile_files' => true,
 		],
 	],

--- a/tests/Fixtures/inc/functions/getRocketAdvancedCacheFile.php
+++ b/tests/Fixtures/inc/functions/getRocketAdvancedCacheFile.php
@@ -6,24 +6,6 @@ return [
 	// Use in tests when the test data starts in this directory.
 	'vfs_dir' => 'wp-content/',
 
-	'structure' => [
-		'wp-content'       => [
-			'plugins' => [
-				'wp-rocket' => [
-					'inc'              => [
-						'process-autoloader.php' => file_get_contents( WP_ROCKET_PLUGIN_ROOT . 'inc/process-autoloader.php' ),
-					],
-					'licence-data.php' => '',
-				],
-			],
-		],
-		'wp-rocket-config' => [
-			'example.org.php' => '<?php $var = "Some contents.";',
-		],
-
-		'advanced-cache.php' => '<?php $var = "Some contents.";',
-	],
-
 	'settings' => [
 		'cache_mobile'            => 0,
 		'do_caching_mobile_files' => 0,

--- a/tests/Fixtures/inc/functions/rocketGenerateAdvancedCacheFile.php
+++ b/tests/Fixtures/inc/functions/rocketGenerateAdvancedCacheFile.php
@@ -5,20 +5,6 @@ $content = require WP_ROCKET_TESTS_FIXTURES_DIR . '/content/advancedCacheContent
 return [
 	'vfs_dir' => 'wp-content/',
 
-	'structure' => [
-		'wp-content' => [
-			'plugins'            => [
-				'wp-rocket' => [
-					'inc'              => [
-						'process-autoloader.php' => file_get_contents( WP_ROCKET_PLUGIN_ROOT . 'inc/process-autoloader.php' ),
-					],
-					'licence-data.php' => '',
-				],
-			],
-			'advanced-cache.php' => '',
-		],
-	],
-
 	'settings' => [
 		'cache_mobile'            => 0,
 		'do_caching_mobile_files' => 0,

--- a/tests/Fixtures/inc/functions/rocketGenerateAdvancedCacheFile.php
+++ b/tests/Fixtures/inc/functions/rocketGenerateAdvancedCacheFile.php
@@ -1,6 +1,6 @@
 <?php
 
-$content = require __DIR__ . '/advancedCacheContent.php';
+$content = require WP_ROCKET_TESTS_FIXTURES_DIR . '/content/advancedCacheContent.php';
 
 return [
 	'vfs_dir' => 'wp-content/',
@@ -27,26 +27,26 @@ return [
 	'test_data' => [
 		[
 			'settings' => [],
-			'content'  => $content['starting'] . $content['ending'],
+			'content'  => $content['non_mobile'],
 		],
 		[
 			'settings' => [
 				'cache_mobile' => 1,
 			],
-			'content'  => $content['starting'] . $content['ending'],
+			'content'  => $content['non_mobile'],
 		],
 		[
 			'settings' => [
 				'do_caching_mobile_files' => 1,
 			],
-			'content'  => $content['starting'] . $content['ending'],
+			'content'  => $content['non_mobile'],
 		],
 		[
 			'settings' => [
 				'cache_mobile'            => 1,
 				'do_caching_mobile_files' => 1,
 			],
-			'content'  => $content['starting'] . $content['mobile'] . $content['ending'],
+			'content'  => $content['mobile'],
 		],
 
 		// When the file doesn't exist.
@@ -55,7 +55,7 @@ return [
 				'cache_mobile'            => 1,
 				'do_caching_mobile_files' => 1,
 			],
-			'content'  => $content['starting'] . $content['mobile'] . $content['ending'],
+			'content'  => $content['mobile'],
 			true,
 		],
 	],

--- a/tests/Fixtures/vfs-structure/default.php
+++ b/tests/Fixtures/vfs-structure/default.php
@@ -192,6 +192,9 @@ return [
 				'script.php' => '',
 			],
 			'wp-rocket'   => [
+				'inc'              => [
+					'process-autoloader.php' => file_get_contents( WP_ROCKET_PLUGIN_ROOT . 'inc/process-autoloader.php' ),
+				],
 				'licence-data.php' => '',
 			],
 		],

--- a/tests/Integration/inc/functions/getRocketAdvancedCacheFile.php
+++ b/tests/Integration/inc/functions/getRocketAdvancedCacheFile.php
@@ -22,6 +22,9 @@ class Test_GetRocketAdvancedCacheFile extends FilesystemTestCase {
 	public function setUp() {
 		parent::setUp();
 
+		// Mocks the various filesystem constants.
+		$this->whenRocketGetConstant();
+
 		$this->original_settings = get_option( 'wp_rocket_settings', [] );
 	}
 
@@ -38,27 +41,11 @@ class Test_GetRocketAdvancedCacheFile extends FilesystemTestCase {
 	/**
 	 * @dataProvider providerTestData
 	 */
-	public function testShouldReturnExpectedContent( $settings, $expected, $is_rocket_generate_caching_mobile_files ) {
+	public function testShouldReturnExpectedContent( $settings, $expected ) {
 		update_option(
 			'wp_rocket_settings',
 			array_merge( $this->original_settings, $this->config['settings'], $settings )
 		);
-
-		Functions\expect( 'rocket_get_constant' )
-			->once()->with( 'WP_ROCKET_PHP_VERSION' )->andReturn( '5.6' )
-			->andAlsoExpectIt()
-			->once()->with( 'WP_ROCKET_INC_PATH' )->andReturn( 'vfs://public/wp-content/plugins/wp-rocket/inc/' )
-			->andAlsoExpectIt()
-			->once()->with( 'WP_ROCKET_PATH' )->andReturn( 'vfs://public/wp-content/plugins/wp-rocket/' )
-			->andAlsoExpectIt()
-			->once()->with( 'WP_ROCKET_CONFIG_PATH' )->andReturn( 'vfs://public/wp-content/wp-rocket-config/' )
-			->andAlsoExpectIt()
-			->once()->with( 'WP_ROCKET_CACHE_PATH' )->andReturn( 'vfs://public/wp-content/cache/wp-rocket/' );
-
-		if ( $is_rocket_generate_caching_mobile_files ) {
-			Functions\expect( 'rocket_get_constant' )
-				->once()->with( 'WP_ROCKET_VENDORS_PATH' )->andReturn( 'vfs://public/wp-content/plugins/wp-rocket/inc/vendors/' );
-		}
 
 		$this->assertSame( $expected, get_rocket_advanced_cache_file() );
 	}

--- a/tests/Unit/inc/functions/getRocketAdvancedCacheFile.php
+++ b/tests/Unit/inc/functions/getRocketAdvancedCacheFile.php
@@ -4,7 +4,6 @@ namespace WP_Rocket\Tests\Unit\inc\functions;
 
 use Brain\Monkey\Functions;
 use WP_Rocket\Tests\Unit\FilesystemTestCase;
-use WPMedia\PHPUnit\Unit\TestCase;
 
 /**
  * @covers ::get_rocket_advanced_cache_file
@@ -19,30 +18,20 @@ use WPMedia\PHPUnit\Unit\TestCase;
 class Test_GetRocketAdvancedCacheFile extends FilesystemTestCase {
 	protected $path_to_test_data = '/inc/functions/getRocketAdvancedCacheFile.php';
 
+	public function setUp() {
+		parent::setUp();
+
+		// Mocks the various filesystem constants.
+		$this->whenRocketGetConstant();
+	}
+
 	/**
 	 * @dataProvider providerTestData
 	 */
 	public function testShouldReturnExpectedContent( $settings, $expected, $is_rocket_generate_caching_mobile_files ) {
-
 		Functions\expect( 'is_rocket_generate_caching_mobile_files' )
 			->once()
 			->andReturn( $is_rocket_generate_caching_mobile_files );
-
-		Functions\expect( 'rocket_get_constant' )
-			->once()->with( 'WP_ROCKET_PHP_VERSION' )->andReturn( '5.6' )
-			->andAlsoExpectIt()
-			->once()->with( 'WP_ROCKET_INC_PATH' )->andReturn( 'vfs://public/wp-content/plugins/wp-rocket/inc/' )
-			->andAlsoExpectIt()
-			->once()->with( 'WP_ROCKET_PATH' )->andReturn( 'vfs://public/wp-content/plugins/wp-rocket/' )
-			->andAlsoExpectIt()
-			->once()->with( 'WP_ROCKET_CONFIG_PATH' )->andReturn( 'vfs://public/wp-content/wp-rocket-config/' )
-			->andAlsoExpectIt()
-			->once()->with( 'WP_ROCKET_CACHE_PATH' )->andReturn( 'vfs://public/wp-content/cache/wp-rocket/' );
-
-		if ( $is_rocket_generate_caching_mobile_files ) {
-			Functions\expect( 'rocket_get_constant' )
-				->once()->with( 'WP_ROCKET_VENDORS_PATH' )->andReturn( 'vfs://public/wp-content/plugins/wp-rocket/inc/vendors/' );
-		}
 
 		$this->assertSame( $expected, get_rocket_advanced_cache_file() );
 	}

--- a/tests/Unit/inc/functions/rocketGenerateAdvancedCacheFile.php
+++ b/tests/Unit/inc/functions/rocketGenerateAdvancedCacheFile.php
@@ -17,7 +17,6 @@ use WP_Rocket\Tests\Unit\FilesystemTestCase;
  */
 class Test_RocketGenerateAdvancedCacheFile extends FilesystemTestCase {
 	protected $path_to_test_data   = '/inc/functions/rocketGenerateAdvancedCacheFile.php';
-	private   $original_settings;
 	private   $advanced_cache_file = 'vfs://public/wp-content/advanced-cache.php';
 
 	public function setUp() {

--- a/tests/Unit/inc/functions/rocketGetFilesystemPerms.php
+++ b/tests/Unit/inc/functions/rocketGetFilesystemPerms.php
@@ -10,7 +10,6 @@ use WP_Rocket\Tests\Unit\FilesystemTestCase;
  *
  * @group  Files
  * @group  Functions
- * @group  thisone
  */
 class Test_RocketGetFilesystemPerms extends FilesystemTestCase {
 	protected $path_to_test_data = '/inc/functions/rocketGetFilesystemPerms.php';

--- a/tests/VirtualFilesystemTrait.php
+++ b/tests/VirtualFilesystemTrait.php
@@ -141,6 +141,9 @@ trait VirtualFilesystemTrait {
 			case 'WP_CONTENT_DIR':
 				return 'vfs://public/wp-content';
 
+			case 'WP_ROCKET_CACHE_PATH':
+				return 'vfs://public/wp-content/cache/wp-rocket/';
+
 			case 'WP_ROCKET_CONFIG_PATH':
 				return 'vfs://public/wp-content/wp-rocket-config/';
 

--- a/tests/VirtualFilesystemTrait.php
+++ b/tests/VirtualFilesystemTrait.php
@@ -6,10 +6,11 @@ use Brain\Monkey\Functions;
 use org\bovigo\vfs\vfsStream;
 
 trait VirtualFilesystemTrait {
-	protected $original_entries = [];
-	protected $shouldNotClean   = [];
-	protected $entriesBefore    = [];
-	protected $dumpResults      = false;
+	protected $original_entries  = [];
+	protected $shouldNotClean    = [];
+	protected $entriesBefore     = [];
+	protected $dumpResults       = false;
+	protected $wp_cache_constant = false;
 
 	protected function initDefaultStructure() {
 		if ( empty( $this->config ) ) {
@@ -133,6 +134,9 @@ trait VirtualFilesystemTrait {
 
 			case 'FS_CHMOD_FILE':
 				return 0666;
+
+			case 'WP_CACHE':
+				return $this->wp_cache_constant;
 
 			case 'WP_CONTENT_DIR':
 				return 'vfs://public/wp-content';

--- a/tests/VirtualFilesystemTrait.php
+++ b/tests/VirtualFilesystemTrait.php
@@ -41,8 +41,11 @@ trait VirtualFilesystemTrait {
 		return str_replace( $search, '', $path );
 	}
 
-	protected function getEntriesBefore() {
-		$dir                 = $this->filesystem->getUrl( $this->config['vfs_dir'] );
+	protected function getEntriesBefore( $dir = '' ) {
+		if ( '' === $dir ) {
+			$dir = $this->filesystem->getUrl( $this->config['vfs_dir'] );
+		}
+
 		$this->entriesBefore = $this->filesystem->getListing( $dir );
 	}
 
@@ -56,8 +59,8 @@ trait VirtualFilesystemTrait {
 		}
 	}
 
-	protected function generateEntriesShouldExistAfter( array $shouldClean ) {
-		$this->getEntriesBefore();
+	protected function generateEntriesShouldExistAfter( array $shouldClean, $dir = '' ) {
+		$this->getEntriesBefore( $dir );
 
 		$cleaned = [];
 		foreach ( $shouldClean as $entry => $contents ) {
@@ -99,8 +102,12 @@ trait VirtualFilesystemTrait {
 		}
 	}
 
-	protected function checkShouldNotDeleteEntries() {
-		$entriesAfterCleaning = $this->filesystem->getListing( $this->filesystem->getUrl( $this->config['vfs_dir'] ) );
+	protected function checkShouldNotDeleteEntries( $dir = '' ) {
+		if ( '' === $dir ) {
+			$dir = $this->filesystem->getUrl( $this->config['vfs_dir'] );
+		}
+
+		$entriesAfterCleaning = $this->filesystem->getListing( $dir );
 		$actual               = array_diff( $entriesAfterCleaning, $this->shouldNotClean );
 		if ( $this->dumpResults ) {
 			var_dump( $actual );

--- a/tests/VirtualFilesystemTrait.php
+++ b/tests/VirtualFilesystemTrait.php
@@ -43,11 +43,7 @@ trait VirtualFilesystemTrait {
 	}
 
 	protected function getEntriesBefore( $dir = '' ) {
-		if ( '' === $dir ) {
-			$dir = $this->filesystem->getUrl( $this->config['vfs_dir'] );
-		}
-
-		$this->entriesBefore = $this->filesystem->getListing( $dir );
+		$this->entriesBefore = $this->filesystem->getListing( $this->getDirUrl( $dir ) );
 	}
 
 	protected function getShouldNotCleanEntries( array $shouldNotClean ) {
@@ -104,11 +100,7 @@ trait VirtualFilesystemTrait {
 	}
 
 	protected function checkShouldNotDeleteEntries( $dir = '' ) {
-		if ( '' === $dir ) {
-			$dir = $this->filesystem->getUrl( $this->config['vfs_dir'] );
-		}
-
-		$entriesAfterCleaning = $this->filesystem->getListing( $dir );
+		$entriesAfterCleaning = $this->filesystem->getListing( $this->getDirUrl( $dir ) );
 		$actual               = array_diff( $entriesAfterCleaning, $this->shouldNotClean );
 		if ( $this->dumpResults ) {
 			var_dump( $actual );
@@ -122,6 +114,14 @@ trait VirtualFilesystemTrait {
 				return $this->getConstant( $constant_name, $default );
 			}
 		);
+	}
+
+	protected function getDirUrl( $dir ) {
+		if ( empty( $dir ) ) {
+			return $this->filesystem->getUrl( $this->config['vfs_dir'] );
+		}
+
+		return $dir;
 	}
 
 	protected function getConstant( $constant_name, $default = null ) {


### PR DESCRIPTION
Improves the virtual filesystem fixtures and tests by:

- Adds ability to pass in the root directory, which allows us to run it  more than once with different directories.
- Adds more constants to the Trait's `getConstant()`
- Uses the Trait's `whenRocketGetConstant()` for `rocket_get_constant()` in the advanced cache tests, i.e. instead of individual expects
- Moves the advanced cache content file to a new `Fixtures\content\` folder for sharing/reuse in the test data
- Adds the different string combinations to the advanced cache content file, i.e. instead of doing it in the test data. Why? Makes it easier and more consistent
- Advanced cache tests now use the default vfs structure

Most of these improvements were identified in PR #2507 and are/will be needed as we build more tests.