### PR TITLE
Applies the new clean strategy to `rocket_clean_domain()`.

### DIFF
--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -1398,52 +1398,6 @@ function _rocket_get_cache_path_iterator( $cache_path ) { // phpcs:ignore WordPr
 }
 
 /**
- * Gets the entries from the URL using RegexIterator.
- *
- * @since  3.5.4
- * @access private
- *
- * @param Iterator     $iterator   Instance of the iterator.
- * @param string|array $url        URL or parsed URL to convert into filesystem path regex to get entries.
- * @param string       $cache_path Optional. Filesystem path to rocket's cache.
- *
- * @return array|RegexIterator when successful, returns iterator; else an empty array.
- */
-function _rocket_get_entries_regex( Iterator $iterator, $url, $cache_path = '' ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
-	if ( empty( $cache_path ) ) {
-		$cache_path = str_replace( '/', '\/', rocket_get_constant( 'WP_ROCKET_CACHE_PATH' ) );
-	}
-
-	$parsed_url = is_array( $url ) ? $url : get_rocket_parse_url( $url );
-	$host       = $cache_path . rtrim( $parsed_url['host'], '*' );
-
-	if ( '' !== $parsed_url['path'] && '/' !== $parsed_url['path'] ) {
-		$path = trim( $parsed_url['path'], '/' );
-
-		// Count the hierarchy to determine the depth.
-		$depth = substr_count( $path, '/' ) + 1;
-
-		// Prepare the paths' separator for regex.
-		if ( $depth > 1 ) {
-			$path = str_replace( '/', '\/', $path );
-		}
-
-		$regex = "/{$host}(.*)\/{$path}/i";
-	} else {
-		$regex = "/{$host}(.*)/i";
-		$depth = 0;
-	}
-
-	try {
-		$iterator->setMaxDepth( $depth );
-
-		return new RegexIterator( $iterator, $regex );
-	} catch ( Exception $e ) {
-		return [];
-	}
-}
-
-/**
  * Gets the directories for the given URL host from the cache/wp-rocket/ directory or stored memory.
  *
  * @since  3.5.5

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -1397,7 +1397,7 @@ function _rocket_get_cache_path_iterator( $cache_path ) { // phpcs:ignore WordPr
 	}
 }
 
-/*
+/**
  * Gets the directories for the given URL host from the cache/wp-rocket/ directory or stored memory.
  *
  * @since  3.5.5

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -1146,7 +1146,7 @@ function rocket_rrmdir( $dir, array $dirs_to_preserve = [], $filesystem = null )
 		if ( ! $filesystem->is_dir( $entry ) ) {
 			$filesystem->delete( $entry );
 		} else {
-			rocket_rrmdir( $entry, $dirs_to_preserve );
+			rocket_rrmdir( $entry, $dirs_to_preserve, $filesystem );
 		}
 	}
 

--- a/tests/Integration/inc/functions/rocketCleanDomain.php
+++ b/tests/Integration/inc/functions/rocketCleanDomain.php
@@ -13,20 +13,37 @@ use WP_Rocket\Tests\Integration\FilesystemTestCase;
  * @uses  ::get_rocket_parse_url
  * @uses  ::rocket_get_constant
  * @uses  ::rocket_rrmdir
+ * @uses  ::_rocket_get_cache_dirs
  *
  * @group Functions
  * @group Files
  * @group vfs
+ * @group Clean
  */
 class Test_RocketCleanDomain extends FilesystemTestCase {
 	use i18nTrait;
 
 	protected $path_to_test_data = '/inc/functions/rocketCleanDomain.php';
 
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		// Clean out the cached dirs before we run these tests.
+		_rocket_get_cache_dirs( '', '', true );
+	}
+
+	public static function tearDownAfterClass() {
+		parent::tearDownAfterClass();
+
+		// Clean out the cached dirs before we leave this test class.
+		_rocket_get_cache_dirs( '', '', true );
+	}
+
 	public function tearDown() {
 		parent::tearDown();
 
 		unset( $GLOBALS['sitepress'], $GLOBALS['q_config'], $GLOBALS['polylang'] );
+		unset( $GLOBALS['debug_fs'] );
 	}
 
 	/**
@@ -36,6 +53,10 @@ class Test_RocketCleanDomain extends FilesystemTestCase {
 		$this->dumpResults = isset( $expected['dump_results'] ) ? $expected['dump_results'] : false;
 		$this->generateEntriesShouldExistAfter( $expected['cleaned'] );
 		$this->setUpI18nPlugin( $i18n['lang'], $i18n );
+
+		if ( isset( $expected['debug'] ) && $expected['debug'] ) {
+			$GLOBALS['debug_fs'] = true;
+		}
 
 		// Run it.
 		rocket_clean_domain( $i18n['lang'] );

--- a/tests/Integration/inc/functions/rocketCleanFiles.php
+++ b/tests/Integration/inc/functions/rocketCleanFiles.php
@@ -12,7 +12,7 @@ use WP_Rocket\Tests\Integration\FilesystemTestCase;
  * @group Functions
  * @group Files
  * @group vfs
- * @group rocket_clean_files
+ * @group Clean
  */
 class Test_RocketCleanFiles extends FilesystemTestCase {
 	protected $path_to_test_data = '/inc/functions/rocketCleanFiles.php';

--- a/tests/Unit/inc/functions/rocketCleanFiles.php
+++ b/tests/Unit/inc/functions/rocketCleanFiles.php
@@ -15,7 +15,7 @@ use WP_Rocket\Tests\Unit\FilesystemTestCase;
  * @group Functions
  * @group Files
  * @group vfs
- * @group rocket_clean_files
+ * @group Clean
  */
 class Test_RocketCleanFiles extends FilesystemTestCase {
 	protected $path_to_test_data = '/inc/functions/rocketCleanFiles.php';


### PR DESCRIPTION
Applies the new clean strategy from PR #2623 to `rocket_clean_domain()`. 

Part of issue #2618 

The new strategy does the following:

- Only runs the wildcard/regex crawl once for each given URL domain host. 
- It stores these directories, which will be in root of `cache/wp-content/`, in memory.
     - Note: Later we will optimize this further to store in db or via mapping module.
- It then runs each URL with each of these root level cache directories without crawling the filesystem. 
     - If the URL's file/directory does not exist in the cache, it skips and goes to the next one.
     - If it's a directory, it runs `rocket_rrmdir()`.
     - Else, it's a file. It deletes it without running `rocket_rrmdir()`.