### PR TITLE
Fixes #2523 Prevent lazyload inline CSS insertion on AMP pages

### DIFF
--- a/inc/ThirdParty/Plugins/Optimization/AMP.php
+++ b/inc/ThirdParty/Plugins/Optimization/AMP.php
@@ -104,6 +104,7 @@ class AMP implements Subscriber_Interface {
 
 		remove_filter( 'wp_resource_hints', 'rocket_dns_prefetch', 10, 2 );
 		add_filter( 'do_rocket_lazyload', '__return_false' );
+		add_filter( 'do_rocket_lazyload_iframes', '__return_false' );
 		unset( $wp_filter['rocket_buffer'] );
 
 		$options = get_option( self::AMP_OPTIONS, [] );

--- a/tests/Integration/inc/ThirdParty/Plugins/Optimization/AMP/disableOptionsOnAmp.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Optimization/AMP/disableOptionsOnAmp.php
@@ -28,13 +28,14 @@ class Test_DisableOptionsOnAmp extends TestCase {
 	 */
 	public function testShouldDoExpected( $config, $expected ) {
 		if ( $expected[ 'bailout' ] ) {
-			$this->assertNotFalse( has_filter( 'wp_resource_hints', 'rocket_dns_prefetch') );
+			$this->assertNotFalse( has_filter( 'wp_resource_hints', 'rocket_dns_prefetch' ) );
 		} else {
 			global $wp_filter;
 
 			add_theme_support( AMP_Theme_Support::SLUG );
-			$this->assertNotFalse( has_filter( 'wp_resource_hints', 'rocket_dns_prefetch') );
-			$this->assertFalse( has_filter( 'do_rocket_lazyload', '__return_false') );
+			$this->assertNotFalse( has_filter( 'wp_resource_hints', 'rocket_dns_prefetch' ) );
+			$this->assertFalse( has_filter( 'do_rocket_lazyload', '__return_false' ) );
+			$this->assertFalse( has_filter( 'do_rocket_lazyload_iframes', '__return_false' ) );
 			$this->assertArrayHasKey( 'rocket_buffer', $wp_filter );
 
 			if ( ! is_null( $config[ 'amp_options' ] ) ) {
@@ -49,10 +50,11 @@ class Test_DisableOptionsOnAmp extends TestCase {
 		do_action( 'wp' );
 
 		if ( $expected[ 'bailout' ] ) {
-			$this->assertNotFalse( has_filter( 'wp_resource_hints', 'rocket_dns_prefetch') );
+			$this->assertNotFalse( has_filter( 'wp_resource_hints', 'rocket_dns_prefetch' ) );
 		} else {
-			$this->assertFalse( has_filter( 'wp_resource_hints', 'rocket_dns_prefetch') );
-			$this->assertNotFalse( has_filter( 'do_rocket_lazyload', '__return_false') );
+			$this->assertFalse( has_filter( 'wp_resource_hints', 'rocket_dns_prefetch' ) );
+			$this->assertNotFalse( has_filter( 'do_rocket_lazyload', '__return_false' ) );
+			$this->assertNotFalse( has_filter( 'do_rocket_lazyload_iframes', '__return_false' ) );
 
 			if ( in_array( $config[ 'amp_options' ][ 'theme_support' ], [ 'transitional', 'reader' ], true ) ) {
 				$this->assertArrayHasKey( 'rocket_buffer', $wp_filter );

--- a/tests/Integration/inc/ThirdParty/Plugins/Optimization/AMP/disableOptionsOnAmpWithCloudflare.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Optimization/AMP/disableOptionsOnAmpWithCloudflare.php
@@ -23,16 +23,18 @@ class Test_DisableOptionsOnAmpWithCloudflare extends TestCase {
 	public function testShouldDisableOptionForAmpWhenCloudflareEnabled() {
 		global $wp_filter;
 		add_theme_support( AMP_Theme_Support::SLUG );
-		$this->assertNotFalse( has_filter( 'wp_resource_hints', 'rocket_dns_prefetch') );
-		$this->assertFalse( has_filter( 'do_rocket_lazyload', '__return_false') );
+		$this->assertNotFalse( has_filter( 'wp_resource_hints', 'rocket_dns_prefetch' ) );
+		$this->assertFalse( has_filter( 'do_rocket_lazyload', '__return_false' ) );
+		$this->assertFalse( has_filter( 'do_rocket_lazyload_iframes', '__return_false' ) );
 		$this->assertArrayHasKey( 'rocket_buffer', $wp_filter );
-		$this->assertNotFalse( has_filter( 'wp_calculate_image_srcset', 'rocket_protocol_rewrite_srcset') );
+		$this->assertNotFalse( has_filter( 'wp_calculate_image_srcset', 'rocket_protocol_rewrite_srcset' ) );
 
 		do_action( 'wp' );
 
-		$this->assertFalse( has_filter( 'wp_resource_hints', 'rocket_dns_prefetch') );
-		$this->assertNotFalse( has_filter( 'do_rocket_lazyload', '__return_false') );
+		$this->assertFalse( has_filter( 'wp_resource_hints', 'rocket_dns_prefetch' ) );
+		$this->assertNotFalse( has_filter( 'do_rocket_lazyload', '__return_false' ) );
+		$this->assertNotFalse( has_filter( 'do_rocket_lazyload_iframes', '__return_false' ) );
 		$this->assertArrayNotHasKey( 'rocket_buffer', $wp_filter );
-		$this->assertFalse( has_filter( 'wp_calculate_image_srcset', 'rocket_protocol_rewrite_srcset') );
+		$this->assertFalse( has_filter( 'wp_calculate_image_srcset', 'rocket_protocol_rewrite_srcset' ) );
 	}
 }

--- a/tests/Unit/inc/ThirdParty/Plugins/Optimization/AMP/disableOptionsOnAmp.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/Optimization/AMP/disableOptionsOnAmp.php
@@ -48,6 +48,7 @@ class Test_DisableOptionsOnAmp extends TestCase {
 			// Check the hooks before invoking the method.
 			$this->assertTrue( has_filter( 'wp_resource_hints', 'rocket_dns_prefetch', 10, 2 ) );
 			$this->assertFalse( has_filter( 'do_rocket_lazyload', '__return_false' ) );
+			$this->assertFalse( has_filter( 'do_rocket_lazyload_iframes', '__return_false' ) );
 			$this->assertTrue( has_filter( 'wp_calculate_image_srcset', 'rocket_protocol_rewrite_srcset', PHP_INT_MAX ) );
 			$this->assertFalse( has_filter( 'rocket_buffer', [ $this->cdn_subscriber, 'rewrite' ] ) );
 			$this->assertFalse( has_filter( 'rocket_buffer', [ $this->cdn_subscriber, 'rewrite_srcset' ] ) );
@@ -83,6 +84,7 @@ class Test_DisableOptionsOnAmp extends TestCase {
 			// Check the hooks after invoking the method.
 			$this->assertFalse( has_filter( 'wp_resource_hints', 'rocket_dns_prefetch', 10, 2 ) );
 			$this->assertTrue( has_filter( 'do_rocket_lazyload', '__return_false' ) );
+			$this->assertTrue( has_filter( 'do_rocket_lazyload_iframes', '__return_false' ) );
 			$this->assertEmpty( $wp_filter );
 
 			if ( $expected[ 'remove_filter' ] ) {


### PR DESCRIPTION
Fixes #2523

The issue is happening because lazyload for images is disabled on AMP pages, but not lazyload for iframes. So the inline CSS fallback is still inserted on the pages.

- [x] Use filter to disable lazyload for iframes on AMP pages
- [x] Update tests