### PR TITLE
Prevent PHP notice when trying to serve the WC empty cart cache

### DIFF
--- a/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber.php
+++ b/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber.php
@@ -64,7 +64,7 @@ class WooCommerceSubscriber implements Event_Manager_Aware_Subscriber_Interface 
 			 * @param bool true to activate, false to deactivate.
 			 */
 			if ( apply_filters( 'rocket_cache_wc_empty_cart', true ) ) {
-				$events['plugins_loaded']    = [ 'serve_cache_empty_cart', 11 ];
+				$events['after_setup_theme'] = [ 'serve_cache_empty_cart', 11 ];
 				$events['template_redirect'] = [ 'cache_empty_cart', -1 ];
 				$events['switch_theme']      = 'delete_cache_empty_cart';
 			}


### PR DESCRIPTION
The `$wp` global is not created yet on `plugins_loaded`, which was triggering the following notices:

```
PHP Notice:  Trying to get property 'query_vars' of non-object
PHP Notice:  Trying to get property 'request' of non-object
```

Changing the hook to `after_setup_theme` solves the issue, at that point the global is populated with the necessary object.