### PR TITLE
Closes #2619 Varnish cache not cleaned at automatic cache purge

### DIFF
--- a/inc/Addon/Varnish/Subscriber.php
+++ b/inc/Addon/Varnish/Subscriber.php
@@ -41,9 +41,10 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events() {
 		return [
-			'before_rocket_clean_domain' => [ 'clean_domain', 10, 3 ],
-			'before_rocket_clean_file'   => [ 'clean_file' ],
-			'before_rocket_clean_home'   => [ 'clean_home', 10, 2 ],
+			'before_rocket_clean_domain'         => [ 'clean_domain', 10, 3 ],
+			'before_rocket_clean_file'           => [ 'clean_file' ],
+			'before_rocket_clean_home'           => [ 'clean_home', 10, 2 ],
+			'rocket_after_automatic_cache_purge' => 'clean_urls',
 		];
 	}
 
@@ -115,5 +116,37 @@ class Subscriber implements Subscriber_Interface {
 
 		$this->varnish->purge( $home_url );
 		$this->varnish->purge( $home_pagination_url );
+	}
+
+	/**
+	 * Clears URLs in Varnish cache.
+	 *
+	 * @param array $urls The path of home cache file.
+	 */
+	public function clean_urls( $urls ) {
+		if ( ! $this->should_purge() ) {
+			return;
+		}
+
+		foreach ( $urls as $data ) {
+			foreach ( $data['files'] as $file_path ) {
+				if ( strpos( $file_path, '#' ) ) {
+					// URL with query string.
+					continue;
+				} else {
+					$file_path         = untrailingslashit( $file_path );
+					$data['home_path'] = untrailingslashit( $data['home_path'] );
+					$data['home_url']  = untrailingslashit( $data['home_url'] );
+					if ( '/' === substr( get_option( 'permalink_structure' ), -1 ) ) {
+						$file_path         .= '/';
+						$data['home_path'] .= '/';
+						$data['home_url']  .= '/';
+					}
+				}
+
+				$url = str_replace( $data['home_path'], $data['home_url'], $file_path );
+				$this->varnish->purge( trailingslashit( $url ) . '?regex' );
+			}
+		}
 	}
 }

--- a/inc/Addon/Varnish/Subscriber.php
+++ b/inc/Addon/Varnish/Subscriber.php
@@ -133,15 +133,15 @@ class Subscriber implements Subscriber_Interface {
 				if ( strpos( $file_path, '#' ) ) {
 					// URL with query string.
 					continue;
-				} else {
-					$file_path         = untrailingslashit( $file_path );
-					$data['home_path'] = untrailingslashit( $data['home_path'] );
-					$data['home_url']  = untrailingslashit( $data['home_url'] );
-					if ( '/' === substr( get_option( 'permalink_structure' ), -1 ) ) {
-						$file_path         .= '/';
-						$data['home_path'] .= '/';
-						$data['home_url']  .= '/';
-					}
+				}
+
+				$file_path         = untrailingslashit( $file_path );
+				$data['home_path'] = untrailingslashit( $data['home_path'] );
+				$data['home_url']  = untrailingslashit( $data['home_url'] );
+				if ( '/' === substr( get_option( 'permalink_structure' ), -1 ) ) {
+					$file_path         .= '/';
+					$data['home_path'] .= '/';
+					$data['home_url']  .= '/';
 				}
 
 				$url = str_replace( $data['home_path'], $data['home_url'], $file_path );

--- a/tests/Fixtures/inc/Addon/Varnish/Subscriber/cleanUrls.php
+++ b/tests/Fixtures/inc/Addon/Varnish/Subscriber/cleanUrls.php
@@ -1,0 +1,228 @@
+<?php
+return [
+	'bailoutShouldNotPurgeRocketVarnishFilter' => [
+		[
+			'varnish_auto_purge'           => true,
+			'do_rocket_varnish_http_purge' => false,
+		],
+		[],
+		[],
+	],
+	'bailoutShouldNotPurgeVanishOption' => [
+		[
+			'varnish_auto_purge'           => false,
+			'do_rocket_varnish_http_purge' => true,
+		],
+		[],
+		[],
+	],
+	'bailoutShouldNotPurgeBoth' => [
+		[
+			'varnish_auto_purge'           => false,
+			'do_rocket_varnish_http_purge' => false,
+		],
+		[],
+		[],
+	],
+	'bailoutShouldNotPurgeNoUrls' => [
+		[
+			'varnish_auto_purge'           => true,
+			'do_rocket_varnish_http_purge' => true,
+		],
+		[],
+		[],
+	],
+	'shoulNotPurgeVarnishQueryUrls' => [
+		[
+			'varnish_auto_purge'           => true,
+			'do_rocket_varnish_http_purge' => true,
+			'permalink_structure'          => '/%postname%/',
+		],
+		[
+			[
+				'home_url'  => 'http://example.org/home1',
+				'home_path' => '/path-to/home1/wp-content/cache/wp-rocket/example.org-Greg-594d03f6ae698691165999/home1',
+				'logged_in' => true,
+				'files'     => [
+					'/path-to/home1/wp-content/cache/wp-rocket/example.org-Greg-594d03f6ae698691165999/home1/#amp=',
+					'/path-to/home1/wp-content/cache/wp-rocket/example.org-Greg-594d03f6ae698691165999/home1/best-source-of-gifs/#amp=',
+				],
+			],
+		],
+		[],
+	],
+	'shouldPurgeVarnishUrlsSlashedPermalink' => [
+		[
+			'varnish_auto_purge'           => true,
+			'do_rocket_varnish_http_purge' => true,
+			'permalink_structure'          => '/%postname%/',
+		],
+		[
+			[
+				'home_url'  => 'http://example.org/home1/',
+				'home_path' => '/path-to/home1/wp-content/cache/wp-rocket/example.org-Greg-594d03f6ae698691165999/home1/',
+				'logged_in' => true,
+				'files'     => [
+					'/path-to/home1/wp-content/cache/wp-rocket/example.org-Greg-594d03f6ae698691165999/home1/how-to-prank-your-coworkers/',
+					'/path-to/home1/wp-content/cache/wp-rocket/example.org-Greg-594d03f6ae698691165999/home1/best-source-of-gifs/',
+				],
+			],
+		],
+		[
+			'http://example.org/home1/how-to-prank-your-coworkers/',
+			'http://example.org/home1/best-source-of-gifs/',
+		],
+	],
+	'shouldPurgeVarnishUrlsUnSlashedPermalink' => [
+		[
+			'varnish_auto_purge'           => true,
+			'do_rocket_varnish_http_purge' => true,
+			'permalink_structure'          => '/%postname%',
+		],
+		[
+			[
+				'home_url'  => 'http://example.org/home1',
+				'home_path' => '/path-to/home1/wp-content/cache/wp-rocket/example.org-Greg-594d03f6ae698691165999/home1',
+				'logged_in' => true,
+				'files'     => [
+					'/path-to/home1/wp-content/cache/wp-rocket/example.org-Greg-594d03f6ae698691165999/home1/how-to-prank-your-coworkers',
+					'/path-to/home1/wp-content/cache/wp-rocket/example.org-Greg-594d03f6ae698691165999/home1/best-source-of-gifs',
+				],
+			],
+		],
+		[
+			'http://example.org/home1/how-to-prank-your-coworkers/',
+			'http://example.org/home1/best-source-of-gifs/',
+		],
+	],
+	'shouldPurgeVarnishUrlSlashedPermalinkWrongSlashUnslash' => [
+		[
+			'varnish_auto_purge'           => true,
+			'do_rocket_varnish_http_purge' => true,
+			'permalink_structure'          => '/%postname%/',
+		],
+		[
+			[
+				'home_url'  => 'http://example.org/home1',
+				'home_path' => '/path-to/home1/wp-content/cache/wp-rocket/example.org-Greg-594d03f6ae698691165999/home1',
+				'logged_in' => false,
+				'files'     => [
+					'/path-to/home1/wp-content/cache/wp-rocket/example.org-Greg-594d03f6ae698691165999/home1/abc',
+				],
+			],
+			[
+				'home_url'  => 'http://example.org/home2/',
+				'home_path' => '/path-to/home1/wp-content/cache/wp-rocket/example.org-Greg-594d03f6ae698691165999/home2',
+				'logged_in' => false,
+				'files'     => [
+					'/path-to/home1/wp-content/cache/wp-rocket/example.org-Greg-594d03f6ae698691165999/home2/abc',
+				],
+			],
+			[
+				'home_url'  => 'http://example.org/home3/',
+				'home_path' => '/path-to/home1/wp-content/cache/wp-rocket/example.org-Greg-594d03f6ae698691165999/home3/',
+				'logged_in' => false,
+				'files'     => [
+					'/path-to/home1/wp-content/cache/wp-rocket/example.org-Greg-594d03f6ae698691165999/home3/abc',
+				],
+			],
+			[
+				'home_url'  => 'http://example.org/home4/',
+				'home_path' => '/path-to/home1/wp-content/cache/wp-rocket/example.org-Greg-594d03f6ae698691165999/home4/',
+				'logged_in' => false,
+				'files'     => [
+					'/path-to/home1/wp-content/cache/wp-rocket/example.org-Greg-594d03f6ae698691165999/home4/abc/',
+				],
+			],
+			[
+				'home_url'  => 'http://example.org/home5/',
+				'home_path' => '/path-to/home1/wp-content/cache/wp-rocket/example.org-Greg-594d03f6ae698691165999/home5',
+				'logged_in' => false,
+				'files'     => [
+					'/path-to/home1/wp-content/cache/wp-rocket/example.org-Greg-594d03f6ae698691165999/home5/abc/',
+				],
+			],
+			[
+				'home_url'  => 'http://example.org/home6',
+				'home_path' => '/path-to/home1/wp-content/cache/wp-rocket/example.org-Greg-594d03f6ae698691165999/home6/',
+				'logged_in' => false,
+				'files'     => [
+					'/path-to/home1/wp-content/cache/wp-rocket/example.org-Greg-594d03f6ae698691165999/home6/abc/',
+				],
+			],
+		],
+		[
+			'http://example.org/home1/abc/',
+			'http://example.org/home2/abc/',
+			'http://example.org/home3/abc/',
+			'http://example.org/home4/abc/',
+			'http://example.org/home5/abc/',
+			'http://example.org/home6/abc/',
+		],
+	],
+	'shouldPurgeVarnishUrlUnSlashedPermalinkWrongSlashUnslash' => [
+		[
+			'varnish_auto_purge'           => true,
+			'do_rocket_varnish_http_purge' => true,
+			'permalink_structure'          => '/%postname%',
+		],
+		[
+			[
+				'home_url'  => 'http://example.org/home1',
+				'home_path' => '/path-to/home1/wp-content/cache/wp-rocket/example.org-Greg-594d03f6ae698691165999/home1',
+				'logged_in' => false,
+				'files'     => [
+					'/path-to/home1/wp-content/cache/wp-rocket/example.org-Greg-594d03f6ae698691165999/home1/abc',
+				],
+			],
+			[
+				'home_url'  => 'http://example.org/home2/',
+				'home_path' => '/path-to/home1/wp-content/cache/wp-rocket/example.org-Greg-594d03f6ae698691165999/home2',
+				'logged_in' => false,
+				'files'     => [
+					'/path-to/home1/wp-content/cache/wp-rocket/example.org-Greg-594d03f6ae698691165999/home2/abc',
+				],
+			],
+			[
+				'home_url'  => 'http://example.org/home3/',
+				'home_path' => '/path-to/home1/wp-content/cache/wp-rocket/example.org-Greg-594d03f6ae698691165999/home3/',
+				'logged_in' => false,
+				'files'     => [
+					'/path-to/home1/wp-content/cache/wp-rocket/example.org-Greg-594d03f6ae698691165999/home3/abc',
+				],
+			],
+			[
+				'home_url'  => 'http://example.org/home4/',
+				'home_path' => '/path-to/home1/wp-content/cache/wp-rocket/example.org-Greg-594d03f6ae698691165999/home4/',
+				'logged_in' => false,
+				'files'     => [
+					'/path-to/home1/wp-content/cache/wp-rocket/example.org-Greg-594d03f6ae698691165999/home4/abc/',
+				],
+			],
+			[
+				'home_url'  => 'http://example.org/home5/',
+				'home_path' => '/path-to/home1/wp-content/cache/wp-rocket/example.org-Greg-594d03f6ae698691165999/home5',
+				'logged_in' => false,
+				'files'     => [
+					'/path-to/home1/wp-content/cache/wp-rocket/example.org-Greg-594d03f6ae698691165999/home5/abc/',
+				],
+			],
+			[
+				'home_url'  => 'http://example.org/home6',
+				'home_path' => '/path-to/home1/wp-content/cache/wp-rocket/example.org-Greg-594d03f6ae698691165999/home6/',
+				'logged_in' => false,
+				'files'     => [
+					'/path-to/home1/wp-content/cache/wp-rocket/example.org-Greg-594d03f6ae698691165999/home6/abc/',
+				],
+			],
+		],
+		[
+			'http://example.org/home1/abc/',
+			'http://example.org/home2/abc/',
+			'http://example.org/home3/abc/',
+			'http://example.org/home4/abc/',
+			'http://example.org/home5/abc/',
+			'http://example.org/home6/abc/',
+		],
+	],
+];

--- a/tests/Integration/inc/Addon/Varnish/Subscriber/cleanUrls.php
+++ b/tests/Integration/inc/Addon/Varnish/Subscriber/cleanUrls.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\Addon\Varnish\Subscriber;
+
+use WPMedia\PHPUnit\Integration\TestCase;
+
+/**
+ * @covers WP_Rocket\Addon\Varnish\Subscriber::clean_urls
+ * @group  Addons
+ * @group  Varnish
+ */
+class Test_CleanUrls extends TestCase {
+	private $permalink_structure;
+	private $varnish_auto_purge;
+	private $did_filter;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->did_filter   = [
+			'rocket_varnish_ip' => 0,
+		];
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+
+		remove_filter( 'pre_get_rocket_option_varnish_auto_purge', [ $this, 'varnish_auto_purge_filter' ] );
+		remove_filter( 'pre_option_permalink_structure', [ $this, 'permalink_structure_filter' ] );
+		remove_filter( 'rocket_varnish_ip', [ $this, 'rocket_varnish_ip_callback' ] );
+	}
+
+	/**
+	 * @dataProvider addDataProvider
+	 */
+	public function testShouldDoExpected( $config, $urls, $expected_clean_urls ) {
+		$this->permalink_structure = $config['do_rocket_varnish_http_purge'];
+		$this->varnish_auto_purge  = $config['varnish_auto_purge'];
+
+		add_filter( 'pre_get_rocket_option_varnish_auto_purge', [ $this, 'varnish_auto_purge_filter' ] );
+		add_filter( 'pre_option_permalink_structure', [ $this, 'permalink_structure_filter' ] );
+		add_filter( 'rocket_varnish_ip', [ $this, 'rocket_varnish_ip_callback' ] );
+
+		do_action( 'rocket_after_automatic_cache_purge', $urls );
+
+		$this->assertEquals( count( $expected_clean_urls ), $this->did_filter['rocket_varnish_ip'] );
+	}
+
+	public function rocket_varnish_ip_callback( $value ) {
+		$this->did_filter['rocket_varnish_ip'] ++;
+		return $value;
+	}
+
+	public function varnish_auto_purge_filter() {
+		return $this->varnish_auto_purge;
+	}
+
+	public function permalink_structure_filter() {
+		return $this->permalink_structure;
+	}
+
+	public function addDataProvider() {
+		return $this->getTestData( __DIR__, 'cleanUrls' );
+	}
+}

--- a/tests/Integration/inc/Addon/Varnish/Subscriber/getSubscribedEvents.php
+++ b/tests/Integration/inc/Addon/Varnish/Subscriber/getSubscribedEvents.php
@@ -14,9 +14,10 @@ class Test_GetSubscribedEvents extends TestCase {
 
 	public function testShouldReturnSubscribedEventsArray() {
 		$events = [
-			'before_rocket_clean_domain' => [ 'clean_domain', 10, 3 ],
-			'before_rocket_clean_file'   => [ 'clean_file' ],
-			'before_rocket_clean_home'   => [ 'clean_home', 10, 2 ],
+			'before_rocket_clean_domain'         => [ 'clean_domain', 10, 3 ],
+			'before_rocket_clean_file'           => [ 'clean_file' ],
+			'before_rocket_clean_home'           => [ 'clean_home', 10, 2 ],
+			'rocket_after_automatic_cache_purge' => 'clean_urls',
 		];
 
 		$this->assertSame(

--- a/tests/Unit/inc/Addon/Varnish/Subscriber/cleanUrls.php
+++ b/tests/Unit/inc/Addon/Varnish/Subscriber/cleanUrls.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Addon\Varnish\Subscriber;
+
+use Mockery;
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+use WP_Rocket\Admin\Options_Data;
+use WPMedia\PHPUnit\Unit\TestCase;
+use WP_Rocket\Addon\Varnish\Subscriber;
+use WP_Rocket\Addon\Varnish\Varnish;
+
+/**
+ * @covers WP_Rocket\Addon\Varnish\Subscriber::clean_urls
+ * @group  Varnish
+ * @group  Addon
+ */
+class Test_CleanUrls extends TestCase {
+	private $options;
+	private $subscriber;
+	private $varnish;
+
+	public function setUp() {
+		$this->options    = Mockery::mock( Options_Data::class );
+		$this->varnish    = Mockery::mock( Varnish::class );
+		$this->subscriber = new Subscriber( $this->varnish, $this->options );
+	}
+	/**
+	 * @dataProvider addDataProvider
+	 */
+	public function testShouldDoExpected( $config, $urls, $expected_clean_urls ) {
+
+		Filters\expectApplied( 'do_rocket_varnish_http_purge' )
+			->once()
+			->andReturn( $config['do_rocket_varnish_http_purge'] );
+
+		if ( ! $config['do_rocket_varnish_http_purge'] ) {
+			$this->options->shouldReceive( 'get' )
+				->with( 'varnish_auto_purge', 0 )
+				->andReturn( $config['varnish_auto_purge'] );
+		}
+
+		if ( ! empty( $expected_clean_urls ) ) {
+			Functions\expect( 'get_option' )
+				->with( 'permalink_structure' )
+				->andReturn( $config['permalink_structure'] );
+
+			foreach ( $expected_clean_urls as $url ) {
+				$this->varnish->shouldReceive( 'purge' )->with( $url . '?regex' );
+			}
+		} else {
+			$this->varnish->shouldNotReceive( 'purge' );
+		}
+
+		$this->subscriber->clean_urls( $urls );
+	}
+
+	public function addDataProvider() {
+		return $this->getTestData( __DIR__, 'cleanUrls' );
+	}
+}

--- a/tests/Unit/inc/Addon/Varnish/Subscriber/cleanUrls.php
+++ b/tests/Unit/inc/Addon/Varnish/Subscriber/cleanUrls.php
@@ -25,6 +25,7 @@ class Test_CleanUrls extends TestCase {
 		$this->varnish    = Mockery::mock( Varnish::class );
 		$this->subscriber = new Subscriber( $this->varnish, $this->options );
 	}
+
 	/**
 	 * @dataProvider addDataProvider
 	 */


### PR DESCRIPTION
**Reproduce the issue** ✅ 
Identified this issue on localhost.

**Identify the root cause** ✅ 
The root cause is that Varnish Addons needs to be hooked in Expired Cache Purge event `rocket_after_automatic_cache_purge`.

**Scope a solution** ✅ 
The solution is to hook Varnish Addon into: `rocket_after_automatic_cache_purge` and clean Varnish cache for the deleted urls:
https://github.com/wp-media/wp-rocket/blob/d6c62d85364f422f4c9f575f5ee661a350856fa7/inc/classes/Cache/class-expired-cache-purge.php#L249

**Effort** ✅ 
Effort is minimal [S]

**TO DO**
- [x] - Unit tests
- [x] - Integration tests