### PR TITLE
Fixes PHP notice on posts list page

### DIFF
--- a/inc/Engine/CriticalPath/AdminSubscriber.php
+++ b/inc/Engine/CriticalPath/AdminSubscriber.php
@@ -85,6 +85,10 @@ class AdminSubscriber extends Abstract_Render implements Subscriber_Interface {
 			return;
 		}
 
+		if ( ! in_array( $pagenow, [ 'post-new.php', 'post.php' ], true ) ) {
+			return;
+		}
+
 		// Bailout if the CPCSS is not enabled for this Post / Page.
 		if ( $this->is_enabled() ) {
 			return;

--- a/tests/Fixtures/inc/Engine/CriticalPath/AdminSubscriber/enqueueAdminEditScript.php
+++ b/tests/Fixtures/inc/Engine/CriticalPath/AdminSubscriber/enqueueAdminEditScript.php
@@ -4,7 +4,8 @@ return [
 
 	'testShouldNotEnqueueScriptDifferentPage' => [
 		'config'   => [
-			'page' => 'options-general.php',
+			'page'               => 'options-general.php',
+			'pagenow'            => 'options-general.php',
 			'post'               => (object) [
 				'ID'          => 1,
 				'post_status' => 'draft',
@@ -14,9 +15,27 @@ return [
 		'expected' => false,
 	],
 
+	'testShouldNotEnqueueScriptWhenPostsList' => [
+		'config'   => [
+			'page'               => 'edit.php',
+			'pagenow'            => 'edit.php',
+			'options'            => [
+				'async_css' => 0,
+			],
+			'post'               => (object) [
+				'ID'          => 1,
+				'post_status' => 'draft',
+				'post_type'   => 'post',
+			],
+			'is_option_excluded' => true,
+		],
+		'expected' => false,
+	],
+
 	'testShouldNotEnqueueScriptDisabledWarning' => [
 		'config'   => [
 			'page'               => 'edit.php',
+			'pagenow'            => 'post.php',
 			'options'            => [
 				'async_css' => 0,
 			],
@@ -33,6 +52,7 @@ return [
 	'testShouldNotEnqueueScriptPostNotPublishedAndOptionExcludedWarning' => [
 		'config'   => [
 			'page'               => 'post.php',
+			'pagenow'            => 'post.php',
 			'options'            => [
 				'async_css' => 1,
 			],
@@ -49,6 +69,7 @@ return [
 	'testShouldNotEnqueueScriptPostNotPublishedWarning' => [
 		'config'   => [
 			'page'               => 'edit.php',
+			'pagenow'            => 'post.php',
 			'options'            => [
 				'async_css' => 1,
 			],
@@ -65,6 +86,7 @@ return [
 	'testShouldNotEnqueueScriptExcludedFromPostWarning' => [
 		'config'   => [
 			'page'               => 'edit.php',
+			'pagenow'            => 'post.php',
 			'options'            => [
 				'async_css' => 1,
 			],
@@ -81,6 +103,7 @@ return [
 	'testShouldEnqueueScript' => [
 		'config'   => [
 			'page'               => 'edit.php',
+			'pagenow'            => 'post.php',
 			'options'            => [
 				'async_css' => 1,
 			],

--- a/tests/Integration/inc/Engine/CriticalPath/AdminSubscriber/enqueueAdminEditScript.php
+++ b/tests/Integration/inc/Engine/CriticalPath/AdminSubscriber/enqueueAdminEditScript.php
@@ -29,6 +29,7 @@ class Test_EnqueueAdminEditScript extends TestCase {
 		remove_filter( 'pre_get_rocket_option_async_css', [ $this, 'setCPCSSOption' ] );
 		delete_post_meta( $this->post_id, '_rocket_exclude_async_css' );
 		unset( $GLOBALS['post'] );
+		unset( $GLOBALS['pagenow'] );
 
 		parent::tearDown();
 	}
@@ -52,7 +53,8 @@ class Test_EnqueueAdminEditScript extends TestCase {
 				add_post_meta( $this->post_id, '_rocket_exclude_async_css', $config['is_option_excluded'], true );
 			}
 
-			$GLOBALS['post'] = $config['post'];
+			$GLOBALS['post']    = $config['post'];
+			$GLOBALS['pagenow'] = $config['pagenow'];
 		}
 
 		$wp_scripts = wp_scripts();

--- a/tests/Unit/inc/Engine/CriticalPath/AdminSubscriber/enqueueAdminEditScript.php
+++ b/tests/Unit/inc/Engine/CriticalPath/AdminSubscriber/enqueueAdminEditScript.php
@@ -30,6 +30,7 @@ class Test_EnqueueAdminEditScript extends TestCase {
 
 	protected function tearDown() {
 		unset( $GLOBALS['post'] );
+		unset( $GLOBALS['pagenow'] );
 		parent::tearDown();
 	}
 
@@ -40,6 +41,8 @@ class Test_EnqueueAdminEditScript extends TestCase {
 		if ( in_array( $config['page'], [ 'edit.php', 'post.php' ], true ) ) {
 			$this->setUpTest( $config );
 		}
+	
+		$GLOBALS['pagenow'] = $config['pagenow'];
 
 		Functions\when( 'wp_create_nonce' )->justReturn( 'wp_rest_nonce' );
 		Functions\when( 'rest_url' )->justReturn( 'http://example.org/wp-rocket/v1/cpcss/post/' . $config['post']->ID );


### PR DESCRIPTION
Following what Arun found during QA here: https://github.com/wp-media/wp-rocket/pull/2652#issuecomment-632240496

```
[21-May-2020 17:28:37 UTC] PHP Notice:  Trying to get property 'post_status' of non-object in /app/public/wp-content/plugins/wp-rocket/inc/Engine/CriticalPath/AdminSubscriber.php on line 220
[21-May-2020 17:28:37 UTC] PHP Stack trace:
[21-May-2020 17:28:37 UTC] PHP   6. WP_Rocket\Engine\CriticalPath\AdminSubscriber->enqueue_admin_edit_script() /app/public/wp-includes/class-wp-hook.php:287
[21-May-2020 17:28:37 UTC] PHP   7. WP_Rocket\Engine\CriticalPath\AdminSubscriber->is_enabled() /app/public/wp-content/plugins/wp-rocket/inc/Engine/CriticalPath/AdminSubscriber.php:89
[21-May-2020 17:28:37 UTC] PHP   8. WP_Rocket\Engine\CriticalPath\AdminSubscriber->get_disabled_data() /app/public/wp-content/plugins/wp-rocket/inc/Engine/CriticalPath/AdminSubscriber.php:243
[21-May-2020 17:28:37 UTC] PHP Notice:  Trying to get property 'ID' of non-object in /app/public/wp-content/plugins/wp-rocket/inc/Engine/CriticalPath/AdminSubscriber.php on line 228
[21-May-2020 17:28:37 UTC] PHP Stack trace:
[21-May-2020 17:28:37 UTC] PHP   6. WP_Rocket\Engine\CriticalPath\AdminSubscriber->enqueue_admin_edit_script() /app/public/wp-includes/class-wp-hook.php:287
[21-May-2020 17:28:37 UTC] PHP   7. WP_Rocket\Engine\CriticalPath\AdminSubscriber->is_enabled() /app/public/wp-content/plugins/wp-rocket/inc/Engine/CriticalPath/AdminSubscriber.php:89
[21-May-2020 17:28:37 UTC] PHP   8. WP_Rocket\Engine\CriticalPath\AdminSubscriber->get_disabled_data() /app/public/wp-content/plugins/wp-rocket/inc/Engine/CriticalPath/AdminSubscriber.php:243
```

The notice is happening because the script is loaded on the posts list page. This is not needed, and we were missing a check for the value of `$pagenow` in addition of the current `$hook_suffix`.

This PR fixes the issue.

- [x] Add additional check for `$pagenow` value
- [x] Update tests
- [x] QA