### PR TITLE
Adjust CPCSS messages to differentiate between custom and specific page types

### DIFF
--- a/inc/Engine/CriticalPath/APIClient.php
+++ b/inc/Engine/CriticalPath/APIClient.php
@@ -55,6 +55,17 @@ class APIClient {
 	 * @return array|WP_Error
 	 */
 	private function prepare_response( $response, $url, $is_mobile = false, $item_type = 'custom' ) {
+
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error(
+				$this->get_response_code( $response ),
+				$response->get_error_message(),
+				[
+					'status' => 400,
+				]
+			);
+		}
+
 		$response_data        = $this->get_response_data( $response );
 		$response_status_code = $this->get_response_status( $response, ( isset( $response_data->status ) ) ? $response_data->status : null );
 		$succeeded            = $this->get_response_success( $response_status_code, $response_data );

--- a/inc/Engine/CriticalPath/APIClient.php
+++ b/inc/Engine/CriticalPath/APIClient.php
@@ -59,7 +59,12 @@ class APIClient {
 		if ( is_wp_error( $response ) ) {
 			return new WP_Error(
 				$this->get_response_code( $response ),
-				$response->get_error_message(),
+				sprintf(
+					// translators: %1$s = type of content, %2$s = error message.
+					__( 'Critical CSS for %1$s not generated. Error: %2$s', 'rocket' ),
+					( 'custom' === $item_type ) ? $url : $item_type,
+					$response->get_error_message()
+				),
 				[
 					'status' => 400,
 				]

--- a/inc/Engine/CriticalPath/Admin/Admin.php
+++ b/inc/Engine/CriticalPath/Admin/Admin.php
@@ -92,11 +92,15 @@ class Admin {
 
 		// Threshold 'check' > 10 = timed out.
 		$timeout          = ( $cpcss_item['check'] > 10 );
+		$additional_params = [
+			'timeout' => $timeout,
+			'is_mobile' => ! empty( $cpcss_item['mobile'] ) ? (bool) $cpcss_item['mobile'] : false,
+			'item_type' => $cpcss_item['type']
+		];
 		$cpcss_generation = $this->processor->process_generate(
 			$cpcss_item['url'],
 			$cpcss_item['path'],
-			$timeout,
-			! empty( $cpcss_item['mobile'] ) ? (bool) $cpcss_item['mobile'] : false
+			$additional_params
 		);
 
 		// Increment this item's threshold count.

--- a/inc/Engine/CriticalPath/Admin/Admin.php
+++ b/inc/Engine/CriticalPath/Admin/Admin.php
@@ -91,13 +91,13 @@ class Admin {
 		}
 
 		// Threshold 'check' > 10 = timed out.
-		$timeout          = ( $cpcss_item['check'] > 10 );
+		$timeout           = ( $cpcss_item['check'] > 10 );
 		$additional_params = [
-			'timeout' => $timeout,
+			'timeout'   => $timeout,
 			'is_mobile' => ! empty( $cpcss_item['mobile'] ) ? (bool) $cpcss_item['mobile'] : false,
-			'item_type' => $cpcss_item['type']
+			'item_type' => $cpcss_item['type'],
 		];
-		$cpcss_generation = $this->processor->process_generate(
+		$cpcss_generation  = $this->processor->process_generate(
 			$cpcss_item['url'],
 			$cpcss_item['path'],
 			$additional_params

--- a/inc/Engine/CriticalPath/CriticalCSSGeneration.php
+++ b/inc/Engine/CriticalPath/CriticalCSSGeneration.php
@@ -63,7 +63,11 @@ class CriticalCSSGeneration extends WP_Background_Process {
 		$transient = get_transient( 'rocket_critical_css_generation_process_running' );
 		$mobile    = isset( $item['mobile'] ) ? $item['mobile'] : 0;
 
-		$generated = $this->processor->process_generate( $item['url'], $item['path'], false, $mobile );
+		$generation_params = [
+			'is_mobile' => $mobile,
+			'item_type' => $item['type']
+		];
+		$generated = $this->processor->process_generate( $item['url'], $item['path'], $generation_params );
 
 		if ( is_wp_error( $generated ) ) {
 			$this->update_running_transient( $transient, $item['path'], $mobile, $generated->get_error_message(), false );

--- a/inc/Engine/CriticalPath/CriticalCSSGeneration.php
+++ b/inc/Engine/CriticalPath/CriticalCSSGeneration.php
@@ -65,9 +65,9 @@ class CriticalCSSGeneration extends WP_Background_Process {
 
 		$generation_params = [
 			'is_mobile' => $mobile,
-			'item_type' => $item['type']
+			'item_type' => $item['type'],
 		];
-		$generated = $this->processor->process_generate( $item['url'], $item['path'], $generation_params );
+		$generated         = $this->processor->process_generate( $item['url'], $item['path'], $generation_params );
 
 		if ( is_wp_error( $generated ) ) {
 			$this->update_running_transient( $transient, $item['path'], $mobile, $generated->get_error_message(), false );

--- a/inc/Engine/CriticalPath/DataManager.php
+++ b/inc/Engine/CriticalPath/DataManager.php
@@ -46,10 +46,11 @@ class DataManager {
 	 * @param string $cpcss     CPCSS code to be saved.
 	 * @param string $url       URL for item to be used in error messages.
 	 * @param bool   $is_mobile If this is cpcss for mobile or not.
+	 * @param string $item_type Optional. Type for this item if it's custom or specific type. Default: custom.
 	 *
 	 * @return bool|WP_Error
 	 */
-	public function save_cpcss( $path, $cpcss, $url, $is_mobile = false ) {
+	public function save_cpcss( $path, $cpcss, $url, $is_mobile = false, $item_type = 'custom' ) {
 		$file_path_directory = dirname( $this->critical_css_path . $path );
 
 		if ( ! $this->filesystem->is_dir( $file_path_directory ) ) {
@@ -66,7 +67,7 @@ class DataManager {
 							:
 							// translators: %s = item URL.
 							__( 'Critical CSS for %1$s not generated. Error: The API returned an empty response.', 'rocket' ),
-						$url
+						( 'custom' === $item_type ) ? $url : $item_type
 						),
 					[
 						'status' => 400,

--- a/inc/Engine/CriticalPath/ProcessorService.php
+++ b/inc/Engine/CriticalPath/ProcessorService.php
@@ -40,18 +40,18 @@ class ProcessorService {
 	 *
 	 * @param string $item_url  URL for item to be used in error messages.
 	 * @param string $item_path Path for item to be processed.
-	 * @param array  $additional_parameter additional parameters for generation.
+	 * @param array  $additional_parameters additional parameters for generation.
 	 *
 	 * @return array|WP_Error
 	 */
-	public function process_generate( $item_url, $item_path, $additional_parameter = [
+	public function process_generate( $item_url, $item_path, $additional_parameters = [
 		'timeout'   => false,
 		'is_mobile' => false,
 		'item_type' => 'custom',
 	] ) {
-		$timeout   = isset( $additional_parameter['timeout'] ) ? $additional_parameter['timeout'] : false;
-		$is_mobile = isset( $additional_parameter['is_mobile'] ) ? $additional_parameter['is_mobile'] : false;
-		$item_type = isset( $additional_parameter['item_type'] ) ? $additional_parameter['item_type'] : 'custom';
+		$timeout   = isset( $additional_parameters['timeout'] ) ? $additional_parameters['timeout'] : false;
+		$is_mobile = isset( $additional_parameters['is_mobile'] ) ? $additional_parameters['is_mobile'] : false;
+		$item_type = isset( $additional_parameters['item_type'] ) ? $additional_parameters['item_type'] : 'custom';
 
 		// Ajax call requested a timeout.
 		if ( $timeout ) {

--- a/inc/Engine/CriticalPath/ProcessorService.php
+++ b/inc/Engine/CriticalPath/ProcessorService.php
@@ -44,27 +44,26 @@ class ProcessorService {
 	 *
 	 * @return array|WP_Error
 	 */
-	public function process_generate( $item_url, $item_path, $additional_parameters = [
-		'timeout'   => false,
-		'is_mobile' => false,
-		'item_type' => 'custom',
-	] ) {
-		$timeout   = isset( $additional_parameters['timeout'] ) ? $additional_parameters['timeout'] : false;
-		$is_mobile = isset( $additional_parameters['is_mobile'] ) ? $additional_parameters['is_mobile'] : false;
-		$item_type = isset( $additional_parameters['item_type'] ) ? $additional_parameters['item_type'] : 'custom';
+	public function process_generate( $item_url, $item_path, $additional_parameters = [] ) {
+		$defaults = [
+			'timeout'   => false,
+			'is_mobile' => false,
+			'item_type' => 'custom',
+		];
+		$args = array_merge( $defaults, $additional_parameters );
 
 		// Ajax call requested a timeout.
-		if ( $timeout ) {
-			return $this->process_timeout( $item_url, $is_mobile, $item_type );
+		if ( $args['timeout'] ) {
+			return $this->process_timeout( $item_url, $args['is_mobile'], $args['item_type'] );
 		}
 
-		$cpcss_job_id = $this->data_manager->get_cache_job_id( $item_url, $is_mobile );
+		$cpcss_job_id = $this->data_manager->get_cache_job_id( $item_url, $args['is_mobile'] );
 		if ( false === $cpcss_job_id ) {
-			return $this->send_generation_request( $item_url, $item_path, $is_mobile, $item_type );
+			return $this->send_generation_request( $item_url, $item_path, $args['is_mobile'], $args['item_type'] );
 		}
 
 		// job_id is found and we need to check status for it.
-		return $this->check_cpcss_job_status( $cpcss_job_id, $item_path, $item_url, $is_mobile, $item_type );
+		return $this->check_cpcss_job_status( $cpcss_job_id, $item_path, $item_url, $args['is_mobile'], $args['item_type'] );
 	}
 
 	/**

--- a/inc/Engine/CriticalPath/ProcessorService.php
+++ b/inc/Engine/CriticalPath/ProcessorService.php
@@ -50,7 +50,7 @@ class ProcessorService {
 			'is_mobile' => false,
 			'item_type' => 'custom',
 		];
-		$args = array_merge( $defaults, $additional_parameters );
+		$args     = array_merge( $defaults, $additional_parameters );
 
 		// Ajax call requested a timeout.
 		if ( $args['timeout'] ) {

--- a/inc/Engine/CriticalPath/ProcessorService.php
+++ b/inc/Engine/CriticalPath/ProcessorService.php
@@ -40,24 +40,31 @@ class ProcessorService {
 	 *
 	 * @param string $item_url  URL for item to be used in error messages.
 	 * @param string $item_path Path for item to be processed.
-	 * @param bool   $timeout   Timeout is requested or not.
-	 * @param bool   $is_mobile If this request is for mobile cpcss.
+	 * @param array  $additional_parameter additional parameters for generation.
 	 *
 	 * @return array|WP_Error
 	 */
-	public function process_generate( $item_url, $item_path, $timeout = false, $is_mobile = false ) {
+	public function process_generate( $item_url, $item_path, $additional_parameter = [
+		'timeout'   => false,
+		'is_mobile' => false,
+		'item_type' => 'custom',
+	] ) {
+		$timeout   = isset( $additional_parameter['timeout'] ) ? $additional_parameter['timeout'] : false;
+		$is_mobile = isset( $additional_parameter['is_mobile'] ) ? $additional_parameter['is_mobile'] : false;
+		$item_type = isset( $additional_parameter['item_type'] ) ? $additional_parameter['item_type'] : 'custom';
+
 		// Ajax call requested a timeout.
 		if ( $timeout ) {
-			return $this->process_timeout( $item_url, $is_mobile );
+			return $this->process_timeout( $item_url, $is_mobile, $item_type );
 		}
 
 		$cpcss_job_id = $this->data_manager->get_cache_job_id( $item_url, $is_mobile );
 		if ( false === $cpcss_job_id ) {
-			return $this->send_generation_request( $item_url, $item_path, $is_mobile );
+			return $this->send_generation_request( $item_url, $item_path, $is_mobile, $item_type );
 		}
 
 		// job_id is found and we need to check status for it.
-		return $this->check_cpcss_job_status( $cpcss_job_id, $item_path, $item_url, $is_mobile );
+		return $this->check_cpcss_job_status( $cpcss_job_id, $item_path, $item_url, $is_mobile, $item_type );
 	}
 
 	/**
@@ -68,15 +75,16 @@ class ProcessorService {
 	 * @param string $item_url  Url for item to send the generation request for.
 	 * @param string $item_path Path for item to send the generation request for.
 	 * @param bool   $is_mobile If this request is for mobile cpcss.
+	 * @param string $item_type Optional. Type for this item if it's custom or specific type. Default: custom.
 	 *
 	 * @return array
 	 */
-	private function send_generation_request( $item_url, $item_path, $is_mobile = false ) {
+	private function send_generation_request( $item_url, $item_path, $is_mobile = false, $item_type = 'custom' ) {
 		// call send generation request from APIClient for the first time.
 		$params        = [
 			'mobile' => (int) $is_mobile,
 		];
-		$generated_job = $this->api_client->send_generation_request( $item_url, $params );
+		$generated_job = $this->api_client->send_generation_request( $item_url, $params, $item_type );
 
 		// validate generate response.
 		if ( is_wp_error( $generated_job ) ) {
@@ -88,7 +96,7 @@ class ProcessorService {
 		// Save job_id into cache.
 		$this->data_manager->set_cache_job_id( $item_url, $generated_job->data->id, $is_mobile );
 
-		return $this->check_cpcss_job_status( $generated_job->data->id, $item_path, $item_url, $is_mobile );
+		return $this->check_cpcss_job_status( $generated_job->data->id, $item_path, $item_url, $is_mobile, $item_type );
 	}
 
 	/**
@@ -98,11 +106,12 @@ class ProcessorService {
 	 *
 	 * @param string $job_id   ID for the job to get details.
 	 * @param string $item_url URL for item to be used in error messages.
+	 * @param string $item_type Optional. Type for this item if it's custom or specific type. Default: custom.
 	 *
 	 * @return array|mixed|WP_Error
 	 */
-	private function get_cpcss_job_details( $job_id, $item_url ) {
-		$job_details = $this->api_client->get_job_details( $job_id, $item_url );
+	private function get_cpcss_job_details( $job_id, $item_url, $item_type = 'custom' ) {
+		$job_details = $this->api_client->get_job_details( $job_id, $item_url, $item_type );
 
 		if ( is_wp_error( $job_details ) ) {
 			return $job_details;
@@ -120,11 +129,12 @@ class ProcessorService {
 	 * @param string $item_path Path for this item to be validated.
 	 * @param string $item_url  URL for item to be used in error messages.
 	 * @param bool   $is_mobile Bool identifier for is_mobile CPCSS generation.
+	 * @param string $item_type Optional. Type for this item if it's custom or specific type. Default: custom.
 	 *
 	 * @return array|WP_Error Response in case of success, failure or pending.
 	 */
-	private function check_cpcss_job_status( $job_id, $item_path, $item_url, $is_mobile = false ) {
-		$job_details = $this->api_client->get_job_details( $job_id, $item_url, $is_mobile );
+	private function check_cpcss_job_status( $job_id, $item_path, $item_url, $is_mobile = false, $item_type = 'custom' ) {
+		$job_details = $this->api_client->get_job_details( $job_id, $item_url, $is_mobile, $item_type );
 
 		if ( is_wp_error( $job_details ) ) {
 			$this->data_manager->delete_cache_job_id( $item_url, $is_mobile );
@@ -134,7 +144,7 @@ class ProcessorService {
 
 		if ( 200 !== $job_details->status ) {
 			// On job error.
-			return $this->on_job_error( $job_details, $item_url, $is_mobile );
+			return $this->on_job_error( $job_details, $item_url, $is_mobile, $item_type );
 		}
 
 		// On job status 200.
@@ -142,7 +152,7 @@ class ProcessorService {
 
 		// For pending job status.
 		if ( isset( $job_state ) && 'complete' !== $job_state ) {
-			return $this->on_job_pending( $item_url, $is_mobile );
+			return $this->on_job_pending( $item_url, $item_type );
 		}
 
 		// For successful job status.
@@ -151,7 +161,7 @@ class ProcessorService {
 			&&
 			'complete' === $job_state
 		) {
-			return $this->on_job_success( $item_path, $item_url, $job_details->data->critical_path, $is_mobile );
+			return $this->on_job_success( $item_path, $item_url, $job_details->data->critical_path, $is_mobile, $item_type );
 		}
 	}
 
@@ -163,18 +173,27 @@ class ProcessorService {
 	 * @param array  $job_details Job details array.
 	 * @param string $item_url    Url for web page to be processed, used for error messages.
 	 * @param bool   $is_mobile   Bool identifier for is_mobile CPCSS generation.
+	 * @param string $item_type Optional. Type for this item if it's custom or specific type. Default: custom.
 	 *
 	 * @return WP_Error
 	 */
-	private function on_job_error( $job_details, $item_url, $is_mobile = false ) {
+	private function on_job_error( $job_details, $item_url, $is_mobile = false, $item_type = 'custom' ) {
 		$this->data_manager->delete_cache_job_id( $item_url, $is_mobile );
 
 		if ( $is_mobile ) {
-			// translators: %1$s = page URL.
-			$error = sprintf( __( 'Mobile Critical CSS for %1$s not generated.', 'rocket' ), $item_url );
+
+			$error = sprintf(
+				// translators: %1$s = item URL or item type.
+				__( 'Mobile Critical CSS for %1$s not generated.', 'rocket' ),
+				( 'custom' === $item_type ) ? $item_url : $item_type
+			);
 		} else {
-			// translators: %1$s = page URL.
-			$error = sprintf( __( 'Critical CSS for %1$s not generated.', 'rocket' ), $item_url );
+
+			$error = sprintf(
+				// translators: %1$s = item URL or item type.
+				__( 'Critical CSS for %1$s not generated.', 'rocket' ),
+				( 'custom' === $item_type ) ? $item_url : $item_type
+			);
 		}
 
 		if ( isset( $job_details->message ) ) {
@@ -197,14 +216,18 @@ class ProcessorService {
 	 * @since 3.6
 	 *
 	 * @param string $item_url Url for web page to be processed, used for error messages.
+	 * @param string $item_type Optional. Type for this item if it's custom or specific type. Default: custom.
 	 *
 	 * @return array
 	 */
-	private function on_job_pending( $item_url ) {
+	private function on_job_pending( $item_url, $item_type = 'custom' ) {
 		return [
 			'code'    => 'cpcss_generation_pending',
-			// translators: %s = post URL.
-			'message' => sprintf( __( 'Critical CSS for %s in progress.', 'rocket' ), $item_url ),
+			'message' => sprintf(
+				// translators: %1$s = Item URL or item type.
+				__( 'Critical CSS for %s in progress.', 'rocket' ),
+				( 'custom' === $item_type ) ? $item_url : $item_type
+			),
 		];
 	}
 
@@ -217,15 +240,16 @@ class ProcessorService {
 	 * @param string $item_url   Item Url for web page to be processed.
 	 * @param string $cpcss_code CPCSS Code to be saved.
 	 * @param bool   $is_mobile  Bool identifier for is_mobile CPCSS generation.
+	 * @param string $item_type Optional. Type for this item if it's custom or specific type. Default: custom.
 	 *
 	 * @return array|WP_Error
 	 */
-	private function on_job_success( $item_path, $item_url, $cpcss_code, $is_mobile = false ) {
+	private function on_job_success( $item_path, $item_url, $cpcss_code, $is_mobile = false, $item_type = 'custom' ) {
 		// delete cache job_id for this item.
 		$this->data_manager->delete_cache_job_id( $item_url, $is_mobile );
 
 		// save the generated CPCSS code into file.
-		$saved = $this->data_manager->save_cpcss( $item_path, $cpcss_code, $item_url, $is_mobile );
+		$saved = $this->data_manager->save_cpcss( $item_path, $cpcss_code, $item_url, $is_mobile, $item_type );
 		if ( is_wp_error( $saved ) ) {
 			return $saved;
 		}
@@ -233,16 +257,22 @@ class ProcessorService {
 		if ( $is_mobile ) {
 			return [
 				'code'    => 'cpcss_generation_successful',
-				// translators: %s = post URL.
-				'message' => sprintf( __( 'Mobile Critical CSS for %s generated.', 'rocket' ), $item_url ),
+				'message' => sprintf(
+					// translators: %1$s = Item URL or item type.
+					__( 'Mobile Critical CSS for %s generated.', 'rocket' ),
+					( 'custom' === $item_type ) ? $item_url : $item_type
+				),
 			];
 		}
 
 		// Send the current status of job.
 		return [
 			'code'    => 'cpcss_generation_successful',
-			// translators: %s = post URL.
-			'message' => sprintf( __( 'Critical CSS for %s generated.', 'rocket' ), $item_url ),
+			'message' => sprintf(
+				// translators: %1$s = Item URL or item type.
+				__( 'Critical CSS for %s generated.', 'rocket' ),
+				( 'custom' === $item_type ) ? $item_url : $item_type
+			),
 		];
 	}
 
@@ -273,16 +303,20 @@ class ProcessorService {
 	 *
 	 * @param string $item_url  URL for item to be used in error messages.
 	 * @param bool   $is_mobile Bool identifier for is_mobile CPCSS generation.
+	 * @param string $item_type Optional. Type for this item if it's custom or specific type. Default: custom.
 	 * @return WP_Error
 	 */
-	private function process_timeout( $item_url, $is_mobile = false ) {
+	private function process_timeout( $item_url, $is_mobile = false, $item_type = 'custom' ) {
 		$this->data_manager->delete_cache_job_id( $item_url, $is_mobile );
 
 		if ( $is_mobile ) {
 			return new WP_Error(
 				'cpcss_generation_timeout',
-				// translators: %1$s = Item URL.
-				sprintf( __( 'Mobile Critical CSS for %1$s timeout. Please retry a little later.', 'rocket' ), $item_url ),
+				sprintf(
+					// translators: %1$s = Item URL or item type.
+					__( 'Mobile Critical CSS for %1$s timeout. Please retry a little later.', 'rocket' ),
+					( 'custom' === $item_type ) ? $item_url : $item_type
+				),
 				[
 					'status' => 400,
 				]
@@ -291,8 +325,11 @@ class ProcessorService {
 
 		return new WP_Error(
 			'cpcss_generation_timeout',
-			// translators: %1$s = Item URL.
-			sprintf( __( 'Critical CSS for %1$s timeout. Please retry a little later.', 'rocket' ), $item_url ),
+			sprintf(
+				// translators: %1$s = Item URL or item type.
+				__( 'Critical CSS for %1$s timeout. Please retry a little later.', 'rocket' ),
+				( 'custom' === $item_type ) ? $item_url : $item_type
+			),
 			[
 				'status' => 400,
 			]

--- a/inc/Engine/CriticalPath/RESTWP.php
+++ b/inc/Engine/CriticalPath/RESTWP.php
@@ -148,11 +148,11 @@ abstract class RESTWP implements RESTWPInterface {
 		$item_path = $this->get_path( $item_id, $is_mobile );
 
 		$additional_params = [
-			'timeout' => $timeout,
+			'timeout'   => $timeout,
 			'is_mobile' => $is_mobile,
-			'item_type' => 'custom'
+			'item_type' => 'custom',
 		];
-		$generated = $this->cpcss_service->process_generate( $item_url, $item_path, $additional_params );
+		$generated         = $this->cpcss_service->process_generate( $item_url, $item_path, $additional_params );
 
 		if ( is_wp_error( $generated ) ) {
 			return rest_ensure_response(

--- a/inc/Engine/CriticalPath/RESTWP.php
+++ b/inc/Engine/CriticalPath/RESTWP.php
@@ -147,7 +147,12 @@ abstract class RESTWP implements RESTWPInterface {
 		$timeout   = ( isset( $request['timeout'] ) && ! empty( $request['timeout'] ) );
 		$item_path = $this->get_path( $item_id, $is_mobile );
 
-		$generated = $this->cpcss_service->process_generate( $item_url, $item_path, $timeout, $is_mobile );
+		$additional_params = [
+			'timeout' => $timeout,
+			'is_mobile' => $is_mobile,
+			'item_type' => 'custom'
+		];
+		$generated = $this->cpcss_service->process_generate( $item_url, $item_path, $additional_params );
 
 		if ( is_wp_error( $generated ) ) {
 			return rest_ensure_response(

--- a/tests/Fixtures/inc/Engine/CriticalPath/APIClient/sendGenerationRequest.php
+++ b/tests/Fixtures/inc/Engine/CriticalPath/APIClient/sendGenerationRequest.php
@@ -13,7 +13,7 @@ return [
 			],
 			'expected' => [
 				'code'    => 'cpcss_generation_failed',
-				'message' => 'User has blocked requests through HTTP.',
+				'message' => 'Critical CSS for http://www.example.com/?p=1 not generated. Error: User has blocked requests through HTTP.',
 				'data'    => [ 'status' => 400 ],
 			],
 		],

--- a/tests/Fixtures/inc/Engine/CriticalPath/APIClient/sendGenerationRequest.php
+++ b/tests/Fixtures/inc/Engine/CriticalPath/APIClient/sendGenerationRequest.php
@@ -2,6 +2,21 @@
 
 return [
 	'test_data' => [
+		'testShouldBailoutIfBlockExternal'     => [
+			'config'   => [
+				'block_external' => true,
+				'item_url'     => 'http://www.example.com/?p=1',
+				'response_data' => [
+					'code' => 400,
+					'body' => '{}',
+				]
+			],
+			'expected' => [
+				'code'    => 'cpcss_generation_failed',
+				'message' => 'User has blocked requests through HTTP.',
+				'data'    => [ 'status' => 400 ],
+			],
+		],
 		'testShouldBailoutIfResponse400'     => [
 			'config'   => [
 				'item_url'     => 'http://www.example.com/?p=1',

--- a/tests/Fixtures/inc/Engine/CriticalPath/Admin/Admin/cpcssHeartbeat.php
+++ b/tests/Fixtures/inc/Engine/CriticalPath/Admin/Admin/cpcssHeartbeat.php
@@ -314,7 +314,6 @@ return [
 					'timeout' => false,
 					'mobile'  => false,
 					'check'   => 0,
-					'type'    => 'category',
 				],
 			],
 			'process_generate'                               => [

--- a/tests/Fixtures/inc/Engine/CriticalPath/Admin/Admin/cpcssHeartbeat.php
+++ b/tests/Fixtures/inc/Engine/CriticalPath/Admin/Admin/cpcssHeartbeat.php
@@ -67,6 +67,7 @@ return [
 					'timeout' => false,
 					'mobile'  => false,
 					'check'   => 0,
+					'type' => 'home',
 				],
 			],
 			'process_generate'                               => [
@@ -74,20 +75,20 @@ return [
 				'status'      => 404,
 				'success'     => false,
 				'code'        => 'cpcss_generation_failed',
-				'message'     => 'Critical CSS for https://example.org/ not generated.',
+				'message'     => 'Critical CSS for home not generated.',
 				'data'        => [
 					'state' => 'failed',
 				],
 			],
 			'notice'                                         => [
-				'get_error_message' => 'Critical CSS for https://example.org/ not generated.',
+				'get_error_message' => 'Critical CSS for home not generated.',
 				'transient'         => [
 					'total' => 1,
 					'items' => [
 						'front_page.css' => [
 							'status' => [
 								'nonmobile' => [
-									'message' => 'Critical CSS for https://example.org/ not generated.',
+									'message' => 'Critical CSS for home not generated.',
 									'success' => false,
 								],
 							],
@@ -120,13 +121,14 @@ return [
 					'timeout' => false,
 					'mobile'  => false,
 					'check'   => 0,
+					'type'    => 'home',
 				],
 			],
 			'process_generate'                               => [
 				'status'  => 200,
 				'success' => true,
 				'code'    => 'cpcss_generation_successful',
-				'message' => 'Critical CSS for https://example.org/ generated.',
+				'message' => 'Critical CSS for home generated.',
 				'data'    => [
 					'state'         => 'complete',
 					'critical_path' => '.critical_path { color: red; }',
@@ -139,7 +141,7 @@ return [
 						'front_page.css' => [
 							'status' => [
 								'nonmobile' => [
-									'message' => 'Critical CSS for https://example.org/ generated.',
+									'message' => 'Critical CSS for home generated.',
 									'success' => true,
 								],
 							],
@@ -170,13 +172,14 @@ return [
 					'timeout' => false,
 					'mobile'  => false,
 					'check'   => 0,
+					'type'    => 'home',
 				],
 			],
 			'process_generate'                               => [
 				'status'  => 404,
 				'success' => false,
 				'code'    => 'cpcss_generation_failed',
-				'message' => 'Critical CSS for https://example.org/ not generated.',
+				'message' => 'Critical CSS for home not generated.',
 				'data'    => [
 					'state' => 'failed',
 				],
@@ -188,7 +191,7 @@ return [
 						'front_page.css' => [
 							'status' => [
 								'nonmobile' => [
-									'message' => 'Critical CSS for https://example.org/ not generated.',
+									'message' => 'Critical CSS for home not generated.',
 									'success' => false,
 								],
 							],
@@ -220,13 +223,14 @@ return [
 					'timeout' => false,
 					'mobile'  => false,
 					'check'   => 11,
+					'type'    => 'home',
 				],
 			],
 			'process_generate'                               => [
 				'status'  => 200,
 				'success' => true,
 				'code'    => 'cpcss_generation_pending',
-				'message' => 'Critical CSS for https://example.org/ in progress.',
+				'message' => 'Critical CSS for home in progress.',
 				'data'    => [
 					'state' => 'pending',
 				],
@@ -258,13 +262,14 @@ return [
 					'timeout' => false,
 					'mobile'  => false,
 					'check'   => 0,
+					'type'    => 'home',
 				],
 			],
 			'process_generate'                => [
 				'status'  => 200,
 				'success' => true,
 				'code'    => 'cpcss_generation_pending',
-				'message' => 'Critical CSS for https://example.org/ in progress.',
+				'message' => 'Critical CSS for home in progress.',
 				'data'    => [
 					'state' => 'pending',
 				],
@@ -282,6 +287,7 @@ return [
 					'timeout' => false,
 					'mobile'  => false,
 					'check'   => 1,
+					'type'    => 'home',
 				],
 			],
 		],
@@ -300,6 +306,7 @@ return [
 					'timeout' => false,
 					'mobile'  => false,
 					'check'   => 0,
+					'type'    => 'home',
 				],
 				'category.css'   => [
 					'url'     => 'https://example.org/category/',
@@ -307,6 +314,7 @@ return [
 					'timeout' => false,
 					'mobile'  => false,
 					'check'   => 0,
+					'type'    => 'category',
 				],
 			],
 			'process_generate'                               => [

--- a/tests/Fixtures/inc/Engine/CriticalPath/CriticalCSSGeneration/task.php
+++ b/tests/Fixtures/inc/Engine/CriticalPath/CriticalCSSGeneration/task.php
@@ -7,6 +7,7 @@ return [
 				'url'    => 'http://example.org/',
 				'path'   => 'front_page.css',
 				'check'  => 0,
+				'type'   => 'home',
 			],
 			'result' => [
 				'success' => false,
@@ -33,6 +34,7 @@ return [
 				'url'    => 'http://example.org/',
 				'path'   => 'front_page.css',
 				'check'  => 0,
+				'type'   => 'home',
 			],
 			'result' => [
 				'success' => true,
@@ -47,6 +49,7 @@ return [
 				'url'    => 'http://example.org/',
 				'path'   => 'front_page.css',
 				'check'  => 0,
+				'type'   => 'home',
 			],
 			'result' => [
 				'success' => true,

--- a/tests/Fixtures/inc/Engine/CriticalPath/ProcessorService/processGenerate.php
+++ b/tests/Fixtures/inc/Engine/CriticalPath/ProcessorService/processGenerate.php
@@ -26,13 +26,8 @@ return [
 		'testShouldBailoutOnRequestTimeOut'       => [
 			'config'   => [
 				'current_user_can'   => true,
-				'post_data'          => [
-					'ID'           => 21,
-					'post_type'    => 'post',
-					'post_status'  => 'publish',
-					'post_title'   => 'CPCSS title',
-					'post_content' => 'content',
-				],
+				'item_url' => 'http://example.org/?p=1',
+				'item_path' => 'posts/post-1.css',
 				'cpcss_exists_after' => false,
 				'request_timeout'    => true,
 				'mobile'             => false,
@@ -50,13 +45,8 @@ return [
 		'testShouldBailoutIfPostRequest400'       => [
 			'config'   => [
 				'current_user_can'              => true,
-				'post_data'                     => [
-					'ID'           => 21,
-					'post_type'    => 'post',
-					'post_status'  => 'publish',
-					'post_title'   => 'CPCSS title',
-					'post_content' => 'content',
-				],
+				'item_url' => 'http://example.org/?p=2',
+				'item_path' => 'posts/post-2.css',
 				'generate_post_request_data'    => [
 					'code' => 400,
 					'body' => '{}',
@@ -64,16 +54,17 @@ return [
 				'cpcss_exists_after'            => false,
 				'send_generation_request_error' => new WP_Error(
 					'cpcss_generation_failed',
-					'Critical CSS for http://example.org/?p=21 not generated.',
+					'Critical CSS for http://example.org/?p=2 not generated.',
 					[
 						'status' => 400,
 					]
 				),
+				'type'               => 'custom',
 			],
 			'expected' => [
 				'success' => false,
 				'code'    => 'cpcss_generation_failed',
-				'message' => 'Critical CSS for http://example.org/?p=21 not generated.',
+				'message' => 'Critical CSS for http://example.org/?p=2 not generated.',
 				'data'    => [
 					'status' => 400,
 				],
@@ -82,11 +73,8 @@ return [
 		'testShouldBailoutIfPostRequestCodeNotExpected' => [
 			'config'   => [
 				'current_user_can'           => true,
-				'post_data'                  => [
-					'ID'          => 21,
-					'post_type'   => 'post',
-					'post_status' => 'publish',
-				],
+				'item_url' => 'http://example.org/?p=3',
+				'item_path' => 'posts/post-3.css',
 				'generate_post_request_data' => [
 					'code' => 403,
 					'body' => '{}',
@@ -94,16 +82,17 @@ return [
 				'cpcss_exists_after'         => false,
 				'send_generation_request_error' => new WP_Error(
 					'cpcss_generation_failed',
-					'Critical CSS for http://example.org/?p=21 not generated. Error: The API returned an invalid response code.',
+					'Critical CSS for http://example.org/?p=3 not generated. Error: The API returned an invalid response code.',
 					[
 						'status' => 403,
 					]
 				),
+				'type'               => 'custom',
 			],
 			'expected' => [
 				'success' => false,
 				'code'    => 'cpcss_generation_failed',
-				'message' => 'Critical CSS for http://example.org/?p=21 not generated. Error: The API returned an invalid response code.',
+				'message' => 'Critical CSS for http://example.org/?p=3 not generated. Error: The API returned an invalid response code.',
 				'data'    => [
 					'status' => 403,
 				],
@@ -112,11 +101,8 @@ return [
 		'testShouldBailoutIfPostRequestBodyEmpty' => [
 			'config'   => [
 				'current_user_can'           => true,
-				'post_data'                  => [
-					'ID'          => 21,
-					'post_type'   => 'post',
-					'post_status' => 'publish',
-				],
+				'item_url' => 'http://example.org/?p=4',
+				'item_path' => 'posts/post-4.css',
 				'generate_post_request_data' => [
 					'code' => 200,
 					'body' => '{}',
@@ -124,16 +110,17 @@ return [
 				'cpcss_exists_after'         => false,
 				'send_generation_request_error' => new WP_Error(
 					'cpcss_generation_failed',
-					'Critical CSS for http://example.org/?p=21 not generated. Error: The API returned an empty response.',
+					'Critical CSS for http://example.org/?p=4 not generated. Error: The API returned an empty response.',
 					[
 						'status' => 400,
 					]
 				),
+				'type'               => 'custom',
 			],
 			'expected' => [
 				'success' => false,
 				'code'    => 'cpcss_generation_failed',
-				'message' => 'Critical CSS for http://example.org/?p=21 not generated. Error: The API returned an empty response.',
+				'message' => 'Critical CSS for http://example.org/?p=4 not generated. Error: The API returned an empty response.',
 				'data'    => [
 					'status' => 400,
 				],
@@ -142,11 +129,8 @@ return [
 		'testShouldBailoutIfGetRequestCode400'    => [
 			'config'   => [
 				'current_user_can'           => true,
-				'post_data'                  => [
-					'ID'          => 21,
-					'post_type'   => 'post',
-					'post_status' => 'publish',
-				],
+				'item_url' => 'http://example.org/?p=5',
+				'item_path' => 'posts/post-5.css',
 				'generate_post_request_data' => [
 					'code' => 200,
 					'body' => '{"success":true,"data":{"id":1}}',
@@ -159,16 +143,17 @@ return [
 				'cpcss_job_id'               => false,
 				'get_job_details_error'      => new WP_Error(
 					'cpcss_generation_failed',
-					'Critical CSS for http://example.org/?p=21 not generated. Error: Error message',
+					'Critical CSS for http://example.org/?p=5 not generated. Error: Error message',
 					[
 						'status' => 400,
 					]
 				),
+				'type'               => 'custom',
 			],
 			'expected' => [
 				'success' => false,
 				'code'    => 'cpcss_generation_failed',
-				'message' => 'Critical CSS for http://example.org/?p=21 not generated. Error: Error message',
+				'message' => 'Critical CSS for http://example.org/?p=5 not generated. Error: Error message',
 				'data'    => [
 					'status' => 400,
 				],
@@ -177,11 +162,8 @@ return [
 		'testShouldBailoutIfGetRequestCode404'    => [
 			'config'   => [
 				'current_user_can'           => true,
-				'post_data'                  => [
-					'ID'          => 21,
-					'post_type'   => 'post',
-					'post_status' => 'publish',
-				],
+				'item_url' => 'http://example.org/?p=6',
+				'item_path' => 'posts/post-6.css',
 				'generate_post_request_data' => [
 					'code' => 200,
 					'body' => '{"success":true,"data":{"id":1}}',
@@ -194,16 +176,17 @@ return [
 				'cpcss_job_id'               => false,
 				'get_job_details_error'      => new WP_Error(
 					'cpcss_generation_failed',
-					'Critical CSS for http://example.org/?p=21 not generated. Error: Job not found',
+					'Critical CSS for http://example.org/?p=6 not generated. Error: Job not found',
 					[
 						'status' => 404,
 					]
 				),
+				'type'               => 'custom',
 			],
 			'expected' => [
 				'success' => false,
 				'code'    => 'cpcss_generation_failed',
-				'message' => 'Critical CSS for http://example.org/?p=21 not generated. Error: Job not found',
+				'message' => 'Critical CSS for http://example.org/?p=6 not generated. Error: Job not found',
 				'data'    => [
 					'status' => 404,
 				],
@@ -212,11 +195,8 @@ return [
 		'testShouldNotSaveCPCSSForPost'           => [
 			'config'   => [
 				'current_user_can'           => true,
-				'post_data'                  => [
-					'ID'          => 21,
-					'post_type'   => 'post',
-					'post_status' => 'publish',
-				],
+				'item_url' => 'http://example.org/?p=7',
+				'item_path' => 'posts/post-7.css',
 				'generate_post_request_data' => [
 					'code' => 200,
 					'body' => '{"success":true,"data":{"id":1}}',
@@ -229,16 +209,17 @@ return [
 				'cpcss_job_id'               => false,
 				'save_cpcss'                 => new WP_Error(
 					'cpcss_generation_failed',
-					'Critical CSS for http://example.org/?p=21 not generated. Error: The API returned an empty response.',
+					'Critical CSS for http://example.org/?p=7 not generated. Error: The API returned an empty response.',
 					[
 						'status' => 400,
 					]
 				),
+				'type'               => 'custom',
 			],
 			'expected' => [
 				'success' => false,
 				'code'    => 'cpcss_generation_failed',
-				'message' => 'Critical CSS for http://example.org/?p=21 not generated. Error: The API returned an empty response.',
+				'message' => 'Critical CSS for http://example.org/?p=7 not generated. Error: The API returned an empty response.',
 				'data'    => [
 					'status' => 400,
 				],
@@ -247,11 +228,8 @@ return [
 		'testShouldSaveCPCSSForPost'              => [
 			'config'   => [
 				'current_user_can'           => true,
-				'post_data'                  => [
-					'ID'          => 21,
-					'post_type'   => 'post',
-					'post_status' => 'publish',
-				],
+				'item_url' => 'http://example.org/?p=8',
+				'item_path' => 'posts/post-8.css',
 				'generate_post_request_data' => [
 					'code' => 200,
 					'body' => '{"success":true,"data":{"id":1}}',
@@ -263,10 +241,57 @@ return [
 				'cpcss_exists_after'         => true,
 				'cpcss_job_id'               => false,
 				'save_cpcss'                 => true,
+				'type'               => 'post',
 			],
 			'expected' => [
 				'code'    => 'cpcss_generation_successful',
-				'message' => 'Critical CSS for http://example.org/?p=21 generated.'
+				'message' => 'Critical CSS for post generated.'
+			],
+		],
+		'testShouldSaveCPCSSForHome'              => [
+			'config'   => [
+				'current_user_can'           => true,
+				'item_url' => 'http://example.org/',
+				'item_path' => 'front-page.css',
+				'generate_post_request_data' => [
+					'code' => 200,
+					'body' => '{"success":true,"data":{"id":1}}',
+				],
+				'generate_get_request_data'  => [
+					'code' => 200,
+					'body' => '{"status":200,"data":{"state":"complete","critical_path":"body{color:#000}"}}',
+				],
+				'cpcss_exists_after'         => true,
+				'cpcss_job_id'               => false,
+				'save_cpcss'                 => true,
+				'type'                       => 'front-page'
+			],
+			'expected' => [
+				'code'    => 'cpcss_generation_successful',
+				'message' => 'Critical CSS for front-page generated.'
+			],
+		],
+		'testShouldSaveCPCSSForCategory'              => [
+			'config'   => [
+				'current_user_can'           => true,
+				'item_url' => 'http://example.org/category/categoryname',
+				'item_path' => 'categoryname.css',
+				'generate_post_request_data' => [
+					'code' => 200,
+					'body' => '{"success":true,"data":{"id":1}}',
+				],
+				'generate_get_request_data'  => [
+					'code' => 200,
+					'body' => '{"status":200,"data":{"state":"complete","critical_path":"body{color:#000}"}}',
+				],
+				'cpcss_exists_after'         => true,
+				'cpcss_job_id'               => false,
+				'save_cpcss'                 => true,
+				'type'                       => 'category'
+			],
+			'expected' => [
+				'code'    => 'cpcss_generation_successful',
+				'message' => 'Critical CSS for category generated.'
 			],
 		],
 	],

--- a/tests/Fixtures/inc/Engine/CriticalPath/ProcessorService/processGenerate.php
+++ b/tests/Fixtures/inc/Engine/CriticalPath/ProcessorService/processGenerate.php
@@ -36,11 +36,12 @@ return [
 				'cpcss_exists_after' => false,
 				'request_timeout'    => true,
 				'mobile'             => false,
+				'type'               => 'post'
 			],
 			'expected' => [
 				'success' => false,
 				'code'    => 'cpcss_generation_timeout',
-				'message' => 'Critical CSS for http://example.org/?p=21 timeout. Please retry a little later.',
+				'message' => 'Critical CSS for post timeout. Please retry a little later.',
 				'data'    => [
 					'status' => 400,
 				],

--- a/tests/Integration/inc/Engine/CriticalPath/APIClient/sendGenerationRequest.php
+++ b/tests/Integration/inc/Engine/CriticalPath/APIClient/sendGenerationRequest.php
@@ -20,6 +20,12 @@ class Test_SendGenerationRequest extends TestCase {
 		$is_mobile     = isset( $config['is_mobile'] ) ? $config['is_mobile'] : false;
 		$response_code = ! isset( $config['response_data']['code'] ) ? 200 : $config['response_data']['code'];
 		$response_body = ! isset( $config['response_data']['body'] ) ? '' : $config['response_data']['body'];
+		$block_external     = isset( $config['block_external'] ) ? $config['block_external'] : false;
+
+		$post_request_response = 'postRequest';
+		if ( $block_external ) {
+			$post_request_response = new WP_Error('code', 'User has blocked requests through HTTP.');
+		}
 
 		Functions\expect( 'wp_remote_post' )
 			->once()
@@ -32,17 +38,19 @@ class Test_SendGenerationRequest extends TestCase {
 					],
 				]
 			)
-			->andReturn( 'postRequest' );
+			->andReturn( $post_request_response );
 
-		Functions\expect( 'wp_remote_retrieve_response_code' )
-			->once()
-			->with( 'postRequest' )
-			->andReturn( $response_code );
+		if ( ! $block_external ) {
+			Functions\expect( 'wp_remote_retrieve_response_code' )
+				->once()
+				->with( 'postRequest' )
+				->andReturn( $response_code );
 
-		Functions\expect( 'wp_remote_retrieve_body' )
-			->once()
-			->with( 'postRequest' )
-			->andReturn( $response_body );
+			Functions\expect( 'wp_remote_retrieve_body' )
+				->once()
+				->with( 'postRequest' )
+				->andReturn( $response_body );
+		}
 
 		$api_client = new APIClient();
 		$actual = $api_client->send_generation_request( $item_url, ['mobile' => (int) $is_mobile] );

--- a/tests/Integration/inc/Engine/CriticalPath/ProcessorService/processGenerate.php
+++ b/tests/Integration/inc/Engine/CriticalPath/ProcessorService/processGenerate.php
@@ -73,10 +73,8 @@ class Test_ProcessGenerate extends FilesystemTestCase {
 		$request_timeout               = isset( $config['request_timeout'] )
 			? $config['request_timeout']
 			: false;
-		$item_path                     = "posts/{$post_type}-{$post_id}.css";
-		$item_url                      = ('post_not_exists' === $expected['code'])
-			? null
-			: "http://example.org/?p={$post_id}";
+		$item_path = isset( $config['item_path'] ) ? $config['item_path'] : '';
+		$item_url  = isset( $config['item_url'] ) ? $config['item_url'] : '';
 		$save_cpcss                    =  ! isset( $config['save_cpcss'] )
 			? true
 			: $config['save_cpcss'];
@@ -97,7 +95,7 @@ class Test_ProcessGenerate extends FilesystemTestCase {
 		if ( ! $request_timeout ) {
 			if ( false === $saved_cpcss_job_id) {
 				// enters send_generation_request()
-				if ( $post_id > 0 && 'publish' === $post_status && $cpcss_post_job_id && 200 === $post_request_response_code ) {
+				if ( $cpcss_post_job_id && 200 === $post_request_response_code ) {
 					$this->api_client->shouldReceive( 'send_generation_request' )
 						->once()
 						->with( $item_url, [ 'mobile' => $is_mobile ], $item_type )

--- a/tests/Unit/inc/Engine/CriticalPath/ProcessorService/processGenerate.php
+++ b/tests/Unit/inc/Engine/CriticalPath/ProcessorService/processGenerate.php
@@ -23,15 +23,6 @@ class Test_ProcessGenerate extends FilesystemTestCase {
 	 * @dataProvider dataProvider
 	 */
 	public function testShouldDoExpected( $config, $expected ) {
-		$post_id                       = isset( $config['post_data'] )
-			? $config['post_data']['ID']
-			: 0;
-		$post_type                     = ! isset( $config['post_data']['post_type'] )
-			? 'post'
-			: $config['post_data']['post_type'];
-		$post_status                   = isset( $config['post_data']['post_status'] )
-			? $config['post_data']['post_status']
-			: false;
 		$post_request_response_code    = ! isset( $config['generate_post_request_data']['code'] )
 			? 200
 			: $config['generate_post_request_data']['code'];
@@ -53,10 +44,8 @@ class Test_ProcessGenerate extends FilesystemTestCase {
 		$request_timeout               = isset( $config['request_timeout'] )
 			? $config['request_timeout']
 			: false;
-		$item_path                     = "posts/{$post_type}-{$post_id}.css";
-		$item_url                      = ('post_not_exists' === $expected['code'])
-			? null
-			: "http://example.org/?p={$post_id}";
+		$item_path = isset( $config['item_path'] ) ? $config['item_path'] : '';
+		$item_url  = isset( $config['item_url'] ) ? $config['item_url'] : '';
 		$save_cpcss                    =  ! isset( $config['save_cpcss'] )
 			? true
 			: $config['save_cpcss'];
@@ -80,11 +69,13 @@ class Test_ProcessGenerate extends FilesystemTestCase {
 		if ( $request_timeout ) {
 			$data_manager->shouldReceive( 'delete_cache_job_id' )->once()->with( $item_url, $is_mobile );
 		} else {
-			$data_manager->shouldReceive( 'get_cache_job_id' )->once()->with( $item_url, $is_mobile )->andReturn( $saved_cpcss_job_id );
+			$data_manager->shouldReceive( 'get_cache_job_id' )->once()
+				->with( $item_url, $is_mobile )
+				->andReturn( $saved_cpcss_job_id );
 
 			if ( false === $saved_cpcss_job_id) {
 				// enters send_generation_request()
-				if ( $post_id > 0 && 'publish' === $post_status && $cpcss_post_job_id && 200 === $post_request_response_code ) {
+				if ( $cpcss_post_job_id && 200 === $post_request_response_code ) {
 					$api_client->shouldReceive( 'send_generation_request' )
 						->once()
 						->with( $item_url, [ 'mobile' => $is_mobile ], $item_type )

--- a/tests/Unit/inc/Engine/CriticalPath/ProcessorService/processGenerate.php
+++ b/tests/Unit/inc/Engine/CriticalPath/ProcessorService/processGenerate.php
@@ -69,6 +69,9 @@ class Test_ProcessGenerate extends FilesystemTestCase {
 		$is_mobile                    = isset( $config['mobile'] )
 			? $config['mobile']
 			: false;
+		$item_type                    = isset( $config['type'] )
+			? $config['type']
+			: 'custom';
 
 		$api_client    = Mockery::mock( APIClient::class );
 		$data_manager  = Mockery::mock( DataManager::class );
@@ -84,7 +87,7 @@ class Test_ProcessGenerate extends FilesystemTestCase {
 				if ( $post_id > 0 && 'publish' === $post_status && $cpcss_post_job_id && 200 === $post_request_response_code ) {
 					$api_client->shouldReceive( 'send_generation_request' )
 						->once()
-						->with( $item_url, [ 'mobile' => $is_mobile ] )
+						->with( $item_url, [ 'mobile' => $is_mobile ], $item_type )
 						->andReturn( $cpcss_post_job_body );
 
 					$data_manager->shouldReceive( 'set_cache_job_id' )->once()->with( $item_url, $cpcss_post_job_id, $is_mobile );
@@ -92,30 +95,36 @@ class Test_ProcessGenerate extends FilesystemTestCase {
 					if ( ! in_array( (int) $get_request_response_code, [ 400, 404 ], true ) ) {
 						$api_client->shouldReceive( 'get_job_details' )
 							->once()
-							->with( $cpcss_post_job_id, $item_url, $is_mobile )
+							->with( $cpcss_post_job_id, $item_url, $is_mobile, $item_type )
 							->andReturn( $get_request_response_decoded );
 						$data_manager->shouldReceive( 'delete_cache_job_id' )->once()->with( $item_url, $is_mobile );
+
 						$data_manager->shouldReceive( 'save_cpcss' )
 							->once()
-							->with( $item_path, $get_request_response_decoded->data->critical_path, $item_url, $is_mobile )
+							->with( $item_path, $get_request_response_decoded->data->critical_path, $item_url, $is_mobile, $item_type )
 							->andReturn( $save_cpcss );
 					} else {
 						$api_client->shouldReceive( 'get_job_details' )
 							->once()
-							->with( $cpcss_post_job_id, $item_url, $is_mobile )
+							->with( $cpcss_post_job_id, $item_url, $is_mobile, $item_type )
 							->andReturn( $get_job_details_error );
 						$data_manager->shouldReceive( 'delete_cache_job_id' )->once()->with( $item_url, $is_mobile );
 					}
 				} else {
 					$api_client->shouldReceive( 'send_generation_request' )
 						->once()
-						->with( $item_url, [ 'mobile' => $is_mobile ] )
+						->with( $item_url, [ 'mobile' => $is_mobile ], $item_type )
 						->andReturn( $send_generation_request_error );
 				}
 			}
 		}
 
-		$generated = $cpcss_service->process_generate( $item_url, $item_path, $request_timeout, $is_mobile );
+		$generation_params = [
+			'is_mobile' => $is_mobile,
+			'timeout' => $request_timeout,
+			'item_type' => $item_type
+		];
+		$generated = $cpcss_service->process_generate( $item_url, $item_path, $generation_params );
 		if( isset( $expected['success'] ) && ! $expected['success'] ){
 			$this->assertSame( $expected['code'], $generated->get_error_code() );
 			$this->assertSame( $expected['message'], $generated->get_error_message() );


### PR DESCRIPTION
Reverts CPCSS notice back per request from @GeekPress in [slack](https://wp-media.slack.com/archives/GUT7FLHF1/p1591288051020400):

>Can we put back the previous behavior: instead of the URL, having the CPT / Taxonomy slug
>
> Why? It’s going to be confused by just displaying that. We can think that the CPCSS is generated only for the pages displayed into the notice.
>
> The URL should be displayed only for custom CPCSS pages

Adjust CPCSS messages to check if this is custom page or a page type so that we can show the url inside the messages or the type itself.

## TODO

- [x] \WP_Rocket\Engine\CriticalPath\ProcessorService
- [x] \WP_Rocket\Engine\CriticalPath\DataManager
- [x] \WP_Rocket\Engine\CriticalPath\APIClient
- [x] process_generate method usages inside RESTWP
- [x] process_generate method usages inside wpBackgroundProcess task
- [x] process_generate method usages inside \WP_Rocket\Engine\CriticalPath\Admin\Admin Hearbeat
- [x] Unit tests
- [x] Integration tests
---------------------------------
- [x] Make CPCSS fail with descriptive message if external requests are blocked.