### PR TITLE
Fixes #2745 Correctly remove advanced-cache notices on WPEngine

### DIFF
--- a/inc/3rd-party/hosting/wpengine.php
+++ b/inc/3rd-party/hosting/wpengine.php
@@ -30,8 +30,11 @@ add_filter( 'rocket_advanced_cache_file', '__return_empty_string' );
 add_action(
 	'admin_init',
 	function() {
-		remove_action( 'admin_notices', 'rocket_warning_advanced_cache_permissions' );
-		remove_action( 'admin_notices', 'rocket_warning_advanced_cache_not_ours' );
+		$container  = apply_filters( 'rocket_container', null );
+		$subscriber = $container->get( 'admin_cache_subscriber' );
+
+		remove_action( 'admin_notices', [ $subscriber, 'notice_advanced_cache_permissions' ] );
+		remove_action( 'admin_notices', [ $subscriber, 'notice_advanced_cache_content_not_ours' ] );
 	}
 );
 


### PR DESCRIPTION
Update compatibility file to remove the notices via the subscriber to comply with changes in 3.6