### PR TITLE
Update WP Rocket admin bar items order

### DIFF
--- a/inc/Engine/CriticalPath/Admin/Subscriber.php
+++ b/inc/Engine/CriticalPath/Admin/Subscriber.php
@@ -58,7 +58,7 @@ class Subscriber implements Subscriber_Interface {
 				[ 'enqueue_admin_edit_script' ],
 				[ 'enqueue_admin_cpcss_heartbeat_script' ],
 			],
-			'admin_bar_menu'                     => [ 'add_regenerate_menu_item', PHP_INT_MAX - 9 ],
+			'rocket_admin_bar_items'             => 'add_regenerate_menu_item',
 		];
 	}
 

--- a/inc/common/admin-bar.php
+++ b/inc/common/admin-bar.php
@@ -310,6 +310,15 @@ function rocket_admin_bar( $wp_admin_bar ) {
 		}
 	}
 
+	/**
+	 * Fires when adding WP Rocket admin bar items
+	 *
+	 * @since 3.6
+	 *
+	 * @param WP_Admin_Bar $wp_admin_bar WP_Admin_Bar instance, passed by reference.
+	 */
+	do_action( 'rocket_admin_bar_items', $wp_admin_bar );
+
 	if ( current_user_can( 'rocket_manage_options' ) ) {
 		$rocketcdn_status = get_transient( 'rocketcdn_status' );
 


### PR DESCRIPTION
Add new hook `rocket_admin_bar_items` to preserve the order of the sub-items in the WP Rocket admin bar menu.

![admin-bar](https://user-images.githubusercontent.com/3465180/83565878-1ed98e00-a4ed-11ea-8586-551c47af53eb.jpg)