### PR TITLE
RocketCDN integration tests home_url change

### DIFF
--- a/tests/Integration/inc/Engine/CDN/RocketCDN/APIClient/getSubscriptionData.php
+++ b/tests/Integration/inc/Engine/CDN/RocketCDN/APIClient/getSubscriptionData.php
@@ -2,10 +2,10 @@
 
 namespace WP_Rocket\Tests\Integration\inc\Engine\CDN\RocketCDN\APIClient;
 
-use WPMedia\PHPUnit\Integration\TestCase;
 use WPMedia\PHPUnit\Integration\ApiTrait;
 use WP_Rocket\Engine\CDN\RocketCDN\APIClient;
 use Brain\Monkey\Functions;
+use WP_Rocket\Tests\Integration\inc\Engine\CDN\RocketCDN\TestCase;
 
 /**
  * @covers \WP_Rocket\Engine\CDN\RocketCDN\APIClient::get_subscription_data
@@ -28,6 +28,7 @@ class Test_GetSubscriptionData extends TestCase {
 		parent::setUp();
 
 		$this->client = new APIClient();
+		add_filter( 'home_url', [ $this, 'home_url_cb' ] );
 	}
 
 	public function tearDown() {

--- a/tests/Integration/inc/Engine/CDN/RocketCDN/APIClient/purgeCacheRequest.php
+++ b/tests/Integration/inc/Engine/CDN/RocketCDN/APIClient/purgeCacheRequest.php
@@ -3,8 +3,9 @@
 namespace WP_Rocket\Tests\Integration\inc\Engine\CDN\RocketCDN\APIClient;
 
 use WPMedia\PHPUnit\Integration\ApiTrait;
-use WP_Rocket\Tests\Integration\TestCase;
 use WP_Rocket\Engine\CDN\RocketCDN\APIClient;
+use WP_Rocket\Tests\Integration\inc\Engine\CDN\RocketCDN\TestCase;
+
 
 /**
  * @covers \WP_Rocket\Engine\CDN\RocketCDN\APIClient::purge_cache_request
@@ -24,6 +25,11 @@ class Test_PurgeCacheRequest extends TestCase {
 		self::pathToApiCredentialsConfigFile( WP_ROCKET_TESTS_DIR . '/../env/local/' );
 	}
 
+	public function setUp() {
+		parent::setUp();
+		add_filter( 'home_url', [ $this, 'home_url_cb' ] );
+	}
+
 	public function tearDown() {
 		parent::tearDown();
 
@@ -39,6 +45,7 @@ class Test_PurgeCacheRequest extends TestCase {
 			$transient = [ 'id' => self::getApiCredential( 'ROCKETCDN_WEBSITE_ID' ) ];
 			$option    = self::getApiCredential( 'ROCKETCDN_TOKEN' );
 		}
+
 		set_transient( 'rocketcdn_status', $transient, MINUTE_IN_SECONDS );
 		if ( ! empty( $option ) ) {
 			update_option( 'rocketcdn_user_token', $option );

--- a/tests/Integration/inc/Engine/CDN/RocketCDN/TestCase.php
+++ b/tests/Integration/inc/Engine/CDN/RocketCDN/TestCase.php
@@ -6,7 +6,7 @@ use WP_Rocket\Tests\Integration\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase {
 	protected $cdn_names;
-	protected $home_url = 'http://example.org';
+	protected $home_url = 'http://myexample.org';
 
 	protected static $transients = [
 		'rocketcdn_status' => null,


### PR DESCRIPTION
Revisit RocketCDN integration tests and change the home_url() to the new website.

