### PR TITLE
Add tests for rocket_clean_cache_dir function

### DIFF
--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -979,10 +979,11 @@ function rocket_clean_cache_dir() {
 	*/
 	do_action( 'before_rocket_clean_cache_dir' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
 
+	$filesystem = rocket_direct_filesystem();
+
 	// Delete all caching files.
-	$dirs = glob( WP_ROCKET_CACHE_PATH . '*', GLOB_NOSORT );
-	if ( $dirs ) {
-		foreach ( $dirs as $dir ) {
+	foreach ( _rocket_get_cache_dirs( '.' ) as $dir ) {
+		if ( $filesystem->is_dir( $dir ) ) {
 			rocket_rrmdir( $dir );
 		}
 	}

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -982,7 +982,8 @@ function rocket_clean_cache_dir() {
 	$filesystem = rocket_direct_filesystem();
 
 	// Delete all caching files/folders.
-	foreach ( _rocket_get_cache_dirs( '.' ) as $path ) {
+	$iterator = _rocket_get_cache_path_iterator( _rocket_get_wp_rocket_cache_path() );
+	foreach ( $iterator as $path ) {
 		if ( ! $filesystem->is_dir( $path ) ) {
 			$filesystem->delete( $path );
 		}else {

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -986,9 +986,10 @@ function rocket_clean_cache_dir() {
 	foreach ( $iterator as $path ) {
 		if ( ! $filesystem->is_dir( $path ) ) {
 			$filesystem->delete( $path );
-		}else {
-			rocket_rrmdir( $path );
+			continue;
 		}
+
+		rocket_rrmdir( $path );
 	}
 
 	/**

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -981,10 +981,12 @@ function rocket_clean_cache_dir() {
 
 	$filesystem = rocket_direct_filesystem();
 
-	// Delete all caching files.
-	foreach ( _rocket_get_cache_dirs( '.' ) as $dir ) {
-		if ( $filesystem->is_dir( $dir ) ) {
-			rocket_rrmdir( $dir );
+	// Delete all caching files/folders.
+	foreach ( _rocket_get_cache_dirs( '.' ) as $path ) {
+		if ( ! $filesystem->is_dir( $path ) ) {
+			$filesystem->delete( $path );
+		}else{
+			rocket_rrmdir( $path );
 		}
 	}
 

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -985,7 +985,7 @@ function rocket_clean_cache_dir() {
 	foreach ( _rocket_get_cache_dirs( '.' ) as $path ) {
 		if ( ! $filesystem->is_dir( $path ) ) {
 			$filesystem->delete( $path );
-		}else{
+		}else {
 			rocket_rrmdir( $path );
 		}
 	}

--- a/tests/Fixtures/inc/functions/rocketCleanCacheDir.php
+++ b/tests/Fixtures/inc/functions/rocketCleanCacheDir.php
@@ -5,6 +5,7 @@ return [
 		'wp-content' => [
 			'cache' => [
 				'wp-rocket' => [
+					'test.html' => '',
 					'example.org'                => [
 						'index.html_gzip' => '',
 						'index.html' => '',
@@ -60,7 +61,8 @@ return [
 		'testShouldCleanCacheDir' => [
 			'config' => [],
 			'expected' => [
-				'removed_dirs' => [
+				'removed_paths' => [
+					'test.html',
 					'example.org',
 					'example.org-wpmedia-123456',
 					'example.org-tester-987654',

--- a/tests/Fixtures/inc/functions/rocketCleanCacheDir.php
+++ b/tests/Fixtures/inc/functions/rocketCleanCacheDir.php
@@ -1,0 +1,7 @@
+<?php
+return [
+	'vfs_dir' => '',
+	'test_data' => [
+
+	],
+];

--- a/tests/Fixtures/inc/functions/rocketCleanCacheDir.php
+++ b/tests/Fixtures/inc/functions/rocketCleanCacheDir.php
@@ -1,7 +1,78 @@
 <?php
 return [
-	'vfs_dir' => '',
-	'test_data' => [
+	'vfs_dir' => 'wp-content/cache/wp-rocket/',
+	'structure' => [
+		'wp-content' => [
+			'cache' => [
+				'wp-rocket' => [
+					'example.org'                => [
+						'index.html_gzip' => '',
+						'index.html' => '',
+						'index-test.html' => '',
+						'.mobile-active' => '',
+						'.no-webp' => '',
+						'page' => [
+							'1' => [
+								'index.html_gzip' => '',
+								'index.html' => '',
+							],
+							'2' => [
+								'index.html_gzip' => '',
+								'index.html' => '',
+							],
+						]
+					],
+					'example.org-wpmedia-123456' => [
+						'index.html_gzip' => '',
+					],
+					'example.org-tester-987654'  => [
+						'index.html_gzip' => '',
+					],
 
+					'baz.example.org'             => [
+						'index.html_gzip' => '',
+					],
+					'baz.example.org-baz1-123456' => [
+						'index.html_gzip' => '',
+					],
+					'baz.example.org-baz2-987654' => [
+						'index.html_gzip' => '',
+					],
+					'baz.example.org-baz3-456789' => [
+						'index.html_gzip' => '',
+					],
+
+					'wp.baz.example.org'               => [
+						'index.html_gzip' => '',
+					],
+					'wp.baz.example.org-wpbaz1-123456' => [
+						'index.html_gzip' => '',
+					],
+
+					'example.org#fr' => [
+						'index.html_gzip' => '',
+					],
+				],
+			],
+		],
+	],
+	'test_data' => [
+		'testShouldCleanCacheDir' => [
+			'config' => [],
+			'expected' => [
+				'removed_dirs' => [
+					'example.org',
+					'example.org-wpmedia-123456',
+					'example.org-tester-987654',
+					'baz.example.org',
+					'baz.example.org-baz1-123456',
+					'baz.example.org-baz2-987654',
+					'baz.example.org-baz3-456789',
+					'wp.baz.example.org',
+					'wp.baz.example.org-wpbaz1-123456',
+					'example.org#fr'
+				]
+			],
+		]
 	],
 ];

--- a/tests/Integration/inc/functions/rocketCleanCacheDir.php
+++ b/tests/Integration/inc/functions/rocketCleanCacheDir.php
@@ -21,8 +21,8 @@ class Test_RocketCleanCacheDir extends FilesystemTestCase {
 	 */
 	public function testShouldReturnValidConfigFileName( $config, $expected ) {
 		rocket_clean_cache_dir();
-		foreach ($expected['removed_dirs'] as $dir) {
-			$this->assertFalse( $this->filesystem->exists( $dir ) );
+		foreach ($expected['removed_paths'] as $path) {
+			$this->assertFalse( $this->filesystem->exists( $path ) );
 		}
 	}
 

--- a/tests/Integration/inc/functions/rocketCleanCacheDir.php
+++ b/tests/Integration/inc/functions/rocketCleanCacheDir.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace WP_Rocket\Tests\Unit\inc\functions;
+namespace WP_Rocket\Tests\Integration\inc\functions;
 
-use WP_Rocket\Tests\Unit\FilesystemTestCase;
+use WP_Rocket\Tests\Integration\FilesystemTestCase;
 
 /**
  * @covers ::rocket_clean_cache_dir

--- a/tests/Unit/inc/functions/rocketCleanCacheDir.php
+++ b/tests/Unit/inc/functions/rocketCleanCacheDir.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\functions;
+
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+use WP_Rocket\Tests\Unit\FilesystemTestCase;
+
+/**
+ * @covers ::rocket_clean_cache_dir
+ * @group Functions
+ */
+class Test_RocketFindWpconfigPath extends FilesystemTestCase {
+	protected $path_to_test_data   = '/inc/functions/rocketCleanCacheDir.php';
+
+	public function setUp()
+	{
+		parent::setUp();
+	}
+
+	/**
+	 * @dataProvider providerTestData
+	 */
+	public function testShouldReturnValidConfigFileName( $config, $expected ) {
+
+	}
+
+}

--- a/tests/Unit/inc/functions/rocketCleanCacheDir.php
+++ b/tests/Unit/inc/functions/rocketCleanCacheDir.php
@@ -21,8 +21,8 @@ class Test_RocketCleanCacheDir extends FilesystemTestCase {
 	 */
 	public function testShouldReturnValidConfigFileName( $config, $expected ) {
 		rocket_clean_cache_dir();
-		foreach ($expected['removed_dirs'] as $dir) {
-			$this->assertFalse( $this->filesystem->exists( $dir ) );
+		foreach ($expected['removed_paths'] as $path) {
+			$this->assertFalse( $this->filesystem->exists( $path ) );
 		}
 	}
 

--- a/tests/Unit/inc/functions/rocketCleanCacheDir.php
+++ b/tests/Unit/inc/functions/rocketCleanCacheDir.php
@@ -10,7 +10,7 @@ use WP_Rocket\Tests\Unit\FilesystemTestCase;
  * @covers ::rocket_clean_cache_dir
  * @group Functions
  */
-class Test_RocketFindWpconfigPath extends FilesystemTestCase {
+class Test_RocketCleanCacheDir extends FilesystemTestCase {
 	protected $path_to_test_data   = '/inc/functions/rocketCleanCacheDir.php';
 
 	public function setUp()
@@ -22,7 +22,10 @@ class Test_RocketFindWpconfigPath extends FilesystemTestCase {
 	 * @dataProvider providerTestData
 	 */
 	public function testShouldReturnValidConfigFileName( $config, $expected ) {
-
+		rocket_clean_cache_dir();
+		foreach ($expected['removed_dirs'] as $dir) {
+			$this->assertFalse( $this->filesystem->exists( $dir ) );
+		}
 	}
 
 }


### PR DESCRIPTION
- [x] Add Unit and Integration tests for rocket_clean_cache_dir method which locates in inc/functions/files.php

- [x] Refactor the code itself to use SPL iterators instead of glob function.

  Why?
- To be able to make the code testable.
- To make the code faster as this function is called multiple times through the code.