### PR TITLE
Fixes 3047 - Guards deprecated Minify_HTML class to avoid fatal errors.

### DIFF
--- a/inc/deprecated/3.7.php
+++ b/inc/deprecated/3.7.php
@@ -5,7 +5,9 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Require deprecated classes.
  */
-require_once __DIR__ . '/vendors/classes/class-minify-html.php';
+if ( ! class_exists( 'Minify_HTML' ) ) {
+	require_once __DIR__ . '/vendors/classes/class-minify-html.php';
+}
 require_once __DIR__ . '/subscriber/admin/Optimization/class-minify-html-subscriber.php';
 
 class_alias( '\WP_Rocket\Engine\Heartbeat\HeartbeatSubscriber', '\WP_Rocket\Subscriber\Heartbeat_Subscriber' );

--- a/inc/deprecated/3.7.php
+++ b/inc/deprecated/3.7.php
@@ -8,7 +8,9 @@ defined( 'ABSPATH' ) || exit;
 if ( ! class_exists( 'Minify_HTML' ) ) {
 	require_once __DIR__ . '/vendors/classes/class-minify-html.php';
 }
-require_once __DIR__ . '/subscriber/admin/Optimization/class-minify-html-subscriber.php';
+if ( ! class_exists( 'WP_Rocket\Subscriber\Optimization\Minify_HTML_Subscriber' ) ) {
+	require_once __DIR__ . '/subscriber/admin/Optimization/class-minify-html-subscriber.php';
+}
 
 class_alias( '\WP_Rocket\Engine\Heartbeat\HeartbeatSubscriber', '\WP_Rocket\Subscriber\Heartbeat_Subscriber' );
 class_alias( '\WP_Rocket_Mobile_Detect', '\Rocket_Mobile_Detect' );


### PR DESCRIPTION
After discussions, we decided to wrap the deprecated classes with `class_exist` to avoid loading when the class already exists in memory.

Closes #3047