### PR TITLE
Fix #2618 for rocket_clean_files() by running RegexIterator once.

### DIFF
--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -1463,11 +1463,6 @@ function _rocket_get_cache_dirs( $url_host, $cache_path = '', $hard_reset = fals
 			new FilesystemIterator( $cache_path )
 		);
 	} catch ( Exception $e ) {
-		if ( isset( $GLOBALS['debug_fs'] ) ) {
-			echo "\n Iterator error: {$e->getMessage()} \n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		}
-
-		// No logging yet.
 		return [];
 	}
 
@@ -1476,20 +1471,12 @@ function _rocket_get_cache_dirs( $url_host, $cache_path = '', $hard_reset = fals
 	try {
 		$entries = new RegexIterator( $iterator, $regex );
 	} catch ( Exception $e ) {
-		if ( isset( $GLOBALS['debug_fs'] ) ) {
-			echo "\n RegexIterator error: {$e->getMessage()} \n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		}
-
 		return [];
 	}
 
 	$domain_dirs[ $url_host ] = [];
 	foreach ( $entries as $entry ) {
 		$domain_dirs[ $url_host ][] = $entry->getPathname();
-	}
-
-	if ( isset( $GLOBALS['debug_fs'] ) ) {
-		var_dump( $domain_dirs ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped, WordPress.PHP.DevelopmentFunctions.error_log_var_dump
 	}
 
 	return $domain_dirs[ $url_host ];

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -610,6 +610,9 @@ function rocket_clean_cache_busting( $extensions = [ 'js', 'css' ] ) {
  */
 function rocket_clean_files( $urls ) {
 	$urls = (array) $urls;
+	if ( empty( $urls ) ) {
+		return;
+	}
 
 	/**
 	 * Filter URLs that the cache file to be deleted.
@@ -624,15 +627,10 @@ function rocket_clean_files( $urls ) {
 		return;
 	}
 
-	$cache_path = rocket_get_constant( 'WP_ROCKET_CACHE_PATH' );
-	$iterator   = _rocket_get_cache_path_iterator( $cache_path );
-	if ( false === $iterator ) {
-		return;
-	}
-
 	/** This filter is documented in inc/front/htaccess.php */
-	$url_no_dots      = (bool) apply_filters( 'rocket_url_no_dots', false );
-	$cache_path_regex = str_replace( '/', '\/', $cache_path );
+	$url_no_dots = (bool) apply_filters( 'rocket_url_no_dots', false );
+	$filesystem  = rocket_direct_filesystem();
+	$cache_path  = rocket_get_constant( 'WP_ROCKET_CACHE_PATH' );
 
 	/**
 	 * Fires before all cache files are deleted.
@@ -644,6 +642,7 @@ function rocket_clean_files( $urls ) {
 	do_action( 'before_rocket_clean_files', $urls ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
 
 	foreach ( $urls as $url ) {
+
 		/**
 		 * Fires before the cache file is deleted.
 		 *
@@ -657,8 +656,20 @@ function rocket_clean_files( $urls ) {
 			$url = str_replace( '.', '_', $url );
 		}
 
-		foreach ( _rocket_get_entries_regex( $iterator, $url, $cache_path_regex ) as $entry ) {
-			rocket_rrmdir( $entry->getPathname() );
+		$parsed_url = get_rocket_parse_url( $url );
+
+		foreach ( _rocket_get_cache_dirs( $parsed_url['host'], $cache_path ) as $dir ) {
+			$entry = $dir . $parsed_url['path'];
+			// Skip if the dir/file does not exist.
+			if ( ! $filesystem->exists( $entry ) ) {
+				continue;
+			}
+
+			if ( $filesystem->is_dir( $entry ) ) {
+				rocket_rrmdir( $entry, [] );
+			} else {
+				$filesystem->delete( $entry );
+			}
 		}
 
 		/**
@@ -1416,4 +1427,64 @@ function _rocket_get_entries_regex( Iterator $iterator, $url, $cache_path = '' )
 	} catch ( Exception $e ) {
 		return [];
 	}
+}
+
+/**
+ * Gets the directories for the given URL host from the cache/wp-rocket/ directory or stored memory.
+ *
+ * @since 3.5.5
+ * @access private
+ *
+ * @param string $url_host   The URL's host.
+ * @param string $cache_path Cache's path, e.g. cache/wp-rocket/.
+ * @param bool   $hard_reset Optional. When true, resets the static domain directories array and bails out.
+ *
+ * @return array
+ */
+function _rocket_get_cache_dirs( $url_host, $cache_path = '', $hard_reset = false ) {
+	static $domain_dirs = [];
+
+	if ( true === $hard_reset ) {
+		$domain_dirs = [];
+
+		return;
+	}
+
+	if ( isset( $domain_dirs[ $url_host ] ) ) {
+		return $domain_dirs[ $url_host ];
+	}
+
+	if ( empty( $cache_path ) ) {
+		$cache_path = rocket_get_constant( 'WP_ROCKET_CACHE_PATH' );
+	}
+
+	try {
+		$iterator = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator( $cache_path ),
+			RecursiveIteratorIterator::SELF_FIRST,
+			RecursiveIteratorIterator::CATCH_GET_CHILD
+		);
+	} catch ( Exception $e ) {
+		// No logging yet.
+		return [];
+	}
+
+	$regex = sprintf( '/%s%s(.*)/i',
+		str_replace( '/', '\/', $cache_path ),
+		$url_host
+	);
+	$iterator->setMaxDepth( 0 );
+
+	try {
+		$entries = new RegexIterator( $iterator, $regex );
+	} catch ( Exception $e ) {
+		return [];
+	}
+
+	$domain_dirs[ $url_host ] = [];
+	foreach ( $entries as $entry ) {
+		$domain_dirs[ $url_host ][] = $entry->getPathname();
+	}
+
+	return $domain_dirs[ $url_host ];
 }

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -615,14 +615,6 @@ function rocket_clean_files( $urls, $filesystem = null ) {
 		return;
 	}
 
-	/**
-	 * Filter URLs that the cache file to be deleted.
-	 *
-	 * @since 1.1.0
-	 *
-	 * @param array URLs that will be returned.
-	 */
-	$urls = (array) apply_filters( 'rocket_clean_files', $urls );
 	$urls = array_filter( $urls );
 	if ( empty( $urls ) ) {
 		return;
@@ -1461,8 +1453,6 @@ function _rocket_get_cache_dirs( $url_host, $cache_path = '', $hard_reset = fals
 	if ( isset( $domain_dirs[ $url_host ] ) ) {
 		return $domain_dirs[ $url_host ];
 	}
-
-	$url_host = rtrim( $url_host, '*' );
 
 	if ( empty( $cache_path ) ) {
 		$cache_path = rocket_get_constant( 'WP_ROCKET_CACHE_PATH' );

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -1466,7 +1466,7 @@ function _rocket_get_cache_dirs( $url_host, $cache_path = '', $hard_reset = fals
 		return [];
 	}
 
-	$regex = sprintf( '/%s%s(.*)/i', str_replace( '/', '\/', $cache_path ), $url_host );
+	$regex = sprintf( '/%1$s%2$s(.*)/i', str_replace( '/', '\/', $cache_path ), $url_host );
 
 	try {
 		$entries = new RegexIterator( $iterator, $regex );

--- a/tests/Fixtures/inc/functions/rocketCleanFiles.php
+++ b/tests/Fixtures/inc/functions/rocketCleanFiles.php
@@ -12,12 +12,12 @@ return [
 				'cleaned' => [],
 			],
 		],
-		'shouldDeleteSingleDirUrl'                              => [
+		'shouldDeleteSingleDirUrl' => [
 			'urls'     => [
 				'http://baz.example.org/',
 			],
 			'expected' => [
-				'cleaned' => [
+				'cleaned'      => [
 					'vfs://public/wp-content/cache/wp-rocket/baz.example.org/' => [],
 				],
 			],

--- a/tests/Fixtures/inc/functions/rocketCleanFiles.php
+++ b/tests/Fixtures/inc/functions/rocketCleanFiles.php
@@ -12,12 +12,12 @@ return [
 				'cleaned' => [],
 			],
 		],
-		'shouldDeleteSingleDirUrl' => [
+		'shouldDeleteSingleDirUrl'                              => [
 			'urls'     => [
 				'http://baz.example.org/',
 			],
 			'expected' => [
-				'cleaned'      => [
+				'cleaned' => [
 					'vfs://public/wp-content/cache/wp-rocket/baz.example.org/' => [],
 				],
 			],

--- a/tests/Fixtures/inc/functions/rocketCleanFiles.php
+++ b/tests/Fixtures/inc/functions/rocketCleanFiles.php
@@ -6,23 +6,49 @@ return [
 
 	// Test data.
 	'test_data' => [
-		'shouldBailOutWhenNoURLsToClean'              => [
+		'shouldBailOutWhenNoURLsToClean'                        => [
 			'urls'     => [],
 			'expected' => [
 				'cleaned' => [],
 			],
 		],
-		'shouldDeleteSingleUrl'                       => [
+		'shouldDeleteSingleDirUrl'                              => [
 			'urls'     => [
 				'http://baz.example.org/',
 			],
 			'expected' => [
-				'cleaned'      => [
+				'cleaned' => [
 					'vfs://public/wp-content/cache/wp-rocket/baz.example.org/' => [],
 				],
 			],
 		],
-		'shouldDeletePageUrlInCacheAndUserCache'      => [
+		'shouldDeleteSingleFileUrlFromDomainAndUserCaches'      => [
+			'urls'     => [
+				'http://example.org/index.html',
+			],
+			'expected' => [
+				'cleaned' => [
+					'vfs://public/wp-content/cache/wp-rocket/example.org/index.html'                => null,
+					'vfs://public/wp-content/cache/wp-rocket/example.org-wpmedia-123456/index.html' => null,
+					'vfs://public/wp-content/cache/wp-rocket/example.org-tester-987654/index.html'  => null,
+				],
+			],
+		],
+		'shouldDeleteGrandchildFilesUrlFromDomainAndUserCaches' => [
+			'urls'     => [
+				'http://example.org/nec-ullamcorper/enim-nunc-faucibus/index.html',
+				'http://example.org/nec-ullamcorper/enim-nunc-faucibus/index.html_gzip',
+			],
+			'expected' => [
+				'cleaned' => [
+					'vfs://public/wp-content/cache/wp-rocket/example.org/nec-ullamcorper/enim-nunc-faucibus/index.html'                    => null,
+					'vfs://public/wp-content/cache/wp-rocket/example.org/nec-ullamcorper/enim-nunc-faucibus/index.html_gzip'               => null,
+					'vfs://public/wp-content/cache/wp-rocket/example.org-tester-987654/nec-ullamcorper/enim-nunc-faucibus/index.html'      => null,
+					'vfs://public/wp-content/cache/wp-rocket/example.org-tester-987654/nec-ullamcorper/enim-nunc-faucibus/index.html_gzip' => null,
+				],
+			],
+		],
+		'shouldDeletePageUrlInCacheAndUserCache'                => [
 			'urls'     => [
 				'http://example.org/lorem-ipsum/',
 			],
@@ -33,7 +59,7 @@ return [
 				],
 			],
 		],
-		'shouldDeleteChildPageUrlInCacheAndUserCache' => [
+		'shouldDeleteChildPageUrlInCacheAndUserCache'           => [
 			'urls'     => [
 				'http://example.org/nec-ullamcorper/enim-nunc-faucibus/',
 			],
@@ -44,7 +70,7 @@ return [
 				],
 			],
 		],
-		'shouldDeleteLangUrlInCacheAndUserCaches'     => [
+		'shouldDeleteLangUrlInCacheAndUserCaches'               => [
 			'urls'     => [
 				'http://example.org/fr/',
 			],
@@ -56,7 +82,27 @@ return [
 				],
 			],
 		],
-		'shouldDeleteSiteUrlInCacheAndUserCaches'     => [
+		'shouldDeleteDirsAndFilesUrlInCacheAndUserCache'        => [
+			'urls'     => [
+				'http://example.org/category/wordpress/',
+				'http://example.org/lorem-ipsum/',
+				'http://example.org/nec-ullamcorper/enim-nunc-faucibus/index.html',
+				'http://example.org/nec-ullamcorper/enim-nunc-faucibus/index.html_gzip',
+			],
+			'expected' => [
+				'cleaned' => [
+					'vfs://public/wp-content/cache/wp-rocket/example.org/category/wordpress/'         => null,
+					'vfs://public/wp-content/cache/wp-rocket/example.org/lorem-ipsum/'                => null,
+					'vfs://public/wp-content/cache/wp-rocket/example.org-wpmedia-123456/lorem-ipsum/' => null,
+
+					'vfs://public/wp-content/cache/wp-rocket/example.org/nec-ullamcorper/enim-nunc-faucibus/index.html'                    => null,
+					'vfs://public/wp-content/cache/wp-rocket/example.org/nec-ullamcorper/enim-nunc-faucibus/index.html_gzip'               => null,
+					'vfs://public/wp-content/cache/wp-rocket/example.org-tester-987654/nec-ullamcorper/enim-nunc-faucibus/index.html'      => null,
+					'vfs://public/wp-content/cache/wp-rocket/example.org-tester-987654/nec-ullamcorper/enim-nunc-faucibus/index.html_gzip' => null,
+				],
+			],
+		],
+		'shouldDeleteSiteUrlInCacheAndUserCaches'               => [
 			'urls'     => [
 				'http://example.org/',
 			],

--- a/tests/Integration/inc/functions/rocketCleanFiles.php
+++ b/tests/Integration/inc/functions/rocketCleanFiles.php
@@ -20,7 +20,7 @@ class Test_RocketCleanFiles extends FilesystemTestCase {
 	public function tearDown() {
 		parent::tearDown();
 
-		unset( $GLOBALS['tonya'] );
+		unset( $GLOBALS['debug_fs'] );
 	}
 
 	/**
@@ -31,7 +31,7 @@ class Test_RocketCleanFiles extends FilesystemTestCase {
 		$this->generateEntriesShouldExistAfter( $expected['cleaned'] );
 
 		if ( isset( $expected['debug'] ) && $expected['debug'] ) {
-			$GLOBALS['tonya'] = true;
+			$GLOBALS['debug_fs'] = true;
 		}
 
 		// Run it.

--- a/tests/Integration/inc/functions/rocketCleanFiles.php
+++ b/tests/Integration/inc/functions/rocketCleanFiles.php
@@ -2,21 +2,26 @@
 
 namespace WP_Rocket\Tests\Integration\inc\functions;
 
-use Brain\Monkey\Functions;
 use WP_Rocket\Tests\Integration\FilesystemTestCase;
 
 /**
  * @covers ::rocket_clean_files
  * @uses  ::rocket_rrmdir
- * @uses  ::_rocket_get_cache_path_iterator
- * @uses  ::_rocket_get_entries_regex
+ * @uses  ::_rocket_get_cache_dirs
  *
  * @group Functions
  * @group Files
  * @group vfs
+ * @group rocket_clean_files
  */
 class Test_RocketCleanFiles extends FilesystemTestCase {
 	protected $path_to_test_data = '/inc/functions/rocketCleanFiles.php';
+
+	public function tearDown() {
+		parent::tearDown();
+
+		unset( $GLOBALS['tonya'] );
+	}
 
 	/**
 	 * @dataProvider providerTestData
@@ -24,6 +29,10 @@ class Test_RocketCleanFiles extends FilesystemTestCase {
 	public function testShouldCleanExpectedFiles( $urls, $expected ) {
 		$this->dumpResults = isset( $expected['dump_results'] ) ? $expected['dump_results'] : false;
 		$this->generateEntriesShouldExistAfter( $expected['cleaned'] );
+
+		if ( isset( $expected['debug'] ) && $expected['debug'] ) {
+			$GLOBALS['tonya'] = true;
+		}
 
 		// Run it.
 		rocket_clean_files( $urls );

--- a/tests/Integration/inc/functions/rocketCleanFiles.php
+++ b/tests/Integration/inc/functions/rocketCleanFiles.php
@@ -17,6 +17,20 @@ use WP_Rocket\Tests\Integration\FilesystemTestCase;
 class Test_RocketCleanFiles extends FilesystemTestCase {
 	protected $path_to_test_data = '/inc/functions/rocketCleanFiles.php';
 
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		// Clean out the cached dirs before we run these tests.
+		_rocket_get_cache_dirs( '', '', true );
+	}
+
+	public static function tearDownAfterClass() {
+		parent::tearDownAfterClass();
+
+		// Clean out the cached dirs before we leave this test class.
+		_rocket_get_cache_dirs( '', '', true );
+	}
+
 	public function tearDown() {
 		parent::tearDown();
 

--- a/tests/Unit/inc/functions/rocketCleanFiles.php
+++ b/tests/Unit/inc/functions/rocketCleanFiles.php
@@ -44,7 +44,7 @@ class Test_RocketCleanFiles extends FilesystemTestCase {
 		}
 
 		if ( empty( $urls ) ) {
-			$this->doBailOutTest( $urls );
+			$this->doBailOutTest();
 		} else {
 			$this->doCleanFilesTest( $urls, $expected );
 		}
@@ -53,8 +53,7 @@ class Test_RocketCleanFiles extends FilesystemTestCase {
 		rocket_clean_files( $urls );
 	}
 
-	private function doBailOutTest( $urls ) {
-		Filters\expectApplied( 'rocket_clean_files' )->never();
+	private function doBailOutTest() {
 		Filters\expectApplied( 'rocket_url_no_dots' )->never();
 		Actions\expectDone( 'before_rocket_clean_files' )->never();
 		Actions\expectDone( 'before_rocket_clean_file' )->never();
@@ -64,22 +63,13 @@ class Test_RocketCleanFiles extends FilesystemTestCase {
 	}
 
 	private function doCleanFilesTest( $urls, $expected ) {
-		$regex_urls = [];
-		foreach ( $urls as $url ) {
-			$host         = parse_url( $url, PHP_URL_HOST );
-			$regex_urls[] = str_replace( $host, "{$host}*", $url );
-		}
-
-		Filters\expectApplied( 'rocket_clean_files' )
-			->once()
-			->with( $urls )
-			->andReturn( $regex_urls );
 		Filters\expectApplied( 'rocket_url_no_dots' )
 			->once()
 			->with( false )
 			->andReturnFirstArg();
-		Actions\expectDone( 'before_rocket_clean_files' )->once()->with( $regex_urls );
-		foreach ( $regex_urls as $url ) {
+		Actions\expectDone( 'before_rocket_clean_files' )->once()->with( $urls );
+
+		foreach ( $urls as $url ) {
 			Actions\expectDone( 'before_rocket_clean_file' )->once()->with( $url );
 			Functions\expect( 'get_rocket_parse_url' )
 				->once()

--- a/tests/Unit/inc/functions/rocketCleanFiles.php
+++ b/tests/Unit/inc/functions/rocketCleanFiles.php
@@ -29,10 +29,20 @@ class Test_RocketCleanFiles extends FilesystemTestCase {
 			->andReturn( 'vfs://public/wp-content/cache/wp-rocket/' );
 	}
 
+	public function tearDown() {
+		parent::tearDown();
+
+		unset( $GLOBALS['debug_fs'] );
+	}
+
 	/**
 	 * @dataProvider providerTestData
 	 */
 	public function testShouldCleanExpectedFiles( $urls, $expected ) {
+		if ( isset( $expected['debug'] ) && $expected['debug'] ) {
+			$GLOBALS['debug_fs'] = true;
+		}
+
 		if ( empty( $urls ) ) {
 			$this->doBailOutTest( $urls );
 		} else {

--- a/tests/Unit/inc/functions/rocketCleanFiles.php
+++ b/tests/Unit/inc/functions/rocketCleanFiles.php
@@ -16,6 +16,7 @@ use WP_Rocket\Tests\Unit\FilesystemTestCase;
  * @group Functions
  * @group Files
  * @group vfs
+ * @group rocket_clean_files
  */
 class Test_RocketCleanFiles extends FilesystemTestCase {
 	protected $path_to_test_data = '/inc/functions/rocketCleanFiles.php';
@@ -43,10 +44,7 @@ class Test_RocketCleanFiles extends FilesystemTestCase {
 	}
 
 	private function doBailOutTest( $urls ) {
-		Filters\expectApplied( 'rocket_clean_files' )
-			->once()
-			->with( $urls )
-			->andReturn( [] );
+		Filters\expectApplied( 'rocket_clean_files' )->never();
 		Filters\expectApplied( 'rocket_url_no_dots' )->never();
 		Actions\expectDone( 'before_rocket_clean_files' )->never();
 		Actions\expectDone( 'before_rocket_clean_file' )->never();
@@ -93,11 +91,14 @@ class Test_RocketCleanFiles extends FilesystemTestCase {
 		}
 
 		foreach ( array_keys( $expected['cleaned'] ) as $file ) {
-			$file = rtrim( $file, '/\\' );
-			Functions\expect( 'rocket_rrmdir' )
-				->once()
-				->with( $file )
-				->andReturnNull();
+			if ( $this->filesystem->is_dir( $file ) ) {
+				Functions\expect( 'rocket_rrmdir' )
+					->once()
+					->with( $file, [] )
+					->andReturnNull();
+			} else {
+				Functions\expect( 'rocket_rrmdir' )->with( $file )->never();
+			}
 		}
 	}
 }

--- a/tests/Unit/inc/functions/rocketCleanFiles.php
+++ b/tests/Unit/inc/functions/rocketCleanFiles.php
@@ -10,8 +10,7 @@ use WP_Rocket\Tests\Unit\FilesystemTestCase;
 /**
  * @covers ::rocket_clean_files
  * @uses  ::rocket_rrmdir
- * @uses  ::_rocket_get_cache_path_iterator
- * @uses  ::_rocket_get_entries_regex
+ * @uses  ::_rocket_get_cache_dirs
  *
  * @group Functions
  * @group Files
@@ -20,6 +19,20 @@ use WP_Rocket\Tests\Unit\FilesystemTestCase;
  */
 class Test_RocketCleanFiles extends FilesystemTestCase {
 	protected $path_to_test_data = '/inc/functions/rocketCleanFiles.php';
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		// Clean out the cached dirs before we run these tests.
+		_rocket_get_cache_dirs( '', '', true );
+	}
+
+	public static function tearDownAfterClass() {
+		parent::tearDownAfterClass();
+
+		// Clean out the cached dirs before we leave this test class.
+		_rocket_get_cache_dirs( '', '', true );
+	}
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/Unit/inc/functions/rocketCleanFiles.php
+++ b/tests/Unit/inc/functions/rocketCleanFiles.php
@@ -104,7 +104,7 @@ class Test_RocketCleanFiles extends FilesystemTestCase {
 			if ( $this->filesystem->is_dir( $file ) ) {
 				Functions\expect( 'rocket_rrmdir' )
 					->once()
-					->with( $file, [] )
+					->with( $file, [], $this->filesystem )
 					->andReturnNull();
 			} else {
 				Functions\expect( 'rocket_rrmdir' )->with( $file )->never();


### PR DESCRIPTION
This PR does the following:

- Redesigns the processing strategy for `rocket_clean_files()` (details below)
- Optimizes its processing by running only the tasks that need to be run, i.e. instead of running them for every given URL.

Results:

- Processing time: `glob()` (<= WPR 3.5.3) === this version with SPL instead of `glob`.
- It also provides scaffolding to further optimize all of the cleaning functionality.

## Background for Context

The previous design used `glob()` (<= v 3.5.3). In WPR 3.5.4, we replaced `glob` with SPL `RegexIterator`. Both of these approaches crawl the filesystem using a wildcard or regex. Why? We need to grab the domain + any user caches for the given URLs to be cleaned. 

For example, let's say the domain is `example.org` and there are 3 user caches for this domain. The cache structure might look like this:

```
cache
	wp-rocket
		example.org
			// cache files/dirs
		example.org-user1-123456
			// cache files/dirs
		example.org-user2-123456
			// cache files/dirs
		example.org-user3-123456
			// cache files/dirs
```

Using a wildcard/regex method allows us to grab all both the domain and all of the user caches. 

But this is an expensive operation. We saw the impact of this when we switched to SPL `RegexIterator`. 

Why? The original design did the wildcard/regex crawl on each and every given URL. When there were 30, 50, 100 URLs given, it took way too long to process these, resulting in timeout errors for some customers. For others, it was visually taking longer to process.

## New Design

The new strategy does the following:

- Only runs the wildcard/regex crawl once for each given URL domain host. 
- It stores these directories, which will be in root of `cache/wp-content/`, in memory.
     - Note: Later we will optimize this further to store in db or via mapping module.
- It then runs each URL with each of these root level cache directories without crawling the filesystem. 
     - If the URL's file/directory does not exist in the cache, it skips and goes to the next one.
     - If it's a directory, it runs `rocket_rrmdir()`.
     - Else, it's a file. It deletes it without running `rocket_rrmdir()`.

## TODO

- [x] Optimization: Add new design
- [x] Optimization: Replace recursive directory and iterator in `_rocket_get_cache_dirs()`
- [x] Optimization: Allow the instance of the filesystem to be passed into `rocket_clean_files()` and `rocket_rrmdir()`
- [x] Optimization: Don't apply `*` after domain's host.
- [x] Add more the test scenarios
- [x] Record benchmarks 🚀 
- [x] Run live tests on our dev test server 🚀 
- [x] Have @vmanthos or @piotrbak  add the changes to customers who are reporting the problem. Validate the design fixes the problem and runs as fast as the WPR 3.5.2.
- [x] QA