### PR TITLE
Adds filter for Preload Links script configuration parameters.

### DIFF
--- a/inc/Engine/Preload/Links/Subscriber.php
+++ b/inc/Engine/Preload/Links/Subscriber.php
@@ -113,7 +113,7 @@ class Subscriber implements Subscriber_Interface {
 
 		$config = [
 			'excludeUris'       => $this->get_uris_to_exclude( $use_trailing_slash ),
-			'usesTrailingSlash' => $use_trailing_slash,
+			'usesTrailingSlash' => (int) $use_trailing_slash,
 			'imageExt'          => $images_ext,
 			'fileExt'           => $images_ext . '|php|pdf|html|htm',
 			'siteUrl'           => site_url(),

--- a/inc/Engine/Preload/Links/Subscriber.php
+++ b/inc/Engine/Preload/Links/Subscriber.php
@@ -96,9 +96,18 @@ class Subscriber implements Subscriber_Interface {
 
 		$use_trailing_slash = $this->use_trailing_slash();
 		$images_ext         = 'jpg|jpeg|gif|png|tiff|bmp|webp|avif';
-		wp_localize_script(
-			'rocket-preload-links',
-			'RocketPreloadLinksConfig',
+		/**
+		 * Preload Links script configuration parameters.
+		 *
+		 * This array of parameters are passed as RocketPreloadLinksConfig object and used by the
+		 * `preload-links.min.js` script to configure the behavior of the Preload Links feature.
+		 *
+		 * @since 3.7
+		 *
+		 * @param string[] $config Preload Links script configuration parameters.
+		 */
+		$preload_links_config = apply_filters(
+			'rocket_preload_links_config',
 			[
 				'excludeUris'       => $this->get_uris_to_exclude( $use_trailing_slash ),
 				'usesTrailingSlash' => $use_trailing_slash,
@@ -109,6 +118,7 @@ class Subscriber implements Subscriber_Interface {
 				'rateThrottle'      => 3, // on hover: limits the number of links preloaded per second.
 			]
 		);
+		wp_localize_script( 'rocket-preload-links', 'RocketPreloadLinksConfig', $preload_links_config );
 	}
 
 	/**


### PR DESCRIPTION
Adds a filter `rocket_preload_links_config` to provide access for developers to tune the feature for their specific website.

Why?

Request from Product - to provide tuning and discovery on customer websites.

Tested on our dev sites:

- [x] tonyam4.sg-host.com
- [x] wp-rocket.dev