### PR TITLE
Hotfix: Prevent PHP fatal error when trying to delete a term

### DIFF
--- a/inc/Engine/Cache/PurgeActionsSubscriber.php
+++ b/inc/Engine/Cache/PurgeActionsSubscriber.php
@@ -35,7 +35,7 @@ class PurgeActionsSubscriber implements Subscriber_Interface {
 			'delete_user'     => 'purge_user_cache',
 			'create_term'     => [ 'maybe_purge_cache_on_term_change', 10, 3 ],
 			'edit_term'       => [ 'maybe_purge_cache_on_term_change', 10, 3 ],
-			'pre_delete_term' => [ 'maybe_purge_cache_on_term_change', 10, 3 ],
+			'delete_term'     => [ 'maybe_purge_cache_on_term_change', 10, 3 ],
 		];
 	}
 

--- a/inc/Engine/Cache/PurgeActionsSubscriber.php
+++ b/inc/Engine/Cache/PurgeActionsSubscriber.php
@@ -31,11 +31,11 @@ class PurgeActionsSubscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events() {
 		return [
-			'profile_update'  => 'purge_user_cache',
-			'delete_user'     => 'purge_user_cache',
-			'create_term'     => [ 'maybe_purge_cache_on_term_change', 10, 3 ],
-			'edit_term'       => [ 'maybe_purge_cache_on_term_change', 10, 3 ],
-			'delete_term'     => [ 'maybe_purge_cache_on_term_change', 10, 3 ],
+			'profile_update' => 'purge_user_cache',
+			'delete_user'    => 'purge_user_cache',
+			'create_term'    => [ 'maybe_purge_cache_on_term_change', 10, 3 ],
+			'edit_term'      => [ 'maybe_purge_cache_on_term_change', 10, 3 ],
+			'delete_term'    => [ 'maybe_purge_cache_on_term_change', 10, 3 ],
 		];
 	}
 

--- a/tests/Fixtures/inc/Engine/Cache/PurgeActionsSubscriber/maybePurgeCacheOnTermChange.php
+++ b/tests/Fixtures/inc/Engine/Cache/PurgeActionsSubscriber/maybePurgeCacheOnTermChange.php
@@ -15,7 +15,7 @@ return [
 			'action' => 'edit_term',
 		],
 		'testDeleteTerm' => [
-			'action' => 'pre_delete_term',
+			'action' => 'delete_term',
 		],
 	],
 	'unit_test_data' => [

--- a/tests/Integration/inc/Engine/Cache/PurgeActionsSubscriber/maybePurgeCacheOnTermChange.php
+++ b/tests/Integration/inc/Engine/Cache/PurgeActionsSubscriber/maybePurgeCacheOnTermChange.php
@@ -44,7 +44,7 @@ class Test_MaybePurgeCacheOnTermChange extends FilesystemTestCase {
 	public function testShouldNotPurgeCacheWhenTaxonomyNotPublic() {
 		do_action( 'create_term', self::$not_public_term->term_id, self::$not_public_term->term_taxonomy_id, self::$not_public_term->taxonomy );
 		do_action( 'edit_term', self::$not_public_term->term_id, self::$not_public_term->term_taxonomy_id, self::$not_public_term->taxonomy );
-		do_action( 'pre_delete_term', self::$not_public_term->term_id, self::$not_public_term->term_taxonomy_id, self::$not_public_term->taxonomy );
+		do_action( 'delete_term', self::$not_public_term->term_id, self::$not_public_term->term_taxonomy_id, self::$not_public_term->taxonomy );
 
 		// Check no files were deleted.
 		foreach( $this->original_files as $file ) {


### PR DESCRIPTION
`PHP Fatal error: Uncaught ArgumentCountError: Too few arguments to function WP_Rocket\Engine\Cache\PurgeActionsSubscriber::maybe_purge_cache_on_term_change(), 2 passed in /home/aswakdriwr/delivery/wp-includes/class-wp-hook.`

This happens because `pre_delete_terms` uses 2 arguments only. I used this hook at the start of the work on the PR, then noticed I could use `delete_term` instead, and forgot to update the hook name in `get_subscribed_events()`.

The error wasn't reported during QA.

- [x] Use `delete_term` instead of `pre_delete_term` hook
- [x] Update tests
- [x] QA