### PR TITLE
Apply font-display: swap in CSS files - On Upgrading to v3.7( 5/5 )

### DIFF
--- a/inc/admin/upgrader.php
+++ b/inc/admin/upgrader.php
@@ -372,5 +372,9 @@ function rocket_new_upgrade( $wp_rocket_version, $actual_version ) {
 	if ( version_compare( $actual_version, '3.6.1', '<' ) ) {
 		rocket_generate_config_file();
 	}
+
+	if ( version_compare( $actual_version, '3.7', '<' ) ) {
+		rocket_clean_minify( 'css' );
+	}
 }
 add_action( 'wp_rocket_upgrade', 'rocket_new_upgrade', 10, 2 );

--- a/tests/Unit/inc/admin/rocketNewUpgrade.php
+++ b/tests/Unit/inc/admin/rocketNewUpgrade.php
@@ -27,7 +27,10 @@ class Test_RocketNewUpgrade extends TestCase {
 			->once();
 		Functions\expect( 'rocket_generate_config_file' )
 			->once();
+		Functions\expect( 'rocket_clean_minify' )
+			->with( 'css' )
+			->once();
 
-		rocket_new_upgrade( '3.6', '3.4.4' );
+		rocket_new_upgrade( '3.7', '3.4.4' );
 	}
 }


### PR DESCRIPTION
Sub-task for epic #2791

Closes https://github.com/wp-media/wp-rocket/issues/2799

## Part5 - On Upgrading to v3.7
Call `clean_minify( CSS )` during upgrading from v3.6.x to v3.7 to regenerate all CSS files and apply the new functionality.

Revisit Unit tests to include the new change