### PR TITLE
Closes #2739 Clean post cache on Specific CPCSS generation or deletion

### DIFF
--- a/inc/Engine/CriticalPath/RESTWP.php
+++ b/inc/Engine/CriticalPath/RESTWP.php
@@ -101,6 +101,17 @@ abstract class RESTWP implements RESTWPInterface {
 	}
 
 	/**
+	 * Clean post cache files on CPCSS generation or deletion.
+	 *
+	 * @since 3.6.1
+	 *
+	 * @param int $item_id ID for this item to get Url for.
+	 */
+	private function clean_post_cache( $item_id ) {
+		rocket_clean_files( $this->get_url( $item_id ) );
+	}
+
+	/**
 	 * Generates the CPCSS for the requested post ID.
 	 *
 	 * @since 3.6
@@ -159,6 +170,8 @@ abstract class RESTWP implements RESTWPInterface {
 				$this->return_error( $generated )
 			);
 		}
+
+		$this->clean_post_cache( $item_id );
 
 		return rest_ensure_response(
 			$this->return_success( $generated )
@@ -239,6 +252,8 @@ abstract class RESTWP implements RESTWPInterface {
 		if ( is_wp_error( $deleted ) ) {
 			return rest_ensure_response( $this->return_error( $deleted ) );
 		}
+
+		$this->clean_post_cache( $item_id );
 
 		return rest_ensure_response( $this->return_success( $deleted ) );
 	}

--- a/tests/Fixtures/inc/Engine/CriticalPath/RESTWPPost/delete.php
+++ b/tests/Fixtures/inc/Engine/CriticalPath/RESTWPPost/delete.php
@@ -2,12 +2,54 @@
 
 
 return [
-	'vfs_dir'   => 'wp-content/cache/critical-css/',
+	'vfs_dir'   => 'wp-content/',
 
 	// Virtual filesystem structure.
 	'structure' => [
 		'wp-content' => [
 			'cache' => [
+				// WP Rocket's cache.
+				'wp-rocket'    => [
+					'index.html'                 => '',
+					// domain cache.
+					'example.org'                => [
+						'.'                      => '',
+						'..'                     => '',
+						'index.html'             => '',
+						'index.html_gzip'        => '',
+
+						'post-title-1'    => [
+							'.'                      => '',
+							'..'                     => '',
+							'index.html'             => '',
+							'index.html_gzip'        => '',
+						],
+						'post-title-2'    => [
+							'.'                      => '',
+							'..'                     => '',
+							'index.html'             => '',
+							'index.html_gzip'        => '',
+						],
+						'post-title-3'    => [
+							'.'                      => '',
+							'..'                     => '',
+							'index.html'             => '',
+							'index.html_gzip'        => '',
+						],
+						'post-title-10'    => [
+							'.'                      => '',
+							'..'                     => '',
+							'index.html'             => '',
+							'index.html_gzip'        => '',
+						],
+						'post-title-20'    => [
+							'.'                      => '',
+							'..'                     => '',
+							'index.html'             => '',
+							'index.html_gzip'        => '',
+						],
+					],
+				],
 				'critical-css' => [
 					'1' => [
 						'.'              => '',
@@ -57,6 +99,7 @@ return [
 				'post_data'                  => [
 					'post_id'   => 1,
 					'post_type' => 'post',
+					'post_title'  => 'post-title-1',
 				],
 				'cpcss_exists_after'         => true,
 				'mobile_cpcss_exists_after'  => true,
@@ -77,6 +120,7 @@ return [
 					'post_id'     => 2,
 					'post_type'   => 'post',
 					'post_status' => null,
+					'post_title'  => 'post-title-2',
 				],
 				'cpcss_exists_after'         => false,
 				'mobile_cpcss_exists_after'  => false,
@@ -98,6 +142,7 @@ return [
 					'import_id'   => 3,
 					'post_type'   => 'post',
 					'post_status' => 'publish',
+					'post_title'  => 'post-title-3',
 				],
 				'cpcss_exists_after'  => false,
 				'mobile_cpcss_exists_after' => false,
@@ -123,6 +168,7 @@ return [
 					'import_id'   => 1,
 					'post_type'   => 'post',
 					'post_status' => 'publish',
+					'post_title'  => 'post-title-1',
 				],
 				'cpcss_exists_after'  => false,
 				'mobile_cpcss_exists_after' => true,
@@ -148,6 +194,7 @@ return [
 					'import_id'   => 10,
 					'post_type'   => 'post',
 					'post_status' => 'publish',
+					'post_title'  => 'post-title-10',
 				],
 				'cpcss_exists_after'  => false,
 				'mobile_cpcss_exists_after' => false,
@@ -173,6 +220,7 @@ return [
 					'import_id'   => 20,
 					'post_type'   => 'page',
 					'post_status' => 'publish',
+					'post_title'  => 'post-title-20',
 				],
 				'cpcss_exists_after'  => false,
 				'mobile_cpcss_exists_after' => false,
@@ -199,6 +247,7 @@ return [
 					'import_id'   => 20,
 					'post_type'   => 'page',
 					'post_status' => 'publish',
+					'post_title'  => 'post-title-20',
 				],
 				'cpcss_exists_after'         => false,
 				'mobile_cpcss_exists_after' => false,
@@ -225,6 +274,7 @@ return [
 					'import_id'   => 1,
 					'post_type'   => 'post',
 					'post_status' => 'publish',
+					'post_title'  => 'post-title-1',
 				],
 				'cpcss_exists_after'         => false,
 				'mobile_cpcss_exists_after'  => false,

--- a/tests/Fixtures/inc/Engine/CriticalPath/RESTWPPost/generate.php
+++ b/tests/Fixtures/inc/Engine/CriticalPath/RESTWPPost/generate.php
@@ -1,7 +1,44 @@
 <?php
 
 return [
-	'vfs_dir'   => 'wp-content/cache/critical-css/',
+	'vfs_dir'   => 'wp-content/',
+	// Virtual filesystem structure.
+	'structure' => [
+		'wp-content' => [
+			'cache' => [
+				// WP Rocket's cache.
+				'wp-rocket'    => [
+					'index.html'                 => '',
+					// domain cache.
+					'example.org'                => [
+						'.'                      => '',
+						'..'                     => '',
+						'index.html'             => '',
+						'index.html_gzip'        => '',
+
+						'CPCSS-title-1'    => [
+							'.'                      => '',
+							'..'                     => '',
+							'index.html'             => '',
+							'index.html_gzip'        => '',
+						],
+						'CPCSS-title-21'    => [
+							'.'                      => '',
+							'..'                     => '',
+							'index.html'             => '',
+							'index.html_gzip'        => '',
+						],
+					],
+				],
+				'critical-css' => [
+					'1' => [
+						'.'              => '',
+						'..'             => '',
+					],
+				],
+			],
+		],
+	],
 
 	'test_data' => [
 		'testShouldBailoutIfAsyncCssMobileDisabled'     => [
@@ -54,7 +91,7 @@ return [
 					'ID'           => 21,
 					'post_type'    => 'post',
 					'post_status'  => 'draft',
-					'post_title'   => 'CPCSS title',
+					'post_title'   => 'CPCSS-title-21',
 					'post_content' => 'content',
 				],
 				'cpcss_exists_after' => false,
@@ -76,7 +113,7 @@ return [
 					'ID'           => 21,
 					'post_type'    => 'post',
 					'post_status'  => 'publish',
-					'post_title'   => 'CPCSS title',
+					'post_title'   => 'CPCSS-title-21',
 					'post_content' => 'content',
 				],
 				'cpcss_exists_after' => false,
@@ -99,7 +136,7 @@ return [
 					'ID'           => 21,
 					'post_type'    => 'post',
 					'post_status'  => 'publish',
-					'post_title'   => 'CPCSS title',
+					'post_title'   => 'CPCSS-title-21',
 					'post_content' => 'content',
 				],
 				'generate_post_request_data' => [
@@ -125,6 +162,7 @@ return [
 					'ID'          => 21,
 					'post_type'   => 'post',
 					'post_status' => 'publish',
+					'post_title'  => 'CPCSS-title-21',
 				],
 				'generate_post_request_data' => [
 					'code' => 403,
@@ -149,6 +187,7 @@ return [
 					'ID'          => 21,
 					'post_type'   => 'post',
 					'post_status' => 'publish',
+					'post_title'  => 'CPCSS-title-21',
 				],
 				'generate_post_request_data' => [
 					'code' => 200,
@@ -173,6 +212,7 @@ return [
 					'ID'          => 21,
 					'post_type'   => 'post',
 					'post_status' => 'publish',
+					'post_title'  => 'CPCSS-title-21',
 				],
 				'generate_post_request_data' => [
 					'code' => 200,
@@ -202,6 +242,7 @@ return [
 					'ID'          => 21,
 					'post_type'   => 'post',
 					'post_status' => 'publish',
+					'post_title'  => 'CPCSS-title-21',
 				],
 				'generate_post_request_data' => [
 					'code' => 200,
@@ -231,6 +272,7 @@ return [
 					'ID'          => 21,
 					'post_type'   => 'post',
 					'post_status' => 'publish',
+					'post_title'  => 'CPCSS-title-21',
 				],
 				'generate_post_request_data' => [
 					'code' => 200,
@@ -275,7 +317,7 @@ return [
 					'ID'           => 21,
 					'post_type'    => 'post',
 					'post_status'  => 'draft',
-					'post_title'   => 'CPCSS title',
+					'post_title'   => 'CPCSS-title-21',
 					'post_content' => 'content',
 				],
 				'cpcss_exists_after'      => false,
@@ -299,7 +341,7 @@ return [
 					'ID'           => 21,
 					'post_type'    => 'post',
 					'post_status'  => 'publish',
-					'post_title'   => 'CPCSS title',
+					'post_title'   => 'CPCSS-title-21',
 					'post_content' => 'content',
 				],
 				'cpcss_exists_after'      => false,
@@ -324,7 +366,7 @@ return [
 					'ID'           => 21,
 					'post_type'    => 'post',
 					'post_status'  => 'publish',
-					'post_title'   => 'CPCSS title',
+					'post_title'   => 'CPCSS-title-21',
 					'post_content' => 'content',
 				],
 				'generate_post_request_data' => [
@@ -352,6 +394,7 @@ return [
 					'ID'          => 21,
 					'post_type'   => 'post',
 					'post_status' => 'publish',
+					'post_title'  => 'CPCSS-title-21',
 				],
 				'generate_post_request_data' => [
 					'code' => 403,
@@ -378,6 +421,7 @@ return [
 					'ID'          => 21,
 					'post_type'   => 'post',
 					'post_status' => 'publish',
+					'post_title'  => 'CPCSS-title-21',
 				],
 				'generate_post_request_data' => [
 					'code' => 200,
@@ -404,6 +448,7 @@ return [
 					'ID'          => 21,
 					'post_type'   => 'post',
 					'post_status' => 'publish',
+					'post_title'  => 'CPCSS-title-21',
 				],
 				'generate_post_request_data' => [
 					'code' => 200,
@@ -435,6 +480,7 @@ return [
 					'ID'          => 21,
 					'post_type'   => 'post',
 					'post_status' => 'publish',
+					'post_title'  => 'CPCSS-title-21',
 				],
 				'generate_post_request_data' => [
 					'code' => 200,
@@ -466,6 +512,7 @@ return [
 					'ID'          => 21,
 					'post_type'   => 'post',
 					'post_status' => 'publish',
+					'post_title'  => 'CPCSS-title-21',
 				],
 				'generate_post_request_data' => [
 					'code' => 200,

--- a/tests/Integration/inc/Engine/CriticalPath/RESTWPPost/delete.php
+++ b/tests/Integration/inc/Engine/CriticalPath/RESTWPPost/delete.php
@@ -59,7 +59,7 @@ class Test_Delete extends RESTVfsTestCase {
 	 * @dataProvider dataProvider
 	 */
 	public function testShouldDoExpectedWhenNotMultisite( $config, $expected ) {
-		$cache_file_path = $this->filesystem->getUrl( "{$this->config['vfs_dir']}cache/wp-rocket/example.org/" . $config['post_data']['post_title'] . '/index.html' );
+		$cache_file_path = $this->filesystem->getUrl( "{$this->config['vfs_dir']}cache/wp-rocket/example.org/{$config['post_data']['post_title']}/index.html" );
 		$this->assertTrue( $this->filesystem->exists( $cache_file_path ) );
 
 		$this->setUpTest( 1, $config );
@@ -72,6 +72,12 @@ class Test_Delete extends RESTVfsTestCase {
 		$actual = $this->doRestDelete( "/wp-rocket/v1/cpcss/post/{$this->post_id}" );
 
 		$this->assertSame( $expected, $actual );
+
+		if ( ! empty ( $expected['success'] ) ) {
+			$this->assertFalse( $this->filesystem->exists( $cache_file_path ) );
+		} else {
+			$this->assertTrue( $this->filesystem->exists( $cache_file_path ) );
+		}
 
 		// Check that the file(s) was(were) deleted.
 		$this->assertFilesDeleted( $config );

--- a/tests/Integration/inc/Engine/CriticalPath/RESTWPPost/delete.php
+++ b/tests/Integration/inc/Engine/CriticalPath/RESTWPPost/delete.php
@@ -10,7 +10,7 @@ use WP_Rocket\Tests\Integration\RESTVfsTestCase;
  * @uses   \WP_Rocket\Engine\CriticalPath\DataManager::delete_cpcss
  * @uses   \WP_Rocket\Admin\Options_Data::get
  *
- * @group  CriticalPathX
+ * @group  CriticalPath
  * @group  vfs
  */
 class Test_Delete extends RESTVfsTestCase {
@@ -50,9 +50,8 @@ class Test_Delete extends RESTVfsTestCase {
 	}
 
 	public function setUp() {
-		parent::setUp();
-
 		$this->set_permalink_structure( '/%postname%/' );
+		parent::setUp();
 	}
 
 	/**

--- a/tests/Integration/inc/Engine/CriticalPath/RESTWPPost/delete.php
+++ b/tests/Integration/inc/Engine/CriticalPath/RESTWPPost/delete.php
@@ -10,7 +10,7 @@ use WP_Rocket\Tests\Integration\RESTVfsTestCase;
  * @uses   \WP_Rocket\Engine\CriticalPath\DataManager::delete_cpcss
  * @uses   \WP_Rocket\Admin\Options_Data::get
  *
- * @group  CriticalPath
+ * @group  CriticalPathX
  * @group  vfs
  */
 class Test_Delete extends RESTVfsTestCase {
@@ -49,10 +49,19 @@ class Test_Delete extends RESTVfsTestCase {
 		$admin->remove_cap( 'rocket_regenerate_critical_css' );
 	}
 
+	public function setUp() {
+		parent::setUp();
+
+		$this->set_permalink_structure( '/%postname%/' );
+	}
+
 	/**
 	 * @dataProvider dataProvider
 	 */
 	public function testShouldDoExpectedWhenNotMultisite( $config, $expected ) {
+		$cache_file_path = $this->filesystem->getUrl( "{$this->config['vfs_dir']}cache/wp-rocket/example.org/" . $config['post_data']['post_title'] . '/index.html' );
+		$this->assertTrue( $this->filesystem->exists( $cache_file_path ) );
+
 		$this->setUpTest( 1, $config );
 
 		$this->assertFilesExistBefore( $config );
@@ -78,7 +87,7 @@ class Test_Delete extends RESTVfsTestCase {
 		$this->post_type = isset( $config['post_data']['post_type'] ) ? $config['post_data']['post_type'] : 'post';
 		$this->is_mobile = isset( $config['is_mobile'] ) ? $config['is_mobile'] : false;
 
-		$dirs        = $this->filesystem->getUrl( "{$this->config['vfs_dir']}{$site_id}/" );
+		$dirs        = $this->filesystem->getUrl( "{$this->config['vfs_dir']}cache/critical-css/{$site_id}/" );
 		$this->files = [
 			'dir'        => $dirs,
 			'non_mobile' => "{$dirs}posts/{$this->post_type}-{$this->post_id}.css",

--- a/tests/Integration/inc/Engine/CriticalPath/RESTWPPost/delete.php
+++ b/tests/Integration/inc/Engine/CriticalPath/RESTWPPost/delete.php
@@ -47,10 +47,6 @@ class Test_Delete extends RESTVfsTestCase {
 		$admin->remove_cap( 'rocket_regenerate_critical_css' );
 	}
 
-	public function setUp() {
-		parent::setUp();
-	}
-
 	/**
 	 * @dataProvider dataProvider
 	 */

--- a/tests/Integration/inc/Engine/CriticalPath/RESTWPPost/delete.php
+++ b/tests/Integration/inc/Engine/CriticalPath/RESTWPPost/delete.php
@@ -27,7 +27,6 @@ class Test_Delete extends RESTVfsTestCase {
 
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-
 		$admin                 = get_role( 'administrator' );
 		static::$had_admin_cap = $admin->has_cap( 'rocket_regenerate_critical_css' );
 	}
@@ -37,7 +36,6 @@ class Test_Delete extends RESTVfsTestCase {
 		if ( ! static::$had_cap ) {
 			$admin->remove_cap( 'rocket_regenerate_critical_css' );
 		}
-
 		parent::tearDownAfterClass();
 	}
 
@@ -47,11 +45,9 @@ class Test_Delete extends RESTVfsTestCase {
 		parent::tearDown();
 		$admin = get_role( 'administrator' );
 		$admin->remove_cap( 'rocket_regenerate_critical_css' );
-		$this->set_permalink_structure( '' );
 	}
 
 	public function setUp() {
-		$this->set_permalink_structure( '/%postname%/' );
 		parent::setUp();
 	}
 

--- a/tests/Integration/inc/Engine/CriticalPath/RESTWPPost/delete.php
+++ b/tests/Integration/inc/Engine/CriticalPath/RESTWPPost/delete.php
@@ -47,6 +47,7 @@ class Test_Delete extends RESTVfsTestCase {
 		parent::tearDown();
 		$admin = get_role( 'administrator' );
 		$admin->remove_cap( 'rocket_regenerate_critical_css' );
+		$this->set_permalink_structure( '' );
 	}
 
 	public function setUp() {

--- a/tests/Integration/inc/Engine/CriticalPath/RESTWPPost/generate.php
+++ b/tests/Integration/inc/Engine/CriticalPath/RESTWPPost/generate.php
@@ -43,7 +43,7 @@ class Test_Generate extends RESTVfsTestCase {
 
 		$post_title = isset( $config['post_data']['post_title'] )
 			? $config['post_data']['post_title']
-			: null;
+			: '';
 
 		$post_request_response_code = ! isset( $config['generate_post_request_data']['code'] )
 			? 200
@@ -116,13 +116,18 @@ class Test_Generate extends RESTVfsTestCase {
 		if ( $request_timeout ) {
 			$body_param['timeout'] = true;
 		}
-		if ( $expected['success'] && isset( $post_title ) ) {
-			$cache_file_path = $this->filesystem->getUrl( "{$this->config['vfs_dir']}cache/wp-rocket/example.org/{$post_title}/index.html" );
+
+		$cache_file_path = $this->filesystem->getUrl( "{$this->config['vfs_dir']}cache/wp-rocket/example.org/{$post_title}/index.html" );
+		if ( $expected['success'] ) {
 			$this->assertTrue( $this->filesystem->exists( $cache_file_path ) );
 		}
 
 		$this->assertSame( $expected, $this->doRestRequest( 'POST', "/wp-rocket/v1/cpcss/post/{$post_id}", $body_param ) );
 		$this->assertSame( $config['cpcss_exists_after'], $this->filesystem->exists( $file ) );
+
+		if ( $expected['success'] ) {
+			$this->assertFalse( $this->filesystem->exists( $cache_file_path ) );
+		}
 	}
 
 	/**

--- a/tests/Integration/inc/Engine/CriticalPath/RESTWPPost/generate.php
+++ b/tests/Integration/inc/Engine/CriticalPath/RESTWPPost/generate.php
@@ -41,6 +41,10 @@ class Test_Generate extends RESTVfsTestCase {
 			? $config['post_data']['post_type']
 			: 'post';
 
+		$post_title = isset( $config['post_data']['post_title'] )
+			? $config['post_data']['post_title']
+			: null;
+
 		$post_request_response_code = ! isset( $config['generate_post_request_data']['code'] )
 			? 200
 			: $config['generate_post_request_data']['code'];
@@ -105,12 +109,16 @@ class Test_Generate extends RESTVfsTestCase {
 		$this->do_caching_mobile_files = $do_caching_mobile_files;
 		add_filter( 'pre_get_rocket_option_do_caching_mobile_files', [ $this, 'setDoCachingMobileFilesOption' ] );
 
-		$file = $this->config['vfs_dir'] . "{$site_id}/posts/{$post_type}-{$post_id}" . ( $is_mobile ? '-mobile' : '' ). ".css";
+		$file = $this->config['vfs_dir'] . "cache/critical-css/{$site_id}/posts/{$post_type}-{$post_id}" . ( $is_mobile ? '-mobile' : '' ). ".css";
 
 		$body_param              = [];
 		$body_param['is_mobile'] = $is_mobile;
 		if ( $request_timeout ) {
 			$body_param['timeout'] = true;
+		}
+		if ( $expected['success'] && isset( $post_title ) ) {
+			$cache_file_path = $this->filesystem->getUrl( "{$this->config['vfs_dir']}cache/wp-rocket/example.org/{$post_title}/index.html" );
+			$this->assertTrue( $this->filesystem->exists( $cache_file_path ) );
 		}
 
 		$this->assertSame( $expected, $this->doRestRequest( 'POST', "/wp-rocket/v1/cpcss/post/{$post_id}", $body_param ) );

--- a/tests/Unit/inc/Engine/CriticalPath/RESTWPPost/delete.php
+++ b/tests/Unit/inc/Engine/CriticalPath/RESTWPPost/delete.php
@@ -155,7 +155,8 @@ class Test_Delete extends TestCase {
 
 	private function assertSuccess( $config, $expected ) {
 		Functions\expect( 'get_permalink' )
-			->once()
+			->atLeast( 1 )
+			->atMost( 2 )
 			->with( $this->post_id )
 			->andReturn( $this->getPermalink() );
 
@@ -192,6 +193,10 @@ class Test_Delete extends TestCase {
 			->with( $deleted )
 			->andReturn( false );
 
+		Functions\expect( 'rocket_clean_files' )
+			->once()
+			->with( $this->getPermalink() );
+
 		Functions\expect( 'rest_ensure_response' )
 			->once()
 			->with( $expected )
@@ -223,4 +228,5 @@ class Test_Delete extends TestCase {
 
 		return "posts/{$this->post_type}-{$this->post_id}.css";
 	}
+
 }

--- a/tests/Unit/inc/Engine/CriticalPath/RESTWPPost/generate.php
+++ b/tests/Unit/inc/Engine/CriticalPath/RESTWPPost/generate.php
@@ -75,7 +75,7 @@ class Test_Generate extends FilesystemTestCase {
 		$is_mobile                    = isset( $config['mobile'] )
 			? $config['mobile']
 			: false;
-		$file                         = $this->config['vfs_dir'] . "1/posts/{$post_type}-{$post_id}" . ( $is_mobile ? '-mobile' : '' ). ".css";
+		$file                         = $this->config['vfs_dir'] . "cache/critical-css/1/posts/{$post_type}-{$post_id}" . ( $is_mobile ? '-mobile' : '' ). ".css";
 		$post_url = ('post_not_exists' === $expected['code'])
 			? null
 			: "http://example.org/?p={$post_id}";

--- a/tests/Unit/inc/Engine/CriticalPath/RESTWPPost/generate.php
+++ b/tests/Unit/inc/Engine/CriticalPath/RESTWPPost/generate.php
@@ -129,8 +129,8 @@ class Test_Generate extends FilesystemTestCase {
 			->once()
 			->andReturn( 1 );
 		Functions\expect( 'get_permalink' )
-			->atMost()
-			->times( 1 )
+			->atLeast( 1 )
+			->atMost( 2 )
 			->with( $post_id )
 			->andReturnUsing(
 				function( $post_id ) use ( $expected ) {
@@ -197,6 +197,15 @@ class Test_Generate extends FilesystemTestCase {
 					->once()
 					->andReturn( $do_caching_mobile_files );
 			}
+		}
+
+		if ( $expected['success'] && 'cpcss_generation_successful' === $expected['code'] ) {
+			Functions\expect( 'rocket_clean_files' )
+				->atMost()
+				->times( 1 )
+				->with( "http://example.org/?p={$post_id}" );
+		} else {
+			Functions\expect( 'rocket_clean_files' )->never();
 		}
 
 		$instance             = new RESTWPPost( $cpcss_service, $options );

--- a/tests/Unit/inc/Engine/CriticalPath/RESTWPPost/generate.php
+++ b/tests/Unit/inc/Engine/CriticalPath/RESTWPPost/generate.php
@@ -201,8 +201,7 @@ class Test_Generate extends FilesystemTestCase {
 
 		if ( $expected['success'] && 'cpcss_generation_successful' === $expected['code'] ) {
 			Functions\expect( 'rocket_clean_files' )
-				->atMost()
-				->times( 1 )
+				->once()
 				->with( "http://example.org/?p={$post_id}" );
 		} else {
 			Functions\expect( 'rocket_clean_files' )->never();


### PR DESCRIPTION
**Reproduce the issue** ✅ 
This is easy to be reproduces on local.

**Identify the root cause** ✅ 
The root cause is in the `RestWP.php`
https://github.com/wp-media/wp-rocket/blob/1455187900e01a22cc6ec8696511f1df01e18de7/inc/Engine/CriticalPath/RESTWP.php#L112
https://github.com/wp-media/wp-rocket/blob/1455187900e01a22cc6ec8696511f1df01e18de7/inc/Engine/CriticalPath/RESTWP.php#L223
In the initial specs of this one we forgot to include the cleaning of the cache for the specific page for which we regenerate the CPCSS.

**Scope a solution** ✅ 
The solution is to create a private method in `RESTWP.php` which cleans the cache based on post id. This method can be shared between delete() & generate() functions.

Preloading this page at this point is not an option because the code is already fragile and it may lead to other complications.

**Effort** ✅ 
Effort `[S]` . Unit tests and Integrations test will need to be updated to reflect this change

 TODO:
- [x] - Integration tests