### PR TITLE
Closes #1523 Wildcards do not work in Always Purge URL(s)

### DIFF
--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -113,24 +113,20 @@ function rocket_get_purge_urls( $post_id, $post ) {
 		}
 
 		foreach ( $cache_purge_pages as $page ) {
-			if ( false !== strpos( $page, '(.*)' ) ) {
+			//check if it contains regex pattern
+			if ( strstr( $page, '*' ) ) {
 				$matches_files = _rocket_get_recursive_dir_files_by_regex( '#' . $page . '#i' );
 				foreach ( $matches_files as $file ) {
-					$pathname = $file->getPathname();
-					$filetype = $file->getType();
-					if ( ! empty( $filetype ) ) {
+					if ( ! empty( $file->getType() ) ) {
 						continue;
 					}
 
 					// Convert path to URL.
-					$home_url_slashed = untrailingslashit( $home_url ) . '/';
-					$page             = str_replace( [ rocket_get_constant( 'WP_ROCKET_CACHE_PATH' ) ], [ $home_url_slashed ], $pathname );
-					$purge_urls[] = $page;
+					$purge_urls[] = str_replace( rocket_get_constant( 'WP_ROCKET_CACHE_PATH' ), untrailingslashit( $home_url ) . '/', $file->getPathname() );
 				}
 				continue;
 			}
-			$page = trailingslashit( $home_url ) . $page;
-			$purge_urls[] = $page;
+			$purge_urls[] = trailingslashit( $home_url ) . $page;
 		}
 	}
 

--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -137,11 +137,11 @@ function rocket_get_purge_urls( $post_id, $post ) {
 	$parents = get_post_ancestors( $post_id );
 	if ( (bool) $parents ) {
 		foreach ( $parents as $parent_id ) {
-			array_push( $purge_urls, get_permalink( $parent_id ) );
+			$purge_urls[] = get_permalink( $parent_id );
 		}
 	}
 
-	return $purge_urls;
+	return array_flip( array_flip( $purge_urls ) );
 }
 
 /**

--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -112,13 +112,15 @@ function rocket_get_purge_urls( $post_id, $post ) {
 			restore_current_blog();
 		}
 
+		$cache_path = rocket_get_constant( 'WP_ROCKET_CACHE_PATH' ) . wp_parse_url( $home_url, PHP_URL_HOST );
+
 		foreach ( $cache_purge_pages as $page ) {
 			// Check if it contains regex pattern.
 			if ( strstr( $page, '*' ) ) {
 				$matches_files = _rocket_get_recursive_dir_files_by_regex( '#' . $page . '#i' );
 				foreach ( $matches_files as $file ) {
 					// Convert path to URL.
-					$purge_urls[] = str_replace( rocket_get_constant( 'WP_ROCKET_CACHE_PATH' ), untrailingslashit( $home_url ) . '/', $file->getPath() );
+					$purge_urls[] = str_replace( $cache_path, untrailingslashit( $home_url ) , $file->getPath() );
 				}
 				continue;
 			}

--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -112,7 +112,9 @@ function rocket_get_purge_urls( $post_id, $post ) {
 			restore_current_blog();
 		}
 
-		$cache_path = rocket_get_constant( 'WP_ROCKET_CACHE_PATH' ) . wp_parse_url( $home_url, PHP_URL_HOST );
+		$home_parts = get_rocket_parse_url( $home_url );
+		$home_url   = "{$home_parts['scheme']}://{$home_parts['host']}";
+		$cache_path = rocket_get_constant( 'WP_ROCKET_CACHE_PATH' ) . $home_parts['host'];
 
 		foreach ( $cache_purge_pages as $page ) {
 			// Check if it contains regex pattern.

--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -125,7 +125,7 @@ function rocket_get_purge_urls( $post_id, $post ) {
 
 		foreach ( $cache_purge_pages as $page ) {
 			if ( strpos( $page, '(.*)' ) ) {
-				$matches_files = rocket_get_recursive_dir_files_by_regex( '#' . $page . '#i' );
+				$matches_files = _rocket_get_recursive_dir_files_by_regex( '#' . $page . '#i' );
 				foreach ( $matches_files as $file ) {
 					$pathname = $file->getPathname();
 					$filetype = pathinfo( $pathname, PATHINFO_EXTENSION );

--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -41,18 +41,6 @@ add_filter( 'widget_update_callback', 'rocket_widget_update_callback' );
 function rocket_get_purge_urls( $post_id, $post ) {
 	$purge_urls = [];
 
-	// Get the post language.
-	$i18n_plugin = rocket_has_i18n();
-	$lang        = false;
-
-	if ( 'wpml' === $i18n_plugin && ! rocket_is_plugin_active( 'woocommerce-multilingual/wpml-woocommerce.php' ) ) {
-		// WPML.
-		$lang = $GLOBALS['sitepress']->get_language_for_element( $post_id, 'post_' . get_post_type( $post_id ) );
-	} elseif ( 'polylang' === $i18n_plugin && function_exists( 'pll_get_post_language' ) ) {
-		// Polylang.
-		$lang = pll_get_post_language( $post_id );
-	}
-
 	// Get the permalink structure.
 	$permalink_structure = get_rocket_sample_permalink( $post_id );
 
@@ -61,17 +49,18 @@ function rocket_get_purge_urls( $post_id, $post ) {
 
 	// Add permalink.
 	if ( rocket_extract_url_component( $permalink, PHP_URL_PATH ) !== '/' ) {
-		array_push( $purge_urls, $permalink );
+		$purge_urls[] = $permalink;
 	}
 
 	// Add Posts page.
 	if ( 'post' === $post->post_type && (int) get_option( 'page_for_posts' ) > 0 ) {
-		array_push( $purge_urls, get_permalink( get_option( 'page_for_posts' ) ) );
+		$purge_urls[] = get_permalink( get_option( 'page_for_posts' ) );
 	}
 
 	// Add Post Type archive.
-	if ( 'post' !== $post->post_type ) {
-		$post_type_archive = get_post_type_archive_link( get_post_type( $post_id ) );
+	$post_type = $post->post_type;
+	if ( 'post' !== $post_type ) {
+		$post_type_archive = get_post_type_archive_link( $post_type );
 		if ( $post_type_archive ) {
 			// Rename the caching filename for SSL URLs.
 			$filename = 'index';
@@ -80,34 +69,34 @@ function rocket_get_purge_urls( $post_id, $post ) {
 			}
 
 			$post_type_archive = trailingslashit( $post_type_archive );
-			array_push( $purge_urls, $post_type_archive . $filename . '.html' );
-			array_push( $purge_urls, $post_type_archive . $filename . '.html_gzip' );
-			array_push( $purge_urls, $post_type_archive . $GLOBALS['wp_rewrite']->pagination_base );
+			$purge_urls[] = $post_type_archive . $filename . '.html';
+			$purge_urls[] = $post_type_archive . $filename . '.html_gzip';
+			$purge_urls[] = $post_type_archive . $filename . $GLOBALS['wp_rewrite']->pagination_base;
 		}
 	}
 
 	// Add next post.
 	$next_post = get_adjacent_post( false, '', false );
 	if ( $next_post ) {
-		array_push( $purge_urls, get_permalink( $next_post ) );
+		$purge_urls[] = get_permalink( $next_post );
 	}
 
 	// Add next post in same category.
 	$next_in_same_cat_post = get_adjacent_post( true, '', false );
 	if ( $next_in_same_cat_post && $next_in_same_cat_post !== $next_post ) {
-		array_push( $purge_urls, get_permalink( $next_in_same_cat_post ) );
+		$purge_urls[] = get_permalink( $next_in_same_cat_post );
 	}
 
 	// Add previous post.
 	$previous_post = get_adjacent_post( false, '', true );
 	if ( $previous_post ) {
-		array_push( $purge_urls, get_permalink( $previous_post ) );
+		$purge_urls[] = get_permalink( $previous_post );
 	}
 
 	// Add previous post in same category.
 	$previous_in_same_cat_post = get_adjacent_post( true, '', true );
 	if ( $previous_in_same_cat_post && $previous_in_same_cat_post !== $previous_post ) {
-		array_push( $purge_urls, get_permalink( $previous_in_same_cat_post ) );
+		$purge_urls[] = get_permalink( $previous_in_same_cat_post );
 	}
 
 	// Add urls page to purge every time a post is save.
@@ -146,8 +135,7 @@ function rocket_get_purge_urls( $post_id, $post ) {
 	}
 
 	// Add the author page.
-	$purge_author = [ get_author_posts_url( $post->post_author ) ];
-	$purge_urls   = array_merge( $purge_urls, $purge_author );
+	$purge_urls[] = get_author_posts_url( $post->post_author );
 
 	// Add all parents.
 	$parents = get_post_ancestors( $post_id );

--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -69,9 +69,9 @@ function rocket_get_purge_urls( $post_id, $post ) {
 			}
 
 			$post_type_archive = trailingslashit( $post_type_archive );
-			$purge_urls[] = $post_type_archive . $filename . '.html';
-			$purge_urls[] = $post_type_archive . $filename . '.html_gzip';
-			$purge_urls[] = $post_type_archive . $filename . $GLOBALS['wp_rewrite']->pagination_base;
+			$purge_urls[]      = $post_type_archive . $filename . '.html';
+			$purge_urls[]      = $post_type_archive . $filename . '.html_gzip';
+			$purge_urls[]      = $post_type_archive . $filename . $GLOBALS['wp_rewrite']->pagination_base;
 		}
 	}
 
@@ -113,7 +113,7 @@ function rocket_get_purge_urls( $post_id, $post ) {
 		}
 
 		foreach ( $cache_purge_pages as $page ) {
-			//check if it contains regex pattern
+			// Check if it contains regex pattern.
 			if ( strstr( $page, '*' ) ) {
 				$matches_files = _rocket_get_recursive_dir_files_by_regex( '#' . $page . '#i' );
 				foreach ( $matches_files as $file ) {

--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -124,6 +124,22 @@ function rocket_get_purge_urls( $post_id, $post ) {
 		}
 
 		foreach ( $cache_purge_pages as $page ) {
+			if ( strpos( $page, '(.*)' ) ) {
+				$matches_files = rocket_get_recursive_dir_files_by_regex( '#' . $page . '#i' );
+				foreach ( $matches_files as $file ) {
+					$pathname = $file->getPathname();
+					$filetype = pathinfo( $pathname, PATHINFO_EXTENSION );
+					if ( ! empty( $filetype ) ) {
+						continue;
+					}
+
+					// Convert path to URL.
+					$home_url_slashed = untrailingslashit( $home_url ) . '/';
+					$page             = str_replace( [ WP_ROCKET_CACHE_PATH, '.' ], [ $home_url_slashed, '' ], $pathname );
+					array_push( $purge_urls, $page );
+				}
+				continue;
+			}
 			$page = trailingslashit( $home_url ) . $page;
 			array_push( $purge_urls, $page );
 		}

--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -117,12 +117,8 @@ function rocket_get_purge_urls( $post_id, $post ) {
 			if ( strstr( $page, '*' ) ) {
 				$matches_files = _rocket_get_recursive_dir_files_by_regex( '#' . $page . '#i' );
 				foreach ( $matches_files as $file ) {
-					if ( ! empty( $file->getType() ) ) {
-						continue;
-					}
-
 					// Convert path to URL.
-					$purge_urls[] = str_replace( rocket_get_constant( 'WP_ROCKET_CACHE_PATH' ), untrailingslashit( $home_url ) . '/', $file->getPathname() );
+					$purge_urls[] = str_replace( rocket_get_constant( 'WP_ROCKET_CACHE_PATH' ), untrailingslashit( $home_url ) . '/', $file->getPath() );
 				}
 				continue;
 			}

--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -113,24 +113,24 @@ function rocket_get_purge_urls( $post_id, $post ) {
 		}
 
 		foreach ( $cache_purge_pages as $page ) {
-			if ( strpos( $page, '(.*)' ) ) {
+			if ( false !== strpos( $page, '(.*)' ) ) {
 				$matches_files = _rocket_get_recursive_dir_files_by_regex( '#' . $page . '#i' );
 				foreach ( $matches_files as $file ) {
 					$pathname = $file->getPathname();
-					$filetype = pathinfo( $pathname, PATHINFO_EXTENSION );
+					$filetype = $file->getType();
 					if ( ! empty( $filetype ) ) {
 						continue;
 					}
 
 					// Convert path to URL.
 					$home_url_slashed = untrailingslashit( $home_url ) . '/';
-					$page             = str_replace( [ WP_ROCKET_CACHE_PATH, '.' ], [ $home_url_slashed, '' ], $pathname );
-					array_push( $purge_urls, $page );
+					$page             = str_replace( [ rocket_get_constant( 'WP_ROCKET_CACHE_PATH' ) ], [ $home_url_slashed ], $pathname );
+					$purge_urls[] = $page;
 				}
 				continue;
 			}
 			$page = trailingslashit( $home_url ) . $page;
-			array_push( $purge_urls, $page );
+			$purge_urls[] = $page;
 		}
 	}
 

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -1461,7 +1461,9 @@ function _rocket_get_wp_rocket_cache_path() { // phpcs:ignore WordPress.NamingCo
 function _rocket_get_recursive_dir_files_by_regex( $regex ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
 	try {
 		$cache_path = _rocket_get_wp_rocket_cache_path();
-		$iterator   = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $cache_path ) );
+		$iterator   = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator( $cache_path, FilesystemIterator::SKIP_DOTS  )
+		);
 		return new RegexIterator( $iterator, $regex, RecursiveRegexIterator::MATCH );
 	} catch ( Exception $e ) {
 		return [];

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -1458,7 +1458,7 @@ function _rocket_get_wp_rocket_cache_path() { // phpcs:ignore WordPress.NamingCo
  *
  * @return array|RegexIterator List of files which match the regular expression (SplFileInfo).
  */
-function _rocket_get_recursive_dir_files_by_regex( $regex ) {
+function _rocket_get_recursive_dir_files_by_regex( $regex ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
 	try {
 		$cache_path = _rocket_get_wp_rocket_cache_path();
 		$iterator   = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $cache_path ) );

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -1458,7 +1458,7 @@ function _rocket_get_wp_rocket_cache_path() { // phpcs:ignore WordPress.NamingCo
  *
  * @return array|RegexIterator List of files which match the regular expression (SplFileInfo).
  */
-function rocket_get_recursive_dir_files_by_regex( $regex ) {
+function _rocket_get_recursive_dir_files_by_regex( $regex ) {
 	try {
 		$cache_path = _rocket_get_wp_rocket_cache_path();
 		$iterator   = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $cache_path ) );

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -1450,3 +1450,20 @@ function _rocket_is_windows_fs( $hard_reset = false ) { // phpcs:ignore WordPres
 function _rocket_get_wp_rocket_cache_path() { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
 	return _rocket_normalize_path( rocket_get_constant( 'WP_ROCKET_CACHE_PATH' ) );
 }
+
+/**
+ * Get recursive files matched by regex.
+ *
+ * @param string $regex Regular Expression to be applied.
+ *
+ * @return array|RegexIterator List of files which match the regular expression (SplFileInfo).
+ */
+function rocket_get_recursive_dir_files_by_regex( $regex ) {
+	try {
+		$cache_path = _rocket_get_wp_rocket_cache_path();
+		$iterator   = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $cache_path ) );
+		return new RegexIterator( $iterator, $regex, RecursiveRegexIterator::MATCH );
+	} catch ( Exception $e ) {
+		return [];
+	}
+}

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -1462,7 +1462,7 @@ function _rocket_get_recursive_dir_files_by_regex( $regex ) { // phpcs:ignore Wo
 	try {
 		$cache_path = _rocket_get_wp_rocket_cache_path();
 		$iterator   = new RecursiveIteratorIterator(
-			new RecursiveDirectoryIterator( $cache_path, FilesystemIterator::SKIP_DOTS  )
+			new RecursiveDirectoryIterator( $cache_path, FilesystemIterator::SKIP_DOTS )
 		);
 		return new RegexIterator( $iterator, $regex, RecursiveRegexIterator::MATCH );
 	} catch ( Exception $e ) {

--- a/tests/Fixtures/inc/common/rocketGetPurgeUrls.php
+++ b/tests/Fixtures/inc/common/rocketGetPurgeUrls.php
@@ -7,9 +7,13 @@ return [
 		'wp-content' => [
 			'cache' => [
 				'wp-rocket' => [
-					'test_purge.html' => '',
+					'test_purge' => [
+						'index.html' => ''
+					],
 					'folder_1' => [
-						'test_purge.html' => ''
+						'test_purge' => [
+							'index.html' => ''
+						]
 					]
 				]
 			]
@@ -18,20 +22,20 @@ return [
 
 	'urls' => [
 		'posts' => [
-			2 => 'http://www.example.org/next_post',
-			3 => 'http://www.example.org/test_parent',
-			4 => 'http://www.example.org/test_parent_2',
-			5 => 'http://www.example.org/test2',
-			6 => 'http://www.example.org/test3',
-			20 => 'http://www.example.org/blog'
+			20 => 'http://example.org/blog/',
+			2 => 'http://example.org/next_post/',
+			3 => 'http://example.org/test_parent/',
+			4 => 'http://example.org/test_parent_2/',
+			5 => 'http://example.org/test2/',
+			6 => 'http://example.org/test3/'
 		],
 		'authors' => [
-			1 => 'http://www.example.org/author/author_name'
+			1 => 'http://example.org/author/author_name/'
 		],
 		'archives' => [
 			'page' => false,
-			'post' => 'http://www.example.org/',
-			'custompost' => 'http://www.example.org/custompost/',
+			'post' => 'http://example.org/',
+			'custompost' => 'http://example.org/custompost/',
 		]
 	],
 
@@ -46,7 +50,7 @@ return [
 				'post_data' => [
 					'ID' => 1,
 					'post_name' => 'test',
-					'url' => '/test',
+					'url' => '/test/',
 					'post_type' => 'post',
 					'next_post_id' => 2,
 					'post_author' => 1,
@@ -54,12 +58,12 @@ return [
 				]
 			],
 			'expected' => [
-				'http://www.example.org/test',
-				'http://www.example.org/blog',
-				'http://www.example.org/next_post',
-				'http://www.example.org/author/author_name',
-				'http://www.example.org/test_parent',
-				'http://www.example.org/test_parent_2'
+				'http://example.org/test/',
+				'http://example.org/blog/',
+				'http://example.org/next_post/',
+				'http://example.org/author/author_name/',
+				'http://example.org/test_parent/',
+				'http://example.org/test_parent_2/'
 			]
 		],
 
@@ -71,21 +75,18 @@ return [
 				],
 				'post_data' => [
 					'ID' => 1,
-					'post_name' => 'test',
-					'url' => '/test',
+					'post_name' => 'test_page',
+					'url' => '/test_page/',
 					'post_type' => 'page',
-					'next_post_id' => 2,
-					'post_author' => 1,
-					'ancestors' => [ 3, 4 ]
+					'next_post_id' => 20,
+					'post_author' => 1
 				],
 
 			],
 			'expected' => [
-				'http://www.example.org/test',
-				'http://www.example.org/next_post',
-				'http://www.example.org/author/author_name',
-				'http://www.example.org/test_parent',
-				'http://www.example.org/test_parent_2'
+				'http://example.org/test_page/',
+				'http://example.org/blog/',
+				'http://example.org/author/author_name/'
 			]
 		],
 
@@ -98,9 +99,8 @@ return [
 				'post_data' => [
 					'ID' => 1,
 					'post_name' => 'test_custom_post',
-					'url' => '/test_custom_post',
+					'url' => '/custompost/test_custom_post/',
 					'post_type' => 'custompost',
-					'next_post_id' => 2,
 					'post_author' => 1,
 					'ancestors' => [ 3, 4 ]
 				],
@@ -108,14 +108,13 @@ return [
 				'is_ssl' => false,
 			],
 			'expected' => [
-				'http://www.example.org/test_custom_post',
-				'http://www.example.org/custompost/index.html',
-				'http://www.example.org/custompost/index.html_gzip',
-				'http://www.example.org/custompost/indexpage',
-				'http://www.example.org/next_post',
-				'http://www.example.org/author/author_name',
-				'http://www.example.org/test_parent',
-				'http://www.example.org/test_parent_2'
+				'http://example.org/custompost/test_custom_post/',
+				'http://example.org/custompost/index.html',
+				'http://example.org/custompost/index.html_gzip',
+				'http://example.org/custompost/indexpage',
+				'http://example.org/author/author_name/',
+				'http://example.org/test_parent/',
+				'http://example.org/test_parent_2/'
 			]
 		],
 
@@ -128,8 +127,8 @@ return [
 
 				'post_data' => [
 					'ID' => 1,
-					'post_name' => 'test',
-					'url' => '/test',
+					'post_name' => 'test_prev',
+					'url' => '/test_prev/',
 					'post_type' => 'post',
 					'next_post_id' => 2,
 					'prev_post_id' => 5,
@@ -139,14 +138,14 @@ return [
 				]
 			],
 			'expected' => [
-				'http://www.example.org/test',
-				'http://www.example.org/blog',
-				'http://www.example.org/next_post',
-				'http://www.example.org/test2',
-				'http://www.example.org/test3',
-				'http://www.example.org/author/author_name',
-				'http://www.example.org/test_parent',
-				'http://www.example.org/test_parent_2'
+				'http://example.org/test_prev/',
+				'http://example.org/blog/',
+				'http://example.org/next_post/',
+				'http://example.org/test2/',
+				'http://example.org/test3/',
+				'http://example.org/author/author_name/',
+				'http://example.org/test_parent/',
+				'http://example.org/test_parent_2/'
 			]
 		],
 
@@ -154,7 +153,7 @@ return [
 			'config' => [
 				'options' => [
 					'page_for_posts' => 20,
-					'home' => 'http://www.example.org/',
+					'home' => 'http://example.org',
 					'cache_purge_pages' => [
 						'(.*)test_purge'
 					]
@@ -162,8 +161,8 @@ return [
 
 				'post_data' => [
 					'ID' => 1,
-					'post_name' => 'test',
-					'url' => '/test',
+					'post_name' => 'test_purge_post',
+					'url' => '/test_purge_post/',
 					'post_type' => 'post',
 					'next_post_id' => 2,
 					'post_author' => 1,
@@ -171,12 +170,12 @@ return [
 				]
 			],
 			'expected' => [
-				'http://www.example.org/test',
-				'http://www.example.org/blog',
-				'http://www.example.org/next_post',
-				'http://www.example.org/author/author_name',
-				'http://www.example.org/test_parent',
-				'http://www.example.org/test_parent_2'
+				'http://example.org/test_purge_post/',
+				'http://example.org/blog/',
+				'http://example.org/next_post/',
+				'http://example.org/author/author_name/',
+				'http://example.org/test_parent/',
+				'http://example.org/test_parent_2/'
 			]
 		],
 

--- a/tests/Fixtures/inc/common/rocketGetPurgeUrls.php
+++ b/tests/Fixtures/inc/common/rocketGetPurgeUrls.php
@@ -173,6 +173,8 @@ return [
 				'http://example.org/test_purge_post/',
 				'http://example.org/blog/',
 				'http://example.org/next_post/',
+				'http://example.org/test_purge',
+				'http://example.org/folder_1/test_purge',
 				'http://example.org/author/author_name/',
 				'http://example.org/test_parent/',
 				'http://example.org/test_parent_2/'

--- a/tests/Fixtures/inc/common/rocketGetPurgeUrls.php
+++ b/tests/Fixtures/inc/common/rocketGetPurgeUrls.php
@@ -1,0 +1,183 @@
+<?php
+
+return [
+	'vfs_dir' => 'wp-content/cache/wp-rocket/',
+
+	'structure' => [
+		'wp-content' => [
+			'cache' => [
+				'wp-rocket' => [
+					'test_purge.html' => ''
+				]
+			]
+		]
+	],
+
+	'urls' => [
+		'posts' => [
+			2 => 'http://www.example.org/next_post',
+			3 => 'http://www.example.org/test_parent',
+			4 => 'http://www.example.org/test_parent_2',
+			5 => 'http://www.example.org/test2',
+			6 => 'http://www.example.org/test3',
+			20 => 'http://www.example.org/blog'
+		],
+		'authors' => [
+			1 => 'http://www.example.org/author/author_name'
+		],
+		'archives' => [
+			'page' => false,
+			'post' => 'http://www.example.org/',
+			'custompost' => 'http://www.example.org/custompost/',
+		]
+	],
+
+	'test_data' => [
+		'shouldReturnPostUrls' => [
+			'config' => [
+				'options' => [
+					'page_for_posts' => 20,
+					'cache_purge_pages' => false
+				],
+
+				'post_data' => [
+					'ID' => 1,
+					'post_name' => 'test',
+					'url' => '/test',
+					'post_type' => 'post',
+					'next_post_id' => 2,
+					'post_author' => 1,
+					'ancestors' => [ 3, 4 ]
+				]
+			],
+			'expected' => [
+				'http://www.example.org/test',
+				'http://www.example.org/blog',
+				'http://www.example.org/next_post',
+				'http://www.example.org/author/author_name',
+				'http://www.example.org/test_parent',
+				'http://www.example.org/test_parent_2'
+			]
+		],
+
+		'shouldReturnPageUrls' => [
+			'config' => [
+				'options' => [
+					'page_for_posts' => 20,
+					'cache_purge_pages' => false
+				],
+				'post_data' => [
+					'ID' => 1,
+					'post_name' => 'test',
+					'url' => '/test',
+					'post_type' => 'page',
+					'next_post_id' => 2,
+					'post_author' => 1,
+					'ancestors' => [ 3, 4 ]
+				],
+
+			],
+			'expected' => [
+				'http://www.example.org/test',
+				'http://www.example.org/next_post',
+				'http://www.example.org/author/author_name',
+				'http://www.example.org/test_parent',
+				'http://www.example.org/test_parent_2'
+			]
+		],
+
+		'shouldReturnCustomPostUrls' => [
+			'config' => [
+				'options' => [
+					'page_for_posts' => 20,
+					'cache_purge_pages' => false
+				],
+				'post_data' => [
+					'ID' => 1,
+					'post_name' => 'test_custom_post',
+					'url' => '/test_custom_post',
+					'post_type' => 'custompost',
+					'next_post_id' => 2,
+					'post_author' => 1,
+					'ancestors' => [ 3, 4 ]
+				],
+
+				'is_ssl' => false,
+			],
+			'expected' => [
+				'http://www.example.org/test_custom_post',
+				'http://www.example.org/custompost/index.html',
+				'http://www.example.org/custompost/index.html_gzip',
+				'http://www.example.org/custompost/indexpage',
+				'http://www.example.org/next_post',
+				'http://www.example.org/author/author_name',
+				'http://www.example.org/test_parent',
+				'http://www.example.org/test_parent_2'
+			]
+		],
+
+		'shouldReturnPostUrlsWithPreviousPost' => [
+			'config' => [
+				'options' => [
+					'page_for_posts' => 20,
+					'cache_purge_pages' => false
+				],
+
+				'post_data' => [
+					'ID' => 1,
+					'post_name' => 'test',
+					'url' => '/test',
+					'post_type' => 'post',
+					'next_post_id' => 2,
+					'prev_post_id' => 5,
+					'prev_in_term_post_id' => 6,
+					'post_author' => 1,
+					'ancestors' => [ 3, 4 ]
+				]
+			],
+			'expected' => [
+				'http://www.example.org/test',
+				'http://www.example.org/blog',
+				'http://www.example.org/next_post',
+				'http://www.example.org/test2',
+				'http://www.example.org/test3',
+				'http://www.example.org/author/author_name',
+				'http://www.example.org/test_parent',
+				'http://www.example.org/test_parent_2'
+			]
+		],
+
+		'shouldReturnPostUrlsWithPurgeUrls' => [
+			'config' => [
+				'options' => [
+					'page_for_posts' => 20,
+					'home' => 'http://www.example.org/',
+					'cache_purge_pages' => [
+						'test_purge'
+					]
+				],
+
+				'post_data' => [
+					'ID' => 1,
+					'post_name' => 'test',
+					'url' => '/test',
+					'post_type' => 'post',
+					'next_post_id' => 2,
+					'post_author' => 1,
+					'ancestors' => [ 3, 4 ]
+				]
+			],
+			'expected' => [
+				'http://www.example.org/test',
+				'http://www.example.org/blog',
+				'http://www.example.org/next_post',
+				'http://www.example.org/test_purge',
+				'http://www.example.org/author/author_name',
+				'http://www.example.org/test_parent',
+				'http://www.example.org/test_parent_2'
+			]
+		],
+
+
+	]
+];

--- a/tests/Fixtures/inc/common/rocketGetPurgeUrls.php
+++ b/tests/Fixtures/inc/common/rocketGetPurgeUrls.php
@@ -7,12 +7,14 @@ return [
 		'wp-content' => [
 			'cache' => [
 				'wp-rocket' => [
-					'test_purge' => [
-						'index.html' => ''
-					],
-					'folder_1' => [
+					'example.org' => [
 						'test_purge' => [
 							'index.html' => ''
+						],
+						'folder_1' => [
+							'test_purge' => [
+								'index.html' => ''
+							]
 						]
 					]
 				]

--- a/tests/Fixtures/inc/common/rocketGetPurgeUrls.php
+++ b/tests/Fixtures/inc/common/rocketGetPurgeUrls.php
@@ -7,7 +7,10 @@ return [
 		'wp-content' => [
 			'cache' => [
 				'wp-rocket' => [
-					'test_purge.html' => ''
+					'test_purge.html' => '',
+					'folder_1' => [
+						'test_purge.html' => ''
+					]
 				]
 			]
 		]
@@ -153,7 +156,7 @@ return [
 					'page_for_posts' => 20,
 					'home' => 'http://www.example.org/',
 					'cache_purge_pages' => [
-						'test_purge'
+						'(.*)test_purge'
 					]
 				],
 
@@ -171,7 +174,6 @@ return [
 				'http://www.example.org/test',
 				'http://www.example.org/blog',
 				'http://www.example.org/next_post',
-				'http://www.example.org/test_purge',
 				'http://www.example.org/author/author_name',
 				'http://www.example.org/test_parent',
 				'http://www.example.org/test_parent_2'

--- a/tests/Fixtures/inc/functions/_rocketGetRecursiveDirFilesByRegex.php
+++ b/tests/Fixtures/inc/functions/_rocketGetRecursiveDirFilesByRegex.php
@@ -7,31 +7,33 @@ return [
 		'wp-content' => [
 			'cache' => [
 				'wp-rocket' => [
-					'folder_1' => [
-						'folder_1_1' => [
-							'file_1_1_1.htm' => '',
-							'file_1_1_2.htm' => '',
-							'file_1_1_3.htm' => ''
+					'example.org' => [
+						'folder_1' => [
+							'folder_1_1' => [
+								'file_1_1_1.htm' => '',
+								'file_1_1_2.htm' => '',
+								'file_1_1_3.htm' => ''
+							],
+							'folder_1_2' => [
+								'file_1_2_1.php' => '',
+								'file_1_2_2.htm' => '',
+								'file_1_3_3.type' => '',
+								'folder_1_2_1' => [
+									'file_1_2_1_1.htm' => '',
+									'file_1_2_1_2.htm' => '',
+									'file_1_2_1_3.htm' => ''
+								]
+							],
 						],
-						'folder_1_2' => [
-							'file_1_2_1.php' => '',
-							'file_1_2_2.htm' => '',
-							'file_1_3_3.type' => '',
-							'folder_1_2_1' => [
-								'file_1_2_1_1.htm' => '',
-								'file_1_2_1_2.htm' => '',
-								'file_1_2_1_3.htm' => ''
+						'folder_2' => [
+							'folder_2_1' => [
+								'file_2_1_1.type' => '',
+								'file_2_1_2.type' => '',
+								'file_2_1_3.type' => ''
 							]
 						],
-					],
-					'folder_2' => [
-						'folder_2_1' => [
-							'file_2_1_1.type' => '',
-							'file_2_1_2.type' => '',
-							'file_2_1_3.type' => ''
-						]
-					],
-					'folder_3' => []
+						'folder_3' => []
+					]
 				]
 			]
 
@@ -44,13 +46,13 @@ return [
 				'regex' => '/.htm$/'
 			],
 			'expected' => [
-				'vfs://public/wp-content/cache/wp-rocket/folder_1/folder_1_1/file_1_1_1.htm',
-				'vfs://public/wp-content/cache/wp-rocket/folder_1/folder_1_1/file_1_1_2.htm',
-				'vfs://public/wp-content/cache/wp-rocket/folder_1/folder_1_1/file_1_1_3.htm',
-				'vfs://public/wp-content/cache/wp-rocket/folder_1/folder_1_2/file_1_2_2.htm',
-				'vfs://public/wp-content/cache/wp-rocket/folder_1/folder_1_2/folder_1_2_1/file_1_2_1_1.htm',
-				'vfs://public/wp-content/cache/wp-rocket/folder_1/folder_1_2/folder_1_2_1/file_1_2_1_2.htm',
-				'vfs://public/wp-content/cache/wp-rocket/folder_1/folder_1_2/folder_1_2_1/file_1_2_1_3.htm'
+				'vfs://public/wp-content/cache/wp-rocket/example.org/folder_1/folder_1_1/file_1_1_1.htm',
+				'vfs://public/wp-content/cache/wp-rocket/example.org/folder_1/folder_1_1/file_1_1_2.htm',
+				'vfs://public/wp-content/cache/wp-rocket/example.org/folder_1/folder_1_1/file_1_1_3.htm',
+				'vfs://public/wp-content/cache/wp-rocket/example.org/folder_1/folder_1_2/file_1_2_2.htm',
+				'vfs://public/wp-content/cache/wp-rocket/example.org/folder_1/folder_1_2/folder_1_2_1/file_1_2_1_1.htm',
+				'vfs://public/wp-content/cache/wp-rocket/example.org/folder_1/folder_1_2/folder_1_2_1/file_1_2_1_2.htm',
+				'vfs://public/wp-content/cache/wp-rocket/example.org/folder_1/folder_1_2/folder_1_2_1/file_1_2_1_3.htm'
 			]
 		],
 		'shouldGetFilesOneFolder' => [
@@ -58,9 +60,9 @@ return [
 				'regex' => '/^.+folder_2.+\\.type/i'
 			],
 			'expected' => [
-				'vfs://public/wp-content/cache/wp-rocket/folder_2/folder_2_1/file_2_1_1.type',
-				'vfs://public/wp-content/cache/wp-rocket/folder_2/folder_2_1/file_2_1_2.type',
-				'vfs://public/wp-content/cache/wp-rocket/folder_2/folder_2_1/file_2_1_3.type'
+				'vfs://public/wp-content/cache/wp-rocket/example.org/folder_2/folder_2_1/file_2_1_1.type',
+				'vfs://public/wp-content/cache/wp-rocket/example.org/folder_2/folder_2_1/file_2_1_2.type',
+				'vfs://public/wp-content/cache/wp-rocket/example.org/folder_2/folder_2_1/file_2_1_3.type'
 			]
 		],
 		'shouldGetEmptyFolder' => [

--- a/tests/Fixtures/inc/functions/_rocketGetRecursiveDirFilesByRegex.php
+++ b/tests/Fixtures/inc/functions/_rocketGetRecursiveDirFilesByRegex.php
@@ -1,0 +1,73 @@
+<?php
+
+return [
+	'vfs_dir' => 'wp-content/cache/wp-rocket/',
+
+	'structure' => [
+		'wp-content' => [
+			'cache' => [
+				'wp-rocket' => [
+					'folder_1' => [
+						'folder_1_1' => [
+							'file_1_1_1.htm' => '',
+							'file_1_1_2.htm' => '',
+							'file_1_1_3.htm' => ''
+						],
+						'folder_1_2' => [
+							'file_1_2_1.php' => '',
+							'file_1_2_2.htm' => '',
+							'file_1_3_3.type' => '',
+							'folder_1_2_1' => [
+								'file_1_2_1_1.htm' => '',
+								'file_1_2_1_2.htm' => '',
+								'file_1_2_1_3.htm' => ''
+							]
+						],
+					],
+					'folder_2' => [
+						'folder_2_1' => [
+							'file_2_1_1.type' => '',
+							'file_2_1_2.type' => '',
+							'file_2_1_3.type' => ''
+						]
+					],
+					'folder_3' => []
+				]
+			]
+
+		]
+	],
+
+	'test_data' => [
+		'shouldGetFilesMultilevel' => [
+			'config' => [
+				'regex' => '/.htm$/'
+			],
+			'expected' => [
+				'vfs://public/wp-content/cache/wp-rocket/folder_1/folder_1_1/file_1_1_1.htm',
+				'vfs://public/wp-content/cache/wp-rocket/folder_1/folder_1_1/file_1_1_2.htm',
+				'vfs://public/wp-content/cache/wp-rocket/folder_1/folder_1_1/file_1_1_3.htm',
+				'vfs://public/wp-content/cache/wp-rocket/folder_1/folder_1_2/file_1_2_2.htm',
+				'vfs://public/wp-content/cache/wp-rocket/folder_1/folder_1_2/folder_1_2_1/file_1_2_1_1.htm',
+				'vfs://public/wp-content/cache/wp-rocket/folder_1/folder_1_2/folder_1_2_1/file_1_2_1_2.htm',
+				'vfs://public/wp-content/cache/wp-rocket/folder_1/folder_1_2/folder_1_2_1/file_1_2_1_3.htm'
+			]
+		],
+		'shouldGetFilesOneFolder' => [
+			'config' => [
+				'regex' => '/^.+folder_2.+\\.type/i'
+			],
+			'expected' => [
+				'vfs://public/wp-content/cache/wp-rocket/folder_2/folder_2_1/file_2_1_1.type',
+				'vfs://public/wp-content/cache/wp-rocket/folder_2/folder_2_1/file_2_1_2.type',
+				'vfs://public/wp-content/cache/wp-rocket/folder_2/folder_2_1/file_2_1_3.type'
+			]
+		],
+		'shouldGetEmptyFolder' => [
+			'config' => [
+				'regex' => '/^.+folder_3.+\\.type/i'
+			],
+			'expected' => []
+		],
+	]
+];

--- a/tests/Integration/inc/common/rocketGetPurgeUrls.php
+++ b/tests/Integration/inc/common/rocketGetPurgeUrls.php
@@ -31,10 +31,6 @@ class Test_RocketGetPurgeUrls extends FilesystemTestCase {
 
 		$this->create_authors( $this->config['urls']['authors'] );
 
-		Functions\expect( 'get_rocket_option' )->withAnyArgs()->andReturnUsing( function( $option_name, $default=null ) {
-			return isset( $this->site_options[$option_name] ) ? $this->site_options[$option_name] : $default;
-		} );
-
 		require_once WP_ROCKET_PLUGIN_ROOT . 'inc/common/purge.php';
 	}
 
@@ -68,10 +64,8 @@ class Test_RocketGetPurgeUrls extends FilesystemTestCase {
 			add_filter( 'pre_option_'.$option_name, [$this, 'prepare_option'], 10, 3 );
 		}
 
-		add_filter( 'get_previous_post_where', [$this, 'get_previous_posts'], 10, 5 );
-		add_filter( 'get_next_post_where', [$this, 'get_next_posts'], 10, 5 );
-
-
+		add_filter( 'get_previous_post_where', [$this, 'get_previous_posts'], 10, 2 );
+		add_filter( 'get_next_post_where', [$this, 'get_next_posts'], 10, 2 );
 
 		// Sort actual and expected arrays to compare between them.
 		$actual = rocket_get_purge_urls( $post_id, $post );
@@ -80,15 +74,11 @@ class Test_RocketGetPurgeUrls extends FilesystemTestCase {
 		$this->assertEquals( array_values( $expected ) , array_values( $actual ) );
 	}
 
-	private function get_archive_url( $post_type ) {
-		return isset( $this->config['urls']['archives'][$post_type] ) ? $this->config['urls']['archives'][$post_type] : '';
-	}
-
 	public function prepare_option( $pre_option, $option, $default ) {
 		return isset( $this->site_options[$option] ) ? $this->site_options[$option] : $default;
 	}
 
-	public function get_previous_posts( $where, $in_same_term, $excluded_terms, $taxonomy, $post ) {
+	public function get_previous_posts( $where, $in_same_term ) {
 		if ( $in_same_term && isset( $this->post_data['prev_in_term_post_id'] ) ) {
 			$where = " WHERE p.ID = {$this->posts_map[ $this->post_data['prev_in_term_post_id'] ]} ";
 		}
@@ -100,7 +90,7 @@ class Test_RocketGetPurgeUrls extends FilesystemTestCase {
 		return $where;
 	}
 
-	public function get_next_posts( $where, $in_same_term, $excluded_terms, $taxonomy, $post ) {
+	public function get_next_posts( $where, $in_same_term ) {
 		if ( $in_same_term && isset( $this->post_data['next_in_term_post_id'] ) ) {
 			$where = " WHERE p.ID = {$this->posts_map[ $this->post_data['next_in_term_post_id'] ]} ";
 		}
@@ -133,7 +123,7 @@ class Test_RocketGetPurgeUrls extends FilesystemTestCase {
 	}
 
 	private function create_authors( $authors ) {
-		foreach ( $this->config['urls']['authors'] as $author_id => $url ) {
+		foreach ( $authors as $author_id => $url ) {
 			$this->authors_map[$author_id] = $this->factory->user->create( [ 'user_login' => str_replace("http://example.org/author/", "", $url), 'role' => 'editor' ] );
 		}
 	}

--- a/tests/Integration/inc/common/rocketGetPurgeUrls.php
+++ b/tests/Integration/inc/common/rocketGetPurgeUrls.php
@@ -1,0 +1,118 @@
+<?php
+namespace WP_Rocket\Tests\Integration\inc\common;
+
+use WP_Rocket\Tests\Integration\FilesystemTestCase;
+use Brain\Monkey\Functions;
+
+/**
+ * @covers ::rocket_clean_cache_theme_update
+ * @uses   ::rocket_clean_domain
+ *
+ * @group  Common
+ * @group  Purge
+ */
+class Test_RocketGetPurgeUrls extends FilesystemTestCase {
+	protected $path_to_test_data = '/inc/common/rocketGetPurgeUrls.php';
+
+	private $site_options = [
+		'stylesheet' => '',
+	];
+
+	public function setUp() {
+		parent::setUp();
+
+		Functions\expect('get_permalink')
+			->withAnyArgs()
+			->andReturnUsing( function ( $post_id ) {
+				return $this->get_post_url( $post_id );
+			} );
+
+		require_once WP_ROCKET_PLUGIN_ROOT . 'inc/common/purge.php';
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+		foreach ( $this->site_options as $option_name => $option_value ) {
+			remove_filter( 'pre_option_'.$option_name, [$this, 'prepare_option'], 10, 3 );
+		}
+	}
+
+	/**
+	 * @dataProvider providerTestData
+	 */
+	public function testShouldReturnUrls( $config, $expected ) {
+		global $post;
+
+		$post_id = isset( $config['post_data']['ID'] ) ? $config['post_data']['ID'] : 0;
+		$post    = isset( $config['post_data'] ) ? (object) $config['post_data'] : null;
+		$options = isset( $config['options'] ) ? $config['options'] : [];
+
+		$this->site_options = array_merge($this->site_options, $options);
+
+		foreach ( $this->site_options as $option_name => $option_value ) {
+			add_filter( 'pre_option_'.$option_name, [$this, 'prepare_option'], 10, 3 );
+		}
+
+		Functions\expect('get_rocket_sample_permalink')
+			->once()
+			->with( $post_id )
+			->andReturn( ['http://www.example.org/%postname%', $post->post_name] );
+
+		Functions\expect('get_adjacent_post')
+			->andReturnUsing( function ( $in_same_term, $excluded_terms, $previous ) use ($post) {
+				if ( ! $previous ) {
+					//next
+					if( ! $in_same_term ) {
+						return isset( $post->next_post_id ) ? $post->next_post_id : false;
+					}
+					return isset( $post->next_in_term_post_id ) ? $post->next_in_term_post_id : false;
+				}
+
+				//prev
+				if (! $in_same_term ) {
+					return isset( $post->prev_post_id ) ? $post->prev_post_id : false;
+				}
+
+				return isset( $post->prev_in_term_post_id ) ? $post->prev_in_term_post_id : false;
+			} );
+
+		Functions\expect('get_author_posts_url')
+			->once()
+			->with($post->post_author)
+			->andReturn( $this->get_author_url( $post->post_author ) );
+
+		Functions\expect('get_post_ancestors')
+			->once()
+			->with($post_id)
+			->andReturn( isset( $post->ancestors ) ? $post->ancestors : [] );
+
+		if( 'post' !== $post->post_type ){
+			$archive_url = $this->get_archive_url( $post->post_type );
+			Functions\expect('get_post_type_archive_link')
+				->once()
+				->with( $post->post_type )
+				->andReturn( $archive_url );
+		}
+
+
+		$actual = rocket_get_purge_urls( $post_id, $post );
+		$this->assertEquals($expected, $actual);
+	}
+
+	private function get_post_url( $post_id ) {
+		return isset( $this->config['urls']['posts'][$post_id] ) ? $this->config['urls']['posts'][$post_id] : '';
+	}
+
+	private function get_author_url( $author_id ) {
+		return isset( $this->config['urls']['authors'][$author_id] ) ? $this->config['urls']['authors'][$author_id] : '';
+	}
+
+	private function get_archive_url( $post_type ) {
+		return isset( $this->config['urls']['archives'][$post_type] ) ? $this->config['urls']['archives'][$post_type] : '';
+	}
+
+	public function prepare_option( $pre_option, $option, $default ) {
+		return isset( $this->site_options[$option] ) ? $this->site_options[$option] : $default;
+	}
+
+}

--- a/tests/Integration/inc/common/rocketGetPurgeUrls.php
+++ b/tests/Integration/inc/common/rocketGetPurgeUrls.php
@@ -15,17 +15,46 @@ class Test_RocketGetPurgeUrls extends FilesystemTestCase {
 	protected $path_to_test_data = '/inc/common/rocketGetPurgeUrls.php';
 
 	private $site_options = [
-		'stylesheet' => '',
+		'stylesheet' => ''
 	];
 
+	private $page_for_posts;
+	private $posts_map   = [];
+	private $authors_map = [];
+
 	public function setUp() {
+		$this->set_permalink_structure( "/%postname%/" );
 		parent::setUp();
 
-		Functions\expect('get_permalink')
-			->withAnyArgs()
-			->andReturnUsing( function ( $post_id ) {
-				return $this->get_post_url( $post_id );
-			} );
+		$k = 1;
+		foreach ( $this->config['urls']['posts'] as $post_id => $url ) {
+			$now = time();
+			$post_name = str_replace("http://example.org/", "", $url);
+			$post_details = [
+				'post_date' => gmdate( 'Y-m-d H:i:s', $now - $k ),
+				'post_title' => !empty( $post_name ) ? $post_name : "home",
+				'post_type' => 20 !== $post_id ? 'post' : 'page'
+			];
+
+			if ( 4 === $post_id ) {
+				$post_details['post_parent'] = $this->posts_map[3];
+			}
+
+			$new_id = $this->factory->post->create($post_details);
+			$this->posts_map[$post_id] = $new_id;
+			if ( 20 === $post_id ) {
+				$this->page_for_posts = $new_id;
+			}
+			$k++;
+		}
+
+		foreach ( $this->config['urls']['authors'] as $author_id => $url ) {
+			$this->authors_map[$author_id] = $this->factory->user->create( [ 'user_login' => str_replace("http://example.org/author/", "", $url), 'role' => 'editor' ] );
+		}
+
+		Functions\expect( 'get_rocket_option' )->withAnyArgs()->andReturnUsing( function( $option_name, $default=null ) {
+			return isset( $this->site_options[$option_name] ) ? $this->site_options[$option_name] : $default;
+		} );
 
 		require_once WP_ROCKET_PLUGIN_ROOT . 'inc/common/purge.php';
 	}
@@ -43,48 +72,35 @@ class Test_RocketGetPurgeUrls extends FilesystemTestCase {
 	public function testShouldReturnUrls( $config, $expected ) {
 		global $post;
 
-		$post_id = isset( $config['post_data']['ID'] ) ? $config['post_data']['ID'] : 0;
-		$post    = isset( $config['post_data'] ) ? (object) $config['post_data'] : null;
+		// Create the custom post firstly.
+		if ( ! post_type_exists( $config['post_data']['post_type'] ) ){
+			register_post_type( $config['post_data']['post_type'] );
+		}
+
+		$post_data = [
+			'post_title' => $config['post_data']['post_name'],
+			'post_name' => $config['post_data']['post_name'],
+			'post_type' => $config['post_data']['post_type'],
+			'post_author' => $this->authors_map[$config['post_data']['post_author']],
+		];
+
+		if ( isset( $config['post_data']['ancestors'] ) ){
+			$post_data['post_parent'] = $this->posts_map[4];
+		}
+
+		$post_id = $this->factory->post->create($post_data);
+		$post    = get_post($post_id);
 		$options = isset( $config['options'] ) ? $config['options'] : [];
+
+		if ( isset( $options['page_for_posts'] ) ) {
+			$options['page_for_posts'] = $this->page_for_posts;
+		}
 
 		$this->site_options = array_merge($this->site_options, $options);
 
 		foreach ( $this->site_options as $option_name => $option_value ) {
 			add_filter( 'pre_option_'.$option_name, [$this, 'prepare_option'], 10, 3 );
 		}
-
-		Functions\expect('get_rocket_sample_permalink')
-			->once()
-			->with( $post_id )
-			->andReturn( ['http://www.example.org/%postname%', $post->post_name] );
-
-		Functions\expect('get_adjacent_post')
-			->andReturnUsing( function ( $in_same_term, $excluded_terms, $previous ) use ($post) {
-				if ( ! $previous ) {
-					//next
-					if( ! $in_same_term ) {
-						return isset( $post->next_post_id ) ? $post->next_post_id : false;
-					}
-					return isset( $post->next_in_term_post_id ) ? $post->next_in_term_post_id : false;
-				}
-
-				//prev
-				if (! $in_same_term ) {
-					return isset( $post->prev_post_id ) ? $post->prev_post_id : false;
-				}
-
-				return isset( $post->prev_in_term_post_id ) ? $post->prev_in_term_post_id : false;
-			} );
-
-		Functions\expect('get_author_posts_url')
-			->once()
-			->with($post->post_author)
-			->andReturn( $this->get_author_url( $post->post_author ) );
-
-		Functions\expect('get_post_ancestors')
-			->once()
-			->with($post_id)
-			->andReturn( isset( $post->ancestors ) ? $post->ancestors : [] );
 
 		if( 'post' !== $post->post_type ){
 			$archive_url = $this->get_archive_url( $post->post_type );
@@ -96,7 +112,9 @@ class Test_RocketGetPurgeUrls extends FilesystemTestCase {
 
 
 		$actual = rocket_get_purge_urls( $post_id, $post );
-		$this->assertEquals($expected, $actual);
+		asort($expected);
+		asort($actual);
+		$this->assertEquals( array_values( $expected ) , array_values( $actual ) );
 	}
 
 	private function get_post_url( $post_id ) {

--- a/tests/Integration/inc/common/rocketGetPurgeUrls.php
+++ b/tests/Integration/inc/common/rocketGetPurgeUrls.php
@@ -31,6 +31,10 @@ class Test_RocketGetPurgeUrls extends FilesystemTestCase {
 
 		$this->create_authors( $this->config['urls']['authors'] );
 
+		Functions\expect( 'get_rocket_option' )->withAnyArgs()->andReturnUsing( function( $option_name, $default=null ) {
+			return isset( $this->site_options[$option_name] ) ? $this->site_options[$option_name] : $default;
+		} );
+
 		require_once WP_ROCKET_PLUGIN_ROOT . 'inc/common/purge.php';
 	}
 

--- a/tests/Integration/inc/common/rocketGetPurgeUrls.php
+++ b/tests/Integration/inc/common/rocketGetPurgeUrls.php
@@ -31,10 +31,6 @@ class Test_RocketGetPurgeUrls extends FilesystemTestCase {
 
 		$this->create_authors( $this->config['urls']['authors'] );
 
-		Functions\expect( 'get_rocket_option' )->withAnyArgs()->andReturnUsing( function( $option_name, $default=null ) {
-			return isset( $this->site_options[$option_name] ) ? $this->site_options[$option_name] : $default;
-		} );
-
 		require_once WP_ROCKET_PLUGIN_ROOT . 'inc/common/purge.php';
 	}
 
@@ -45,6 +41,10 @@ class Test_RocketGetPurgeUrls extends FilesystemTestCase {
 		}
 		remove_filter( 'get_previous_post_where', [$this, 'get_previous_posts'], 10 );
 		remove_filter( 'get_next_post_where', [$this, 'get_next_posts'], 10 );
+
+		if ( isset( $this->site_options['cache_purge_pages'] ) ){
+			remove_filter( 'pre_get_rocket_option_cache_purge_pages', [ $this, 'set_cache_purge_pages' ] );
+		}
 	}
 
 	/**
@@ -66,6 +66,10 @@ class Test_RocketGetPurgeUrls extends FilesystemTestCase {
 
 		foreach ( $this->site_options as $option_name => $option_value ) {
 			add_filter( 'pre_option_'.$option_name, [$this, 'prepare_option'], 10, 3 );
+		}
+
+		if ( isset( $this->site_options['cache_purge_pages'] ) ){
+			add_filter( 'pre_get_rocket_option_cache_purge_pages', [ $this, 'set_cache_purge_pages' ] );
 		}
 
 		add_filter( 'get_previous_post_where', [$this, 'get_previous_posts'], 10, 2 );
@@ -152,6 +156,10 @@ class Test_RocketGetPurgeUrls extends FilesystemTestCase {
 		$this->post_data = $current_post_data;
 
 		return $this->factory->post->create( $post_data );
+	}
+
+	public function set_cache_purge_pages() {
+		return $this->site_options['cache_purge_pages'];
 	}
 
 }

--- a/tests/Integration/inc/common/rocketGetPurgeUrls.php
+++ b/tests/Integration/inc/common/rocketGetPurgeUrls.php
@@ -21,36 +21,15 @@ class Test_RocketGetPurgeUrls extends FilesystemTestCase {
 	private $page_for_posts;
 	private $posts_map   = [];
 	private $authors_map = [];
+	private $post_data   = [];
 
 	public function setUp() {
 		$this->set_permalink_structure( "/%postname%/" );
 		parent::setUp();
 
-		$k = 1;
-		foreach ( $this->config['urls']['posts'] as $post_id => $url ) {
-			$now = time();
-			$post_name = str_replace("http://example.org/", "", $url);
-			$post_details = [
-				'post_date' => gmdate( 'Y-m-d H:i:s', $now - $k ),
-				'post_title' => !empty( $post_name ) ? $post_name : "home",
-				'post_type' => 20 !== $post_id ? 'post' : 'page'
-			];
+		$this->create_posts( $this->config['urls']['posts'] );
 
-			if ( 4 === $post_id ) {
-				$post_details['post_parent'] = $this->posts_map[3];
-			}
-
-			$new_id = $this->factory->post->create($post_details);
-			$this->posts_map[$post_id] = $new_id;
-			if ( 20 === $post_id ) {
-				$this->page_for_posts = $new_id;
-			}
-			$k++;
-		}
-
-		foreach ( $this->config['urls']['authors'] as $author_id => $url ) {
-			$this->authors_map[$author_id] = $this->factory->user->create( [ 'user_login' => str_replace("http://example.org/author/", "", $url), 'role' => 'editor' ] );
-		}
+		$this->create_authors( $this->config['urls']['authors'] );
 
 		Functions\expect( 'get_rocket_option' )->withAnyArgs()->andReturnUsing( function( $option_name, $default=null ) {
 			return isset( $this->site_options[$option_name] ) ? $this->site_options[$option_name] : $default;
@@ -62,8 +41,10 @@ class Test_RocketGetPurgeUrls extends FilesystemTestCase {
 	public function tearDown() {
 		parent::tearDown();
 		foreach ( $this->site_options as $option_name => $option_value ) {
-			remove_filter( 'pre_option_'.$option_name, [$this, 'prepare_option'], 10, 3 );
+			remove_filter( 'pre_option_'.$option_name, [$this, 'prepare_option'], 10 );
 		}
+		remove_filter( 'get_previous_post_where', [$this, 'get_previous_posts'], 10 );
+		remove_filter( 'get_next_post_where', [$this, 'get_next_posts'], 10 );
 	}
 
 	/**
@@ -72,23 +53,8 @@ class Test_RocketGetPurgeUrls extends FilesystemTestCase {
 	public function testShouldReturnUrls( $config, $expected ) {
 		global $post;
 
-		// Create the custom post firstly.
-		if ( ! post_type_exists( $config['post_data']['post_type'] ) ){
-			register_post_type( $config['post_data']['post_type'] );
-		}
+		$post_id = $this->create_current_post( $config['post_data'] );
 
-		$post_data = [
-			'post_title' => $config['post_data']['post_name'],
-			'post_name' => $config['post_data']['post_name'],
-			'post_type' => $config['post_data']['post_type'],
-			'post_author' => $this->authors_map[$config['post_data']['post_author']],
-		];
-
-		if ( isset( $config['post_data']['ancestors'] ) ){
-			$post_data['post_parent'] = $this->posts_map[4];
-		}
-
-		$post_id = $this->factory->post->create($post_data);
 		$post    = get_post($post_id);
 		$options = isset( $config['options'] ) ? $config['options'] : [];
 
@@ -102,27 +68,16 @@ class Test_RocketGetPurgeUrls extends FilesystemTestCase {
 			add_filter( 'pre_option_'.$option_name, [$this, 'prepare_option'], 10, 3 );
 		}
 
-		if( 'post' !== $post->post_type ){
-			$archive_url = $this->get_archive_url( $post->post_type );
-			Functions\expect('get_post_type_archive_link')
-				->once()
-				->with( $post->post_type )
-				->andReturn( $archive_url );
-		}
+		add_filter( 'get_previous_post_where', [$this, 'get_previous_posts'], 10, 5 );
+		add_filter( 'get_next_post_where', [$this, 'get_next_posts'], 10, 5 );
 
 
+
+		// Sort actual and expected arrays to compare between them.
 		$actual = rocket_get_purge_urls( $post_id, $post );
 		asort($expected);
 		asort($actual);
 		$this->assertEquals( array_values( $expected ) , array_values( $actual ) );
-	}
-
-	private function get_post_url( $post_id ) {
-		return isset( $this->config['urls']['posts'][$post_id] ) ? $this->config['urls']['posts'][$post_id] : '';
-	}
-
-	private function get_author_url( $author_id ) {
-		return isset( $this->config['urls']['authors'][$author_id] ) ? $this->config['urls']['authors'][$author_id] : '';
 	}
 
 	private function get_archive_url( $post_type ) {
@@ -131,6 +86,78 @@ class Test_RocketGetPurgeUrls extends FilesystemTestCase {
 
 	public function prepare_option( $pre_option, $option, $default ) {
 		return isset( $this->site_options[$option] ) ? $this->site_options[$option] : $default;
+	}
+
+	public function get_previous_posts( $where, $in_same_term, $excluded_terms, $taxonomy, $post ) {
+		if ( $in_same_term && isset( $this->post_data['prev_in_term_post_id'] ) ) {
+			$where = " WHERE p.ID = {$this->posts_map[ $this->post_data['prev_in_term_post_id'] ]} ";
+		}
+
+		if ( ! $in_same_term && isset( $this->post_data['prev_post_id'] ) ) {
+			$where = " WHERE p.ID = {$this->posts_map[ $this->post_data['prev_post_id'] ]} ";
+		}
+
+		return $where;
+	}
+
+	public function get_next_posts( $where, $in_same_term, $excluded_terms, $taxonomy, $post ) {
+		if ( $in_same_term && isset( $this->post_data['next_in_term_post_id'] ) ) {
+			$where = " WHERE p.ID = {$this->posts_map[ $this->post_data['next_in_term_post_id'] ]} ";
+		}
+
+		if ( ! $in_same_term && isset( $this->post_data['next_post_id'] ) ) {
+			$where = " WHERE p.ID = {$this->posts_map[ $this->post_data['next_post_id'] ]} ";
+		}
+
+		return $where;
+	}
+
+	private function create_posts( $posts ) {
+		foreach ( $posts as $post_id => $url ) {
+			$post_name = str_replace("http://example.org/", "", $url);
+			$post_details = [
+				'post_title' => !empty( $post_name ) ? $post_name : "home",
+				'post_type' => 20 !== $post_id ? 'post' : 'page'
+			];
+
+			if ( 4 === $post_id ) {
+				$post_details['post_parent'] = $this->posts_map[3];
+			}
+
+			$new_id = $this->factory->post->create($post_details);
+			$this->posts_map[$post_id] = $new_id;
+			if ( 20 === $post_id ) {
+				$this->page_for_posts = $new_id;
+			}
+		}
+	}
+
+	private function create_authors( $authors ) {
+		foreach ( $this->config['urls']['authors'] as $author_id => $url ) {
+			$this->authors_map[$author_id] = $this->factory->user->create( [ 'user_login' => str_replace("http://example.org/author/", "", $url), 'role' => 'editor' ] );
+		}
+	}
+
+	private function create_current_post( $current_post_data ) {
+		// Create the custom post firstly.
+		if ( ! post_type_exists( $current_post_data['post_type'] ) ){
+			register_post_type( $current_post_data['post_type'], ['has_archive' => true] );
+		}
+
+		$post_data = [
+			'post_title'  => $current_post_data['post_name'],
+			'post_name'   => $current_post_data['post_name'],
+			'post_type'   => $current_post_data['post_type'],
+			'post_author' => $this->authors_map[$current_post_data['post_author']],
+		];
+
+		if ( isset( $current_post_data['ancestors'] ) ){
+			$post_data['post_parent'] = $this->posts_map[4];
+		}
+
+		$this->post_data = $current_post_data;
+
+		return $this->factory->post->create( $post_data );
 	}
 
 }

--- a/tests/Unit/inc/common/rocketGetPurgeUrls.php
+++ b/tests/Unit/inc/common/rocketGetPurgeUrls.php
@@ -51,11 +51,11 @@ class Test_RocketGetPurgeUrls extends FilesystemTestCase {
 		Functions\expect('get_rocket_sample_permalink')
 			->once()
 			->with( $post_id )
-			->andReturn( ['http://www.example.org/%postname%', $post->post_name] );
+			->andReturn( ['http://example.org/%postname%/', ( ( ! in_array( $post->post_type, [ 'page', 'post' ] ) ) ? $post->post_type."/" : "" ) . $post->post_name] );
 
 		Functions\expect('rocket_extract_url_component')
 			->once()
-			->with('http://www.example.org' . $post->url, PHP_URL_PATH)
+			->with('http://example.org' . $post->url, PHP_URL_PATH)
 			->andReturn( $post->url );
 
 		Functions\expect('get_adjacent_post')

--- a/tests/Unit/inc/common/rocketGetPurgeUrls.php
+++ b/tests/Unit/inc/common/rocketGetPurgeUrls.php
@@ -1,0 +1,125 @@
+<?php
+namespace WP_Rocket\Tests\Unit\inc\common;
+
+use WP_Rocket\Tests\Unit\TestCase;
+use Brain\Monkey\Functions;
+
+/**
+ * @covers ::rocket_clean_cache_theme_update
+ * @uses   ::rocket_clean_domain
+ *
+ * @group  Common
+ * @group  Purge
+ */
+class Test_RocketGetPurgeUrls extends TestCase {
+	protected $path_to_test_data = '/inc/common/rocketGetPurgeUrls.php';
+	protected static $mockCommonWpFunctionsInSetUp = true;
+
+	private $site_options = [
+		'stylesheet' => '',
+	];
+
+	protected function setUp() {
+		parent::setUp();
+
+		Functions\expect( 'get_option' )->withAnyArgs()->andReturnUsing( function( $option_name, $default=null ) {
+			return isset( $this->site_options[$option_name] ) ? $this->site_options[$option_name] : $default;
+		} );
+
+		Functions\expect( 'get_rocket_option' )->withAnyArgs()->andReturnUsing( function( $option_name, $default=null ) {
+			return isset( $this->site_options[$option_name] ) ? $this->site_options[$option_name] : $default;
+		} );
+
+		Functions\expect('get_permalink')
+			->withAnyArgs()
+			->andReturnUsing( function ( $post_id ) {
+				return $this->get_post_url( $post_id );
+			} );
+
+		require_once WP_ROCKET_PLUGIN_ROOT . 'inc/common/purge.php';
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnUrls( $config, $expected ) {
+		$post_id = isset( $config['post_data']['ID'] ) ? $config['post_data']['ID'] : 0;
+		$post    = isset( $config['post_data'] ) ? (object) $config['post_data'] : null;
+		$options = isset( $config['options'] ) ? $config['options'] : [];
+
+		$this->site_options = array_merge($this->site_options, $options);
+
+		Functions\expect('get_rocket_sample_permalink')
+			->once()
+			->with( $post_id )
+			->andReturn( ['http://www.example.org/%postname%', $post->post_name] );
+
+		Functions\expect('rocket_extract_url_component')
+			->once()
+			->with('http://www.example.org' . $post->url, PHP_URL_PATH)
+			->andReturn( $post->url );
+
+		Functions\expect('get_adjacent_post')
+			->andReturnUsing( function ( $in_same_term, $excluded_terms, $previous ) use ($post) {
+				if ( ! $previous ) {
+					//next
+					if( ! $in_same_term ) {
+						return isset( $post->next_post_id ) ? $post->next_post_id : false;
+					}
+					return isset( $post->next_in_term_post_id ) ? $post->next_in_term_post_id : false;
+				}
+
+				//prev
+				if (! $in_same_term ) {
+					return isset( $post->prev_post_id ) ? $post->prev_post_id : false;
+				}
+
+				return isset( $post->prev_in_term_post_id ) ? $post->prev_in_term_post_id : false;
+			} );
+
+		Functions\expect('get_author_posts_url')
+			->once()
+			->with($post->post_author)
+			->andReturn( $this->get_author_url( $post->post_author ) );
+
+		Functions\expect('get_post_ancestors')
+			->once()
+			->with($post_id)
+			->andReturn( isset( $post->ancestors ) ? $post->ancestors : [] );
+
+		if( 'post' !== $post->post_type ){
+			$archive_url = $this->get_archive_url( $post->post_type );
+			Functions\expect('get_post_type_archive_link')
+				->once()
+				->with( $post->post_type )
+				->andReturn( $archive_url );
+
+			if ( $archive_url ) {
+				Functions\expect('is_ssl')
+					->once()
+					->andReturn( $config['is_ssl'] );
+
+				$GLOBALS['wp_rewrite'] = (object) [
+					'pagination_base' => 'page'
+				];
+			}
+		}
+
+
+		$actual = rocket_get_purge_urls( $post_id, $post );
+		$this->assertEquals($expected, $actual);
+	}
+
+	private function get_post_url( $post_id ) {
+		return isset( $this->config['urls']['posts'][$post_id] ) ? $this->config['urls']['posts'][$post_id] : '';
+	}
+
+	private function get_author_url( $author_id ) {
+		return isset( $this->config['urls']['authors'][$author_id] ) ? $this->config['urls']['authors'][$author_id] : '';
+	}
+
+	private function get_archive_url( $post_type ) {
+		return isset( $this->config['urls']['archives'][$post_type] ) ? $this->config['urls']['archives'][$post_type] : '';
+	}
+
+}

--- a/tests/Unit/inc/common/rocketGetPurgeUrls.php
+++ b/tests/Unit/inc/common/rocketGetPurgeUrls.php
@@ -48,6 +48,10 @@ class Test_RocketGetPurgeUrls extends FilesystemTestCase {
 
 		$this->site_options = array_merge($this->site_options, $options);
 
+		Functions\when( 'wp_parse_url' )->alias( function( $url, $component = -1 ) {
+			return parse_url( $url, $component );
+		} );
+
 		Functions\expect('get_rocket_sample_permalink')
 			->once()
 			->with( $post_id )

--- a/tests/Unit/inc/common/rocketGetPurgeUrls.php
+++ b/tests/Unit/inc/common/rocketGetPurgeUrls.php
@@ -1,7 +1,7 @@
 <?php
 namespace WP_Rocket\Tests\Unit\inc\common;
 
-use WP_Rocket\Tests\Unit\TestCase;
+use WP_Rocket\Tests\Unit\FilesystemTestCase;
 use Brain\Monkey\Functions;
 
 /**
@@ -11,15 +11,14 @@ use Brain\Monkey\Functions;
  * @group  Common
  * @group  Purge
  */
-class Test_RocketGetPurgeUrls extends TestCase {
+class Test_RocketGetPurgeUrls extends FilesystemTestCase {
 	protected $path_to_test_data = '/inc/common/rocketGetPurgeUrls.php';
-	protected static $mockCommonWpFunctionsInSetUp = true;
 
 	private $site_options = [
 		'stylesheet' => '',
 	];
 
-	protected function setUp() {
+	public function setUp() {
 		parent::setUp();
 
 		Functions\expect( 'get_option' )->withAnyArgs()->andReturnUsing( function( $option_name, $default=null ) {
@@ -40,7 +39,7 @@ class Test_RocketGetPurgeUrls extends TestCase {
 	}
 
 	/**
-	 * @dataProvider configTestData
+	 * @dataProvider providerTestData
 	 */
 	public function testShouldReturnUrls( $config, $expected ) {
 		$post_id = isset( $config['post_data']['ID'] ) ? $config['post_data']['ID'] : 0;

--- a/tests/Unit/inc/functions/_rocketGetRecursiveDirFilesByRegex.php
+++ b/tests/Unit/inc/functions/_rocketGetRecursiveDirFilesByRegex.php
@@ -1,0 +1,31 @@
+<?php
+namespace WP_Rocket\Tests\Unit\inc\functions;
+
+use WP_Rocket\Tests\Unit\FilesystemTestCase;
+
+/**
+ * @covers ::_rocket_get_cache_dirs
+ *
+ * @group Files
+ * @group vfs
+ * @group Clean
+ */
+class Test__RocketGetRecursiveDirFilesByRegex extends FilesystemTestCase {
+	protected $path_to_test_data = '/inc/functions/_rocketGetRecursiveDirFilesByRegex.php';
+
+	/**
+	 * @dataProvider providerTestData
+	 */
+	public function testShouldGetFiles( $config, $expected ) {
+		$regex = isset( $config['regex'] ) ? $config['regex'] : '';
+
+		$actual = [];
+		$actual_files = _rocket_get_recursive_dir_files_by_regex( $regex );
+		foreach ( $actual_files as $item ) {
+			$actual[] = $item->getPathName();
+		}
+		$this->assertEquals($expected, $actual);
+
+	}
+
+}


### PR DESCRIPTION
**Reproduce the issue** ✅ 
Identified the issue on my localhost.

**Identify the root cause** ✅ 
This was never working: RegEx never worked for Always purge URL(s) field though. The code is expecting standard paths.

**Scope a solution** ✅ 
I made some prototyping / discovery work and this code should work just fine:
```
function get_recursive_dir_files_by_regex( $dir, $regex ) {
	try {
		$iterator = new RecursiveIteratorIterator(
			new RecursiveDirectoryIterator( $dir )
		);
		return new RegexIterator( $iterator, $regex,  RecursiveRegexIterator::MATCH);
	} catch ( Exception $e ) {
		return [];
	}
}
$files = get_recursive_dir_files_by_regex( WP_CONTENT_DIR . '/cache/wp-rocket/wp.local/' , '/category\/(.*)\/sub-category\/(.*)/i');


```

**Effort** ✅ 
I would assume this will be an [S]. 



TO DO: @engahmeds3ed 
- [x] - Unit tests
- [x] - Integration tests

This will need both Unit and Integration tests for `rocket_get_recursive_dir_files_by_regex()` & `rocket_get_purge_urls()`