### PR TITLE
Add Gulp task for compiling a single JS script

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -68,7 +68,7 @@ function compile(watch) {
         });
     }
 
-    rebundle(); 
+    rebundle();
 }
 
 function watch() {
@@ -83,3 +83,26 @@ gulp.task('watch', function () {
 });
 
 gulp.task('default', ['watch', 'sass', 'sass:watch']);
+
+/**
+ * Compiles a standalone script file.
+ *
+ * Command line: gulp js:compile_single --script=script-name.js
+ */
+gulp.task('js:compile_single', () => {
+	const {argv} = require("yargs");
+	const transpile = require('gulp-babel');
+	const source = './assets/js/' + argv.script;
+
+	return gulp.src( source )
+		// Transpile newer JS for cross-browser support.
+		.pipe( transpile({
+			presets: ["es2015"]
+		}))
+		// Minify the script.
+		.pipe( uglify() )
+		// Rename the .js to .min.js.
+		.pipe( rename( { suffix: '.min' } ) )
+		// Write out the script to the configured <filename>.min.js destination.
+		.pipe( gulp.dest( './assets/js/' ) );
+});

--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
   "devDependencies": {
     "babel-core": "^6.26.3",
     "babel-preset-env": "^1.7.0",
+	"babel-preset-es2015": "^6.18.0",
     "babelify": "^8",
     "browserify": "^16.5.0",
     "gulp": "^3.9.1",
+	"gulp-babel": "^6.1.3",
     "gulp-concat": "latest",
     "gulp-rename": "^1.4.0",
     "gulp-sass": "^4.0.2",
@@ -21,6 +23,7 @@
     "gulp-uglify": "^3.0.2",
     "vinyl-buffer": "latest",
     "vinyl-source-stream": "latest",
-    "watchify": "latest"
+    "watchify": "latest",
+	"yargs": "^15.4.1"
   }
 }


### PR DESCRIPTION
Breaking this PR out of the delay JS feature branch as it's also needed for Prefetch Pages script.

This new Gulp task allows us to compile a single `assets/js/` script by:

- Running babel to transpile modern JS back into older ES5 version for wider browser compatibility
- Running uglify to minify the script
- Renaming the new compiled script to `.min.js`