### PR TITLE
Preserve WP_CACHE & advanced-cache.php if on multisite with WPR active on other sites

### DIFF
--- a/inc/Engine/Cache/AdvancedCache.php
+++ b/inc/Engine/Cache/AdvancedCache.php
@@ -57,14 +57,9 @@ class AdvancedCache implements ActivationInterface, DeactivationInterface {
 	 *
 	 * @since 3.6.3
 	 *
-	 * @param int $sites_number Number of WP Rocket config files found.
 	 * @return void
 	 */
-	public function deactivate( $sites_number = 0 ) {
-		if ( is_multisite() && 0 !== $sites_number ) {
-			return;
-		}
-
+	public function deactivate() {
 		add_action( 'rocket_deactivation', [ $this, 'update_advanced_cache' ] );
 	}
 
@@ -73,9 +68,10 @@ class AdvancedCache implements ActivationInterface, DeactivationInterface {
 	 *
 	 * @since 3.6.3
 	 *
+	 * @param int $sites_number Number of WP Rocket config files found.
 	 * @return void
 	 */
-	public function update_advanced_cache() {
+	public function update_advanced_cache( $sites_number = 0 ) {
 		/**
 		 * Filters whether to generate the advanced-cache.php file.
 		 *
@@ -87,7 +83,15 @@ class AdvancedCache implements ActivationInterface, DeactivationInterface {
 			return;
 		}
 
-		$content = 'rocket_activation' === current_filter() ? $this->get_advanced_cache_content() : '';
+		$content = $this->get_advanced_cache_content();
+
+		if ( 'rocket_deactivation' === current_filter() ) {
+			if ( is_multisite() && 0 !== $sites_number ) {
+				return;
+			}
+
+			$content = '';
+		}
 
 		$this->filesystem->put_contents(
 			"{$this->content_dir}/advanced-cache.php",

--- a/inc/Engine/Cache/AdvancedCache.php
+++ b/inc/Engine/Cache/AdvancedCache.php
@@ -57,9 +57,14 @@ class AdvancedCache implements ActivationInterface, DeactivationInterface {
 	 *
 	 * @since 3.6.3
 	 *
+	 * @param int $sites_number Number of WP Rocket config files found.
 	 * @return void
 	 */
-	public function deactivate() {
+	public function deactivate( $sites_number = 0 ) {
+		if ( is_multisite() && 0 !== $sites_number ) {
+			return;
+		}
+
 		add_action( 'rocket_deactivation', [ $this, 'update_advanced_cache' ] );
 	}
 

--- a/inc/Engine/Cache/WPCache.php
+++ b/inc/Engine/Cache/WPCache.php
@@ -47,7 +47,7 @@ class WPCache implements ActivationInterface, DeactivationInterface {
 	 * @since 3.6.3
 	 *
 	 * @param int $sites_number Number of WP Rocket config files found.
-	 * @return bool
+	 * @return void
 	 */
 	public function update_wp_cache( $sites_number = 0 ) {
 		if ( ! rocket_valid_key() ) {

--- a/inc/Engine/Cache/WPCache.php
+++ b/inc/Engine/Cache/WPCache.php
@@ -34,14 +34,9 @@ class WPCache implements ActivationInterface, DeactivationInterface {
 	/**
 	 * Performs these actions during the plugin deactivation
 	 *
-	 * @param int $sites_number Number of WP Rocket config files found.
 	 * @return void
 	 */
-	public function deactivate( $sites_number = 0 ) {
-		if ( is_multisite() && 0 !== $sites_number ) {
-			return;
-		}
-
+	public function deactivate() {
 		add_action( 'rocket_deactivation', [ $this, 'update_wp_cache' ] );
 		add_filter( 'rocket_prevent_deactivation', [ $this, 'maybe_prevent_deactivation' ] );
 	}
@@ -51,14 +46,23 @@ class WPCache implements ActivationInterface, DeactivationInterface {
 	 *
 	 * @since 3.6.3
 	 *
+	 * @param int $sites_number Number of WP Rocket config files found.
 	 * @return bool
 	 */
-	public function update_wp_cache() {
+	public function update_wp_cache( $sites_number = 0 ) {
 		if ( ! rocket_valid_key() ) {
 			return;
 		}
 
-		$value = 'rocket_deactivation' === current_filter() ? false : true;
+		$value = true;
+
+		if ( 'rocket_deactivation' === current_filter() ) {
+			if ( is_multisite() && 0 !== $sites_number ) {
+				return;
+			}
+
+			$value = false;
+		}
 
 		$this->set_wp_cache_constant( $value );
 	}

--- a/inc/Engine/Cache/WPCache.php
+++ b/inc/Engine/Cache/WPCache.php
@@ -34,9 +34,14 @@ class WPCache implements ActivationInterface, DeactivationInterface {
 	/**
 	 * Performs these actions during the plugin deactivation
 	 *
+	 * @param int $sites_number Number of WP Rocket config files found.
 	 * @return void
 	 */
-	public function deactivate() {
+	public function deactivate( $sites_number = 0 ) {
+		if ( is_multisite() && 0 !== $sites_number ) {
+			return;
+		}
+
 		add_action( 'rocket_deactivation', [ $this, 'update_wp_cache' ] );
 		add_filter( 'rocket_prevent_deactivation', [ $this, 'maybe_prevent_deactivation' ] );
 	}
@@ -46,11 +51,11 @@ class WPCache implements ActivationInterface, DeactivationInterface {
 	 *
 	 * @since 3.6.3
 	 *
-	 * @return bool|void False if rocket key is invalid.
+	 * @return bool
 	 */
 	public function update_wp_cache() {
 		if ( ! rocket_valid_key() ) {
-			return false;
+			return;
 		}
 
 		$value = 'rocket_deactivation' === current_filter() ? false : true;

--- a/inc/Engine/Deactivation/Deactivation.php
+++ b/inc/Engine/Deactivation/Deactivation.php
@@ -61,7 +61,9 @@ class Deactivation {
 		// Delete config files.
 		rocket_delete_config_file();
 
-		if ( ! count( glob( WP_ROCKET_CONFIG_PATH . '*.php' ) ) ) {
+		$sites_number = count( glob( WP_ROCKET_CONFIG_PATH . '*.php' ) );
+
+		if ( ! $sites_number ) {
 			// Delete All WP Rocket rules of the .htaccess file.
 			flush_rocket_htaccess( true );
 		}
@@ -87,8 +89,11 @@ class Deactivation {
 		/**
 		 * WP Rocket deactivation.
 		 *
+		 * @since 3.6.3 add $sites_count parameter.
 		 * @since  3.1.5
+		 *
+		 * @param int $sites_number Number of WP Rocket config files found.
 		 */
-		do_action( 'rocket_deactivation' );
+		do_action( 'rocket_deactivation', $sites_number );
 	}
 }

--- a/tests/Integration/inc/Engine/Cache/AdvancedCache/deactivate.php
+++ b/tests/Integration/inc/Engine/Cache/AdvancedCache/deactivate.php
@@ -20,4 +20,29 @@ class Test_Deactivate extends TestCase {
 			has_action( 'rocket_deactivation', [ $advanced_cache, 'update_advanced_cache' ] )
 		);
 	}
+
+	/**
+	 * @group Multisite
+	 */
+	public function testShouldNotAddActionsWhenSitesNotZeroOnMultisite() {
+		$advanced_cache = new AdvancedCache( 'http://path/to/filesystem', null );
+
+		$advanced_cache->deactivate( 1 );
+
+		$this->assertFalse( has_action( 'rocket_deactivation', [ $advanced_cache, 'update_advanced_cache' ] ) );
+	}
+
+	/**
+	 * @group Multisite
+	 */
+	public function testShouldAddActionsWhenSitesZeroOnMultisite() {
+		$advanced_cache = new AdvancedCache( 'http://path/to/filesystem', null );
+
+		$advanced_cache->deactivate();
+
+		$this->assertEquals(
+			10,
+			has_action( 'rocket_deactivation', [ $advanced_cache, 'update_advanced_cache' ] )
+		);
+	}
 }

--- a/tests/Integration/inc/Engine/Cache/AdvancedCache/deactivate.php
+++ b/tests/Integration/inc/Engine/Cache/AdvancedCache/deactivate.php
@@ -20,29 +20,4 @@ class Test_Deactivate extends TestCase {
 			has_action( 'rocket_deactivation', [ $advanced_cache, 'update_advanced_cache' ] )
 		);
 	}
-
-	/**
-	 * @group Multisite
-	 */
-	public function testShouldNotAddActionsWhenSitesNotZeroOnMultisite() {
-		$advanced_cache = new AdvancedCache( 'http://path/to/filesystem', null );
-
-		$advanced_cache->deactivate( 1 );
-
-		$this->assertFalse( has_action( 'rocket_deactivation', [ $advanced_cache, 'update_advanced_cache' ] ) );
-	}
-
-	/**
-	 * @group Multisite
-	 */
-	public function testShouldAddActionsWhenSitesZeroOnMultisite() {
-		$advanced_cache = new AdvancedCache( 'http://path/to/filesystem', null );
-
-		$advanced_cache->deactivate();
-
-		$this->assertEquals(
-			10,
-			has_action( 'rocket_deactivation', [ $advanced_cache, 'update_advanced_cache' ] )
-		);
-	}
 }

--- a/tests/Integration/inc/Engine/Cache/AdvancedCache/updateAdvancedCache.php
+++ b/tests/Integration/inc/Engine/Cache/AdvancedCache/updateAdvancedCache.php
@@ -1,6 +1,7 @@
 <?php
 namespace WP_Rocket\Tests\Integration\inc\Engine\Cache\AdvancedCache;
 
+use Brain\Monkey\Functions;
 use WP_Rocket\Engine\Cache\AdvancedCache;
 use WP_Rocket\Tests\Integration\FilesystemTestCase;
 
@@ -35,5 +36,41 @@ class Test_UpdateAdvancedCache extends FilesystemTestCase {
 		$advanced_cache->update_advanced_cache();
 
 		$this->assertSame( $expected, $this->filesystem->getFilesListing( 'vfs://public/wp-content/' ) );
+	}
+
+	/**
+	 * @group Multisite
+	 */
+	public function testShouldNotUpdateWhenMultisiteAndSitesNotZero() {
+		$advanced_cache = new AdvancedCache(
+			$this->filesystem->getUrl( $this->config['vfs_dir'] ),
+			$this->filesystem
+		);
+
+		Functions\when( 'current_filter' )->justReturn( 'rocket_deactivation' );
+
+		$this->assertNull( $advanced_cache->update_advanced_cache( 1 ) );
+	}
+
+	/**
+	 * @group Multisite
+	 */
+	public function testShouldUpdateWhenMultisiteAndSitesZero() {
+		$advanced_cache = new AdvancedCache(
+			$this->filesystem->getUrl( $this->config['vfs_dir'] ),
+			$this->filesystem
+		);
+
+		Functions\when( 'current_filter' )->justReturn( 'rocket_deactivation' );
+
+		$advanced_cache->update_advanced_cache();
+
+		$this->assertSame(
+			[
+				'vfs://public/wp-content/cache/wp-rocket/index.html',
+				'vfs://public/wp-content/advanced-cache.php',
+			],
+			$this->filesystem->getFilesListing( 'vfs://public/wp-content/' )
+		);
 	}
 }

--- a/tests/Integration/inc/Engine/Cache/WPCache/deactivate.php
+++ b/tests/Integration/inc/Engine/Cache/WPCache/deactivate.php
@@ -1,7 +1,6 @@
 <?php
 namespace WP_Rocket\Tests\Integration\inc\Engine\Cache\WPCache;
 
-use WP_Rocket\Engine\Cache\AdvancedCache;
 use WP_Rocket\Engine\Cache\WPCache;
 use WP_Rocket\Tests\Integration\TestCase;
 
@@ -12,6 +11,38 @@ use WP_Rocket\Tests\Integration\TestCase;
  */
 class Test_Deactivate extends TestCase {
 	public function testShouldSetCorrectHooks() {
+		$wp_cache = new WPCache( null );
+
+		$wp_cache->deactivate();
+
+		$this->assertEquals(
+			10,
+			has_action( 'rocket_deactivation', [ $wp_cache, 'update_wp_cache' ] )
+		);
+
+		$this->assertEquals(
+			10,
+			has_action( 'rocket_prevent_deactivation', [ $wp_cache, 'maybe_prevent_deactivation' ] )
+		);
+	}
+
+	/**
+	 * @group Multisite
+	 */
+	public function testShouldNotAddActionsWhenSitesNotZeroOnMultisite() {
+		$wp_cache = new WPCache( null );
+
+		$wp_cache->deactivate( 1 );
+
+		$this->assertFalse( has_action( 'rocket_deactivation', [ $wp_cache, 'update_wp_cache' ] ) );
+
+		$this->assertFalse( has_action( 'rocket_prevent_deactivation', [ $wp_cache, 'maybe_prevent_deactivation' ] ) );
+	}
+
+	/**
+	 * @group Multisite
+	 */
+	public function testShouldAddActionsWhenSitesZeroOnMultisite() {
 		$wp_cache = new WPCache( null );
 
 		$wp_cache->deactivate();

--- a/tests/Integration/inc/Engine/Cache/WPCache/deactivate.php
+++ b/tests/Integration/inc/Engine/Cache/WPCache/deactivate.php
@@ -25,36 +25,4 @@ class Test_Deactivate extends TestCase {
 			has_action( 'rocket_prevent_deactivation', [ $wp_cache, 'maybe_prevent_deactivation' ] )
 		);
 	}
-
-	/**
-	 * @group Multisite
-	 */
-	public function testShouldNotAddActionsWhenSitesNotZeroOnMultisite() {
-		$wp_cache = new WPCache( null );
-
-		$wp_cache->deactivate( 1 );
-
-		$this->assertFalse( has_action( 'rocket_deactivation', [ $wp_cache, 'update_wp_cache' ] ) );
-
-		$this->assertFalse( has_action( 'rocket_prevent_deactivation', [ $wp_cache, 'maybe_prevent_deactivation' ] ) );
-	}
-
-	/**
-	 * @group Multisite
-	 */
-	public function testShouldAddActionsWhenSitesZeroOnMultisite() {
-		$wp_cache = new WPCache( null );
-
-		$wp_cache->deactivate();
-
-		$this->assertEquals(
-			10,
-			has_action( 'rocket_deactivation', [ $wp_cache, 'update_wp_cache' ] )
-		);
-
-		$this->assertEquals(
-			10,
-			has_action( 'rocket_prevent_deactivation', [ $wp_cache, 'maybe_prevent_deactivation' ] )
-		);
-	}
 }

--- a/tests/Integration/inc/Engine/Cache/WPCache/updateWPCache.php
+++ b/tests/Integration/inc/Engine/Cache/WPCache/updateWPCache.php
@@ -21,7 +21,7 @@ class Test_UpdateWPCache extends TestCase {
 			->once()
 			->andReturn( false );
 
-		$this->assertFalse( $wp_cache->update_wp_cache() );
+		$this->assertNull( $wp_cache->update_wp_cache() );
 	}
 
 	public function testShouldCallSetCacheConstant() {

--- a/tests/Integration/inc/Engine/Cache/WPCache/updateWPCache.php
+++ b/tests/Integration/inc/Engine/Cache/WPCache/updateWPCache.php
@@ -34,4 +34,15 @@ class Test_UpdateWPCache extends TestCase {
 
 		$wp_cache->update_wp_cache();
 	}
+
+	/**
+	 * @group Multisite
+	 */
+	public function testShouldNotUpdateWhenMultisiteAndSitesNotZero() {
+		$wp_cache = new WPCache( null );
+
+		Functions\when( 'current_filter' )->justReturn( 'rocket_deactivation' );
+
+		$this->assertNull( $wp_cache->update_wp_cache( 1 ) );
+	}
 }

--- a/tests/Unit/inc/Engine/Cache/WPCache/updateWPCache.php
+++ b/tests/Unit/inc/Engine/Cache/WPCache/updateWPCache.php
@@ -34,4 +34,19 @@ class Test_UpdateWPCache extends TestCase {
 
 		$wp_cache->update_wp_cache();
 	}
+
+	/**
+	 * @group Multisite
+	 */
+	public function testShouldNotUpdateWhenMultisiteAndSitesNotZero() {
+		$wp_cache = new WPCache( null );
+
+		Functions\expect( 'rocket_valid_key' )
+			->once()
+			->andReturn( true );
+		Functions\when( 'current_filter' )->justReturn( 'rocket_deactivation' );
+		Functions\when( 'is_multisite' )->justReturn( true );
+
+		$this->assertNull( $wp_cache->update_wp_cache( 1 ) );
+	}
 }

--- a/tests/Unit/inc/Engine/Cache/WPCache/updateWPCache.php
+++ b/tests/Unit/inc/Engine/Cache/WPCache/updateWPCache.php
@@ -21,7 +21,7 @@ class Test_UpdateWPCache extends TestCase {
 			->once()
 			->andReturn( false );
 
-		$this->assertFalse( $wp_cache->update_wp_cache() );
+		$this->assertNull( $wp_cache->update_wp_cache() );
 	}
 
 	public function testShouldCallSetCacheConstant() {


### PR DESCRIPTION
When on a multisite configuration, all sites share the same `wp-config.php` & `advanced-cache.php` files.

When deactivating WP Rocket on a sub-site, the `WP_CACHE` value & the `advanced-cache.php` content should be preserved, except if this site was the last one with WP Rocket active. We check this on deactivation by looking at the number of config files found in `wp-content/wp-rocket-config`.

When adding the new deactivation process, this behaviour was not preserved (oversight on my part). This PR is fixing that, reverting it to the intended, while still using the new process.

As comparison, here is how the code looked on version 3.6.2.1: https://github.com/wp-media/wp-rocket/blob/b1fdd13fbe78c8fc54f26a586061fd79b9a1966b/inc/main.php#L154

### Acceptance criteria
On a _single site_, the `WP_CACHE` value & advanced-cache.php content should be updated respectively to `false` & an empty content when deactivating WP Rocket.

On a _multisite_, the following should happen:
- If WP Rocket is still active on another site of the network, the value & content should not be touched
- If the site where WP Rocket is deactivated is the last one with the plugin active, the same behaviour as for a single site is expected