### PR TITLE
Closes #2471 - Clean WP Rocket cache when RocketCDN REST Endpoints are called

### DIFF
--- a/inc/Engine/CDN/RocketCDN/CDNOptionsManager.php
+++ b/inc/Engine/CDN/RocketCDN/CDNOptionsManager.php
@@ -51,6 +51,7 @@ class CDNOptionsManager {
 		$this->options_api->set( 'settings', $this->options->get_options() );
 
 		delete_transient( 'rocketcdn_status' );
+		rocket_clean_domain();
 	}
 
 	/**
@@ -69,5 +70,6 @@ class CDNOptionsManager {
 
 		delete_option( 'rocketcdn_user_token' );
 		delete_transient( 'rocketcdn_status' );
+		rocket_clean_domain();
 	}
 }

--- a/tests/Fixtures/inc/Engine/CDN/RocketCDN/CDNOptionsManager/enable_disable.php
+++ b/tests/Fixtures/inc/Engine/CDN/RocketCDN/CDNOptionsManager/enable_disable.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+	// Use in tests when the test data starts in this directory.
+	'vfs_dir'   => 'wp-content/cache/',
+
+	// Test data.
+	'test_data' => [
+		'shouldDeleteAll' => [
+			'cleaned'      => [
+				'vfs://public/wp-content/cache/wp-rocket/example.org/'                => null,
+				'vfs://public/wp-content/cache/wp-rocket/example.org-wpmedia-123456/' => null,
+				'vfs://public/wp-content/cache/wp-rocket/example.org-tester-987654/'  => null,
+			],
+		],
+	],
+];

--- a/tests/Integration/inc/Engine/CDN/RocketCDN/CDNOptionsManager/disable.php
+++ b/tests/Integration/inc/Engine/CDN/RocketCDN/CDNOptionsManager/disable.php
@@ -2,24 +2,31 @@
 
 namespace WP_Rocket\Tests\Integration\inc\Engine\CDN\RocketCDN\CDNOptionsManager;
 
-use WPMedia\PHPUnit\Integration\TestCase;
-use WP_Rocket\Engine\CDN\RocketCDN\CDNOptionsManager;
 use WP_Rocket\Admin\Options;
 use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Tests\Integration\FilesystemTestCase;
+use WP_Rocket\Engine\CDN\RocketCDN\CDNOptionsManager;
 
 /**
  * @covers \WP_Rocket\Engine\CDN\RocketCDN\CDNOptionsManager::disable
+ * @uses :rocket_clean_domain
  * @uses \WP_Rocket\Admin\Options_Data::set
  * @uses \WP_Rocket\Admin\Options::set
  * @uses \WP_Rocket\Admin\Options::get_option_name
  *
  * @group RocketCDN
  */
-class Test_Disable extends TestCase {
+class Test_Disable extends FilesystemTestCase {
+	protected $path_to_test_data = '/inc/Engine/CDN/RocketCDN/CDNOptionsManager/enable_disable.php';
 
-	public function testShouldDisableCDNOptions() {
+	/**
+	 * @dataProvider providerTestData
+	 */
+	public function testShouldDisableCDNOptions( $cleanedUrls ) {
         add_option( 'rocketcdn_user_token', '123456' );
 		set_transient( 'rocketcdn_status', [ 'transient' ], MINUTE_IN_SECONDS );
+
+		$this->generateEntriesShouldExistAfter( $cleanedUrls );
 
 		$options      = new Options( 'wp_rocket_' );
 		$option_array = new Options_Data( $options->get( 'settings' ) );
@@ -41,6 +48,8 @@ class Test_Disable extends TestCase {
 			$this->assertArrayHasKey( $key, $options );
 			$this->assertSame( $value, $options[$key] );
 		}
+
+		$this->checkEntriesDeleted( $cleanedUrls );
 
         $this->assertFalse( get_option( 'rocketcdn_user_token' ) );
 		$this->assertFalse( get_transient( 'rocketcdn_status' ) );

--- a/tests/Integration/inc/Engine/CDN/RocketCDN/CDNOptionsManager/enable.php
+++ b/tests/Integration/inc/Engine/CDN/RocketCDN/CDNOptionsManager/enable.php
@@ -2,23 +2,30 @@
 
 namespace WP_Rocket\Tests\Integration\inc\Engine\CDN\RocketCDN\CDNOptionsManager;
 
-use WPMedia\PHPUnit\Integration\TestCase;
-use WP_Rocket\Engine\CDN\RocketCDN\CDNOptionsManager;
 use WP_Rocket\Admin\Options;
 use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Tests\Integration\FilesystemTestCase;
+use WP_Rocket\Engine\CDN\RocketCDN\CDNOptionsManager;
 
 /**
  * @covers \WP_Rocket\Engine\CDN\RocketCDN\CDNOptionsManager::enable
+ * @uses :rocket_clean_domain
  * @uses \WP_Rocket\Admin\Options_Data::set
  * @uses \WP_Rocket\Admin\Options::set
  * @uses \WP_Rocket\Admin\Options::get_option_name
  *
  * @group RocketCDN
  */
-class Test_Enable extends TestCase {
+class Test_Enable extends FilesystemTestCase {
+	protected $path_to_test_data = '/inc/Engine/CDN/RocketCDN/CDNOptionsManager/enable_disable.php';
 
-	public function testShouldEnableCDNOptions() {
+	/**
+	 * @dataProvider providerTestData
+	 */
+	public function testShouldEnableCDNOptions( $cleanedUrls ) {
 		set_transient( 'rocketcdn_status', [ 'transient' ], MINUTE_IN_SECONDS );
+
+		$this->generateEntriesShouldExistAfter( $cleanedUrls );
 
 		$options      = new Options( 'wp_rocket_' );
 		$option_array = new Options_Data( $options->get( 'settings' ) );
@@ -40,6 +47,8 @@ class Test_Enable extends TestCase {
 			$this->assertArrayHasKey( $key, $options );
 			$this->assertSame( $value, $options[$key] );
 		}
+
+		$this->checkEntriesDeleted( $cleanedUrls );
 
 		$this->assertFalse( get_transient( 'rocketcdn_status' ) );
 	}

--- a/tests/Unit/inc/Engine/CDN/RocketCDN/CDNOptionsManager/disable.php
+++ b/tests/Unit/inc/Engine/CDN/RocketCDN/CDNOptionsManager/disable.php
@@ -44,6 +44,8 @@ class Test_Disable extends TestCase {
 				->once()
 		        ->with( 'settings', $expected );
 
+		Functions\expect( 'rocket_clean_domain' )->once();
+
 		( new CDNOptionsManager(
 			$options,
 			$options_array

--- a/tests/Unit/inc/Engine/CDN/RocketCDN/CDNOptionsManager/enable.php
+++ b/tests/Unit/inc/Engine/CDN/RocketCDN/CDNOptionsManager/enable.php
@@ -44,6 +44,8 @@ class Test_Enable extends TestCase {
 		$options->shouldReceive( 'set' )
 		        ->with( 'settings', $expected );
 
+		Functions\expect( 'rocket_clean_domain' )->once();
+
 		( new CDNOptionsManager(
 			$options,
 			$options_array


### PR DESCRIPTION
**Describe the bug**
RocketCDN Rest API endpoints do not refresh WP Rocket cache while activating / deactivating RocketCDN. At disable the website will be broken because it still have the CDN URL in the cache files.

**Reproduce the problem** ✅ 
Issue reproduced

**Identify the root cause** ✅ 
it’s not auto-cleaning here because the callback function that does it in a regular context (ie from WP Rocket settings page), is only loaded when is_admin() is true, which won’t be for a REST request.

**Scope a solution** ✅ 
Add a call to `rocket_clean_domain()` in the enable/disable callbacks methods of `CDNOptionsManager`

**Estimate the effort** ✅ 
Effort [S]

**Backlog Grooming**
- [x] Reproduce the problem
- [x] Identify the root cause
- [x] Scope a solution
- [x] Estimate the effort

TO DO:
- [x] Revisit Unit Tests
- [x] Revisit Integration Tests
