### PR TITLE
Closes #3149 PricingClient class to get data from pricing endpoint

### DIFF
--- a/inc/Engine/License/API/PricingClient.php
+++ b/inc/Engine/License/API/PricingClient.php
@@ -48,6 +48,12 @@ class PricingClient {
 			return false;
 		}
 
-		return json_decode( wp_remote_retrieve_body( $response ) );
+		$body = wp_remote_retrieve_body( $response );
+
+		if ( empty( $body ) ) {
+			return false;
+		}
+
+		return json_decode( $body );
 	}
 }

--- a/inc/Engine/License/API/PricingClient.php
+++ b/inc/Engine/License/API/PricingClient.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace WP_Rocket\Engine\License\API;
+
+class PricingClient {
+	const PRICING_ENDPOINT = 'https://wp-rocket.me/stat/1.0/wp-rocket/pricing.php';
+
+	/**
+	 * Gets pricing data from cache if it exists, else gets it from the pricing endpoint
+	 *
+	 * Cache the pricing data for 6 hours in a transient
+	 *
+	 * @since 3.7.3
+	 *
+	 * @return bool|object
+	 */
+	public function get_pricing_data() {
+		$cached_data = get_transient( 'wp_rocket_pricing' );
+
+		if ( false !== $cached_data ) {
+			return $cached_data;
+		}
+
+		$data = $this->get_raw_pricing_data();
+
+		if ( false === $data ) {
+			return false;
+		}
+
+		set_transient( 'wp_rocket_pricing', $data, 6 * HOUR_IN_SECONDS );
+
+		return $data;
+	}
+
+	/**
+	 * Gets the pricing data from the pricing endpoint
+	 *
+	 * @since 3.7.3
+	 *
+	 * @return bool|object
+	 */
+	private function get_raw_pricing_data() {
+		$response = wp_safe_remote_get(
+			self::PRICING_ENDPOINT
+		);
+
+		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return false;
+		}
+
+		return json_decode( wp_remote_retrieve_body( $response ) );
+	}
+}

--- a/inc/Engine/License/ServiceProvider.php
+++ b/inc/Engine/License/ServiceProvider.php
@@ -4,12 +4,6 @@ namespace WP_Rocket\Engine\License;
 
 use WP_Rocket\Engine\Container\ServiceProvider\AbstractServiceProvider;
 use WP_Rocket\Engine\License\API\PricingClient;
-use WP_Rocket\Engine\License\API\Pricing;
-use WP_Rocket\Engine\License\API\UserClient;
-use WP_Rocket\Engine\License\API\User;
-use WP_Rocket\Engine\License\Renewal;
-use WP_Rocket\Engine\License\Subscriber;
-use WP_Rocket\Engine\License\Upgrade;
 
 /**
  * Service Provider for the License module
@@ -24,12 +18,6 @@ class ServiceProvider extends AbstractServiceProvider {
 	 */
 	protected $provides = [
 		'pricing_client',
-		'user_client',
-		'pricing',
-		'user',
-		'upgrade',
-		'renewal',
-		'license_subscriber',
 	];
 
 	/**
@@ -41,22 +29,5 @@ class ServiceProvider extends AbstractServiceProvider {
 		$views = __DIR__ . '/views';
 
 		$this->getContainer()->add( 'pricing_client', PricingClient::class );
-		$this->getContainer()->add( 'user_client', UserClient::class )
-			->withArgument( $this->getContainer()->get( 'options' ) );
-		$this->getContainer()->add( 'pricing', Pricing::class )
-			->withArgument( $this->getContainer()->get( 'pricing_client' )->get_pricing_data() );
-		$this->getContainer()->add( 'user', User::class )
-			->withArgument( $this->getContainer()->get( 'user_client' )->get_user_data() );
-		$this->getContainer()->add( 'upgrade', Upgrade::class )
-			->withArgument( $this->getContainer()->get( 'pricing' ) )
-			->withArgument( $this->getContainer()->get( 'user' ) )
-			->withArgument( $views );
-		$this->getContainer()->add( 'renewal', Renewal::class )
-			->withArgument( $this->getContainer()->get( 'pricing' ) )
-			->withArgument( $this->getContainer()->get( 'user' ) )
-			->withArgument( $views );
-		$this->getContainer()->share( 'license_subscriber', Subscriber::class )
-			->withArgument( $this->getContainer()->get( 'upgrade' ) )
-			->withArgument( $this->getContainer()->get( 'renewal' ) );
 	}
 }

--- a/inc/Engine/License/ServiceProvider.php
+++ b/inc/Engine/License/ServiceProvider.php
@@ -26,8 +26,6 @@ class ServiceProvider extends AbstractServiceProvider {
 	 * @return void
 	 */
 	public function register() {
-		$views = __DIR__ . '/views';
-
 		$this->getContainer()->add( 'pricing_client', PricingClient::class );
 	}
 }

--- a/inc/Engine/License/ServiceProvider.php
+++ b/inc/Engine/License/ServiceProvider.php
@@ -4,8 +4,9 @@ namespace WP_Rocket\Engine\License;
 
 use WP_Rocket\Engine\Container\ServiceProvider\AbstractServiceProvider;
 use WP_Rocket\Engine\License\API\PricingClient;
+use WP_Rocket\Engine\License\API\Pricing;
 use WP_Rocket\Engine\License\API\UserClient;
-use WP_Rocket\Engine\License\Pricing;
+use WP_Rocket\Engine\License\API\User;
 use WP_Rocket\Engine\License\Renewal;
 use WP_Rocket\Engine\License\Subscriber;
 use WP_Rocket\Engine\License\Upgrade;
@@ -25,6 +26,7 @@ class ServiceProvider extends AbstractServiceProvider {
 		'pricing_client',
 		'user_client',
 		'pricing',
+		'user',
 		'upgrade',
 		'renewal',
 		'license_subscriber',
@@ -42,15 +44,16 @@ class ServiceProvider extends AbstractServiceProvider {
 		$this->getContainer()->add( 'user_client', UserClient::class )
 			->withArgument( $this->getContainer()->get( 'options' ) );
 		$this->getContainer()->add( 'pricing', Pricing::class )
-			->withArgument( $this->getContainer()->get( 'pricing_client' ) )
-			->withArgument( $this->getContainer()->get( 'user_client' ) );
+			->withArgument( $this->getContainer()->get( 'pricing_client' )->get_pricing_data() );
+		$this->getContainer()->add( 'user', User::class )
+			->withArgument( $this->getContainer()->get( 'user_client' )->get_user_data() );
 		$this->getContainer()->add( 'upgrade', Upgrade::class )
 			->withArgument( $this->getContainer()->get( 'pricing' ) )
-			->withArgument( $this->getContainer()->get( 'user_client' ) )
+			->withArgument( $this->getContainer()->get( 'user' ) )
 			->withArgument( $views );
 		$this->getContainer()->add( 'renewal', Renewal::class )
 			->withArgument( $this->getContainer()->get( 'pricing' ) )
-			->withArgument( $this->getContainer()->get( 'user_client' ) )
+			->withArgument( $this->getContainer()->get( 'user' ) )
 			->withArgument( $views );
 		$this->getContainer()->share( 'license_subscriber', Subscriber::class )
 			->withArgument( $this->getContainer()->get( 'upgrade' ) )

--- a/inc/Engine/License/ServiceProvider.php
+++ b/inc/Engine/License/ServiceProvider.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace WP_Rocket\Engine\License;
+
+use WP_Rocket\Engine\Container\ServiceProvider\AbstractServiceProvider;
+use WP_Rocket\Engine\License\API\PricingClient;
+use WP_Rocket\Engine\License\API\UserClient;
+use WP_Rocket\Engine\License\Pricing;
+use WP_Rocket\Engine\License\Renewal;
+use WP_Rocket\Engine\License\Subscriber;
+use WP_Rocket\Engine\License\Upgrade;
+
+/**
+ * Service Provider for the License module
+ *
+ * @since 3.7.3
+ */
+class ServiceProvider extends AbstractServiceProvider {
+	/**
+	 * Aliases the service provider provides
+	 *
+	 * @var array
+	 */
+	protected $provides = [
+		'pricing_client',
+		'user_client',
+		'pricing',
+		'upgrade',
+		'renewal',
+		'license_subscriber',
+	];
+
+	/**
+	 * Registers items with the container
+	 *
+	 * @return void
+	 */
+	public function register() {
+		$views = __DIR__ . '/views';
+
+		$this->getContainer()->add( 'pricing_client', PricingClient::class );
+		$this->getContainer()->add( 'user_client', UserClient::class )
+			->withArgument( $this->getContainer()->get( 'options' ) );
+		$this->getContainer()->add( 'pricing', Pricing::class )
+			->withArgument( $this->getContainer()->get( 'pricing_client' ) )
+			->withArgument( $this->getContainer()->get( 'user_client' ) );
+		$this->getContainer()->add( 'upgrade', Upgrade::class )
+			->withArgument( $this->getContainer()->get( 'pricing' ) )
+			->withArgument( $this->getContainer()->get( 'user_client' ) )
+			->withArgument( $views );
+		$this->getContainer()->add( 'renewal', Renewal::class )
+			->withArgument( $this->getContainer()->get( 'pricing' ) )
+			->withArgument( $this->getContainer()->get( 'user_client' ) )
+			->withArgument( $views );
+		$this->getContainer()->share( 'license_subscriber', Subscriber::class )
+			->withArgument( $this->getContainer()->get( 'upgrade' ) )
+			->withArgument( $this->getContainer()->get( 'renewal' ) );
+	}
+}

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -172,7 +172,6 @@ class Plugin {
 			'minify_css_admin_subscriber',
 			'admin_cache_subscriber',
 			'google_fonts_admin_subscriber',
-			'license_subscriber',
 		];
 	}
 

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -157,6 +157,7 @@ class Plugin {
 		$this->container->addServiceProvider( 'WP_Rocket\Engine\Admin\Settings\ServiceProvider' );
 		$this->container->addServiceProvider( 'WP_Rocket\Engine\Admin\ServiceProvider' );
 		$this->container->addServiceProvider( 'WP_Rocket\Engine\Optimization\AdminServiceProvider' );
+		$this->container->addServiceProvider( 'WP_Rocket\Engine\License\ServiceProvider' );
 
 		return [
 			'beacon',
@@ -171,6 +172,7 @@ class Plugin {
 			'minify_css_admin_subscriber',
 			'admin_cache_subscriber',
 			'google_fonts_admin_subscriber',
+			'license_subscriber',
 		];
 	}
 

--- a/tests/Fixtures/inc/Engine/License/API/PricingClient/getPricingData.php
+++ b/tests/Fixtures/inc/Engine/License/API/PricingClient/getPricingData.php
@@ -1,0 +1,42 @@
+<?php
+
+$json = '{"licenses":{"single":{"prices":{"regular":49,"sale":39.2,"renewal":{"is_grandfather":24.5,"not_grandfather":34.3,"is_expired":39.2}},"websites":1},"plus":{"prices":{"regular":99,"sale":79.2,"from_single":{"regular":50,"sale":40},"renewal":{"is_grandfather":49.5,"not_grandfather":69.3,"is_expired":79.2}},"websites":3},"infinite":{"prices":{"regular":249,"sale":199.2,"from_single":{"regular":200,"sale":160},"from_plus":{"regular":150,"sale":120},"renewal":{"is_grandfather":124.5,"not_grandfather":174.3,"is_expired":199.2}},"websites":"unlimited"}},"renewals":{"extra_days":90,"grandfather_date":1567296000,"discount_percent":{"is_grandfather":50,"not_grandfather":30,"is_expired":20}},"promo":{"name":"Halloween","discount_percent":20,"start_date":1603756800,"end_date":1604361600}}';
+
+$data = json_decode( $json );
+
+return [
+	'testShouldReturnFalseWhenWPError' => [
+		'config'   => [
+			'transient' => false,
+			'response'  => new WP_Error( 'http_request_failed', 'error' ),
+		],
+		'expected' => false,
+	],
+	'testShouldReturnFalseWhenNot200'  => [
+		'config'   => [
+			'transient' => false,
+			'response'  => [
+				'code' => 404,
+				'body' => false,
+			],
+		],
+		'expected' => false,
+	],
+	'testShouldReturnDataWhenCached'   => [
+		'config'   => [
+			'transient' => true,
+			'response'  => false,
+		],
+		'expected' => $data,
+	],
+	'testShouldReturnDataWhenSuccess'  => [
+		'config'   => [
+			'transient' => false,
+			'response'  => [
+				'code' => 200,
+				'body' => $json,
+			],
+		],
+		'expected' => $data,
+	],
+];

--- a/tests/Fixtures/inc/Engine/License/API/PricingClient/getPricingData.php
+++ b/tests/Fixtures/inc/Engine/License/API/PricingClient/getPricingData.php
@@ -22,6 +22,15 @@ return [
 		],
 		'expected' => false,
 	],
+	'testShouldReturnFalseWhenNoBody'  => [
+		'config'   => [
+			'transient' => false,
+			'response'  => [
+				'code' => 200,
+			],
+		],
+		'expected' => false,
+	],
 	'testShouldReturnDataWhenCached'   => [
 		'config'   => [
 			'transient' => true,

--- a/tests/Integration/inc/Engine/License/API/PricingClient/getPricingData.php
+++ b/tests/Integration/inc/Engine/License/API/PricingClient/getPricingData.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\License\API\PricingClient;
+
+use Brain\Monkey\Functions;
+use WP_Rocket\Engine\License\API\PricingClient;
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\License\API\PricingClient::get_pricing_data
+ *
+ * @group License
+ */
+class GetPricingData extends TestCase {
+	public function tearDown() {
+		delete_transient( 'wp_rocket_pricing' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnExpected( $config, $expected ) {
+		$client = new PricingClient();
+
+		if ( true === $config['transient'] ) {
+			set_transient( 'wp_rocket_pricing', $expected );
+		}
+
+		if ( false === $expected ) {
+			Functions\expect( 'wp_safe_remote_get' )
+			->once()
+			->with( 'https://wp-rocket.me/stat/1.0/wp-rocket/pricing.php' )
+			->andReturn( $config['response'] );
+		}
+
+		$this->assertEquals(
+			$expected,
+			$client->get_pricing_data()
+		);
+
+		if (
+			false === $config['transient']
+			&&
+			false !== $expected
+		) {
+			$this->assertEquals(
+				$expected,
+				get_transient( 'wp_rocket_pricing' )
+			);
+		}
+	}
+}

--- a/tests/Integration/inc/Engine/License/API/PricingClient/getPricingData.php
+++ b/tests/Integration/inc/Engine/License/API/PricingClient/getPricingData.php
@@ -31,7 +31,7 @@ class GetPricingData extends TestCase {
 		if ( false === $expected ) {
 			Functions\expect( 'wp_safe_remote_get' )
 			->once()
-			->with( 'https://wp-rocket.me/stat/1.0/wp-rocket/pricing.php' )
+			->with( PricingClient::PRICING_ENDPOINT )
 			->andReturn( $config['response'] );
 		}
 

--- a/tests/Unit/inc/Engine/License/API/PricingClient/getPricingData.php
+++ b/tests/Unit/inc/Engine/License/API/PricingClient/getPricingData.php
@@ -19,17 +19,10 @@ class GetPricingData extends TestCase {
 	public function testShouldReturnExpected( $config, $expected ) {
 		$client = new PricingClient();
 
-		if ( true === $config['transient'] ) {
-			Functions\expect( 'get_transient' )
-				->once()
-				->with( 'wp_rocket_pricing' )
-				->andReturn( $expected );
-		} else {
-			Functions\expect( 'get_transient' )
-				->once()
-				->with( 'wp_rocket_pricing' )
-				->andReturn( false );
-		}
+		Functions\expect( 'get_transient' )
+			->once()
+			->with( 'wp_rocket_pricing' )
+			->andReturn( true === $config['transient'] ? $expected : false );
 
 		if ( false !== $config['response'] ) {
 			Functions\expect( 'wp_safe_remote_get' )
@@ -37,26 +30,19 @@ class GetPricingData extends TestCase {
 				->with( PricingClient::PRICING_ENDPOINT )
 				->andReturn( $config['response'] );
 
-			if ( ! is_array( $config['response'] ) ) {
 				Functions\when( 'wp_remote_retrieve_response_code' )
-				->justReturn( '' );
-			} elseif (
-				is_array( $config['response'] )
-				&&
-				isset( $config['response']['code'] )
-			) {
-				Functions\when( 'wp_remote_retrieve_response_code' )
-				->justReturn( $config['response']['code'] );
-			}
+				->justReturn(
+					is_array( $config['response'] ) && isset( $config['response']['code'] )
+					? $config['response']['code']
+					: ''
+				);
 
-			if (
-				is_array( $config['response'] )
-				&&
-				isset( $config['response']['body'] )
-			) {
 				Functions\when( 'wp_remote_retrieve_body' )
-					->justReturn( $config['response']['body'] );
-			}
+				->justReturn(
+					is_array( $config['response'] ) && isset( $config['response']['body'] )
+					? $config['response']['body']
+					: ''
+				);
 		} else {
 			Functions\expect( 'wp_safe_remote_get' )->never();
 		}

--- a/tests/Unit/inc/Engine/License/API/PricingClient/getPricingData.php
+++ b/tests/Unit/inc/Engine/License/API/PricingClient/getPricingData.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\License\API\PricingClient;
+
+use Brain\Monkey\Functions;
+use Mockery;
+use WP_Rocket\Engine\License\API\PricingClient;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\License\API\PricingClient::get_pricing_data
+ *
+ * @group License
+ */
+class GetPricingData extends TestCase {
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnExpected( $config, $expected ) {
+		$client = new PricingClient();
+
+		if ( true === $config['transient'] ) {
+			Functions\expect( 'get_transient' )
+				->once()
+				->with( 'wp_rocket_pricing' )
+				->andReturn( $expected );
+		} else {
+			Functions\expect( 'get_transient' )
+				->once()
+				->with( 'wp_rocket_pricing' )
+				->andReturn( false );
+		}
+
+		if ( false !== $config['response'] ) {
+			Functions\expect( 'wp_safe_remote_get' )
+				->once()
+				->with( 'https://wp-rocket.me/stat/1.0/wp-rocket/pricing.php' )
+				->andReturn( $config['response'] );
+
+			if ( ! is_array( $config['response'] ) ) {
+				Functions\when( 'wp_remote_retrieve_response_code' )
+				->justReturn( '' );
+			} elseif (
+				is_array( $config['response'] )
+				&&
+				isset( $config['response']['code'] )
+			) {
+				Functions\when( 'wp_remote_retrieve_response_code' )
+				->justReturn( $config['response']['code'] );
+			}
+
+			if (
+				is_array( $config['response'] )
+				&&
+				isset( $config['response']['body'] )
+			) {
+				Functions\when( 'wp_remote_retrieve_body' )
+					->justReturn( $config['response']['body'] );
+			}
+		} else {
+			Functions\expect( 'wp_remote_get' )->never();
+		}
+
+		if (
+			false === $config['transient']
+			&&
+			false !== $expected
+		) {
+			Functions\expect( 'set_transient' )
+				->once()
+				->with( 'wp_rocket_pricing', Mockery::type( 'object' ), 6 * HOUR_IN_SECONDS );
+		} else {
+			Functions\expect( 'set_transient' )->never();
+		}
+
+		$this->assertEquals(
+			$expected,
+			$client->get_pricing_data()
+		);
+	}
+}

--- a/tests/Unit/inc/Engine/License/API/PricingClient/getPricingData.php
+++ b/tests/Unit/inc/Engine/License/API/PricingClient/getPricingData.php
@@ -34,7 +34,7 @@ class GetPricingData extends TestCase {
 		if ( false !== $config['response'] ) {
 			Functions\expect( 'wp_safe_remote_get' )
 				->once()
-				->with( 'https://wp-rocket.me/stat/1.0/wp-rocket/pricing.php' )
+				->with( PricingClient::PRICING_ENDPOINT )
 				->andReturn( $config['response'] );
 
 			if ( ! is_array( $config['response'] ) ) {
@@ -58,7 +58,7 @@ class GetPricingData extends TestCase {
 					->justReturn( $config['response']['body'] );
 			}
 		} else {
-			Functions\expect( 'wp_remote_get' )->never();
+			Functions\expect( 'wp_safe_remote_get' )->never();
 		}
 
 		if (


### PR DESCRIPTION
Closes #3149 

This class is used to get the pricing data using `get_pricing_data()`

If the data is already cached in a transient `wp_rocket_pricing`, it uses the cached data. Else, it sends a request to the API endpoint, and caches the returned JSON data for 6 hours in the transient.

If an error occurs (`WP_Error`, or response code not `200`), the method returns false.