### PR TITLE
Stop the infinite loop when purging cache on Pagely

### DIFF
--- a/inc/3rd-party/hosting/pagely.php
+++ b/inc/3rd-party/hosting/pagely.php
@@ -10,6 +10,13 @@ defined( 'ABSPATH' ) || exit;
  * @return void
  */
 function rocket_clear_cache_after_pagely() {
+        //  End the cycle of purges after a single purge has happened
+        if (!empty($GLOBALS['pagely_rocket_stop_cache_purge'])){
+            $GLOBALS['pagely_rocket_stop_cache_purge']=false;
+            return;
+        }
+        $GLOBALS['pagely_rocket_stop_cache_purge']=true;
+
 	// Clear all caching files.
 	rocket_clean_domain();
 }
@@ -23,6 +30,13 @@ add_action( 'pagely_cache_purge_after', 'rocket_clear_cache_after_pagely' );
  * @return void
  */
 function rocket_clean_pagely() {
+        //  End the cycle of purges after a single purge has happened
+        if (!empty($GLOBALS['pagely_rocket_stop_cache_purge'])){
+            $GLOBALS['pagely_rocket_stop_cache_purge']=false;
+            return;
+        }
+        $GLOBALS['pagely_rocket_stop_cache_purge']=true;
+
 	if ( class_exists( 'PagelyCachePurge' ) ) {
 			$purger = new PagelyCachePurge();
 			$purger->purgeAll();

--- a/inc/3rd-party/hosting/pagely.php
+++ b/inc/3rd-party/hosting/pagely.php
@@ -9,18 +9,16 @@ defined( 'ABSPATH' ) || exit;
  *
  * @return void
  */
-function rocket_clear_cache_after_pagely() {
-        //  End the cycle of purges after a single purge has happened
-        if (!empty($GLOBALS['pagely_rocket_stop_cache_purge'])){
-            $GLOBALS['pagely_rocket_stop_cache_purge']=false;
-            return;
-        }
-        $GLOBALS['pagely_rocket_stop_cache_purge']=true;
-
-	// Clear all caching files.
-	rocket_clean_domain();
-}
-add_action( 'pagely_cache_purge_after', 'rocket_clear_cache_after_pagely' );
+//  We can't have both this action and the next without infinite loop
+//    So commenting out until such time as this can be re-worked. See
+//    the following pull for comments on the way the wp-rocket team
+//    would like this refactored.
+//    https://github.com/wp-media/wp-rocket/pull/3166
+//function rocket_clear_cache_after_pagely() {
+//	// Clear all caching files.
+//	rocket_clean_domain();
+//}
+//add_action( 'pagely_cache_purge_after', 'rocket_clear_cache_after_pagely' );
 
 /**
  * Call the cache server to purge the cache with Pagely hosting.
@@ -30,13 +28,6 @@ add_action( 'pagely_cache_purge_after', 'rocket_clear_cache_after_pagely' );
  * @return void
  */
 function rocket_clean_pagely() {
-        //  End the cycle of purges after a single purge has happened
-        if (!empty($GLOBALS['pagely_rocket_stop_cache_purge'])){
-            $GLOBALS['pagely_rocket_stop_cache_purge']=false;
-            return;
-        }
-        $GLOBALS['pagely_rocket_stop_cache_purge']=true;
-
 	if ( class_exists( 'PagelyCachePurge' ) ) {
 			$purger = new PagelyCachePurge();
 			$purger->purgeAll();


### PR DESCRIPTION
This relates to the following two issues:

https://github.com/wp-media/wp-rocket/issues/2664
https://github.com/wp-media/wp-rocket/issues/1759

There is a hook for pagely_cache_purge_after to run a rocket_clean_domain.  Then on rocket_clean_domain there is a hook for after_rocket_clean_domain to run a pagely cache purge.  This causes a loop where it just keeps purging and purging until a timeout happens.  

This pull simply adds a global variable which is set when either hook is called that stops the purge from continuing beyond a single cycle.