### PR TITLE
Remove minify HTML option: front (1/3)

### DIFF
--- a/inc/Engine/Optimization/ServiceProvider.php
+++ b/inc/Engine/Optimization/ServiceProvider.php
@@ -28,7 +28,6 @@ class ServiceProvider extends AbstractServiceProvider {
 		'buffer_subscriber',
 		'cache_dynamic_resource',
 		'ie_conditionals_subscriber',
-		'minify_html_subscriber',
 		'combine_google_fonts_subscriber',
 		'minify_css_subscriber',
 		'minify_js_subscriber',
@@ -59,8 +58,6 @@ class ServiceProvider extends AbstractServiceProvider {
 			->withArgument( WP_ROCKET_CACHE_BUSTING_PATH )
 			->withArgument( WP_ROCKET_CACHE_BUSTING_URL );
 		$this->getContainer()->share( 'ie_conditionals_subscriber', 'WP_Rocket\Subscriber\Optimization\IE_Conditionals_Subscriber' );
-		$this->getContainer()->share( 'minify_html_subscriber', 'WP_Rocket\Subscriber\Optimization\Minify_HTML_Subscriber' )
-			->withArgument( $options );
 		$this->getContainer()->share( 'combine_google_fonts_subscriber', 'WP_Rocket\Engine\Optimization\GoogleFonts\Subscriber' )
 			->withArgument( $options );
 		$this->getContainer()->share( 'minify_css_subscriber', 'WP_Rocket\Engine\Optimization\Minify\CSS\Subscriber' )

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -186,7 +186,6 @@ class Plugin {
 		$subscribers = [
 			'buffer_subscriber',
 			'ie_conditionals_subscriber',
-			'minify_html_subscriber',
 			'combine_google_fonts_subscriber',
 			'minify_css_subscriber',
 			'minify_js_subscriber',

--- a/inc/deprecated/3.6.php
+++ b/inc/deprecated/3.6.php
@@ -346,4 +346,3 @@ function rocket_sccss_create_cache_file( $cache_busting_path, $cache_sccss_filep
 
 	rocket_put_content( $cache_sccss_filepath, $content );
 }
-

--- a/inc/deprecated/3.7.php
+++ b/inc/deprecated/3.7.php
@@ -1,0 +1,9 @@
+<?php
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Require deprecated classes.
+ */
+require_once __DIR__ . '/vendors/classes/class-minify-html.php';
+require_once __DIR__ . '/subscriber/admin/Optimization/class-minify-html-subscriber.php';

--- a/inc/deprecated/subscriber/admin/Optimization/class-minify-html-subscriber.php
+++ b/inc/deprecated/subscriber/admin/Optimization/class-minify-html-subscriber.php
@@ -1,6 +1,7 @@
 <?php
 namespace WP_Rocket\Subscriber\Optimization;
 
+use WP_Rocket\deprecated\DeprecatedClassTrait;
 use WP_Rocket\Event_Management\Subscriber_Interface;
 use WP_Rocket\Admin\Options_Data as Options;
 use MatthiasMullie\Minify;
@@ -12,6 +13,7 @@ use MatthiasMullie\Minify;
  * @author Remy Perona
  */
 class Minify_HTML_Subscriber implements Subscriber_Interface {
+	use DeprecatedClassTrait;
 	/**
 	 * Plugin options
 	 *
@@ -31,6 +33,7 @@ class Minify_HTML_Subscriber implements Subscriber_Interface {
 	 * @param Options $options Plugin options.
 	 */
 	public function __construct( Options $options ) {
+		self::deprecated_class( '3.7' );
 		$this->options = $options;
 	}
 

--- a/inc/deprecated/vendors/classes/class-minify-html.php
+++ b/inc/deprecated/vendors/classes/class-minify-html.php
@@ -1,4 +1,7 @@
 <?php
+
+use WP_Rocket\deprecated\DeprecatedClassTrait;
+
 /**
  * Class Minify_HTML
  * @package Minify
@@ -18,6 +21,8 @@
  */
 class Minify_HTML
 {
+	use DeprecatedClassTrait;
+
     /**
      * @var boolean
      */
@@ -68,6 +73,8 @@ class Minify_HTML
      */
     public function __construct($html, $options = array())
     {
+		self::deprecated_class( '3.7' );
+
         $this->_html = str_replace("\r\n", "\n", trim($html));
         if (isset($options['xhtml'])) {
             $this->_isXhtml = (bool)$options['xhtml'];

--- a/inc/main.php
+++ b/inc/main.php
@@ -63,6 +63,7 @@ function rocket_init() {
 	require WP_ROCKET_DEPRECATED_PATH . '3.4.php';
 	require WP_ROCKET_DEPRECATED_PATH . '3.5.php';
 	require WP_ROCKET_DEPRECATED_PATH . '3.6.php';
+	require WP_ROCKET_DEPRECATED_PATH . '3.7.php';
 	require WP_ROCKET_3RD_PARTY_PATH . '3rd-party.php';
 	require WP_ROCKET_COMMON_PATH . 'admin-bar.php';
 	require WP_ROCKET_COMMON_PATH . 'emoji.php';


### PR DESCRIPTION
Sub-task for epic #2682 

### inc/Plugin.php ✔️ 
- Remove the minify_html_subscriber entry from the subscribers

### inc/classes/subscriber/Optimization/class-minify-html-subscriber.php ✔️ 
- Deprecate the class

### inc/Engine/Optimization/ServiceProvider.php ✔️ 
- Remove registering minify HTML subscriber in $provides and register()

### inc/vendors/classes/class-minify-html.php ✔️ 
- Deprecate the class
