### PR TITLE
Exclude Gleam.io JS From Being Merged

### DIFF
--- a/inc/Engine/Optimization/Minify/JS/Combine.php
+++ b/inc/Engine/Optimization/Minify/JS/Combine.php
@@ -734,6 +734,7 @@ class Combine extends AbstractJSOptimization {
 			'a.omappapi.com/app/js/api.min.js',
 			'static.zdassets.com',
 			'feedbackcompany.com/widgets/feedback-company-widget.min.js',
+			'widget.gleamjs.io',
 		];
 
 		$excluded_external = array_merge( $defaults, $this->options->get( 'exclude_js', [] ) );


### PR DESCRIPTION
If you're using a gleam.io widget on a website and the combine js feature is enabled the widget will not render. This can be fixed by excluding the JS in the plugin options. (had to do this on a client site basically the widget never renders). This patch simply makes it permanent to save people time and to avoid issues. 