### PR TITLE
Removes filter "rocket_wp_content_dir"

### DIFF
--- a/inc/functions/formatting.php
+++ b/inc/functions/formatting.php
@@ -488,14 +488,7 @@ function rocket_realpath( $file ) {
  * @return string|bool
  */
 function rocket_url_to_path( $url, array $zones = [ 'all' ] ) {
-	/**
-	 * Filters the filepath to the WP content directory
-	 *
-	 * @since 3.5.3
-	 *
-	 * @param string $filepath wp-content directory filepath.
-	 */
-	$wp_content_dir = apply_filters( 'rocket_wp_content_dir', rocket_get_constant( 'WP_CONTENT_DIR' ) );
+	$wp_content_dir = rocket_get_constant( 'WP_CONTENT_DIR' );
 	$root_dir       = trailingslashit( dirname( $wp_content_dir ) );
 	$root_url       = str_replace( wp_basename( $wp_content_dir ), '', content_url() );
 	$url_host       = wp_parse_url( $url, PHP_URL_HOST );

--- a/tests/Fixtures/inc/Engine/Optimization/Minify/CSS/Combine/combine.php
+++ b/tests/Fixtures/inc/Engine/Optimization/Minify/CSS/Combine/combine.php
@@ -1,6 +1,7 @@
 <?php
 return [
-	'vfs_dir'   => 'public/',
+	'vfs_dir'   => 'wordpress/',
+
 	'structure' => [
 		'wordpress' => [
 			'wp-includes' => [
@@ -36,6 +37,7 @@ return [
 			],
 		],
 	],
+
 	'test_data' => [
 		// Combine CSS files.
 		[

--- a/tests/Fixtures/inc/Engine/Optimization/Minify/JS/Subscriber/process.php
+++ b/tests/Fixtures/inc/Engine/Optimization/Minify/JS/Subscriber/process.php
@@ -1,6 +1,7 @@
 <?php
 return [
-	'vfs_dir'   => 'public/',
+	'vfs_dir'   => 'wordpress/',
+
 	'structure' => [
 		'wordpress' => [
 			'wp-includes' => [
@@ -36,6 +37,7 @@ return [
 			],
 		],
 	],
+
 	'test_data' => [
 		// Minify JS files
 		[
@@ -61,7 +63,7 @@ return [
 				<body>
 				</body>
 			</html>',
-			[
+			'settings' => [
 				'minify_concatenate_js' => 0,
 				'cdn'                   => 0,
 				'cdn_cnames'            => [],
@@ -92,7 +94,7 @@ return [
 				<body>
 				</body>
             </html>',
-            [
+            'settings' => [
 				'minify_concatenate_js' => 0,
 				'cdn'                   => 1,
 				'cdn_cnames'            => [
@@ -127,7 +129,7 @@ return [
 				<body>
 				</body>
 			</html>',
-			[
+			'settings' => [
 				'minify_concatenate_js' => 0,
 				'cdn'                   => 1,
 				'cdn_cnames'            => [
@@ -162,7 +164,7 @@ return [
 				<body>
 				</body>
 			</html>',
-			[
+			'settings' => [
 				'minify_concatenate_js' => 0,
 				'cdn'                   => 1,
 				'cdn_cnames'            => [
@@ -204,7 +206,7 @@ return [
 					<script src="http://example.org/wp-content/cache/min/1/f819bcaed244d53d3b4ffc4c5cc0efdc.js" data-minify="1"></script>
 				</body>
 			</html>',
-			[
+			'settings' => [
 				'minify_concatenate_js' => 1,
 				'cdn'                   => 0,
 				'cdn_cnames'            => [],
@@ -242,7 +244,7 @@ return [
 					<script src="https://123456.rocketcdn.me/wp-content/cache/min/1/f819bcaed244d53d3b4ffc4c5cc0efdc.js" data-minify="1"></script>
 				</body>
 			</html>',
-			[
+			'settings' => [
 				'minify_concatenate_js' => 1,
 				'cdn'                   => 1,
 				'cdn_cnames'            => [
@@ -284,7 +286,7 @@ return [
 					<script src="https://123456.rocketcdn.me/wp-content/cache/min/1/f819bcaed244d53d3b4ffc4c5cc0efdc.js" data-minify="1"></script>
 				</body>
 			</html>',
-			[
+			'settings' => [
 				'minify_concatenate_js' => 1,
 				'cdn'                   => 1,
 				'cdn_cnames'            => [
@@ -326,7 +328,7 @@ return [
 					<script src="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/f819bcaed244d53d3b4ffc4c5cc0efdc.js" data-minify="1"></script>
 				</body>
 			</html>',
-			[
+			'settings' => [
 				'minify_concatenate_js' => 1,
 				'cdn'                   => 1,
 				'cdn_cnames'            => [

--- a/tests/Fixtures/inc/Engine/Optimization/QueryString/RemoveSubscriber/remove-query-strings.php
+++ b/tests/Fixtures/inc/Engine/Optimization/QueryString/RemoveSubscriber/remove-query-strings.php
@@ -1,6 +1,7 @@
 <?php
 return [
 	'vfs_dir' => 'public/',
+
 	'structure' => [
         'wp-includes' => [
             'js' => [
@@ -34,6 +35,7 @@ return [
             ],
         ],
 	],
+
 	'test_data' => [
 		[
 			// Scripts & styles are commented in HTML comments = ignored.
@@ -59,7 +61,7 @@ return [
 				<!-- <script src="http://example.org/wp-content/plugins/hello-dolly/script.js?ver=3.5"></script> -->
 				</body>
 			</html>',
-			[
+			'settings' => [
 				'cdn'        => 0,
 				'cdn_cnames' => [],
 				'cdn_zone'   => [],
@@ -97,7 +99,7 @@ return [
 					<script src="https://maps.google.com/map.js"></script>
 				</body>
 			</html>',
-			[
+			'settings' => [
 				'cdn'        => 0,
 				'cdn_cnames' => [],
 				'cdn_zone'   => [],
@@ -135,7 +137,7 @@ return [
 					<script src="https://maps.google.com/map.js"></script>
 				</body>
 			</html>',
-			[
+			'settings' => [
 				'cdn'        => 1,
 				'cdn_cnames' => [
 					'https://123456.rocketcdn.me',
@@ -177,7 +179,7 @@ return [
 					<script src="https://maps.google.com/map.js"></script>
 				</body>
 			</html>',
-			[
+			'settings' => [
 				'cdn'        => 1,
 				'cdn_cnames' => [
 					'https://123456.rocketcdn.me/cdnpath',

--- a/tests/Integration/inc/Engine/Optimization/Minify/CSS/Subscriber/process.php
+++ b/tests/Integration/inc/Engine/Optimization/Minify/CSS/Subscriber/process.php
@@ -2,7 +2,7 @@
 
 namespace WP_Rocket\Tests\Integration\inc\Engine\Optimization\Minify\CSS\Subscriber;
 
-use WP_Rocket\Tests\Integration\FilesystemTestCase;
+use WP_Rocket\Tests\Integration\inc\Engine\Optimization\TestCase;
 
 /**
  * @covers \WP_Rocket\Engine\Optimization\Minify\CSS\Subscriber::process
@@ -17,11 +17,8 @@ use WP_Rocket\Tests\Integration\FilesystemTestCase;
  *
  * @group  MinifyCSS
  */
-class Test_Process extends FilesystemTestCase {
+class Test_Process extends TestCase {
 	protected $path_to_test_data = '/inc/Engine/Optimization/Minify/CSS/Subscriber/process.php';
-	protected $cnames;
-	protected $zones;
-	private   $settings;
 
 	public function setUp() {
 		$this->wp_content_dir = 'vfs://public/wordpress/wp-content';
@@ -37,7 +34,7 @@ class Test_Process extends FilesystemTestCase {
 
 		remove_filter( 'pre_get_rocket_option_minify_css', [ $this, 'return_true' ] );
 		remove_filter( 'pre_get_rocket_option_minify_css_key', [ $this, 'return_key' ] );
-		$this->unset_settings( $this->settings );
+		$this->unsetSettings();
 	}
 
 	/**
@@ -48,77 +45,11 @@ class Test_Process extends FilesystemTestCase {
 		add_filter( 'pre_get_rocket_option_minify_css_key', [ $this, 'return_key' ] );
 
 		$this->settings = $settings;
-		$this->set_settings( $settings );
+		$this->setSettings();
 
 		$this->assertSame(
 			$this->format_the_html( $expected ),
 			$this->format_the_html( apply_filters( 'rocket_buffer', $original ) )
 		);
-	}
-
-	private function set_settings( array $settings ) {
-		foreach ( $settings as $key => $value ) {
-			if ( 'minify_concatenate_css' === $key ) {
-				$callback = $value === 0 ? 'return_false' : 'return_true';
-				add_filter( 'pre_get_rocket_option_minify_concatenate_css', [ $this, $callback ] );
-				continue;
-			}
-
-			if ( 'cdn' === $key ) {
-				$callback = $value === 0 ? 'return_false' : 'return_true';
-				add_filter( 'pre_get_rocket_option_cdn', [ $this, $callback ] );
-				continue;
-			}
-
-			if ( 'cdn_cnames' === $key ) {
-				$this->cnames = $value;
-				add_filter( 'pre_get_rocket_option_cdn_cnames', [ $this, 'set_cnames' ] );
-				continue;
-			}
-
-			if ( 'cdn_zone' === $key ) {
-				$this->zones = $value;
-				add_filter( 'pre_get_rocket_option_cdn_zone', [ $this, 'set_zones' ] );
-				continue;
-			}
-		}
-	}
-
-	private function unset_settings( array $settings ) {
-		foreach ( $settings as $key => $value ) {
-			if ( 'minify_concatenate_css' === $key ) {
-				$callback = $value === 0 ? 'return_false' : 'return_true';
-				remove_filter( 'pre_get_rocket_option_minify_concatenate_css', [ $this, $callback ] );
-				continue;
-			}
-
-			if ( 'cdn' === $key ) {
-				$callback = $value === 0 ? 'return_false' : 'return_true';
-				remove_filter( 'pre_get_rocket_option_cdn', [ $this, $callback ] );
-				continue;
-			}
-
-			if ( 'cdn_cnames' === $key ) {
-				remove_filter( 'pre_get_rocket_option_cdn_cnames', [ $this, 'set_cnames' ] );
-				continue;
-			}
-
-			if ( 'cdn_zone' === $key ) {
-				remove_filter( 'pre_get_rocket_option_cdn_zone', [ $this, 'set_zones' ] );
-				continue;
-			}
-		}
-	}
-
-	public function return_key() {
-		return 123456;
-	}
-
-	public function set_cnames() {
-		return $this->cnames;
-	}
-
-	public function set_zones() {
-		return $this->zones;
 	}
 }

--- a/tests/Integration/inc/Engine/Optimization/Minify/CSS/Subscriber/process.php
+++ b/tests/Integration/inc/Engine/Optimization/Minify/CSS/Subscriber/process.php
@@ -2,17 +2,43 @@
 
 namespace WP_Rocket\Tests\Integration\inc\Engine\Optimization\Minify\CSS\Subscriber;
 
-use Brain\Monkey\Functions;
 use WP_Rocket\Tests\Integration\FilesystemTestCase;
 
 /**
  * @covers \WP_Rocket\Engine\Optimization\Minify\CSS\Subscriber::process
+ * @uses   \WP_Rocket\Engine\Optimization\Minify\CSS\Combine::optimize
+ * @uses   \WP_Rocket\Engine\Optimization\Minify\CSS\Minify::optimize
+ * @uses   ::get_rocket_parse_url
+ * @uses   ::get_rocket_i18n_uri
+ * @uses   ::rocket_url_to_path
+ * @uses   ::rocket_direct_filesystem
+ * @uses   ::rocket_mkdir_p
+ * @uses   ::rocket_put_content
+ *
  * @group  MinifyCSS
  */
 class Test_Process extends FilesystemTestCase {
-    protected $path_to_test_data = '/inc/Engine/Optimization/Minify/CSS/Subscriber/process.php';
-    protected $cnames;
-    protected $zones;
+	protected $path_to_test_data = '/inc/Engine/Optimization/Minify/CSS/Subscriber/process.php';
+	protected $cnames;
+	protected $zones;
+	private   $settings;
+
+	public function setUp() {
+		$this->wp_content_dir = 'vfs://public/wordpress/wp-content';
+
+		parent::setUp();
+
+		// Mocks constants for the virtual filesystem.
+		$this->whenRocketGetConstant();
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+
+		remove_filter( 'pre_get_rocket_option_minify_css', [ $this, 'return_true' ] );
+		remove_filter( 'pre_get_rocket_option_minify_css_key', [ $this, 'return_key' ] );
+		$this->unset_settings( $this->settings );
+	}
 
 	/**
 	 * @dataProvider providerTestData
@@ -20,87 +46,79 @@ class Test_Process extends FilesystemTestCase {
 	public function testShouldMinifyCSS( $original, $expected, $settings ) {
 		add_filter( 'pre_get_rocket_option_minify_css', [ $this, 'return_true' ] );
 		add_filter( 'pre_get_rocket_option_minify_css_key', [ $this, 'return_key' ] );
-		add_filter( 'rocket_wp_content_dir', [ $this, 'virtual_wp_content_dir' ] );
+
+		$this->settings = $settings;
 		$this->set_settings( $settings );
 
 		$this->assertSame(
 			$this->format_the_html( $expected ),
 			$this->format_the_html( apply_filters( 'rocket_buffer', $original ) )
 		);
-
-		$this->unset_settings( $settings );
-		remove_filter( 'pre_get_rocket_option_minify_css', [ $this, 'return_true' ] );
-		remove_filter( 'pre_get_rocket_option_minify_css_key', [ $this, 'return_key' ] );
-		remove_filter( 'rocket_wp_content_dir', [ $this, 'virtual_wp_content_dir' ] );
 	}
 
-    public function virtual_wp_content_dir() {
-        return $this->filesystem->getUrl( 'wordpress/wp-content' );
-    }
+	private function set_settings( array $settings ) {
+		foreach ( $settings as $key => $value ) {
+			if ( 'minify_concatenate_css' === $key ) {
+				$callback = $value === 0 ? 'return_false' : 'return_true';
+				add_filter( 'pre_get_rocket_option_minify_concatenate_css', [ $this, $callback ] );
+				continue;
+			}
 
-    public function return_key() {
-        return 123456;
-    }
+			if ( 'cdn' === $key ) {
+				$callback = $value === 0 ? 'return_false' : 'return_true';
+				add_filter( 'pre_get_rocket_option_cdn', [ $this, $callback ] );
+				continue;
+			}
 
-    private function set_settings( array $settings ) {
-        foreach ( $settings as $key => $value ) {
-            if ( 'minify_concatenate_css' === $key ) {
-                $callback = $value === 0 ? 'return_false' : 'return_true';
-                add_filter( 'pre_get_rocket_option_minify_concatenate_css', [ $this, $callback ] );
-                continue;
-            }
+			if ( 'cdn_cnames' === $key ) {
+				$this->cnames = $value;
+				add_filter( 'pre_get_rocket_option_cdn_cnames', [ $this, 'set_cnames' ] );
+				continue;
+			}
 
-            if ( 'cdn' === $key ) {
-                $callback = $value === 0 ? 'return_false' : 'return_true';
-                add_filter( 'pre_get_rocket_option_cdn', [ $this, $callback ] );
-                continue;
-            }
+			if ( 'cdn_zone' === $key ) {
+				$this->zones = $value;
+				add_filter( 'pre_get_rocket_option_cdn_zone', [ $this, 'set_zones' ] );
+				continue;
+			}
+		}
+	}
 
-            if ( 'cdn_cnames' === $key ) {
-                $this->cnames = $value;
-                add_filter( 'pre_get_rocket_option_cdn_cnames', [ $this, 'set_cnames'] );
-                continue;
-            }
+	private function unset_settings( array $settings ) {
+		foreach ( $settings as $key => $value ) {
+			if ( 'minify_concatenate_css' === $key ) {
+				$callback = $value === 0 ? 'return_false' : 'return_true';
+				remove_filter( 'pre_get_rocket_option_minify_concatenate_css', [ $this, $callback ] );
+				continue;
+			}
 
-            if ( 'cdn_zone' === $key ) {
-                $this->zones = $value;
-                add_filter( 'pre_get_rocket_option_cdn_zone', [ $this, 'set_zones'] );
-                continue;
-            }
-        }
-    }
+			if ( 'cdn' === $key ) {
+				$callback = $value === 0 ? 'return_false' : 'return_true';
+				remove_filter( 'pre_get_rocket_option_cdn', [ $this, $callback ] );
+				continue;
+			}
 
-    private function unset_settings( array $settings ) {
-        foreach ( $settings as $key => $value ) {
-            if ( 'minify_concatenate_css' === $key ) {
-                $callback = $value === 0 ? 'return_false' : 'return_true';
-                remove_filter( 'pre_get_rocket_option_minify_concatenate_css', [ $this, $callback ] );
-                continue;
-            }
+			if ( 'cdn_cnames' === $key ) {
+				remove_filter( 'pre_get_rocket_option_cdn_cnames', [ $this, 'set_cnames' ] );
+				continue;
+			}
 
-            if ( 'cdn' === $key ) {
-                $callback = $value === 0 ? 'return_false' : 'return_true';
-                remove_filter( 'pre_get_rocket_option_cdn', [ $this, $callback ] );
-                continue;
-            }
+			if ( 'cdn_zone' === $key ) {
+				remove_filter( 'pre_get_rocket_option_cdn_zone', [ $this, 'set_zones' ] );
+				continue;
+			}
+		}
+	}
 
-            if ( 'cdn_cnames' === $key ) {
-                remove_filter( 'pre_get_rocket_option_cdn_cnames', [ $this, 'set_cnames'] );
-                continue;
-            }
+	public function return_key() {
+		return 123456;
+	}
 
-            if ( 'cdn_zone' === $key ) {
-                remove_filter( 'pre_get_rocket_option_cdn_zone', [ $this, 'set_zones'] );
-                continue;
-            }
-        }
-    }
+	public function set_cnames() {
+		return $this->cnames;
+	}
 
-    public function set_cnames() {
-        return $this->cnames;
-    }
-
-    public function set_zones() {
-        return $this->zones;
-    }
+	public function set_zones() {
+		return $this->zones;
+	}
 }

--- a/tests/Integration/inc/Engine/Optimization/Minify/JS/Subscriber/process.php
+++ b/tests/Integration/inc/Engine/Optimization/Minify/JS/Subscriber/process.php
@@ -2,7 +2,7 @@
 
 namespace WP_Rocket\Tests\Integration\inc\Engine\Optimization\Minify\JS\Subscriber;
 
-use WP_Rocket\Tests\Integration\FilesystemTestCase;
+use WP_Rocket\Tests\Integration\inc\Engine\Optimization\TestCase;
 
 /**
  * @covers \WP_Rocket\Engine\Optimization\Minify\JS\Subscriber::process
@@ -17,11 +17,8 @@ use WP_Rocket\Tests\Integration\FilesystemTestCase;
  *
  * @group  MinifyJS
  */
-class Test_Process extends FilesystemTestCase {
+class Test_Process extends TestCase {
 	protected $path_to_test_data = '/inc/Engine/Optimization/Minify/JS/Subscriber/process.php';
-	protected $cnames;
-	protected $zones;
-	private   $settings;
 
 	public function setUp() {
 		$this->wp_content_dir = 'vfs://public/wordpress/wp-content';
@@ -37,7 +34,7 @@ class Test_Process extends FilesystemTestCase {
 
 		remove_filter( 'pre_get_rocket_option_minify_js', [ $this, 'return_true' ] );
 		remove_filter( 'pre_get_rocket_option_minify_js_key', [ $this, 'return_key' ] );
-		$this->unset_settings( $this->settings );
+		$this->unsetSettings();
 	}
 
 	/**
@@ -48,79 +45,11 @@ class Test_Process extends FilesystemTestCase {
 		add_filter( 'pre_get_rocket_option_minify_js_key', [ $this, 'return_key' ] );
 
 		$this->settings = $settings;
-		$this->set_settings( $settings );
+		$this->setSettings();
 
 		$this->assertSame(
 			$this->format_the_html( $expected ),
 			$this->format_the_html( apply_filters( 'rocket_buffer', $original ) )
 		);
-
-		$this->unset_settings( $settings );
-	}
-
-	private function set_settings( array $settings ) {
-		foreach ( $settings as $key => $value ) {
-			if ( 'minify_concatenate_js' === $key ) {
-				$callback = 0 === $value ? 'return_false' : 'return_true';
-				add_filter( 'pre_get_rocket_option_minify_concatenate_js', [ $this, $callback ] );
-				continue;
-			}
-
-			if ( 'cdn' === $key ) {
-				$callback = 0 === $value ? 'return_false' : 'return_true';
-				add_filter( 'pre_get_rocket_option_cdn', [ $this, $callback ] );
-				continue;
-			}
-
-			if ( 'cdn_cnames' === $key ) {
-				$this->cnames = $value;
-				add_filter( 'pre_get_rocket_option_cdn_cnames', [ $this, 'set_cnames' ] );
-				continue;
-			}
-
-			if ( 'cdn_zone' === $key ) {
-				$this->zones = $value;
-				add_filter( 'pre_get_rocket_option_cdn_zone', [ $this, 'set_zones' ] );
-				continue;
-			}
-		}
-	}
-
-	private function unset_settings( array $settings ) {
-		foreach ( $settings as $key => $value ) {
-			if ( 'minify_concatenate_js' === $key ) {
-				$callback = 0 === $value ? 'return_false' : 'return_true';
-				remove_filter( 'pre_get_rocket_option_minify_concatenate_js', [ $this, $callback ] );
-				continue;
-			}
-
-			if ( 'cdn' === $key ) {
-				$callback = 0 === $value ? 'return_false' : 'return_true';
-				remove_filter( 'pre_get_rocket_option_cdn', [ $this, $callback ] );
-				continue;
-			}
-
-			if ( 'cdn_cnames' === $key ) {
-				remove_filter( 'pre_get_rocket_option_cdn_cnames', [ $this, 'set_cnames' ] );
-				continue;
-			}
-
-			if ( 'cdn_zone' === $key ) {
-				remove_filter( 'pre_get_rocket_option_cdn_zone', [ $this, 'set_zones' ] );
-				continue;
-			}
-		}
-	}
-
-	public function return_key() {
-		return 123456;
-	}
-
-	public function set_cnames() {
-		return $this->cnames;
-	}
-
-	public function set_zones() {
-		return $this->zones;
 	}
 }

--- a/tests/Integration/inc/Engine/Optimization/QueryString/RemoveSubscriber/process.php
+++ b/tests/Integration/inc/Engine/Optimization/QueryString/RemoveSubscriber/process.php
@@ -2,18 +2,23 @@
 
 namespace WP_Rocket\Tests\Integration\inc\Engine\Optimization\QueryString\RemoveSubscriber;
 
-use WP_Rocket\Tests\Integration\FilesystemTestCase;
+use WP_Rocket\Tests\Integration\inc\Engine\Optimization\TestCase;
 
 /**
  * @covers \WP_Rocket\Engine\Optimization\QueryString\RemoveSubscriber::process
+ * @uses   \WP_Rocket\Engine\Optimization\QueryString\Remove::remove_query_strings_css
+ * @uses   \WP_Rocket\Engine\Optimization\QueryString\Remove::remove_query_strings_js
+ * @uses   ::get_rocket_parse_url
+ * @uses   ::rocket_direct_filesystem
+ * @uses   ::get_rocket_i18n_uri
+ * @uses   ::rocket_url_to_path
+ * @uses   ::rocket_mkdir_p
+ * @uses   ::rocket_put_content
  *
  * @group  RemoveQueryStrings
  */
-class Test_Process extends FilesystemTestCase {
-    protected $path_to_test_data = '/inc/Engine/Optimization/QueryString/RemoveSubscriber/remove-query-strings.php';
-    protected $cnames;
-    protected $zones;
-    private $settings;
+class Test_Process extends TestCase {
+	protected $path_to_test_data = '/inc/Engine/Optimization/QueryString/RemoveSubscriber/remove-query-strings.php';
 
 	public function setUp() {
 		parent::setUp();
@@ -25,7 +30,7 @@ class Test_Process extends FilesystemTestCase {
 	public function tearDown() {
 		parent::tearDown();
 
-		$this->unset_settings();
+		$this->unsetSettings();
 		remove_filter( 'pre_get_rocket_option_remove_query_strings', [ $this, 'return_true' ] );
 	}
 
@@ -36,50 +41,11 @@ class Test_Process extends FilesystemTestCase {
 		add_filter( 'pre_get_rocket_option_remove_query_strings', [ $this, 'return_true' ] );
 
 		$this->settings = $settings;
-		$this->set_settings();
+		$this->setSettings();
 
 		$this->assertSame(
 			$expected,
 			apply_filters( 'rocket_buffer', $original )
 		);
 	}
-
-    private function set_settings() {
-        foreach ( (array) $this->settings as $key => $value ) {
-	        $this->handleSetting( $key, $value );
-        }
-    }
-
-    private function unset_settings() {
-        foreach ( (array) $this->settings as $key => $value ) {
-        	$this->handleSetting( $key, $value, false );
-        }
-    }
-
-    private function handleSetting( $key, $value, $set = true ) {
-		$func = $set ? 'add_filter' : 'remove_filter';
-
-		switch( $key ) {
-		    case 'cdn':
-			    $callback = 0 === $value ? 'return_false' : 'return_true';
-			    $func( 'pre_get_rocket_option_cdn', [ $this, $callback ] );
-
-			    break;
-		    case 'cdn_cnames':
-			    $this->cnames = $value;
-			    $func( 'pre_get_rocket_option_cdn_cnames', [ $this, 'set_cnames'] );
-			    break;
-		    case 'cdn_zone':
-			    $this->zones = $value;
-			    $func( 'pre_get_rocket_option_cdn_zone', [ $this, 'set_zones'] );
-	    }
-    }
-
-    public function set_cnames() {
-        return $this->cnames;
-    }
-
-    public function set_zones() {
-        return $this->zones;
-    }
 }

--- a/tests/Integration/inc/Engine/Optimization/TestCase.php
+++ b/tests/Integration/inc/Engine/Optimization/TestCase.php
@@ -1,0 +1,64 @@
+<?php
+
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\Optimization;
+
+use WP_Rocket\Tests\Integration\FilesystemTestCase;
+
+abstract class TestCase extends FilesystemTestCase {
+	protected $cnames;
+	protected $zones;
+	protected   $settings;
+
+	protected function setSettings() {
+		foreach ( (array) $this->settings as $key => $value ) {
+			$this->handleSetting( $key, $value );
+		}
+	}
+
+	protected function unsetSettings() {
+		foreach ( (array) $this->settings as $key => $value ) {
+			$this->handleSetting( $key, $value, false );
+		}
+	}
+
+	protected function handleSetting( $key, $value, $set = true ) {
+		$func = $set ? 'add_filter' : 'remove_filter';
+		$callback = $value === 0 ? 'return_false' : 'return_true';
+
+		switch( $key ) {
+			case 'minify_concatenate_css':
+				$func( 'pre_get_rocket_option_minify_concatenate_css', [ $this, $callback ] );
+				break;
+
+			case 'minify_concatenate_js':
+				$func( 'pre_get_rocket_option_minify_concatenate_js', [ $this, $callback ] );
+				break;
+
+			case 'cdn':
+				$func( 'pre_get_rocket_option_cdn', [ $this, $callback ] );
+				break;
+
+			case 'cdn_cnames':
+				$this->cnames = $value;
+				$func( 'pre_get_rocket_option_cdn_cnames', [ $this, 'set_cnames' ] );
+				break;
+
+			case 'cdn_zone':
+				$this->zones = $value;
+				$func( 'pre_get_rocket_option_cdn_zone', [ $this, 'set_zones' ] );
+		}
+	}
+
+	public function return_key() {
+		return 123456;
+	}
+
+	public function set_cnames() {
+		return $this->cnames;
+	}
+
+	public function set_zones() {
+		return $this->zones;
+	}
+}

--- a/tests/VirtualFilesystemTrait.php
+++ b/tests/VirtualFilesystemTrait.php
@@ -10,7 +10,9 @@ trait VirtualFilesystemTrait {
 	protected $shouldNotClean    = [];
 	protected $entriesBefore     = [];
 	protected $dumpResults       = false;
+	protected $abspath           = 'vfs://public/';
 	protected $wp_cache_constant = false;
+	protected $wp_content_dir    = 'vfs://public/wp-content';
 
 	protected function initDefaultStructure() {
 		if ( empty( $this->config ) ) {
@@ -127,7 +129,7 @@ trait VirtualFilesystemTrait {
 	protected function getConstant( $constant_name, $default = null ) {
 		switch ( $constant_name ) {
 			case 'ABSPATH':
-				return 'vfs://public/';
+				return $this->abspath;
 
 			case 'FS_CHMOD_DIR':
 				return 0777;
@@ -139,25 +141,25 @@ trait VirtualFilesystemTrait {
 				return $this->wp_cache_constant;
 
 			case 'WP_CONTENT_DIR':
-				return 'vfs://public/wp-content';
+				return $this->wp_content_dir;
 
 			case 'WP_ROCKET_CACHE_PATH':
-				return 'vfs://public/wp-content/cache/wp-rocket/';
+				return "{$this->wp_content_dir}/cache/wp-rocket/";
 
 			case 'WP_ROCKET_CONFIG_PATH':
-				return 'vfs://public/wp-content/wp-rocket-config/';
+				return "{$this->wp_content_dir}/wp-rocket-config/";
 
 			case 'WP_ROCKET_INC_PATH':
-				return 'vfs://public/wp-content/plugins/wp-rocket/inc/';
+				return "{$this->wp_content_dir}/plugins/wp-rocket/inc/";
 
 			case 'WP_ROCKET_PATH':
-				return 'vfs://public/wp-content/plugins/wp-rocket/';
+				return "{$this->wp_content_dir}/plugins/wp-rocket/";
 
 			case 'WP_ROCKET_PHP_VERSION':
 				return '5.6';
 
 			case 'WP_ROCKET_VENDORS_PATH':
-				return 'vfs://public/wp-content/plugins/wp-rocket/inc/vendors/';
+				return "{$this->wp_content_dir}/plugins/wp-rocket/inc/vendors/";
 
 			default:
 				if ( ! rocket_has_constant( $constant_name ) ) {


### PR DESCRIPTION
The filter was added for testing purposes, but is not longer needed. This PR removes the filter and then updates the tests that were using it.