### PR TITLE
Auto exclude preload delay js scripts

### DIFF
--- a/inc/Engine/Optimization/Minify/JS/Combine.php
+++ b/inc/Engine/Optimization/Minify/JS/Combine.php
@@ -408,7 +408,6 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 	 */
 	protected function get_excluded_inline_content() {
 		$defaults = [
-			'RocketBrowserCompatibilityChecker',
 			'document.write',
 			'google_ad',
 			'edToolbar',
@@ -761,6 +760,7 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 			'wp_post_blocks_vars.listed_posts=[',
 			'captcha-hash',
 			'mapdata={',
+			'RocketBrowserCompatibilityChecker'
 		];
 
 		/**

--- a/inc/Engine/Optimization/Minify/JS/Combine.php
+++ b/inc/Engine/Optimization/Minify/JS/Combine.php
@@ -409,8 +409,6 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 	protected function get_excluded_inline_content() {
 		$defaults = [
 			'RocketBrowserCompatibilityChecker',
-			'RocketLazyLoadScripts',
-			'RocketPreloadLinks',
 			'document.write',
 			'google_ad',
 			'edToolbar',

--- a/inc/Engine/Optimization/Minify/JS/Combine.php
+++ b/inc/Engine/Optimization/Minify/JS/Combine.php
@@ -408,6 +408,9 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 	 */
 	protected function get_excluded_inline_content() {
 		$defaults = [
+			'RocketBrowserCompatibilityChecker',
+			'RocketLazyLoadScripts',
+			'RocketPreloadLinks',
 			'document.write',
 			'google_ad',
 			'edToolbar',

--- a/inc/Engine/Optimization/Minify/JS/Combine.php
+++ b/inc/Engine/Optimization/Minify/JS/Combine.php
@@ -760,7 +760,7 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 			'wp_post_blocks_vars.listed_posts=[',
 			'captcha-hash',
 			'mapdata={',
-			'RocketBrowserCompatibilityChecker'
+			'RocketBrowserCompatibilityChecker',
 		];
 
 		/**


### PR DESCRIPTION
This PR will automatically exclude our Preload and Delay JS inline scripts. It will ensure us that these features will always work. By being included into the combined JS files, our features can stop to work if a JS error is triggered.

Slack conversation: https://wp-media.slack.com/archives/GUT7FLHF1/p1599831075030100