### PR TITLE
Fixes #3003 Prevent fatal error following WooCommerce 4.4 update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
 		"php": ">=5.6.0",
 		"wp-media/background-processing": "^1.3",
 		"composer/installers": "~1.0",
+		"container-interop/container-interop": "1.2.0",
 		"matthiasmullie/minify": "1.3.*",
 		"monolog/monolog": "^1.0",
 		"wp-media/rocket-lazyload-common": "^2"
@@ -109,7 +110,7 @@
 		"test-integration-pdfembedder": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group PDFEmbedder",
 		"test-integration-pdfembedderpremium": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group PDFEmbedderPremium",
 		"test-integration-pdfembeddersecure": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group PDFEmbedderSecure",
-	  	"test-integration-o2switch": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group O2Switch",
+	    "test-integration-o2switch": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group O2Switch",
 		"run-tests": [
 			"@test-unit",
 			"@test-integration",

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,6 @@
 		"php": ">=5.6.0",
 		"wp-media/background-processing": "^1.3",
 		"composer/installers": "~1.0",
-		"league/container": "^2.4",
 		"matthiasmullie/minify": "1.3.*",
 		"monolog/monolog": "^1.0",
 		"wp-media/rocket-lazyload-common": "^2"

--- a/inc/Addon/ServiceProvider.php
+++ b/inc/Addon/ServiceProvider.php
@@ -1,7 +1,7 @@
 <?php
 namespace WP_Rocket\Addon;
 
-use League\Container\ServiceProvider\AbstractServiceProvider;
+use WP_Rocket\Engine\Container\ServiceProvider\AbstractServiceProvider;
 use WP_Rocket\Admin\Options_Data;
 
 /**

--- a/inc/Engine/Activation/Activation.php
+++ b/inc/Engine/Activation/Activation.php
@@ -2,7 +2,7 @@
 
 namespace WP_Rocket\Engine\Activation;
 
-use League\Container\Container;
+use WP_Rocket\Engine\Container\Container;
 use WP_Rocket\ThirdParty\Hostings\HostResolver;
 
 /**

--- a/inc/Engine/Activation/ServiceProvider.php
+++ b/inc/Engine/Activation/ServiceProvider.php
@@ -1,8 +1,8 @@
 <?php
 namespace WP_Rocket\Engine\Activation;
 
-use League\Container\ServiceProvider\AbstractServiceProvider;
-use League\Container\ServiceProvider\BootableServiceProviderInterface;
+use WP_Rocket\Engine\Container\ServiceProvider\AbstractServiceProvider;
+use WP_Rocket\Engine\Container\ServiceProvider\BootableServiceProviderInterface;
 
 /**
  * Service Provider for the activation process.

--- a/inc/Engine/Admin/Beacon/ServiceProvider.php
+++ b/inc/Engine/Admin/Beacon/ServiceProvider.php
@@ -1,7 +1,7 @@
 <?php
 namespace WP_Rocket\Engine\Admin\Beacon;
 
-use League\Container\ServiceProvider\AbstractServiceProvider;
+use WP_Rocket\Engine\Container\ServiceProvider\AbstractServiceProvider;
 
 /**
  * Service Provider for Beacon

--- a/inc/Engine/Admin/ServiceProvider.php
+++ b/inc/Engine/Admin/ServiceProvider.php
@@ -1,7 +1,7 @@
 <?php
 namespace WP_Rocket\Engine\Admin;
 
-use League\Container\ServiceProvider\AbstractServiceProvider;
+use WP_Rocket\Engine\Container\ServiceProvider\AbstractServiceProvider;
 
 /**
  * Service Provider for admin subscribers.

--- a/inc/Engine/Admin/Settings/ServiceProvider.php
+++ b/inc/Engine/Admin/Settings/ServiceProvider.php
@@ -1,7 +1,7 @@
 <?php
 namespace WP_Rocket\Engine\Admin\Settings;
 
-use League\Container\ServiceProvider\AbstractServiceProvider;
+use WP_Rocket\Engine\Container\ServiceProvider\AbstractServiceProvider;
 
 /**
  * Service provider for the WP Rocket settings.

--- a/inc/Engine/CDN/RocketCDN/RESTSubscriber.php
+++ b/inc/Engine/CDN/RocketCDN/RESTSubscriber.php
@@ -61,9 +61,9 @@ class RESTSubscriber implements Subscriber_Interface {
 			self::ROUTE_NAMESPACE,
 			'rocketcdn/enable',
 			[
-				'methods'  => 'PUT',
-				'callback' => [ $this, 'enable' ],
-				'args'     => [
+				'methods'             => 'PUT',
+				'callback'            => [ $this, 'enable' ],
+				'args'                => [
 					'email' => [
 						'required'          => true,
 						'validate_callback' => [ $this, 'validate_email' ],
@@ -74,16 +74,17 @@ class RESTSubscriber implements Subscriber_Interface {
 					],
 					'url'   => [
 						'required'          => true,
-						'validate_callback' => function( $param ) {
+						'validate_callback' => function ( $param ) {
 							$url = esc_url_raw( $param );
 
 							return ! empty( $url );
 						},
-						'sanitize_callback' => function( $param ) {
+						'sanitize_callback' => function ( $param ) {
 							return esc_url_raw( $param );
 						},
 					],
 				],
+				'permission_callback' => __return_true(),
 			]
 		);
 	}
@@ -100,9 +101,9 @@ class RESTSubscriber implements Subscriber_Interface {
 			self::ROUTE_NAMESPACE,
 			'rocketcdn/disable',
 			[
-				'methods'  => 'PUT',
-				'callback' => [ $this, 'disable' ],
-				'args'     => [
+				'methods'             => 'PUT',
+				'callback'            => [ $this, 'disable' ],
+				'args'                => [
 					'email' => [
 						'required'          => true,
 						'validate_callback' => [ $this, 'validate_email' ],
@@ -112,6 +113,7 @@ class RESTSubscriber implements Subscriber_Interface {
 						'validate_callback' => [ $this, 'validate_key' ],
 					],
 				],
+				'permission_callback' => __return_true(),
 			]
 		);
 	}
@@ -122,6 +124,7 @@ class RESTSubscriber implements Subscriber_Interface {
 	 * @since 3.5
 	 *
 	 * @param \WP_REST_Request $request the WP REST Request object.
+	 *
 	 * @return string
 	 */
 	public function enable( \WP_REST_Request $request ) {
@@ -146,6 +149,7 @@ class RESTSubscriber implements Subscriber_Interface {
 	 * @since 3.5
 	 *
 	 * @param \WP_REST_Request $request the WP Rest Request object.
+	 *
 	 * @return string
 	 */
 	public function disable( \WP_REST_Request $request ) {
@@ -168,6 +172,7 @@ class RESTSubscriber implements Subscriber_Interface {
 	 * @since 3.5
 	 *
 	 * @param string $param Parameter value to validate.
+	 *
 	 * @return bool
 	 */
 	public function validate_email( $param ) {
@@ -180,6 +185,7 @@ class RESTSubscriber implements Subscriber_Interface {
 	 * @since 3.5
 	 *
 	 * @param string $param Parameter value to validate.
+	 *
 	 * @return bool
 	 */
 	public function validate_key( $param ) {

--- a/inc/Engine/CDN/RocketCDN/RESTSubscriber.php
+++ b/inc/Engine/CDN/RocketCDN/RESTSubscriber.php
@@ -84,7 +84,7 @@ class RESTSubscriber implements Subscriber_Interface {
 						},
 					],
 				],
-				'permission_callback' => __return_true(),
+				'permission_callback' => '__return_true',
 			]
 		);
 	}
@@ -113,7 +113,7 @@ class RESTSubscriber implements Subscriber_Interface {
 						'validate_callback' => [ $this, 'validate_key' ],
 					],
 				],
-				'permission_callback' => __return_true(),
+				'permission_callback' => '__return_true',
 			]
 		);
 	}

--- a/inc/Engine/CDN/RocketCDN/ServiceProvider.php
+++ b/inc/Engine/CDN/RocketCDN/ServiceProvider.php
@@ -1,7 +1,7 @@
 <?php
 namespace WP_Rocket\Engine\CDN\RocketCDN;
 
-use League\Container\ServiceProvider\AbstractServiceProvider;
+use WP_Rocket\Engine\Container\ServiceProvider\AbstractServiceProvider;
 
 /**
  * Service provider for RocketCDN

--- a/inc/Engine/CDN/ServiceProvider.php
+++ b/inc/Engine/CDN/ServiceProvider.php
@@ -1,7 +1,7 @@
 <?php
 namespace WP_Rocket\Engine\CDN;
 
-use League\Container\ServiceProvider\AbstractServiceProvider;
+use WP_Rocket\Engine\Container\ServiceProvider\AbstractServiceProvider;
 
 /**
  * Service provider for WP Rocket CDN

--- a/inc/Engine/Cache/ServiceProvider.php
+++ b/inc/Engine/Cache/ServiceProvider.php
@@ -1,7 +1,7 @@
 <?php
 namespace WP_Rocket\Engine\Cache;
 
-use League\Container\ServiceProvider\AbstractServiceProvider;
+use WP_Rocket\Engine\Container\ServiceProvider\AbstractServiceProvider;
 
 /**
  * Service Provider for cache subscribers

--- a/inc/Engine/Capabilities/ServiceProvider.php
+++ b/inc/Engine/Capabilities/ServiceProvider.php
@@ -1,7 +1,7 @@
 <?php
 namespace WP_Rocket\Engine\Capabilities;
 
-use League\Container\ServiceProvider\AbstractServiceProvider;
+use WP_Rocket\Engine\Container\ServiceProvider\AbstractServiceProvider;
 
 /**
  * Service Provider for capabilities

--- a/inc/Engine/Container/Argument/ArgumentResolverInterface.php
+++ b/inc/Engine/Container/Argument/ArgumentResolverInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace League\Container\Argument;
+
+use League\Container\ImmutableContainerAwareInterface;
+use ReflectionFunctionAbstract;
+
+interface ArgumentResolverInterface extends ImmutableContainerAwareInterface
+{
+    /**
+     * Resolve an array of arguments to their concrete implementations.
+     *
+     * @param  array $arguments
+     * @return array
+     */
+    public function resolveArguments(array $arguments);
+
+    /**
+     * Resolves the correct arguments to be passed to a method.
+     *
+     * @param  \ReflectionFunctionAbstract $method
+     * @param  array                       $args
+     * @return array
+     */
+    public function reflectArguments(ReflectionFunctionAbstract $method, array $args = []);
+}

--- a/inc/Engine/Container/Argument/ArgumentResolverInterface.php
+++ b/inc/Engine/Container/Argument/ArgumentResolverInterface.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace League\Container\Argument;
+namespace WP_Rocket\Engine\Container\Argument;
 
-use League\Container\ImmutableContainerAwareInterface;
+use WP_Rocket\Engine\Container\ImmutableContainerAwareInterface;
 use ReflectionFunctionAbstract;
 
 interface ArgumentResolverInterface extends ImmutableContainerAwareInterface

--- a/inc/Engine/Container/Argument/ArgumentResolverTrait.php
+++ b/inc/Engine/Container/Argument/ArgumentResolverTrait.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace League\Container\Argument;
+
+use League\Container\Exception\NotFoundException;
+use League\Container\ReflectionContainer;
+use ReflectionFunctionAbstract;
+use ReflectionParameter;
+
+trait ArgumentResolverTrait
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function resolveArguments(array $arguments)
+    {
+        foreach ($arguments as &$arg) {
+            if ($arg instanceof RawArgumentInterface) {
+                $arg = $arg->getValue();
+                continue;
+            }
+
+            if (! is_string($arg)) {
+                 continue;
+            }
+
+            $container = $this->getContainer();
+
+            if (is_null($container) && $this instanceof ReflectionContainer) {
+                $container = $this;
+            }
+
+            if (! is_null($container) && $container->has($arg)) {
+                $arg = $container->get($arg);
+
+                if ($arg instanceof RawArgumentInterface) {
+                    $arg = $arg->getValue();
+                }
+
+                continue;
+            }
+        }
+
+        return $arguments;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reflectArguments(ReflectionFunctionAbstract $method, array $args = [])
+    {
+        $arguments = array_map(function (ReflectionParameter $param) use ($method, $args) {
+            $name  = $param->getName();
+            $class = $param->getClass();
+
+            if (array_key_exists($name, $args)) {
+                return $args[$name];
+            }
+
+            if (! is_null($class)) {
+                return $class->getName();
+            }
+
+            if ($param->isDefaultValueAvailable()) {
+                return $param->getDefaultValue();
+            }
+
+            throw new NotFoundException(sprintf(
+                'Unable to resolve a value for parameter (%s) in the function/method (%s)',
+                $name,
+                $method->getName()
+            ));
+        }, $method->getParameters());
+
+        return $this->resolveArguments($arguments);
+    }
+
+    /**
+     * @return \League\Container\ContainerInterface
+     */
+    abstract public function getContainer();
+}

--- a/inc/Engine/Container/Argument/ArgumentResolverTrait.php
+++ b/inc/Engine/Container/Argument/ArgumentResolverTrait.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace League\Container\Argument;
+namespace WP_Rocket\Engine\Container\Argument;
 
-use League\Container\Exception\NotFoundException;
-use League\Container\ReflectionContainer;
+use WP_Rocket\Engine\Container\Exception\NotFoundException;
+use WP_Rocket\Engine\Container\ReflectionContainer;
 use ReflectionFunctionAbstract;
 use ReflectionParameter;
 
@@ -76,7 +76,7 @@ trait ArgumentResolverTrait
     }
 
     /**
-     * @return \League\Container\ContainerInterface
+     * @return \WP_Rocket\Engine\Container\ContainerInterface
      */
     abstract public function getContainer();
 }

--- a/inc/Engine/Container/Argument/RawArgument.php
+++ b/inc/Engine/Container/Argument/RawArgument.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace League\Container\Argument;
+
+class RawArgument implements RawArgumentInterface
+{
+    /**
+     * @var mixed
+     */
+    protected $value;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+}

--- a/inc/Engine/Container/Argument/RawArgument.php
+++ b/inc/Engine/Container/Argument/RawArgument.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace League\Container\Argument;
+namespace WP_Rocket\Engine\Container\Argument;
 
 class RawArgument implements RawArgumentInterface
 {

--- a/inc/Engine/Container/Argument/RawArgumentInterface.php
+++ b/inc/Engine/Container/Argument/RawArgumentInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace League\Container\Argument;
+
+interface RawArgumentInterface
+{
+    /**
+     * Return the value of the raw argument.
+     *
+     * @return mixed
+     */
+    public function getValue();
+}

--- a/inc/Engine/Container/Argument/RawArgumentInterface.php
+++ b/inc/Engine/Container/Argument/RawArgumentInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace League\Container\Argument;
+namespace WP_Rocket\Engine\Container\Argument;
 
 interface RawArgumentInterface
 {

--- a/inc/Engine/Container/Container.php
+++ b/inc/Engine/Container/Container.php
@@ -1,0 +1,305 @@
+<?php
+
+namespace League\Container;
+
+use Interop\Container\ContainerInterface as InteropContainerInterface;
+use League\Container\Argument\RawArgumentInterface;
+use League\Container\Definition\DefinitionFactory;
+use League\Container\Definition\DefinitionFactoryInterface;
+use League\Container\Definition\DefinitionInterface;
+use League\Container\Exception\NotFoundException;
+use League\Container\Inflector\InflectorAggregate;
+use League\Container\Inflector\InflectorAggregateInterface;
+use League\Container\ServiceProvider\ServiceProviderAggregate;
+use League\Container\ServiceProvider\ServiceProviderAggregateInterface;
+
+class Container implements ContainerInterface
+{
+    /**
+     * @var \League\Container\Definition\DefinitionFactoryInterface
+     */
+    protected $definitionFactory;
+
+    /**
+     * @var \League\Container\Definition\DefinitionInterface[]
+     */
+    protected $definitions = [];
+
+    /**
+     * @var \League\Container\Definition\DefinitionInterface[]
+     */
+    protected $sharedDefinitions = [];
+
+    /**
+     * @var \League\Container\Inflector\InflectorAggregateInterface
+     */
+    protected $inflectors;
+
+    /**
+     * @var \League\Container\ServiceProvider\ServiceProviderAggregateInterface
+     */
+    protected $providers;
+
+    /**
+     * @var array
+     */
+    protected $shared = [];
+
+    /**
+     * @var \Interop\Container\ContainerInterface[]
+     */
+    protected $delegates = [];
+
+    /**
+     * Constructor.
+     *
+     * @param \League\Container\ServiceProvider\ServiceProviderAggregateInterface|null $providers
+     * @param \League\Container\Inflector\InflectorAggregateInterface|null             $inflectors
+     * @param \League\Container\Definition\DefinitionFactoryInterface|null             $definitionFactory
+     */
+    public function __construct(
+        ServiceProviderAggregateInterface $providers         = null,
+        InflectorAggregateInterface       $inflectors        = null,
+        DefinitionFactoryInterface        $definitionFactory = null
+    ) {
+        // set required dependencies
+        $this->providers         = (is_null($providers))
+                                 ? (new ServiceProviderAggregate)->setContainer($this)
+                                 : $providers->setContainer($this);
+
+        $this->inflectors        = (is_null($inflectors))
+                                 ? (new InflectorAggregate)->setContainer($this)
+                                 : $inflectors->setContainer($this);
+
+        $this->definitionFactory = (is_null($definitionFactory))
+                                 ? (new DefinitionFactory)->setContainer($this)
+                                 : $definitionFactory->setContainer($this);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get($alias, array $args = [])
+    {
+        try {
+            return $this->getFromThisContainer($alias, $args);
+        } catch (NotFoundException $exception) {
+            if ($this->providers->provides($alias)) {
+                $this->providers->register($alias);
+
+                return $this->getFromThisContainer($alias, $args);
+            }
+
+            $resolved = $this->getFromDelegate($alias, $args);
+
+            return $this->inflectors->inflect($resolved);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has($alias)
+    {
+        if (array_key_exists($alias, $this->definitions) || $this->hasShared($alias)) {
+            return true;
+        }
+
+        if ($this->providers->provides($alias)) {
+            return true;
+        }
+
+        return $this->hasInDelegate($alias);
+    }
+
+    /**
+     * Returns a boolean to determine if the container has a shared instance of an alias.
+     *
+     * @param  string  $alias
+     * @param  boolean $resolved
+     * @return boolean
+     */
+    public function hasShared($alias, $resolved = false)
+    {
+        $shared = ($resolved === false) ? array_merge($this->shared, $this->sharedDefinitions) : $this->shared;
+
+        return (array_key_exists($alias, $shared));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function add($alias, $concrete = null, $share = false)
+    {
+        unset($this->shared[$alias]);
+        unset($this->definitions[$alias]);
+        unset($this->sharedDefinitions[$alias]);
+
+        if (is_null($concrete)) {
+            $concrete = $alias;
+        }
+
+        $definition = $this->definitionFactory->getDefinition($alias, $concrete);
+
+        if ($definition instanceof DefinitionInterface) {
+            if ($share === false) {
+                $this->definitions[$alias] = $definition;
+            } else {
+                $this->sharedDefinitions[$alias] = $definition;
+            }
+
+            return $definition;
+        }
+
+        // dealing with a value that cannot build a definition
+        $this->shared[$alias] = $concrete;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function share($alias, $concrete = null)
+    {
+        return $this->add($alias, $concrete, true);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addServiceProvider($provider)
+    {
+        $this->providers->add($provider);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function extend($alias)
+    {
+        if ($this->providers->provides($alias)) {
+            $this->providers->register($alias);
+        }
+
+        if (array_key_exists($alias, $this->definitions)) {
+            return $this->definitions[$alias];
+        }
+
+        if (array_key_exists($alias, $this->sharedDefinitions)) {
+            return $this->sharedDefinitions[$alias];
+        }
+
+        throw new NotFoundException(
+            sprintf('Unable to extend alias (%s) as it is not being managed as a definition', $alias)
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function inflector($type, callable $callback = null)
+    {
+        return $this->inflectors->add($type, $callback);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function call(callable $callable, array $args = [])
+    {
+        return (new ReflectionContainer)->setContainer($this)->call($callable, $args);
+    }
+
+    /**
+     * Delegate a backup container to be checked for services if it
+     * cannot be resolved via this container.
+     *
+     * @param  \Interop\Container\ContainerInterface $container
+     * @return $this
+     */
+    public function delegate(InteropContainerInterface $container)
+    {
+        $this->delegates[] = $container;
+
+        if ($container instanceof ImmutableContainerAwareInterface) {
+            $container->setContainer($this);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Returns true if service is registered in one of the delegated backup containers.
+     *
+     * @param  string $alias
+     * @return boolean
+     */
+    public function hasInDelegate($alias)
+    {
+        foreach ($this->delegates as $container) {
+            if ($container->has($alias)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Attempt to get a service from the stack of delegated backup containers.
+     *
+     * @param  string $alias
+     * @param  array  $args
+     * @return mixed
+     */
+    protected function getFromDelegate($alias, array $args = [])
+    {
+        foreach ($this->delegates as $container) {
+            if ($container->has($alias)) {
+                return $container->get($alias, $args);
+            }
+
+            continue;
+        }
+
+        throw new NotFoundException(
+            sprintf('Alias (%s) is not being managed by the container', $alias)
+        );
+
+    }
+
+    /**
+     * Get a service that has been registered in this container.
+     *
+     * @param  string $alias
+     * @param  array $args
+     * @return mixed
+     */
+    protected function getFromThisContainer($alias, array $args = [])
+    {
+        if ($this->hasShared($alias, true)) {
+            $shared = $this->inflectors->inflect($this->shared[$alias]);
+            if ($shared instanceof RawArgumentInterface) {
+                return $shared->getValue();
+            }
+            return $shared;
+        }
+
+        if (array_key_exists($alias, $this->sharedDefinitions)) {
+            $shared = $this->inflectors->inflect($this->sharedDefinitions[$alias]->build());
+            $this->shared[$alias] = $shared;
+            return $shared;
+        }
+
+        if (array_key_exists($alias, $this->definitions)) {
+            return $this->inflectors->inflect(
+                $this->definitions[$alias]->build($args)
+            );
+        }
+
+        throw new NotFoundException(
+            sprintf('Alias (%s) is not being managed by the container', $alias)
+        );
+    }
+}

--- a/inc/Engine/Container/Container.php
+++ b/inc/Engine/Container/Container.php
@@ -1,42 +1,42 @@
 <?php
 
-namespace League\Container;
+namespace WP_Rocket\Engine\Container;
 
 use Interop\Container\ContainerInterface as InteropContainerInterface;
-use League\Container\Argument\RawArgumentInterface;
-use League\Container\Definition\DefinitionFactory;
-use League\Container\Definition\DefinitionFactoryInterface;
-use League\Container\Definition\DefinitionInterface;
-use League\Container\Exception\NotFoundException;
-use League\Container\Inflector\InflectorAggregate;
-use League\Container\Inflector\InflectorAggregateInterface;
-use League\Container\ServiceProvider\ServiceProviderAggregate;
-use League\Container\ServiceProvider\ServiceProviderAggregateInterface;
+use WP_Rocket\Engine\Container\Argument\RawArgumentInterface;
+use WP_Rocket\Engine\Container\Definition\DefinitionFactory;
+use WP_Rocket\Engine\Container\Definition\DefinitionFactoryInterface;
+use WP_Rocket\Engine\Container\Definition\DefinitionInterface;
+use WP_Rocket\Engine\Container\Exception\NotFoundException;
+use WP_Rocket\Engine\Container\Inflector\InflectorAggregate;
+use WP_Rocket\Engine\Container\Inflector\InflectorAggregateInterface;
+use WP_Rocket\Engine\Container\ServiceProvider\ServiceProviderAggregate;
+use WP_Rocket\Engine\Container\ServiceProvider\ServiceProviderAggregateInterface;
 
 class Container implements ContainerInterface
 {
     /**
-     * @var \League\Container\Definition\DefinitionFactoryInterface
+     * @var \WP_Rocket\Engine\Container\Definition\DefinitionFactoryInterface
      */
     protected $definitionFactory;
 
     /**
-     * @var \League\Container\Definition\DefinitionInterface[]
+     * @var \WP_Rocket\Engine\Container\Definition\DefinitionInterface[]
      */
     protected $definitions = [];
 
     /**
-     * @var \League\Container\Definition\DefinitionInterface[]
+     * @var \WP_Rocket\Engine\Container\Definition\DefinitionInterface[]
      */
     protected $sharedDefinitions = [];
 
     /**
-     * @var \League\Container\Inflector\InflectorAggregateInterface
+     * @var \WP_Rocket\Engine\Container\Inflector\InflectorAggregateInterface
      */
     protected $inflectors;
 
     /**
-     * @var \League\Container\ServiceProvider\ServiceProviderAggregateInterface
+     * @var \WP_Rocket\Engine\Container\ServiceProvider\ServiceProviderAggregateInterface
      */
     protected $providers;
 
@@ -53,9 +53,9 @@ class Container implements ContainerInterface
     /**
      * Constructor.
      *
-     * @param \League\Container\ServiceProvider\ServiceProviderAggregateInterface|null $providers
-     * @param \League\Container\Inflector\InflectorAggregateInterface|null             $inflectors
-     * @param \League\Container\Definition\DefinitionFactoryInterface|null             $definitionFactory
+     * @param \WP_Rocket\Engine\Container\ServiceProvider\ServiceProviderAggregateInterface|null $providers
+     * @param \WP_Rocket\Engine\Container\Inflector\InflectorAggregateInterface|null             $inflectors
+     * @param \WP_Rocket\Engine\Container\Definition\DefinitionFactoryInterface|null             $definitionFactory
      */
     public function __construct(
         ServiceProviderAggregateInterface $providers         = null,

--- a/inc/Engine/Container/ContainerAwareInterface.php
+++ b/inc/Engine/Container/ContainerAwareInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace League\Container;
+
+interface ContainerAwareInterface
+{
+    /**
+     * Set a container
+     *
+     * @param \League\Container\ContainerInterface $container
+     */
+    public function setContainer(ContainerInterface $container);
+
+    /**
+     * Get the container
+     *
+     * @return \League\Container\ContainerInterface
+     */
+    public function getContainer();
+}

--- a/inc/Engine/Container/ContainerAwareInterface.php
+++ b/inc/Engine/Container/ContainerAwareInterface.php
@@ -1,20 +1,20 @@
 <?php
 
-namespace League\Container;
+namespace WP_Rocket\Engine\Container;
 
 interface ContainerAwareInterface
 {
     /**
      * Set a container
      *
-     * @param \League\Container\ContainerInterface $container
+     * @param \WP_Rocket\Engine\Container\ContainerInterface $container
      */
     public function setContainer(ContainerInterface $container);
 
     /**
      * Get the container
      *
-     * @return \League\Container\ContainerInterface
+     * @return \WP_Rocket\Engine\Container\ContainerInterface
      */
     public function getContainer();
 }

--- a/inc/Engine/Container/ContainerAwareTrait.php
+++ b/inc/Engine/Container/ContainerAwareTrait.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace League\Container;
+
+trait ContainerAwareTrait
+{
+    /**
+     * @var \League\Container\ContainerInterface
+     */
+    protected $container;
+
+    /**
+     * Set a container.
+     *
+     * @param  \League\Container\ContainerInterface $container
+     * @return $this
+     */
+    public function setContainer(ContainerInterface $container)
+    {
+        $this->container = $container;
+
+        return $this;
+    }
+
+    /**
+     * Get the container.
+     *
+     * @return \League\Container\ContainerInterface
+     */
+    public function getContainer()
+    {
+        return $this->container;
+    }
+}

--- a/inc/Engine/Container/ContainerAwareTrait.php
+++ b/inc/Engine/Container/ContainerAwareTrait.php
@@ -1,18 +1,18 @@
 <?php
 
-namespace League\Container;
+namespace WP_Rocket\Engine\Container;
 
 trait ContainerAwareTrait
 {
     /**
-     * @var \League\Container\ContainerInterface
+     * @var \WP_Rocket\Engine\Container\ContainerInterface
      */
     protected $container;
 
     /**
      * Set a container.
      *
-     * @param  \League\Container\ContainerInterface $container
+     * @param  \WP_Rocket\Engine\Container\ContainerInterface $container
      * @return $this
      */
     public function setContainer(ContainerInterface $container)
@@ -25,7 +25,7 @@ trait ContainerAwareTrait
     /**
      * Get the container.
      *
-     * @return \League\Container\ContainerInterface
+     * @return \WP_Rocket\Engine\Container\ContainerInterface
      */
     public function getContainer()
     {

--- a/inc/Engine/Container/ContainerInterface.php
+++ b/inc/Engine/Container/ContainerInterface.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace League\Container;
+
+interface ContainerInterface extends ImmutableContainerInterface
+{
+    /**
+     * Add an item to the container.
+     *
+     * @param  string     $alias
+     * @param  mixed|null $concrete
+     * @param  boolean    $share
+     * @return \League\Container\Definition\DefinitionInterface
+     */
+    public function add($alias, $concrete = null, $share = false);
+
+    /**
+     * Convenience method to add an item to the container as a shared item.
+     *
+     * @param  string     $alias
+     * @param  mixed|null $concrete
+     * @return \League\Container\Definition\DefinitionInterface
+     */
+    public function share($alias, $concrete = null);
+
+    /**
+     * Add a service provider to the container.
+     *
+     * @param  string|\League\Container\ServiceProvider\ServiceProviderInterface $provider
+     * @return void
+     */
+    public function addServiceProvider($provider);
+
+    /**
+     * Returns a definition of an item to be extended.
+     *
+     * @param  string $alias
+     * @return \League\Container\Definition\DefinitionInterface
+     */
+    public function extend($alias);
+
+    /**
+     * Allows for manipulation of specific types on resolution.
+     *
+     * @param  string        $type
+     * @param  callable|null $callback
+     * @return \League\Container\Inflector\Inflector|void
+     */
+    public function inflector($type, callable $callback = null);
+
+    /**
+     * Invoke a callable via the container.
+     *
+     * @param  callable $callable
+     * @param  array    $args
+     * @return mixed
+     */
+    public function call(callable $callable, array $args = []);
+}

--- a/inc/Engine/Container/ContainerInterface.php
+++ b/inc/Engine/Container/ContainerInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace League\Container;
+namespace WP_Rocket\Engine\Container;
 
 interface ContainerInterface extends ImmutableContainerInterface
 {
@@ -10,7 +10,7 @@ interface ContainerInterface extends ImmutableContainerInterface
      * @param  string     $alias
      * @param  mixed|null $concrete
      * @param  boolean    $share
-     * @return \League\Container\Definition\DefinitionInterface
+     * @return \WP_Rocket\Engine\Container\Definition\DefinitionInterface
      */
     public function add($alias, $concrete = null, $share = false);
 
@@ -19,14 +19,14 @@ interface ContainerInterface extends ImmutableContainerInterface
      *
      * @param  string     $alias
      * @param  mixed|null $concrete
-     * @return \League\Container\Definition\DefinitionInterface
+     * @return \WP_Rocket\Engine\Container\Definition\DefinitionInterface
      */
     public function share($alias, $concrete = null);
 
     /**
      * Add a service provider to the container.
      *
-     * @param  string|\League\Container\ServiceProvider\ServiceProviderInterface $provider
+     * @param  string|\WP_Rocket\Engine\Container\ServiceProvider\ServiceProviderInterface $provider
      * @return void
      */
     public function addServiceProvider($provider);
@@ -35,7 +35,7 @@ interface ContainerInterface extends ImmutableContainerInterface
      * Returns a definition of an item to be extended.
      *
      * @param  string $alias
-     * @return \League\Container\Definition\DefinitionInterface
+     * @return \WP_Rocket\Engine\Container\Definition\DefinitionInterface
      */
     public function extend($alias);
 
@@ -44,7 +44,7 @@ interface ContainerInterface extends ImmutableContainerInterface
      *
      * @param  string        $type
      * @param  callable|null $callback
-     * @return \League\Container\Inflector\Inflector|void
+     * @return \WP_Rocket\Engine\Container\Inflector\Inflector|void
      */
     public function inflector($type, callable $callback = null);
 

--- a/inc/Engine/Container/Definition/AbstractDefinition.php
+++ b/inc/Engine/Container/Definition/AbstractDefinition.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace League\Container\Definition;
+
+use League\Container\Argument\ArgumentResolverInterface;
+use League\Container\Argument\ArgumentResolverTrait;
+use League\Container\ImmutableContainerAwareTrait;
+
+abstract class AbstractDefinition implements ArgumentResolverInterface, DefinitionInterface
+{
+    use ArgumentResolverTrait;
+    use ImmutableContainerAwareTrait;
+
+    /**
+     * @var string
+     */
+    protected $alias;
+
+    /**
+     * @var mixed
+     */
+    protected $concrete;
+
+    /**
+     * @var array
+     */
+    protected $arguments = [];
+
+    /**
+     * Constructor.
+     *
+     * @param string $alias
+     * @param mixed  $concrete
+     */
+    public function __construct($alias, $concrete)
+    {
+        $this->alias     = $alias;
+        $this->concrete  = $concrete;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function withArgument($arg)
+    {
+        $this->arguments[] = $arg;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function withArguments(array $args)
+    {
+        foreach ($args as $arg) {
+            $this->withArgument($arg);
+        }
+
+        return $this;
+    }
+}

--- a/inc/Engine/Container/Definition/AbstractDefinition.php
+++ b/inc/Engine/Container/Definition/AbstractDefinition.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace League\Container\Definition;
+namespace WP_Rocket\Engine\Container\Definition;
 
-use League\Container\Argument\ArgumentResolverInterface;
-use League\Container\Argument\ArgumentResolverTrait;
-use League\Container\ImmutableContainerAwareTrait;
+use WP_Rocket\Engine\Container\Argument\ArgumentResolverInterface;
+use WP_Rocket\Engine\Container\Argument\ArgumentResolverTrait;
+use WP_Rocket\Engine\Container\ImmutableContainerAwareTrait;
 
 abstract class AbstractDefinition implements ArgumentResolverInterface, DefinitionInterface
 {

--- a/inc/Engine/Container/Definition/CallableDefinition.php
+++ b/inc/Engine/Container/Definition/CallableDefinition.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace League\Container\Definition;
+
+class CallableDefinition extends AbstractDefinition
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function build(array $args = [])
+    {
+        $args     = (empty($args)) ? $this->arguments : $args;
+        $resolved = $this->resolveArguments($args);
+
+        if (is_array($this->concrete) && is_string($this->concrete[0])) {
+            $this->concrete[0] = ($this->getContainer()->has($this->concrete[0]))
+                               ? $this->getContainer()->get($this->concrete[0])
+                               : $this->concrete[0];
+        }
+
+        return call_user_func_array($this->concrete, $resolved);
+    }
+}

--- a/inc/Engine/Container/Definition/CallableDefinition.php
+++ b/inc/Engine/Container/Definition/CallableDefinition.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace League\Container\Definition;
+namespace WP_Rocket\Engine\Container\Definition;
 
 class CallableDefinition extends AbstractDefinition
 {

--- a/inc/Engine/Container/Definition/ClassDefinition.php
+++ b/inc/Engine/Container/Definition/ClassDefinition.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace League\Container\Definition;
+
+use ReflectionClass;
+
+class ClassDefinition extends AbstractDefinition implements ClassDefinitionInterface
+{
+    /**
+     * @var array
+     */
+    protected $methods = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function withMethodCall($method, array $args = [])
+    {
+        $this->methods[] = [
+            'method'    => $method,
+            'arguments' => $args
+        ];
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function withMethodCalls(array $methods = [])
+    {
+        foreach ($methods as $method => $args) {
+            $this->withMethodCall($method, $args);
+        }
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function build(array $args = [])
+    {
+        $args       = (empty($args)) ? $this->arguments : $args;
+        $resolved   = $this->resolveArguments($args);
+        $reflection = new ReflectionClass($this->concrete);
+        $instance   = $reflection->newInstanceArgs($resolved);
+
+        return $this->invokeMethods($instance);
+    }
+
+    /**
+     * Invoke methods on resolved instance.
+     *
+     * @param  object $instance
+     * @return object
+     */
+    protected function invokeMethods($instance)
+    {
+        foreach ($this->methods as $method) {
+            $args = $this->resolveArguments($method['arguments']);
+            call_user_func_array([$instance, $method['method']], $args);
+        }
+
+        return $instance;
+    }
+}

--- a/inc/Engine/Container/Definition/ClassDefinition.php
+++ b/inc/Engine/Container/Definition/ClassDefinition.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace League\Container\Definition;
+namespace WP_Rocket\Engine\Container\Definition;
 
 use ReflectionClass;
 

--- a/inc/Engine/Container/Definition/ClassDefinitionInterface.php
+++ b/inc/Engine/Container/Definition/ClassDefinitionInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace League\Container\Definition;
+
+interface ClassDefinitionInterface extends DefinitionInterface
+{
+    /**
+     * Add a method to be invoked
+     *
+     * @param  string $method
+     * @param  array  $args
+     * @return $this
+     */
+    public function withMethodCall($method, array $args = []);
+
+    /**
+     * Add multiple methods to be invoked
+     *
+     * @param  array $methods
+     * @return $this
+     */
+    public function withMethodCalls(array $methods = []);
+}

--- a/inc/Engine/Container/Definition/ClassDefinitionInterface.php
+++ b/inc/Engine/Container/Definition/ClassDefinitionInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace League\Container\Definition;
+namespace WP_Rocket\Engine\Container\Definition;
 
 interface ClassDefinitionInterface extends DefinitionInterface
 {

--- a/inc/Engine/Container/Definition/DefinitionFactory.php
+++ b/inc/Engine/Container/Definition/DefinitionFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace League\Container\Definition;
+
+use League\Container\ImmutableContainerAwareTrait;
+
+class DefinitionFactory implements DefinitionFactoryInterface
+{
+    use ImmutableContainerAwareTrait;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition($alias, $concrete)
+    {
+        if (is_callable($concrete)) {
+            return (new CallableDefinition($alias, $concrete))->setContainer($this->getContainer());
+        }
+
+        if (is_string($concrete) && class_exists($concrete)) {
+            return (new ClassDefinition($alias, $concrete))->setContainer($this->getContainer());
+        }
+
+        // if the item is not definable we just return the value to be stored
+        // in the container as an arbitrary value/instance
+        return $concrete;
+    }
+}

--- a/inc/Engine/Container/Definition/DefinitionFactory.php
+++ b/inc/Engine/Container/Definition/DefinitionFactory.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace League\Container\Definition;
+namespace WP_Rocket\Engine\Container\Definition;
 
-use League\Container\ImmutableContainerAwareTrait;
+use WP_Rocket\Engine\Container\ImmutableContainerAwareTrait;
 
 class DefinitionFactory implements DefinitionFactoryInterface
 {

--- a/inc/Engine/Container/Definition/DefinitionFactoryInterface.php
+++ b/inc/Engine/Container/Definition/DefinitionFactoryInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace League\Container\Definition;
+
+use League\Container\ImmutableContainerAwareInterface;
+
+interface DefinitionFactoryInterface extends ImmutableContainerAwareInterface
+{
+    /**
+     * Return a definition based on type of concrete.
+     *
+     * @param  string $alias
+     * @param  mixed  $concrete
+     * @return mixed
+     */
+    public function getDefinition($alias, $concrete);
+}

--- a/inc/Engine/Container/Definition/DefinitionFactoryInterface.php
+++ b/inc/Engine/Container/Definition/DefinitionFactoryInterface.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace League\Container\Definition;
+namespace WP_Rocket\Engine\Container\Definition;
 
-use League\Container\ImmutableContainerAwareInterface;
+use WP_Rocket\Engine\Container\ImmutableContainerAwareInterface;
 
 interface DefinitionFactoryInterface extends ImmutableContainerAwareInterface
 {

--- a/inc/Engine/Container/Definition/DefinitionInterface.php
+++ b/inc/Engine/Container/Definition/DefinitionInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace League\Container\Definition;
+
+interface DefinitionInterface
+{
+    /**
+     * Handle instantiation and manipulation of value and return.
+     *
+     * @param  array $args
+     * @return mixed
+     */
+    public function build(array $args = []);
+
+    /**
+     * Add an argument to be injected.
+     *
+     * @param  mixed $arg
+     * @return $this
+     */
+    public function withArgument($arg);
+
+    /**
+     * Add multiple arguments to be injected.
+     *
+     * @param  array $args
+     * @return $this
+     */
+    public function withArguments(array $args);
+}

--- a/inc/Engine/Container/Definition/DefinitionInterface.php
+++ b/inc/Engine/Container/Definition/DefinitionInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace League\Container\Definition;
+namespace WP_Rocket\Engine\Container\Definition;
 
 interface DefinitionInterface
 {

--- a/inc/Engine/Container/Exception/NotFoundException.php
+++ b/inc/Engine/Container/Exception/NotFoundException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace League\Container\Exception;
+
+use Interop\Container\Exception\NotFoundException as NotFoundExceptionInterface;
+use InvalidArgumentException;
+
+class NotFoundException extends InvalidArgumentException implements NotFoundExceptionInterface
+{
+}

--- a/inc/Engine/Container/Exception/NotFoundException.php
+++ b/inc/Engine/Container/Exception/NotFoundException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace League\Container\Exception;
+namespace WP_Rocket\Engine\Container\Exception;
 
 use Interop\Container\Exception\NotFoundException as NotFoundExceptionInterface;
 use InvalidArgumentException;

--- a/inc/Engine/Container/ImmutableContainerAwareInterface.php
+++ b/inc/Engine/Container/ImmutableContainerAwareInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace League\Container;
+
+use Interop\Container\ContainerInterface as InteropContainerInterface;
+
+interface ImmutableContainerAwareInterface
+{
+    /**
+     * Set a container
+     *
+     * @param \Interop\Container\ContainerInterface $container
+     */
+    public function setContainer(InteropContainerInterface $container);
+
+    /**
+     * Get the container
+     *
+     * @return \League\Container\ImmutableContainerInterface
+     */
+    public function getContainer();
+}

--- a/inc/Engine/Container/ImmutableContainerAwareInterface.php
+++ b/inc/Engine/Container/ImmutableContainerAwareInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace League\Container;
+namespace WP_Rocket\Engine\Container;
 
 use Interop\Container\ContainerInterface as InteropContainerInterface;
 
@@ -16,7 +16,7 @@ interface ImmutableContainerAwareInterface
     /**
      * Get the container
      *
-     * @return \League\Container\ImmutableContainerInterface
+     * @return \WP_Rocket\Engine\Container\ImmutableContainerInterface
      */
     public function getContainer();
 }

--- a/inc/Engine/Container/ImmutableContainerAwareTrait.php
+++ b/inc/Engine/Container/ImmutableContainerAwareTrait.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace League\Container;
+
+use Interop\Container\ContainerInterface as InteropContainerInterface;
+
+trait ImmutableContainerAwareTrait
+{
+    /**
+     * @var \Interop\Container\ContainerInterface
+     */
+    protected $container;
+
+    /**
+     * Set a container.
+     *
+     * @param  \Interop\Container\ContainerInterface $container
+     * @return $this
+     */
+    public function setContainer(InteropContainerInterface $container)
+    {
+        $this->container = $container;
+
+        return $this;
+    }
+
+    /**
+     * Get the container.
+     *
+     * @return \League\Container\ImmutableContainerInterface
+     */
+    public function getContainer()
+    {
+        return $this->container;
+    }
+}

--- a/inc/Engine/Container/ImmutableContainerAwareTrait.php
+++ b/inc/Engine/Container/ImmutableContainerAwareTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace League\Container;
+namespace WP_Rocket\Engine\Container;
 
 use Interop\Container\ContainerInterface as InteropContainerInterface;
 
@@ -27,7 +27,7 @@ trait ImmutableContainerAwareTrait
     /**
      * Get the container.
      *
-     * @return \League\Container\ImmutableContainerInterface
+     * @return \WP_Rocket\Engine\Container\ImmutableContainerInterface
      */
     public function getContainer()
     {

--- a/inc/Engine/Container/ImmutableContainerInterface.php
+++ b/inc/Engine/Container/ImmutableContainerInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace League\Container;
+
+use Interop\Container\ContainerInterface as InteropContainerInterface;
+
+interface ImmutableContainerInterface extends InteropContainerInterface
+{
+
+}

--- a/inc/Engine/Container/ImmutableContainerInterface.php
+++ b/inc/Engine/Container/ImmutableContainerInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace League\Container;
+namespace WP_Rocket\Engine\Container;
 
 use Interop\Container\ContainerInterface as InteropContainerInterface;
 

--- a/inc/Engine/Container/Inflector/Inflector.php
+++ b/inc/Engine/Container/Inflector/Inflector.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace League\Container\Inflector;
+
+use League\Container\ImmutableContainerAwareTrait;
+use League\Container\Argument\ArgumentResolverInterface;
+use League\Container\Argument\ArgumentResolverTrait;
+
+class Inflector implements ArgumentResolverInterface
+{
+    use ArgumentResolverTrait;
+    use ImmutableContainerAwareTrait;
+
+    /**
+     * @var array
+     */
+    protected $methods = [];
+
+    /**
+     * @var array
+     */
+    protected $properties = [];
+
+    /**
+     * Defines a method to be invoked on the subject object.
+     *
+     * @param  string $name
+     * @param  array  $args
+     * @return $this
+     */
+    public function invokeMethod($name, array $args)
+    {
+        $this->methods[$name] = $args;
+
+        return $this;
+    }
+
+    /**
+     * Defines multiple methods to be invoked on the subject object.
+     *
+     * @param  array $methods
+     * @return $this
+     */
+    public function invokeMethods(array $methods)
+    {
+        foreach ($methods as $name => $args) {
+            $this->invokeMethod($name, $args);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Defines a property to be set on the subject object.
+     *
+     * @param  string $property
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function setProperty($property, $value)
+    {
+        $this->properties[$property] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Defines multiple properties to be set on the subject object.
+     *
+     * @param  array $properties
+     * @return $this
+     */
+    public function setProperties(array $properties)
+    {
+        foreach ($properties as $property => $value) {
+            $this->setProperty($property, $value);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Apply inflections to an object.
+     *
+     * @param  object $object
+     * @return void
+     */
+    public function inflect($object)
+    {
+        $properties = $this->resolveArguments(array_values($this->properties));
+        $properties = array_combine(array_keys($this->properties), $properties);
+
+        foreach ($properties as $property => $value) {
+            $object->{$property} = $value;
+        }
+
+        foreach ($this->methods as $method => $args) {
+            $args = $this->resolveArguments($args);
+
+            call_user_func_array([$object, $method], $args);
+        }
+    }
+}

--- a/inc/Engine/Container/Inflector/Inflector.php
+++ b/inc/Engine/Container/Inflector/Inflector.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace League\Container\Inflector;
+namespace WP_Rocket\Engine\Container\Inflector;
 
-use League\Container\ImmutableContainerAwareTrait;
-use League\Container\Argument\ArgumentResolverInterface;
-use League\Container\Argument\ArgumentResolverTrait;
+use WP_Rocket\Engine\Container\ImmutableContainerAwareTrait;
+use WP_Rocket\Engine\Container\Argument\ArgumentResolverInterface;
+use WP_Rocket\Engine\Container\Argument\ArgumentResolverTrait;
 
 class Inflector implements ArgumentResolverInterface
 {

--- a/inc/Engine/Container/Inflector/InflectorAggregate.php
+++ b/inc/Engine/Container/Inflector/InflectorAggregate.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace League\Container\Inflector;
+
+use League\Container\ImmutableContainerAwareTrait;
+
+class InflectorAggregate implements InflectorAggregateInterface
+{
+    use ImmutableContainerAwareTrait;
+
+    /**
+     * @var array
+     */
+    protected $inflectors = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function add($type, callable $callback = null)
+    {
+        if (is_null($callback)) {
+            $inflector = new Inflector;
+            $this->inflectors[$type] = $inflector;
+
+            return $inflector;
+        }
+
+        $this->inflectors[$type] = $callback;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function inflect($object)
+    {
+        foreach ($this->inflectors as $type => $inflector) {
+            if (! $object instanceof $type) {
+                continue;
+            }
+
+            if ($inflector instanceof Inflector) {
+                $inflector->setContainer($this->getContainer());
+                $inflector->inflect($object);
+                continue;
+            }
+
+            // must be dealing with a callable as the inflector
+            call_user_func_array($inflector, [$object]);
+        }
+
+        return $object;
+    }
+}

--- a/inc/Engine/Container/Inflector/InflectorAggregate.php
+++ b/inc/Engine/Container/Inflector/InflectorAggregate.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace League\Container\Inflector;
+namespace WP_Rocket\Engine\Container\Inflector;
 
-use League\Container\ImmutableContainerAwareTrait;
+use WP_Rocket\Engine\Container\ImmutableContainerAwareTrait;
 
 class InflectorAggregate implements InflectorAggregateInterface
 {

--- a/inc/Engine/Container/Inflector/InflectorAggregateInterface.php
+++ b/inc/Engine/Container/Inflector/InflectorAggregateInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace League\Container\Inflector;
+
+use League\Container\ImmutableContainerAwareInterface;
+
+interface InflectorAggregateInterface extends ImmutableContainerAwareInterface
+{
+    /**
+     * Add an inflector to the aggregate.
+     *
+     * @param  string   $type
+     * @param  callable $callback
+     * @return \League\Container\Inflector\Inflector
+     */
+    public function add($type, callable $callback = null);
+
+    /**
+     * Applies all inflectors to an object.
+     *
+     * @param  object $object
+     * @return object
+     */
+    public function inflect($object);
+}

--- a/inc/Engine/Container/Inflector/InflectorAggregateInterface.php
+++ b/inc/Engine/Container/Inflector/InflectorAggregateInterface.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace League\Container\Inflector;
+namespace WP_Rocket\Engine\Container\Inflector;
 
-use League\Container\ImmutableContainerAwareInterface;
+use WP_Rocket\Engine\Container\ImmutableContainerAwareInterface;
 
 interface InflectorAggregateInterface extends ImmutableContainerAwareInterface
 {
@@ -11,7 +11,7 @@ interface InflectorAggregateInterface extends ImmutableContainerAwareInterface
      *
      * @param  string   $type
      * @param  callable $callback
-     * @return \League\Container\Inflector\Inflector
+     * @return \WP_Rocket\Engine\Container\Inflector\Inflector
      */
     public function add($type, callable $callback = null);
 

--- a/inc/Engine/Container/ReflectionContainer.php
+++ b/inc/Engine/Container/ReflectionContainer.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace League\Container;
+
+use League\Container\Argument\ArgumentResolverInterface;
+use League\Container\Argument\ArgumentResolverTrait;
+use League\Container\Exception\NotFoundException;
+use ReflectionClass;
+use ReflectionFunction;
+use ReflectionMethod;
+
+class ReflectionContainer implements
+    ArgumentResolverInterface,
+    ImmutableContainerInterface
+{
+    use ArgumentResolverTrait;
+    use ImmutableContainerAwareTrait;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get($alias, array $args = [])
+    {
+        if (! $this->has($alias)) {
+            throw new NotFoundException(
+                sprintf('Alias (%s) is not an existing class and therefore cannot be resolved', $alias)
+            );
+        }
+
+        $reflector = new ReflectionClass($alias);
+        $construct = $reflector->getConstructor();
+
+        if ($construct === null) {
+            return new $alias;
+        }
+
+        return $reflector->newInstanceArgs(
+            $this->reflectArguments($construct, $args)
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has($alias)
+    {
+        return class_exists($alias);
+    }
+
+    /**
+     * Invoke a callable via the container.
+     *
+     * @param  callable $callable
+     * @param  array    $args
+     * @return mixed
+     */
+    public function call(callable $callable, array $args = [])
+    {
+        if (is_string($callable) && strpos($callable, '::') !== false) {
+            $callable = explode('::', $callable);
+        }
+
+        if (is_array($callable)) {
+            if (is_string($callable[0])) {
+                $callable[0] = $this->getContainer()->get($callable[0]);
+            }
+
+            $reflection = new ReflectionMethod($callable[0], $callable[1]);
+
+            if ($reflection->isStatic()) {
+                $callable[0] = null;
+            }
+
+            return $reflection->invokeArgs($callable[0], $this->reflectArguments($reflection, $args));
+        }
+
+        if (is_object($callable)) {
+            $reflection = new ReflectionMethod($callable, '__invoke');
+
+            return $reflection->invokeArgs($callable, $this->reflectArguments($reflection, $args));
+        }
+
+        $reflection = new ReflectionFunction($callable);
+
+        return $reflection->invokeArgs($this->reflectArguments($reflection, $args));
+    }
+}

--- a/inc/Engine/Container/ReflectionContainer.php
+++ b/inc/Engine/Container/ReflectionContainer.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace League\Container;
+namespace WP_Rocket\Engine\Container;
 
-use League\Container\Argument\ArgumentResolverInterface;
-use League\Container\Argument\ArgumentResolverTrait;
-use League\Container\Exception\NotFoundException;
+use WP_Rocket\Engine\Container\Argument\ArgumentResolverInterface;
+use WP_Rocket\Engine\Container\Argument\ArgumentResolverTrait;
+use WP_Rocket\Engine\Container\Exception\NotFoundException;
 use ReflectionClass;
 use ReflectionFunction;
 use ReflectionMethod;

--- a/inc/Engine/Container/ServiceProvider/AbstractServiceProvider.php
+++ b/inc/Engine/Container/ServiceProvider/AbstractServiceProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace League\Container\ServiceProvider;
+
+use League\Container\ContainerAwareTrait;
+
+abstract class AbstractServiceProvider implements ServiceProviderInterface
+{
+    use ContainerAwareTrait;
+
+    /**
+     * @var array
+     */
+    protected $provides = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function provides($alias = null)
+    {
+        if (! is_null($alias)) {
+            return (in_array($alias, $this->provides));
+        }
+
+        return $this->provides;
+    }
+}

--- a/inc/Engine/Container/ServiceProvider/AbstractServiceProvider.php
+++ b/inc/Engine/Container/ServiceProvider/AbstractServiceProvider.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace League\Container\ServiceProvider;
+namespace WP_Rocket\Engine\Container\ServiceProvider;
 
-use League\Container\ContainerAwareTrait;
+use WP_Rocket\Engine\Container\ContainerAwareTrait;
 
 abstract class AbstractServiceProvider implements ServiceProviderInterface
 {

--- a/inc/Engine/Container/ServiceProvider/AbstractSignatureServiceProvider.php
+++ b/inc/Engine/Container/ServiceProvider/AbstractSignatureServiceProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace League\Container\ServiceProvider;
+
+abstract class AbstractSignatureServiceProvider
+    extends AbstractServiceProvider
+    implements SignatureServiceProviderInterface
+{
+    /**
+     * @var string
+     */
+    protected $signature;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function withSignature($signature)
+    {
+        $this->signature = $signature;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSignature()
+    {
+        return (is_null($this->signature)) ? get_class($this) : $this->signature;
+    }
+}

--- a/inc/Engine/Container/ServiceProvider/AbstractSignatureServiceProvider.php
+++ b/inc/Engine/Container/ServiceProvider/AbstractSignatureServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace League\Container\ServiceProvider;
+namespace WP_Rocket\Engine\Container\ServiceProvider;
 
 abstract class AbstractSignatureServiceProvider
     extends AbstractServiceProvider

--- a/inc/Engine/Container/ServiceProvider/BootableServiceProviderInterface.php
+++ b/inc/Engine/Container/ServiceProvider/BootableServiceProviderInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace League\Container\ServiceProvider;
+
+interface BootableServiceProviderInterface extends ServiceProviderInterface
+{
+    /**
+     * Method will be invoked on registration of a service provider implementing
+     * this interface. Provides ability for eager loading of Service Providers.
+     *
+     * @return void
+     */
+    public function boot();
+}

--- a/inc/Engine/Container/ServiceProvider/BootableServiceProviderInterface.php
+++ b/inc/Engine/Container/ServiceProvider/BootableServiceProviderInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace League\Container\ServiceProvider;
+namespace WP_Rocket\Engine\Container\ServiceProvider;
 
 interface BootableServiceProviderInterface extends ServiceProviderInterface
 {

--- a/inc/Engine/Container/ServiceProvider/ServiceProviderAggregate.php
+++ b/inc/Engine/Container/ServiceProvider/ServiceProviderAggregate.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace League\Container\ServiceProvider;
+
+use League\Container\ContainerAwareInterface;
+use League\Container\ContainerAwareTrait;
+
+class ServiceProviderAggregate implements ServiceProviderAggregateInterface
+{
+    use ContainerAwareTrait;
+
+    /**
+     * @var array
+     */
+    protected $providers = [];
+
+    /**
+     * @var array
+     */
+    protected $registered = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function add($provider)
+    {
+        if (is_string($provider) && class_exists($provider)) {
+            $provider = new $provider;
+        }
+
+        if ($provider instanceof ContainerAwareInterface) {
+            $provider->setContainer($this->getContainer());
+        }
+
+        if ($provider instanceof BootableServiceProviderInterface) {
+            $provider->boot();
+        }
+
+        if ($provider instanceof ServiceProviderInterface) {
+            foreach ($provider->provides() as $service) {
+                $this->providers[$service] = $provider;
+            }
+
+            return $this;
+        }
+
+        throw new \InvalidArgumentException(
+            'A service provider must be a fully qualified class name or instance ' .
+            'of (\League\Container\ServiceProvider\ServiceProviderInterface)'
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function provides($service)
+    {
+        return array_key_exists($service, $this->providers);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function register($service)
+    {
+        if (! array_key_exists($service, $this->providers)) {
+            throw new \InvalidArgumentException(
+                sprintf('(%s) is not provided by a service provider', $service)
+            );
+        }
+
+        $provider  = $this->providers[$service];
+        $signature = get_class($provider);
+
+        if ($provider instanceof SignatureServiceProviderInterface) {
+            $signature = $provider->getSignature();
+        }
+
+        // ensure that the provider hasn't already been invoked by any other service request
+        if (in_array($signature, $this->registered)) {
+            return;
+        }
+
+        $provider->register();
+
+        $this->registered[] = $signature;
+    }
+}

--- a/inc/Engine/Container/ServiceProvider/ServiceProviderAggregate.php
+++ b/inc/Engine/Container/ServiceProvider/ServiceProviderAggregate.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace League\Container\ServiceProvider;
+namespace WP_Rocket\Engine\Container\ServiceProvider;
 
-use League\Container\ContainerAwareInterface;
-use League\Container\ContainerAwareTrait;
+use WP_Rocket\Engine\Container\ContainerAwareInterface;
+use WP_Rocket\Engine\Container\ContainerAwareTrait;
 
 class ServiceProviderAggregate implements ServiceProviderAggregateInterface
 {
@@ -46,7 +46,7 @@ class ServiceProviderAggregate implements ServiceProviderAggregateInterface
 
         throw new \InvalidArgumentException(
             'A service provider must be a fully qualified class name or instance ' .
-            'of (\League\Container\ServiceProvider\ServiceProviderInterface)'
+            'of (\WP_Rocket\Engine\Container\ServiceProvider\ServiceProviderInterface)'
         );
     }
 

--- a/inc/Engine/Container/ServiceProvider/ServiceProviderAggregateInterface.php
+++ b/inc/Engine/Container/ServiceProvider/ServiceProviderAggregateInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace League\Container\ServiceProvider;
+
+use League\Container\ContainerAwareInterface;
+
+interface ServiceProviderAggregateInterface extends ContainerAwareInterface
+{
+    /**
+     * Add a service provider to the aggregate.
+     *
+     * @param  string|\League\Container\ServiceProvider\ServiceProviderInterface $provider
+     * @return $this
+     */
+    public function add($provider);
+
+    /**
+     * Determines whether a service is provided by the aggregate.
+     *
+     * @param  string $service
+     * @return boolean
+     */
+    public function provides($service);
+
+    /**
+     * Invokes the register method of a provider that provides a specific service.
+     *
+     * @param  string $service
+     * @return void
+     */
+    public function register($service);
+}

--- a/inc/Engine/Container/ServiceProvider/ServiceProviderAggregateInterface.php
+++ b/inc/Engine/Container/ServiceProvider/ServiceProviderAggregateInterface.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace League\Container\ServiceProvider;
+namespace WP_Rocket\Engine\Container\ServiceProvider;
 
-use League\Container\ContainerAwareInterface;
+use WP_Rocket\Engine\Container\ContainerAwareInterface;
 
 interface ServiceProviderAggregateInterface extends ContainerAwareInterface
 {
     /**
      * Add a service provider to the aggregate.
      *
-     * @param  string|\League\Container\ServiceProvider\ServiceProviderInterface $provider
+     * @param  string|\WP_Rocket\Engine\Container\ServiceProvider\ServiceProviderInterface $provider
      * @return $this
      */
     public function add($provider);

--- a/inc/Engine/Container/ServiceProvider/ServiceProviderInterface.php
+++ b/inc/Engine/Container/ServiceProvider/ServiceProviderInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace League\Container\ServiceProvider;
+
+use League\Container\ContainerAwareInterface;
+
+interface ServiceProviderInterface extends ContainerAwareInterface
+{
+    /**
+     * Returns a boolean if checking whether this provider provides a specific
+     * service or returns an array of provided services if no argument passed.
+     *
+     * @param  string $service
+     * @return boolean|array
+     */
+    public function provides($service = null);
+
+    /**
+     * Use the register method to register items with the container via the
+     * protected $this->container property or the `getContainer` method
+     * from the ContainerAwareTrait.
+     *
+     * @return void
+     */
+    public function register();
+}

--- a/inc/Engine/Container/ServiceProvider/ServiceProviderInterface.php
+++ b/inc/Engine/Container/ServiceProvider/ServiceProviderInterface.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace League\Container\ServiceProvider;
+namespace WP_Rocket\Engine\Container\ServiceProvider;
 
-use League\Container\ContainerAwareInterface;
+use WP_Rocket\Engine\Container\ContainerAwareInterface;
 
 interface ServiceProviderInterface extends ContainerAwareInterface
 {

--- a/inc/Engine/Container/ServiceProvider/SignatureServiceProviderInterface.php
+++ b/inc/Engine/Container/ServiceProvider/SignatureServiceProviderInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace League\Container\ServiceProvider;
+
+interface SignatureServiceProviderInterface
+{
+    /**
+     * Set a custom signature for the service provider. This enables
+     * registering the same service provider multiple times.
+     *
+     * @param  string $signature
+     * @return self
+     */
+    public function withSignature($signature);
+
+    /**
+     * The signature of the service provider uniquely identifies it, so
+     * that we can quickly determine if it has already been registered.
+     * Defaults to get_class($provider).
+     *
+     * @return string
+     */
+    public function getSignature();
+}

--- a/inc/Engine/Container/ServiceProvider/SignatureServiceProviderInterface.php
+++ b/inc/Engine/Container/ServiceProvider/SignatureServiceProviderInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace League\Container\ServiceProvider;
+namespace WP_Rocket\Engine\Container\ServiceProvider;
 
 interface SignatureServiceProviderInterface
 {

--- a/inc/Engine/CriticalPath/ServiceProvider.php
+++ b/inc/Engine/CriticalPath/ServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace WP_Rocket\Engine\CriticalPath;
 
-use League\Container\ServiceProvider\AbstractServiceProvider;
+use WP_Rocket\Engine\Container\ServiceProvider\AbstractServiceProvider;
 
 /**
  * Service provider for the Critical CSS classes

--- a/inc/Engine/Deactivation/Deactivation.php
+++ b/inc/Engine/Deactivation/Deactivation.php
@@ -2,7 +2,7 @@
 
 namespace WP_Rocket\Engine\Deactivation;
 
-use League\Container\Container;
+use WP_Rocket\Engine\Container\Container;
 use WP_Rocket\ThirdParty\Hostings\HostResolver;
 
 class Deactivation {

--- a/inc/Engine/Deactivation/ServiceProvider.php
+++ b/inc/Engine/Deactivation/ServiceProvider.php
@@ -1,8 +1,8 @@
 <?php
 namespace WP_Rocket\Engine\Deactivation;
 
-use League\Container\ServiceProvider\AbstractServiceProvider;
-use League\Container\ServiceProvider\BootableServiceProviderInterface;
+use WP_Rocket\Engine\Container\ServiceProvider\AbstractServiceProvider;
+use WP_Rocket\Engine\Container\ServiceProvider\BootableServiceProviderInterface;
 
 /**
  * Service Provider for the activation process.

--- a/inc/Engine/HealthCheck/ServiceProvider.php
+++ b/inc/Engine/HealthCheck/ServiceProvider.php
@@ -1,7 +1,7 @@
 <?php
 namespace WP_Rocket\Engine\HealthCheck;
 
-use League\Container\ServiceProvider\AbstractServiceProvider;
+use WP_Rocket\Engine\Container\ServiceProvider\AbstractServiceProvider;
 
 /**
  * Service Provider for health check subscribers

--- a/inc/Engine/Media/ServiceProvider.php
+++ b/inc/Engine/Media/ServiceProvider.php
@@ -1,7 +1,7 @@
 <?php
 namespace WP_Rocket\Engine\Media;
 
-use League\Container\ServiceProvider\AbstractServiceProvider;
+use WP_Rocket\Engine\Container\ServiceProvider\AbstractServiceProvider;
 
 /**
  * Service provider for Media module

--- a/inc/Engine/Optimization/AdminServiceProvider.php
+++ b/inc/Engine/Optimization/AdminServiceProvider.php
@@ -1,7 +1,7 @@
 <?php
 namespace WP_Rocket\Engine\Optimization;
 
-use League\Container\ServiceProvider\AbstractServiceProvider;
+use WP_Rocket\Engine\Container\ServiceProvider\AbstractServiceProvider;
 
 /**
  * Service provider for the WP Rocket optimizations

--- a/inc/Engine/Optimization/ServiceProvider.php
+++ b/inc/Engine/Optimization/ServiceProvider.php
@@ -1,7 +1,7 @@
 <?php
 namespace WP_Rocket\Engine\Optimization;
 
-use League\Container\ServiceProvider\AbstractServiceProvider;
+use WP_Rocket\Engine\Container\ServiceProvider\AbstractServiceProvider;
 
 /**
  * Service provider for the WP Rocket optimizations

--- a/inc/Engine/Preload/ServiceProvider.php
+++ b/inc/Engine/Preload/ServiceProvider.php
@@ -1,7 +1,7 @@
 <?php
 namespace WP_Rocket\Engine\Preload;
 
-use League\Container\ServiceProvider\AbstractServiceProvider;
+use WP_Rocket\Engine\Container\ServiceProvider\AbstractServiceProvider;
 
 /**
  * Service provider for the WP Rocket preload.

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -3,7 +3,7 @@
 namespace WP_Rocket;
 
 use Imagify_Partner;
-use League\Container\Container;
+use WP_Rocket\Engine\Container\Container;
 use WP_Rocket\Admin\Options;
 use WP_Rocket\Event_Management\Event_Manager;
 use WP_Rocket\ThirdParty\Hostings\HostResolver;

--- a/inc/ThirdParty/Hostings/ServiceProvider.php
+++ b/inc/ThirdParty/Hostings/ServiceProvider.php
@@ -2,8 +2,8 @@
 
 namespace WP_Rocket\ThirdParty\Hostings;
 
-use League\Container\ServiceProvider\AbstractServiceProvider;
-use League\Container\ServiceProvider\BootableServiceProviderInterface;
+use WP_Rocket\Engine\Container\ServiceProvider\AbstractServiceProvider;
+use WP_Rocket\Engine\Container\ServiceProvider\BootableServiceProviderInterface;
 use WP_Rocket\ThirdParty\Hostings\HostResolver;
 use WP_Rocket\ThirdParty\Hostings\HostSubscriberFactory;
 

--- a/inc/ThirdParty/ServiceProvider.php
+++ b/inc/ThirdParty/ServiceProvider.php
@@ -1,7 +1,7 @@
 <?php
 namespace WP_Rocket\ThirdParty;
 
-use League\Container\ServiceProvider\AbstractServiceProvider;
+use WP_Rocket\Engine\Container\ServiceProvider\AbstractServiceProvider;
 
 /**
  * Service provider for WP Rocket third party compatibility

--- a/inc/classes/ServiceProvider/class-common-subscribers.php
+++ b/inc/classes/ServiceProvider/class-common-subscribers.php
@@ -1,7 +1,7 @@
 <?php
 namespace WP_Rocket\ServiceProvider;
 
-use League\Container\ServiceProvider\AbstractServiceProvider;
+use WP_Rocket\Engine\Container\ServiceProvider\AbstractServiceProvider;
 
 /**
  * Service provider for WP Rocket features common for admin and front

--- a/inc/classes/ServiceProvider/class-database.php
+++ b/inc/classes/ServiceProvider/class-database.php
@@ -1,7 +1,7 @@
 <?php
 namespace WP_Rocket\ServiceProvider;
 
-use League\Container\ServiceProvider\AbstractServiceProvider;
+use WP_Rocket\Engine\Container\ServiceProvider\AbstractServiceProvider;
 
 /**
  * Service Provider for database optimization

--- a/inc/classes/ServiceProvider/class-options.php
+++ b/inc/classes/ServiceProvider/class-options.php
@@ -1,7 +1,7 @@
 <?php
 namespace WP_Rocket\ServiceProvider;
 
-use League\Container\ServiceProvider\AbstractServiceProvider;
+use WP_Rocket\Engine\Container\ServiceProvider\AbstractServiceProvider;
 
 /**
  * Service provider for the WP Rocket options

--- a/inc/classes/ServiceProvider/class-updater-subscribers.php
+++ b/inc/classes/ServiceProvider/class-updater-subscribers.php
@@ -1,7 +1,7 @@
 <?php
 namespace WP_Rocket\ServiceProvider;
 
-use League\Container\ServiceProvider\AbstractServiceProvider;
+use WP_Rocket\Engine\Container\ServiceProvider\AbstractServiceProvider;
 
 /**
  * Service provider for the WP Rocket updates.

--- a/inc/main.php
+++ b/inc/main.php
@@ -1,6 +1,6 @@
 <?php
 
-use League\Container\Container;
+use WP_Rocket\Engine\Container\Container;
 use WP_Rocket\Plugin;
 
 defined( 'ABSPATH' ) || exit;

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -10,6 +10,7 @@
 	<file>.</file>
 	<!-- Ignoring Files and Folders: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
 	<exclude-pattern>/inc/deprecated/*</exclude-pattern>
+	<exclude-pattern>/inc/Engine/Container/*</exclude-pattern>
 	<exclude-pattern>/inc/vendors/*</exclude-pattern>
 	<exclude-pattern>/tests/*</exclude-pattern>
 	<exclude-pattern>/vendor/*</exclude-pattern>

--- a/tests/Integration/inc/classes/subscriber/Optimization/Dequeue_JQuery_Migrate_Subscriber/dequeueJqueryMigrate.php
+++ b/tests/Integration/inc/classes/subscriber/Optimization/Dequeue_JQuery_Migrate_Subscriber/dequeueJqueryMigrate.php
@@ -43,18 +43,25 @@ class Test_DequeueJqueryMigrate extends TestCase {
 	}
 
 	public function testShouldNotDequeueJqueryMigrate() {
+		global $wp_version;
 		add_filter( 'pre_get_rocket_option_dequeue_jquery_migrate', '__return_false' );
 
 		$this->wp_scripts->init();
 		$this->assertGreaterThan( $this->count, did_action( 'wp_default_scripts' ) );
 		$jquery_dependencies = $this->wp_scripts->registered['jquery']->deps;
 
-		$this->assertContains( 'jquery-migrate', $jquery_dependencies );
+		if ( version_compare( $wp_version, '5.5', '>=' ) ) {
+			$this->assertNotContains( 'jquery-migrate', $jquery_dependencies );
+		} else {
+			$this->assertContains( 'jquery-migrate', $jquery_dependencies );
+		}
 
 		remove_filter( 'pre_get_rocket_option_dequeue_jquery_migrate', '__return_false' );
 	}
 
 	public function testShouldNotDequeueJqueryMigrateWithDONOTROCKETOPTIMIZE() {
+		global $wp_version;
+
 		add_filter( 'pre_get_rocket_option_dequeue_jquery_migrate', '__return_true' );
 
 		Monkey\Functions\expect( 'rocket_get_constant' )
@@ -65,7 +72,11 @@ class Test_DequeueJqueryMigrate extends TestCase {
 		$this->assertGreaterThan( $this->count, did_action( 'wp_default_scripts' ) );
 		$jquery_dependencies = $this->wp_scripts->registered['jquery']->deps;
 
-		$this->assertContains( 'jquery-migrate', $jquery_dependencies );
+		if ( version_compare( $wp_version, '5.5', '>=' ) ) {
+			$this->assertNotContains( 'jquery-migrate', $jquery_dependencies );
+		} else {
+			$this->assertContains( 'jquery-migrate', $jquery_dependencies );
+		}
 
 		remove_filter( 'pre_get_rocket_option_dequeue_jquery_migrate', '__return_true' );
 	}

--- a/wp-rocket.php
+++ b/wp-rocket.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Rocket
  * Plugin URI: https://wp-rocket.me
  * Description: The best WordPress performance plugin.
- * Version: 3.6.3
+ * Version: 3.6.4
  * Code Name: Coruscant
  * Author: WP Media
  * Author URI: https://wp-media.me
@@ -18,7 +18,7 @@
 defined( 'ABSPATH' ) || exit;
 
 // Rocket defines.
-define( 'WP_ROCKET_VERSION',               '3.6.3' );
+define( 'WP_ROCKET_VERSION',               '3.6.4' );
 define( 'WP_ROCKET_WP_VERSION',            '4.9' );
 define( 'WP_ROCKET_WP_VERSION_TESTED',     '5.4.1' );
 define( 'WP_ROCKET_PHP_VERSION',           '5.6' );


### PR DESCRIPTION
Namespace the container inside our own namespace to prevent conflict when WooCommerce 4.4 uses league/container version 3

Also prevent the PHP notice related to the REST API with WP 5.5