### PR TITLE
Exclude loaded.knack.com from JS optimizations

### DIFF
--- a/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
+++ b/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
@@ -264,6 +264,7 @@ abstract class AbstractJSOptimization extends AbstractOptimization {
 			'simplybook.me/v2/widget/widget.js',
 			'static.botsrv.com/website/js/widget2.36cf1446.js',
 			'static.mailerlite.com/data/',
+			'loader.knack.com',
 		];
 
 		$excluded_external = array_merge( $defaults, $this->options->get( 'exclude_js', [] ) );


### PR DESCRIPTION
Exclude external script from Minify and Combine JS per Lucy's ticket here:

File exclusion: loader.knack.com

https://secure.helpscout.net/conversation/1293470917/197816?folderId=2683093