### PR TITLE
Closes #2879 Set browser cache expiration to 4 months for videos/audios files

### DIFF
--- a/inc/functions/htaccess.php
+++ b/inc/functions/htaccess.php
@@ -470,10 +470,10 @@ function get_rocket_htaccess_mod_expires() { // phpcs:ignore WordPress.NamingCon
 	ExpiresByType image/png                     "access plus 4 months"
 	ExpiresByType image/jpeg                    "access plus 4 months"
 	ExpiresByType image/webp                    "access plus 4 months"
-	ExpiresByType video/ogg                     "access plus 1 month"
-	ExpiresByType audio/ogg                     "access plus 1 month"
-	ExpiresByType video/mp4                     "access plus 1 month"
-	ExpiresByType video/webm                    "access plus 1 month"
+	ExpiresByType video/ogg                     "access plus 4 months"
+	ExpiresByType audio/ogg                     "access plus 4 months"
+	ExpiresByType video/mp4                     "access plus 4 months"
+	ExpiresByType video/webm                    "access plus 4 months"
 	# HTC files  (css3pie)
 	ExpiresByType text/x-component              "access plus 1 month"
 	# Webfonts


### PR DESCRIPTION
Closes #2879 

### Code changes
Update `get_rocket_htaccess_mod_expires()` function to change the browser cache expiration for `ogg`, `mp4` and `webm` to 4 months instead of one. This is to improve results in PageSpeed Insights tests.