### PR TITLE
Fixes #3100 Exclude RocketPreloadLinksConfig from combine JS

### DIFF
--- a/inc/Engine/Optimization/Minify/JS/Combine.php
+++ b/inc/Engine/Optimization/Minify/JS/Combine.php
@@ -636,6 +636,7 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 			'archives-dropdown',
 			'loftloaderCache',
 			'SmartSliderSimple',
+			'RocketPreloadLinksConfig',
 		];
 
 		$excluded_inline = array_merge( $defaults, $this->options->get( 'exclude_inline_js', [] ) );

--- a/inc/Engine/Optimization/Minify/JS/Combine.php
+++ b/inc/Engine/Optimization/Minify/JS/Combine.php
@@ -636,6 +636,7 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 			'archives-dropdown',
 			'loftloaderCache',
 			'SmartSliderSimple',
+			'RocketBrowserCompatibilityChecker',
 			'RocketPreloadLinksConfig',
 		];
 
@@ -761,7 +762,6 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 			'wp_post_blocks_vars.listed_posts=[',
 			'captcha-hash',
 			'mapdata={',
-			'RocketBrowserCompatibilityChecker',
 		];
 
 		/**


### PR DESCRIPTION
This prevents it from being combined if the theme is not supporting the `html5` argument in its config.