### PR TITLE
Add Speed Booster Pack to the list of plugins to disable

### DIFF
--- a/inc/admin/ui/notices.php
+++ b/inc/admin/ui/notices.php
@@ -122,7 +122,7 @@ function rocket_plugins_to_deactivate() {
 		'cache-enabler'                              => 'cache-enabler/cache-enabler.php',
 		'swift-performance-lite'                     => 'swift-performance-lite/performance.php',
 		'swift-performance'                          => 'swift-performance/performance.php',
-		'speed-booster-pack'                         => 'speed-booster-pack.php',
+		'speed-booster-pack'                         => 'speed-booster-pack/speed-booster-pack.php',
 		'wp-http-compression'                        => 'wp-http-compression/wp-http-compression.php',
 		'wordpress-gzip-compression'                 => 'wordpress-gzip-compression/ezgz.php',
 		'gzip-ninja-speed-compression'               => 'gzip-ninja-speed-compression/gzip-ninja-speed.php',


### PR DESCRIPTION
Speed Booster Pack has a page caching option since their recent update (4.0).

For this reason, we need to add this plugin to the list of plugins to disable when WP Rocket is activated.