### PR TITLE
Closes #2493 Exclude external jQuery from combine when Defer Safe Mode is active

### DIFF
--- a/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
+++ b/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
@@ -39,10 +39,10 @@ abstract class AbstractJSOptimization extends AbstractOptimization {
 	 */
 	protected function get_excluded_files() {
 		$excluded_files = $this->options->get( 'exclude_js', [] );
-		$jquery_url     = $this->get_jquery_url();
+		$jquery_urls    = $this->get_jquery_urls();
 
-		if ( $jquery_url ) {
-			$excluded_files[] = $jquery_url;
+		if ( ! empty( $jquery_urls ) ) {
+			$excluded_files = array_merge( $excluded_files, $jquery_urls );
 		}
 
 		/**
@@ -146,23 +146,21 @@ abstract class AbstractJSOptimization extends AbstractOptimization {
 	 * @since  3.1
 	 * @author Remy Perona
 	 *
-	 * @return bool|string
+	 * @return array
 	 */
-	protected function get_jquery_url() {
+	protected function get_jquery_urls() {
 		global $wp_scripts;
 
 		if ( ! $this->options->get( 'defer_all_js', 0 ) || ! $this->options->get( 'defer_all_js_safe', 0 ) ) {
-			return false;
+			return [];
 		}
+		$jquery           = site_url( wp_scripts()->registered['jquery-core']->src );
+		$exclude_jquery   = [];
+		$exclude_jquery[] = rocket_clean_exclude_file( $jquery );
+		$exclude_jquery[] = 'c0.wp.com/c/(?:.+)/wp-includes/js/jquery/jquery.js';
+		$exclude_jquery[] = 'ajax.googleapis.com/ajax/libs/jquery/(?:.+)/jquery(?:\.min)?.js';
+		$exclude_jquery[] = 'cdnjs.cloudflare.com/ajax/libs/jquery/(?:.+)/jquery(?:\.min)?.js';
 
-		if ( ! isset( $wp_scripts->registered['jquery-core']->src ) ) {
-			return false;
-		}
-
-		if ( '' === wp_parse_url( $wp_scripts->registered['jquery-core']->src, PHP_URL_HOST ) ) {
-			return wp_parse_url( site_url( $wp_scripts->registered['jquery-core']->src, PHP_URL_PATH ) );
-		}
-
-		return $wp_scripts->registered['jquery-core']->src;
+		return $exclude_jquery;
 	}
 }

--- a/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
+++ b/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
@@ -149,14 +149,14 @@ abstract class AbstractJSOptimization extends AbstractOptimization {
 	 * @return array
 	 */
 	protected function get_jquery_urls() {
-		global $wp_scripts;
-
 		if ( ! $this->options->get( 'defer_all_js', 0 ) || ! $this->options->get( 'defer_all_js_safe', 0 ) ) {
 			return [];
 		}
-		$jquery           = site_url( wp_scripts()->registered['jquery-core']->src );
-		$exclude_jquery   = [];
-		$exclude_jquery[] = rocket_clean_exclude_file( $jquery );
+		$jquery         = rocket_clean_exclude_file( site_url( wp_scripts()->registered['jquery-core']->src ) );
+		$exclude_jquery = [];
+		if ( $jquery ) {
+			$exclude_jquery[] = $jquery;
+		}
 		$exclude_jquery[] = 'c0.wp.com/c/(?:.+)/wp-includes/js/jquery/jquery.js';
 		$exclude_jquery[] = 'ajax.googleapis.com/ajax/libs/jquery/(?:.+)/jquery(?:\.min)?.js';
 		$exclude_jquery[] = 'cdnjs.cloudflare.com/ajax/libs/jquery/(?:.+)/jquery(?:\.min)?.js';

--- a/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
+++ b/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
@@ -152,11 +152,14 @@ abstract class AbstractJSOptimization extends AbstractOptimization {
 		if ( ! $this->options->get( 'defer_all_js', 0 ) || ! $this->options->get( 'defer_all_js_safe', 0 ) ) {
 			return [];
 		}
-		$jquery         = rocket_clean_exclude_file( site_url( wp_scripts()->registered['jquery-core']->src ) );
+
 		$exclude_jquery = [];
-		if ( $jquery ) {
+		$jquery         = wp_scripts()->registered['jquery-core']->src;
+
+		if ( isset( $jquery ) ) {
 			$exclude_jquery[] = $jquery;
 		}
+
 		$exclude_jquery[] = 'c0.wp.com/c/(?:.+)/wp-includes/js/jquery/jquery.js';
 		$exclude_jquery[] = 'ajax.googleapis.com/ajax/libs/jquery/(?:.+)/jquery(?:\.min)?.js';
 		$exclude_jquery[] = 'cdnjs.cloudflare.com/ajax/libs/jquery/(?:.+)/jquery(?:\.min)?.js';

--- a/inc/Engine/Optimization/Minify/JS/Combine.php
+++ b/inc/Engine/Optimization/Minify/JS/Combine.php
@@ -195,7 +195,7 @@ class Combine extends AbstractJSOptimization {
 
 						if ( ! empty( $this->jquery_urls ) ) {
 							$jquery_urls = implode( '|', $this->jquery_urls );
-							if ( preg_match( '#^(' . $jquery_urls . ')$#', rocket_remove_url_protocol( $matches['url'] ) ) ) {
+							if ( preg_match( '#^(' . $jquery_urls . ')$#', rocket_remove_url_protocol( strtok( $matches['url'], '?' ) ) ) ) {
 								return;
 							}
 						}

--- a/inc/Engine/Optimization/Minify/JS/Combine.php
+++ b/inc/Engine/Optimization/Minify/JS/Combine.php
@@ -39,9 +39,9 @@ class Combine extends AbstractJSOptimization {
 	 * @since 3.1
 	 * @author Remy Perona
 	 *
-	 * @var bool|string
+	 * @var array
 	 */
-	private $jquery_url;
+	private $jquery_urls;
 
 	/**
 	 * Scripts to combine
@@ -78,7 +78,7 @@ class Combine extends AbstractJSOptimization {
 
 		$this->minifier    = $minifier;
 		$this->local_cache = $local_cache;
-		$this->jquery_url  = $this->get_jquery_url();
+		$this->jquery_urls = $this->get_jquery_urls();
 	}
 
 	/**
@@ -178,7 +178,6 @@ class Combine extends AbstractJSOptimization {
 		$scripts = array_map(
 			function( $script ) {
 				preg_match( '/<script\s+([^>]+[\s\'"])?src\s*=\s*[\'"]\s*?(?<url>[^\'"]+\.js(?:\?[^\'"]*)?)\s*?[\'"]([^>]+)?\/?>/Umsi', $script[0], $matches );
-
 				if ( isset( $matches['url'] ) ) {
 					if ( $this->is_external_file( $matches['url'] ) ) {
 						foreach ( $this->get_excluded_external_file_path() as $excluded_file ) {
@@ -194,6 +193,13 @@ class Combine extends AbstractJSOptimization {
 							}
 						}
 
+						if ( ! empty( $this->jquery_urls ) ) {
+							$jquery_urls = implode( '|', $this->jquery_urls );
+							if ( preg_match( '#^(' . $jquery_urls . ')$#', rocket_remove_url_protocol( $matches['url'] ) ) ) {
+								return;
+							}
+						}
+
 						$this->scripts[] = [
 							'type'    => 'url',
 							'content' => $matches['url'],
@@ -205,17 +211,6 @@ class Combine extends AbstractJSOptimization {
 					if ( $this->is_minify_excluded_file( $matches ) ) {
 						Logger::debug(
 							'Script is excluded.',
-							[
-								'js combine process',
-								'tag' => $matches[0],
-							]
-						);
-						return;
-					}
-
-					if ( $this->jquery_url && false !== strpos( $matches['url'], $this->jquery_url ) ) {
-						Logger::debug(
-							'Script is jQuery.',
 							[
 								'js combine process',
 								'tag' => $matches[0],
@@ -373,7 +368,6 @@ class Combine extends AbstractJSOptimization {
 
 		$filename      = md5( $content . $this->minify_key ) . '.js';
 		$minified_file = $this->minify_base_path . $filename;
-
 		if ( ! rocket_direct_filesystem()->is_readable( $minified_file ) ) {
 			$minified_content = $this->minify();
 

--- a/tests/Fixtures/inc/Engine/Optimization/Minify/JS/Combine/combine.php
+++ b/tests/Fixtures/inc/Engine/Optimization/Minify/JS/Combine/combine.php
@@ -31,20 +31,72 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
+		<script type="text/javascript" src="http://example.org/wp-includes/js/jquery/jquery.js"></script>
 		<script>
 		nonce = "nonce";
 		</script>
 	</head>
 	<body>
-		<script src="http://example.org/wp-content/cache/min/1/900b339c19ff5a927b3311bf5ddb4dfd.js" data-minify="1"></script>
+		<script src="http://example.org/wp-content/cache/min/1/cfe4eede7af9db7e8fa8951ee9782333.js" data-minify="1"></script>
 	</body>
 </html>
 EXPECTED_HTML
 				,
 
 				'files' => [
-					'wp-content/cache/min/1/900b339c19ff5a927b3311bf5ddb4dfd.js',
-					'wp-content/cache/min/1/900b339c19ff5a927b3311bf5ddb4dfd.js.gz',
+					'wp-content/cache/min/1/cfe4eede7af9db7e8fa8951ee9782333.js',
+					'wp-content/cache/min/1/cfe4eede7af9db7e8fa8951ee9782333.js.gz',
+				],
+			],
+
+			'cdn_host' => [],
+			'cdn_url'  => 'http://example.org',
+			'site_url' => 'http://example.org',
+		],
+
+		'combineJsFilesExceptExcluded' => [
+			'original' => <<<ORIGINAL_HTML
+<html>
+	<head>
+		<title>Sample Page</title>
+		<script type="text/javascript" src="http://example.org/wp-content/themes/twentytwenty/assets/script.js"></script>
+		<script type="text/javascript" src="http://example.org/wp-content/plugins/hello-dolly/script.js"></script>
+		<script type="text/javascript" src="http://example.org/wp-includes/js/jquery/jquery.js"></script>
+		<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.js"></script>
+		<script>
+		document.getElementById("demo").innerHTML = "Hello JavaScript!";
+		</script>
+		<script>
+		nonce = "nonce";
+		</script>
+	</head>
+	<body>
+	</body>
+</html>
+ORIGINAL_HTML
+			,
+
+			'expected' => [
+				'html' => <<<EXPECTED_HTML
+<html>
+	<head>
+		<title>Sample Page</title>
+		<script type="text/javascript" src="http://example.org/wp-includes/js/jquery/jquery.js"></script>
+		<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.js"></script>
+		<script>
+		nonce = "nonce";
+		</script>
+	</head>
+	<body>
+		<script src="http://example.org/wp-content/cache/min/1/cfe4eede7af9db7e8fa8951ee9782333.js" data-minify="1"></script>
+	</body>
+</html>
+EXPECTED_HTML
+				,
+
+				'files' => [
+					'wp-content/cache/min/1/cfe4eede7af9db7e8fa8951ee9782333.js',
+					'wp-content/cache/min/1/cfe4eede7af9db7e8fa8951ee9782333.js.gz',
 				],
 			],
 
@@ -79,20 +131,21 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
+		<script type="text/javascript" src="http://example.org/wp-includes/js/jquery/jquery.js"></script>
 		<script>
 		nonce = "nonce";
 		</script>
 	</head>
 	<body>
-		<script src="https://123456.rocketcdn.me/wp-content/cache/min/1/900b339c19ff5a927b3311bf5ddb4dfd.js" data-minify="1"></script>
+		<script src="https://123456.rocketcdn.me/wp-content/cache/min/1/cfe4eede7af9db7e8fa8951ee9782333.js" data-minify="1"></script>
 	</body>
 </html>
 EXPECTED_HTML
 				,
 
 				'files' => [
-					'wp-content/cache/min/1/900b339c19ff5a927b3311bf5ddb4dfd.js',
-					'wp-content/cache/min/1/900b339c19ff5a927b3311bf5ddb4dfd.js.gz',
+					'wp-content/cache/min/1/cfe4eede7af9db7e8fa8951ee9782333.js',
+					'wp-content/cache/min/1/cfe4eede7af9db7e8fa8951ee9782333.js.gz',
 				],
 			],
 
@@ -127,19 +180,20 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
+		<script type="text/javascript" src="https://123456.rocketcdn.me/wp-includes/js/jquery/jquery.js"></script>
 		<script>
 		nonce = "nonce";
 		</script>
 	</head>
 	<body>
-		<script src="https://123456.rocketcdn.me/wp-content/cache/min/1/900b339c19ff5a927b3311bf5ddb4dfd.js" data-minify="1"></script>
+		<script src="https://123456.rocketcdn.me/wp-content/cache/min/1/cfe4eede7af9db7e8fa8951ee9782333.js" data-minify="1"></script>
 	</body>
 </html>
 EXPECTED_HTML
 				,
 				'files' => [
-					'wp-content/cache/min/1/900b339c19ff5a927b3311bf5ddb4dfd.js',
-					'wp-content/cache/min/1/900b339c19ff5a927b3311bf5ddb4dfd.js.gz',
+					'wp-content/cache/min/1/cfe4eede7af9db7e8fa8951ee9782333.js',
+					'wp-content/cache/min/1/cfe4eede7af9db7e8fa8951ee9782333.js.gz',
 				],
 			],
 

--- a/tests/Fixtures/inc/Engine/Optimization/Minify/JS/Subscriber/process.php
+++ b/tests/Fixtures/inc/Engine/Optimization/Minify/JS/Subscriber/process.php
@@ -7,6 +7,8 @@ return [
 		'cdn'                   => 0,
 		'cdn_cnames'            => [],
 		'cdn_zone'              => [],
+		'defer_all_js'          => 0,
+		'defer_all_js_safe'     => 0,
 	],
 
 	'test_data' => [
@@ -46,6 +48,8 @@ return [
 				'cdn'                   => 0,
 				'cdn_cnames'            => [],
 				'cdn_zone'              => [],
+				'defer_all_js'          => 0,
+				'defer_all_js_safe'     => 0,
 			],
 		],
 
@@ -85,6 +89,8 @@ return [
 				'cdn'                   => 1,
 				'cdn_cnames'            => [ 'https://123456.rocketcdn.me' ],
 				'cdn_zone'              => [ 'all' ],
+				'defer_all_js'          => 0,
+				'defer_all_js_safe'     => 0,
 			],
 		],
 
@@ -125,6 +131,8 @@ return [
 				'cdn'                   => 1,
 				'cdn_cnames'            => [ 'https://123456.rocketcdn.me' ],
 				'cdn_zone'              => [ 'all' ],
+				'defer_all_js'          => 0,
+				'defer_all_js_safe'     => 0,
 			],
 		],
 
@@ -163,6 +171,8 @@ return [
 				'cdn'                   => 1,
 				'cdn_cnames'            => [ 'https://123456.rocketcdn.me/cdnpath' ],
 				'cdn_zone'              => [ 'all' ],
+				'defer_all_js'          => 0,
+				'defer_all_js_safe'     => 0,
 			],
 		],
 
@@ -207,6 +217,8 @@ return [
 				'cdn'                   => 0,
 				'cdn_cnames'            => [],
 				'cdn_zone'              => [],
+				'defer_all_js'          => 0,
+				'defer_all_js_safe'     => 0,
 			],
 		],
 
@@ -251,6 +263,201 @@ return [
 				'cdn'                   => 1,
 				'cdn_cnames'            => [ 'https://123456.rocketcdn.me' ],
 				'cdn_zone'              => [ 'all' ],
+				'defer_all_js'          => 0,
+				'defer_all_js_safe'     => 0,
+			],
+		],
+
+		'shouldCombineJSFilesWithDefer' => [
+			'original' => '<html>
+				<head>
+					<title>Sample Page</title>
+					<script type="text/javascript" src="http://example.org/wp-content/themes/twentytwenty/assets/script.js"></script>
+					<script type="text/javascript" src="http://example.org/wp-content/plugins/hello-dolly/script.js"></script>
+					<script type="text/javascript" src="http://example.org/wp-includes/js/jquery/jquery.js"></script>
+					<script>
+					document.getElementById("demo").innerHTML = "Hello JavaScript!";
+					</script>
+					<script>
+					nonce = "nonce";
+					</script>
+				</head>
+				<body>
+				</body>
+			</html>',
+
+			'expected' => [
+				'html'  => '<html>
+					<head>
+						<title>Sample Page</title>
+						<script type="text/javascript" src="http://example.org/wp-includes/js/jquery/jquery.js"></script>
+						<script>
+						nonce = "nonce";
+						</script>
+					</head>
+					<body>
+						<script src="http://example.org/wp-content/cache/min/1/1100e4606ab35f45752eb8c3c8da0427.js" data-minify="1"></script>
+					</body>
+				</html>',
+				'files' => [
+					'wp-content/cache/min/1/1100e4606ab35f45752eb8c3c8da0427.js',
+					'wp-content/cache/min/1/1100e4606ab35f45752eb8c3c8da0427.js.gz',
+				],
+			],
+
+			'settings' => [
+				'minify_concatenate_js' => 1,
+				'cdn'                   => 0,
+				'cdn_cnames'            => [ ],
+				'cdn_zone'              => [ ],
+				'defer_all_js'          => 1,
+				'defer_all_js_safe'     => 1,
+			],
+		],
+
+		'shouldCombineJSFilesWithDeferAndExternalJQueryLibrary' => [
+			'original' => '<html>
+				<head>
+					<title>Sample Page</title>
+					<script type="text/javascript" src="http://example.org/wp-content/themes/twentytwenty/assets/script.js"></script>
+					<script type="text/javascript" src="http://example.org/wp-content/plugins/hello-dolly/script.js"></script>
+					<script type="text/javascript" src="http://example.org/wp-includes/js/jquery/jquery.js"></script>
+					<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.js"></script>
+					<script>
+					document.getElementById("demo").innerHTML = "Hello JavaScript!";
+					</script>
+					<script>
+					nonce = "nonce";
+					</script>
+				</head>
+				<body>
+				</body>
+			</html>',
+
+			'expected' => [
+				'html'  => '<html>
+					<head>
+						<title>Sample Page</title>
+						<script type="text/javascript" src="http://example.org/wp-includes/js/jquery/jquery.js"></script>
+						<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.js"></script>
+						<script>
+						nonce = "nonce";
+						</script>
+					</head>
+					<body>
+						<script src="http://example.org/wp-content/cache/min/1/1100e4606ab35f45752eb8c3c8da0427.js" data-minify="1"></script>
+					</body>
+				</html>',
+				'files' => [
+					'wp-content/cache/min/1/1100e4606ab35f45752eb8c3c8da0427.js',
+					'wp-content/cache/min/1/1100e4606ab35f45752eb8c3c8da0427.js.gz',
+				],
+			],
+
+			'settings' => [
+				'minify_concatenate_js' => 1,
+				'cdn'                   => 0,
+				'cdn_cnames'            => [ ],
+				'cdn_zone'              => [ ],
+				'defer_all_js'          => 1,
+				'defer_all_js_safe'     => 1,
+			],
+		],
+
+
+		'shouldCombineJSWithCdnFilesWithDefer' => [
+			'original' => '<html>
+				<head>
+					<title>Sample Page</title>
+					<script type="text/javascript" src="http://example.org/wp-content/themes/twentytwenty/assets/script.js"></script>
+					<script type="text/javascript" src="http://example.org/wp-content/plugins/hello-dolly/script.js"></script>
+					<script type="text/javascript" src="http://example.org/wp-includes/js/jquery/jquery.js"></script>
+					<script>
+					document.getElementById("demo").innerHTML = "Hello JavaScript!";
+					</script>
+					<script>
+					nonce = "nonce";
+					</script>
+				</head>
+				<body>
+				</body>
+			</html>',
+
+			'expected' => [
+				'html'  => '<html>
+					<head>
+						<title>Sample Page</title>
+						<script type="text/javascript" src="https://123456.rocketcdn.me/wp-includes/js/jquery/jquery.js"></script>
+						<script>
+						nonce = "nonce";
+						</script>
+					</head>
+					<body>
+						<script src="https://123456.rocketcdn.me/wp-content/cache/min/1/1100e4606ab35f45752eb8c3c8da0427.js" data-minify="1"></script>
+					</body>
+				</html>',
+				'files' => [
+					'wp-content/cache/min/1/1100e4606ab35f45752eb8c3c8da0427.js',
+					'wp-content/cache/min/1/1100e4606ab35f45752eb8c3c8da0427.js.gz',
+				],
+			],
+
+			'settings' => [
+				'minify_concatenate_js' => 1,
+				'cdn'                   => 1,
+				'cdn_cnames'            => [ 'https://123456.rocketcdn.me' ],
+				'cdn_zone'              => [ 'all' ],
+				'defer_all_js'          => 1,
+				'defer_all_js_safe'     => 1,
+			],
+		],
+
+		'shouldCombineJSFilesWithCDNUrlWithDeferAndExternalJQueryLibrary' => [
+			'original' => '<html>
+				<head>
+					<title>Sample Page</title>
+					<script type="text/javascript" src="http://example.org/wp-content/themes/twentytwenty/assets/script.js"></script>
+					<script type="text/javascript" src="http://example.org/wp-content/plugins/hello-dolly/script.js"></script>
+					<script type="text/javascript" src="http://example.org/wp-includes/js/jquery/jquery.js"></script>
+					<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.js"></script>
+					<script>
+					document.getElementById("demo").innerHTML = "Hello JavaScript!";
+					</script>
+					<script>
+					nonce = "nonce";
+					</script>
+				</head>
+				<body>
+				</body>
+			</html>',
+
+			'expected' => [
+				'html'  => '<html>
+					<head>
+						<title>Sample Page</title>
+						<script type="text/javascript" src="https://123456.rocketcdn.me/wp-includes/js/jquery/jquery.js"></script>
+						<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.js"></script>
+						<script>
+						nonce = "nonce";
+						</script>
+					</head>
+					<body>
+						<script src="https://123456.rocketcdn.me/wp-content/cache/min/1/1100e4606ab35f45752eb8c3c8da0427.js" data-minify="1"></script>
+					</body>
+				</html>',
+				'files' => [
+					'wp-content/cache/min/1/1100e4606ab35f45752eb8c3c8da0427.js',
+					'wp-content/cache/min/1/1100e4606ab35f45752eb8c3c8da0427.js.gz',
+				],
+			],
+
+			'settings' => [
+				'minify_concatenate_js' => 1,
+				'cdn'                   => 1,
+				'cdn_cnames'            => [ 'https://123456.rocketcdn.me' ],
+				'cdn_zone'              => [ 'all' ],
+				'defer_all_js'          => 1,
+				'defer_all_js_safe'     => 1,
 			],
 		],
 
@@ -295,6 +502,8 @@ return [
 				'cdn'                   => 1,
 				'cdn_cnames'            => [ 'https://123456.rocketcdn.me' ],
 				'cdn_zone'              => [ 'all' ],
+				'defer_all_js'          => 0,
+				'defer_all_js_safe'     => 0,
 			],
 		],
 
@@ -340,6 +549,8 @@ return [
 				'cdn'                   => 1,
 				'cdn_cnames'            => [ 'https://123456.rocketcdn.me/cdnpath' ],
 				'cdn_zone'              => [ 'all' ],
+				'defer_all_js'          => 0,
+				'defer_all_js_safe'     => 0,
 			],
 		],
 	],

--- a/tests/Integration/inc/Engine/Optimization/Minify/JS/Subscriber/process.php
+++ b/tests/Integration/inc/Engine/Optimization/Minify/JS/Subscriber/process.php
@@ -28,6 +28,9 @@ class Test_Process extends TestCase {
 		remove_filter( 'pre_get_rocket_option_minify_js', [ $this, 'return_true' ] );
 		remove_filter( 'pre_get_rocket_option_minify_js_key', [ $this, 'return_key' ] );
 
+		remove_filter( 'pre_get_rocket_option_defer_all_js', [ $this, 'return_defer_all_js' ] );
+		remove_filter( 'pre_get_rocket_option_defer_all_js_safe', [ $this, 'return_defer_all_js_safe' ] );
+
 		$this->unsetSettings();
 	}
 
@@ -38,6 +41,12 @@ class Test_Process extends TestCase {
 		add_filter( 'pre_get_rocket_option_minify_js', [ $this, 'return_true' ] );
 		add_filter( 'pre_get_rocket_option_minify_js_key', [ $this, 'return_key' ] );
 
+		$this->defer_all_js      = $settings['defer_all_js'];
+		$this->defer_all_js_safe = $settings['defer_all_js_safe'];
+
+		add_filter( 'pre_get_rocket_option_defer_all_js', [ $this, 'return_defer_all_js' ] );
+		add_filter( 'pre_get_rocket_option_defer_all_js_safe', [ $this, 'return_defer_all_js_safe' ] );
+
 		$this->settings = $settings;
 		$this->setSettings();
 
@@ -47,5 +56,13 @@ class Test_Process extends TestCase {
 		);
 
 		$this->assertFilesExists( $expected['files'] );
+	}
+
+	public function return_defer_all_js() {
+		return $this->defer_all_js;
+	}
+
+	public function return_defer_all_js_safe() {
+		return $this->defer_all_js_safe;
 	}
 }

--- a/tests/Unit/inc/Engine/Optimization/Minify/CSS/Combine/optimize.php
+++ b/tests/Unit/inc/Engine/Optimization/Minify/CSS/Combine/optimize.php
@@ -30,6 +30,9 @@ class Test_Optimize extends TestCase {
 		$this->minify->shouldReceive( 'minify' )
 		             ->andReturn( 'body{font-family:Helvetica,Arial,sans-serif;text-align:center;}' );
 
+		$this->options
+			 ->shouldReceive( 'get' )
+			 ->andReturnArg( 1 );
 		$this->combine = new Combine( $this->options, $this->minify );
 	}
 

--- a/tests/Unit/inc/Engine/Optimization/Minify/CSS/Minify/optimize.php
+++ b/tests/Unit/inc/Engine/Optimization/Minify/CSS/Minify/optimize.php
@@ -19,6 +19,10 @@ class Test_Optimize extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
+		$this->options
+			->shouldReceive( 'get' )
+			->andReturnArg( 1 );
+
 		$this->minify = new Minify( $this->options );
 	}
 

--- a/tests/Unit/inc/Engine/Optimization/Minify/JS/Combine/optimize.php
+++ b/tests/Unit/inc/Engine/Optimization/Minify/JS/Combine/optimize.php
@@ -33,13 +33,34 @@ class Test_Optimize extends TestCase {
 
 		Functions\when( 'esc_url' )->returnArg();
 		Functions\when( 'wp_scripts' )->alias( function () {
-			$wp_scripts        = new \stdClass();
-			$jquery            = new \stdClass();
-			$jquery->src       = '/wp-includes/js/jquery/jquery.js';
-			$wp_scripts->queue = [];
+			$wp_scripts                                 = new \stdClass();
+			$jquery                                     = new \stdClass();
+			$jquery->src                                = '/wp-includes/js/jquery/jquery.js';
+			$wp_scripts->registered                = [];
+			$wp_scripts->registered['jquery-core'] = $jquery;
+			$wp_scripts->queue                     = [];
 
 			return $wp_scripts;
 		} );
+
+		Functions\when( 'site_url' )->returnArg();
+		Functions\when('rocket_clean_exclude_file')->returnArg();
+
+		$this->options->shouldReceive( 'get' )
+			->with( 'minify_js_key', 'rocket_uniqid' )
+			->andReturn( 'rocket_uniqid' );
+		$this->options->shouldReceive( 'get' )
+			->with( 'exclude_inline_js', [] )
+			->andReturn( [] );
+		$this->options->shouldReceive( 'get' )
+			->with( 'defer_all_js', 0 )
+			->andReturn( 1 );
+		$this->options->shouldReceive( 'get' )
+			->with( 'defer_all_js_safe', 0 )
+			->andReturn( 1 );
+		$this->options->shouldReceive( 'get' )
+			->with( 'exclude_js', [] )
+			->andReturn( [] );
 
 		$this->combine = new Combine( $this->options, $this->minify, Mockery::mock( Assets_Local_Cache::class ) );
 	}

--- a/tests/Unit/inc/Engine/Optimization/Minify/JS/Minify/optimize.php
+++ b/tests/Unit/inc/Engine/Optimization/Minify/JS/Minify/optimize.php
@@ -28,6 +28,10 @@ class Test_Optimize extends TestCase {
 			],
 		];
 
+		$this->options
+			->shouldReceive( 'get' )
+			->andReturnArg( 1 );
+
 		$this->minify = new Minify( $this->options );
 	}
 

--- a/tests/Unit/inc/Engine/Optimization/TestCase.php
+++ b/tests/Unit/inc/Engine/Optimization/TestCase.php
@@ -21,9 +21,6 @@ abstract class TestCase extends FilesystemTestCase {
 		$this->stubfillWpBasename();
 
 		$this->options = Mockery::mock( Options_Data::class );
-		$this->options
-			->shouldReceive( 'get' )
-			->andReturnArg( 1 );
 
 		Functions\when( 'get_current_blog_id' )->justReturn( 1 );
 		Functions\when( 'create_rocket_uniqid' )->justReturn( 'rocket_uniqid' );


### PR DESCRIPTION
**Reproduce the problem** ✅ 
Reproduced on test installation

**Identify the root cause** ✅ 
In https://github.com/wp-media/wp-rocket/blob/00cf7a1c5e0b2e7354b0aa76ca86603ee4420eae/inc/classes/optimization/JS/class-abstract-js-optimization.php#L145

We only get the URL for the WP core jQuery, not for any externally hosted jQuery like we do for deferred JS.

**Scope a solution** ✅ 
Improve this method to also exclude known externally hosted jQuery, like from Jetpack, googleapis.com or cdnjs.cloudflare.com

**Effort** ✅ 
Effort `[S]`