### PR TITLE
Fixes #2828: CriticalCSS removal can cause delayed FOUC in Firefox

### DIFF
--- a/inc/Engine/CriticalPath/CriticalCSSSubscriber.php
+++ b/inc/Engine/CriticalPath/CriticalCSSSubscriber.php
@@ -579,16 +579,20 @@ JS;
 	 */
 	protected function return_remove_cpcss_script() {
 		if ( ! rocket_get_constant( 'SCRIPT_DEBUG' ) ) {
-			return '<script>const wprRemoveCPCSS = () => { $elem = document.getElementById( "rocket-critical-css" ); if ( $elem ) { $elem.remove(); } }; if ( window.addEventListener ) { window.addEventListener( "load", wprRemoveCPCSS ); } else if ( window.attachEvent ) { window.attachEvent( "onload", wprRemoveCPCSS ); }</script>';
+			return '<script>const wprRemoveCPCSS = () => { if( document.querySelector("link[data-rocket-async=\'style\'][rel=\'preload\']") ){ setTimeout(wprRemoveCPCSS, 200); }else{ $elem = document.getElementById( "rocket-critical-css" );if ( $elem ) {$elem.remove();} } }; if ( window.addEventListener ) { window.addEventListener( "load", wprRemoveCPCSS ); } else if ( window.attachEvent ) { window.attachEvent( "onload", wprRemoveCPCSS ); }</script>';
 		}
 
 		return '
 			<script>
 				const wprRemoveCPCSS = () => {
-					$elem = document.getElementById( "rocket-critical-css" );
-					if ( $elem ) {
-						$elem.remove();
-					}
+				    if( document.querySelector("link[data-rocket-async=\'style\'][rel=\'preload\']") ){
+				        setTimeout(wprRemoveCPCSS, 200);
+				    }else{
+				        $elem = document.getElementById( "rocket-critical-css" );
+						if ( $elem ) {
+							$elem.remove();
+						}
+				    }
 				};
 				if ( window.addEventListener ) {
 					window.addEventListener( "load", wprRemoveCPCSS );
@@ -668,7 +672,7 @@ JS;
 			}
 
 			$preload = str_replace( 'stylesheet', 'preload', $tags_match[1][ $i ] );
-			$onload  = preg_replace( '~' . preg_quote( $tags_match[3][ $i ], '~' ) . '~iU', ' as="style" onload=""' . $tags_match[3][ $i ] . '>', $tags_match[3][ $i ] );
+			$onload  = preg_replace( '~' . preg_quote( $tags_match[3][ $i ], '~' ) . '~iU', ' data-rocket-async="style" as="style" onload=""' . $tags_match[3][ $i ] . '>', $tags_match[3][ $i ] );
 			$tag     = str_replace( $tags_match[3][ $i ] . '>', $onload, $tag );
 			$tag     = str_replace( $tags_match[1][ $i ], $preload, $tag );
 			$tag     = str_replace( 'onload=""', 'onload="this.onload=null;this.rel=\'stylesheet\'"', $tag );

--- a/tests/Fixtures/inc/Engine/CriticalPath/CriticalCSSSubscriber/insertCriticalCssBuffer.php
+++ b/tests/Fixtures/inc/Engine/CriticalPath/CriticalCSSSubscriber/insertCriticalCssBuffer.php
@@ -88,7 +88,7 @@ return [
 			],
 			'expected_file' => 'wp-content/cache/critical-css/1/front_page.css',
 			null,
-			'js_script'     => '<script>const wprRemoveCPCSS = () => { $elem = document.getElementById( "rocket-critical-css" ); if ( $elem ) { $elem.remove(); } }; if ( window.addEventListener ) { window.addEventListener( "load", wprRemoveCPCSS ); } else if ( window.attachEvent ) { window.attachEvent( "onload", wprRemoveCPCSS ); }</script>',
+			'js_script'     => '<script>const wprRemoveCPCSS = () => { if( document.querySelector("link[data-rocket-async=\'style\'][rel=\'preload\']") ){ setTimeout(wprRemoveCPCSS, 200); }else{ $elem = document.getElementById( "rocket-critical-css" );if ( $elem ) {$elem.remove();} } }; if ( window.addEventListener ) { window.addEventListener( "load", wprRemoveCPCSS ); } else if ( window.attachEvent ) { window.attachEvent( "onload", wprRemoveCPCSS ); }</script>',
 		],
 
 		'testShouldReturnHomeCSS' => [
@@ -112,7 +112,7 @@ return [
 			],
 			'expected_file' => 'wp-content/cache/critical-css/1/home.css',
 			null,
-			'js_script'     => '<script>const wprRemoveCPCSS = () => { $elem = document.getElementById( "rocket-critical-css" ); if ( $elem ) { $elem.remove(); } }; if ( window.addEventListener ) { window.addEventListener( "load", wprRemoveCPCSS ); } else if ( window.attachEvent ) { window.attachEvent( "onload", wprRemoveCPCSS ); }</script>',
+			'js_script'     => '<script>const wprRemoveCPCSS = () => { if( document.querySelector("link[data-rocket-async=\'style\'][rel=\'preload\']") ){ setTimeout(wprRemoveCPCSS, 200); }else{ $elem = document.getElementById( "rocket-critical-css" );if ( $elem ) {$elem.remove();} } }; if ( window.addEventListener ) { window.addEventListener( "load", wprRemoveCPCSS ); } else if ( window.attachEvent ) { window.attachEvent( "onload", wprRemoveCPCSS ); }</script>',
 		],
 
 		'testShouldReturnFrontPageCSS' => [
@@ -136,7 +136,7 @@ return [
 			],
 			'expected_file' => 'wp-content/cache/critical-css/1/front_page.css',
 			null,
-			'js_script'     => '<script>const wprRemoveCPCSS = () => { $elem = document.getElementById( "rocket-critical-css" ); if ( $elem ) { $elem.remove(); } }; if ( window.addEventListener ) { window.addEventListener( "load", wprRemoveCPCSS ); } else if ( window.attachEvent ) { window.attachEvent( "onload", wprRemoveCPCSS ); }</script>',
+			'js_script'     => '<script>const wprRemoveCPCSS = () => { if( document.querySelector("link[data-rocket-async=\'style\'][rel=\'preload\']") ){ setTimeout(wprRemoveCPCSS, 200); }else{ $elem = document.getElementById( "rocket-critical-css" );if ( $elem ) {$elem.remove();} } }; if ( window.addEventListener ) { window.addEventListener( "load", wprRemoveCPCSS ); } else if ( window.attachEvent ) { window.attachEvent( "onload", wprRemoveCPCSS ); }</script>',
 		],
 
 		'testShouldReturnCategoryPageCSS' => [
@@ -164,7 +164,7 @@ return [
 			],
 			'expected_file' => 'wp-content/cache/critical-css/1/category.css',
 			null,
-			'js_script'     => '<script>const wprRemoveCPCSS = () => { $elem = document.getElementById( "rocket-critical-css" ); if ( $elem ) { $elem.remove(); } }; if ( window.addEventListener ) { window.addEventListener( "load", wprRemoveCPCSS ); } else if ( window.attachEvent ) { window.attachEvent( "onload", wprRemoveCPCSS ); }</script>',
+			'js_script'     => '<script>const wprRemoveCPCSS = () => { if( document.querySelector("link[data-rocket-async=\'style\'][rel=\'preload\']") ){ setTimeout(wprRemoveCPCSS, 200); }else{ $elem = document.getElementById( "rocket-critical-css" );if ( $elem ) {$elem.remove();} } }; if ( window.addEventListener ) { window.addEventListener( "load", wprRemoveCPCSS ); } else if ( window.attachEvent ) { window.attachEvent( "onload", wprRemoveCPCSS ); }</script>',
 		],
 
 		'testShouldReturnTagCSS' => [
@@ -197,7 +197,7 @@ return [
 			],
 			'expected_file' => 'wp-content/cache/critical-css/1/post_tag.css',
 			null,
-			'js_script'     => '<script>const wprRemoveCPCSS = () => { $elem = document.getElementById( "rocket-critical-css" ); if ( $elem ) { $elem.remove(); } }; if ( window.addEventListener ) { window.addEventListener( "load", wprRemoveCPCSS ); } else if ( window.attachEvent ) { window.attachEvent( "onload", wprRemoveCPCSS ); }</script>',
+			'js_script'     => '<script>const wprRemoveCPCSS = () => { if( document.querySelector("link[data-rocket-async=\'style\'][rel=\'preload\']") ){ setTimeout(wprRemoveCPCSS, 200); }else{ $elem = document.getElementById( "rocket-critical-css" );if ( $elem ) {$elem.remove();} } }; if ( window.addEventListener ) { window.addEventListener( "load", wprRemoveCPCSS ); } else if ( window.attachEvent ) { window.attachEvent( "onload", wprRemoveCPCSS ); }</script>',
 		],
 
 		'testShouldReturnTaxCSS' => [
@@ -241,7 +241,7 @@ return [
 			],
 			'expected_file' => 'wp-content/cache/critical-css/1/wptests_tax1.css',
 			null,
-			'js_script'     => '<script>const wprRemoveCPCSS = () => { $elem = document.getElementById( "rocket-critical-css" ); if ( $elem ) { $elem.remove(); } }; if ( window.addEventListener ) { window.addEventListener( "load", wprRemoveCPCSS ); } else if ( window.attachEvent ) { window.attachEvent( "onload", wprRemoveCPCSS ); }</script>',
+			'js_script'     => '<script>const wprRemoveCPCSS = () => { if( document.querySelector("link[data-rocket-async=\'style\'][rel=\'preload\']") ){ setTimeout(wprRemoveCPCSS, 200); }else{ $elem = document.getElementById( "rocket-critical-css" );if ( $elem ) {$elem.remove();} } }; if ( window.addEventListener ) { window.addEventListener( "load", wprRemoveCPCSS ); } else if ( window.attachEvent ) { window.attachEvent( "onload", wprRemoveCPCSS ); }</script>',
 		],
 
 		'testShouldReturnTaxDoesNotExistReturnFalseFallbackCSS' => [
@@ -340,7 +340,7 @@ return [
 			],
 			'expected_file'     => '',
 			'expected_fallback' => 'fallback',
-			'js_script'         => '<script>const wprRemoveCPCSS = () => { $elem = document.getElementById( "rocket-critical-css" ); if ( $elem ) { $elem.remove(); } }; if ( window.addEventListener ) { window.addEventListener( "load", wprRemoveCPCSS ); } else if ( window.attachEvent ) { window.attachEvent( "onload", wprRemoveCPCSS ); }</script>',
+			'js_script'         => '<script>const wprRemoveCPCSS = () => { if( document.querySelector("link[data-rocket-async=\'style\'][rel=\'preload\']") ){ setTimeout(wprRemoveCPCSS, 200); }else{ $elem = document.getElementById( "rocket-critical-css" );if ( $elem ) {$elem.remove();} } }; if ( window.addEventListener ) { window.addEventListener( "load", wprRemoveCPCSS ); } else if ( window.attachEvent ) { window.attachEvent( "onload", wprRemoveCPCSS ); }</script>',
 		],
 
 		'testShouldReturnSingularCSS' => [

--- a/tests/Fixtures/inc/Engine/CriticalPath/CriticalCSSSubscriber/insertCriticalCssBufferUnit.php
+++ b/tests/Fixtures/inc/Engine/CriticalPath/CriticalCSSSubscriber/insertCriticalCssBufferUnit.php
@@ -127,12 +127,7 @@ return [
 				'SCRIPT_DEBUG'                   => false,
 			],
 			'expected' => true,
-			'html'     => '<script>const wprRemoveCPCSS = () => { if( document.querySelector("link[data-rocket-async=\'style\']") ){
-                setTimeout(wprRemoveCPCSS, 200);
-            }else{
-            	$elem = document.getElementById( "rocket-critical-css" ); if ( $elem ) { $elem.remove(); } };
-            }
-            if ( window.addEventListener ) { window.addEventListener( "load", wprRemoveCPCSS ); } else if ( window.attachEvent ) { window.attachEvent( "onload", wprRemoveCPCSS ); }</script>'
+			'html'     => '<html><head><title></title><style id="rocket-critical-css">.fallback { color: red; }</style></head><body><script>const wprRemoveCPCSS = () => { if( document.querySelector("link[data-rocket-async=\'style\'][rel=\'preload\']") ){ setTimeout(wprRemoveCPCSS, 200); }else{ $elem = document.getElementById( "rocket-critical-css" );if ( $elem ) {$elem.remove();} } }; if ( window.addEventListener ) { window.addEventListener( "load", wprRemoveCPCSS ); } else if ( window.attachEvent ) { window.attachEvent( "onload", wprRemoveCPCSS ); }</script></body></html>'
 		],
 
 		'testShouldDisplayFileCriticalCSS'          => [
@@ -153,12 +148,7 @@ return [
 				'SCRIPT_DEBUG'                   => false,
 			],
 			'expected' => true,
-			'html'     => '<script>const wprRemoveCPCSS = () => { if( document.querySelector("link[data-rocket-async=\'style\']") ){
-                setTimeout(wprRemoveCPCSS, 200);
-            }else{
-            	$elem = document.getElementById( "rocket-critical-css" ); if ( $elem ) { $elem.remove(); } };
-            }
-            if ( window.addEventListener ) { window.addEventListener( "load", wprRemoveCPCSS ); } else if ( window.attachEvent ) { window.attachEvent( "onload", wprRemoveCPCSS ); }</script>'
+			'html'     => '<html><head><title></title><style id="rocket-critical-css">.post_tag { color: red; }</style></head><body><script>const wprRemoveCPCSS = () => { if( document.querySelector("link[data-rocket-async=\'style\'][rel=\'preload\']") ){ setTimeout(wprRemoveCPCSS, 200); }else{ $elem = document.getElementById( "rocket-critical-css" );if ( $elem ) {$elem.remove();} } }; if ( window.addEventListener ) { window.addEventListener( "load", wprRemoveCPCSS ); } else if ( window.attachEvent ) { window.attachEvent( "onload", wprRemoveCPCSS ); }</script></body></html>'
 		],
 
 		'testShouldDisplayCustomFileCriticalCSS'    => [
@@ -182,19 +172,19 @@ return [
 			'html'     => '<html><head><title></title><style id="rocket-critical-css">.page { color: red; }</style></head><body>
 			<script>
 				const wprRemoveCPCSS = () => {
-				    if( document.querySelector("link[data-rocket-async=\'style\']") ) {
+				    if( document.querySelector("link[data-rocket-async=\'style\'][rel=\'preload\']") ){
 				        setTimeout(wprRemoveCPCSS, 200);
-				    } else {
+				    }else{
 				        $elem = document.getElementById( "rocket-critical-css" );
-				        if ( $elem ) {
-				            $elem.remove();
-				        }
+						if ( $elem ) {
+							$elem.remove();
+						}
 				    }
-				}
+				};
 				if ( window.addEventListener ) {
-				    window.addEventListener( "load", wprRemoveCPCSS );
+					window.addEventListener( "load", wprRemoveCPCSS );
 				} else if ( window.attachEvent ) {
-				    window.attachEvent( "onload", wprRemoveCPCSS );
+					window.attachEvent( "onload", wprRemoveCPCSS );
 				}
 			</script>
 			</body></html>',

--- a/tests/Fixtures/inc/Engine/CriticalPath/CriticalCSSSubscriber/insertCriticalCssBufferUnit.php
+++ b/tests/Fixtures/inc/Engine/CriticalPath/CriticalCSSSubscriber/insertCriticalCssBufferUnit.php
@@ -127,8 +127,14 @@ return [
 				'SCRIPT_DEBUG'                   => false,
 			],
 			'expected' => true,
-			'html'     => '<html><head><title></title><style id="rocket-critical-css">.fallback { color: red; }</style></head><body><script>const wprRemoveCPCSS = () => { $elem = document.getElementById( "rocket-critical-css" ); if ( $elem ) { $elem.remove(); } }; if ( window.addEventListener ) { window.addEventListener( "load", wprRemoveCPCSS ); } else if ( window.attachEvent ) { window.attachEvent( "onload", wprRemoveCPCSS ); }</script></body></html>',
+			'html'     => '<script>const wprRemoveCPCSS = () => { if( document.querySelector("link[data-rocket-async=\'style\']") ){
+                setTimeout(wprRemoveCPCSS, 200);
+            }else{
+            	$elem = document.getElementById( "rocket-critical-css" ); if ( $elem ) { $elem.remove(); } };
+            }
+            if ( window.addEventListener ) { window.addEventListener( "load", wprRemoveCPCSS ); } else if ( window.attachEvent ) { window.attachEvent( "onload", wprRemoveCPCSS ); }</script>'
 		],
+
 		'testShouldDisplayFileCriticalCSS'          => [
 			'config'   => [
 				'DONOTROCKETOPTIMIZE'            => false,
@@ -147,8 +153,14 @@ return [
 				'SCRIPT_DEBUG'                   => false,
 			],
 			'expected' => true,
-			'html'     => '<html><head><title></title><style id="rocket-critical-css">.post_tag { color: red; }</style></head><body><script>const wprRemoveCPCSS = () => { $elem = document.getElementById( "rocket-critical-css" ); if ( $elem ) { $elem.remove(); } }; if ( window.addEventListener ) { window.addEventListener( "load", wprRemoveCPCSS ); } else if ( window.attachEvent ) { window.attachEvent( "onload", wprRemoveCPCSS ); }</script></body></html>',
+			'html'     => '<script>const wprRemoveCPCSS = () => { if( document.querySelector("link[data-rocket-async=\'style\']") ){
+                setTimeout(wprRemoveCPCSS, 200);
+            }else{
+            	$elem = document.getElementById( "rocket-critical-css" ); if ( $elem ) { $elem.remove(); } };
+            }
+            if ( window.addEventListener ) { window.addEventListener( "load", wprRemoveCPCSS ); } else if ( window.attachEvent ) { window.attachEvent( "onload", wprRemoveCPCSS ); }</script>'
 		],
+
 		'testShouldDisplayCustomFileCriticalCSS'    => [
 			'config'   => [
 				'DONOTROCKETOPTIMIZE'            => false,
@@ -170,15 +182,19 @@ return [
 			'html'     => '<html><head><title></title><style id="rocket-critical-css">.page { color: red; }</style></head><body>
 			<script>
 				const wprRemoveCPCSS = () => {
-					$elem = document.getElementById( "rocket-critical-css" );
-					if ( $elem ) {
-						$elem.remove();
-					}
-				};
+				    if( document.querySelector("link[data-rocket-async=\'style\']") ) {
+				        setTimeout(wprRemoveCPCSS, 200);
+				    } else {
+				        $elem = document.getElementById( "rocket-critical-css" );
+				        if ( $elem ) {
+				            $elem.remove();
+				        }
+				    }
+				}
 				if ( window.addEventListener ) {
-					window.addEventListener( "load", wprRemoveCPCSS );
+				    window.addEventListener( "load", wprRemoveCPCSS );
 				} else if ( window.attachEvent ) {
-					window.attachEvent( "onload", wprRemoveCPCSS );
+				    window.attachEvent( "onload", wprRemoveCPCSS );
 				}
 			</script>
 			</body></html>',


### PR DESCRIPTION
Closes #2828 

- Modifies the `wprRemoveCPCSS` script to check timing for removal of CriticalCSS to make sure all default CSS links have been reset from `preload` to `stylesheet`.
- Adds `data-rocket-async="style"` attribute to target preloaded style links.
- Updates relevant `CriticalCSSSubscriber` tests.