### PR TITLE
Fix #2800 fallback cpcss css files are not loaded async

### DIFF
--- a/inc/Engine/CriticalPath/CriticalCSSSubscriber.php
+++ b/inc/Engine/CriticalPath/CriticalCSSSubscriber.php
@@ -675,6 +675,10 @@ JS;
 			return $buffer;
 		}
 
+		if ( ! $this->critical_css->get_current_page_critical_css() && ! $this->options->get( 'critical_css', '' ) ) {
+			return $buffer;
+		}
+
 		$excluded_css = array_flip( get_rocket_exclude_async_css() );
 
 		/**

--- a/inc/Engine/CriticalPath/CriticalCSSSubscriber.php
+++ b/inc/Engine/CriticalPath/CriticalCSSSubscriber.php
@@ -675,10 +675,6 @@ JS;
 			return $buffer;
 		}
 
-		if ( ! $this->critical_css->get_current_page_critical_css() ) {
-			return $buffer;
-		}
-
 		$excluded_css = array_flip( get_rocket_exclude_async_css() );
 
 		/**

--- a/inc/Engine/CriticalPath/CriticalCSSSubscriber.php
+++ b/inc/Engine/CriticalPath/CriticalCSSSubscriber.php
@@ -675,7 +675,7 @@ JS;
 			return $buffer;
 		}
 
-		if ( ! $this->critical_css->get_current_page_critical_css() && ! $this->options->get( 'critical_css', '' ) ) {
+		if ( empty( $this->critical_css->get_current_page_critical_css() ) && empty( $this->options->get( 'critical_css', '' ) ) ) {
 			return $buffer;
 		}
 


### PR DESCRIPTION
This was introduced while refactoring the Critical Path code. 
I identified while doing the PR https://github.com/wp-media/wp-rocket/pull/2786 .
This should be included in the next minor release v3.6.1

When using Fallback CPCSS, the CSS files are not loaded asynchronously anymore.

**Steps to reproduce**
- Enter CSS into Fallback CPCSS field (also take appropriate steps to apply it, delete existing cpcss, stop automatic regeneration.
- Observe the the CPCSS is correctly inserted into the page, but the CSS files are loaded normally and render-blocking