### PR TITLE
Fix #2996 Deactivate button from conflict notice doesn't work since 3.5

### DIFF
--- a/inc/admin/admin.php
+++ b/inc/admin/admin.php
@@ -165,7 +165,7 @@ function rocket_deactivate_plugin() {
 		wp_nonce_ays( '' );
 	}
 
-	deactivate_plugins( sanitize_text_field( $_GET['plugin'] ) );
+	deactivate_plugins( sanitize_text_field( wp_unslash( $_GET['plugin'] ) ) );
 
 	wp_safe_redirect( wp_get_referer() );
 	die();


### PR DESCRIPTION
Fixes #2996 

- [x] Replace sanitize_key() function by sanitize_text_field() here: https://github.com/wp-media/wp-rocket/blob/bdcfdca33b5040219bb3a9c5f8d6d3916290a8bb/inc/admin/admin.php#L168