### PR TITLE
Adding new staging site

### DIFF
--- a/inc/functions/api.php
+++ b/inc/functions/api.php
@@ -127,6 +127,7 @@ function rocket_is_live_site() {
 		'.wpserveur.net',
 		'-liquidwebsites.com',
 		'.myftpupload.com',
+		'.dream.press',
 	];
 	foreach ( $staging as $partial_host ) {
 		if ( strpos( $host, $partial_host ) ) {


### PR DESCRIPTION
Initial ticket: https://secure.helpscout.net/conversation/1287933357/196396/

Adds .dream.press staging to the list.
Related in part to https://github.com/wp-media/wp-rocket/issues/2789