### PR TITLE
Adjust tests not to support jquery-migrate after WP version 5.5

### DIFF
--- a/tests/Integration/inc/classes/subscriber/Optimization/Dequeue_JQuery_Migrate_Subscriber/dequeueJqueryMigrate.php
+++ b/tests/Integration/inc/classes/subscriber/Optimization/Dequeue_JQuery_Migrate_Subscriber/dequeueJqueryMigrate.php
@@ -43,18 +43,25 @@ class Test_DequeueJqueryMigrate extends TestCase {
 	}
 
 	public function testShouldNotDequeueJqueryMigrate() {
+		global $wp_version;
 		add_filter( 'pre_get_rocket_option_dequeue_jquery_migrate', '__return_false' );
 
 		$this->wp_scripts->init();
 		$this->assertGreaterThan( $this->count, did_action( 'wp_default_scripts' ) );
 		$jquery_dependencies = $this->wp_scripts->registered['jquery']->deps;
 
-		$this->assertContains( 'jquery-migrate', $jquery_dependencies );
+		if ( version_compare( $wp_version, '5.5', '>=' ) ) {
+			$this->assertNotContains( 'jquery-migrate', $jquery_dependencies );
+		} else {
+			$this->assertContains( 'jquery-migrate', $jquery_dependencies );
+		}
 
 		remove_filter( 'pre_get_rocket_option_dequeue_jquery_migrate', '__return_false' );
 	}
 
 	public function testShouldNotDequeueJqueryMigrateWithDONOTROCKETOPTIMIZE() {
+		global $wp_version;
+
 		add_filter( 'pre_get_rocket_option_dequeue_jquery_migrate', '__return_true' );
 
 		Monkey\Functions\expect( 'rocket_get_constant' )
@@ -65,7 +72,11 @@ class Test_DequeueJqueryMigrate extends TestCase {
 		$this->assertGreaterThan( $this->count, did_action( 'wp_default_scripts' ) );
 		$jquery_dependencies = $this->wp_scripts->registered['jquery']->deps;
 
-		$this->assertContains( 'jquery-migrate', $jquery_dependencies );
+		if ( version_compare( $wp_version, '5.5', '>=' ) ) {
+			$this->assertNotContains( 'jquery-migrate', $jquery_dependencies );
+		} else {
+			$this->assertContains( 'jquery-migrate', $jquery_dependencies );
+		}
 
 		remove_filter( 'pre_get_rocket_option_dequeue_jquery_migrate', '__return_true' );
 	}


### PR DESCRIPTION
fixes #2990 

Wordpress from version 5.5 stopped support for jquery-migrate script out of the box so we need to adjust the code/tests to check the wordpress version if greater than or equals 5.5 so do the followings:-

Adjust the tests not to expect this script to be returned from WP.