### PR TITLE
Fixes "max execution time" when due to "path" matching

### DIFF
--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -1375,6 +1375,7 @@ function _rocket_get_cache_path_iterator( $cache_path ) { // phpcs:ignore WordPr
 /**
  * Gets the entries from the URL using RegexIterator.
  *
+ * @since  3.5.5 Limited regex search to exact "path" matches.
  * @since  3.5.4
  * @access private
  *
@@ -1403,7 +1404,7 @@ function _rocket_get_entries_regex( Iterator $iterator, $url, $cache_path = '' )
 			$path = str_replace( '/', '\/', $path );
 		}
 
-		$regex = "/{$host}(.*)\/{$path}/i";
+		$regex = "/{$host}(.*)\/{$path}\b/i";
 	} else {
 		$regex = "/{$host}(.*)/i";
 		$depth = 0;


### PR DESCRIPTION
This PR fixes the URL "path" matching by limiting it to exact word matches. We have customers who have experienced "max execution time" errors due to this specific problem.

How fixed? 

Adds `\b` to the `_rocket_get_entries_regex()` "path" regex.

This fix does not need QA. Why? @vmanthos has applied the change to an impacted customer and validated that it did fix the problem.

Note: The `max execution time` error may also be caused by other problems. This PR fixes the one bug we've validated thus far.