### PR TITLE
Prevent false positive notice "content not ours" after license validation

### DIFF
--- a/inc/Engine/Cache/AdvancedCache.php
+++ b/inc/Engine/Cache/AdvancedCache.php
@@ -140,6 +140,10 @@ class AdvancedCache {
 			return;
 		}
 
+		if ( ! rocket_get_constant( 'WP_CACHE' ) ) {
+			return;
+		}
+
 		if ( rocket_get_constant( 'WP_ROCKET_ADVANCED_CACHE' ) ) {
 			return;
 		}

--- a/tests/Fixtures/inc/Engine/Cache/AdvancedCache/noticeContentNotOurs.php
+++ b/tests/Fixtures/inc/Engine/Cache/AdvancedCache/noticeContentNotOurs.php
@@ -4,60 +4,78 @@ return [
 
 	'testShouldReturnNullWhenPluginsActivate' => [
 		'config'   => [
-			'pagenow'   => 'plugins.php',
-			'activate'  => true,
-			'cap'       => false,
-			'valid_key' => true,
-			'constant'  => true,
-			'message'   => '',
+			'pagenow'                  => 'plugins.php',
+			'activate'                 => true,
+			'cap'                      => false,
+			'valid_key'                => true,
+			'wp_cache'                 => true,
+			'wp_rocket_advanced_cache' => true,
+			'message'                  => '',
 		],
 		'expected' => null,
 	],
 
 	'testShouldReturnNullWhenNoCap' => [
 		'config'   => [
-			'pagenow'   => 'settings-general.php',
-			'activate'  => null,
-			'cap'       => false,
-			'valid_key' => true,
-			'constant'  => true,
-			'message'   => '',
+			'pagenow'                  => 'settings-general.php',
+			'activate'                 => null,
+			'cap'                      => false,
+			'valid_key'                => true,
+			'wp_cache'                 => true,
+			'wp_rocket_advanced_cache' => true,
+			'message'                  => '',
 		],
 		'expected' => null,
 	],
 
 	'testShouldReturnNullWhenNoValidKey' => [
 		'config'   => [
-			'pagenow'   => 'settings-general.php',
-			'activate'  => null,
-			'cap'       => true,
-			'valid_key' => false,
-			'constant'  => true,
-			'message'   => '',
+			'pagenow'                  => 'settings-general.php',
+			'activate'                 => null,
+			'cap'                      => true,
+			'valid_key'                => false,
+			'wp_cache'                 => true,
+			'wp_rocket_advanced_cache' => true,
+			'message'                  => '',
+		],
+		'expected' => null,
+	],
+
+	'testShouldReturnNullWPCacheFalse' => [
+		'config'   => [
+			'pagenow'                  => 'settings-general.php',
+			'activate'                 => null,
+			'cap'                      => true,
+			'valid_key'                => true,
+			'wp_cache'                 => false,
+			'wp_rocket_advanced_cache' => true,
+			'message'                  => '',
 		],
 		'expected' => null,
 	],
 
 	'testShouldReturnNullWhenConstantSet' => [
 		'config'   => [
-			'pagenow'   => 'settings-general.php',
-			'activate'  => null,
-			'cap'       => true,
-			'valid_key' => true,
-			'constant'  => true,
-			'message'   => '',
+			'pagenow'                  => 'settings-general.php',
+			'activate'                 => null,
+			'cap'                      => true,
+			'valid_key'                => true,
+			'wp_cache'                 => true,
+			'wp_rocket_advanced_cache' => true,
+			'message'                  => '',
 		],
 		'expected' => null,
 	],
 
 	'testShouldDisplayNotice' => [
 		'config'   => [
-			'pagenow'   => 'settings-general.php',
-			'activate'  => null,
-			'cap'       => true,
-			'valid_key' => true,
-			'constant'  => false,
-			'message'   => <<<HTML
+			'pagenow'                  => 'settings-general.php',
+			'activate'                 => null,
+			'cap'                      => true,
+			'valid_key'                => true,
+			'wp_cache'                 => true,
+			'wp_rocket_advanced_cache' => false,
+			'message'                  => <<<HTML
 <strong>WP Rocket</strong> cannot configure itself due to missing writing permissions.
 <br>Affected file/folder: <code>wp-content/advanced-cache.php</code>
 <br>Troubleshoot: <a href="https://docs.wp-rocket.me/article/626-how-to-make-system-files-htaccess-wp-config-writeable/?utm_source=wp_plugin&utm_medium=wp_rocket" target="_blank">How to make system files writeable</a>

--- a/tests/Integration/inc/Engine/Cache/AdvancedCache/noticeContentNotOurs.php
+++ b/tests/Integration/inc/Engine/Cache/AdvancedCache/noticeContentNotOurs.php
@@ -38,7 +38,8 @@ class Test_NoticeContentNotOurs extends TestCase {
 	public function testShouldEchoNotice( $config, $expected ) {
 		$GLOBALS['pagenow']             = $config['pagenow'];
 		$_GET['activate']               = $config['activate'];
-		$this->wp_rocket_advanced_cache = $config['constant'];
+		this->wp_cache_constant         = $config['wp_cache'];
+		$this->wp_rocket_advanced_cache = $config['wp_rocket_advanced_cache'];
 
 		if ( $config['cap'] ) {
 			wp_set_current_user( self::$user_id );

--- a/tests/Integration/inc/Engine/Cache/AdvancedCache/noticeContentNotOurs.php
+++ b/tests/Integration/inc/Engine/Cache/AdvancedCache/noticeContentNotOurs.php
@@ -38,7 +38,7 @@ class Test_NoticeContentNotOurs extends TestCase {
 	public function testShouldEchoNotice( $config, $expected ) {
 		$GLOBALS['pagenow']             = $config['pagenow'];
 		$_GET['activate']               = $config['activate'];
-		this->wp_cache_constant         = $config['wp_cache'];
+		$this->wp_cache_constant        = $config['wp_cache'];
 		$this->wp_rocket_advanced_cache = $config['wp_rocket_advanced_cache'];
 
 		if ( $config['cap'] ) {

--- a/tests/Unit/inc/Engine/Cache/AdvancedCache/noticeContentNotOurs.php
+++ b/tests/Unit/inc/Engine/Cache/AdvancedCache/noticeContentNotOurs.php
@@ -28,7 +28,8 @@ class Test_NoticeContentNotOurs extends TestCase {
 	public function testShouldEchoNotice( $config, $expected ) {
 		$GLOBALS['pagenow']             = $config['pagenow'];
 		$_GET['activate']               = $config['activate'];
-		$this->wp_rocket_advanced_cache = $config['constant'];
+		$this->wp_cache_constant        = $config['wp_cache'];
+		$this->wp_rocket_advanced_cache = $config['wp_rocket_advanced_cache'];
 
 		Functions\expect( 'current_user_can' )
 			->once()


### PR DESCRIPTION
Closes #2721 

- Add check for `WP_CACHE` before displaying this notice
- Update tests