### PR TITLE
Fixes PHP Fatal error in 3.7.1 because of missing autoload for Cloudflare module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,8 @@
 			"inc/classes/class-wp-rocket-requirements-check.php"
 		],
 		"psr-4": {
-			"WP_Rocket\\": "inc/"
+			"WP_Rocket\\": "inc/",
+			"WPMedia\\Cloudflare\\": "inc/Addon/Cloudflare/"
 		}
 	},
 	"autoload-dev": {


### PR DESCRIPTION
The Cloudflare module PSR-4 is not in the main composer.json file, which is preventing the classes from being added to the autoloader, and causing a fatal error when the addon is activated.
