### PR TITLE
Closes #3150 Pricing class to manage pricing data usage

### DIFF
--- a/inc/Engine/License/API/Pricing.php
+++ b/inc/Engine/License/API/Pricing.php
@@ -3,34 +3,83 @@
 namespace WP_Rocket\Engine\License\API;
 
 class Pricing {
+	/**
+	 * The pricing data object
+	 *
+	 * @var object
+	 */
 	private $pricing;
 
+	/**
+	 * Instantiate the class
+	 *
+	 * @param object $pricing The pricing object.
+	 */
 	public function __construct( $pricing ) {
 		$this->pricing = $pricing;
 	}
 
+	/**
+	 * Gets the single license pricing data
+	 *
+	 * @return null|object
+	 */
 	public function get_single_pricing() {
-		return $this->pricing->licenses->single;
+		return isset( $this->pricing->licenses->single ) ? $this->pricing->licenses->single : null;
 	}
 
+	/**
+	 * Gets the plus license pricing data
+	 *
+	 * @return null|object
+	 */
 	public function get_plus_pricing() {
-		return $this->pricing->licenses->plus;
+		return isset( $this->pricing->licenses->plus ) ? $this->pricing->licenses->plus : null;
 	}
 
+	/**
+	 * Gets the infinite license pricing data
+	 *
+	 * @return null|object
+	 */
 	public function get_infinite_pricing() {
-		return $this->pricing->licenses->infinite;
+		return isset( $this->pricing->licenses->infinite ) ? $this->pricing->licenses->infinite : null;
 	}
 
+	/**
+	 * Gets the license renewal pricing data
+	 *
+	 * @return null|object
+	 */
 	public function get_renewals_data() {
-		return $this->pricing->renewals;
+		return isset( $this->pricing->renewals ) ? $this->pricing->renewals : null;
 	}
 
+	/**
+	 * Gets the promotion data
+	 *
+	 * @return null|object
+	 */
 	public function get_promo_data() {
-		return $this->pricing->promo;
+		return isset( $this->pricing->promo ) ? $this->pricing->promo : null;
 	}
 
+	/**
+	 * Checks if a promotion is currently active
+	 *
+	 * @return boolean
+	 */
 	public function is_promo_active() {
-		$promo_data   = $this->get_promo_data();
+		$promo_data = $this->get_promo_data();
+
+		if ( is_null( $promo_data ) ) {
+			return false;
+		}
+
+		if ( ! isset( $promo_data->start_date, $promo_data->end_date ) ) {
+			return false;
+		}
+
 		$current_time = time();
 
 		return (
@@ -40,31 +89,84 @@ class Pricing {
 		);
 	}
 
+	/**
+	 * Gets promotion end date
+	 *
+	 * @return int
+	 */
 	public function get_promo_end() {
-		return $this->get_promo_data()->end_date;
+		return isset( $this->get_promo_data()->end_date ) ? $this->get_promo_data()->end_date : 0;
 	}
 
+	/**
+	 * Gets the regular upgrade price from single to plus
+	 *
+	 * @return int
+	 */
 	public function get_regular_single_to_plus_price() {
-		return $this->get_plus_pricing()->prices->from_single->regular;
+		return isset( $this->get_plus_pricing()->prices->from_single->regular )
+		? $this->get_plus_pricing()->prices->from_single->regular
+		: 0;
 	}
 
+	/**
+	 * Gets the current upgrade price from single to plus
+	 *
+	 * @return int
+	 */
 	public function get_single_to_plus_price() {
-		return $this->is_promo_active() ? $this->get_plus_pricing()->prices->from_single->sale : $this->get_plus_pricing()->prices->from_single->regular;
+		$sale_price = isset( $this->get_plus_pricing()->prices->from_single->sale )
+		? $this->get_plus_pricing()->prices->from_single->sale
+		: 0;
+
+		return $this->is_promo_active() ? $sale_price : $this->get_regular_single_to_plus_price();
 	}
 
+	/**
+	 * Gets the regular upgrade price from single to infinite
+	 *
+	 * @return int
+	 */
 	public function get_regular_single_to_infinite_price() {
-		return $this->get_infinite_pricing()->prices->from_single->regular;
+		return isset( $this->get_infinite_pricing()->prices->from_single->regular )
+		? $this->get_infinite_pricing()->prices->from_single->regular
+		: 0;
 	}
 
+	/**
+	 * Gets the current upgrade price from single to plus
+	 *
+	 * @return int
+	 */
 	public function get_single_to_infinite_price() {
-		return $this->is_promo_active() ? $this->get_infinite_pricing()->prices->from_single->sale : $this->get_infinite_pricing()->prices->from_single->regular;
+		$sale_price = isset( $this->get_infinite_pricing()->prices->from_single->sale )
+		? $this->get_infinite_pricing()->prices->from_single->sale
+		: 0;
+
+		return $this->is_promo_active() ? $sale_price : $this->get_regular_single_to_infinite_price();
 	}
 
+	/**
+	 * Gets the regular upgrade price from plus to infinite
+	 *
+	 * @return int
+	 */
 	public function get_regular_plus_to_infinite_price() {
-		return $this->get_infinite_pricing()->prices->from_plus->regular;
+		return isset( $this->get_infinite_pricing()->prices->from_plus->regular )
+		? $this->get_infinite_pricing()->prices->from_plus->regular
+		: 0;
 	}
 
+	/**
+	 * Gets the current upgrade price from plus to infinite
+	 *
+	 * @return int
+	 */
 	public function get_plus_to_infinite_price() {
-		return $this->is_promo_active() ? $this->get_infinite_pricing()->prices->from_plus->sale : $this->get_infinite_pricing()->prices->from_plus->regular;
+		$sale_price = isset( $this->get_infinite_pricing()->prices->from_plus->sale )
+		? $this->get_infinite_pricing()->prices->from_plus->sale
+		: 0;
+
+		return $this->is_promo_active() ? $sale_price : $this->get_regular_plus_to_infinite_price();
 	}
 }

--- a/inc/Engine/License/API/Pricing.php
+++ b/inc/Engine/License/API/Pricing.php
@@ -25,7 +25,15 @@ class Pricing {
 	 * @return null|object
 	 */
 	public function get_single_pricing() {
-		return isset( $this->pricing->licenses->single ) ? $this->pricing->licenses->single : null;
+		if (
+			! isset( $this->pricing->licenses->single )
+			||
+			! is_object( $this->pricing->licenses->single )
+		) {
+			return null;
+		}
+
+		return $this->pricing->licenses->single;
 	}
 
 	/**
@@ -34,7 +42,15 @@ class Pricing {
 	 * @return null|object
 	 */
 	public function get_plus_pricing() {
-		return isset( $this->pricing->licenses->plus ) ? $this->pricing->licenses->plus : null;
+		if (
+			! isset( $this->pricing->licenses->plus )
+			||
+			! is_object( $this->pricing->licenses->plus )
+		) {
+			return null;
+		}
+
+		return $this->pricing->licenses->plus;
 	}
 
 	/**
@@ -43,7 +59,15 @@ class Pricing {
 	 * @return null|object
 	 */
 	public function get_infinite_pricing() {
-		return isset( $this->pricing->licenses->infinite ) ? $this->pricing->licenses->infinite : null;
+		if (
+			! isset( $this->pricing->licenses->infinite )
+			||
+			! is_object( $this->pricing->licenses->infinite )
+		) {
+			return null;
+		}
+
+		return $this->pricing->licenses->infinite;
 	}
 
 	/**
@@ -52,7 +76,15 @@ class Pricing {
 	 * @return null|object
 	 */
 	public function get_renewals_data() {
-		return isset( $this->pricing->renewals ) ? $this->pricing->renewals : null;
+		if (
+			! isset( $this->pricing->renewals )
+			||
+			! is_object( $this->pricing->renewals )
+		) {
+			return null;
+		}
+
+		return $this->pricing->renewals;
 	}
 
 	/**
@@ -61,7 +93,15 @@ class Pricing {
 	 * @return null|object
 	 */
 	public function get_promo_data() {
-		return isset( $this->pricing->promo ) ? $this->pricing->promo : null;
+		if (
+			! isset( $this->pricing->promo )
+			||
+			! is_object( $this->pricing->promo )
+		) {
+			return null;
+		}
+
+		return $this->pricing->promo;
 	}
 
 	/**
@@ -83,9 +123,9 @@ class Pricing {
 		$current_time = time();
 
 		return (
-			$promo_data->start_date < $current_time
+			absint( $promo_data->start_date ) < $current_time
 			&&
-			$promo_data->end_date > $current_time
+			absint( $promo_data->end_date ) > $current_time
 		);
 	}
 
@@ -95,7 +135,17 @@ class Pricing {
 	 * @return int
 	 */
 	public function get_promo_end() {
-		return isset( $this->get_promo_data()->end_date ) ? $this->get_promo_data()->end_date : 0;
+		$promo = $this->get_promo_data();
+
+		if (
+			is_null( $promo )
+			||
+			! isset( $promo->end_date )
+		) {
+			return 0;
+		}
+
+		return absint( $promo->end_date );
 	}
 
 	/**
@@ -104,9 +154,17 @@ class Pricing {
 	 * @return int
 	 */
 	public function get_regular_single_to_plus_price() {
-		return isset( $this->get_plus_pricing()->prices->from_single->regular )
-		? $this->get_plus_pricing()->prices->from_single->regular
-		: 0;
+		$plus_pricing = $this->get_plus_pricing();
+
+		if (
+			is_null( $plus_pricing )
+			||
+			! isset( $plus_pricing->prices->from_single->regular )
+		) {
+			return 0;
+		}
+
+		return $this->get_plus_pricing()->prices->from_single->regular;
 	}
 
 	/**
@@ -115,11 +173,18 @@ class Pricing {
 	 * @return int
 	 */
 	public function get_single_to_plus_price() {
-		$sale_price = isset( $this->get_plus_pricing()->prices->from_single->sale )
-		? $this->get_plus_pricing()->prices->from_single->sale
-		: 0;
+		$plus_pricing = $this->get_plus_pricing();
+		$regular      = $this->get_regular_single_to_plus_price();
 
-		return $this->is_promo_active() ? $sale_price : $this->get_regular_single_to_plus_price();
+		if (
+			is_null( $plus_pricing )
+			||
+			! isset( $plus_pricing->prices->from_single->sale )
+		) {
+			return $regular;
+		}
+
+		return $this->is_promo_active() ? $plus_pricing->prices->from_single->sale : $regular;
 	}
 
 	/**
@@ -128,9 +193,17 @@ class Pricing {
 	 * @return int
 	 */
 	public function get_regular_single_to_infinite_price() {
-		return isset( $this->get_infinite_pricing()->prices->from_single->regular )
-		? $this->get_infinite_pricing()->prices->from_single->regular
-		: 0;
+		$infinite_pricing = $this->get_infinite_pricing();
+
+		if (
+			is_null( $infinite_pricing )
+			||
+			! isset( $infinite_pricing->prices->from_single->regular )
+		) {
+			return 0;
+		}
+
+		return $infinite_pricing->prices->from_single->regular;
 	}
 
 	/**
@@ -139,11 +212,18 @@ class Pricing {
 	 * @return int
 	 */
 	public function get_single_to_infinite_price() {
-		$sale_price = isset( $this->get_infinite_pricing()->prices->from_single->sale )
-		? $this->get_infinite_pricing()->prices->from_single->sale
-		: 0;
+		$infinite_pricing = $this->get_infinite_pricing();
+		$regular          = $this->get_regular_single_to_infinite_price();
 
-		return $this->is_promo_active() ? $sale_price : $this->get_regular_single_to_infinite_price();
+		if (
+			is_null( $infinite_pricing )
+			||
+			! isset( $infinite_pricing->prices->from_single->sale )
+		) {
+			return $regular;
+		}
+
+		return $this->is_promo_active() ? $infinite_pricing->prices->from_single->sale : $regular;
 	}
 
 	/**
@@ -152,9 +232,17 @@ class Pricing {
 	 * @return int
 	 */
 	public function get_regular_plus_to_infinite_price() {
-		return isset( $this->get_infinite_pricing()->prices->from_plus->regular )
-		? $this->get_infinite_pricing()->prices->from_plus->regular
-		: 0;
+		$infinite_pricing = $this->get_infinite_pricing();
+
+		if (
+			is_null( $infinite_pricing )
+			||
+			! isset( $infinite_pricing->prices->from_plus->regular )
+		) {
+			return 0;
+		}
+
+		return $infinite_pricing->prices->from_plus->regular;
 	}
 
 	/**
@@ -163,10 +251,17 @@ class Pricing {
 	 * @return int
 	 */
 	public function get_plus_to_infinite_price() {
-		$sale_price = isset( $this->get_infinite_pricing()->prices->from_plus->sale )
-		? $this->get_infinite_pricing()->prices->from_plus->sale
-		: 0;
+		$infinite_pricing = $this->get_infinite_pricing();
+		$regular          = $this->get_regular_plus_to_infinite_price();
 
-		return $this->is_promo_active() ? $sale_price : $this->get_regular_plus_to_infinite_price();
+		if (
+			is_null( $infinite_pricing )
+			||
+			! isset( $infinite_pricing->prices->from_single->sale )
+		) {
+			return $regular;
+		}
+
+		return $this->is_promo_active() ? $infinite_pricing->prices->from_single->sale : $regular;
 	}
 }

--- a/inc/Engine/License/API/Pricing.php
+++ b/inc/Engine/License/API/Pricing.php
@@ -257,11 +257,11 @@ class Pricing {
 		if (
 			is_null( $infinite_pricing )
 			||
-			! isset( $infinite_pricing->prices->from_single->sale )
+			! isset( $infinite_pricing->prices->from_plus->sale )
 		) {
 			return $regular;
 		}
 
-		return $this->is_promo_active() ? $infinite_pricing->prices->from_single->sale : $regular;
+		return $this->is_promo_active() ? $infinite_pricing->prices->from_plus->sale : $regular;
 	}
 }

--- a/inc/Engine/License/API/Pricing.php
+++ b/inc/Engine/License/API/Pricing.php
@@ -164,7 +164,7 @@ class Pricing {
 			return 0;
 		}
 
-		return $this->get_plus_pricing()->prices->from_single->regular;
+		return $plus_pricing->prices->from_single->regular;
 	}
 
 	/**

--- a/inc/Engine/License/API/Pricing.php
+++ b/inc/Engine/License/API/Pricing.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace WP_Rocket\Engine\License\API;
+
+class Pricing {
+	private $pricing;
+
+	public function __construct( $pricing ) {
+		$this->pricing = $pricing;
+	}
+
+	public function get_single_pricing() {
+		return $this->pricing->licenses->single;
+	}
+
+	public function get_plus_pricing() {
+		return $this->pricing->licenses->plus;
+	}
+
+	public function get_infinite_pricing() {
+		return $this->pricing->licenses->infinite;
+	}
+
+	public function get_renewals_data() {
+		return $this->pricing->renewals;
+	}
+
+	public function get_promo_data() {
+		return $this->pricing->promo;
+	}
+
+	public function is_promo_active() {
+		$promo_data   = $this->get_promo_data();
+		$current_time = time();
+
+		return (
+			$promo_data->start_date < $current_time
+			&&
+			$promo_data->end_date > $current_time
+		);
+	}
+
+	public function get_promo_end() {
+		return $this->get_promo_data()->end_date;
+	}
+
+	public function get_regular_single_to_plus_price() {
+		return $this->get_plus_pricing()->prices->from_single->regular;
+	}
+
+	public function get_single_to_plus_price() {
+		return $this->is_promo_active() ? $this->get_plus_pricing()->prices->from_single->sale : $this->get_plus_pricing()->prices->from_single->regular;
+	}
+
+	public function get_regular_single_to_infinite_price() {
+		return $this->get_infinite_pricing()->prices->from_single->regular;
+	}
+
+	public function get_single_to_infinite_price() {
+		return $this->is_promo_active() ? $this->get_infinite_pricing()->prices->from_single->sale : $this->get_infinite_pricing()->prices->from_single->regular;
+	}
+
+	public function get_regular_plus_to_infinite_price() {
+		return $this->get_infinite_pricing()->prices->from_plus->regular;
+	}
+
+	public function get_plus_to_infinite_price() {
+		return $this->is_promo_active() ? $this->get_infinite_pricing()->prices->from_plus->sale : $this->get_infinite_pricing()->prices->from_plus->regular;
+	}
+}

--- a/inc/Engine/License/ServiceProvider.php
+++ b/inc/Engine/License/ServiceProvider.php
@@ -4,8 +4,8 @@ namespace WP_Rocket\Engine\License;
 
 use WP_Rocket\Engine\Container\ServiceProvider\AbstractServiceProvider;
 use WP_Rocket\Engine\License\API\PricingClient;
+use WP_Rocket\Engine\License\API\Pricing;
 use WP_Rocket\Engine\License\API\UserClient;
-
 
 /**
  * Service Provider for the License module
@@ -21,6 +21,7 @@ class ServiceProvider extends AbstractServiceProvider {
 	protected $provides = [
 		'pricing_client',
 		'user_client',
+		'pricing',
 	];
 
 	/**
@@ -32,5 +33,7 @@ class ServiceProvider extends AbstractServiceProvider {
 		$this->getContainer()->add( 'pricing_client', PricingClient::class );
 		$this->getContainer()->add( 'user_client', UserClient::class )
 			->withArgument( $this->getContainer()->get( 'options' ) );
+		$this->getContainer()->add( 'pricing', Pricing::class )
+			->withArgument( $this->getContainer()->get( 'pricing_client' )->get_pricing_data() );
 	}
 }

--- a/tests/Fixtures/inc/Engine/License/API/Pricing/GetRegularSingleToInfinitePrice.php
+++ b/tests/Fixtures/inc/Engine/License/API/Pricing/GetRegularSingleToInfinitePrice.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+	'testShouldReturnZeroWhenNotObject' => [
+		'data'     => [
+			'promo' => [],
+		],
+		'expected' => 0,
+	],
+	'testShouldReturnZeroWhenPlusNotSet' => [
+		'data'     => json_decode( json_encode( [
+			'licenses' => [],
+		] ) ),
+		'expected' => 0,
+	],
+	'testShouldReturnZeroWhenPropertyNotSet' => [
+		'data'     => json_decode( json_encode( [
+			'licenses' => [
+				'infinite' => [
+					'prices' => [
+						'from_single' => [
+							'sale'    => 120,
+						],
+					],
+				],
+			],
+		] ) ),
+		'expected' => 0,
+	],
+	'testShouldReturnIntWhenPropertySet' => [
+		'data'     => json_decode( json_encode( [
+			'licenses' => [
+				'infinite' => [
+					'prices' => [
+						'from_single' => [
+							'regular' => 150,
+							'sale'    => 120,
+						],
+					],
+				],
+			],
+		] ) ),
+		'expected' => 150,
+	],
+];

--- a/tests/Fixtures/inc/Engine/License/API/Pricing/getInfinitePricing.php
+++ b/tests/Fixtures/inc/Engine/License/API/Pricing/getInfinitePricing.php
@@ -1,0 +1,35 @@
+<?php
+
+return [
+	'testShouldReturnNullWhenNotObject' => [
+		'data'     => [
+			'licenses' => [],
+		],
+		'expected' => null,
+	],
+	'testShouldReturnNullWhenNotSet' => [
+		'data'     => json_decode( json_encode( [
+			'licenses' => [
+				'single' => [
+					'prices'   => [],
+					'websites' => 1,
+				],
+			],
+		] ) ),
+		'expected' => null,
+	],
+	'testShouldReturnObjectWhenSet' => [
+		'data'     => json_decode( json_encode( [
+			'licenses' => [
+				'infinite' => [
+					'prices'   => [],
+					'websites' => -1,
+				],
+			],
+		] ) ),
+		'expected' => (object) [
+			'prices'   => [],
+			'websites' => -1,
+		],
+	],
+];

--- a/tests/Fixtures/inc/Engine/License/API/Pricing/getPlusPricing.php
+++ b/tests/Fixtures/inc/Engine/License/API/Pricing/getPlusPricing.php
@@ -1,0 +1,35 @@
+<?php
+
+return [
+	'testShouldReturnNullWhenNotObject' => [
+		'data'     => [
+			'licenses' => [],
+		],
+		'expected' => null,
+	],
+	'testShouldReturnNullWhenNotSet' => [
+		'data'     => json_decode( json_encode( [
+			'licenses' => [
+				'single' => [
+					'prices'   => [],
+					'websites' => 1,
+				],
+			],
+		] ) ),
+		'expected' => null,
+	],
+	'testShouldReturnObjectWhenSet' => [
+		'data'     => json_decode( json_encode( [
+			'licenses' => [
+				'plus' => [
+					'prices'   => [],
+					'websites' => 3,
+				],
+			],
+		] ) ),
+		'expected' => (object) [
+			'prices'   => [],
+			'websites' => 3,
+		],
+	],
+];

--- a/tests/Fixtures/inc/Engine/License/API/Pricing/getPlusToInfinitePrice.php
+++ b/tests/Fixtures/inc/Engine/License/API/Pricing/getPlusToInfinitePrice.php
@@ -1,0 +1,72 @@
+<?php
+
+return [
+	'testShouldReturnZeroWhenNotObject' => [
+		'data'     => [
+			'promo' => [],
+		],
+		'expected' => 0,
+	],
+	'testShouldReturnZeroWhenPlusNotSet' => [
+		'data'     => json_decode( json_encode( [
+			'licenses' => [],
+		] ) ),
+		'expected' => 0,
+	],
+	'testShouldReturnRegularWhenSalePropertyNotSet' => [
+		'data'     => json_decode( json_encode( [
+			'licenses' => [
+				'infinite' => [
+					'prices' => [
+						'from_plus' => [
+							'regular' => 200,
+						],
+					],
+				],
+			],
+		] ) ),
+		'expected' => 200,
+	],
+	'testShouldReturnRegularIntWhenPropertySetAndNoPromo' => [
+		'data'     => json_decode( json_encode( [
+			'licenses' => [
+				'infinite' => [
+					'prices' => [
+						'from_plus' => [
+							'regular' => 200,
+							'sale'    => 160,
+						],
+					],
+				],
+			],
+			'promo' => [
+				'name'             => 'Halloween',
+				'discount_percent' => 20,
+				'start_date'       => strtotime( 'tomorrow' ),
+				'end_date'         => strtotime( 'next month' ),
+			],
+		] ) ),
+		'expected' => 200,
+	],
+	'testShouldReturnSaleIntWhenPropertySetAndPromo' => [
+		'data'     => json_decode( json_encode( [
+			'licenses' => [
+				'infinite' => [
+					'prices' => [
+						'from_plus' => [
+							'regular' => 200,
+							'sale'    => 160,
+						],
+					],
+				],
+			],
+			'promo' => [
+				'name'             => 'Halloween',
+				'discount_percent' => 20,
+				'start_date'       => strtotime( 'last week' ),
+				'end_date'         => strtotime( 'next week' ),
+			],
+		] ) ),
+		'expected' => 160,
+	],
+];

--- a/tests/Fixtures/inc/Engine/License/API/Pricing/getPromoData.php
+++ b/tests/Fixtures/inc/Engine/License/API/Pricing/getPromoData.php
@@ -1,0 +1,32 @@
+<?php
+
+return [
+	'testShouldReturnNullWhenNotObject' => [
+		'data'     => [
+			'licenses' => [],
+		],
+		'expected' => null,
+	],
+	'testShouldReturnNullWhenNotSet' => [
+		'data'     => json_decode( json_encode( [
+			'licenses' => [],
+		] ) ),
+		'expected' => null,
+	],
+	'testShouldReturnObjectWhenSet' => [
+		'data'     => json_decode( json_encode( [
+			'promo' => [
+				'name'             => 'Halloween',
+				'discount_percent' => 20,
+				'start_date'       => 1603756800,
+				'end_date'         => 1604361600,
+			],
+		] ) ),
+		'expected' => (object) [
+			'name'             => 'Halloween',
+			'discount_percent' => 20,
+			'start_date'       => 1603756800,
+			'end_date'         => 1604361600,
+		],
+	],
+];

--- a/tests/Fixtures/inc/Engine/License/API/Pricing/getPromoEnd.php
+++ b/tests/Fixtures/inc/Engine/License/API/Pricing/getPromoEnd.php
@@ -1,0 +1,37 @@
+<?php
+
+return [
+	'testShouldReturnZeroWhenNotObject' => [
+		'data'     => [
+			'promo' => [],
+		],
+		'expected' => 0,
+	],
+	'testShouldReturnZeroWhenPromoNotSet' => [
+		'data'     => json_decode( json_encode( [
+			'licenses' => [],
+		] ) ),
+		'expected' => 0,
+	],
+	'testShouldReturnZeroWhenPromoEndDatePropertyNotSet' => [
+		'data'     => json_decode( json_encode( [
+			'promo' => [
+				'name'             => 'Halloween',
+				'discount_percent' => 20,
+				'start_date'       => 1603756800,
+			],
+		] ) ),
+		'expected' => 0,
+	],
+	'testShouldReturnIntWhenEndDateSet' => [
+		'data'     => json_decode( json_encode( [
+			'promo' => [
+				'name'             => 'Halloween',
+				'discount_percent' => 20,
+				'start_date'       => strtotime( 'last week' ),
+				'end_date'         => 12345,
+			],
+		] ) ),
+		'expected' => 12345,
+	],
+];

--- a/tests/Fixtures/inc/Engine/License/API/Pricing/getRegularPlusToInfinitePrice.php
+++ b/tests/Fixtures/inc/Engine/License/API/Pricing/getRegularPlusToInfinitePrice.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+	'testShouldReturnZeroWhenNotObject' => [
+		'data'     => [
+			'promo' => [],
+		],
+		'expected' => 0,
+	],
+	'testShouldReturnZeroWhenPlusNotSet' => [
+		'data'     => json_decode( json_encode( [
+			'licenses' => [],
+		] ) ),
+		'expected' => 0,
+	],
+	'testShouldReturnZeroWhenPropertyNotSet' => [
+		'data'     => json_decode( json_encode( [
+			'licenses' => [
+				'infinite' => [
+					'prices' => [
+						'from_plus' => [
+							'sale'    => 160,
+						],
+					],
+				],
+			],
+		] ) ),
+		'expected' => 0,
+	],
+	'testShouldReturnIntWhenPropertySet' => [
+		'data'     => json_decode( json_encode( [
+			'licenses' => [
+				'infinite' => [
+					'prices' => [
+						'from_plus' => [
+							'regular' => 200,
+							'sale'    => 160,
+						],
+					],
+				],
+			],
+		] ) ),
+		'expected' => 200,
+	],
+];

--- a/tests/Fixtures/inc/Engine/License/API/Pricing/getRegularSingleToPlusPrice.php
+++ b/tests/Fixtures/inc/Engine/License/API/Pricing/getRegularSingleToPlusPrice.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+	'testShouldReturnZeroWhenNotObject' => [
+		'data'     => [
+			'promo' => [],
+		],
+		'expected' => 0,
+	],
+	'testShouldReturnZeroWhenPlusNotSet' => [
+		'data'     => json_decode( json_encode( [
+			'licenses' => [],
+		] ) ),
+		'expected' => 0,
+	],
+	'testShouldReturnZeroWhenPropertyNotSet' => [
+		'data'     => json_decode( json_encode( [
+			'licenses' => [
+				'plus' => [
+					'prices' => [
+						'from_single' => [
+							'sale'    => 40,
+						],
+					],
+				],
+			],
+		] ) ),
+		'expected' => 0,
+	],
+	'testShouldReturnIntWhenPropertySet' => [
+		'data'     => json_decode( json_encode( [
+			'licenses' => [
+				'plus' => [
+					'prices' => [
+						'from_single' => [
+							'regular' => 50,
+							'sale'    => 40,
+						],
+					],
+				],
+			],
+		] ) ),
+		'expected' => 50,
+	],
+];

--- a/tests/Fixtures/inc/Engine/License/API/Pricing/getRenewalsData.php
+++ b/tests/Fixtures/inc/Engine/License/API/Pricing/getRenewalsData.php
@@ -1,0 +1,38 @@
+<?php
+
+return [
+	'testShouldReturnNullWhenNotObject' => [
+		'data'     => [
+			'licenses' => [],
+		],
+		'expected' => null,
+	],
+	'testShouldReturnNullWhenNotSet' => [
+		'data'     => json_decode( json_encode( [
+			'licenses' => [],
+		] ) ),
+		'expected' => null,
+	],
+	'testShouldReturnObjectWhenSet' => [
+		'data'     => json_decode( json_encode( [
+			'renewals' => [
+				'extra_days'       => 90,
+				'grandfather_date' => 1567296000,
+				'discount_percent' => [
+					'is_grandfather'  => 50,
+					'not_grandfather' => 30,
+					'is_expired'      => 20,
+				],
+			],
+		] ) ),
+		'expected' => json_decode( json_encode( [
+			'extra_days'       => 90,
+			'grandfather_date' => 1567296000,
+			'discount_percent' => [
+				'is_grandfather'  => 50,
+				'not_grandfather' => 30,
+				'is_expired'      => 20,
+			],
+		] ) ),
+	],
+];

--- a/tests/Fixtures/inc/Engine/License/API/Pricing/getSinglePricing.php
+++ b/tests/Fixtures/inc/Engine/License/API/Pricing/getSinglePricing.php
@@ -1,0 +1,35 @@
+<?php
+
+return [
+	'testShouldReturnNullWhenNotObject' => [
+		'data'     => [
+			'licenses' => [],
+		],
+		'expected' => null,
+	],
+	'testShouldReturnNullWhenNotSet' => [
+		'data'     => json_decode( json_encode( [
+			'licenses' => [
+				'plus' => [
+					'prices'   => [],
+					'websites' => 3,
+				],
+			],
+		] ) ),
+		'expected' => null,
+	],
+	'testShouldReturnObjectWhenSet' => [
+		'data'     => json_decode( json_encode( [
+			'licenses' => [
+				'single' => [
+					'prices'   => [],
+					'websites' => 1,
+				],
+			],
+		] ) ),
+		'expected' => (object) [
+			'prices'   => [],
+			'websites' => 1,
+		],
+	],
+];

--- a/tests/Fixtures/inc/Engine/License/API/Pricing/getSingleToInfinitePrice.php
+++ b/tests/Fixtures/inc/Engine/License/API/Pricing/getSingleToInfinitePrice.php
@@ -1,0 +1,72 @@
+<?php
+
+return [
+	'testShouldReturnZeroWhenNotObject' => [
+		'data'     => [
+			'promo' => [],
+		],
+		'expected' => 0,
+	],
+	'testShouldReturnZeroWhenPlusNotSet' => [
+		'data'     => json_decode( json_encode( [
+			'licenses' => [],
+		] ) ),
+		'expected' => 0,
+	],
+	'testShouldReturnRegularWhenSalePropertyNotSet' => [
+		'data'     => json_decode( json_encode( [
+			'licenses' => [
+				'infinite' => [
+					'prices' => [
+						'from_single' => [
+							'regular' => 150,
+						],
+					],
+				],
+			],
+		] ) ),
+		'expected' => 150,
+	],
+	'testShouldReturnRegularIntWhenPropertySetAndNoPromo' => [
+		'data'     => json_decode( json_encode( [
+			'licenses' => [
+				'infinite' => [
+					'prices' => [
+						'from_single' => [
+							'regular' => 150,
+							'sale'    => 120,
+						],
+					],
+				],
+			],
+			'promo' => [
+				'name'             => 'Halloween',
+				'discount_percent' => 20,
+				'start_date'       => strtotime( 'tomorrow' ),
+				'end_date'         => strtotime( 'next month' ),
+			],
+		] ) ),
+		'expected' => 150,
+	],
+	'testShouldReturnSaleIntWhenPropertySetAndPromo' => [
+		'data'     => json_decode( json_encode( [
+			'licenses' => [
+				'infinite' => [
+					'prices' => [
+						'from_single' => [
+							'regular' => 150,
+							'sale'    => 120,
+						],
+					],
+				],
+			],
+			'promo' => [
+				'name'             => 'Halloween',
+				'discount_percent' => 20,
+				'start_date'       => strtotime( 'last week' ),
+				'end_date'         => strtotime( 'next week' ),
+			],
+		] ) ),
+		'expected' => 120,
+	],
+];

--- a/tests/Fixtures/inc/Engine/License/API/Pricing/getSingleToPlusPrice.php
+++ b/tests/Fixtures/inc/Engine/License/API/Pricing/getSingleToPlusPrice.php
@@ -1,0 +1,72 @@
+<?php
+
+return [
+	'testShouldReturnZeroWhenNotObject' => [
+		'data'     => [
+			'promo' => [],
+		],
+		'expected' => 0,
+	],
+	'testShouldReturnZeroWhenPlusNotSet' => [
+		'data'     => json_decode( json_encode( [
+			'licenses' => [],
+		] ) ),
+		'expected' => 0,
+	],
+	'testShouldReturnRegularWhenSalePropertyNotSet' => [
+		'data'     => json_decode( json_encode( [
+			'licenses' => [
+				'plus' => [
+					'prices' => [
+						'from_single' => [
+							'regular' => 50,
+						],
+					],
+				],
+			],
+		] ) ),
+		'expected' => 50,
+	],
+	'testShouldReturnRegularIntWhenPropertySetAndNoPromo' => [
+		'data'     => json_decode( json_encode( [
+			'licenses' => [
+				'plus' => [
+					'prices' => [
+						'from_single' => [
+							'regular' => 50,
+							'sale'    => 40,
+						],
+					],
+				],
+			],
+			'promo' => [
+				'name'             => 'Halloween',
+				'discount_percent' => 20,
+				'start_date'       => strtotime( 'tomorrow' ),
+				'end_date'         => strtotime( 'next month' ),
+			],
+		] ) ),
+		'expected' => 50,
+	],
+	'testShouldReturnSaleIntWhenPropertySetAndPromo' => [
+		'data'     => json_decode( json_encode( [
+			'licenses' => [
+				'plus' => [
+					'prices' => [
+						'from_single' => [
+							'regular' => 50,
+							'sale'    => 40,
+						],
+					],
+				],
+			],
+			'promo' => [
+				'name'             => 'Halloween',
+				'discount_percent' => 20,
+				'start_date'       => strtotime( 'last week' ),
+				'end_date'         => strtotime( 'next week' ),
+			],
+		] ) ),
+		'expected' => 40,
+	],
+];

--- a/tests/Fixtures/inc/Engine/License/API/Pricing/isPromoActive.php
+++ b/tests/Fixtures/inc/Engine/License/API/Pricing/isPromoActive.php
@@ -1,0 +1,67 @@
+<?php
+
+return [
+	'testShouldReturnFalseWhenNotObject' => [
+		'data'     => [
+			'promo' => [],
+		],
+		'expected' => false,
+	],
+	'testShouldReturnFalseWhenPromoNotSet' => [
+		'data'     => json_decode( json_encode( [
+			'licenses' => [],
+		] ) ),
+		'expected' => false,
+	],
+	'testShouldReturnFalseWhenPromoPropertiesNotSet' => [
+		'data'     => json_decode( json_encode( [
+			'promo' => [
+				'name'             => 'Halloween',
+				'discount_percent' => 20,
+			],
+		] ) ),
+		'expected' => false,
+	],
+	'testShouldReturnFalseWhenPromoStartDatePropertyNotSet' => [
+		'data'     => json_decode( json_encode( [
+			'promo' => [
+				'name'             => 'Halloween',
+				'discount_percent' => 20,
+				'end_date'         => 1604361600,
+			],
+		] ) ),
+		'expected' => false,
+	],
+	'testShouldReturnFalseWhenPromoEndDatePropertyNotSet' => [
+		'data'     => json_decode( json_encode( [
+			'promo' => [
+				'name'             => 'Halloween',
+				'discount_percent' => 20,
+				'start_date'       => 1603756800,
+			],
+		] ) ),
+		'expected' => false,
+	],
+	'testShouldReturnFalseWhenPromoNotActive' => [
+		'data'     => json_decode( json_encode( [
+			'promo' => [
+				'name'             => 'Halloween',
+				'discount_percent' => 20,
+				'start_date'       => strtotime( 'tomorrow' ),
+				'end_date'         => strtotime( 'next month' ),
+			],
+		] ) ),
+		'expected' => false,
+	],
+	'testShouldReturnTrueWhenPromoActive' => [
+		'data'     => json_decode( json_encode( [
+			'promo' => [
+				'name'             => 'Halloween',
+				'discount_percent' => 20,
+				'start_date'       => strtotime( 'last week' ),
+				'end_date'         => strtotime( 'next week' ),
+			],
+		] ) ),
+		'expected' => true,
+	],
+];

--- a/tests/Unit/inc/Engine/License/API/Pricing/getInfinitePricing.php
+++ b/tests/Unit/inc/Engine/License/API/Pricing/getInfinitePricing.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\License\API\Pricing;
+
+use WP_Rocket\Engine\License\API\Pricing;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\License\API\Pricing::get_infinite_pricing
+ *
+ * @group License
+ */
+class GetInfinitePricing extends TestCase {
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnExpected( $data, $expected ) {
+		$pricing = new Pricing( $data );
+
+		$this->assertEquals(
+			$expected,
+			$pricing->get_infinite_pricing()
+		);
+	}
+}

--- a/tests/Unit/inc/Engine/License/API/Pricing/getPlusPricing.php
+++ b/tests/Unit/inc/Engine/License/API/Pricing/getPlusPricing.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\License\API\Pricing;
+
+use WP_Rocket\Engine\License\API\Pricing;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\License\API\Pricing::get_plus_pricing
+ *
+ * @group License
+ */
+class GetPlusPricing extends TestCase {
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnExpected( $data, $expected ) {
+		$pricing = new Pricing( $data );
+
+		$this->assertEquals(
+			$expected,
+			$pricing->get_plus_pricing()
+		);
+	}
+}

--- a/tests/Unit/inc/Engine/License/API/Pricing/getPlusToInfinitePrice.php
+++ b/tests/Unit/inc/Engine/License/API/Pricing/getPlusToInfinitePrice.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\License\API\Pricing;
+
+use Brain\Monkey\Functions;
+use WP_Rocket\Engine\License\API\Pricing;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\License\API\Pricing::get_plus_to_infinite_price
+ *
+ * @group License
+ */
+class GetPlusToInfinitePrice extends TestCase {
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnExpected( $data, $expected ) {
+		$pricing = new Pricing( $data );
+
+		$this->assertEquals(
+			$expected,
+			$pricing->get_plus_to_infinite_price()
+		);
+	}
+}

--- a/tests/Unit/inc/Engine/License/API/Pricing/getPromoData.php
+++ b/tests/Unit/inc/Engine/License/API/Pricing/getPromoData.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\License\API\Pricing;
+
+use WP_Rocket\Engine\License\API\Pricing;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\License\API\Pricing::get_promo_data
+ *
+ * @group License
+ */
+class GetPromoData extends TestCase {
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnExpected( $data, $expected ) {
+		$pricing = new Pricing( $data );
+
+		$this->assertEquals(
+			$expected,
+			$pricing->get_promo_data()
+		);
+	}
+}

--- a/tests/Unit/inc/Engine/License/API/Pricing/getPromoEnd.php
+++ b/tests/Unit/inc/Engine/License/API/Pricing/getPromoEnd.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\License\API\Pricing;
+
+use Brain\Monkey\Functions;
+use WP_Rocket\Engine\License\API\Pricing;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\License\API\Pricing::get_promo_end
+ *
+ * @group License
+ */
+class GetPromoEnd extends TestCase {
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnExpected( $data, $expected ) {
+		Functions\when( 'absint' )->returnArg();
+
+		$pricing = new Pricing( $data );
+
+		$this->assertEquals(
+			$expected,
+			$pricing->get_promo_end()
+		);
+	}
+}

--- a/tests/Unit/inc/Engine/License/API/Pricing/getRegularPlusToInfinitePrice.php
+++ b/tests/Unit/inc/Engine/License/API/Pricing/getRegularPlusToInfinitePrice.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\License\API\Pricing;
+
+use Brain\Monkey\Functions;
+use WP_Rocket\Engine\License\API\Pricing;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\License\API\Pricing::get_regular_plus_to_infinite_price
+ *
+ * @group License
+ */
+class GetRegularPlusToInfinitePrice extends TestCase {
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnExpected( $data, $expected ) {
+		$pricing = new Pricing( $data );
+
+		$this->assertEquals(
+			$expected,
+			$pricing->get_regular_plus_to_infinite_price()
+		);
+	}
+}

--- a/tests/Unit/inc/Engine/License/API/Pricing/getRegularSingleToInfinitePrice.php
+++ b/tests/Unit/inc/Engine/License/API/Pricing/getRegularSingleToInfinitePrice.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\License\API\Pricing;
+
+use Brain\Monkey\Functions;
+use WP_Rocket\Engine\License\API\Pricing;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\License\API\Pricing::get_regular_single_to_infinite_price
+ *
+ * @group License
+ */
+class GetRegularSingleToInfinitePrice extends TestCase {
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnExpected( $data, $expected ) {
+		$pricing = new Pricing( $data );
+
+		$this->assertEquals(
+			$expected,
+			$pricing->get_regular_single_to_infinite_price()
+		);
+	}
+}

--- a/tests/Unit/inc/Engine/License/API/Pricing/getRegularSingleToPlusPrice.php
+++ b/tests/Unit/inc/Engine/License/API/Pricing/getRegularSingleToPlusPrice.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\License\API\Pricing;
+
+use Brain\Monkey\Functions;
+use WP_Rocket\Engine\License\API\Pricing;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\License\API\Pricing::get_regular_single_to_plus_price
+ *
+ * @group License
+ */
+class GetRegularSingleToPlusPrice extends TestCase {
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnExpected( $data, $expected ) {
+		$pricing = new Pricing( $data );
+
+		$this->assertEquals(
+			$expected,
+			$pricing->get_regular_single_to_plus_price()
+		);
+	}
+}

--- a/tests/Unit/inc/Engine/License/API/Pricing/getRenewalsData.php
+++ b/tests/Unit/inc/Engine/License/API/Pricing/getRenewalsData.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\License\API\Pricing;
+
+use WP_Rocket\Engine\License\API\Pricing;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\License\API\Pricing::get_renewals_data
+ *
+ * @group License
+ */
+class GetRenewalsData extends TestCase {
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnExpected( $data, $expected ) {
+		$pricing = new Pricing( $data );
+
+		$this->assertEquals(
+			$expected,
+			$pricing->get_renewals_data()
+		);
+	}
+}

--- a/tests/Unit/inc/Engine/License/API/Pricing/getSinglePricing.php
+++ b/tests/Unit/inc/Engine/License/API/Pricing/getSinglePricing.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\License\API\Pricing;
+
+use WP_Rocket\Engine\License\API\Pricing;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\License\API\Pricing::get_single_pricing
+ *
+ * @group License
+ */
+class GetSinglePricing extends TestCase {
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnExpected( $data, $expected ) {
+		$pricing = new Pricing( $data );
+
+		$this->assertEquals(
+			$expected,
+			$pricing->get_single_pricing()
+		);
+	}
+}

--- a/tests/Unit/inc/Engine/License/API/Pricing/getSingleToInfinitePrice.php
+++ b/tests/Unit/inc/Engine/License/API/Pricing/getSingleToInfinitePrice.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\License\API\Pricing;
+
+use Brain\Monkey\Functions;
+use WP_Rocket\Engine\License\API\Pricing;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\License\API\Pricing::get_single_to_infinite_price
+ *
+ * @group License
+ */
+class GetSingleToInfinitePrice extends TestCase {
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnExpected( $data, $expected ) {
+		$pricing = new Pricing( $data );
+
+		$this->assertEquals(
+			$expected,
+			$pricing->get_single_to_infinite_price()
+		);
+	}
+}

--- a/tests/Unit/inc/Engine/License/API/Pricing/getSingleToPlusPrice.php
+++ b/tests/Unit/inc/Engine/License/API/Pricing/getSingleToPlusPrice.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\License\API\Pricing;
+
+use Brain\Monkey\Functions;
+use WP_Rocket\Engine\License\API\Pricing;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\License\API\Pricing::get_single_to_plus_price
+ *
+ * @group License
+ */
+class GetSingleToPlusPrice extends TestCase {
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnExpected( $data, $expected ) {
+		$pricing = new Pricing( $data );
+
+		$this->assertEquals(
+			$expected,
+			$pricing->get_single_to_plus_price()
+		);
+	}
+}

--- a/tests/Unit/inc/Engine/License/API/Pricing/isPromoActive.php
+++ b/tests/Unit/inc/Engine/License/API/Pricing/isPromoActive.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\License\API\Pricing;
+
+use Brain\Monkey\Functions;
+use WP_Rocket\Engine\License\API\Pricing;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\License\API\Pricing::is_promo_active
+ *
+ * @group License
+ */
+class IsPromoActive extends TestCase {
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnExpected( $data, $expected ) {
+		Functions\when( 'absint' )->returnArg();
+
+		$pricing = new Pricing( $data );
+
+		$this->assertEquals(
+			$expected,
+			$pricing->is_promo_active()
+		);
+	}
+}


### PR DESCRIPTION
Closes #3150 

The pricing class provides ready to use methods to get specific pricing values from the pricing API.

### Methods
- `get_single_pricing()`: Gets the single license pricing data
- `get_plus_pricing()`: Gets the plus license pricing data
- `get_infinite_pricing()`: Gets the inifinite license pricing data
- `get_renewals_data()`: Gets the renewals data
- `get_promo_data()`: Gets the promotion data
- `is_promo_active()`: Checks if a promotion is currently active
- `get_promo_end()`: Gets the promotion end timestamp
- `get_regular_single_to_plus_price()`: Gets the regular single to plus upgrade price
- `get_single_to_plus_price()`: Gets the current single to plus upgrade price. Different if a promotion is active
- `get_regular_single_to_infinite_price()`: Gets the regular single to infinite upgrade price
- `get_single_to_infinite_price()`: Gets the current single to infinite upgrade price. Different if a promotion is active
- `get_regular_plus_to_infinite_price()`: Gets the regular plus to infinite upgrade price
- `get_plus_to_infinite_price()`: Gets the current plus to infinite upgrade price. Different if a promotion is active