### PR TITLE
Closes #2607 - Improve sub-feeds exclusions

### DIFF
--- a/inc/admin/upgrader.php
+++ b/inc/admin/upgrader.php
@@ -356,12 +356,6 @@ function rocket_new_upgrade( $wp_rocket_version, $actual_version ) {
 		wp_safe_remote_get( esc_url( home_url() ) );
 	}
 
-	if ( version_compare( $actual_version, '3.3.2', '<' )
-		||
-		version_compare( $actual_version, '3.6.1', '<' ) ) {
-		rocket_generate_config_file();
-	}
-
 	if ( version_compare( $actual_version, '3.3.6', '<' ) ) {
 		delete_site_transient( 'update_wprocket' );
 		delete_site_transient( 'update_wprocket_response' );
@@ -392,6 +386,10 @@ function rocket_new_upgrade( $wp_rocket_version, $actual_version ) {
 		rocket_clean_cache_busting();
 		rocket_clean_domain();
 		rocket_generate_advanced_cache_file();
+	}
+
+	if ( version_compare( $actual_version, '3.6.1', '<' ) ) {
+		rocket_generate_config_file();
 	}
 }
 add_action( 'wp_rocket_upgrade', 'rocket_new_upgrade', 10, 2 );

--- a/inc/admin/upgrader.php
+++ b/inc/admin/upgrader.php
@@ -356,7 +356,9 @@ function rocket_new_upgrade( $wp_rocket_version, $actual_version ) {
 		wp_safe_remote_get( esc_url( home_url() ) );
 	}
 
-	if ( version_compare( $actual_version, '3.3.2', '<' ) ) {
+	if ( version_compare( $actual_version, '3.3.2', '<' )
+		||
+		version_compare( $actual_version, '3.6.1', '<' ) ) {
 		rocket_generate_config_file();
 	}
 

--- a/inc/functions/options.php
+++ b/inc/functions/options.php
@@ -203,7 +203,7 @@ function rocket_get_ignored_parameters() {
  */
 function get_rocket_cache_reject_uri( $force = false ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
 	static $uris;
-	$wp_rewrite = $GLOBALS['wp_rewrite'];
+	global $wp_rewrite;
 
 	if ( $force ) {
 		$uris = null;

--- a/inc/functions/options.php
+++ b/inc/functions/options.php
@@ -232,7 +232,7 @@ function get_rocket_cache_reject_uri() { // phpcs:ignore WordPress.NamingConvent
 	}
 
 	// Exclude feeds.
-	$uris[] = '/(.+/)?' . $GLOBALS['wp_rewrite']->feed_base . '/?';
+	$uris[] = '/(.+/)?' . $GLOBALS['wp_rewrite']->feed_base . '/?.+/?';
 
 	// Exlude embedded URLs.
 	$uris[] = '/(?:.+/)?embed/';

--- a/inc/functions/options.php
+++ b/inc/functions/options.php
@@ -197,24 +197,26 @@ function rocket_get_ignored_parameters() {
  * @since 2.4.1 Auto-exclude WordPress REST API.
  * @since 2.0
  *
+ * @param bool $force Force the static uris to be reverted to null.
+ *
  * @return string A pipe separated list of rejected uri.
  */
-function get_rocket_cache_reject_uri() { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
+function get_rocket_cache_reject_uri( $force = false ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
 	static $uris;
-
+	if ( $force ) {
+		$uris = null;
+	}
 	if ( $uris ) {
 		return $uris;
 	}
 
-	$uris      = get_rocket_option( 'cache_reject_uri', [] );
-	$uris      = is_array( $uris ) ? $uris : [];
-	$home_root = rocket_get_home_dirname();
+	$uris              = get_rocket_option( 'cache_reject_uri', [] );
+	$uris              = is_array( $uris ) ? $uris : [];
+	$home_root         = rocket_get_home_dirname();
+	$home_root_escaped = preg_quote( $home_root, '/' ); // The site is not at the domain root, it's in a folder.
 
 	if ( '' !== $home_root && $uris ) {
-		// The site is not at the domain root, it's in a folder.
-		$home_root_escaped = preg_quote( $home_root, '/' );
-		$home_root_len     = strlen( $home_root );
-
+		$home_root_len = strlen( $home_root );
 		foreach ( $uris as $i => $uri ) {
 			/**
 			 * Since these URIs can be regex patterns like `/homeroot(/.+)/`, we can't simply search for the string `/homeroot/` (nor `/homeroot`).

--- a/inc/functions/options.php
+++ b/inc/functions/options.php
@@ -203,6 +203,8 @@ function rocket_get_ignored_parameters() {
  */
 function get_rocket_cache_reject_uri( $force = false ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
 	static $uris;
+	$wp_rewrite = $GLOBALS['wp_rewrite'];
+
 	if ( $force ) {
 		$uris = null;
 	}
@@ -210,8 +212,7 @@ function get_rocket_cache_reject_uri( $force = false ) { // phpcs:ignore WordPre
 		return $uris;
 	}
 
-	$uris              = get_rocket_option( 'cache_reject_uri', [] );
-	$uris              = is_array( $uris ) ? $uris : [];
+	$uris              = (array) get_rocket_option( 'cache_reject_uri', [] );
 	$home_root         = rocket_get_home_dirname();
 	$home_root_escaped = preg_quote( $home_root, '/' ); // The site is not at the domain root, it's in a folder.
 
@@ -234,7 +235,7 @@ function get_rocket_cache_reject_uri( $force = false ) { // phpcs:ignore WordPre
 	}
 
 	// Exclude feeds.
-	$uris[] = '/(.+/)?' . $GLOBALS['wp_rewrite']->feed_base . '/?.+/?';
+	$uris[] = '/(.+/)?' . $wp_rewrite->feed_base . '/?.+/?';
 
 	// Exlude embedded URLs.
 	$uris[] = '/(?:.+/)?embed/';

--- a/tests/Fixtures/inc/functions/getRocketCacheRejectUri.php
+++ b/tests/Fixtures/inc/functions/getRocketCacheRejectUri.php
@@ -1,0 +1,128 @@
+<?php
+return [
+	[
+		'config' => [
+			'options'                        => [
+				'cache_reject_uri' => [],
+			],
+			'home_dirname'                   => '',
+			'filter_rocket_cache_reject_uri' => [],
+		],
+		'expected' => '',
+	],
+	[
+		'config' => [
+			'options'                        => [
+				'cache_reject_uri' => [
+					'/members/(.*)',
+				],
+			],
+			'home_dirname'                   => '',
+			'filter_rocket_cache_reject_uri' => [],
+		],
+		'expected' => '',
+	],
+	[
+		'config' => [
+			'options'                        => [
+				'cache_reject_uri' => [],
+			],
+			'home_dirname'                   => '',
+			'filter_rocket_cache_reject_uri' => [
+				'/(.+/)?feed/?.+/?',
+				'/(?:.+/)?embed/',
+			],
+		],
+		'expected' => '/(.+/)?feed/?.+/?|/(?:.+/)?embed/',
+	],
+	[
+		'config' => [
+			'options'                        => [
+				'cache_reject_uri' => [
+					'/members/(.*)',
+				],
+			],
+			'home_dirname'                   => '',
+			'filter_rocket_cache_reject_uri' => [
+				'/(.+/)?feed/?.+/?',
+				'/(?:.+/)?embed/',
+				'/members/(.*)',
+			],
+		],
+		'expected' => '/(.+/)?feed/?.+/?|/(?:.+/)?embed/|/members/(.*)',
+	],
+	[
+		'config' => [
+			'options'                        => [
+				'cache_reject_uri' => [],
+			],
+			'home_dirname'                   => '/',
+			'filter_rocket_cache_reject_uri' => [
+				'/(.+/)?feed/?.+/?',
+				'/(?:.+/)?embed/',
+			],
+		],
+		'expected' => '/(/(.+/)?feed/?.+/?|/(?:.+/)?embed/)',
+	],
+	[
+		'config' => [
+			'options'                        => [
+				'cache_reject_uri' => [
+					'/members/(.*)',
+				],
+			],
+			'home_dirname'                   => '/',
+			'filter_rocket_cache_reject_uri' => [
+				'/(.+/)?feed/?.+/?',
+				'/(?:.+/)?embed/',
+				'/members/(.*)',
+			],
+		],
+		'expected' => '/(/(.+/)?feed/?.+/?|/(?:.+/)?embed/|/members/(.*))',
+	],
+	[
+		'config' => [
+			'options'                        => [
+				'cache_reject_uri' => [],
+			],
+			'home_dirname'                   => '/subfolder/',
+			'filter_rocket_cache_reject_uri' => [
+				'/(.+/)?feed/?.+/?',
+				'/(?:.+/)?embed/',
+			],
+		],
+		'expected' => '/subfolder/(/(.+/)?feed/?.+/?|/(?:.+/)?embed/)',
+	],
+	[
+		'config' => [
+			'options'                        => [
+				'cache_reject_uri' => [
+					'/subfolder/members/(.*)',
+				],
+			],
+			'home_dirname'                   => '/subfolder/',
+			'filter_rocket_cache_reject_uri' => [
+				'/(.+/)?feed/?.+/?',
+				'/(?:.+/)?embed/',
+				'/members/(.*)',
+			],
+		],
+		'expected' => '/subfolder/(/(.+/)?feed/?.+/?|/(?:.+/)?embed/|/members/(.*))',
+	],
+	[
+		'config' => [
+			'options'                        => [
+				'cache_reject_uri' => [
+					'/members/(.*)',
+				],
+			],
+			'home_dirname'                   => '/subfolder/',
+			'filter_rocket_cache_reject_uri' => [
+				'/(.+/)?feed/?.+/?',
+				'/(?:.+/)?embed/',
+				'/members/(.*)',
+			],
+		],
+		'expected' => '/subfolder/(/(.+/)?feed/?.+/?|/(?:.+/)?embed/|/members/(.*))',
+	],
+];

--- a/tests/Integration/inc/functions/getRocketCacheRejectUri.php
+++ b/tests/Integration/inc/functions/getRocketCacheRejectUri.php
@@ -3,7 +3,7 @@
 namespace WP_Rocket\Tests\Integration\inc\functions;
 
 use Brain\Monkey\Functions;
-use WPMedia\PHPUnit\Integration\TestCase;
+use WP_Rocket\Tests\Integration\TestCase;
 
 /**
  * @covers ::get_rocket_cache_reject_uri
@@ -16,10 +16,7 @@ class Test_GetRocketCacheRejectUri extends TestCase {
 	 * @dataProvider providerTestData
 	 */
 	public function testShouldReturnExcludeDeferJSArray( $config, $expected ) {
-		$options = [
-			'cache_reject_uri' => $config['options']['cache_reject_uri'],
-		];
-		update_option( 'wp_rocket_settings', $options );
+		$this->mergeExistingSettingsAndUpdate( $config['options'] );
 
 		Functions\when( 'rocket_get_home_dirname' )->justReturn( $config['home_dirname'] );
 

--- a/tests/Integration/inc/functions/getRocketCacheRejectUri.php
+++ b/tests/Integration/inc/functions/getRocketCacheRejectUri.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\functions;
+
+use Brain\Monkey\Functions;
+use WPMedia\PHPUnit\Integration\TestCase;
+
+/**
+ * @covers ::get_rocket_cache_reject_uri
+ * @group FunctionsX
+ * @group Options
+ */
+class Test_GetRocketCacheRejectUri extends TestCase {
+
+	/**
+	 * @dataProvider providerTestData
+	 */
+	public function testShouldReturnExcludeDeferJSArray( $config, $expected ) {
+		$options = [
+			'cache_reject_uri' => $config['options']['cache_reject_uri'],
+		];
+		update_option( 'wp_rocket_settings', $options );
+
+		Functions\when( 'rocket_get_home_dirname' )->justReturn( $config['home_dirname'] );
+
+		$this->cache_reject_uri = $config['filter_rocket_cache_reject_uri'];
+		add_filter( 'rocket_cache_reject_uri', [ $this, 'filter_rocket_cache_reject_uri' ] );
+
+		$this->assertSame(
+			$expected,
+			get_rocket_cache_reject_uri( true )
+		);
+
+		remove_filter( 'rocket_cache_reject_uri', [ $this, 'filter_rocket_cache_reject_uri' ] );
+	}
+
+	public function providerTestData() {
+		return $this->getTestData( __DIR__, basename( __FILE__, '.php' ) );
+	}
+
+	public function filter_rocket_cache_reject_uri() {
+		return $this->cache_reject_uri;
+	}
+}

--- a/tests/Integration/inc/functions/getRocketCacheRejectUri.php
+++ b/tests/Integration/inc/functions/getRocketCacheRejectUri.php
@@ -7,7 +7,7 @@ use WPMedia\PHPUnit\Integration\TestCase;
 
 /**
  * @covers ::get_rocket_cache_reject_uri
- * @group FunctionsX
+ * @group Functions
  * @group Options
  */
 class Test_GetRocketCacheRejectUri extends TestCase {

--- a/tests/Unit/inc/admin/rocketNewUpgrade.php
+++ b/tests/Unit/inc/admin/rocketNewUpgrade.php
@@ -25,6 +25,8 @@ class Test_RocketNewUpgrade extends TestCase {
 			->once();
 		Functions\expect( 'rocket_clean_domain' )
 			->once();
+		Functions\expect( 'rocket_generate_config_file' )
+			->once();
 
 		rocket_new_upgrade( '3.6', '3.4.4' );
 	}

--- a/tests/Unit/inc/functions/getRocketCacheRejectUri.php
+++ b/tests/Unit/inc/functions/getRocketCacheRejectUri.php
@@ -1,0 +1,41 @@
+<?php
+namespace WP_Rocket\Tests\Unit\inc\functions;
+
+use stdClass;
+use Brain\Monkey\Functions;
+use WPMedia\PHPUnit\Unit\TestCase;
+
+/**
+ * @covers ::get_rocket_cache_reject_uri
+ * @group Functions
+ * @group Options
+ */
+class Test_GetRocketCacheRejectUri extends TestCase {
+	/**
+	 * @dataProvider providerTestData
+	 */
+    public function testShouldGetRocketCacheRejectUri( $config, $expected ) {
+		$GLOBALS['wp_rewrite']            = new stdClass();
+		$GLOBALS['wp_rewrite']->feed_base = 'feed/';
+
+		Functions\expect( 'get_rocket_option' )
+			->once()
+			->with( 'cache_reject_uri', [] )
+			->andReturn( $config['options']['cache_reject_uri'] );
+
+		Functions\when( 'rocket_get_home_dirname' )->justReturn( $config['home_dirname'] );
+
+		Functions\expect( 'apply_filters' )
+			->once()
+			->andReturn( (array) $config['filter_rocket_cache_reject_uri'] );
+
+        $this->assertSame(
+			$expected,
+            get_rocket_cache_reject_uri( true )
+        );
+    }
+
+	public function providerTestData() {
+		return $this->getTestData( __DIR__, 'getRocketCacheRejectUri' );
+	}
+}

--- a/tests/Unit/inc/functions/getRocketCacheRejectUri.php
+++ b/tests/Unit/inc/functions/getRocketCacheRejectUri.php
@@ -14,7 +14,7 @@ class Test_GetRocketCacheRejectUri extends TestCase {
 	/**
 	 * @dataProvider providerTestData
 	 */
-    public function testShouldGetRocketCacheRejectUri( $config, $expected ) {
+	public function testShouldGetRocketCacheRejectUri( $config, $expected ) {
 		$GLOBALS['wp_rewrite']            = new stdClass();
 		$GLOBALS['wp_rewrite']->feed_base = 'feed/';
 
@@ -29,11 +29,11 @@ class Test_GetRocketCacheRejectUri extends TestCase {
 			->once()
 			->andReturn( (array) $config['filter_rocket_cache_reject_uri'] );
 
-        $this->assertSame(
+		$this->assertSame(
 			$expected,
-            get_rocket_cache_reject_uri( true )
-        );
-    }
+			get_rocket_cache_reject_uri( true )
+		);
+	}
 
 	public function providerTestData() {
 		return $this->getTestData( __DIR__, 'getRocketCacheRejectUri' );

--- a/tests/Unit/inc/functions/getRocketCacheRejectUri.php
+++ b/tests/Unit/inc/functions/getRocketCacheRejectUri.php
@@ -11,6 +11,13 @@ use WPMedia\PHPUnit\Unit\TestCase;
  * @group Options
  */
 class Test_GetRocketCacheRejectUri extends TestCase {
+
+	public function tearDown() {
+		parent::tearDown();
+
+		unset( $GLOBALS['wp_rewrite'] );
+	}
+
 	/**
 	 * @dataProvider providerTestData
 	 */


### PR DESCRIPTION
**Reproduce the issue** ✅ 
Identified the issue on my localhost.

**Identify the root cause** ✅ 
https://github.com/wp-media/wp-rocket/blob/00cf7a1c5e0b2e7354b0aa76ca86603ee4420eae/inc/functions/options.php#L234-L235

**Scope a solution** ✅ 
The feed url should include also all sub-urls (eg. `/feed/`, `/feed/mp3/`)
Regex which should work:
`$uris[] = '/(.+/)?' . $GLOBALS['wp_rewrite']->feed_base . '/?.+/?';`

**Effort** ✅ 
Effort `[S]` , I think Unit & Integration tests will need almost all the effort

To Do
- [x] - Unit tests
- [x] - Integration tests