### PR TITLE
Fixes #2504 Prevent deprecated notice on WooCommerce terms list pages

### DIFF
--- a/inc/Engine/Cache/AdminSubscriber.php
+++ b/inc/Engine/Cache/AdminSubscriber.php
@@ -25,7 +25,7 @@ class AdminSubscriber implements Event_Manager_Aware_Subscriber_Interface {
 	 */
 	public static function get_subscribed_events() {
 		return [
-			'admin_init' => 'add_terms_purge_links',
+			'admin_init' => 'register_terms_row_action',
 		];
 	}
 
@@ -45,7 +45,7 @@ class AdminSubscriber implements Event_Manager_Aware_Subscriber_Interface {
 	 *
 	 * @return void
 	 */
-	public function add_terms_purge_links() {
+	public function register_terms_row_action() {
 		$taxonomies = get_taxonomies(
 			[
 				'public'             => true,

--- a/inc/Engine/Cache/AdminSubscriber.php
+++ b/inc/Engine/Cache/AdminSubscriber.php
@@ -72,7 +72,7 @@ class AdminSubscriber implements Event_Manager_Aware_Subscriber_Interface {
 		}
 
 		$url = wp_nonce_url(
-			admin_url( "admin-post.php?action=purge_cache&type=term-{$term->term_id}&taxonomy={$term->name}" ),
+			admin_url( "admin-post.php?action=purge_cache&type=term-{$term->term_id}&taxonomy={$term->taxonomy}" ),
 			"purge_cache_term-{$term->term_id}"
 		);
 

--- a/inc/Engine/Cache/AdminSubscriber.php
+++ b/inc/Engine/Cache/AdminSubscriber.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace WP_Rocket\Engine\Cache;
+
+use WP_Rocket\Event_Management\Event_Manager;
+use WP_Rocket\Event_Management\Event_Manager_Aware_Subscriber_Interface;
+
+/**
+ * Subscriber for the cache admin events
+ *
+ * @since 3.5.5
+ */
+class AdminSubscriber implements Event_Manager_Aware_Subscriber_Interface {
+	/**
+	 * Event Manager instance
+	 *
+	 * @var Event_Manager;
+	 */
+	protected $event_manager;
+
+	/**
+	 * Returns an array of events that this subscriber wants to listen to.
+	 *
+	 * @return array
+	 */
+	public static function get_subscribed_events() {
+		return [
+			'admin_init' => 'add_terms_purge_links',
+		];
+	}
+
+	/**
+	 * Sets the event manager for the subscriber.
+	 *
+	 * @param Event_Manager $event_manager Event Manager instance.
+	 */
+	public function set_event_manager( Event_Manager $event_manager ) {
+		$this->event_manager = $event_manager;
+	}
+
+	/**
+	 * Registers the action for each public taxonomy
+	 *
+	 * @since 3.5.5
+	 *
+	 * @return void
+	 */
+	public function add_terms_purge_links() {
+		$taxonomies = get_taxonomies(
+			[
+				'public'             => true,
+				'publicly_queryable' => true,
+			]
+		);
+
+		foreach ( $taxonomies as $taxonomy ) {
+			$this->event_manager->add_callback( "{$taxonomy}_row_actions", [ $this, 'add_purge_term_link' ], 10, 2 );
+		}
+	}
+
+	/**
+	 * Adds a link "Purge this cache" in the terms list table
+	 *
+	 * @param array   $actions An array of action links to be displayed.
+	 * @param WP_Term $term Term object.
+	 *
+	 * @return array
+	 */
+	public function add_purge_term_link( $actions, $term ) {
+		if ( ! current_user_can( 'rocket_purge_terms' ) ) {
+			return $actions;
+		}
+
+		$url = wp_nonce_url(
+			admin_url( "admin-post.php?action=purge_cache&type=term-{$term->term_id}&taxonomy={$term->name}" ),
+			"purge_cache_term-{$term->term_id}"
+		);
+
+		$actions['rocket_purge'] = sprintf(
+			'<a href="%1$s">%2$s</a>',
+			$url,
+			__( 'Clear this cache', 'rocket' )
+		);
+
+		return $actions;
+	}
+}

--- a/inc/Engine/Cache/ServiceProvider.php
+++ b/inc/Engine/Cache/ServiceProvider.php
@@ -1,0 +1,34 @@
+<?php
+namespace WP_Rocket\Engine\Cache;
+
+use League\Container\ServiceProvider\AbstractServiceProvider;
+
+/**
+ * Service Provider for cache subscribers
+ *
+ * @since 3.5.5
+ */
+class ServiceProvider extends AbstractServiceProvider {
+
+	/**
+	 * The provides array is a way to let the container
+	 * know that a service is provided by this service
+	 * provider. Every service that is registered via
+	 * this service provider must have an alias added
+	 * to this array or it will be ignored.
+	 *
+	 * @var array
+	 */
+	protected $provides = [
+		'admin_cache_subscriber',
+	];
+
+	/**
+	 * Registers the option array in the container
+	 *
+	 * @return void
+	 */
+	public function register() {
+		$this->getContainer()->share( 'admin_cache_subscriber', 'WP_Rocket\Engine\Cache\AdminSubscriber' );
+	}
+}

--- a/inc/admin/admin.php
+++ b/inc/admin/admin.php
@@ -76,29 +76,6 @@ add_filter( 'page_row_actions', 'rocket_post_row_actions', 10, 2 );
 add_filter( 'post_row_actions', 'rocket_post_row_actions', 10, 2 );
 
 /**
- * Add a link "Purge this cache" in the taxonomy edit area
- *
- * @since 1.0
- *
- * @param array  $actions An array of row action links.
- * @param object $term The term object.
- * @return array Updated array of row action links
- */
-function rocket_tag_row_actions( $actions, $term ) {
-	global $taxnow;
-
-	if ( ! current_user_can( 'rocket_purge_terms' ) ) {
-		return $actions;
-	}
-
-	$url                     = wp_nonce_url( admin_url( 'admin-post.php?action=purge_cache&type=term-' . $term->term_id . '&taxonomy=' . $taxnow ), 'purge_cache_term-' . $term->term_id );
-	$actions['rocket_purge'] = sprintf( '<a href="%s">%s</a>', $url, __( 'Clear this cache', 'rocket' ) );
-
-	return $actions;
-}
-add_filter( 'tag_row_actions', 'rocket_tag_row_actions', 10, 2 );
-
-/**
  * Add a link "Purge this cache" in the user edit area
  *
  * @since 2.6.12

--- a/inc/classes/class-plugin.php
+++ b/inc/classes/class-plugin.php
@@ -67,6 +67,7 @@ class Plugin {
 		$this->container->addServiceProvider( 'WP_Rocket\ServiceProvider\Database' );
 		$this->container->addServiceProvider( 'WP_Rocket\Engine\Admin\Beacon\ServiceProvider' );
 		$this->container->addServiceProvider( 'WP_Rocket\ServiceProvider\RocketCDN' );
+		$this->container->addServiceProvider( 'WP_Rocket\Engine\Cache\ServiceProvider' );
 
 		$subscribers = [];
 
@@ -99,6 +100,7 @@ class Plugin {
 				'rocketcdn_data_manager_subscriber',
 				'health_check',
 				'minify_css_admin_subscriber',
+				'admin_cache_subscriber',
 			];
 		} elseif ( \rocket_valid_key() ) {
 			$this->container->addServiceProvider( 'WP_Rocket\Engine\Optimization\ServiceProvider' );

--- a/inc/deprecated/3.5.php
+++ b/inc/deprecated/3.5.php
@@ -870,3 +870,27 @@ function rocket_warning_cron() {
 		]
 	);
 }
+
+/**
+ * Add a link "Purge this cache" in the taxonomy edit area
+ *
+ * @since 3.5.5 deprecated
+ * @since 1.0
+ *
+ * @param array  $actions An array of row action links.
+ * @param object $term The term object.
+ * @return array Updated array of row action links
+ */
+function rocket_tag_row_actions( $actions, $term ) {
+	_deprecated_function( __FUNCTION__ . '()', '3.5.5', 'WP_Rocket\Engine\Cache\AdminSubscriber::add_purge_term_link()' );
+	global $taxnow;
+
+	if ( ! current_user_can( 'rocket_purge_terms' ) ) {
+		return $actions;
+	}
+
+	$url                     = wp_nonce_url( admin_url( 'admin-post.php?action=purge_cache&type=term-' . $term->term_id . '&taxonomy=' . $taxnow ), 'purge_cache_term-' . $term->term_id );
+	$actions['rocket_purge'] = sprintf( '<a href="%s">%s</a>', $url, __( 'Clear this cache', 'rocket' ) );
+
+	return $actions;
+}

--- a/tests/Fixtures/inc/Engine/Cache/AdminSubscriber/addPurgeTermLink.php
+++ b/tests/Fixtures/inc/Engine/Cache/AdminSubscriber/addPurgeTermLink.php
@@ -1,0 +1,18 @@
+<?php
+
+return [
+	'testShouldReturnDefaultArrayWhenNoCap' => [
+		'config' => [
+			'cap' => false,
+		],
+		'expected' => [],
+	],
+	'testShouldReturnArrayWithPurgeTermAction' => [
+		'config' => [
+			'cap' => true,
+		],
+		'expected' => [
+			'rocket_purge' => '<a href="http://example.org/wp-admin/admin-post.php?action=purge_cache&type=term-1&taxonomy=post_tag&amp;_wpnonce=123456">Clear this cache</a>',
+		],
+	],
+];

--- a/tests/Fixtures/inc/Engine/Cache/AdminSubscriber/addPurgeTermLink.php
+++ b/tests/Fixtures/inc/Engine/Cache/AdminSubscriber/addPurgeTermLink.php
@@ -5,14 +5,13 @@ return [
 		'config' => [
 			'cap' => false,
 		],
-		'expected' => [],
+		'expected' => '',
 	],
 	'testShouldReturnArrayWithPurgeTermAction' => [
 		'config' => [
 			'cap' => true,
+			'nonce' => '123456',
 		],
-		'expected' => [
-			'rocket_purge' => '<a href="http://example.org/wp-admin/admin-post.php?action=purge_cache&type=term-1&taxonomy=post_tag&amp;_wpnonce=123456">Clear this cache</a>',
-		],
+		'expected' => '<a href="http://example.org/wp-admin/admin-post.php?action=purge_cache&amp;type=term-1&amp;taxonomy=post_tag&amp;_wpnonce=123456">Clear this cache</a>',
 	],
 ];

--- a/tests/Integration/AdminTestCase.php
+++ b/tests/Integration/AdminTestCase.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration;
+
+use WPMedia\PHPUnit\Integration\TestCase;
+
+abstract class AdminTestCase extends TestCase {
+	protected $error_lel;
+	protected $user_id = 0;
+
+	public static function setUpBeforeClass() {
+		remove_action( 'admin_init', '_maybe_update_core' );
+		remove_action( 'admin_init', '_maybe_update_plugins' );
+		remove_action( 'admin_init', '_maybe_update_themes' );
+	}
+
+	public function setUp() {
+		parent::setUp();
+
+		// Suppress warnings from "Cannot modify header information - headers already sent by".
+		$this->error_level = error_reporting();
+		error_reporting( $this->error_level & ~E_WARNING );
+	}
+
+	public function tearDown() {
+		$_POST = [];
+		$_GET  = [];
+		unset( $GLOBALS['post'], $GLOBALS['comment'] );
+
+		parent::tearDown();
+
+		error_reporting( $this->_error_level );
+		set_current_screen( 'front' );
+		if ( $this->user_id > 0 ) {
+			wp_delete_user( $this->user_id );
+		}
+	}
+
+	protected function setRoleCap( $role_type, $cap ) {
+		$role = get_role( $role_type );
+		$role->add_cap( $cap );
+	}
+
+	protected function removeRoleCap( $role_type, $cap ) {
+		$role = get_role( $role_type );
+		$role->remove_cap( $cap );
+	}
+
+	protected function setCurrentUser( $role ) {
+		$this->user_id = $this->factory->user->create( [ 'role' => $role ] );
+		wp_set_current_user( $this->user_id );
+	}
+
+	protected function fireAdminInit() {
+		do_action( 'admin_init' );
+	}
+
+	protected function hasCallbackRegistered( $event, $class, $method, $priority = 10 ) {
+		global $wp_filter;
+
+		$this->assertArrayHasKey( $event, $wp_filter );
+		$this->assertArrayHasKey( $priority, $wp_filter[ $event ]->callbacks );
+
+		$object = null;
+		foreach ( $wp_filter['post_tag_row_actions']->callbacks[ $priority ] as $key => $callback ) {
+			if ( isset( $callback['function'][1] ) && $method === $callback['function'][1] ) {
+				$object = $callback['function'][0];
+				break;
+			}
+		}
+		$this->assertInstanceOf( $class, $object );
+	}
+
+	protected function setEditTagsAsCurrentScreen( $tax = 'category' ) {
+		set_current_screen( "edit-tags.php?taxonomy={$tax}" );
+	}
+}

--- a/tests/Integration/inc/Engine/Cache/AdminSubscriber/addPurgeTermLink.php
+++ b/tests/Integration/inc/Engine/Cache/AdminSubscriber/addPurgeTermLink.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\Cache\AdminSubscriber;
+
+use WPMedia\PHPUnit\Integration\TestCase;
+
+/**
+ * @covers WP_Rocket\Engine\Cache\AdminSubscriber::add_purge_term_link
+ *
+ * @group AdminOnly
+ * @group Cache
+ */
+class Test_AddPurgeTermLink extends TestCase {
+    /**
+	 * @dataProvider providerTestData
+	 */
+    public function testShouldAddCallbackForEachTerm( $config, $expected ) {
+        set_current_screen( 'edit-tags' );
+
+        $term = (object) [
+			'term_id'  => 1,
+			'taxonomy' => 'post_tag'
+		];
+
+        if ( ! $config['cap'] ) {
+            $this->assertArrayNotHasKey(
+                'rocket_purge',
+                apply_filters( 'post_tag_row_actions', [], $term )
+            );
+        } else {
+            $admin = get_role( 'administrator' );
+            $admin->add_cap( 'rocket_purge_terms' );
+
+            $user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+            wp_set_current_user( $user_id );
+            
+
+            $actions = apply_filters( 'post_tag_row_actions', [], $term );
+
+            $this->assertArrayHasKey(
+                'rocket_purge',
+                $actions
+            );
+
+            $this->assertContains(
+                $expected,
+                $actions
+            );
+        }
+    }
+
+    public function providerTestData() {
+		return $this->getTestData( __DIR__, 'addPurgeTermLink' );
+	}
+}

--- a/tests/Integration/inc/Engine/Cache/AdminSubscriber/registerTermsRowAction.php
+++ b/tests/Integration/inc/Engine/Cache/AdminSubscriber/registerTermsRowAction.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\Cache\AdminSubscriber;
+
+use WPMedia\PHPUnit\Integration\TestCase;
+
+/**
+ * @covers WP_Rocket\Engine\Cache\AdminSubscriber::register_terms_row_action
+ *
+ * @group AdminOnly
+ * @group Cache
+ */
+class Test_RegisterTermsRowAction extends TestCase {
+	private static $container;
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		self::$container = apply_filters( 'rocket_container', '' );
+	}
+
+	public function testShouldAddCallbackForEachTerm() {
+		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $user_id );
+		set_current_screen( 'edit-tags' );
+
+		$taxonomies = get_taxonomies(
+			[
+				'public'             => true,
+				'publicly_queryable' => true,
+			]
+		);
+
+		$subscriber = self::$container->get( 'admin_cache_subscriber' );
+
+		foreach( $taxonomies as $taxonomy ) {
+			$this->assertTrue(
+				has_action( "{$taxonomy}_row_actions", [ $subscriber, 'add_purge_term_link' ] )
+			);
+		}
+	}
+}

--- a/tests/Integration/inc/Engine/Cache/AdminSubscriber/registerTermsRowAction.php
+++ b/tests/Integration/inc/Engine/Cache/AdminSubscriber/registerTermsRowAction.php
@@ -2,7 +2,7 @@
 
 namespace WP_Rocket\Tests\Integration\inc\Engine\Cache\AdminSubscriber;
 
-use WPMedia\PHPUnit\Integration\TestCase;
+use WP_Rocket\Tests\Integration\AdminTestCase;
 
 /**
  * @covers WP_Rocket\Engine\Cache\AdminSubscriber::register_terms_row_action
@@ -10,7 +10,7 @@ use WPMedia\PHPUnit\Integration\TestCase;
  * @group AdminOnly
  * @group Cache
  */
-class Test_RegisterTermsRowAction extends TestCase {
+class Test_RegisterTermsRowAction extends AdminTestCase {
 	private static $container;
 
 	public static function setUpBeforeClass() {
@@ -20,9 +20,10 @@ class Test_RegisterTermsRowAction extends TestCase {
 	}
 
 	public function testShouldAddCallbackForEachTerm() {
-		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
-		wp_set_current_user( $user_id );
-		set_current_screen( 'edit-tags' );
+		$this->setRoleCap( 'administrator', 'rocket_purge_terms' );
+		$this->setCurrentUser( 'administrator' );
+		$this->setEditTagsAsCurrentScreen( 'post_tag' );
+		$this->fireAdminInit();
 
 		$taxonomies = get_taxonomies(
 			[
@@ -34,7 +35,8 @@ class Test_RegisterTermsRowAction extends TestCase {
 		$subscriber = self::$container->get( 'admin_cache_subscriber' );
 
 		foreach( $taxonomies as $taxonomy ) {
-			$this->assertTrue(
+			$this->assertSame(
+				10,
 				has_action( "{$taxonomy}_row_actions", [ $subscriber, 'add_purge_term_link' ] )
 			);
 		}

--- a/tests/Unit/inc/Engine/Cache/AdminSubscriber/addPurgeTermLink.php
+++ b/tests/Unit/inc/Engine/Cache/AdminSubscriber/addPurgeTermLink.php
@@ -34,16 +34,21 @@ class Test_AddPurgeTermLink extends TestCase {
 
 		Functions\when( 'current_user_can' )->justReturn( $config['cap'] );
 		Functions\when( 'wp_nonce_url' )->alias( function( $url ) {
-			return "{$url}&amp;_wpnonce=123456";
+			return str_replace( '&', '&amp;', "{$url}&_wpnonce=123456" );
 		} );
 		Functions\when( 'admin_url' )->alias( function( $path ) {
 			return "http://example.org/wp-admin/{$path}";
 		} );
 
-		$this->assertSame(
-			$expected,
-			$this->subscriber->add_purge_term_link( $actions, $term )
-		);
+		$actions = $this->subscriber->add_purge_term_link( $actions, $term );
+
+		if ( $config['cap'] ) {
+			$this->assertArrayHasKey( 'rocket_purge', $actions );
+
+			$this->assertSame( $expected, $actions['rocket_purge'] );
+		} else {
+			$this->assertArrayNotHasKey( 'rocket_purge', $actions );
+		}
 	}
 
 	public function providerTestData() {

--- a/tests/Unit/inc/Engine/Cache/AdminSubscriber/addPurgeTermLink.php
+++ b/tests/Unit/inc/Engine/Cache/AdminSubscriber/addPurgeTermLink.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\Cache\AdminSubscriber;
+
+use Brain\Monkey\Functions;
+use WPMedia\PHPUnit\Unit\TestCase;
+use WP_Rocket\Engine\Cache\AdminSubscriber;
+
+/**
+ * @covers WP_Rocket\Engine\Cache\AdminSubscriber::add_purge_term_link
+ *
+ * @group Cache
+ */
+class Test_AddPurgeTermLink extends TestCase {
+	protected static $mockCommonWpFunctionsInSetUp = true;
+
+	private $subscriber;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->subscriber = new AdminSubscriber();
+	}
+
+	/**
+	 * @dataProvider providerTestData
+	 */
+	public function testShouldReturnActionsArray( $config, $expected ) {
+		$actions = [];
+		$term    = (object) [
+			'term_id'  => 1,
+			'taxonomy' => 'post_tag'
+		];
+
+		Functions\when( 'current_user_can' )->justReturn( $config['cap'] );
+		Functions\when( 'wp_nonce_url' )->alias( function( $url ) {
+			return "{$url}&amp;_wpnonce=123456";
+		} );
+		Functions\when( 'admin_url' )->alias( function( $path ) {
+			return "http://example.org/wp-admin/{$path}";
+		} );
+
+		$this->assertSame(
+			$expected,
+			$this->subscriber->add_purge_term_link( $actions, $term )
+		);
+	}
+
+	public function providerTestData() {
+		return $this->getTestData( __DIR__, 'addPurgeTermLink' );
+	}
+}

--- a/tests/Unit/inc/Engine/Cache/AdminSubscriber/registerTermsRowAction.php
+++ b/tests/Unit/inc/Engine/Cache/AdminSubscriber/registerTermsRowAction.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\Cache\AdminSubscriber;
+
+use Mockery;
+use Brain\Monkey\Functions;
+use WPMedia\PHPUnit\Unit\TestCase;
+use WP_Rocket\Engine\Cache\AdminSubscriber;
+use WP_Rocket\Event_Management\Event_Manager;
+
+/**
+ * @covers WP_Rocket\Engine\Cache\AdminSubscriber::register_terms_row_action
+ *
+ * @group Cache
+ */
+class Test_RegisterTermsRowAction extends TestCase {
+	private $event_manager;
+	private $subscriber;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->event_manager = Mockery::mock( Event_manager::class );
+		$this->subscriber    = new AdminSubscriber();
+		$this->subscriber->set_event_manager( $this->event_manager );
+	}
+
+	public function testShouldAddCallbackForEachTerm() {
+		Functions\when( 'get_taxonomies' )->justReturn(
+			[
+				'category',
+				'post_tag',
+			]
+		);
+
+		$this->event_manager->shouldReceive( 'add_callback' )
+			->twice();
+
+		$this->subscriber->register_terms_row_action();
+	}
+}


### PR DESCRIPTION
Fixes #2504 

- [x] Deprecate `rocket_tag_row_actions`
- [x] Create a `Cache\AdminSubscriber`
- [x] Add methods to add the purge term link for each public taxonomy
- [x] Write tests
- [x] QA