### PR TITLE
Normalizes filesystem paths for IIS

### DIFF
--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -847,7 +847,7 @@ function rocket_clean_domain( $lang = '', $filesystem = null ) {
 
 	/** This filter is documented in inc/front/htaccess.php */
 	$url_no_dots      = (bool) apply_filters( 'rocket_url_no_dots', false );
-	$cache_path       = _rocket_get_cache_path( 'WP_ROCKET_CACHE_PATH' );
+	$cache_path       = _rocket_get_cache_path();
 	$dirs_to_preserve = get_rocket_i18n_to_preserve( $lang );
 
 	if ( empty( $filesystem ) ) {

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -848,7 +848,7 @@ function rocket_clean_domain( $lang = '', $filesystem = null ) {
 	/** This filter is documented in inc/front/htaccess.php */
 	$url_no_dots      = (bool) apply_filters( 'rocket_url_no_dots', false );
 	$cache_path       = _rocket_get_wp_rocket_cache_path();
-	$dirs_to_preserve = get_rocket_i18n_to_preserve( $lang );
+	$dirs_to_preserve = get_rocket_i18n_to_preserve( $lang, $cache_path );
 
 	if ( empty( $filesystem ) ) {
 		$filesystem = rocket_direct_filesystem();

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -1471,6 +1471,7 @@ function _rocket_get_cache_dirs( $url_host, $cache_path = '', $hard_reset = fals
 function _rocket_normalize_path( $path, $escape = false, $force = false ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
 	if ( _rocket_is_windows_fs( $path ) ) {
 		$path = str_replace( '/', '\\', $path );
+
 		return $escape
 			? str_replace( '\\', '\\\\', $path )
 			: $path;

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -622,7 +622,7 @@ function rocket_clean_files( $urls, $filesystem = null ) {
 
 	/** This filter is documented in inc/front/htaccess.php */
 	$url_no_dots = (bool) apply_filters( 'rocket_url_no_dots', false );
-	$cache_path  = _rocket_get_cache_path( 'WP_ROCKET_CACHE_PATH' );
+	$cache_path  = _rocket_get_wp_rocket_cache_path();
 
 	if ( empty( $filesystem ) ) {
 		$filesystem = rocket_direct_filesystem();
@@ -847,7 +847,7 @@ function rocket_clean_domain( $lang = '', $filesystem = null ) {
 
 	/** This filter is documented in inc/front/htaccess.php */
 	$url_no_dots      = (bool) apply_filters( 'rocket_url_no_dots', false );
-	$cache_path       = _rocket_get_cache_path();
+	$cache_path       = _rocket_get_wp_rocket_cache_path();
 	$dirs_to_preserve = get_rocket_i18n_to_preserve( $lang );
 
 	if ( empty( $filesystem ) ) {
@@ -1423,7 +1423,7 @@ function _rocket_get_cache_dirs( $url_host, $cache_path = '', $hard_reset = fals
 	}
 
 	if ( empty( $cache_path ) ) {
-		$cache_path = _rocket_get_cache_path();
+		$cache_path = _rocket_get_wp_rocket_cache_path();
 	}
 
 	try {
@@ -1524,6 +1524,6 @@ function _rocket_is_windows_fs( $hard_reset = false ) { // phpcs:ignore WordPres
  *
  * @return string
  */
-function _rocket_get_cache_path() { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
+function _rocket_get_wp_rocket_cache_path() { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
 	return _rocket_normalize_path( rocket_get_constant( 'WP_ROCKET_CACHE_PATH' ) );
 }

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -1470,9 +1470,10 @@ function _rocket_get_cache_dirs( $url_host, $cache_path = '', $hard_reset = fals
  */
 function _rocket_normalize_path( $path, $escape = false, $force = false ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
 	if ( _rocket_is_windows_fs( $path ) ) {
+		$path = str_replace( '/', '\\', $path );
 		return $escape
-			? str_replace( [ '/', '\\' ] , '\\\\', $path )
-			: str_replace( '/', '\\', $path );
+			? str_replace( '\\', '\\\\', $path )
+			: $path;
 	}
 
 	if ( $escape ) {

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -1470,11 +1470,9 @@ function _rocket_get_cache_dirs( $url_host, $cache_path = '', $hard_reset = fals
  */
 function _rocket_normalize_path( $path, $escape = false, $force = false ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
 	if ( _rocket_is_windows_fs( $path ) ) {
-		return str_replace(
-			'/',
-			$escape ? '\\\\' : '\\',
-			$path
-		);
+		return $escape
+			? str_replace( [ '/', '\\' ] , '\\\\', $path )
+			: str_replace( '/', '\\', $path );
 	}
 
 	if ( $escape ) {

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -1423,21 +1423,7 @@ function _rocket_get_cache_dirs( $url_host, $cache_path = '', $hard_reset = fals
 	}
 
 	if ( empty( $cache_path ) ) {
-		$cache_path = rocket_get_constant( 'WP_ROCKET_CACHE_PATH' );
-	}
-
-	$is_windows = (
-		DIRECTORY_SEPARATOR === '\\'
-		&&
-		(
-			! rocket_get_constant( 'WP_ROCKET_IS_TESTING', false )
-			||
-			substr( $cache_path, 0, 6 ) !== 'vfs://'
-		)
-	);
-
-	if ( $is_windows ) {
-		$cache_path = str_replace( '/', '\\', $cache_path );
+		$cache_path = _rocket_get_cache_path();
 	}
 
 	try {
@@ -1450,9 +1436,7 @@ function _rocket_get_cache_dirs( $url_host, $cache_path = '', $hard_reset = fals
 
 	$regex = sprintf(
 		'/%1$s%2$s(.*)/i',
-		$is_windows
-			? str_replace( '\\', '\\\\', $cache_path )
-			: str_replace( '/', '\/', $cache_path ),
+		_rocket_normalize_path( $cache_path, true ),
 		$url_host
 	);
 
@@ -1530,4 +1514,16 @@ function _rocket_is_windows_fs( $hard_reset = false ) { // phpcs:ignore WordPres
 	}
 
 	return $is_windows;
+}
+
+/**
+ * Gets the normalized cache path, i.e. normalizes constant "WP_ROCKET_CACHE_PATH".
+ *
+ * @since  3.5.5
+ * @access private
+ *
+ * @return string
+ */
+function _rocket_get_cache_path() { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
+	return _rocket_normalize_path( rocket_get_constant( 'WP_ROCKET_CACHE_PATH' ) );
 }

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -622,7 +622,7 @@ function rocket_clean_files( $urls, $filesystem = null ) {
 
 	/** This filter is documented in inc/front/htaccess.php */
 	$url_no_dots = (bool) apply_filters( 'rocket_url_no_dots', false );
-	$cache_path  = rocket_get_constant( 'WP_ROCKET_CACHE_PATH' );
+	$cache_path  = _rocket_get_cache_path( 'WP_ROCKET_CACHE_PATH' );
 
 	if ( empty( $filesystem ) ) {
 		$filesystem = rocket_direct_filesystem();
@@ -847,7 +847,7 @@ function rocket_clean_domain( $lang = '', $filesystem = null ) {
 
 	/** This filter is documented in inc/front/htaccess.php */
 	$url_no_dots      = (bool) apply_filters( 'rocket_url_no_dots', false );
-	$cache_path       = rocket_get_constant( 'WP_ROCKET_CACHE_PATH' );
+	$cache_path       = _rocket_get_cache_path( 'WP_ROCKET_CACHE_PATH' );
 	$dirs_to_preserve = get_rocket_i18n_to_preserve( $lang );
 
 	if ( empty( $filesystem ) ) {

--- a/inc/functions/i18n.php
+++ b/inc/functions/i18n.php
@@ -323,7 +323,8 @@ function get_rocket_i18n_to_preserve( $current_lang ) { // phpcs:ignore WordPres
 	foreach ( $langs as $lang ) {
 		$parse_url           = get_rocket_parse_url( get_rocket_i18n_home_url( $lang ) );
 		$langs_to_preserve[] = _rocket_normalize_path(
-			"{$cache_path}{$parse_url['host']}(.*)/" . trim( $parse_url['path'], '/' )
+			"{$cache_path}{$parse_url['host']}(.*)/" . trim( $parse_url['path'], '/' ),
+			true // escape directory separators for regex.
 		);
 	}
 

--- a/inc/functions/i18n.php
+++ b/inc/functions/i18n.php
@@ -319,10 +319,12 @@ function get_rocket_i18n_to_preserve( $current_lang ) { // phpcs:ignore WordPres
 
 	// Stock all URLs of langs to preserve.
 	$langs_to_preserve = [];
-	$cache_path        = rocket_get_constant( 'WP_ROCKET_CACHE_PATH' );
+	$cache_path        = _rocket_get_wp_rocket_cache_path();
 	foreach ( $langs as $lang ) {
 		$parse_url           = get_rocket_parse_url( get_rocket_i18n_home_url( $lang ) );
-		$langs_to_preserve[] = "{$cache_path}{$parse_url['host']}(.*)/" . trim( $parse_url['path'], '/' );
+		$langs_to_preserve[] = _rocket_normalize_path(
+			"{$cache_path}{$parse_url['host']}(.*)/" . trim( $parse_url['path'], '/' )
+		);
 	}
 
 	/**

--- a/inc/functions/i18n.php
+++ b/inc/functions/i18n.php
@@ -285,15 +285,19 @@ function get_rocket_i18n_uri() { // phpcs:ignore WordPress.NamingConventions.Pre
 /**
  * Get directories paths to preserve languages ​​when purging a domain.
  * This function is required when the domains of languages (​​other than the default) are managed by subdirectories.
- * By default, when you clear the cache of the french website with the domain example.com, all subdirectory like /en/ and /de/ are deleted.
- * But, if you have a domain for your english and german websites with example.com/en/ and example.com/de/, you want to keep the /en/ and /de/ directory when the french domain is cleared.
+ * By default, when you clear the cache of the french website with the domain example.com, all subdirectory like /en/
+ * and /de/ are deleted. But, if you have a domain for your english and german websites with example.com/en/ and
+ * example.com/de/, you want to keep the /en/ and /de/ directory when the french domain is cleared.
  *
+ * @since 3.5.5 Normalize paths + micro-optimization by passing in the cache path.
  * @since 2.0
  *
- * @param  string $current_lang The current language code.
+ * @param string $current_lang The current language code.
+ * @param string $cache_path   Optional. WP Rocket's cache path.
+ *
  * @return array                A list of directories path to preserve.
  */
-function get_rocket_i18n_to_preserve( $current_lang ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
+function get_rocket_i18n_to_preserve( $current_lang, $cache_path = '' ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
 	// Must not be an empty string.
 	if ( empty( $current_lang ) ) {
 		return [];
@@ -317,9 +321,12 @@ function get_rocket_i18n_to_preserve( $current_lang ) { // phpcs:ignore WordPres
 	// Remove current lang to the preserve dirs.
 	$langs = array_diff( $langs, [ $current_lang ] );
 
+	if ( '' === $cache_path ) {
+		$cache_path = _rocket_get_wp_rocket_cache_path();
+	}
+
 	// Stock all URLs of langs to preserve.
 	$langs_to_preserve = [];
-	$cache_path        = _rocket_get_wp_rocket_cache_path();
 	foreach ( $langs as $lang ) {
 		$parse_url           = get_rocket_parse_url( get_rocket_i18n_home_url( $lang ) );
 		$langs_to_preserve[] = _rocket_normalize_path(
@@ -334,7 +341,7 @@ function get_rocket_i18n_to_preserve( $current_lang ) { // phpcs:ignore WordPres
 	 * @since 2.1
 	 *
 	 * @param array $langs_to_preserve List of directories path to preserve.
-	*/
+	 */
 	return (array) apply_filters( 'rocket_langs_to_preserve', $langs_to_preserve );
 }
 

--- a/tests/Fixtures/inc/functions/_rocketNormalizePath.php
+++ b/tests/Fixtures/inc/functions/_rocketNormalizePath.php
@@ -1,0 +1,46 @@
+<?php
+
+return [
+	// Use in tests when the test data starts in this directory.
+	'vfs_dir' => 'wp-content/cache/wp-rocket/',
+
+	'structure' => [
+		'wp-content' => [
+			'cache' => [
+				'wp-rocket' => [],
+			],
+		],
+	],
+
+	// Test data.
+	'test_data' => [
+		[
+			'config'   => [
+				'path' => 'public/wp-content/cache/wp-rocket/example.org',
+			],
+			'expected' => 'public/wp-content/cache/wp-rocket/example.org',
+		],
+		[
+			'config'   => [
+				'path'   => 'vfs://public/wp-content/cache/wp-rocket/',
+				'escape' => true,
+			],
+			'expected' => 'vfs:\/\/public\/wp-content\/cache\/wp-rocket\/',
+		],
+		[
+			'config'   => [
+				'path'       => 'C:\public\wp-content\cache/wp-rocket/example.org',
+				'is_windows' => true,
+			],
+			'expected' => 'C:\public\wp-content\cache\wp-rocket\example.org',
+		],
+		[
+			'config'   => [
+				'path'       => 'C:\public\wp-content\cache/wp-rocket/example.org/',
+				'is_windows' => true,
+				'escape'     => true,
+			],
+			'expected' => 'C:\\\\public\\\\wp-content\\\\cache\\\\wp-rocket\\\\example.org\\\\',
+		],
+	],
+];

--- a/tests/Fixtures/inc/functions/getRocketI18nToPreserve.php
+++ b/tests/Fixtures/inc/functions/getRocketI18nToPreserve.php
@@ -76,8 +76,8 @@ return [
 			'rocket_has_i18n' => 'wpml',
 		],
 		'expected'     => [
-			'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/',
-			'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/',
+			'vfs:\/\/public\/wp-content\/cache\/wp-rocket\/example.org(.*)\/',
+			'vfs:\/\/public\/wp-content\/cache\/wp-rocket\/example.org(.*)\/',
 		],
 		'mocks'        => [
 			'get_rocket_i18n_code'     => $i18n_plugins['wpml']['langs'],
@@ -111,8 +111,8 @@ return [
 			'rocket_has_i18n' => 'wpml',
 		],
 		'expected'     => [
-			'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/',
-			'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/',
+			'vfs:\/\/public\/wp-content\/cache\/wp-rocket\/example.org(.*)\/',
+			'vfs:\/\/public\/wp-content\/cache\/wp-rocket\/example.org(.*)\/',
 		],
 		'unit_tests'   => [
 			'get_rocket_i18n_code'     => $i18n_plugins['wpml']['langs'],
@@ -146,8 +146,8 @@ return [
 			'rocket_has_i18n' => 'wpml',
 		],
 		'expected'     => [
-			'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/',
-			'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/',
+			'vfs:\/\/public\/wp-content\/cache\/wp-rocket\/example.org(.*)\/',
+			'vfs:\/\/public\/wp-content\/cache\/wp-rocket\/example.org(.*)\/',
 		],
 		'unit_tests'   => [
 			'get_rocket_i18n_code'     => $i18n_plugins['wpml']['langs'],
@@ -215,8 +215,8 @@ return [
 			'get_rocket_i18n_code' => $i18n_plugins['polylang']['codes'],
 		],
 		'expected'     => [
-			'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/',
-			'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/de',
+			'vfs:\/\/public\/wp-content\/cache\/wp-rocket\/example.org(.*)\/',
+			'vfs:\/\/public\/wp-content\/cache\/wp-rocket\/example.org(.*)\/de',
 		],
 		'mocks'        => [
 			'get_rocket_i18n_code'     => $i18n_plugins['wpml']['langs'],
@@ -251,8 +251,8 @@ return [
 			'get_rocket_i18n_code' => $i18n_plugins['polylang']['codes'],
 		],
 		'expected'     => [
-			'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/fr',
-			'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/de',
+			'vfs:\/\/public\/wp-content\/cache\/wp-rocket\/example.org(.*)\/fr',
+			'vfs:\/\/public\/wp-content\/cache\/wp-rocket\/example.org(.*)\/de',
 		],
 		'mocks'        => [
 			'get_rocket_i18n_code'     => $i18n_plugins['wpml']['langs'],
@@ -287,8 +287,8 @@ return [
 			'get_rocket_i18n_code' => $i18n_plugins['polylang']['codes'],
 		],
 		'expected'     => [
-			'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/',
-			'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/fr',
+			'vfs:\/\/public\/wp-content\/cache\/wp-rocket\/example.org(.*)\/',
+			'vfs:\/\/public\/wp-content\/cache\/wp-rocket\/example.org(.*)\/fr',
 		],
 		'mocks'        => [
 			'get_rocket_i18n_code'     => $i18n_plugins['wpml']['langs'],
@@ -365,8 +365,8 @@ return [
 			'get_rocket_i18n_code' => $i18n_plugins['polylang']['codes'],
 		],
 		'expected'     => [
-			'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/fr',
-			'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/de',
+			'vfs:\/\/public\/wp-content\/cache\/wp-rocket\/example.org(.*)\/fr',
+			'vfs:\/\/public\/wp-content\/cache\/wp-rocket\/example.org(.*)\/de',
 		],
 		'mocks'        => [
 			'get_rocket_i18n_code'     => $i18n_plugins['polylang']['codes'],
@@ -401,8 +401,8 @@ return [
 			'get_rocket_i18n_code' => $i18n_plugins['polylang']['codes'],
 		],
 		'expected'     => [
-			'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/',
-			'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/fr',
+			'vfs:\/\/public\/wp-content\/cache\/wp-rocket\/example.org(.*)\/',
+			'vfs:\/\/public\/wp-content\/cache\/wp-rocket\/example.org(.*)\/fr',
 		],
 		'mocks'        => [
 			'get_rocket_i18n_code'     => $i18n_plugins['polylang']['codes'],
@@ -436,8 +436,8 @@ return [
 			'data'            => $i18n_plugins['polylang'],
 		],
 		'expected'     => [
-			'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/',
-			'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/de',
+			'vfs:\/\/public\/wp-content\/cache\/wp-rocket\/example.org(.*)\/',
+			'vfs:\/\/public\/wp-content\/cache\/wp-rocket\/example.org(.*)\/de',
 		],
 		'mocks'        => [
 			'get_rocket_i18n_code'     => $i18n_plugins['polylang']['codes'],

--- a/tests/Fixtures/inc/functions/rocketCleanDomain.php
+++ b/tests/Fixtures/inc/functions/rocketCleanDomain.php
@@ -70,8 +70,8 @@ return [
 				'data'             => $i18n_plugins['wpml'],
 				'i18n_plugin'      => 'wpml',
 				'dirs_to_preserve' => [
-					'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/',
-					'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/',
+					'vfs:\/\/public\/wp-content\/cache\/wp-rocket\/example.org(.*)\/',
+					'vfs:\/\/public\/wp-content\/cache\/wp-rocket\/example.org(.*)\/',
 				],
 			],
 			'expected'  => [
@@ -101,8 +101,8 @@ return [
 				'data'             => $i18n_plugins['qtranslate'],
 				'i18n_plugin'      => 'qtranslate',
 				'dirs_to_preserve' => [
-					'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/fr',
-					'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/de',
+					'vfs:\/\/public\/wp-content\/cache\/wp-rocket\/example.org(.*)\/fr',
+					'vfs:\/\/public\/wp-content\/cache\/wp-rocket\/example.org(.*)\/de',
 				],
 			],
 			'expected'  => [
@@ -140,8 +140,8 @@ return [
 				'data'             => $i18n_plugins['qtranslate'],
 				'i18n_plugin'      => 'qtranslate',
 				'dirs_to_preserve' => [
-					'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/',
-					'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/de',
+					'vfs:\/\/public\/wp-content\/cache\/wp-rocket\/example.org(.*)\/',
+					'vfs:\/\/public\/wp-content\/cache\/wp-rocket\/example.org(.*)\/de',
 				],
 			],
 			'expected'  => [
@@ -171,8 +171,8 @@ return [
 				'data'             => $i18n_plugins['polylang'],
 				'i18n_plugin'      => 'polylang',
 				'dirs_to_preserve' => [
-					'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/',
-					'vfs://public/wp-content/cache/wp-rocket/example.org(.*)/fr',
+					'vfs:\/\/public\/wp-content\/cache\/wp-rocket\/example.org(.*)\/',
+					'vfs:\/\/public\/wp-content\/cache\/wp-rocket\/example.org(.*)\/fr',
 				],
 			],
 			'expected'  => [

--- a/tests/Integration/FilesystemTestCase.php
+++ b/tests/Integration/FilesystemTestCase.php
@@ -8,6 +8,14 @@ use WPMedia\PHPUnit\Integration\VirtualFilesystemTestCase;
 abstract class FilesystemTestCase extends VirtualFilesystemTestCase {
 	use VirtualFilesystemTrait;
 
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		if ( ! defined( 'WP_ROCKET_RUNNING_VFS' ) ) {
+			define( 'WP_ROCKET_RUNNING_VFS', true );
+		}
+	}
+
 	public function setUp() {
 		$this->initDefaultStructure();
 

--- a/tests/Integration/FilesystemTestCase.php
+++ b/tests/Integration/FilesystemTestCase.php
@@ -2,25 +2,28 @@
 
 namespace WP_Rocket\Tests\Integration;
 
+use Brain\Monkey\Functions;
 use WP_Rocket\Tests\VirtualFilesystemTrait;
 use WPMedia\PHPUnit\Integration\VirtualFilesystemTestCase;
 
 abstract class FilesystemTestCase extends VirtualFilesystemTestCase {
 	use VirtualFilesystemTrait;
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-
-		if ( ! defined( 'WP_ROCKET_RUNNING_VFS' ) ) {
-			define( 'WP_ROCKET_RUNNING_VFS', true );
-		}
-	}
-
 	public function setUp() {
 		$this->initDefaultStructure();
 
 		parent::setUp();
 
+		// Set the constant to true when running the virtual filesystem.
+		Functions\expect( 'rocket_get_constant' )->with( 'WP_ROCKET_RUNNING_VFS' )->andReturn( true );
+
 		$this->redefineRocketDirectFilesystem();
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+
+		// Reset to the default of false, i.e. to ensure this constant does not impact other tests.
+		Functions\expect( 'rocket_get_constant' )->with( 'WP_ROCKET_RUNNING_VFS' )->andReturn( false );
 	}
 }

--- a/tests/Integration/FilesystemTestCase.php
+++ b/tests/Integration/FilesystemTestCase.php
@@ -3,10 +3,12 @@
 namespace WP_Rocket\Tests\Integration;
 
 use Brain\Monkey\Functions;
+use WP_Rocket\Tests\StubTrait;
 use WP_Rocket\Tests\VirtualFilesystemTrait;
 use WPMedia\PHPUnit\Integration\VirtualFilesystemTestCase;
 
 abstract class FilesystemTestCase extends VirtualFilesystemTestCase {
+	use StubTrait;
 	use VirtualFilesystemTrait;
 
 	public function setUp() {
@@ -14,16 +16,7 @@ abstract class FilesystemTestCase extends VirtualFilesystemTestCase {
 
 		parent::setUp();
 
-		// Set the constant to true when running the virtual filesystem.
-		Functions\expect( 'rocket_get_constant' )->with( 'WP_ROCKET_RUNNING_VFS' )->andReturn( true );
-
+		$this->stubRocketGetConstant();
 		$this->redefineRocketDirectFilesystem();
-	}
-
-	public function tearDown() {
-		parent::tearDown();
-
-		// Reset to the default of false, i.e. to ensure this constant does not impact other tests.
-		Functions\expect( 'rocket_get_constant' )->with( 'WP_ROCKET_RUNNING_VFS' )->andReturn( false );
 	}
 }

--- a/tests/Integration/inc/Engine/Optimization/Minify/CSS/AdminSubscriber/cleanMinify.php
+++ b/tests/Integration/inc/Engine/Optimization/Minify/CSS/AdminSubscriber/cleanMinify.php
@@ -31,9 +31,6 @@ class Test_CleanMinify extends FilesystemTestCase {
 	public function setUp() {
 		parent::setUp();
 
-		// Mocks the various filesystem constants.
-		$this->whenRocketGetConstant();
-
 		$this->old_settings = array_merge( self::$original_settings, $this->config['settings'] );
 		update_option( 'wp_rocket_settings', $this->old_settings );
 	}

--- a/tests/Integration/inc/Engine/Optimization/Minify/CSS/Subscriber/process.php
+++ b/tests/Integration/inc/Engine/Optimization/Minify/CSS/Subscriber/process.php
@@ -24,9 +24,6 @@ class Test_Process extends TestCase {
 		$this->wp_content_dir = 'vfs://public/wordpress/wp-content';
 
 		parent::setUp();
-
-		// Mocks constants for the virtual filesystem.
-		$this->whenRocketGetConstant();
 	}
 
 	public function tearDown() {

--- a/tests/Integration/inc/Engine/Optimization/Minify/JS/Subscriber/process.php
+++ b/tests/Integration/inc/Engine/Optimization/Minify/JS/Subscriber/process.php
@@ -24,9 +24,6 @@ class Test_Process extends TestCase {
 		$this->wp_content_dir = 'vfs://public/wordpress/wp-content';
 
 		parent::setUp();
-
-		// Mocks constants for the virtual filesystem.
-		$this->whenRocketGetConstant();
 	}
 
 	public function tearDown() {

--- a/tests/Integration/inc/Engine/Optimization/QueryString/RemoveSubscriber/process.php
+++ b/tests/Integration/inc/Engine/Optimization/QueryString/RemoveSubscriber/process.php
@@ -20,13 +20,6 @@ use WP_Rocket\Tests\Integration\inc\Engine\Optimization\TestCase;
 class Test_Process extends TestCase {
 	protected $path_to_test_data = '/inc/Engine/Optimization/QueryString/RemoveSubscriber/remove-query-strings.php';
 
-	public function setUp() {
-		parent::setUp();
-
-		// Mocks constants for the virtual filesystem.
-		$this->whenRocketGetConstant();
-	}
-
 	public function tearDown() {
 		parent::tearDown();
 

--- a/tests/Integration/inc/functions/getRocketAdvancedCacheFile.php
+++ b/tests/Integration/inc/functions/getRocketAdvancedCacheFile.php
@@ -2,7 +2,6 @@
 
 namespace WP_Rocket\Tests\Integration\inc\functions;
 
-use Brain\Monkey\Functions;
 use WP_Rocket\Tests\Integration\FilesystemTestCase;
 
 /**
@@ -21,9 +20,6 @@ class Test_GetRocketAdvancedCacheFile extends FilesystemTestCase {
 
 	public function setUp() {
 		parent::setUp();
-
-		// Mocks the various filesystem constants.
-		$this->whenRocketGetConstant();
 
 		$this->original_settings = get_option( 'wp_rocket_settings', [] );
 	}

--- a/tests/Integration/inc/functions/rocketDeleteLicenceDataFile.php
+++ b/tests/Integration/inc/functions/rocketDeleteLicenceDataFile.php
@@ -15,11 +15,6 @@ class Test_RocketDeleteLicenceDataFile extends FilesystemTestCase {
 	protected $path_to_test_data = '/inc/functions/rocketDeleteLicenceDataFile.php';
 
 	public function testShouldDeleteLicenceDataFileWhenExists() {
-		Functions\expect( 'rocket_get_constant' )
-			->once()
-			->with( 'WP_ROCKET_PATH' )
-			->andReturn( $this->filesystem->getUrl( $this->config['vfs_dir'] ) );
-
 		$this->assertTrue( $this->filesystem->exists( 'wp-content/plugins/wp-rocket/licence-data.php' ) );
 
 		rocket_delete_licence_data_file();

--- a/tests/Integration/inc/functions/rocketGenerateAdvancedCacheFile.php
+++ b/tests/Integration/inc/functions/rocketGenerateAdvancedCacheFile.php
@@ -34,9 +34,6 @@ class Test_RocketGenerateAdvancedCacheFile extends FilesystemTestCase {
 	public function setUp() {
 		parent::setUp();
 
-		// Mocks the various filesystem constants.
-		$this->whenRocketGetConstant();
-
 		$this->old_settings = array_merge( self::$original_settings, $this->config['settings'] );
 		update_option( 'wp_rocket_settings', $this->old_settings );
 	}

--- a/tests/StubTrait.php
+++ b/tests/StubTrait.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace WP_Rocket\Tests;
+
+use Brain\Monkey\Functions;
+
+trait StubTrait {
+	protected $abspath = 'vfs://public/';
+	protected $is_running_vfs = true;
+	protected $mock_rocket_get_constant = true;
+	protected $just_return_path = false;
+	protected $wp_cache_constant = false;
+	protected $wp_content_dir = 'vfs://public/wp-content';
+
+
+	protected function stubRocketGetConstant() {
+		if ( ! $this->mock_rocket_get_constant ) {
+			return;
+		}
+
+		Functions\when( 'rocket_get_constant' )->alias(
+			function( $constant_name, $default = null ) {
+				return $this->getConstant( $constant_name, $default );
+			}
+		);
+	}
+
+	protected function getConstant( $constant_name, $default = null ) {
+		switch ( $constant_name ) {
+			case 'ABSPATH':
+				return $this->abspath;
+
+			case 'FS_CHMOD_DIR':
+				return 0777;
+
+			case 'FS_CHMOD_FILE':
+				return 0666;
+
+			case 'WP_CACHE':
+				return $this->wp_cache_constant;
+
+			case 'WP_CONTENT_DIR':
+				return $this->wp_content_dir;
+
+			case 'WP_ROCKET_CACHE_PATH':
+				return "{$this->wp_content_dir}/cache/wp-rocket/";
+
+			case 'WP_ROCKET_CONFIG_PATH':
+				return "{$this->wp_content_dir}/wp-rocket-config/";
+
+			case 'WP_ROCKET_INC_PATH':
+				return "{$this->wp_content_dir}/plugins/wp-rocket/inc/";
+
+			case 'WP_ROCKET_MINIFY_CACHE_PATH':
+				return "{$this->wp_content_dir}/cache/min/";
+
+			case 'WP_ROCKET_MINIFY_CACHE_URL':
+				return 'http://example.org/wp-content/cache/min/';
+
+			case 'WP_ROCKET_PATH':
+				return "{$this->wp_content_dir}/plugins/wp-rocket/";
+
+			case 'WP_ROCKET_PHP_VERSION':
+				return '5.6';
+
+			case 'WP_ROCKET_RUNNING_VFS':
+				return $this->is_running_vfs;
+
+			case 'WP_ROCKET_VENDORS_PATH':
+				return "{$this->wp_content_dir}/plugins/wp-rocket/inc/vendors/";
+
+			default:
+				if ( ! rocket_has_constant( $constant_name ) ) {
+					return $default;
+				}
+
+				return constant( $constant_name );
+		}
+	}
+
+	protected function stubWpNormalizePath() {
+		Functions\when( 'wp_normalize_path' )->alias(
+			function( $path ) {
+				if ( true === $this->just_return_path ) {
+					return $path;
+				}
+
+				$path = str_replace( '\\', '/', $path );
+				$path = preg_replace( '|(?<=.)/+|', '/', $path );
+
+				if ( ':' === substr( $path, 1, 1 ) ) {
+					$path = ucfirst( $path );
+				}
+
+				return $path;
+			}
+		);
+	}
+
+	protected function stubGetRocketParseUrl( $url = '' ) {
+		if ( empty( $url ) ) {
+			Functions\when( 'get_rocket_parse_url' )
+				->alias(
+					function( $url ) {
+						return $this->get_rocket_parse_url( $url );
+					}
+				);
+		} else {
+			Functions\expect( 'get_rocket_parse_url' )
+				->once()
+				->with( $url )
+				->andReturnUsing(
+					function( $url ) {
+						return $this->get_rocket_parse_url( $url );
+					}
+				);
+		}
+	}
+
+	protected function get_rocket_parse_url( $url ) {
+			$parsed = parse_url( $url );
+
+			$host     = isset( $parsed['host'] ) ? strtolower( urldecode( $parsed['host'] ) ) : '';
+			$path     = isset( $parsed['path'] ) ? urldecode( $parsed['path'] ) : '';
+			$scheme   = isset( $parsed['scheme'] ) ? urldecode( $parsed['scheme'] ) : '';
+			$query    = isset( $parsed['query'] ) ? urldecode( $parsed['query'] ) : '';
+			$fragment = isset( $parsed['fragment'] ) ? urldecode( $parsed['fragment'] ) : '';
+
+			return [
+				'host'     => $host,
+				'path'     => $path,
+				'scheme'   => $scheme,
+				'query'    => $query,
+				'fragment' => $fragment,
+			];
+	}
+}

--- a/tests/StubTrait.php
+++ b/tests/StubTrait.php
@@ -5,12 +5,12 @@ namespace WP_Rocket\Tests;
 use Brain\Monkey\Functions;
 
 trait StubTrait {
-	protected $abspath = 'vfs://public/';
-	protected $is_running_vfs = true;
+	protected $abspath                  = 'vfs://public/';
+	protected $is_running_vfs           = true;
 	protected $mock_rocket_get_constant = true;
-	protected $just_return_path = false;
-	protected $wp_cache_constant = false;
-	protected $wp_content_dir = 'vfs://public/wp-content';
+	protected $just_return_path         = false;
+	protected $wp_cache_constant        = false;
+	protected $wp_content_dir           = 'vfs://public/wp-content';
 
 
 	protected function stubRocketGetConstant() {
@@ -118,20 +118,20 @@ trait StubTrait {
 	}
 
 	protected function get_rocket_parse_url( $url ) {
-			$parsed = parse_url( $url );
+		$parsed = parse_url( $url );
 
-			$host     = isset( $parsed['host'] ) ? strtolower( urldecode( $parsed['host'] ) ) : '';
-			$path     = isset( $parsed['path'] ) ? urldecode( $parsed['path'] ) : '';
-			$scheme   = isset( $parsed['scheme'] ) ? urldecode( $parsed['scheme'] ) : '';
-			$query    = isset( $parsed['query'] ) ? urldecode( $parsed['query'] ) : '';
-			$fragment = isset( $parsed['fragment'] ) ? urldecode( $parsed['fragment'] ) : '';
+		$host     = isset( $parsed['host'] ) ? strtolower( urldecode( $parsed['host'] ) ) : '';
+		$path     = isset( $parsed['path'] ) ? urldecode( $parsed['path'] ) : '';
+		$scheme   = isset( $parsed['scheme'] ) ? urldecode( $parsed['scheme'] ) : '';
+		$query    = isset( $parsed['query'] ) ? urldecode( $parsed['query'] ) : '';
+		$fragment = isset( $parsed['fragment'] ) ? urldecode( $parsed['fragment'] ) : '';
 
-			return [
-				'host'     => $host,
-				'path'     => $path,
-				'scheme'   => $scheme,
-				'query'    => $query,
-				'fragment' => $fragment,
-			];
+		return [
+			'host'     => $host,
+			'path'     => $path,
+			'scheme'   => $scheme,
+			'query'    => $query,
+			'fragment' => $fragment,
+		];
 	}
 }

--- a/tests/Unit/FilesystemTestCase.php
+++ b/tests/Unit/FilesystemTestCase.php
@@ -8,6 +8,14 @@ use WPMedia\PHPUnit\Unit\VirtualFilesystemTestCase;
 abstract class FilesystemTestCase extends VirtualFilesystemTestCase {
 	use VirtualFilesystemTrait;
 
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		if ( ! defined( 'WP_ROCKET_RUNNING_VFS' ) ) {
+			define( 'WP_ROCKET_RUNNING_VFS', true );
+		}
+	}
+
 	public function setUp() {
 		$this->initDefaultStructure();
 

--- a/tests/Unit/FilesystemTestCase.php
+++ b/tests/Unit/FilesystemTestCase.php
@@ -2,25 +2,21 @@
 
 namespace WP_Rocket\Tests\Unit;
 
+use WP_Rocket\Tests\StubTrait;
 use WP_Rocket\Tests\VirtualFilesystemTrait;
 use WPMedia\PHPUnit\Unit\VirtualFilesystemTestCase;
 
 abstract class FilesystemTestCase extends VirtualFilesystemTestCase {
+	use StubTrait;
 	use VirtualFilesystemTrait;
-
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-
-		if ( ! defined( 'WP_ROCKET_RUNNING_VFS' ) ) {
-			define( 'WP_ROCKET_RUNNING_VFS', true );
-		}
-	}
 
 	public function setUp() {
 		$this->initDefaultStructure();
 
 		parent::setUp();
 
+		$this->stubRocketGetConstant();
+		$this->stubWpNormalizePath();
 		$this->redefineRocketDirectFilesystem();
 	}
 }

--- a/tests/Unit/inc/Engine/Optimization/Minify/CSS/Combine/insertCombinedCSS.php
+++ b/tests/Unit/inc/Engine/Optimization/Minify/CSS/Combine/insertCombinedCSS.php
@@ -16,15 +16,6 @@ class Test_InsertCombinedCSS extends TestCase {
 		Functions\when( 'create_rocket_uniqid' )->justReturn( '1234' );
 		Functions\when( 'get_current_blog_id' )->justReturn( '1' );
 
-		Functions\expect( 'rocket_get_constant' )
-			->once()
-			->with( 'WP_ROCKET_MINIFY_CACHE_PATH' )
-			->andReturn( 'wp-content/cache/' )
-			->andAlsoExpectIt()
-			->once()
-			->with( 'WP_ROCKET_MINIFY_CACHE_URL' )
-			->andReturn( 'http://example.com/wp-content/cache/' );
-
 		$options = $this->createMock( 'WP_Rocket\Admin\Options_Data' );
 		$minify  = $this->createMock( 'MatthiasMullie\Minify\CSS' );
 

--- a/tests/Unit/inc/Engine/Optimization/Minify/CSS/Combine/optimize.php
+++ b/tests/Unit/inc/Engine/Optimization/Minify/CSS/Combine/optimize.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\Minify\CSS\Combine;
 
 use Brain\Monkey\Filters;
@@ -6,34 +7,30 @@ use Brain\Monkey\Functions;
 use MatthiasMullie\Minify;
 use Mockery;
 use WP_Rocket\Engine\Optimization\Minify\CSS\Combine;
+use WP_Rocket\Tests\StubTrait;
 use WP_Rocket\Tests\Unit\inc\Engine\Optimization\TestCase;
 
 /**
  * @covers \WP_Rocket\Engine\Optimization\Minify\CSS\Combine::optimize
- * @group Combine
- * @group CombineCSS
+ * @group  Combine
+ * @group  CombineCSS
  */
 class Test_Optimize extends TestCase {
+	use StubTrait;
+
 	protected $path_to_test_data = '/inc/Engine/Optimization/Minify/CSS/Combine/combine.php';
 	private $combine;
 	private $minify;
 
 	public function setUp() {
+		$this->wp_content_dir = 'vfs://public/wordpress/wp-content';
+
 		parent::setUp();
 
 		$this->minify = Mockery::mock( Minify\CSS::class );
 		$this->minify->shouldReceive( 'add' );
 		$this->minify->shouldReceive( 'minify' )
-			->andReturn( 'body{font-family:Helvetica,Arial,sans-serif;text-align:center;}' );
-
-		Functions\expect( 'rocket_get_constant' )
-			->once()
-			->with( 'WP_ROCKET_MINIFY_CACHE_PATH' )
-			->andReturn( $this->filesystem->getUrl( 'wordpress/wp-content/cache/min/' ) )
-			->andAlsoExpectIt()
-			->once()
-			->with( 'WP_ROCKET_MINIFY_CACHE_URL' )
-			->andReturn( 'http://example.org/wp-content/cache/min/' );
+		             ->andReturn( 'body{font-family:Helvetica,Arial,sans-serif;text-align:center;}' );
 
 		$this->combine = new Combine( $this->options, $this->minify );
 	}

--- a/tests/Unit/inc/Engine/Optimization/Minify/CSS/Minify/optimize.php
+++ b/tests/Unit/inc/Engine/Optimization/Minify/CSS/Minify/optimize.php
@@ -16,16 +16,9 @@ class Test_Optimize extends TestCase {
 	protected $minify;
 
 	public function setUp() {
-		parent::setUp();
+		$this->wp_content_dir = 'vfs://public/wordpress/wp-content';
 
-		Functions\expect( 'rocket_get_constant' )
-			->once()
-			->with( 'WP_ROCKET_MINIFY_CACHE_PATH' )
-			->andReturn( $this->filesystem->getUrl( 'wordpress/wp-content/cache/min/' ) )
-			->andAlsoExpectIt()
-			->once()
-			->with( 'WP_ROCKET_MINIFY_CACHE_URL' )
-			->andReturn( 'http://example.org/wp-content/cache/min/' );
+		parent::setUp();
 
 		$this->minify = new Minify( $this->options );
 	}
@@ -38,7 +31,7 @@ class Test_Optimize extends TestCase {
 			->zeroOrMoreTimes()
 			->with( [], [ 'all', 'css_and_js', 'css' ] )
 			->andReturn( $cdn_host );
-		
+
 		Filters\expectApplied( 'rocket_asset_url' )
 			->zeroOrMoreTimes()
 			->andReturnUsing( function( $url ) use ( $cdn_url, $site_url ) {

--- a/tests/Unit/inc/Engine/Optimization/Minify/JS/Combine/optimize.php
+++ b/tests/Unit/inc/Engine/Optimization/Minify/JS/Combine/optimize.php
@@ -20,6 +20,8 @@ class Test_Optimize extends TestCase {
 	private $minify;
 
 	public function setUp() {
+		$this->wp_content_dir = 'vfs://public/wordpress/wp-content';
+
 		parent::setUp();
 
 		$this->minify = Mockery::mock( Minify\JS::class );
@@ -36,15 +38,6 @@ class Test_Optimize extends TestCase {
 
 			return $wp_scripts;
 		} );
-
-		Functions\expect( 'rocket_get_constant' )
-			->once()
-			->with( 'WP_ROCKET_MINIFY_CACHE_PATH' )
-			->andReturn( $this->filesystem->getUrl( 'wordpress/wp-content/cache/min/' ) )
-			->andAlsoExpectIt()
-			->once()
-			->with( 'WP_ROCKET_MINIFY_CACHE_URL' )
-			->andReturn( 'http://example.org/wp-content/cache/min/' );
 
 		$this->combine = new Combine( $this->options, $this->minify, Mockery::mock( Assets_Local_Cache::class ) );
 	}

--- a/tests/Unit/inc/Engine/Optimization/Minify/JS/Minify/optimize.php
+++ b/tests/Unit/inc/Engine/Optimization/Minify/JS/Minify/optimize.php
@@ -16,6 +16,8 @@ class Test_Optimize extends TestCase {
 	protected $minify;
 
 	public function setUp() {
+		$this->wp_content_dir = 'vfs://public/wordpress/wp-content';
+
 		parent::setUp();
 
 		$GLOBALS['wp_scripts'] = (object) [
@@ -24,16 +26,7 @@ class Test_Optimize extends TestCase {
 					'src' => 'wp-includes/js/jquery/jquery.js',
 				],
 			]
-		]; 
-
-		Functions\expect( 'rocket_get_constant' )
-			->once()
-			->with( 'WP_ROCKET_MINIFY_CACHE_PATH' )
-			->andReturn( $this->filesystem->getUrl( 'wordpress/wp-content/cache/min/' ) )
-			->andAlsoExpectIt()
-			->once()
-			->with( 'WP_ROCKET_MINIFY_CACHE_URL' )
-			->andReturn( 'http://example.org/wp-content/cache/min/' );
+		];
 
 		$this->minify = new Minify( $this->options );
 	}

--- a/tests/Unit/inc/Engine/Optimization/TestCase.php
+++ b/tests/Unit/inc/Engine/Optimization/TestCase.php
@@ -12,37 +12,18 @@ abstract class TestCase extends FilesystemTestCase {
 	protected $options;
 
 	public function setUp() {
+		$this->wp_content_dir = 'vfs://public/wordpress/wp-content';
+
 		parent::setUp();
+
+		$this->stubGetRocketParseUrl();
 
 		$this->options = Mockery::mock( Options_Data::class );
 		$this->options->shouldReceive( 'get' )
 			->andReturnArg(1);
 
-		Functions\expect( 'rocket_get_constant' )
-			->zeroOrMoreTimes()
-			->with( 'WP_CONTENT_DIR' )
-			->andReturn( $this->filesystem->getUrl( 'wordpress/wp-content/' ) );
-
 		Functions\when( 'get_current_blog_id' )->justReturn( 1 );
 		Functions\when( 'create_rocket_uniqid' )->justReturn( 'rocket_uniqid' );
-
-		Functions\when( 'get_rocket_parse_url' )->alias( function( $url ) {
-			$parsed = parse_url( $url );
-
-			$host     = isset( $parsed['host'] ) ? strtolower( urldecode( $parsed['host'] ) ) : '';
-			$path     = isset( $parsed['path'] ) ? urldecode( $parsed['path'] ) : '';
-			$scheme   = isset( $parsed['scheme'] ) ? urldecode( $parsed['scheme'] ) : '';
-			$query    = isset( $parsed['query'] ) ? urldecode( $parsed['query'] ) : '';
-			$fragment = isset( $parsed['fragment'] ) ? urldecode( $parsed['fragment'] ) : '';
-
-			return [
-				'host'     => $host,
-				'path'     => $path,
-				'scheme'   => $scheme,
-				'query'    => $query,
-				'fragment' => $fragment,
-			];
-		} );
 
 		Functions\when( 'content_url' )->justReturn( 'http://example.org/wp-content' );
 		Functions\when( 'get_rocket_i18n_uri' )->justReturn( [

--- a/tests/Unit/inc/functions/_rocketGetCacheDirs.php
+++ b/tests/Unit/inc/functions/_rocketGetCacheDirs.php
@@ -14,6 +14,7 @@ use WP_Rocket\Tests\Unit\FilesystemTestCase;
  */
 class Test__RocketGetCacheDirs extends FilesystemTestCase {
 	protected $path_to_test_data = '/inc/functions/_rocketGetCacheDirs.php';
+	protected $mock_rocket_get_constant = false;
 
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();

--- a/tests/Unit/inc/functions/_rocketNormalizePath.php
+++ b/tests/Unit/inc/functions/_rocketNormalizePath.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\functions;
+
+use Brain\Monkey\Functions;
+use WP_Rocket\Tests\Unit\FilesystemTestCase;
+
+/**
+ * @covers ::_rocket_normalize_path
+ * @uses  ::_rocket_is_windows_fs
+ *
+ * @group Files
+ * @group vfs
+ * @group Clean
+ * @group normalize
+ */
+class Test__RocketNormalizePath extends FilesystemTestCase {
+	protected $path_to_test_data = '/inc/functions/_rocketNormalizePath.php';
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		// Reset before starting.
+		_rocket_is_windows_fs( true );
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+
+		// Reset after each test.
+		_rocket_is_windows_fs( true );
+	}
+
+	/**
+	 * @dataProvider providerTestData
+	 */
+	public function testShouldNormalizePath( $config, $expected ) {
+		$path       = array_key_exists( 'path', $config ) ? $config['path'] : '';
+		$escape     = array_key_exists( 'escape', $config ) ? $config['escape'] : '';
+		$force      = array_key_exists( 'force', $config ) ? $config['force'] : '';
+		$is_windows = array_key_exists( 'is_windows', $config ) ? $config['is_windows'] : false;
+
+		Functions\expect( '_rocket_is_windows_fs' )
+			->once()
+			->with( $path )
+			->andReturn( $is_windows );
+
+		$this->assertSame( $expected, _rocket_normalize_path( $path, $escape, $force ) );
+	}
+}

--- a/tests/Unit/inc/functions/getRocketAdvancedCacheFile.php
+++ b/tests/Unit/inc/functions/getRocketAdvancedCacheFile.php
@@ -18,13 +18,6 @@ use WP_Rocket\Tests\Unit\FilesystemTestCase;
 class Test_GetRocketAdvancedCacheFile extends FilesystemTestCase {
 	protected $path_to_test_data = '/inc/functions/getRocketAdvancedCacheFile.php';
 
-	public function setUp() {
-		parent::setUp();
-
-		// Mocks the various filesystem constants.
-		$this->whenRocketGetConstant();
-	}
-
 	/**
 	 * @dataProvider providerTestData
 	 */

--- a/tests/Unit/inc/functions/getRocketI18nUri.php
+++ b/tests/Unit/inc/functions/getRocketI18nUri.php
@@ -11,6 +11,7 @@ use WPMedia\PHPUnit\Unit\TestCase;
  * @covers ::get_rocket_i18n_uri
  * @uses  ::rocket_has_i18n
  * @uses  ::get_rocket_i18n_code
+ *
  * @group Functions
  * @group i18n
  */

--- a/tests/Unit/inc/functions/rocketCleanDomain.php
+++ b/tests/Unit/inc/functions/rocketCleanDomain.php
@@ -13,9 +13,12 @@ use WP_Rocket\Tests\Unit\FilesystemTestCase;
  * @uses  ::get_rocket_i18n_to_preserve
  * @uses  ::get_rocket_i18n_uri
  * @uses  ::get_rocket_parse_url
+ * @uses  ::_rocket_get_wp_rocket_cache_path
  * @uses  ::rocket_get_constant
  * @uses  ::rocket_rrmdir
  * @uses  ::_rocket_get_cache_dirs
+ * @uses  ::_rocket_normalize_path
+ * @uses  ::_rocket_is_windows_fs
  *
  * @group Functions
  * @group Files

--- a/tests/Unit/inc/functions/rocketCleanDomain.php
+++ b/tests/Unit/inc/functions/rocketCleanDomain.php
@@ -62,6 +62,7 @@ class Test_RocketCleanDomain extends FilesystemTestCase {
 		$dirsToPreserve = $i18n['dirs_to_preserve'];
 		$url            = $expected['rocket_clean_domain_urls'][0];
 		$lang           = $i18n['lang'];
+		$cache_path     = _rocket_get_wp_rocket_cache_path();
 
 		if ( ! is_null( $config['get_rocket_i18n_uri'] ) ) {
 			Functions\expect( 'get_rocket_i18n_uri' )->once()->andReturn( $config['get_rocket_i18n_uri'] );
@@ -80,24 +81,10 @@ class Test_RocketCleanDomain extends FilesystemTestCase {
 
 		Functions\expect( 'get_rocket_i18n_to_preserve' )
 			->once()
-			->with( $lang )
+			->with( $lang, $cache_path )
 			->andReturn( $dirsToPreserve );
-		Functions\expect( 'get_rocket_parse_url' )
-			->once()
-			->with( $url )
-			->andReturnUsing(
-				function ( $url ) {
-					return array_merge(
-						[
-							'host'   => '',
-							'path'   => '',
-							'scheme' => '',
-							'query'  => '',
-						],
-						parse_url( $url )
-					);
-				}
-			);
+
+		$this->stubGetRocketParseUrl( $url );
 
 		foreach ( $config['rocket_rrmdir'] as $dir ) {
 			if ( $this->filesystem->is_dir( $dir ) ) {
@@ -107,7 +94,7 @@ class Test_RocketCleanDomain extends FilesystemTestCase {
 					->with( $dir, $dirsToPreserve, $this->filesystem )
 					->andReturnNull();
 			} else {
-				Functions\expect( 'rocket_rrmdir' )->with( $dir )->never();
+				Functions\expect( 'rocket_rrmdir' )->never();
 			}
 		}
 

--- a/tests/Unit/inc/functions/rocketCleanFiles.php
+++ b/tests/Unit/inc/functions/rocketCleanFiles.php
@@ -9,8 +9,12 @@ use WP_Rocket\Tests\Unit\FilesystemTestCase;
 
 /**
  * @covers ::rocket_clean_files
+ * @uses  ::_rocket_get_wp_rocket_cache_path
+ * @uses  ::rocket_get_constant
  * @uses  ::rocket_rrmdir
  * @uses  ::_rocket_get_cache_dirs
+ * @uses  ::_rocket_normalize_path
+ * @uses  ::_rocket_is_windows_fs
  *
  * @group Functions
  * @group Files
@@ -32,14 +36,6 @@ class Test_RocketCleanFiles extends FilesystemTestCase {
 
 		// Clean out the cached dirs before we leave this test class.
 		_rocket_get_cache_dirs( '', '', true );
-	}
-
-	public function setUp() {
-		parent::setUp();
-
-		Functions\expect( 'rocket_get_constant' )
-			->with( 'WP_ROCKET_CACHE_PATH' )
-			->andReturn( 'vfs://public/wp-content/cache/wp-rocket/' );
 	}
 
 	public function tearDown() {
@@ -84,22 +80,7 @@ class Test_RocketCleanFiles extends FilesystemTestCase {
 
 		foreach ( $urls as $url ) {
 			Actions\expectDone( 'before_rocket_clean_file' )->once()->with( $url );
-			Functions\expect( 'get_rocket_parse_url' )
-				->once()
-				->with( $url )
-				->andReturnUsing(
-					function ( $url ) {
-						return array_merge(
-							[
-								'host'   => '',
-								'path'   => '',
-								'scheme' => '',
-								'query'  => '',
-							],
-							parse_url( $url )
-						);
-					}
-				);
+			$this->stubGetRocketParseUrl( $url );
 			Actions\expectDone( 'after_rocket_clean_file' )->once()->with( $url );
 		}
 

--- a/tests/Unit/inc/functions/rocketCleanMinify.php
+++ b/tests/Unit/inc/functions/rocketCleanMinify.php
@@ -22,7 +22,6 @@ class Test_RocketCleanMinify extends FilesystemTestCase {
 		parent::setUp();
 
 		Functions\when( 'get_current_blog_id' )->justReturn( 1 );
-		Functions\expect( 'rocket_get_constant' )->with( 'WP_ROCKET_MINIFY_CACHE_PATH' )->andReturn( 'vfs://public/wp-content/cache/min/' );
 	}
 
 	/**

--- a/tests/Unit/inc/functions/rocketDeleteLicenceDataFile.php
+++ b/tests/Unit/inc/functions/rocketDeleteLicenceDataFile.php
@@ -22,10 +22,6 @@ class Test_RocketDeleteLicenceDataFile extends FilesystemTestCase {
 
 	public function testShouldDeleteLicenceDataFileWhenExists() {
 		Functions\when( 'is_multisite' )->justReturn( false );
-		Functions\expect( 'rocket_get_constant' )
-			->once()
-			->with( 'WP_ROCKET_PATH' )
-			->andReturn( $this->filesystem->getUrl( $this->config['vfs_dir'] ) );
 
 		$this->assertTrue( $this->filesystem->exists( 'wp-content/plugins/wp-rocket/licence-data.php' ) );
 

--- a/tests/Unit/inc/functions/rocketGenerateAdvancedCacheFile.php
+++ b/tests/Unit/inc/functions/rocketGenerateAdvancedCacheFile.php
@@ -19,13 +19,6 @@ class Test_RocketGenerateAdvancedCacheFile extends FilesystemTestCase {
 	protected $path_to_test_data   = '/inc/functions/rocketGenerateAdvancedCacheFile.php';
 	private   $advanced_cache_file = 'vfs://public/wp-content/advanced-cache.php';
 
-	public function setUp() {
-		parent::setUp();
-
-		// Mocks the various filesystem constants.
-		$this->whenRocketGetConstant();
-	}
-
 	/**
 	 * @dataProvider providerTestData
 	 */

--- a/tests/VirtualFilesystemTrait.php
+++ b/tests/VirtualFilesystemTrait.php
@@ -6,17 +6,10 @@ use Brain\Monkey\Functions;
 use org\bovigo\vfs\vfsStream;
 
 trait VirtualFilesystemTrait {
-	protected $original_entries  = [];
-	protected $shouldNotClean    = [];
-	protected $entriesBefore     = [];
-	protected $dumpResults       = false;
-	protected $abspath           = 'vfs://public/';
-	protected $wp_cache_constant = false;
-	protected $wp_content_dir    = 'vfs://public/wp-content';
-
-	protected function defineRunningVfsConstant() {
-
-	}
+	protected $original_entries = [];
+	protected $shouldNotClean = [];
+	protected $entriesBefore = [];
+	protected $dumpResults = false;
 
 	protected function initDefaultStructure() {
 		if ( empty( $this->config ) ) {
@@ -114,64 +107,12 @@ trait VirtualFilesystemTrait {
 		$this->assertEmpty( $actual );
 	}
 
-	protected function whenRocketGetConstant() {
-		Functions\when( 'rocket_get_constant' )->alias(
-			function ( $constant_name, $default = null ) {
-				return $this->getConstant( $constant_name, $default );
-			}
-		);
-	}
-
 	protected function getDirUrl( $dir ) {
 		if ( empty( $dir ) ) {
 			return $this->filesystem->getUrl( $this->config['vfs_dir'] );
 		}
 
 		return $dir;
-	}
-
-	protected function getConstant( $constant_name, $default = null ) {
-		switch ( $constant_name ) {
-			case 'ABSPATH':
-				return $this->abspath;
-
-			case 'FS_CHMOD_DIR':
-				return 0777;
-
-			case 'FS_CHMOD_FILE':
-				return 0666;
-
-			case 'WP_CACHE':
-				return $this->wp_cache_constant;
-
-			case 'WP_CONTENT_DIR':
-				return $this->wp_content_dir;
-
-			case 'WP_ROCKET_CACHE_PATH':
-				return "{$this->wp_content_dir}/cache/wp-rocket/";
-
-			case 'WP_ROCKET_CONFIG_PATH':
-				return "{$this->wp_content_dir}/wp-rocket-config/";
-
-			case 'WP_ROCKET_INC_PATH':
-				return "{$this->wp_content_dir}/plugins/wp-rocket/inc/";
-
-			case 'WP_ROCKET_PATH':
-				return "{$this->wp_content_dir}/plugins/wp-rocket/";
-
-			case 'WP_ROCKET_PHP_VERSION':
-				return '5.6';
-
-			case 'WP_ROCKET_VENDORS_PATH':
-				return "{$this->wp_content_dir}/plugins/wp-rocket/inc/vendors/";
-
-			default:
-				if ( ! rocket_has_constant( $constant_name ) ) {
-					return $default;
-				}
-
-				return constant( $constant_name );
-		}
 	}
 
 	public function getPathToFixturesDir() {

--- a/tests/VirtualFilesystemTrait.php
+++ b/tests/VirtualFilesystemTrait.php
@@ -7,9 +7,9 @@ use org\bovigo\vfs\vfsStream;
 
 trait VirtualFilesystemTrait {
 	protected $original_entries = [];
-	protected $shouldNotClean = [];
-	protected $entriesBefore = [];
-	protected $dumpResults = false;
+	protected $shouldNotClean   = [];
+	protected $entriesBefore    = [];
+	protected $dumpResults      = false;
 
 	protected function initDefaultStructure() {
 		if ( empty( $this->config ) ) {

--- a/tests/VirtualFilesystemTrait.php
+++ b/tests/VirtualFilesystemTrait.php
@@ -14,6 +14,10 @@ trait VirtualFilesystemTrait {
 	protected $wp_cache_constant = false;
 	protected $wp_content_dir    = 'vfs://public/wp-content';
 
+	protected function defineRunningVfsConstant() {
+
+	}
+
 	protected function initDefaultStructure() {
 		if ( empty( $this->config ) ) {
 			$this->loadConfig();


### PR DESCRIPTION
This PR adds normalizing for a Windows/IIS filesystem (fs) to fix various problems in the filesystem that impacts i18n and Preload.

Closes #2642 

Changes include:

- Adds a private function `__rocket_is_windows_fs()` to determine if this filesystem is for Windows/IIS. Note: This is turned off when running our virtual filesystem in our automated test suites.
- Adds a private function `_rocket_normalize_path()` to encapsulate the normalizing process:
    - If Windows/IIS fs, converts all `/` directory separators into:
        - when character escaping => `\\\\` (for regex)
        - Else => `\\`
    - For non-Windows/IIS fs:
        - when character escaping => `\/` (for regex)
        - Else => returns original given path
- Adds a private function `_rocket_get_wp_rocket_cache_path()` to get and normalize the `WP_ROCKET_CACHE_PATH` constant. This function can be reused throughout Rocket for now, until we create a new Filesystem module.

## TODO

- [x] Add normalizing function
- [x] Add `WP_ROCKET_CACHE_PATH` normalizing getter
- [x] Update `_rocket_get_cache_dirs()`
- [x] Update `rocket_clean_files()`
- [x] Update `rocket_clean_domain()`
- [x] Update `get_rocket_i18n_to_preserve()` - which fixes #2642 
- [x] Add unit tests for the new private functions
- [ ] QA