### PR TITLE
Remove class alias for Rocket_Mobile_Detect

### DIFF
--- a/inc/deprecated/3.7.php
+++ b/inc/deprecated/3.7.php
@@ -9,7 +9,6 @@ require_once __DIR__ . '/vendors/classes/class-minify-html.php';
 require_once __DIR__ . '/subscriber/admin/Optimization/class-minify-html-subscriber.php';
 
 class_alias( '\WP_Rocket\Engine\Heartbeat\HeartbeatSubscriber', '\WP_Rocket\Subscriber\Heartbeat_Subscriber' );
-class_alias( '\WP_Rocket_Mobile_Detect', '\Rocket_Mobile_Detect' );
 
 /**
  * Conflict with WP Serveur hosting: don't apply inline JS on all pages.


### PR DESCRIPTION
Prevent a PHP warning in 3.7:

`Warning: Cannot declare class \ Rocket_Mobile_Detect, because the name is already in use in plugins/wp-rocket/ inc / deprecated / 3.7.php on line 12`

The class alias is not necessary as the class is still present in the codebase.

Closes #3052 