### PR TITLE
Prevent PHP notice in CPCSS running notice

### DIFF
--- a/inc/Engine/CriticalPath/CriticalCSSSubscriber.php
+++ b/inc/Engine/CriticalPath/CriticalCSSSubscriber.php
@@ -326,6 +326,7 @@ class CriticalCSSSubscriber implements Subscriber_Interface {
 		}
 
 		$transient = get_transient( 'rocket_critical_css_generation_process_running' );
+
 		if ( ! $transient ) {
 			return;
 		}
@@ -350,7 +351,14 @@ class CriticalCSSSubscriber implements Subscriber_Interface {
 			$items_message .= '</ul>';
 		}
 
-		if ( 0 === $success_counter && 0 === $transient['total'] ) {
+		if ( ! isset( $transient['total'] ) ) {
+			return;
+		}
+
+		if (
+			0 === $success_counter
+			&& 0 === $transient['total']
+		) {
 			return;
 		}
 

--- a/inc/Engine/CriticalPath/CriticalCSSSubscriber.php
+++ b/inc/Engine/CriticalPath/CriticalCSSSubscriber.php
@@ -357,7 +357,8 @@ class CriticalCSSSubscriber implements Subscriber_Interface {
 
 		if (
 			0 === $success_counter
-			&& 0 === $transient['total']
+			&&
+			0 === $transient['total']
 		) {
 			return;
 		}


### PR DESCRIPTION
- Check for `total` transient index before using it in the notice