### PR TITLE
Fixes #2846 Correctly exclude jQuery from combine when WP is in a subfolder

### DIFF
--- a/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
+++ b/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
@@ -166,11 +166,11 @@ abstract class AbstractJSOptimization extends AbstractOptimization {
 		$exclude_jquery = [];
 		$jquery         = wp_scripts()->registered['jquery-core']->src;
 
-		if ( isset( $jquery  ) ) {
-			if ( '' === wp_parse_url( $jquery , PHP_URL_HOST ) ) {
-				$exclude_jquery[] = wp_parse_url( site_url( $jquery  ), PHP_URL_PATH );
+		if ( isset( $jquery ) ) {
+			if ( '' === wp_parse_url( $jquery, PHP_URL_HOST ) ) {
+				$exclude_jquery[] = wp_parse_url( site_url( $jquery ), PHP_URL_PATH );
 			} else {
-				$exclude_jquery[] = $jquery ;
+				$exclude_jquery[] = $jquery;
 			}
 		}
 

--- a/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
+++ b/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
@@ -166,8 +166,12 @@ abstract class AbstractJSOptimization extends AbstractOptimization {
 		$exclude_jquery = [];
 		$jquery         = wp_scripts()->registered['jquery-core']->src;
 
-		if ( isset( $jquery ) ) {
-			$exclude_jquery[] = $jquery;
+		if ( isset( $jquery  ) ) {
+			if ( '' === wp_parse_url( $jquery , PHP_URL_HOST ) ) {
+				$exclude_jquery[] = wp_parse_url( site_url( $jquery  ), PHP_URL_PATH );
+			} else {
+				$exclude_jquery[] = $jquery ;
+			}
 		}
 
 		$exclude_jquery[] = 'c0.wp.com/c/(?:.+)/wp-includes/js/jquery/jquery.js';

--- a/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
+++ b/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
@@ -167,7 +167,7 @@ abstract class AbstractJSOptimization extends AbstractOptimization {
 		$jquery         = wp_scripts()->registered['jquery-core']->src;
 
 		if ( isset( $jquery ) ) {
-			if ( '' === wp_parse_url( $jquery, PHP_URL_HOST ) ) {
+			if ( empty( wp_parse_url( $jquery, PHP_URL_HOST ) ) ) {
 				$exclude_jquery[] = wp_parse_url( site_url( $jquery ), PHP_URL_PATH );
 			} else {
 				$exclude_jquery[] = $jquery;

--- a/inc/functions/formatting.php
+++ b/inc/functions/formatting.php
@@ -266,7 +266,7 @@ function rocket_sanitize_ua( $user_agent ) {
  * @return string $url The URL without protocol
  */
 function rocket_remove_url_protocol( $url, $no_dots = false ) {
-	$url = str_replace( [ 'http://', 'https://' ], '', $url );
+	$url = preg_replace( '#^(https?:)?\/\/#im', '', $url );
 
 	/** This filter is documented in inc/front/htaccess.php */
 	if ( apply_filters( 'rocket_url_no_dots', $no_dots ) ) {

--- a/tests/Fixtures/inc/Engine/Optimization/Minify/JS/Combine/combine.php
+++ b/tests/Fixtures/inc/Engine/Optimization/Minify/JS/Combine/combine.php
@@ -5,7 +5,59 @@ return [
 
 	'test_data' => [
 
-		'combineJsFiles' => [
+		'testShouldCombineJsFiles' => [
+			'original' => <<<ORIGINAL_HTML
+<html>
+	<head>
+		<title>Sample Page</title>
+		<script type="text/javascript" src="http://example.org/wp-content/themes/twentytwenty/assets/script.js"></script>
+		<script type="text/javascript" src="http://example.org/wp-content/plugins/hello-dolly/script.js"></script>
+		<script type="text/javascript" src="http://example.org/wp-includes/js/jquery/jquery.js"></script>
+		<script>
+		document.getElementById("demo").innerHTML = "Hello JavaScript!";
+		</script>
+		<script>
+		nonce = "nonce";
+		</script>
+	</head>
+	<body>
+	</body>
+</html>
+ORIGINAL_HTML
+			,
+
+			'expected' => [
+				'html' => <<<EXPECTED_HTML
+<html>
+	<head>
+		<title>Sample Page</title>
+		<script>
+		nonce = "nonce";
+		</script>
+	</head>
+	<body>
+		<script src="http://example.org/wp-content/cache/min/1/900b339c19ff5a927b3311bf5ddb4dfd.js" data-minify="1"></script>
+	</body>
+</html>
+EXPECTED_HTML
+				,
+
+				'files' => [
+					'wp-content/cache/min/1/900b339c19ff5a927b3311bf5ddb4dfd.js',
+					'wp-content/cache/min/1/900b339c19ff5a927b3311bf5ddb4dfd.js.gz',
+				],
+			],
+
+			'config'   => [
+				'cdn_host'          => [],
+				'cdn_url'           => 'http://example.org',
+				'site_url'          => 'http://example.org',
+				'defer_all_js'      => false,
+				'defer_all_js_safe' => false,
+			],
+		],
+
+		'testShouldCombineJsFilesWithoutjQueryWhenDeferSafeMode' => [
 			'original' => <<<ORIGINAL_HTML
 <html>
 	<head>
@@ -49,12 +101,16 @@ EXPECTED_HTML
 				],
 			],
 
-			'cdn_host' => [],
-			'cdn_url'  => 'http://example.org',
-			'site_url' => 'http://example.org',
+			'config'   => [
+				'cdn_host'          => [],
+				'cdn_url'           => 'http://example.org',
+				'site_url'          => 'http://example.org',
+				'defer_all_js'      => true,
+				'defer_all_js_safe' => true,
+			],
 		],
 
-		'combineJsFilesExceptExcluded' => [
+		'testShouldCombineJsFilesExceptExcluded' => [
 			'original' => <<<ORIGINAL_HTML
 <html>
 	<head>
@@ -62,7 +118,6 @@ EXPECTED_HTML
 		<script type="text/javascript" src="http://example.org/wp-content/themes/twentytwenty/assets/script.js"></script>
 		<script type="text/javascript" src="http://example.org/wp-content/plugins/hello-dolly/script.js"></script>
 		<script type="text/javascript" src="http://example.org/wp-includes/js/jquery/jquery.js"></script>
-		<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.js"></script>
 		<script>
 		document.getElementById("demo").innerHTML = "Hello JavaScript!";
 		</script>
@@ -81,31 +136,33 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<script type="text/javascript" src="http://example.org/wp-includes/js/jquery/jquery.js"></script>
-		<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.js"></script>
 		<script>
 		nonce = "nonce";
 		</script>
 	</head>
 	<body>
-		<script src="http://example.org/wp-content/cache/min/1/cfe4eede7af9db7e8fa8951ee9782333.js" data-minify="1"></script>
+		<script src="http://example.org/wp-content/cache/min/1/900b339c19ff5a927b3311bf5ddb4dfd.js" data-minify="1"></script>
 	</body>
 </html>
 EXPECTED_HTML
 				,
 
 				'files' => [
-					'wp-content/cache/min/1/cfe4eede7af9db7e8fa8951ee9782333.js',
-					'wp-content/cache/min/1/cfe4eede7af9db7e8fa8951ee9782333.js.gz',
+					'wp-content/cache/min/1/900b339c19ff5a927b3311bf5ddb4dfd.js',
+					'wp-content/cache/min/1/900b339c19ff5a927b3311bf5ddb4dfd.js.gz',
 				],
 			],
 
-			'cdn_host' => [],
-			'cdn_url'  => 'http://example.org',
-			'site_url' => 'http://example.org',
+			'config'   => [
+				'cdn_host'          => [],
+				'cdn_url'           => 'http://example.org',
+				'site_url'          => 'http://example.org',
+				'defer_all_js'      => false,
+				'defer_all_js_safe' => false,
+			],
 		],
 
-		'combineJsFilesExceptDelayed' => [
+		'testShouldCombineJsFilesExceptDelayed' => [
 			'original' => <<<ORIGINAL_HTML
 <html>
 	<head>
@@ -151,12 +208,16 @@ EXPECTED_HTML
 				],
 			],
 
-			'cdn_host' => [],
-			'cdn_url'  => 'http://example.org',
-			'site_url' => 'http://example.org',
+			'config'   => [
+				'cdn_host'          => [],
+				'cdn_url'           => 'http://example.org',
+				'site_url'          => 'http://example.org',
+				'defer_all_js'      => false,
+				'defer_all_js_safe' => false,
+			],
 		],
 
-		'combineJsFiles_andUseCdnUrl' => [
+		'testShouldCombineJsFilesAndUseCdnUrl' => [
 			'original' => <<<ORIGINAL_HTML
 <html>
 	<head>
@@ -182,30 +243,33 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<script type="text/javascript" src="http://example.org/wp-includes/js/jquery/jquery.js"></script>
 		<script>
 		nonce = "nonce";
 		</script>
 	</head>
 	<body>
-		<script src="https://123456.rocketcdn.me/wp-content/cache/min/1/cfe4eede7af9db7e8fa8951ee9782333.js" data-minify="1"></script>
+		<script src="https://123456.rocketcdn.me/wp-content/cache/min/1/900b339c19ff5a927b3311bf5ddb4dfd.js" data-minify="1"></script>
 	</body>
 </html>
 EXPECTED_HTML
 				,
 
 				'files' => [
-					'wp-content/cache/min/1/cfe4eede7af9db7e8fa8951ee9782333.js',
-					'wp-content/cache/min/1/cfe4eede7af9db7e8fa8951ee9782333.js.gz',
+					'wp-content/cache/min/1/900b339c19ff5a927b3311bf5ddb4dfd.js',
+					'wp-content/cache/min/1/900b339c19ff5a927b3311bf5ddb4dfd.js.gz',
 				],
 			],
 
-			'cdn_host' => [ '123456.rocketcdn.me' ],
-			'cdn_url'  => 'https://123456.rocketcdn.me',
-			'site_url' => 'http://example.org',
+			'config'   => [
+				'cdn_host' => [ '123456.rocketcdn.me' ],
+				'cdn_url'  => 'https://123456.rocketcdn.me',
+				'site_url' => 'http://example.org',
+				'defer_all_js'      => false,
+				'defer_all_js_safe' => false,
+			],
 		],
 
-		'combineJsFiles_whenCdnUrl' => [
+		'testShouldCombineJsFilesWhenCdnUrl' => [
 			'original' => <<<ORIGINAL_HTML
 <html>
 	<head>
@@ -231,29 +295,32 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<script type="text/javascript" src="https://123456.rocketcdn.me/wp-includes/js/jquery/jquery.js"></script>
 		<script>
 		nonce = "nonce";
 		</script>
 	</head>
 	<body>
-		<script src="https://123456.rocketcdn.me/wp-content/cache/min/1/cfe4eede7af9db7e8fa8951ee9782333.js" data-minify="1"></script>
+		<script src="https://123456.rocketcdn.me/wp-content/cache/min/1/900b339c19ff5a927b3311bf5ddb4dfd.js" data-minify="1"></script>
 	</body>
 </html>
 EXPECTED_HTML
 				,
 				'files' => [
-					'wp-content/cache/min/1/cfe4eede7af9db7e8fa8951ee9782333.js',
-					'wp-content/cache/min/1/cfe4eede7af9db7e8fa8951ee9782333.js.gz',
+					'wp-content/cache/min/1/900b339c19ff5a927b3311bf5ddb4dfd.js',
+					'wp-content/cache/min/1/900b339c19ff5a927b3311bf5ddb4dfd.js.gz',
 				],
 			],
 
-			'cdn_host' => [ '123456.rocketcdn.me' ],
-			'cdn_url'  => 'https://123456.rocketcdn.me',
-			'site_url' => 'http://example.org',
+			'config'   => [
+				'cdn_host' => [ '123456.rocketcdn.me' ],
+				'cdn_url'  => 'https://123456.rocketcdn.me',
+				'site_url' => 'http://example.org',
+				'defer_all_js'      => false,
+				'defer_all_js_safe' => false,
+			],
 		],
 
-		'combineCssFiles_whenCdnUrlWithSubdir' => [
+		'testShouldCombineCssFilesWhenCdnUrlWithSubdir' => [
 			'original' => <<<ORIGINAL_HTML
 <html>
 	<head>
@@ -295,9 +362,13 @@ EXPECTED_HTML
 				],
 			],
 
-			'cdn_host' => [ '123456.rocketcdn.me/cdnpath' ],
-			'cdn_url'  => 'https://123456.rocketcdn.me/cdnpath',
-			'site_url' => 'http://example.org',
+			'config'   => [
+				'cdn_host' => [ '123456.rocketcdn.me/cdnpath' ],
+				'cdn_url'  => 'https://123456.rocketcdn.me/cdnpath',
+				'site_url' => 'http://example.org',
+				'defer_all_js'      => false,
+				'defer_all_js_safe' => false,
+			],
 		],
 	],
 ];

--- a/tests/Unit/inc/Engine/Optimization/Minify/JS/Combine/optimize.php
+++ b/tests/Unit/inc/Engine/Optimization/Minify/JS/Combine/optimize.php
@@ -43,8 +43,12 @@ class Test_Optimize extends TestCase {
 			return $wp_scripts;
 		} );
 
-		Functions\when( 'site_url' )->returnArg();
-		Functions\when('rocket_clean_exclude_file')->returnArg();
+		Functions\when( 'site_url' )->alias( function( $path = '') {
+			return 'http://example.org/' . ltrim( $path, '/' );
+		} );
+		Functions\when( 'rocket_clean_exclude_file' )->alias( function( $file = '' ) {
+			return parse_url( $file, PHP_URL_PATH );
+		} );
 
 		$this->options->shouldReceive( 'get' )
 			->with( 'minify_js_key', 'rocket_uniqid' )


### PR DESCRIPTION
Fixes #2846 

### Code changes
Instead of directly using the value from the `src` property for jQuery, we check if the `host` is set for it. If not, we call `site_url()` to make sure we get the absolute URL for the file, and then keep only the path.

This is reverting to how we did it previously.