### PR TITLE
Closes #2620 - BNFW plugin - Duplicate emails are send when preload is enabled

### DIFF
--- a/inc/Engine/Preload/PartialPreloadSubscriber.php
+++ b/inc/Engine/Preload/PartialPreloadSubscriber.php
@@ -69,7 +69,7 @@ class PartialPreloadSubscriber implements Subscriber_Interface {
 			'after_rocket_clean_post'            => [ 'preload_after_clean_post', 10, 3 ],
 			'after_rocket_clean_term'            => [ 'preload_after_clean_term', 10, 3 ],
 			'rocket_after_automatic_cache_purge' => 'preload_after_automatic_cache_purge',
-			'shutdown'                           => [ 'maybe_dispatch', 0 ],
+			'shutdown'                           => [ 'maybe_dispatch', PHP_INT_MAX ],
 		];
 	}
 


### PR DESCRIPTION
The [Better Notifications for WP](https://wordpress.org/plugins/bnfw/) plugin sends each email notification twice when WP Rocket's preload feature is enabled.

Both plugins are hooking to the shutdown action:
https://github.com/jackmcconnell/bnfw/blob/8560dc81d33b17418aadf06abeed33a7a4fa4e19/bnfw.php#L207
https://github.com/wp-media/wp-rocket/blob/adab7a846f85e1edbdeb7e6a63575789d0f0bf7b/inc/Engine/Preload/PartialPreloadSubscriber.php#L72

**Reproduce the issue** ✅ 
Identified this issue on Vasilis test website.

**Identify the root cause** ✅ 
https://github.com/wp-media/wp-rocket/blob/adab7a846f85e1edbdeb7e6a63575789d0f0bf7b/inc/Engine/Preload/PartialPreloadSubscriber.php#L72

The issue is that both plugins run on shutdown action and this may end up in conflict. 

**Scope a solution** ✅ 
The solution is to move our Partial Preload the last with  `PHP_INT_MAX` 
```
'shutdown' => [ 'maybe_dispatch', PHP_INT_MAX ], 
```

**Effort** ✅ 
Effort seems minimal [XS]
 