### PR TITLE
Fixes #3109 Add back the single line flag for inline JS content match in delay JS

### DIFF
--- a/inc/Engine/Optimization/DelayJS/HTML.php
+++ b/inc/Engine/Optimization/DelayJS/HTML.php
@@ -88,7 +88,7 @@ class HTML {
 	 * @return string
 	 */
 	private function parse( $html ) {
-		return preg_replace_callback( '/<script\s*(?<attr>[^>]*)?>(?<content>.*)?<\/script>/Uim', [ $this, 'replace_scripts' ], $html );
+		return preg_replace_callback( '/<script\s*(?<attr>[^>]*)?>(?<content>.*)?<\/script>/Uims', [ $this, 'replace_scripts' ], $html );
 	}
 
 	/**


### PR DESCRIPTION
The single line flag `s` is required to match inline JS content containing new lines.