### PR TITLE
Fixes #2962 Prevent whitescreen when Optimizing Google Fonts in some cases

### DIFF
--- a/inc/Engine/Optimization/GoogleFonts/Combine.php
+++ b/inc/Engine/Optimization/GoogleFonts/Combine.php
@@ -76,7 +76,7 @@ class Combine extends AbstractOptimization {
 			return $html;
 		}
 
-		$html = preg_replace( '@(<head[^>]*>.*<title[^>]*>.*</title>)(.*</head>)@isU', '$1' . $this->get_combine_tag() . '$2', $html, 1 );
+		$html = preg_replace( '@<\/title>@i', '$0' . $this->get_combine_tag(), $html, 1 );
 
 		foreach ( $fonts as $font ) {
 			$html = str_replace( $font[0], '', $html );

--- a/tests/Integration/inc/Engine/Optimization/GoogleFonts/Combine/optimize.php
+++ b/tests/Integration/inc/Engine/Optimization/GoogleFonts/Combine/optimize.php
@@ -9,6 +9,7 @@ use WP_Rocket\Engine\Optimization\GoogleFonts\Combine;
  * @covers \WP_Rocket\Engine\Optimization\GoogleFonts::optimize
  * @uses   \WP_Rocket\Logger\Logger
  * @group  Optimize
+ * @group  GoogleFonts
  */
 class Test_Optimize extends TestCase {
 

--- a/tests/Unit/inc/Engine/Optimization/GoogleFonts/Combine/optimize.php
+++ b/tests/Unit/inc/Engine/Optimization/GoogleFonts/Combine/optimize.php
@@ -9,6 +9,7 @@ use WP_Rocket\Engine\Optimization\GoogleFonts\Combine;
 /**
  * @covers \ WP_Rocket\Engine\Optimization\GoogleFonts\Combine::optimize
  * @group  Optimize
+ * @group  GoogleFonts
  */
 class Test_Optimize extends TestCase {
 


### PR DESCRIPTION
Fixes #2962 

The current regEx used was causing a catastrophic backtracking fatal error when the content inside the `<head>` was too big.

This PR changes the regEx to a simpler expression, similar to the one used for combine CSS or inserting the critical CSS.