### PR TITLE
Correctly generate CPCSS on Optimize CSS delivery activation

### DIFF
--- a/inc/Engine/CriticalPath/CriticalCSSSubscriber.php
+++ b/inc/Engine/CriticalPath/CriticalCSSSubscriber.php
@@ -168,17 +168,16 @@ class CriticalCSSSubscriber implements Subscriber_Interface {
 
 		try {
 			$critical_css_path_file_iterator = ( new FilesystemIterator( $critical_css_path, FilesystemIterator::SKIP_DOTS ) );
-			if ( $critical_css_path_file_iterator->valid() ) {
-				// Bail out if this folder has no files (not folders).
-				foreach ( $critical_css_path_file_iterator as $file ) {
-					if ( $file->isFile() ) {
-						return;
-					}
-				}
-			}
 		} catch ( UnexpectedValueException $e ) {
 			// Bail out when folder is invalid.
 			return;
+		}
+
+		// Bail out if this folder has no files (not folders).
+		foreach ( $critical_css_path_file_iterator as $file ) {
+			if ( $file->isFile() ) {
+				return;
+			}
 		}
 
 		// Generate the CPCSS files.

--- a/inc/Engine/CriticalPath/CriticalCSSSubscriber.php
+++ b/inc/Engine/CriticalPath/CriticalCSSSubscriber.php
@@ -173,7 +173,7 @@ class CriticalCSSSubscriber implements Subscriber_Interface {
 			return;
 		}
 
-		// Bail out if this folder has no files (not folders).
+		// Bail out if this folder has no files in it.
 		foreach ( $critical_css_path_file_iterator as $file ) {
 			if ( $file->isFile() ) {
 				return;

--- a/inc/Engine/CriticalPath/CriticalCSSSubscriber.php
+++ b/inc/Engine/CriticalPath/CriticalCSSSubscriber.php
@@ -167,7 +167,7 @@ class CriticalCSSSubscriber implements Subscriber_Interface {
 		}
 
 		try {
-			$critical_css_path_file_iterator = ( new FilesystemIterator( $critical_css_path, FilesystemIterator::SKIP_DOTS ) );
+			$critical_css_path_file_iterator = new FilesystemIterator( $critical_css_path, FilesystemIterator::SKIP_DOTS );
 		} catch ( UnexpectedValueException $e ) {
 			// Bail out when folder is invalid.
 			return;

--- a/inc/Engine/CriticalPath/CriticalCSSSubscriber.php
+++ b/inc/Engine/CriticalPath/CriticalCSSSubscriber.php
@@ -167,9 +167,14 @@ class CriticalCSSSubscriber implements Subscriber_Interface {
 		}
 
 		try {
-			if ( ( new FilesystemIterator( $critical_css_path, FilesystemIterator::SKIP_DOTS ) )->valid() ) {
-				// Bail out if the folder has no files (not folders).
-				return;
+			$critical_css_path_file_iterator = ( new FilesystemIterator( $critical_css_path, FilesystemIterator::SKIP_DOTS ) );
+			if ( $critical_css_path_file_iterator->valid() ) {
+				// Bail out if this folder has no files (not folders).
+				foreach ( $critical_css_path_file_iterator as $file ) {
+					if ( $file->isFile() ) {
+						return;
+					}
+				}
 			}
 		} catch ( UnexpectedValueException $e ) {
 			// Bail out when folder is invalid.

--- a/inc/Engine/CriticalPath/CriticalCSSSubscriber.php
+++ b/inc/Engine/CriticalPath/CriticalCSSSubscriber.php
@@ -168,7 +168,7 @@ class CriticalCSSSubscriber implements Subscriber_Interface {
 
 		try {
 			if ( ( new FilesystemIterator( $critical_css_path, FilesystemIterator::SKIP_DOTS ) )->valid() ) {
-				// Bail out if the folder is not empty.
+				// Bail out if the folder has no files (not folders).
 				return;
 			}
 		} catch ( UnexpectedValueException $e ) {


### PR DESCRIPTION
Solve the issue of checking critical css folder that has any files to bailout and stop generation.
## Solution

- [x] Check the critical css path if has files or not
- [x] Skip folders and don't check them