### PR TITLE
Prevent update of rocket-lazyload-common package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
 		"league/container": "^2.4",
 		"matthiasmullie/minify": "1.3.*",
 		"monolog/monolog": "^1.0",
-		"wp-media/rocket-lazyload-common": "^2"
+		"wp-media/rocket-lazyload-common": "2.5.6"
 	},
 	"require-dev": {
 		"php": "^5.6 || ^7",


### PR DESCRIPTION
Package needs to stays to version 2.5.6 for now because of https://github.com/wp-media/wp-rocket/issues/2570

We will be able to revert this change when releasing version 3.6.