### PR TITLE
Closes #2900: Preload links: admin part (1/3)

### DIFF
--- a/inc/Engine/Admin/Beacon/Beacon.php
+++ b/inc/Engine/Admin/Beacon/Beacon.php
@@ -138,7 +138,7 @@ class Beacon extends Abstract_Render implements Subscriber_Interface {
 			'minify_google_fonts'     => 'Combine Google Fonts',
 			'manual_preload'          => 'Preload',
 			'sitemap_preload'         => 'Sitemap Preload',
-			'preload_links'           => 'Preload links',
+			'preload_links'           => 'Preload Links',
 			'cdn'                     => 'CDN Enabled',
 			'do_cloudflare'           => 'Cloudflare Enabled',
 			'varnish_auto_purge'      => 'Varnish Purge Enabled',

--- a/inc/Engine/Admin/Beacon/Beacon.php
+++ b/inc/Engine/Admin/Beacon/Beacon.php
@@ -138,6 +138,7 @@ class Beacon extends Abstract_Render implements Subscriber_Interface {
 			'minify_google_fonts'     => 'Combine Google Fonts',
 			'manual_preload'          => 'Preload',
 			'sitemap_preload'         => 'Sitemap Preload',
+			'preload_links'           => 'Preload links',
 			'cdn'                     => 'CDN Enabled',
 			'do_cloudflare'           => 'Cloudflare Enabled',
 			'varnish_auto_purge'      => 'Varnish Purge Enabled',

--- a/inc/Engine/Admin/Settings/Page.php
+++ b/inc/Engine/Admin/Settings/Page.php
@@ -1081,6 +1081,17 @@ class Page {
 					],
 					'page'        => 'preload',
 				],
+				'preload_links_section' => [
+					'title'       => __( 'Preload Links', 'rocket' ),
+					'type'        => 'fields_container',
+					// translators: %1$s = opening <a> tag, %2$s = closing </a> tag.
+					'description' => sprintf( __( 'Link preloading improves the perceived load time by downloading a page when a user hovers over the link. %1$sMore info%2$s', 'rocket' ), '<a href="' . esc_url( $fonts_preload['url'] ) . '" data-beacon-article="' . esc_attr( $fonts_preload['id'] ) . '" target="_blank">', '</a>' ),
+					'help'        => [
+						'id'  => $fonts_preload['id'],
+						'url' => $fonts_preload['url'],
+					],
+					'page'        => 'preload',
+				],
 			]
 		);
 
@@ -1158,6 +1169,14 @@ class Page {
 					'page'              => 'preload',
 					'default'           => [],
 					'sanitize_callback' => 'sanitize_textarea',
+				],
+				'preload_links' => [
+					'type'              => 'checkbox',
+					'label'             => __( 'Enable link preloading', 'rocket' ),
+					'section'           => 'preload_links_section',
+					'page'              => 'preload',
+					'default'           => 0,
+					'sanitize_callback' => 'sanitize_checkbox',
 				],
 			]
 		);

--- a/inc/Engine/Preload/Links/AdminSubscriber.php
+++ b/inc/Engine/Preload/Links/AdminSubscriber.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace WP_Rocket\Engine\Preload\Links;
+
+use WP_Rocket\Event_Management\Subscriber_Interface;
+
+class AdminSubscriber implements Subscriber_Interface {
+	/**
+	 * Events this subscriber wants to listen to.
+	 *
+	 * @return array
+	 */
+	public static function get_subscribed_events() {
+		return [
+			'rocket_first_install_options' => 'add_option',
+		];
+	}
+
+	/**
+	 * Adds the option key & value to the WP Rocket options array
+	 *
+	 * @since 3.7
+	 *
+	 * @param array $options WP Rocket options array.
+	 * @return array
+	 */
+	public function add_option( $options ) {
+		$options = (array) $options;
+
+		$options['preload_links'] = 0;
+
+		return $options;
+	}
+}

--- a/inc/Engine/Preload/Links/ServiceProvider.php
+++ b/inc/Engine/Preload/Links/ServiceProvider.php
@@ -5,7 +5,6 @@ use League\Container\ServiceProvider\AbstractServiceProvider;
 
 /**
  * Service provider for WP Rocket preload links.
- *
  */
 class ServiceProvider extends AbstractServiceProvider {
 	/**

--- a/inc/Engine/Preload/Links/ServiceProvider.php
+++ b/inc/Engine/Preload/Links/ServiceProvider.php
@@ -1,0 +1,32 @@
+<?php
+namespace WP_Rocket\Engine\Preload\Links;
+
+use League\Container\ServiceProvider\AbstractServiceProvider;
+
+/**
+ * Service provider for WP Rocket preload links.
+ *
+ */
+class ServiceProvider extends AbstractServiceProvider {
+	/**
+	 * The provides array is a way to let the container
+	 * know that a service is provided by this service
+	 * provider. Every service that is registered via
+	 * this service provider must have an alias added
+	 * to this array or it will be ignored.
+	 *
+	 * @var array
+	 */
+	protected $provides = [
+		'preload_links_admin_subscriber',
+	];
+
+	/**
+	 * Registers the subscribers in the container
+	 *
+	 * @return void
+	 */
+	public function register() {
+		$this->getContainer()->share( 'preload_links_admin_subscriber', 'WP_Rocket\Engine\Preload\Links\AdminSubscriber' );
+	}
+}

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -214,6 +214,7 @@ class Plugin {
 		$this->container->addServiceProvider( 'WP_Rocket\Engine\Capabilities\ServiceProvider' );
 		$this->container->addServiceProvider( 'WP_Rocket\Addon\ServiceProvider' );
 		$this->container->addServiceProvider( 'WP_Rocket\Engine\Preload\ServiceProvider' );
+		$this->container->addServiceProvider( 'WP_Rocket\Engine\Preload\Links\ServiceProvider' );
 		$this->container->addServiceProvider( 'WP_Rocket\Engine\CDN\ServiceProvider' );
 		$this->container->addServiceProvider( 'WP_Rocket\ServiceProvider\Common_Subscribers' );
 		$this->container->addServiceProvider( 'WP_Rocket\ThirdParty\ServiceProvider' );
@@ -257,6 +258,7 @@ class Plugin {
 			'simple_custom_css',
 			'pdfembedder',
 			'divi',
+			'preload_links_admin_subscriber',
 		];
 
 		$host_type = HostResolver::get_host_service();

--- a/tests/Fixtures/inc/Engine/Preload/Links/AdminSubscriber/addOption.php
+++ b/tests/Fixtures/inc/Engine/Preload/Links/AdminSubscriber/addOption.php
@@ -1,0 +1,30 @@
+<?php
+
+return [
+	'test_data' => [
+		'testShouldAddOptionWhenString' => [
+			'options'  => 'test',
+			'expected' => [
+				0               => 'test',
+				'preload_links' => 0,
+			],
+		],
+		'testShouldAddOptionWhenEmptyArray' => [
+			'options'  => [],
+			'expected' => [
+				'preload_links' => 0,
+			],
+		],
+		'testShouldAddOptionWhenNotEmptyArray' => [
+			'options'  => [
+				'async_css'  => 0,
+				'minify_css' => 1,
+			],
+			'expected' => [
+				'async_css'     => 0,
+				'minify_css'    => 1,
+				'preload_links' => 0,
+			],
+		],
+	],
+];

--- a/tests/Fixtures/inc/admin/rocketFirstInstall.php
+++ b/tests/Fixtures/inc/admin/rocketFirstInstall.php
@@ -76,6 +76,7 @@ $default = [
 
 $integration = $default;
 $integration[ 'async_css_mobile' ] = 1;
+$integration[ 'preload_links' ]    = 0;
 
 return [
 	'test_data' => [

--- a/tests/Integration/inc/Engine/CriticalPath/Admin/Subscriber/addAsyncCssMobileOption.php
+++ b/tests/Integration/inc/Engine/CriticalPath/Admin/Subscriber/addAsyncCssMobileOption.php
@@ -19,9 +19,9 @@ class Test_AddAsyncCssMobileOption extends TestCase {
 	 * @dataProvider providerTestData
 	 */
 	public function testShouldAddOption( $options, $expected ) {
-		$this->assertSame(
-			$expected,
-			apply_filters( 'rocket_first_install_options', $options )
-		);
+		$filtered_options = apply_filters( 'rocket_first_install_options', $options );
+
+		$this->assertArrayHasKey( 'async_css_mobile', $filtered_options );
+		$this->assertSame( $expected['async_css_mobile'], $filtered_options['async_css_mobile'] );
 	}
 }

--- a/tests/Integration/inc/Engine/CriticalPath/Admin/Subscriber/addAsyncCssMobileOption.php
+++ b/tests/Integration/inc/Engine/CriticalPath/Admin/Subscriber/addAsyncCssMobileOption.php
@@ -12,9 +12,6 @@ use WP_Rocket\Tests\Integration\TestCase;
  * @group  CriticalPathAdminSubscriber
  */
 class Test_AddAsyncCssMobileOption extends TestCase {
-	use ProviderTrait;
-	protected static $provider_class = 'Settings';
-
 	/**
 	 * @dataProvider providerTestData
 	 */

--- a/tests/Integration/inc/Engine/Preload/Links/AdminSubscriber/addOption.php
+++ b/tests/Integration/inc/Engine/Preload/Links/AdminSubscriber/addOption.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\Preload\Links\AdminSubscriber;
+
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Preload\Links\AdminSubscriber::add_option
+ *
+ * @group  AdminOnly
+ * @group  PreloadLinks
+ */
+class Test_AddOption extends TestCase {
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldAddOption( $options, $expected ) {
+		$result = apply_filters( 'rocket_first_install_options', $options );
+
+		$this->assertArrayHasKey( 'preload_links', $result );
+		$this->assertSame( $expected['preload_links'], $result['preload_links'] );
+	}
+}

--- a/tests/Unit/inc/Engine/Preload/Links/AdminSubscriber/addOption.php
+++ b/tests/Unit/inc/Engine/Preload/Links/AdminSubscriber/addOption.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\Preload\Links\AdminSubscriber;
+
+use WP_Rocket\Engine\Preload\Links\AdminSubscriber;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Preload\Links\AdminSubscriber::add_option
+ *
+ * @group  PreloadLinks
+ */
+class Test_AddOption extends TestCase {
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldAddOption( $options, $expected ) {
+		$subscriber = new AdminSubscriber();
+
+		$result = $subscriber->add_option( $options );
+
+		$this->assertArrayHasKey( 'preload_links', $result );
+		$this->assertSame( $expected['preload_links'], $result['preload_links'] );
+	}
+}


### PR DESCRIPTION
Closes #2900, first sub-task of the epic.

### Code Changes
This part adds the new Preload Links option to the UI of WP Rocket settings page, and add the option index `preload_links` to the WPR options array.

- [x] Create the admin subscriber
- [x] Create the service provider
- [x] Add the service provider & the subscriber to the load process
- [x] Add the settings section & field to the settings page
- [x] Add the new option to the Beacon session data