### PR TITLE
Alfonso exclude inlinejs

### DIFF
--- a/inc/Engine/Optimization/Minify/JS/Combine.php
+++ b/inc/Engine/Optimization/Minify/JS/Combine.php
@@ -645,6 +645,11 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 			'var useEdit',
 			'var DTGS_NONCE_FRONTEND',
 			'n2jQuery',
+			'et_core_api_spam_recaptcha',
+			'cnArgs',
+			'__CF$cv$params',
+			'trustbox_settings',
+			'aepro',
 		];
 
 		$excluded_inline = array_merge( $defaults, $this->options->get( 'exclude_inline_js', [] ) );

--- a/inc/Engine/Optimization/Minify/JS/Combine.php
+++ b/inc/Engine/Optimization/Minify/JS/Combine.php
@@ -650,7 +650,7 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 			'__CF$cv$params',
 			'trustbox_settings',
 			'aepro',
-			'cdn.jst.ai'
+			'cdn.jst.ai',
 		];
 
 		$excluded_inline = array_merge( $defaults, $this->options->get( 'exclude_inline_js', [] ) );

--- a/inc/Engine/Optimization/Minify/JS/Combine.php
+++ b/inc/Engine/Optimization/Minify/JS/Combine.php
@@ -650,6 +650,7 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 			'__CF$cv$params',
 			'trustbox_settings',
 			'aepro',
+			'cdn.jst.ai'
 		];
 
 		$excluded_inline = array_merge( $defaults, $this->options->get( 'exclude_inline_js', [] ) );

--- a/inc/Engine/Optimization/Minify/JS/Combine.php
+++ b/inc/Engine/Optimization/Minify/JS/Combine.php
@@ -651,6 +651,7 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 			'trustbox_settings',
 			'aepro',
 			'cdn.jst.ai',
+			'w2dc_fields_in_categories',
 		];
 
 		$excluded_inline = array_merge( $defaults, $this->options->get( 'exclude_inline_js', [] ) );


### PR DESCRIPTION
- Excluding 5 scripts related to Cache dir size issues:

https://secure.helpscout.net/conversation/1284375275/195431?folderId=2683093
https://secure.helpscout.net/conversation/1292295543/197509?folderId=2683093

```
'et_core_api_spam_recaptcha',
'cnArgs',
'__CF$cv$params',
'trustbox_settings',
'aepro',
```

- Excluding one script related to Justuno Compatibility:
`'cdn.jst.ai'`
ticket from Lucy: https://secure.helpscout.net/conversation/1293553549/197832?folderId=2683093

- cache dir size related inline JS exclusion: 
`w2dc_fields_in_categories`
coming from Web 2.0 Directory plugin
Ticket:  https://secure.helpscout.net/conversation/1282752535/194994/