### PR TITLE
Fixes 2633: RegexIterator regex to use Windows dir separator when IIS/Windows

### DIFF
--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -1460,7 +1460,16 @@ function _rocket_get_cache_dirs( $url_host, $cache_path = '', $hard_reset = fals
 	}
 
 	// When Windows-based.
-	$is_windows = ( DIRECTORY_SEPARATOR === '\\' && ( substr( $cache_path, 0, 7 ) !== 'vfs://' ) );
+	$is_windows = (
+		DIRECTORY_SEPARATOR === '\\'
+		&&
+		(
+			! rocket_get_constant( 'WP_ROCKET_IS_TESTING', false )
+			||
+			substr( $cache_path, 0, 6 ) !== 'vfs://'
+		)
+	);
+
 	if ( $is_windows ) {
 		$cache_path = str_replace( '/', '\\', $cache_path );
 	}

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -1429,6 +1429,7 @@ function _rocket_get_entries_regex( Iterator $iterator, $url, $cache_path = '' )
 	}
 }
 
+
 /**
  * Gets the directories for the given URL host from the cache/wp-rocket/ directory or stored memory.
  *
@@ -1472,7 +1473,8 @@ function _rocket_get_cache_dirs( $url_host, $cache_path = '', $hard_reset = fals
 		return [];
 	}
 
-	$regex = sprintf( '/%1$s%2$s(.*)/i',
+	$regex = sprintf(
+		'/%1$s%2$s(.*)/i',
 		$is_windows
 			? str_replace( '\\', '\\\\', $cache_path )
 			: str_replace( '/', '\/', $cache_path ),

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -1458,6 +1458,12 @@ function _rocket_get_cache_dirs( $url_host, $cache_path = '', $hard_reset = fals
 		$cache_path = rocket_get_constant( 'WP_ROCKET_CACHE_PATH' );
 	}
 
+	// When Windows-based.
+	$is_windows = ( DIRECTORY_SEPARATOR === '\\' && ( substr( $cache_path, 0, 7 ) !== 'vfs://' ) );
+	if ( $is_windows ) {
+		$cache_path = str_replace( '/', '\\', $cache_path );
+	}
+
 	try {
 		$iterator = new IteratorIterator(
 			new FilesystemIterator( $cache_path )
@@ -1466,7 +1472,12 @@ function _rocket_get_cache_dirs( $url_host, $cache_path = '', $hard_reset = fals
 		return [];
 	}
 
-	$regex = sprintf( '/%1$s%2$s(.*)/i', str_replace( '/', '\/', $cache_path ), $url_host );
+	$regex = sprintf( '/%1$s%2$s(.*)/i',
+		$is_windows
+			? str_replace( '\\', '\\\\', $cache_path )
+			: str_replace( '/', '\/', $cache_path ),
+		$url_host
+	);
 
 	try {
 		$entries = new RegexIterator( $iterator, $regex );

--- a/tests/Fixtures/inc/functions/_rocketGetCacheDirs.php
+++ b/tests/Fixtures/inc/functions/_rocketGetCacheDirs.php
@@ -1,0 +1,127 @@
+<?php
+
+return [
+	// Use in tests when the test data starts in this directory.
+	'vfs_dir' => 'wp-content/cache/wp-rocket/',
+
+	'structure' => [
+		'wp-content' => [
+			'cache' => [
+				'wp-rocket' => [
+					'example.org'                => [
+						'index.html_gzip' => '',
+					],
+					'example.org-wpmedia-123456' => [
+						'index.html_gzip' => '',
+					],
+					'example.org-tester-987654'  => [
+						'index.html_gzip' => '',
+					],
+
+					'baz.example.org'             => [
+						'index.html_gzip' => '',
+					],
+					'baz.example.org-baz1-123456' => [
+						'index.html_gzip' => '',
+					],
+					'baz.example.org-baz2-987654' => [
+						'index.html_gzip' => '',
+					],
+					'baz.example.org-baz3-456789' => [
+						'index.html_gzip' => '',
+					],
+
+					'wp.baz.example.org'               => [
+						'index.html_gzip' => '',
+					],
+					'wp.baz.example.org-wpbaz1-123456' => [
+						'index.html_gzip' => '',
+					],
+
+					'example.org#fr' => [
+						'index.html_gzip' => '',
+					],
+				],
+			],
+		],
+	],
+
+	// Test data.
+	'test_data' => [
+		'non_cached' => [
+			'shouldReturnDomainAndUserCaches'                => [
+				'config'   => [
+					'url_host' => 'example.org',
+				],
+				'expected' => [
+					'vfs://public/wp-content/cache/wp-rocket/example.org',
+					'vfs://public/wp-content/cache/wp-rocket/example.org-wpmedia-123456',
+					'vfs://public/wp-content/cache/wp-rocket/example.org-tester-987654',
+					'vfs://public/wp-content/cache/wp-rocket/example.org#fr',
+				],
+			],
+			'shouldReturnDomainAndUserCaches_cachePathGiven' => [
+				'config'   => [
+					'url_host'   => 'example.org',
+					'cache_path' => 'vfs://public/wp-content/cache/wp-rocket/',
+				],
+				'expected' => [
+					'vfs://public/wp-content/cache/wp-rocket/example.org',
+					'vfs://public/wp-content/cache/wp-rocket/example.org-wpmedia-123456',
+					'vfs://public/wp-content/cache/wp-rocket/example.org-tester-987654',
+					'vfs://public/wp-content/cache/wp-rocket/example.org#fr',
+				],
+			],
+
+			'shouldReturnSubDomainAndUserCaches'             => [
+				'config'   => [
+					'url_host' => 'baz.example.org',
+				],
+				'expected' => [
+					'vfs://public/wp-content/cache/wp-rocket/baz.example.org',
+					'vfs://public/wp-content/cache/wp-rocket/baz.example.org-baz1-123456',
+					'vfs://public/wp-content/cache/wp-rocket/baz.example.org-baz2-987654',
+					'vfs://public/wp-content/cache/wp-rocket/baz.example.org-baz3-456789',
+				],
+			],
+			'shouldReturnDomainAndUserCaches_cachePathGiven' => [
+				'config'   => [
+					'url_host'   => 'baz.example.org',
+					'cache_path' => 'vfs://public/wp-content/cache/wp-rocket/',
+				],
+				'expected' => [
+					'vfs://public/wp-content/cache/wp-rocket/baz.example.org',
+					'vfs://public/wp-content/cache/wp-rocket/baz.example.org-baz1-123456',
+					'vfs://public/wp-content/cache/wp-rocket/baz.example.org-baz2-987654',
+					'vfs://public/wp-content/cache/wp-rocket/baz.example.org-baz3-456789',
+				],
+			],
+
+			'shouldReturnSubDomainAndUserCaches'                   => [
+				'config'   => [
+					'url_host' => 'wp.baz.example.org',
+				],
+				'expected' => [
+					'vfs://public/wp-content/cache/wp-rocket/wp.baz.example.org',
+					'vfs://public/wp-content/cache/wp-rocket/wp.baz.example.org-wpbaz1-123456',
+				],
+			],
+			'shouldReturnSubSubDomainAndUserCaches_cachePathGiven' => [
+				'config'   => [
+					'url_host'   => 'wp.baz.example.org',
+					'cache_path' => 'vfs://public/wp-content/cache/wp-rocket/',
+				],
+				'expected' => [
+					'vfs://public/wp-content/cache/wp-rocket/wp.baz.example.org',
+					'vfs://public/wp-content/cache/wp-rocket/wp.baz.example.org-wpbaz1-123456',
+				],
+			],
+		],
+
+		'crawlOnce' => [
+			[ 'example.org' ],
+			[ 'baz.example.org' ],
+			[ 'wp.baz.example.org' ],
+		],
+	],
+];

--- a/tests/Unit/inc/functions/_rocketGetCacheDirs.php
+++ b/tests/Unit/inc/functions/_rocketGetCacheDirs.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\functions;
+
+use Brain\Monkey\Functions;
+use WP_Rocket\Tests\Unit\FilesystemTestCase;
+
+/**
+ * @covers ::_rocket_get_cache_dirs
+ *
+ * @group Files
+ * @group vfs
+ * @group Clean
+ */
+class Test__RocketGetCacheDirs extends FilesystemTestCase {
+	protected $path_to_test_data = '/inc/functions/_rocketGetCacheDirs.php';
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		// Clean out the cached dirs before we run these tests.
+		_rocket_get_cache_dirs( '', '', true );
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+
+		// Reset after each test.
+		_rocket_get_cache_dirs( '', '', true );
+	}
+
+	/**
+	 * @dataProvider noncachedTestData
+	 */
+	public function testShouldGetDirs( $config, $expected ) {
+		$url_host   = array_key_exists( 'url_host', $config ) ? $config['url_host'] : '';
+		$cache_path = array_key_exists( 'cache_path', $config ) ? $config['cache_path'] : '';
+		$hard_reset = array_key_exists( 'hard_reset', $config ) ? $config['hard_reset'] : '';
+
+		if ( empty( $cache_path ) ) {
+			$this->expectRocketGetConstant();
+		} else {
+			Functions\expect( 'rocket_get_constant' )->with( 'WP_ROCKET_CACHE_PATH' )->never();
+		}
+
+		// Run it.
+		$dirs = _rocket_get_cache_dirs( $url_host, $cache_path, $hard_reset );
+
+		$this->assertSame( $expected, $dirs );
+	}
+
+	/**
+	 * @dataProvider crawlOnceTestData
+	 */
+	public function testShouldCrawlFilesystemOnlyOnce( $url ) {
+		// Run it once to cache the dirs.
+		$this->expectRocketGetConstant();
+		$expected = _rocket_get_cache_dirs( $url );
+
+		// Run it again. This time it should return the cached version and not crawl the filesystem.
+		Functions\expect( 'rocket_get_constant' )->with( 'WP_ROCKET_CACHE_PATH' )->never();
+		$this->assertSame( $expected, _rocket_get_cache_dirs( $url ) );
+	}
+
+	private function expectRocketGetConstant() {
+		Functions\expect( 'rocket_get_constant' )
+			->once()
+			->with( 'WP_ROCKET_CACHE_PATH' )
+			->andReturn( 'vfs://public/wp-content/cache/wp-rocket/' );
+	}
+
+	public function noncachedTestData() {
+		$this->loadConfig();
+
+		return $this->config['test_data']['non_cached'];
+	}
+
+	public function crawlOnceTestData() {
+		$this->loadConfig();
+
+		return $this->config['test_data']['crawlOnce'];
+	}
+}


### PR DESCRIPTION
This PR fixes #2633 by:

1. Checking if it's a Windows-based machine, i.e. via the constant `DIRECTORY_SEPARATOR`.
2. If yes:
    - Changes `/` into `\` for the `FilesystemIterator`
    - Prepares the directory separator for regex.

Note: Skips this switching code when using the virtual filesystem. 

## TODO 

- [x] Add unit tests.
- [x] Test in Parallels (VM for Windows on Mac). ✅ Works
- [x] Test on Windows laptop/desktop. ✅ Works
- [x] Test on customer's IIS servers, i.e. customers who have reported this problem. @vmanthos @piotrbak 
- [x] QA