### PR TITLE
Exclude inline JavaScript keywords to prevent the cache dir size issue

### DIFF
--- a/inc/Engine/Optimization/Minify/JS/Combine.php
+++ b/inc/Engine/Optimization/Minify/JS/Combine.php
@@ -621,6 +621,22 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 			'scriptParams',
 			'form-adv-pagination',
 			'borlabsCookiePrioritize',
+			'quickViewNonce',
+			'frontendscripts_params',
+			'nj-facebook-messenger',
+			'var fb_mess_position',
+			'init_particles_row_background_script',
+			'setREVStartSize',
+			'fl-node',
+			'PPAccordion',
+			'soliloquy_',
+			'wprevpublicjs_script_vars',
+			'DTGS_NONCE_FRONTEND',
+			'et_animation_data',
+			'archives-dropdown',
+			'loftloaderCache',
+			'SmartSliderSimple',
+			
 		];
 
 		$excluded_inline = array_merge( $defaults, $this->options->get( 'exclude_inline_js', [] ) );

--- a/inc/Engine/Optimization/Minify/JS/Combine.php
+++ b/inc/Engine/Optimization/Minify/JS/Combine.php
@@ -636,7 +636,6 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 			'archives-dropdown',
 			'loftloaderCache',
 			'SmartSliderSimple',
-			
 		];
 
 		$excluded_inline = array_merge( $defaults, $this->options->get( 'exclude_inline_js', [] ) );


### PR DESCRIPTION
Tickets:
- https://secure.helpscout.net/conversation/1260607059/189022/
- https://secure.helpscout.net/conversation/1249427807/185531/
- https://secure.helpscout.net/conversation/1248829743/185389/
