### PR TITLE
Closes #2665 Expired Cache preload doesn't fetch correct URLs

### DIFF
--- a/inc/Engine/Preload/PartialPreloadSubscriber.php
+++ b/inc/Engine/Preload/PartialPreloadSubscriber.php
@@ -142,9 +142,11 @@ class PartialPreloadSubscriber implements Subscriber_Interface {
 				} else {
 					$file_path         = untrailingslashit( $file_path );
 					$data['home_path'] = untrailingslashit( $data['home_path'] );
+					$data['home_url']  = untrailingslashit( $data['home_url'] );
 					if ( '/' === substr( get_option( 'permalink_structure' ), -1 ) ) {
 						$file_path         .= '/';
 						$data['home_path'] .= '/';
+						$data['home_url']  .= '/';
 					}
 				}
 

--- a/tests/Fixtures/inc/Engine/Preload/PartialPreloadSubscriber/preloadAfterAutomaticCachePurge.php
+++ b/tests/Fixtures/inc/Engine/Preload/PartialPreloadSubscriber/preloadAfterAutomaticCachePurge.php
@@ -38,6 +38,7 @@ return [
 				'logged_in' => false,
 				'files'     => [
 					'/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home1',
+					'/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home1/abc',
 				],
 			],
 			[
@@ -46,6 +47,7 @@ return [
 				'logged_in' => false,
 				'files'     => [
 					'/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home2',
+					'/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home2/abc',
 				],
 			],
 			[
@@ -54,6 +56,7 @@ return [
 				'logged_in' => false,
 				'files'     => [
 					'/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home3',
+					'/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home3/abc',
 				],
 			],
 			[
@@ -62,6 +65,7 @@ return [
 				'logged_in' => false,
 				'files'     => [
 					'/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home4/',
+					'/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home4/abc/',
 				],
 			],
 			[
@@ -70,6 +74,7 @@ return [
 				'logged_in' => false,
 				'files'     => [
 					'/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home5/',
+					'/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home5/abc/',
 				],
 			],
 			[
@@ -78,16 +83,23 @@ return [
 				'logged_in' => false,
 				'files'     => [
 					'/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home6/',
+					'/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home6/abc/',
 				],
 			],
 		],
 		[
-			'http://example.com/home1',
+			'http://example.com/home1/',
+			'http://example.com/home1/abc/',
 			'http://example.com/home2/',
+			'http://example.com/home2/abc/',
 			'http://example.com/home3/',
+			'http://example.com/home3/abc/',
 			'http://example.com/home4/',
+			'http://example.com/home4/abc/',
 			'http://example.com/home5/',
-			'http://example.com/home6',
+			'http://example.com/home5/abc/',
+			'http://example.com/home6/',
+			'http://example.com/home6/abc/',
 		],
 	],
 	'preloadUrlsUnSlashedPermalink' => [
@@ -100,6 +112,7 @@ return [
 				'logged_in' => false,
 				'files'     => [
 					'/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home1',
+					'/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home1/abc',
 				],
 			],
 			[
@@ -108,6 +121,7 @@ return [
 				'logged_in' => false,
 				'files'     => [
 					'/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home2',
+					'/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home2/abc',
 				],
 			],
 			[
@@ -116,6 +130,7 @@ return [
 				'logged_in' => false,
 				'files'     => [
 					'/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home3',
+					'/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home3/abc',
 				],
 			],
 			[
@@ -124,6 +139,7 @@ return [
 				'logged_in' => false,
 				'files'     => [
 					'/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home4/',
+					'/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home4/abc',
 				],
 			],
 			[
@@ -132,6 +148,7 @@ return [
 				'logged_in' => false,
 				'files'     => [
 					'/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home5/',
+					'/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home5/abc',
 				],
 			],
 			[
@@ -140,16 +157,23 @@ return [
 				'logged_in' => false,
 				'files'     => [
 					'/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home6/',
+					'/path-to/home1/wp-content/cache/wp-rocket/example.com-Greg-594d03f6ae698691165999/home6/abc/',
 				],
 			],
 		],
 		[
 			'http://example.com/home1',
-			'http://example.com/home2/',
-			'http://example.com/home3/',
-			'http://example.com/home4/',
-			'http://example.com/home5/',
+			'http://example.com/home1/abc',
+			'http://example.com/home2',
+			'http://example.com/home2/abc',
+			'http://example.com/home3',
+			'http://example.com/home3/abc',
+			'http://example.com/home4',
+			'http://example.com/home4/abc',
+			'http://example.com/home5',
+			'http://example.com/home5/abc',
 			'http://example.com/home6',
+			'http://example.com/home6/abc',
 		],
 	],
 ];


### PR DESCRIPTION
**Describe the bug**
In 3.5.5 version we fixed the problem with expired cache preload for WPML. In this fix, we introduced another problem. When `$data['home_url']` doesn't contain `/`:
https://github.com/wp-media/wp-rocket/blob/c7a020448d6639ca3cb4cddf72195f9d9c18fbec/inc/Engine/Preload/PartialPreloadSubscriber.php#L151

We're not preloading the expired cache.

**To Reproduce**
Steps to reproduce the behavior:
1. Go to the WordPress site without WPML and other plugins manipulating home_url
2. Set Cache Lifespan to 10 minutes
3. Preload cache manually
4. Confirm that the expired cache is not preloaded

**Expected behavior**
We need to preload expired cache correctly

**Additional context**
The solution would be to make an additional check and append `/` if it's missing:
http://snippi.com/s/wpld6o2

We need to be sure that `$data['home_url']` doesn't contain `/` before appending it because we might introduce another bug.

**Backlog Grooming (for WP Media dev team use only)**
- [x] Reproduce the problem
- [x] Identify the root cause
- [x] Scope a solution
- [x] Estimate the effort
