### PR TITLE
Disable the Varnish purge on Cloudways when Varnish has been disabled…

### DIFF
--- a/inc/ThirdParty/Hostings/Cloudways.php
+++ b/inc/ThirdParty/Hostings/Cloudways.php
@@ -18,7 +18,7 @@ class Cloudways implements Subscriber_Interface {
 	 * @return array
 	 */
 	public static function get_subscribed_events() {
-		if ( ! isset( $_SERVER['cw_allowed_ip'] ) ) {
+		if ( ! isset( $_SERVER['cw_allowed_ip'] ) || ! self::is_varnish_running() ) {
 			return [];
 		}
 
@@ -28,6 +28,26 @@ class Cloudways implements Subscriber_Interface {
 			'rocket_varnish_field_settings'           => 'varnish_addon_title',
 			'rocket_varnish_ip'                       => 'varnish_ip',
 		];
+	}
+
+	/**
+	 * Determine if the Varnish server is up and running.
+	 *
+	 * @since 3.6.1
+	 */
+	private static function is_varnish_running() {
+		if ( ! isset( $_SERVER['HTTP_X_VARNISH'] ) ) {
+			return false;
+		}
+
+		if ( ! isset( $_SERVER['HTTP_X_APPLICATION'] ) ) {
+			return false;
+		}
+
+		if ( 'varnishpass' === trim( strtolower( $_SERVER['HTTP_X_APPLICATION'] ) ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+			return false;
+		}
+		return true;
 	}
 
 	/**

--- a/inc/ThirdParty/Hostings/Cloudways.php
+++ b/inc/ThirdParty/Hostings/Cloudways.php
@@ -44,10 +44,7 @@ class Cloudways implements Subscriber_Interface {
 			return false;
 		}
 
-		if ( 'varnishpass' === trim( strtolower( $_SERVER['HTTP_X_APPLICATION'] ) ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-			return false;
-		}
-		return true;
+		return ( 'varnishpass' !== trim( strtolower( $_SERVER['HTTP_X_APPLICATION'] ) ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 	}
 
 	/**

--- a/inc/ThirdParty/Hostings/Cloudways.php
+++ b/inc/ThirdParty/Hostings/Cloudways.php
@@ -18,13 +18,13 @@ class Cloudways implements Subscriber_Interface {
 	 * @return array
 	 */
 	public static function get_subscribed_events() {
-		if ( ! isset( $_SERVER['cw_allowed_ip'] ) || ! self::is_varnish_running() ) {
+		if ( ! isset( $_SERVER['cw_allowed_ip'] ) ) {
 			return [];
 		}
 
 		return [
 			'rocket_display_input_varnish_auto_purge' => 'return_false',
-			'do_rocket_varnish_http_purge'            => 'return_true',
+			'do_rocket_varnish_http_purge'            => 'should_purge',
 			'rocket_varnish_field_settings'           => 'varnish_addon_title',
 			'rocket_varnish_ip'                       => 'varnish_ip',
 		];
@@ -59,14 +59,14 @@ class Cloudways implements Subscriber_Interface {
 	}
 
 	/**
-	 * Returns true
+	 * Returns should purge Varnish.
 	 *
 	 * @since 3.5.5
 	 *
 	 * @return true
 	 */
-	public function return_true() {
-		return true;
+	public function should_purge() {
+		return self::is_varnish_running();
 	}
 
 	/**
@@ -78,6 +78,15 @@ class Cloudways implements Subscriber_Interface {
 	 * @return array
 	 */
 	public function varnish_addon_title( array $settings ) {
+		if ( ! self::is_varnish_running() ) {
+			$settings['varnish_auto_purge']['title'] = sprintf(
+				// Translators: %s = Hosting name.
+				__( 'Varnish auto-purge will be automatically enabled once Varnish is enabled on your %s server.', 'rocket' ),
+				'Cloudways'
+			);
+
+			return $settings;
+		}
 		$settings['varnish_auto_purge']['title'] = sprintf(
 			// Translators: %s = Hosting name.
 			__( 'Your site is hosted on %s, we have enabled Varnish auto-purge for compatibility.', 'rocket' ),
@@ -96,6 +105,9 @@ class Cloudways implements Subscriber_Interface {
 	 * @return array
 	 */
 	public function varnish_ip( $varnish_ip ) {
+		if ( ! self::is_varnish_running() ) {
+			return $varnish_ip;
+		}
 		if ( ! is_array( $varnish_ip ) ) {
 			$varnish_ip = (array) $varnish_ip;
 		}

--- a/tests/Fixtures/inc/ThirdParty/Hostings/Cloudways/varnishAddonTitle.php
+++ b/tests/Fixtures/inc/ThirdParty/Hostings/Cloudways/varnishAddonTitle.php
@@ -1,21 +1,61 @@
 <?php
 
 return [
+	'testShouldReplaceEmptyValueWithCloudwaysTitleNoVarnish' => [
+		'settings'      => [],
+		'config_server' => [],
+		'expected'      => [
+			'varnish_auto_purge' => [
+				'title' => 'Varnish auto-purge will be automatically enabled once Varnish is enabled on your Cloudways server.'
+			],
+		],
+	],
+	'testShouldReplaceEmptyValueWithCloudwaysTitleWithoutVarnishApp' => [
+		'settings'      => [],
+		'config_server' => [
+			'HTTP_X_VARNISH'     => 'HTTP_X_VARNISH',
+		],
+		'expected'      => [
+			'varnish_auto_purge' => [
+				'title' => 'Varnish auto-purge will be automatically enabled once Varnish is enabled on your Cloudways server.'
+			],
+		],
+	],
+	'testShouldReplaceEmptyValueWithCloudwaysTitleWithVarnishPass' => [
+		'settings'      => [],
+		'config_server' => [
+			'HTTP_X_VARNISH'     => 'HTTP_X_VARNISH',
+			'HTTP_X_APPLICATION' => 'varnishpass',
+		],
+		'expected'      => [
+			'varnish_auto_purge' => [
+				'title' => 'Varnish auto-purge will be automatically enabled once Varnish is enabled on your Cloudways server.'
+			],
+		],
+	],
 	'testShouldReplaceEmptyValueWithCloudwaysTitle' => [
-		'settings' => [],
-		'expected' => [
+		'settings'      => [],
+		'config_server' => [
+			'HTTP_X_VARNISH'     => 'HTTP_X_VARNISH',
+			'HTTP_X_APPLICATION' => 'HTTP_X_APPLICATION',
+		],
+		'expected'      => [
 			'varnish_auto_purge' => [
 				'title' => 'Your site is hosted on Cloudways, we have enabled Varnish auto-purge for compatibility.'
 			],
 		],
 	],
 	'testShouldReplaceDefaultTitleWithCloudwaysTitle' => [
-		'settings' => [
+		'settings'      => [
 			'varnish_auto_purge' => [
 				'title' => 'If Varnish runs on your server, you must activate this add-on.',
 			],
 		],
-		'expected' => [
+		'config_server' => [
+			'HTTP_X_VARNISH'     => 'HTTP_X_VARNISH',
+			'HTTP_X_APPLICATION' => 'HTTP_X_APPLICATION',
+		],
+		'expected'      => [
 			'varnish_auto_purge' => [
 				'title' => 'Your site is hosted on Cloudways, we have enabled Varnish auto-purge for compatibility.'
 			],

--- a/tests/Fixtures/inc/ThirdParty/Hostings/Cloudways/varnishIP.php
+++ b/tests/Fixtures/inc/ThirdParty/Hostings/Cloudways/varnishIP.php
@@ -1,31 +1,67 @@
 <?php
 
 return [
+	'testWhenEmptyArrayWithoutVarnishPermission' => [
+		'varnish_ip'    => [],
+		'config_server' => [],
+		'expected'      => [],
+	],
+	'testWhenEmptyArrayWithoutVarnishApp' => [
+		'varnish_ip'    => [],
+		'config_server' => [
+			'HTTP_X_VARNISH'     => 'HTTP_X_VARNISH',
+		],
+		'expected'      => [],
+	],
+	'testWhenEmptyArrayWithoutVarnishPass' => [
+		'varnish_ip'    => [],
+		'config_server' => [
+			'HTTP_X_VARNISH'     => 'HTTP_X_VARNISH',
+			'HTTP_X_APPLICATION' => 'varnishpass',
+		],
+		'expected'      => [],
+	],
 	'testWhenEmptyArray' => [
-		'varnish_ip' => [],
-		'expected'   => [
+		'varnish_ip'    => [],
+		'config_server' => [
+			'HTTP_X_VARNISH'     => 'HTTP_X_VARNISH',
+			'HTTP_X_APPLICATION' => 'HTTP_X_APPLICATION',
+		],
+		'expected'      => [
 			'127.0.0.1:8080',
 		],
 	],
 	'testWhenArrayWithData' => [
-		'varnish_ip' => [
+		'varnish_ip'    => [
 			'localhost',
 		],
-		'expected'   => [
+		'config_server' => [
+			'HTTP_X_VARNISH'     => 'HTTP_X_VARNISH',
+			'HTTP_X_APPLICATION' => 'HTTP_X_APPLICATION',
+		],
+		'expected'      => [
 			'localhost',
 			'127.0.0.1:8080',
 		],
 	],
 	'testWhenString' => [
-		'varnish_ip' => 'localhost',
-		'expected'   => [
+		'varnish_ip'    => 'localhost',
+		'config_server' => [
+			'HTTP_X_VARNISH'     => 'HTTP_X_VARNISH',
+			'HTTP_X_APPLICATION' => 'HTTP_X_APPLICATION',
+		],
+		'expected'      => [
 			'localhost',
 			'127.0.0.1:8080',
 		],
 	],
 	'testWhenBool' => [
-		'varnish_ip' => false,
-		'expected'   => [
+		'varnish_ip'    => false,
+		'config_server' => [
+			'HTTP_X_VARNISH'     => 'HTTP_X_VARNISH',
+			'HTTP_X_APPLICATION' => 'HTTP_X_APPLICATION',
+		],
+		'expected'      => [
 			false,
 			'127.0.0.1:8080',
 		],

--- a/tests/Integration/bootstrap.php
+++ b/tests/Integration/bootstrap.php
@@ -73,7 +73,9 @@ tests_add_filter(
 		}
 
 		if ( BootstrapManager::isGroup( 'Cloudways' ) ) {
-			$_SERVER['cw_allowed_ip'] = true;
+			$_SERVER['cw_allowed_ip']      = true;
+			$_SERVER['HTTP_X_VARNISH']     = 'VARNISH ID';
+			$_SERVER['HTTP_X_APPLICATION'] = 'APPLICATION NAME';
 		}
 
 		// Overload the license key for testing.

--- a/tests/Integration/bootstrap.php
+++ b/tests/Integration/bootstrap.php
@@ -73,9 +73,7 @@ tests_add_filter(
 		}
 
 		if ( BootstrapManager::isGroup( 'Cloudways' ) ) {
-			$_SERVER['cw_allowed_ip']      = true;
-			$_SERVER['HTTP_X_VARNISH']     = 'VARNISH ID';
-			$_SERVER['HTTP_X_APPLICATION'] = 'APPLICATION NAME';
+			$_SERVER['cw_allowed_ip'] = true;
 		}
 
 		// Overload the license key for testing.

--- a/tests/Integration/inc/ThirdParty/Hostings/Cloudways/varnishAddonTitle.php
+++ b/tests/Integration/inc/ThirdParty/Hostings/Cloudways/varnishAddonTitle.php
@@ -10,10 +10,25 @@ use WPMedia\PHPUnit\Integration\TestCase;
  * @group ThirdParty
  */
 class Test_VarnishAddonTitle extends TestCase {
+	public function tearDown() {
+		parent::tearDown();
+
+		// Reset after each test.
+		unset( $_SERVER['HTTP_X_VARNISH'] );
+		unset( $_SERVER['HTTP_X_APPLICATION'] );
+	}
+
 	/**
 	 * @dataProvider providerTestData
 	 */
-	public function testShouldDisplayVarnishTitleWithCloudways( $settings, $expected ) {
+	public function testShouldDisplayVarnishTitleWithCloudways( $settings, $config_server, $expected ) {
+		if ( isset( $config_server['HTTP_X_VARNISH'] ) ) {
+			$_SERVER['HTTP_X_VARNISH'] = $config_server['HTTP_X_VARNISH'];
+		}
+		if ( isset( $config_server['HTTP_X_APPLICATION'] ) ) {
+			$_SERVER['HTTP_X_APPLICATION'] = $config_server['HTTP_X_APPLICATION'];
+		}
+
 		$this->assertSame(
 			$expected,
 			apply_filters( 'rocket_varnish_field_settings', $settings )

--- a/tests/Integration/inc/ThirdParty/Hostings/Cloudways/varnishIP.php
+++ b/tests/Integration/inc/ThirdParty/Hostings/Cloudways/varnishIP.php
@@ -10,10 +10,25 @@ use WPMedia\PHPUnit\Integration\TestCase;
  * @group ThirdParty
  */
 class Test_VarnishIP extends TestCase {
+	public function tearDown() {
+		parent::tearDown();
+
+		// Reset after each test.
+		unset( $_SERVER['HTTP_X_VARNISH'] );
+		unset( $_SERVER['HTTP_X_APPLICATION'] );
+	}
+
 	/**
 	 * @dataProvider providerTestData
 	 */
-	public function testShouldReturnCloudwaysVarnishIP( $varnish_ip, $expected ) {
+	public function testShouldReturnCloudwaysVarnishIP( $varnish_ip, $config_server, $expected ) {
+		if ( isset( $config_server['HTTP_X_VARNISH'] ) ) {
+			$_SERVER['HTTP_X_VARNISH'] = $config_server['HTTP_X_VARNISH'];
+		}
+		if ( isset( $config_server['HTTP_X_APPLICATION'] ) ) {
+			$_SERVER['HTTP_X_APPLICATION'] = $config_server['HTTP_X_APPLICATION'];
+		}
+
 		$this->assertSame(
 			$expected,
 			apply_filters( 'rocket_varnish_ip', $varnish_ip )

--- a/tests/Unit/inc/ThirdParty/Hostings/Cloudways/varnishAddonTitle.php
+++ b/tests/Unit/inc/ThirdParty/Hostings/Cloudways/varnishAddonTitle.php
@@ -12,10 +12,25 @@ use WPMedia\PHPUnit\Unit\TestCase;
 class Test_VarnishAddonTitle extends TestCase {
 	protected static $mockCommonWpFunctionsInSetUp = true;
 
+	public function tearDown() {
+		parent::tearDown();
+
+		// Reset after each test.
+		unset( $_SERVER['HTTP_X_VARNISH'] );
+		unset( $_SERVER['HTTP_X_APPLICATION'] );
+	}
+
 	/**
 	 * @dataProvider providerTestData
 	 */
-	public function testShouldDisplayVarnishTitleWithCloudways( $settings, $expected ) {
+	public function testShouldDisplayVarnishTitleWithCloudways( $settings, $config_server,$expected ) {
+		if ( isset( $config_server['HTTP_X_VARNISH'] ) ) {
+			$_SERVER['HTTP_X_VARNISH'] = $config_server['HTTP_X_VARNISH'];
+		}
+		if ( isset( $config_server['HTTP_X_APPLICATION'] ) ) {
+			$_SERVER['HTTP_X_APPLICATION'] = $config_server['HTTP_X_APPLICATION'];
+		}
+
 		$cloudways = new Cloudways();
 
 		$this->assertSame(

--- a/tests/Unit/inc/ThirdParty/Hostings/Cloudways/varnishIP.php
+++ b/tests/Unit/inc/ThirdParty/Hostings/Cloudways/varnishIP.php
@@ -10,10 +10,24 @@ use WPMedia\PHPUnit\Unit\TestCase;
  * @group ThirdParty
  */
 class Test_VarnishIP extends TestCase {
+	public function tearDown() {
+		parent::tearDown();
+
+		// Reset after each test.
+		unset( $_SERVER['HTTP_X_VARNISH'] );
+		unset( $_SERVER['HTTP_X_APPLICATION'] );
+	}
 	/**
 	 * @dataProvider providerTestData
 	 */
-	public function testShouldReturnCloudwaysVarnishIP( $varnish_ip, $expected ) {
+	public function testShouldReturnCloudwaysVarnishIP( $varnish_ip, $config_server, $expected ) {
+		if ( isset( $config_server['HTTP_X_VARNISH'] ) ) {
+			$_SERVER['HTTP_X_VARNISH'] = $config_server['HTTP_X_VARNISH'];
+		}
+		if ( isset( $config_server['HTTP_X_APPLICATION'] ) ) {
+			$_SERVER['HTTP_X_APPLICATION'] = $config_server['HTTP_X_APPLICATION'];
+		}
+
 		$cloudways = new Cloudways();
 
 		$this->assertSame(


### PR DESCRIPTION
Closes #2668 

### Scope a solution ✅ 
In `inc/ThirdParty/Hostings/Cloudways.php`, update the check in `get_subscribed_events()` to also check for `HTTP_X_VARNISH` & `HTTP_X_APPLICATION` values, following this logic:
- X-Varnish → True → X-Application → varnishpass → return false
- X-Varnish → True → X-Application → other than varnishpass → Go to function
- X-Varnish → False → return false

### Estimate the effort ✅ 
Effort `[XS]`