### PR TITLE
Closes #3143 User Client class to manage data collection from user endpoint

### DIFF
--- a/inc/Engine/License/API/UserClient.php
+++ b/inc/Engine/License/API/UserClient.php
@@ -76,6 +76,12 @@ class UserClient {
 			return false;
 		}
 
-		return json_decode( wp_remote_retrieve_body( $response ) );
+		$body = wp_remote_retrieve_body( $response );
+
+		if ( empty( $body ) ) {
+			return false;
+		}
+
+		return json_decode( $body );
 	}
 }

--- a/inc/Engine/License/API/UserClient.php
+++ b/inc/Engine/License/API/UserClient.php
@@ -61,7 +61,7 @@ class UserClient {
 		$customer_key   = ! empty( $this->options->get( 'consumer_key', '' ) )
 			? $this->options->get( 'consumer_key', '' )
 			: rocket_get_constant( 'WP_ROCKET_KEY', '' );
-		$customer_email = !empty ( $this->options->get( 'consumer_email', '' ) )
+		$customer_email = ! empty( $this->options->get( 'consumer_email', '' ) )
 			? $this->options->get( 'consumer_email', '' )
 			: rocket_get_constant( 'WP_ROCKET_EMAIL', '' );
 

--- a/inc/Engine/License/API/UserClient.php
+++ b/inc/Engine/License/API/UserClient.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace WP_Rocket\Engine\License\API;
+
+use WP_Rocket\Admin\Options_Data;
+
+class UserClient {
+	const USER_ENDPOINT = 'https://wp-rocket.me/stat/1.0/wp-rocket/user.php';
+
+	/**
+	 * WP Rocket options instance
+	 *
+	 * @var Options_Data
+	 */
+	private $options;
+
+	/**
+	 * Instantiate the class
+	 *
+	 * @param Options_Data $options WP Rocket options instance.
+	 */
+	public function __construct( Options_Data $options ) {
+		$this->options = $options;
+	}
+
+	/**
+	 * Gets user data from cache if it exists, else gets it from the user endpoint
+	 *
+	 * Cache the user data for 24 hours in a transient
+	 *
+	 * @since 3.7.3
+	 *
+	 * @return bool|object
+	 */
+	public function get_user_data() {
+		$cached_data = get_transient( 'wp_rocket_customer_data' );
+
+		if ( false !== $cached_data ) {
+			return $cached_data;
+		}
+
+		$data = $this->get_raw_user_data();
+
+		if ( false === $data ) {
+			return false;
+		}
+
+		set_transient( 'wp_rocket_customer_data', $data, DAY_IN_SECONDS );
+
+		return $data;
+	}
+
+	/**
+	 * Gets the user data from the user endpoint
+	 *
+	 * @since 3.7.3
+	 *
+	 * @return bool|object
+	 */
+	private function get_raw_user_data() {
+		$customer_key   = rocket_has_constant( 'WP_ROCKET_KEY' )
+			? rocket_get_constant( 'WP_ROCKET_KEY', '' )
+			: $this->options->get( 'consumer_key', '' );
+		$customer_email = rocket_has_constant( 'WP_ROCKET_EMAIL' )
+			? rocket_get_constant( 'WP_ROCKET_EMAIL', '' )
+			: $this->options->get( 'consumer_email', '' );
+
+		$response = wp_safe_remote_post(
+			self::USER_ENDPOINT,
+			[
+				'body' => 'user_id=' . rawurlencode( $customer_email ) . '&consumer_key=' . sanitize_key( $customer_key ),
+			]
+		);
+
+		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return false;
+		}
+
+		return json_decode( wp_remote_retrieve_body( $response ) );
+	}
+}

--- a/inc/Engine/License/API/UserClient.php
+++ b/inc/Engine/License/API/UserClient.php
@@ -58,12 +58,12 @@ class UserClient {
 	 * @return bool|object
 	 */
 	private function get_raw_user_data() {
-		$customer_key   = rocket_has_constant( 'WP_ROCKET_KEY' )
-			? rocket_get_constant( 'WP_ROCKET_KEY', '' )
-			: $this->options->get( 'consumer_key', '' );
-		$customer_email = rocket_has_constant( 'WP_ROCKET_EMAIL' )
-			? rocket_get_constant( 'WP_ROCKET_EMAIL', '' )
-			: $this->options->get( 'consumer_email', '' );
+		$customer_key   = ! empty( $this->options->get( 'consumer_key', '' ) )
+			? $this->options->get( 'consumer_key', '' )
+			: rocket_get_constant( 'WP_ROCKET_KEY', '' );
+		$customer_email = !empty ( $this->options->get( 'consumer_email', '' ) )
+			? $this->options->get( 'consumer_email', '' )
+			: rocket_get_constant( 'WP_ROCKET_EMAIL', '' );
 
 		$response = wp_safe_remote_post(
 			self::USER_ENDPOINT,

--- a/inc/Engine/License/ServiceProvider.php
+++ b/inc/Engine/License/ServiceProvider.php
@@ -4,8 +4,9 @@ namespace WP_Rocket\Engine\License;
 
 use WP_Rocket\Engine\Container\ServiceProvider\AbstractServiceProvider;
 use WP_Rocket\Engine\License\API\PricingClient;
+use WP_Rocket\Engine\License\API\Pricing;
 use WP_Rocket\Engine\License\API\UserClient;
-use WP_Rocket\Engine\License\Pricing;
+use WP_Rocket\Engine\License\API\User;
 use WP_Rocket\Engine\License\Renewal;
 use WP_Rocket\Engine\License\Subscriber;
 use WP_Rocket\Engine\License\Upgrade;
@@ -25,6 +26,7 @@ class ServiceProvider extends AbstractServiceProvider {
 		'pricing_client',
 		'user_client',
 		'pricing',
+		'user',
 		'upgrade',
 		'renewal',
 		'license_subscriber',
@@ -42,15 +44,16 @@ class ServiceProvider extends AbstractServiceProvider {
 		$this->getContainer()->add( 'user_client', UserClient::class )
 			->withArgument( $this->getContainer()->get( 'options' ) );
 		$this->getContainer()->add( 'pricing', Pricing::class )
-			->withArgument( $this->getContainer()->get( 'pricing_client' ) )
-			->withArgument( $this->getContainer()->get( 'user_client' ) );
+			->withArgument( $this->getContainer()->get( 'pricing_client' )->get_pricing_data() );
+		$this->getContainer()->add( 'user', User::class )
+			->withArgument( $this->getContainer()->get( 'user_client' )->get_user_data() );
 		$this->getContainer()->add( 'upgrade', Upgrade::class )
 			->withArgument( $this->getContainer()->get( 'pricing' ) )
-			->withArgument( $this->getContainer()->get( 'user_client' ) )
+			->withArgument( $this->getContainer()->get( 'user' ) )
 			->withArgument( $views );
 		$this->getContainer()->add( 'renewal', Renewal::class )
 			->withArgument( $this->getContainer()->get( 'pricing' ) )
-			->withArgument( $this->getContainer()->get( 'user_client' ) )
+			->withArgument( $this->getContainer()->get( 'user' ) )
 			->withArgument( $views );
 		$this->getContainer()->share( 'license_subscriber', Subscriber::class )
 			->withArgument( $this->getContainer()->get( 'upgrade' ) )

--- a/inc/Engine/License/ServiceProvider.php
+++ b/inc/Engine/License/ServiceProvider.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace WP_Rocket\Engine\License;
+
+use WP_Rocket\Engine\Container\ServiceProvider\AbstractServiceProvider;
+use WP_Rocket\Engine\License\API\PricingClient;
+use WP_Rocket\Engine\License\API\UserClient;
+use WP_Rocket\Engine\License\Pricing;
+use WP_Rocket\Engine\License\Renewal;
+use WP_Rocket\Engine\License\Subscriber;
+use WP_Rocket\Engine\License\Upgrade;
+
+/**
+ * Service Provider for the License module
+ *
+ * @since 3.7.3
+ */
+class ServiceProvider extends AbstractServiceProvider {
+	/**
+	 * Aliases the service provider provides
+	 *
+	 * @var array
+	 */
+	protected $provides = [
+		'pricing_client',
+		'user_client',
+		'pricing',
+		'upgrade',
+		'renewal',
+		'license_subscriber',
+	];
+
+	/**
+	 * Registers items with the container
+	 *
+	 * @return void
+	 */
+	public function register() {
+		$views = __DIR__ . '/views';
+
+		$this->getContainer()->add( 'pricing_client', PricingClient::class );
+		$this->getContainer()->add( 'user_client', UserClient::class )
+			->withArgument( $this->getContainer()->get( 'options' ) );
+		$this->getContainer()->add( 'pricing', Pricing::class )
+			->withArgument( $this->getContainer()->get( 'pricing_client' ) )
+			->withArgument( $this->getContainer()->get( 'user_client' ) );
+		$this->getContainer()->add( 'upgrade', Upgrade::class )
+			->withArgument( $this->getContainer()->get( 'pricing' ) )
+			->withArgument( $this->getContainer()->get( 'user_client' ) )
+			->withArgument( $views );
+		$this->getContainer()->add( 'renewal', Renewal::class )
+			->withArgument( $this->getContainer()->get( 'pricing' ) )
+			->withArgument( $this->getContainer()->get( 'user_client' ) )
+			->withArgument( $views );
+		$this->getContainer()->share( 'license_subscriber', Subscriber::class )
+			->withArgument( $this->getContainer()->get( 'upgrade' ) )
+			->withArgument( $this->getContainer()->get( 'renewal' ) );
+	}
+}

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -172,7 +172,6 @@ class Plugin {
 			'minify_css_admin_subscriber',
 			'admin_cache_subscriber',
 			'google_fonts_admin_subscriber',
-			'license_subscriber',
 		];
 	}
 

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -157,6 +157,7 @@ class Plugin {
 		$this->container->addServiceProvider( 'WP_Rocket\Engine\Admin\Settings\ServiceProvider' );
 		$this->container->addServiceProvider( 'WP_Rocket\Engine\Admin\ServiceProvider' );
 		$this->container->addServiceProvider( 'WP_Rocket\Engine\Optimization\AdminServiceProvider' );
+		$this->container->addServiceProvider( 'WP_Rocket\Engine\License\ServiceProvider' );
 
 		return [
 			'beacon',
@@ -171,6 +172,7 @@ class Plugin {
 			'minify_css_admin_subscriber',
 			'admin_cache_subscriber',
 			'google_fonts_admin_subscriber',
+			'license_subscriber',
 		];
 	}
 

--- a/tests/Fixtures/inc/Engine/License/API/UserClient/getUserData.php
+++ b/tests/Fixtures/inc/Engine/License/API/UserClient/getUserData.php
@@ -21,6 +21,15 @@ return [
 		],
 		'expected' => false,
 	],
+	'testShouldReturnFalseWhenNoBody'  => [
+		'config'   => [
+			'transient' => false,
+			'response'  => [
+				'code' => 200,
+			],
+		],
+		'expected' => false,
+	],
 	'testShouldReturnDataWhenCached'   => [
 		'config'   => [
 			'transient' => true,

--- a/tests/Fixtures/inc/Engine/License/API/UserClient/getUserData.php
+++ b/tests/Fixtures/inc/Engine/License/API/UserClient/getUserData.php
@@ -1,0 +1,42 @@
+<?php
+
+$json = '{"ID":"129383","first_name":"Roger","email":"roger@wp-rocket.me","date_created":"1586207688","licence_account":"3","licence_version":"3.7.2","licence_expiration":"1612310400","consumer_key":"d89e18ee","is_blacklisted":"","is_staggered":"","status":"active","is_blocked":"","has_auto_renew":"","renewal_url":"https:\/\/wp-rocket.me\/checkout\/renew\/roger@wp-rocket.me\/da5891162a3bc2d8a9670267fd07c9eb\/","upgrade_plus_url":"https:\/\/wp-rocket.me\/checkout\/upgrade\/roger@wp-rocket.me \/d89e18ee\/plus\/","upgrade_infinite_url":"https:\/\/wp-rocket.me\/checkout\/upgrade\/roger@wp-rocket.me \/d89e18ee\/infinite\/"}';
+$data = json_decode( $json );
+
+return [
+	'testShouldReturnFalseWhenWPError' => [
+		'config'   => [
+			'transient' => false,
+			'response'  => new WP_Error( 'http_request_failed', 'error' ),
+		],
+		'expected' => false,
+	],
+	'testShouldReturnFalseWhenNot200'  => [
+		'config'   => [
+			'transient' => false,
+			'response'  => [
+				'code' => 404,
+				'body' => false,
+			],
+		],
+		'expected' => false,
+	],
+	'testShouldReturnDataWhenCached'   => [
+		'config'   => [
+			'transient' => true,
+			'response'  => false,
+		],
+		'expected' => $data,
+	],
+	'testShouldReturnDataWhenSuccess'  => [
+		'config'   => [
+			'transient' => false,
+			'response'  => [
+				'code' => 200,
+				'body' => $json,
+			],
+		],
+		'expected' => $data,
+	],
+];
+

--- a/tests/Integration/inc/Engine/License/API/UserClient/getUserData.php
+++ b/tests/Integration/inc/Engine/License/API/UserClient/getUserData.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\License\API\UserClient;
+
+use Brain\Monkey\Functions;
+use WP_Rocket\Engine\License\API\UserClient;
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\License\API\UserClient::get_user_data
+ *
+ * @group License
+ */
+class GetUserData extends TestCase {
+	public function tearDown() {
+		delete_transient( 'wp_rocket_customer_data' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnExpected( $config, $expected ) {
+		$client = new UserClient();
+
+		if ( true === $config['transient'] ) {
+			set_transient( 'wp_rocket_customer_data', $expected );
+		}
+
+		if ( false === $expected ) {
+			Functions\expect( 'wp_safe_remote_post' )
+			->once()
+			->with( UserClient::USER_ENDPOINT )
+			->andReturn( $config['response'] );
+		}
+
+		$this->assertEquals(
+			$expected,
+			$client->get_user_data()
+		);
+
+		if (
+			false === $config['transient']
+			&&
+			false !== $expected
+		) {
+			$this->assertEquals(
+				$expected,
+				get_transient( 'wp_rocket_customer_data' )
+			);
+		}
+	}
+}

--- a/tests/Unit/inc/Engine/License/API/UserClient/getUserData.php
+++ b/tests/Unit/inc/Engine/License/API/UserClient/getUserData.php
@@ -44,12 +44,12 @@ class GetPricingData extends TestCase {
 
 		if ( false !== $config['response'] ) {
 			$this->options->shouldReceive( 'get' )
-			->once()
+			->twice()
 			->with( 'consumer_key', '' )
 			->andReturn( self::getApiCredential( 'ROCKET_KEY' ) );
 
 			$this->options->shouldReceive( 'get' )
-				->once()
+				->twice()
 				->with( 'consumer_email', '' )
 				->andReturn( self::getApiCredential( 'ROCKET_EMAIL' ) );
 
@@ -60,7 +60,7 @@ class GetPricingData extends TestCase {
 				->with(
 					UserClient::USER_ENDPOINT,
 					[
-						'body' => 'user_id=' . self::getApiCredential( 'ROCKET_EMAIL' ) . '&consumer_key=' . self::getApiCredential( 'ROCKET_KEY' ),
+						'body' => 'user_id=' . rawurlencode( self::getApiCredential( 'ROCKET_EMAIL' ) ) . '&consumer_key=' . self::getApiCredential( 'ROCKET_KEY' ),
 					]
 				)
 				->andReturn( $config['response'] );

--- a/tests/Unit/inc/Engine/License/API/UserClient/getUserData.php
+++ b/tests/Unit/inc/Engine/License/API/UserClient/getUserData.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\License\API\UserClient;
+
+use Brain\Monkey\Functions;
+use Mockery;
+use WP_Rocket\Engine\License\API\UserClient;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\License\API\UserClient::get_user_data
+ *
+ * @group License
+ */
+class GetPricingData extends TestCase {
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnExpected( $config, $expected ) {
+		$client = new UserClient();
+
+		if ( true === $config['transient'] ) {
+			Functions\expect( 'get_transient' )
+				->once()
+				->with( 'wp_rocket_customer_data' )
+				->andReturn( $expected );
+		} else {
+			Functions\expect( 'get_transient' )
+				->once()
+				->with( 'wp_rocket_customer_data' )
+				->andReturn( false );
+		}
+
+		if ( false !== $config['response'] ) {
+			Functions\expect( 'wp_safe_remote_post' )
+				->once()
+				->with( UserClient::USER_ENDPOINT )
+				->andReturn( $config['response'] );
+
+			if ( ! is_array( $config['response'] ) ) {
+				Functions\when( 'wp_remote_retrieve_response_code' )
+				->justReturn( '' );
+			} elseif (
+				is_array( $config['response'] )
+				&&
+				isset( $config['response']['code'] )
+			) {
+				Functions\when( 'wp_remote_retrieve_response_code' )
+				->justReturn( $config['response']['code'] );
+			}
+
+			if (
+				is_array( $config['response'] )
+				&&
+				isset( $config['response']['body'] )
+			) {
+				Functions\when( 'wp_remote_retrieve_body' )
+					->justReturn( $config['response']['body'] );
+			}
+		} else {
+			Functions\expect( 'wp_safe_remote_post' )->never();
+		}
+
+		if (
+			false === $config['transient']
+			&&
+			false !== $expected
+		) {
+			Functions\expect( 'set_transient' )
+				->once()
+				->with( 'wp_rocket_customer_data', Mockery::type( 'object' ), DAY_IN_SECONDS );
+		} else {
+			Functions\expect( 'set_transient' )->never();
+		}
+
+		$this->assertEquals(
+			$expected,
+			$client->get_user_data()
+		);
+	}
+}

--- a/tests/Unit/inc/Engine/License/API/UserClient/getUserData.php
+++ b/tests/Unit/inc/Engine/License/API/UserClient/getUserData.php
@@ -4,6 +4,8 @@ namespace WP_Rocket\Tests\Unit\inc\Engine\License\API\UserClient;
 
 use Brain\Monkey\Functions;
 use Mockery;
+use WPMedia\PHPUnit\Integration\ApiTrait;
+use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\License\API\UserClient;
 use WP_Rocket\Tests\Unit\TestCase;
 
@@ -13,50 +15,69 @@ use WP_Rocket\Tests\Unit\TestCase;
  * @group License
  */
 class GetPricingData extends TestCase {
+	use ApiTrait;
+
+	protected static $api_credentials_config_file = 'license.php';
+
+	private $client;
+	private $options;
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		self::pathToApiCredentialsConfigFile( WP_ROCKET_TESTS_DIR . '/../env/local/' );
+	}
+
+	public function setUp() {
+		$this->options = Mockery::mock( Options_Data::class );
+		$this->client  = new UserClient( $this->options );
+	}
+
 	/**
 	 * @dataProvider configTestData
 	 */
 	public function testShouldReturnExpected( $config, $expected ) {
-		$client = new UserClient();
-
-		if ( true === $config['transient'] ) {
-			Functions\expect( 'get_transient' )
-				->once()
-				->with( 'wp_rocket_customer_data' )
-				->andReturn( $expected );
-		} else {
-			Functions\expect( 'get_transient' )
-				->once()
-				->with( 'wp_rocket_customer_data' )
-				->andReturn( false );
-		}
+		Functions\expect( 'get_transient' )
+			->once()
+			->with( 'wp_rocket_customer_data' )
+			->andReturn( true === $config['transient'] ? $expected : false );
 
 		if ( false !== $config['response'] ) {
+			$this->options->shouldReceive( 'get' )
+			->once()
+			->with( 'consumer_key', '' )
+			->andReturn( self::getApiCredential( 'ROCKET_KEY' ) );
+
+			$this->options->shouldReceive( 'get' )
+				->once()
+				->with( 'consumer_email', '' )
+				->andReturn( self::getApiCredential( 'ROCKET_EMAIL' ) );
+
+			Functions\when( 'sanitize_key' )->returnArg();
+
 			Functions\expect( 'wp_safe_remote_post' )
 				->once()
-				->with( UserClient::USER_ENDPOINT )
+				->with(
+					UserClient::USER_ENDPOINT,
+					[
+						'body' => 'user_id=' . self::getApiCredential( 'ROCKET_EMAIL' ) . '&consumer_key=' . self::getApiCredential( 'ROCKET_KEY' ),
+					]
+				)
 				->andReturn( $config['response'] );
 
-			if ( ! is_array( $config['response'] ) ) {
-				Functions\when( 'wp_remote_retrieve_response_code' )
-				->justReturn( '' );
-			} elseif (
-				is_array( $config['response'] )
-				&&
-				isset( $config['response']['code'] )
-			) {
-				Functions\when( 'wp_remote_retrieve_response_code' )
-				->justReturn( $config['response']['code'] );
-			}
+			Functions\when( 'wp_remote_retrieve_response_code' )
+			->justReturn(
+				is_array( $config['response'] ) && isset( $config['response']['code'] )
+				? $config['response']['code']
+				: ''
+			);
 
-			if (
-				is_array( $config['response'] )
-				&&
-				isset( $config['response']['body'] )
-			) {
-				Functions\when( 'wp_remote_retrieve_body' )
-					->justReturn( $config['response']['body'] );
-			}
+			Functions\when( 'wp_remote_retrieve_body' )
+			->justReturn(
+				is_array( $config['response'] ) && isset( $config['response']['body'] )
+				? $config['response']['body']
+				: ''
+			);
 		} else {
 			Functions\expect( 'wp_safe_remote_post' )->never();
 		}
@@ -75,7 +96,7 @@ class GetPricingData extends TestCase {
 
 		$this->assertEquals(
 			$expected,
-			$client->get_user_data()
+			$this->client->get_user_data()
 		);
 	}
 }


### PR DESCRIPTION
Closes #3143 

This class is used to get the user data using `get_user_data()`

If the data is already cached in a transient `wp_rocket_customer_data`, it uses the cached data. Else, it sends a request to the API endpoint, and caches the returned JSON data for a day in the transient.

If an error occurs (`WP_Error`, or response code not `200`), the method returns false.