### PR TITLE
Reverts `usesTrailingSlash` config for Preload Links

### DIFF
--- a/inc/Engine/Preload/Links/Subscriber.php
+++ b/inc/Engine/Preload/Links/Subscriber.php
@@ -113,7 +113,7 @@ class Subscriber implements Subscriber_Interface {
 
 		$config = [
 			'excludeUris'       => $this->get_uris_to_exclude( $use_trailing_slash ),
-			'usesTrailingSlash' => (int) $use_trailing_slash,
+			'usesTrailingSlash' => $use_trailing_slash,
 			'imageExt'          => $images_ext,
 			'fileExt'           => $images_ext . '|php|pdf|html|htm',
 			'siteUrl'           => site_url(),


### PR DESCRIPTION
Reverts the tiny change I did yesterday when adding the configuration filter:

- reverts the `usesTrailingSlash` parameter back to boolean (from int).

Why?

The script expects this format (doh). It uses this to know whether to add or not add the trailingslash. Without it, it causes retries when prefetching  - not what we want.

This change has already been QA'd by @Davidacu through the extensive Preload Links QA/testing. One of those last minute changes that bite me in the backside. Doh.

Tested and working again on https://wp-rocket.dev/.

👉  No QA is needed for this PR as it reverts it back to what David already tested.