### PR TITLE
Excluding aos.js from DeferJS

### DIFF
--- a/inc/functions/options.php
+++ b/inc/functions/options.php
@@ -427,6 +427,7 @@ function get_rocket_exclude_defer_js() { // phpcs:ignore WordPress.NamingConvent
 		'simplybook.(.*)/v2/widget/widget.js',
 		'/wp-includes/js/dist/i18n.min.js',
 		'/wp-content/plugins/wpfront-notification-bar/js/wpfront-notification-bar(.*).js',
+		'/wp-content/plugins/oxygen/component-framework/vendor/aos/aos.js',
 	];
 
 	if ( get_rocket_option( 'defer_all_js', 0 ) && get_rocket_option( 'defer_all_js_safe', 0 ) ) {

--- a/tests/Integration/inc/functions/getRocketExcludeDeferJs.php
+++ b/tests/Integration/inc/functions/getRocketExcludeDeferJs.php
@@ -47,7 +47,7 @@ class Test_GetRocketExcludeDeferJS extends TestCase {
 			'simplybook.(.*)/v2/widget/widget.js',
 			'/wp-includes/js/dist/i18n.min.js',
 			'/wp-content/plugins/wpfront-notification-bar/js/wpfront-notification-bar(.*).js',
-			
+			'/wp-content/plugins/oxygen/component-framework/vendor/aos/aos.js',
 		];
 
 		if ( $defer_jquery ) {

--- a/tests/Unit/inc/functions/getRocketExcludeDeferJS.php
+++ b/tests/Unit/inc/functions/getRocketExcludeDeferJS.php
@@ -56,6 +56,7 @@ class Test_GetRocketExcludeDeferJS extends TestCase {
 			'simplybook.(.*)/v2/widget/widget.js',
 			'/wp-includes/js/dist/i18n.min.js',
             '/wp-content/plugins/wpfront-notification-bar/js/wpfront-notification-bar(.*).js',
+            '/wp-content/plugins/oxygen/component-framework/vendor/aos/aos.js',
         ];
 
         if ( $defer_jquery ) {


### PR DESCRIPTION
The aos.js library (https://github.com/michalsnik/aos) is used by  https://oxygenbuilder.com/
When DeferJS is enabled, there is and "AOS is undefined" error on AOS.init, excluding the JS file from deferring solves the issue.

Ticket: https://secure.helpscout.net/conversation/1267928807/190825?folderId=2683093