### PR TITLE
Added check to make sure variable is iterable

### DIFF
--- a/inc/classes/Cache/class-expired-cache-purge.php
+++ b/inc/classes/Cache/class-expired-cache-purge.php
@@ -117,25 +117,27 @@ class Expired_Cache_Purge {
 				$sub_dir = rtrim( $file['path'], '/' );
 				$files   = $this->get_cache_files_in_dir( $file );
 
-				foreach ( $files as $item ) {
-					$dir_path     = $item->getPathname();
-					$sub_dir_path = $dir_path . $sub_dir;
+				if ( is_iterable( $files ) ) {
+					foreach ( $files as $item ) {
+						$dir_path     = $item->getPathname();
+						$sub_dir_path = $dir_path . $sub_dir;
 
-					// Time to cut old leaves.
-					$item_paths = $this->purge_dir( $sub_dir_path, $file_age_limit );
+						// Time to cut old leaves.
+						$item_paths = $this->purge_dir( $sub_dir_path, $file_age_limit );
 
-					if ( $item_paths ) {
-						$url_deleted[] = [
-							'home_url'  => $url,
-							'home_path' => $sub_dir_path,
-							'logged_in' => $dir_path !== $this->cache_path . $file['host'],
-							'files'     => $item_paths,
-						];
-					}
+						if ( $item_paths ) {
+							$url_deleted[] = [
+								'home_url'  => $url,
+								'home_path' => $sub_dir_path,
+								'logged_in' => $dir_path !== $this->cache_path . $file['host'],
+								'files'     => $item_paths,
+							];
+						}
 
-					if ( $this->is_dir_empty( $dir_path ) ) {
-						// If the folder is empty, remove it.
-						$this->filesystem->delete( $dir_path );
+						if ( $this->is_dir_empty( $dir_path ) ) {
+							// If the folder is empty, remove it.
+							$this->filesystem->delete( $dir_path );
+						}
 					}
 				}
 


### PR DESCRIPTION
Fixes https://github.com/wp-media/wp-rocket/issues/2909

Added check to make sure `$files` variable is iterable before calling the foreach loop. 