### PR TITLE
Remove minify HTML option: backend (2/3)

### DIFF
--- a/inc/Engine/Admin/Beacon/Beacon.php
+++ b/inc/Engine/Admin/Beacon/Beacon.php
@@ -136,7 +136,6 @@ class Beacon extends Abstract_Render implements Subscriber_Interface {
 			'minify_js'               => 'Minify JS',
 			'minify_concatenate_js'   => 'Combine JS',
 			'minify_google_fonts'     => 'Combine Google Fonts',
-			'minify_html'             => 'Minify HTML',
 			'manual_preload'          => 'Preload',
 			'sitemap_preload'         => 'Sitemap Preload',
 			'cdn'                     => 'CDN Enabled',

--- a/inc/Engine/Admin/Deactivation/DeactivationIntent.php
+++ b/inc/Engine/Admin/Deactivation/DeactivationIntent.php
@@ -150,7 +150,6 @@ mixpanel.init("a36067b00a263cce0299cfd960e26ecf", {
 			'minify_concatenate_css' => 0,
 			'minify_js'              => 0,
 			'minify_concatenate_js'  => 0,
-			'minify_html'            => 0,
 			'minify_google_fonts'    => 0,
 			'cdn'                    => 0,
 		];

--- a/inc/Engine/Admin/Settings/Page.php
+++ b/inc/Engine/Admin/Settings/Page.php
@@ -547,10 +547,8 @@ class Page {
 		$this->settings->add_settings_sections(
 			[
 				'basic' => [
-					'title'  => __( 'Basic Settings', 'rocket' ),
-					'page'   => 'file_optimization',
-					// translators: %1$s = type of minification (HTML, CSS or JS), %2$s = “WP Rocket”.
-					'helper' => rocket_maybe_disable_minify_html() ? sprintf( __( '%1$s Minification is currently activated in <strong>Autoptimize</strong>. If you want to use %2$s’s minification, disable those options in Autoptimize.', 'rocket' ), 'HTML', WP_ROCKET_PLUGIN_NAME ) : '',
+					'title' => __( 'Basic Settings', 'rocket' ),
+					'page'  => 'file_optimization',
 				],
 				'css'   => [
 					'title'  => __( 'CSS Files', 'rocket' ),
@@ -577,21 +575,6 @@ class Page {
 
 		$this->settings->add_settings_fields(
 			[
-				'minify_html'            => [
-					'type'              => 'checkbox',
-					'label'             => __( 'Minify HTML', 'rocket' ),
-					'container_class'   => [
-						rocket_maybe_disable_minify_html() ? 'wpr-isDisabled' : '',
-					],
-					'description'       => __( 'Minifying HTML removes whitespace and comments to reduce the size.', 'rocket' ),
-					'section'           => 'basic',
-					'page'              => 'file_optimization',
-					'default'           => 0,
-					'sanitize_callback' => 'sanitize_checkbox',
-					'input_attr'        => [
-						'disabled' => rocket_maybe_disable_minify_html() ? 1 : 0,
-					],
-				],
 				'minify_google_fonts'    => [
 					'type'              => 'checkbox',
 					'label'             => __( 'Optimize Google Fonts', 'rocket' ),

--- a/inc/Engine/Admin/Settings/Settings.php
+++ b/inc/Engine/Admin/Settings/Settings.php
@@ -219,7 +219,6 @@ class Settings {
 		$input['do_caching_mobile_files'] = ! empty( $input['do_caching_mobile_files'] ) ? 1 : 0;
 
 		$input['minify_google_fonts'] = ! empty( $input['minify_google_fonts'] ) ? 1 : 0;
-		$input['minify_html']         = ! empty( $input['minify_html'] ) ? 1 : 0;
 
 		// Option : Minification CSS & JS.
 		$input['minify_css'] = ! empty( $input['minify_css'] ) ? 1 : 0;

--- a/inc/admin/ui/meta-boxes.php
+++ b/inc/admin/ui/meta-boxes.php
@@ -71,7 +71,6 @@ function rocket_display_cache_options_meta_boxes() {
 			$fields = [
 				'lazyload'         => __( 'LazyLoad for images', 'rocket' ),
 				'lazyload_iframes' => __( 'LazyLoad for iframes/videos', 'rocket' ),
-				'minify_html'      => __( 'Minify HTML', 'rocket' ),
 				'minify_css'       => __( 'Minify/combine CSS', 'rocket' ),
 				'minify_js'        => __( 'Minify/combine JS', 'rocket' ),
 				'cdn'              => __( 'CDN', 'rocket' ),
@@ -153,7 +152,6 @@ function rocket_save_metabox_options() {
 		$fields = [
 			'lazyload',
 			'lazyload_iframes',
-			'minify_html',
 			'minify_css',
 			'minify_js',
 			'cdn',

--- a/inc/admin/ui/notices.php
+++ b/inc/admin/ui/notices.php
@@ -155,7 +155,7 @@ function rocket_plugins_to_deactivate() {
 		$plugins['lazy-load-for-videos'] = 'lazy-load-for-videos/codeispoetry.php';
 	}
 
-	if ( get_rocket_option( 'minify_css' ) || get_rocket_option( 'minify_js' ) || get_rocket_option( 'minify_html' ) ) {
+	if ( get_rocket_option( 'minify_css' ) || get_rocket_option( 'minify_js' ) ) {
 		$plugins['wp-super-minify']         = 'wp-super-minify/wp-super-minify.php';
 		$plugins['bwp-minify']              = 'bwp-minify/bwp-minify.php';
 		$plugins['wp-minify']               = 'wp-minify/wp-minify.php';
@@ -168,11 +168,6 @@ function rocket_plugins_to_deactivate() {
 	if ( get_rocket_option( 'minify_css' ) || get_rocket_option( 'minify_js' ) ) {
 		$plugins['async-js-and-css']     = 'async-js-and-css/asyncJSandCSS.php';
 		$plugins['merge-minify-refresh'] = 'merge-minify-refresh/merge-minify-refresh.php';
-	}
-
-	if ( get_rocket_option( 'minify_html' ) ) {
-		$plugins['wp-html-compression'] = 'wp-html-compression/wp-html-compression.php';
-		$plugins['wp-compress-html']    = 'wp-compress-html/wp_compress_html.php';
 	}
 
 	if ( get_rocket_option( 'minify_js' ) ) {

--- a/inc/admin/upgrader.php
+++ b/inc/admin/upgrader.php
@@ -198,7 +198,6 @@ function rocket_first_install() {
 				'minify_js_key'               => $minify_js_key,
 				'minify_concatenate_js'       => 0,
 				'minify_google_fonts'         => 1,
-				'minify_html'                 => 0,
 				'manual_preload'              => 1,
 				'sitemap_preload'             => 0,
 				'sitemap_preload_url_crawl'   => '500000',
@@ -258,18 +257,6 @@ function rocket_new_upgrade( $wp_rocket_version, $actual_version ) {
 		delete_transient( 'rocket_ask_for_update' );
 	}
 
-	if ( version_compare( $actual_version, '2.6', '<' ) ) {
-		// Activate Inline CSS & JS minification if HTML minification is activated.
-		$options = get_option( WP_ROCKET_SLUG );
-
-		if ( ! empty( $options['minify_html'] ) ) {
-			$options['minify_html_inline_css'] = 1;
-			$options['minify_html_inline_js']  = 1;
-		}
-
-		update_option( WP_ROCKET_SLUG, $options );
-	}
-
 	if ( version_compare( $actual_version, '2.8', '<' ) ) {
 		$options                              = get_option( WP_ROCKET_SLUG );
 		$options['manual_preload']            = 1;
@@ -297,7 +284,6 @@ function rocket_new_upgrade( $wp_rocket_version, $actual_version ) {
 	if ( version_compare( $actual_version, '2.9.5', '<' ) ) {
 		if ( is_plugin_active( 'autoptimize/autoptimize.php' ) ) {
 			if ( 'on' === get_option( 'autoptimize_html' ) ) {
-				update_rocket_option( 'minify_html', 0 );
 				update_rocket_option( 'minify_html_inline_css', 0 );
 				update_rocket_option( 'minify_html_inline_js', 0 );
 			}

--- a/inc/admin/upgrader.php
+++ b/inc/admin/upgrader.php
@@ -283,11 +283,6 @@ function rocket_new_upgrade( $wp_rocket_version, $actual_version ) {
 	// Disable minification options if they're active in Autoptimize.
 	if ( version_compare( $actual_version, '2.9.5', '<' ) ) {
 		if ( is_plugin_active( 'autoptimize/autoptimize.php' ) ) {
-			if ( 'on' === get_option( 'autoptimize_html' ) ) {
-				update_rocket_option( 'minify_html_inline_css', 0 );
-				update_rocket_option( 'minify_html_inline_js', 0 );
-			}
-
 			if ( 'on' === get_option( 'autoptimize_css' ) ) {
 				update_rocket_option( 'minify_css', 0 );
 			}

--- a/tests/Fixtures/inc/admin/rocketFirstInstall.php
+++ b/tests/Fixtures/inc/admin/rocketFirstInstall.php
@@ -33,7 +33,6 @@ $default = [
 	'minify_js_key'               => 'minify_js_key_uniqid',
 	'minify_concatenate_js'       => 0,
 	'minify_google_fonts'         => 1,
-	'minify_html'                 => 0,
 	'manual_preload'              => 1,
 	'sitemap_preload'             => 0,
 	'sitemap_preload_url_crawl'   => '500000',

--- a/tests/Integration/inc/Engine/Admin/Deactivation/DeactivationIntent/activateSafeMode.php
+++ b/tests/Integration/inc/Engine/Admin/Deactivation/DeactivationIntent/activateSafeMode.php
@@ -64,7 +64,6 @@ class Test_ActivateSafeMode extends AjaxTestCase {
 			'minify_concatenate_css' => 0,
 			'minify_js'              => 0,
 			'minify_concatenate_js'  => 0,
-			'minify_html'            => 0,
 			'minify_google_fonts'    => 0,
 			'cdn'                    => 0,
 		];

--- a/tests/Unit/inc/Engine/Admin/Deactivation/DeactivationIntent/activateSafeMode.php
+++ b/tests/Unit/inc/Engine/Admin/Deactivation/DeactivationIntent/activateSafeMode.php
@@ -46,7 +46,6 @@ class Test_ActivateSafeMode extends TestCase {
 			'minify_concatenate_css' => 0,
 			'minify_js'              => 0,
 			'minify_concatenate_js'  => 0,
-			'minify_html'            => 0,
 			'minify_google_fonts'    => 0,
 			'cdn'                    => 0,
 		];


### PR DESCRIPTION
Sub-task for epic #2682 

### inc/admin/upgrader.php ✔️
- Remove the entry for `minify_html` in `rocket_first_install()`
- Remove the checks for `minify_html` in `rocket_new_upgrade()`

### inc/admin/ui/meta-boxes.php ✔️
- Remove `minify_html` from the `$fields` in `rocket_display_cache_options_meta_boxes()` and `rocket_save_metabox_options()`

### inc/admin/ui/notices.php ✔️ 
- Remove the checks for `minify_html` in `rocket_plugins_to_deactivate()`

### inc/Engine/Beacon/Beacon.php ✔️ 
- Remove `minify_html` from `session_data()`

### inc/Engine/Admin/Deactivation/DeactivationIntent.php ✔️
- Remove `minify_html` from `activate_safe_mode()`

### inc/Engine/Admin/Settings/Page.php ✔️
- Remove references to minify HTML option

### inc/Engine/Admin/Settings/Settings.php ✔️
- Remove references to `minify_html` in `sanitize_callback()`

+ Removed from fixture & Unit & Integration test `activateSafeMode.php`