### PR TITLE
Solve error 500 on WP Rocket activation - Opening comment tag in wp-config.php removed

### DIFF
--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -319,13 +319,13 @@ function set_rocket_wp_cache_define( $turn_it_on ) { // phpcs:ignore WordPress.N
 	$turn_it_on = apply_filters( 'set_rocket_wp_cache_define', $turn_it_on ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
 
 	// Get WP_CACHE constant define.
-	$constant = "define('WP_CACHE', $turn_it_on); // Added by WP Rocket\r\n";
+	$constant = "define('WP_CACHE', $turn_it_on); // Added by WP Rocket";
 
 	// Lets find out if the constant WP_CACHE is defined or not.
 	$wp_cache_found = preg_match( '/^define\(\s*\'WP_CACHE\',(.*)\)/m', $config_file_contents, $matches );
 
 	if ( ! $wp_cache_found ) {
-		$config_file_contents = preg_replace( '/(<\?php)/i', "<?php\r\n{$constant}", $config_file_contents );
+		$config_file_contents = preg_replace( '/(<\?php)/i', "<?php\r\n{$constant}\r\n", $config_file_contents );
 	} elseif ( ! empty( $matches[1] ) && $matches[1] !== $turn_it_on ) {
 		$config_file_contents = preg_replace( '/^define\(\s*\'WP_CACHE\',(.*)\).+/m', $constant, $config_file_contents );
 	}

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -322,7 +322,7 @@ function set_rocket_wp_cache_define( $turn_it_on ) { // phpcs:ignore WordPress.N
 	$constant = "define('WP_CACHE', $turn_it_on); // Added by WP Rocket\r\n";
 
 	// Lets find out if the constant WP_CACHE is defined or not.
-	if ( ! preg_match( '/^define\(\s*\'WP_CACHE\',(.*)\)/m', $config_file_contents, $match ) ) {
+	if ( ! preg_match( '/^define\(\s*\'WP_CACHE\',(.*)\)/m', $config_file_contents ) ) {
 		$config_file_contents = preg_replace( '/(<\?php)/i', "<?php \r\n{$constant}", $config_file_contents );
 	}
 

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -322,8 +322,12 @@ function set_rocket_wp_cache_define( $turn_it_on ) { // phpcs:ignore WordPress.N
 	$constant = "define('WP_CACHE', $turn_it_on); // Added by WP Rocket\r\n";
 
 	// Lets find out if the constant WP_CACHE is defined or not.
-	if ( ! preg_match( '/^define\(\s*\'WP_CACHE\',(.*)\)/m', $config_file_contents ) ) {
+	$wp_cache_found = preg_match( '/^define\(\s*\'WP_CACHE\',(.*)\)/m', $config_file_contents, $matches );
+
+	if ( ! $wp_cache_found ) {
 		$config_file_contents = preg_replace( '/(<\?php)/i', "<?php\r\n{$constant}", $config_file_contents );
+	} elseif ( ! empty( $matches[1] ) && $matches[1] !== $turn_it_on ) {
+		$config_file_contents = preg_replace( '/^define\(\s*\'WP_CACHE\',(.*)\).+/m', $constant, $config_file_contents );
 	}
 
 	// Insert the constant in wp-config.php file.

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -336,7 +336,7 @@ function set_rocket_wp_cache_define( $turn_it_on ) { // phpcs:ignore WordPress.N
 
 	// If the constant does not exist, create it.
 	if ( ! $is_wp_cache_exist ) {
-		$config_file[0] = preg_replace('/(<\?php)/i', "<?php \r\n{$constant}", $config_file[0]);
+		$config_file[0] = preg_replace( '/(<\?php)/i', "<?php \r\n{$constant}", $config_file[0] );
 	}
 
 	// Insert the constant in wp-config.php file.

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -323,7 +323,7 @@ function set_rocket_wp_cache_define( $turn_it_on ) { // phpcs:ignore WordPress.N
 
 	// Lets find out if the constant WP_CACHE is defined or not.
 	if ( ! preg_match( '/^define\(\s*\'WP_CACHE\',(.*)\)/m', $config_file_contents ) ) {
-		$config_file_contents = preg_replace( '/(<\?php)/i', "<?php \r\n{$constant}", $config_file_contents );
+		$config_file_contents = preg_replace( '/(<\?php)/i', "<?php\r\n{$constant}", $config_file_contents );
 	}
 
 	// Insert the constant in wp-config.php file.

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -336,8 +336,7 @@ function set_rocket_wp_cache_define( $turn_it_on ) { // phpcs:ignore WordPress.N
 
 	// If the constant does not exist, create it.
 	if ( ! $is_wp_cache_exist ) {
-		array_shift( $config_file );
-		array_unshift( $config_file, "<?php\r\n", $constant );
+		$config_file[0] = preg_replace('/(<\?php)/i', "<?php \r\n{$constant}", $config_file[0]);
 	}
 
 	// Insert the constant in wp-config.php file.

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -301,8 +301,10 @@ function set_rocket_wp_cache_define( $turn_it_on ) { // phpcs:ignore WordPress.N
 		return;
 	}
 
+	$filesystem = rocket_direct_filesystem();
+
 	// Get content of the config file.
-	$config_file = file( $config_file_path );
+	$config_file_contents = $filesystem->get_contents( $config_file_path );
 
 	// Get the value of WP_CACHE constant.
 	$turn_it_on = $turn_it_on ? 'true' : 'false';
@@ -316,41 +318,16 @@ function set_rocket_wp_cache_define( $turn_it_on ) { // phpcs:ignore WordPress.N
 	*/
 	$turn_it_on = apply_filters( 'set_rocket_wp_cache_define', $turn_it_on ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
 
-	// Lets find out if the constant WP_CACHE is defined or not.
-	$is_wp_cache_exist = false;
-
 	// Get WP_CACHE constant define.
 	$constant = "define('WP_CACHE', $turn_it_on); // Added by WP Rocket\r\n";
 
-	foreach ( $config_file as &$line ) {
-		if ( ! preg_match( '/^define\(\s*\'([A-Z_]+)\',(.*)\)/', $line, $match ) ) {
-			continue;
-		}
-
-		if ( 'WP_CACHE' === $match[1] ) {
-			$is_wp_cache_exist = true;
-			$line              = $constant;
-		}
-	}
-	unset( $line );
-
-	// If the constant does not exist, create it.
-	if ( ! $is_wp_cache_exist ) {
-		$config_file[0] = preg_replace( '/(<\?php)/i', "<?php \r\n{$constant}", $config_file[0] );
+	// Lets find out if the constant WP_CACHE is defined or not.
+	if ( ! preg_match( '/^define\(\s*\'WP_CACHE\',(.*)\)/m', $config_file_contents, $match ) ) {
+		$config_file_contents = preg_replace( '/(<\?php)/i', "<?php \r\n{$constant}", $config_file_contents );
 	}
 
 	// Insert the constant in wp-config.php file.
-	// @codingStandardsIgnoreStart
-	$handle = @fopen( $config_file_path, 'w' );
-	foreach ( $config_file as $line ) {
-		@fwrite( $handle, $line );
-	}
-
-	@fclose( $handle );
-	// @codingStandardsIgnoreEnd
-	// Update the writing permissions of wp-config.php file.
-	$chmod = rocket_get_filesystem_perms( 'file' );
-	rocket_direct_filesystem()->chmod( $config_file_path, $chmod );
+	rocket_put_content( $config_file_path, $config_file_contents );
 }
 
 /**

--- a/tests/Fixtures/inc/functions/setRocketWpCacheDefine.php
+++ b/tests/Fixtures/inc/functions/setRocketWpCacheDefine.php
@@ -143,28 +143,28 @@ return [
 	'test_data' => [
 		'ShouldAddWpCache' => [
 			'config' => [
-				'file' => 'wp-config-has-no-wp-cache.php',
+				'file' => 'wp-config-has-no-wp-cache',
 				'valid_key' => true,
 			],
 			'expected' => $wp_config_has_no_wp_cache_expected
 		],
 		'ShouldAddWpCacheWhenCommentInFirstLine' => [
 			'config' => [
-				'file' => 'wp-config-has-no-wp-cache-comment-on-first-line.php',
+				'file' => 'wp-config-has-no-wp-cache-comment-on-first-line',
 				'valid_key' => true,
 			],
 			'expected' => $wp_config_has_no_wp_cache_comment_on_first_line_expected
 		],
 		'ShouldNotAddWpCache' => [
 			'config' => [
-				'file' => 'wp-config-has-wp-cache.php',
+				'file' => 'wp-config-has-wp-cache',
 				'valid_key' => true,
 			],
 			'expected' => $wp_config_has_wp_cache_expected
 		],
 		'ShouldBailOutWhenNotValidKey' => [
 			'config' => [
-				'file' => 'wp-config-has-no-wp-cache.php',
+				'file' => 'wp-config-has-no-wp-cache',
 				'valid_key' => false,
 			],
 			'expected' => $wp_config_has_no_wp_cache

--- a/tests/Fixtures/inc/functions/setRocketWpCacheDefine.php
+++ b/tests/Fixtures/inc/functions/setRocketWpCacheDefine.php
@@ -1,0 +1,324 @@
+<?php
+$wp_config_has_no_wp_cache = "<?php
+/*
+ * The base configuration for WordPress
+ *
+ * The wp-config.php creation script uses this file during the
+ * installation. You don't have to use the web site, you can
+ * copy this file to \"wp-config.php\" and fill in the values.
+ *
+ * This file contains the following configurations:
+ *
+ * * MySQL settings
+ * * Secret keys
+ * * Database table prefix
+ * * ABSPATH
+ *
+ * @link https://codex.wordpress.org/Editing_wp-config.php
+ *
+ * @package WordPress
+ */
+
+// ** MySQL settings - You can get this info from your web host ** //
+/** The name of the database for WordPress */
+define( 'DB_NAME', 'wordpress' );
+
+/** MySQL database username */
+define( 'DB_USER', 'root' );
+
+/** MySQL database password */
+define( 'DB_PASSWORD', 'root' );
+
+/** MySQL hostname */
+define( 'DB_HOST', 'localhost' );
+
+/** Database Charset to use in creating database tables. */
+define( 'DB_CHARSET', 'utf8mb4' );
+
+/** The Database Collate type. Don't change this if in doubt. */
+define( 'DB_COLLATE', '' );
+
+/**#@+
+ * Authentication Unique Keys and Salts.
+ *
+ * Change these to different unique phrases!
+ * You can generate these using the {@link https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org secret-key service}
+ * You can change these at any point in time to invalidate all existing cookies. This will force all users to have to log in again.
+ *
+ * @since 2.6.0
+ */
+define( 'AUTH_KEY',         '' );
+define( 'SECURE_AUTH_KEY',  '' );
+define( 'LOGGED_IN_KEY',    '' );
+define( 'NONCE_KEY',        '' );
+define( 'AUTH_SALT',        '' );
+define( 'SECURE_AUTH_SALT', '' );
+define( 'LOGGED_IN_SALT',   '' );
+define( 'NONCE_SALT',       '' );
+
+/**#@-*/
+
+/**
+ * WordPress Database Table prefix.
+ *
+ * You can have multiple installations in one database if you give each
+ * a unique prefix. Only numbers, letters, and underscores please!
+ */
+$table_prefix = 'wp_';
+
+/**
+ * For developers: WordPress debugging mode.
+ *
+ * Change this to true to enable the display of notices during development.
+ * It is strongly recommended that plugin and theme developers use WP_DEBUG
+ * in their development environments.
+ *
+ * For information on other constants that can be used for debugging,
+ * visit the Codex.
+ *
+ * @link https://codex.wordpress.org/Debugging_in_WordPress
+ */
+define( 'WP_DEBUG', true );
+define('FS_METHOD','direct');
+
+if ( ! defined( 'WP_ROCKET_KEY' ) ) {
+    define( 'WP_ROCKET_KEY', '');
+}
+
+// Your email, the one you used for the purchase.
+if ( ! defined( 'WP_ROCKET_EMAIL' ) ) {
+    define( 'WP_ROCKET_EMAIL', '' );
+}
+
+/* That's all, stop editing! Happy publishing. */
+
+/** Absolute path to the WordPress directory. */
+if ( ! defined( 'ABSPATH' ) ) {
+    define( 'ABSPATH', dirname( __FILE__ ) . '/' );
+}
+
+/** Sets up WordPress vars and included files. */
+require_once( ABSPATH . 'wp-settings.php' );
+";
+
+$wp_config_has_no_wp_cache_comment_on_first_line = "<?php /*
+ * The base configuration for WordPress
+ *
+ * The wp-config.php creation script uses this file during the
+ * installation. You don't have to use the web site, you can
+ * copy this file to \"wp-config.php\" and fill in the values.
+ *
+ * This file contains the following configurations:
+ *
+ * * MySQL settings
+ * * Secret keys
+ * * Database table prefix
+ * * ABSPATH
+ *
+ * @link https://codex.wordpress.org/Editing_wp-config.php
+ *
+ * @package WordPress
+ */
+
+// ** MySQL settings - You can get this info from your web host ** //
+/** The name of the database for WordPress */
+define( 'DB_NAME', 'wordpress' );
+
+/** MySQL database username */
+define( 'DB_USER', 'root' );
+
+/** MySQL database password */
+define( 'DB_PASSWORD', 'root' );
+
+/** MySQL hostname */
+define( 'DB_HOST', 'localhost' );
+
+/** Database Charset to use in creating database tables. */
+define( 'DB_CHARSET', 'utf8mb4' );
+
+/** The Database Collate type. Don't change this if in doubt. */
+define( 'DB_COLLATE', '' );
+
+/**#@+
+ * Authentication Unique Keys and Salts.
+ *
+ * Change these to different unique phrases!
+ * You can generate these using the {@link https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org secret-key service}
+ * You can change these at any point in time to invalidate all existing cookies. This will force all users to have to log in again.
+ *
+ * @since 2.6.0
+ */
+define( 'AUTH_KEY',         '' );
+define( 'SECURE_AUTH_KEY',  '' );
+define( 'LOGGED_IN_KEY',    '' );
+define( 'NONCE_KEY',        '' );
+define( 'AUTH_SALT',        '' );
+define( 'SECURE_AUTH_SALT', '' );
+define( 'LOGGED_IN_SALT',   '' );
+define( 'NONCE_SALT',       '' );
+
+/**#@-*/
+
+/**
+ * WordPress Database Table prefix.
+ *
+ * You can have multiple installations in one database if you give each
+ * a unique prefix. Only numbers, letters, and underscores please!
+ */
+$table_prefix = 'wp_';
+
+/**
+ * For developers: WordPress debugging mode.
+ *
+ * Change this to true to enable the display of notices during development.
+ * It is strongly recommended that plugin and theme developers use WP_DEBUG
+ * in their development environments.
+ *
+ * For information on other constants that can be used for debugging,
+ * visit the Codex.
+ *
+ * @link https://codex.wordpress.org/Debugging_in_WordPress
+ */
+define( 'WP_DEBUG', true );
+define('FS_METHOD','direct');
+
+if ( ! defined( 'WP_ROCKET_KEY' ) ) {
+    define( 'WP_ROCKET_KEY', 'f760c170');
+}
+
+// Your email, the one you used for the purchase.
+if ( ! defined( 'WP_ROCKET_EMAIL' ) ) {
+    define( 'WP_ROCKET_EMAIL', 'ahmed@wp-media.me' );
+}
+
+/* That's all, stop editing! Happy publishing. */
+
+/** Absolute path to the WordPress directory. */
+if ( ! defined( 'ABSPATH' ) ) {
+    define( 'ABSPATH', dirname( __FILE__ ) . '/' );
+}
+
+/** Sets up WordPress vars and included files. */
+require_once( ABSPATH . 'wp-settings.php' );
+";
+
+$wp_config_has_wp_cache = "<?php
+define('WP_CACHE', true); // Added by WP Rocket
+
+ /*
+ * The base configuration for WordPress
+ *
+ * The wp-config.php creation script uses this file during the
+ * installation. You don't have to use the web site, you can
+ * copy this file to \"wp-config.php\" and fill in the values.
+ *
+ * This file contains the following configurations:
+ *
+ * * MySQL settings
+ * * Secret keys
+ * * Database table prefix
+ * * ABSPATH
+ *
+ * @link https://codex.wordpress.org/Editing_wp-config.php
+ *
+ * @package WordPress
+ */
+
+// ** MySQL settings - You can get this info from your web host ** //
+/** The name of the database for WordPress */
+define( 'DB_NAME', 'wordpress' );
+
+/** MySQL database username */
+define( 'DB_USER', 'root' );
+
+/** MySQL database password */
+define( 'DB_PASSWORD', 'root' );
+
+/** MySQL hostname */
+define( 'DB_HOST', 'localhost' );
+
+/** Database Charset to use in creating database tables. */
+define( 'DB_CHARSET', 'utf8mb4' );
+
+/** The Database Collate type. Don't change this if in doubt. */
+define( 'DB_COLLATE', '' );
+
+/**#@+
+ * Authentication Unique Keys and Salts.
+ *
+ * Change these to different unique phrases!
+ * You can generate these using the {@link https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org secret-key service}
+ * You can change these at any point in time to invalidate all existing cookies. This will force all users to have to log in again.
+ *
+ * @since 2.6.0
+ */
+define( 'AUTH_KEY',         '' );
+define( 'SECURE_AUTH_KEY',  '' );
+define( 'LOGGED_IN_KEY',    '' );
+define( 'NONCE_KEY',        '' );
+define( 'AUTH_SALT',        '' );
+define( 'SECURE_AUTH_SALT', '' );
+define( 'LOGGED_IN_SALT',   '' );
+define( 'NONCE_SALT',       '' );
+
+/**#@-*/
+
+/**
+ * WordPress Database Table prefix.
+ *
+ * You can have multiple installations in one database if you give each
+ * a unique prefix. Only numbers, letters, and underscores please!
+ */
+$table_prefix = 'wp_';
+
+/**
+ * For developers: WordPress debugging mode.
+ *
+ * Change this to true to enable the display of notices during development.
+ * It is strongly recommended that plugin and theme developers use WP_DEBUG
+ * in their development environments.
+ *
+ * For information on other constants that can be used for debugging,
+ * visit the Codex.
+ *
+ * @link https://codex.wordpress.org/Debugging_in_WordPress
+ */
+define( 'WP_DEBUG', true );
+define('FS_METHOD','direct');
+
+if ( ! defined( 'WP_ROCKET_KEY' ) ) {
+    define( 'WP_ROCKET_KEY', '');
+}
+
+// Your email, the one you used for the purchase.
+if ( ! defined( 'WP_ROCKET_EMAIL' ) ) {
+    define( 'WP_ROCKET_EMAIL', '' );
+}
+
+/* That's all, stop editing! Happy publishing. */
+
+/** Absolute path to the WordPress directory. */
+if ( ! defined( 'ABSPATH' ) ) {
+    define( 'ABSPATH', dirname( __FILE__ ) . '/' );
+}
+
+/** Sets up WordPress vars and included files. */
+require_once( ABSPATH . 'wp-settings.php' );
+";
+
+return [
+	'vfs_dir' => 'public/',
+
+	'structure' => [
+		'wp-config-has-no-wp-cache.php' => $wp_config_has_no_wp_cache,
+		'wp-config-has-no-wp-cache-comment-on-first-line.php' => $wp_config_has_no_wp_cache_comment_on_first_line,
+		'wp-config-has-wp-cache.php' => $wp_config_has_wp_cache,
+	],
+
+	'test_data' => [
+		'ShouldAddWpCache' => [
+			'config' => [],
+			'expected' => []
+		]
+	],
+];

--- a/tests/Fixtures/inc/functions/setRocketWpCacheDefine.php
+++ b/tests/Fixtures/inc/functions/setRocketWpCacheDefine.php
@@ -18,87 +18,29 @@ $wp_config_has_no_wp_cache = "<?php
  *
  * @package WordPress
  */
+";
 
-// ** MySQL settings - You can get this info from your web host ** //
-/** The name of the database for WordPress */
-define( 'DB_NAME', 'wordpress' );
+$wp_config_has_no_wp_cache_expected = "<?php
+define('WP_CACHE', true); // Added by WP Rocket
 
-/** MySQL database username */
-define( 'DB_USER', 'root' );
-
-/** MySQL database password */
-define( 'DB_PASSWORD', 'root' );
-
-/** MySQL hostname */
-define( 'DB_HOST', 'localhost' );
-
-/** Database Charset to use in creating database tables. */
-define( 'DB_CHARSET', 'utf8mb4' );
-
-/** The Database Collate type. Don't change this if in doubt. */
-define( 'DB_COLLATE', '' );
-
-/**#@+
- * Authentication Unique Keys and Salts.
+/*
+ * The base configuration for WordPress
  *
- * Change these to different unique phrases!
- * You can generate these using the {@link https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org secret-key service}
- * You can change these at any point in time to invalidate all existing cookies. This will force all users to have to log in again.
+ * The wp-config.php creation script uses this file during the
+ * installation. You don't have to use the web site, you can
+ * copy this file to \"wp-config.php\" and fill in the values.
  *
- * @since 2.6.0
+ * This file contains the following configurations:
+ *
+ * * MySQL settings
+ * * Secret keys
+ * * Database table prefix
+ * * ABSPATH
+ *
+ * @link https://codex.wordpress.org/Editing_wp-config.php
+ *
+ * @package WordPress
  */
-define( 'AUTH_KEY',         '' );
-define( 'SECURE_AUTH_KEY',  '' );
-define( 'LOGGED_IN_KEY',    '' );
-define( 'NONCE_KEY',        '' );
-define( 'AUTH_SALT',        '' );
-define( 'SECURE_AUTH_SALT', '' );
-define( 'LOGGED_IN_SALT',   '' );
-define( 'NONCE_SALT',       '' );
-
-/**#@-*/
-
-/**
- * WordPress Database Table prefix.
- *
- * You can have multiple installations in one database if you give each
- * a unique prefix. Only numbers, letters, and underscores please!
- */
-$table_prefix = 'wp_';
-
-/**
- * For developers: WordPress debugging mode.
- *
- * Change this to true to enable the display of notices during development.
- * It is strongly recommended that plugin and theme developers use WP_DEBUG
- * in their development environments.
- *
- * For information on other constants that can be used for debugging,
- * visit the Codex.
- *
- * @link https://codex.wordpress.org/Debugging_in_WordPress
- */
-define( 'WP_DEBUG', true );
-define('FS_METHOD','direct');
-
-if ( ! defined( 'WP_ROCKET_KEY' ) ) {
-    define( 'WP_ROCKET_KEY', '');
-}
-
-// Your email, the one you used for the purchase.
-if ( ! defined( 'WP_ROCKET_EMAIL' ) ) {
-    define( 'WP_ROCKET_EMAIL', '' );
-}
-
-/* That's all, stop editing! Happy publishing. */
-
-/** Absolute path to the WordPress directory. */
-if ( ! defined( 'ABSPATH' ) ) {
-    define( 'ABSPATH', dirname( __FILE__ ) . '/' );
-}
-
-/** Sets up WordPress vars and included files. */
-require_once( ABSPATH . 'wp-settings.php' );
 ";
 
 $wp_config_has_no_wp_cache_comment_on_first_line = "<?php /*
@@ -119,87 +61,28 @@ $wp_config_has_no_wp_cache_comment_on_first_line = "<?php /*
  *
  * @package WordPress
  */
+";
 
-// ** MySQL settings - You can get this info from your web host ** //
-/** The name of the database for WordPress */
-define( 'DB_NAME', 'wordpress' );
-
-/** MySQL database username */
-define( 'DB_USER', 'root' );
-
-/** MySQL database password */
-define( 'DB_PASSWORD', 'root' );
-
-/** MySQL hostname */
-define( 'DB_HOST', 'localhost' );
-
-/** Database Charset to use in creating database tables. */
-define( 'DB_CHARSET', 'utf8mb4' );
-
-/** The Database Collate type. Don't change this if in doubt. */
-define( 'DB_COLLATE', '' );
-
-/**#@+
- * Authentication Unique Keys and Salts.
+$wp_config_has_no_wp_cache_comment_on_first_line_expected = "<?php
+define('WP_CACHE', true); // Added by WP Rocket
+ /*
+ * The base configuration for WordPress
  *
- * Change these to different unique phrases!
- * You can generate these using the {@link https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org secret-key service}
- * You can change these at any point in time to invalidate all existing cookies. This will force all users to have to log in again.
+ * The wp-config.php creation script uses this file during the
+ * installation. You don't have to use the web site, you can
+ * copy this file to \"wp-config.php\" and fill in the values.
  *
- * @since 2.6.0
+ * This file contains the following configurations:
+ *
+ * * MySQL settings
+ * * Secret keys
+ * * Database table prefix
+ * * ABSPATH
+ *
+ * @link https://codex.wordpress.org/Editing_wp-config.php
+ *
+ * @package WordPress
  */
-define( 'AUTH_KEY',         '' );
-define( 'SECURE_AUTH_KEY',  '' );
-define( 'LOGGED_IN_KEY',    '' );
-define( 'NONCE_KEY',        '' );
-define( 'AUTH_SALT',        '' );
-define( 'SECURE_AUTH_SALT', '' );
-define( 'LOGGED_IN_SALT',   '' );
-define( 'NONCE_SALT',       '' );
-
-/**#@-*/
-
-/**
- * WordPress Database Table prefix.
- *
- * You can have multiple installations in one database if you give each
- * a unique prefix. Only numbers, letters, and underscores please!
- */
-$table_prefix = 'wp_';
-
-/**
- * For developers: WordPress debugging mode.
- *
- * Change this to true to enable the display of notices during development.
- * It is strongly recommended that plugin and theme developers use WP_DEBUG
- * in their development environments.
- *
- * For information on other constants that can be used for debugging,
- * visit the Codex.
- *
- * @link https://codex.wordpress.org/Debugging_in_WordPress
- */
-define( 'WP_DEBUG', true );
-define('FS_METHOD','direct');
-
-if ( ! defined( 'WP_ROCKET_KEY' ) ) {
-    define( 'WP_ROCKET_KEY', 'f760c170');
-}
-
-// Your email, the one you used for the purchase.
-if ( ! defined( 'WP_ROCKET_EMAIL' ) ) {
-    define( 'WP_ROCKET_EMAIL', 'ahmed@wp-media.me' );
-}
-
-/* That's all, stop editing! Happy publishing. */
-
-/** Absolute path to the WordPress directory. */
-if ( ! defined( 'ABSPATH' ) ) {
-    define( 'ABSPATH', dirname( __FILE__ ) . '/' );
-}
-
-/** Sets up WordPress vars and included files. */
-require_once( ABSPATH . 'wp-settings.php' );
 ";
 
 $wp_config_has_wp_cache = "<?php
@@ -223,87 +106,29 @@ define('WP_CACHE', true); // Added by WP Rocket
  *
  * @package WordPress
  */
+";
 
-// ** MySQL settings - You can get this info from your web host ** //
-/** The name of the database for WordPress */
-define( 'DB_NAME', 'wordpress' );
+$wp_config_has_wp_cache_expected = "<?php
+define('WP_CACHE', true); // Added by WP Rocket
 
-/** MySQL database username */
-define( 'DB_USER', 'root' );
-
-/** MySQL database password */
-define( 'DB_PASSWORD', 'root' );
-
-/** MySQL hostname */
-define( 'DB_HOST', 'localhost' );
-
-/** Database Charset to use in creating database tables. */
-define( 'DB_CHARSET', 'utf8mb4' );
-
-/** The Database Collate type. Don't change this if in doubt. */
-define( 'DB_COLLATE', '' );
-
-/**#@+
- * Authentication Unique Keys and Salts.
+ /*
+ * The base configuration for WordPress
  *
- * Change these to different unique phrases!
- * You can generate these using the {@link https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org secret-key service}
- * You can change these at any point in time to invalidate all existing cookies. This will force all users to have to log in again.
+ * The wp-config.php creation script uses this file during the
+ * installation. You don't have to use the web site, you can
+ * copy this file to \"wp-config.php\" and fill in the values.
  *
- * @since 2.6.0
+ * This file contains the following configurations:
+ *
+ * * MySQL settings
+ * * Secret keys
+ * * Database table prefix
+ * * ABSPATH
+ *
+ * @link https://codex.wordpress.org/Editing_wp-config.php
+ *
+ * @package WordPress
  */
-define( 'AUTH_KEY',         '' );
-define( 'SECURE_AUTH_KEY',  '' );
-define( 'LOGGED_IN_KEY',    '' );
-define( 'NONCE_KEY',        '' );
-define( 'AUTH_SALT',        '' );
-define( 'SECURE_AUTH_SALT', '' );
-define( 'LOGGED_IN_SALT',   '' );
-define( 'NONCE_SALT',       '' );
-
-/**#@-*/
-
-/**
- * WordPress Database Table prefix.
- *
- * You can have multiple installations in one database if you give each
- * a unique prefix. Only numbers, letters, and underscores please!
- */
-$table_prefix = 'wp_';
-
-/**
- * For developers: WordPress debugging mode.
- *
- * Change this to true to enable the display of notices during development.
- * It is strongly recommended that plugin and theme developers use WP_DEBUG
- * in their development environments.
- *
- * For information on other constants that can be used for debugging,
- * visit the Codex.
- *
- * @link https://codex.wordpress.org/Debugging_in_WordPress
- */
-define( 'WP_DEBUG', true );
-define('FS_METHOD','direct');
-
-if ( ! defined( 'WP_ROCKET_KEY' ) ) {
-    define( 'WP_ROCKET_KEY', '');
-}
-
-// Your email, the one you used for the purchase.
-if ( ! defined( 'WP_ROCKET_EMAIL' ) ) {
-    define( 'WP_ROCKET_EMAIL', '' );
-}
-
-/* That's all, stop editing! Happy publishing. */
-
-/** Absolute path to the WordPress directory. */
-if ( ! defined( 'ABSPATH' ) ) {
-    define( 'ABSPATH', dirname( __FILE__ ) . '/' );
-}
-
-/** Sets up WordPress vars and included files. */
-require_once( ABSPATH . 'wp-settings.php' );
 ";
 
 return [
@@ -317,8 +142,32 @@ return [
 
 	'test_data' => [
 		'ShouldAddWpCache' => [
-			'config' => [],
-			'expected' => []
+			'config' => [
+				'file' => 'wp-config-has-no-wp-cache.php',
+				'valid_key' => true,
+			],
+			'expected' => $wp_config_has_no_wp_cache_expected
+		],
+		'ShouldAddWpCacheWhenCommentInFirstLine' => [
+			'config' => [
+				'file' => 'wp-config-has-no-wp-cache-comment-on-first-line.php',
+				'valid_key' => true,
+			],
+			'expected' => $wp_config_has_no_wp_cache_comment_on_first_line_expected
+		],
+		'ShouldNotAddWpCache' => [
+			'config' => [
+				'file' => 'wp-config-has-wp-cache.php',
+				'valid_key' => true,
+			],
+			'expected' => $wp_config_has_wp_cache_expected
+		],
+		'ShouldBailOutWhenNotValidKey' => [
+			'config' => [
+				'file' => 'wp-config-has-no-wp-cache.php',
+				'valid_key' => false,
+			],
+			'expected' => $wp_config_has_no_wp_cache
 		]
 	],
 ];

--- a/tests/Integration/inc/functions/setRocketWpCacheDefine.php
+++ b/tests/Integration/inc/functions/setRocketWpCacheDefine.php
@@ -20,8 +20,7 @@ class Test_SetRocketWpCacheDefine extends FilesystemTestCase {
 	protected $path_to_test_data = '/inc/functions/setRocketWpCacheDefine.php';
 	protected $config_file = '';
 
-	public function tearDown()
-	{
+	public function tearDown() {
 		remove_filter( 'rocket_wp_config_name', [ $this, 'setWpCacheFilePath' ] );
 		parent::tearDown();
 	}
@@ -43,7 +42,7 @@ class Test_SetRocketWpCacheDefine extends FilesystemTestCase {
 		$this->assertEquals( $expected, str_replace( "\r\n", "\n", $actual ) );
 	}
 
-	public function setWpCacheFilePath($file) {
+	public function setWpCacheFilePath( $file ) {
 		return $this->config_file;
 	}
 }

--- a/tests/Integration/inc/functions/setRocketWpCacheDefine.php
+++ b/tests/Integration/inc/functions/setRocketWpCacheDefine.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace WP_Rocket\Tests\Unit\inc\functions;
+namespace WP_Rocket\Tests\Integration\inc\functions;
 
 use Brain\Monkey\Functions;
-use WP_Rocket\Tests\Unit\FilesystemTestCase;
+use WP_Rocket\Tests\Integration\FilesystemTestCase;
 
 /**
  * @covers ::set_rocket_wp_cache_define
@@ -18,18 +18,31 @@ use WP_Rocket\Tests\Unit\FilesystemTestCase;
  */
 class Test_SetRocketWpCacheDefine extends FilesystemTestCase {
 	protected $path_to_test_data = '/inc/functions/setRocketWpCacheDefine.php';
+	protected $config_file = '';
+
+	public function tearDown()
+	{
+		remove_filter( 'rocket_wp_config_name', [$this, 'setWpCacheFilePath'] );
+		parent::tearDown();
+	}
 
 	/**
 	 * @dataProvider providerTestData
 	 */
 	public function testShouldAddWpCacheDefine( $config, $expected ) {
-		$config_file_full_path = $this->config['vfs_dir'] . $config['file'] . '.php';
-		Functions\when('rocket_find_wpconfig_path')->justReturn( $config_file_full_path );
-		Functions\expect( 'rocket_valid_key' )->once()->andReturn( $config['valid_key'] );
+		$this->config_file = $config['file'];
+		$config_file_full_path = $this->config['vfs_dir'] . $this->config_file . '.php';
+		add_filter( 'rocket_wp_config_name', [$this, 'setWpCacheFilePath'] );
+
+		Functions\when( 'rocket_valid_key' )->justReturn( $config['valid_key'] );
 
 		set_rocket_wp_cache_define( true );
 
 		$actual = $this->filesystem->get_contents( $config_file_full_path );
 		$this->assertEquals( $expected, str_replace( "\r\n", "\n", $actual ) );
+	}
+
+	public function setWpCacheFilePath($file) {
+		return $this->config_file;
 	}
 }

--- a/tests/Integration/inc/functions/setRocketWpCacheDefine.php
+++ b/tests/Integration/inc/functions/setRocketWpCacheDefine.php
@@ -22,7 +22,7 @@ class Test_SetRocketWpCacheDefine extends FilesystemTestCase {
 
 	public function tearDown()
 	{
-		remove_filter( 'rocket_wp_config_name', [$this, 'setWpCacheFilePath'] );
+		remove_filter( 'rocket_wp_config_name', [ $this, 'setWpCacheFilePath' ] );
 		parent::tearDown();
 	}
 
@@ -30,9 +30,10 @@ class Test_SetRocketWpCacheDefine extends FilesystemTestCase {
 	 * @dataProvider providerTestData
 	 */
 	public function testShouldAddWpCacheDefine( $config, $expected ) {
-		$this->config_file = $config['file'];
+		$this->config_file     = $config['file'];
 		$config_file_full_path = $this->config['vfs_dir'] . $this->config_file . '.php';
-		add_filter( 'rocket_wp_config_name', [$this, 'setWpCacheFilePath'] );
+
+		add_filter( 'rocket_wp_config_name', [ $this, 'setWpCacheFilePath' ] );
 
 		Functions\when( 'rocket_valid_key' )->justReturn( $config['valid_key'] );
 

--- a/tests/Unit/inc/functions/setRocketWpCacheDefine.php
+++ b/tests/Unit/inc/functions/setRocketWpCacheDefine.php
@@ -24,7 +24,8 @@ class Test_SetRocketWpCacheDefine extends FilesystemTestCase {
 	 */
 	public function testShouldAddWpCacheDefine( $config, $expected ) {
 		$config_file_full_path = $this->config['vfs_dir'] . $config['file'] . '.php';
-		Functions\when('rocket_find_wpconfig_path')->justReturn( $config_file_full_path );
+
+		Functions\when( 'rocket_find_wpconfig_path' )->justReturn( $config_file_full_path );
 		Functions\expect( 'rocket_valid_key' )->once()->andReturn( $config['valid_key'] );
 
 		set_rocket_wp_cache_define( true );

--- a/tests/Unit/inc/functions/setRocketWpCacheDefine.php
+++ b/tests/Unit/inc/functions/setRocketWpCacheDefine.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\functions;
+
+use Brain\Monkey\Functions;
+use WP_Rocket\Tests\Unit\FilesystemTestCase;
+
+/**
+ * @covers ::set_rocket_wp_cache_define
+ * @uses   ::rocket_valid_key
+ * @uses   ::rocket_find_wpconfig_path
+ * @uses   ::rocket_direct_filesystem
+ * @uses   ::rocket_put_content
+ *
+ * @group Functions
+ * @group Files
+ * @group vfs
+ */
+class Test_SetRocketWpCacheDefine extends FilesystemTestCase {
+	protected $path_to_test_data = '/inc/functions/setRocketWpCacheDefine.php';
+
+	/**
+	 * @dataProvider providerTestData
+	 */
+	public function testShouldAddWpCacheDefine( $config, $expected ) {
+
+	}
+}

--- a/tests/Unit/inc/functions/setRocketWpCacheDefine.php
+++ b/tests/Unit/inc/functions/setRocketWpCacheDefine.php
@@ -23,6 +23,13 @@ class Test_SetRocketWpCacheDefine extends FilesystemTestCase {
 	 * @dataProvider providerTestData
 	 */
 	public function testShouldAddWpCacheDefine( $config, $expected ) {
+		$config_file_full_path = $this->config['vfs_dir'] . $config['file'];
+		Functions\when('rocket_find_wpconfig_path')->justReturn( $config_file_full_path );
+		Functions\expect( 'rocket_valid_key' )->once()->andReturn( $config['valid_key'] );
 
+		set_rocket_wp_cache_define( true );
+
+		$actual = $this->filesystem->get_contents( $config_file_full_path );
+		$this->assertEquals( $expected, str_replace( "\r\n", "\n", $actual ) );
 	}
 }


### PR DESCRIPTION
Closes #2537 
Here I will add after the php starter keyword `<?php` our constant `WP_CACHE` not to replace the full line with the constant.
That will solve the following issues:-
1. If there is a comment starter or a single line comment on the first line beside `<?php`, it won't be removed.
2. The default case is that `<?php` will be alone in the first line.
