### PR TITLE
Add protocol early to external URL to prevent incorrect rewriting paths during combine CSS

### DIFF
--- a/inc/Engine/Optimization/Minify/CSS/Combine.php
+++ b/inc/Engine/Optimization/Minify/CSS/Combine.php
@@ -98,7 +98,7 @@ class Combine extends AbstractCSSOptimization implements ProcessorInterface {
 				$this->styles[ $style['url'] ] = [
 					'type' => 'external',
 					'tag'  => $style[0],
-					'url'  => $style['url'],
+					'url'  => rocket_add_url_protocol( $style['url'] ),
 				];
 
 				continue;
@@ -284,7 +284,7 @@ class Combine extends AbstractCSSOptimization implements ProcessorInterface {
 				$file_content = $this->get_file_content( $filepath );
 				$file_content = $this->rewrite_paths( $filepath, $combined_file, $file_content );
 			} elseif ( 'external' === $style['type'] ) {
-				$file_content = $this->local_cache->get_content( rocket_add_url_protocol( $style['url'] ) );
+				$file_content = $this->local_cache->get_content( $style['url'] );
 				$file_content = $this->rewrite_paths( $style['url'], $combined_file, $file_content );
 			}
 


### PR DESCRIPTION
An external URL without protocol (starting with `//`), including `url()` inside, caused the paths rewritting inside of it to be incorrect.

This PR fixes the issue by setting the protocol on the external URL earlier.