### PR TITLE
Fixes #3071: Preload Links siteUrl configuration for when WordPress is in sub-directory

### DIFF
--- a/inc/Engine/Preload/Links/Subscriber.php
+++ b/inc/Engine/Preload/Links/Subscriber.php
@@ -116,7 +116,7 @@ class Subscriber implements Subscriber_Interface {
 			'usesTrailingSlash' => $use_trailing_slash,
 			'imageExt'          => $images_ext,
 			'fileExt'           => $images_ext . '|php|pdf|html|htm',
-			'siteUrl'           => site_url(),
+			'siteUrl'           => home_url(),
 			'onHoverDelay'      => 100, // milliseconds. -1 disables the "on hover" feature.
 			'rateThrottle'      => 3, // on hover: limits the number of links preloaded per second.
 		];


### PR DESCRIPTION
Closes #3071 

Changes the `RocketPreloadLinksConfig.siteUrl` config parameter to use `home_url()` instead of `site_url()`. This fixes the problem of when WordPress is in a sub-directory environment (such as when using Bedrock).
