### PR TITLE
Closes #3154 Subscriber class for the upgrade events

### DIFF
--- a/inc/Engine/Admin/Settings/Subscriber.php
+++ b/inc/Engine/Admin/Settings/Subscriber.php
@@ -83,7 +83,7 @@ class Subscriber implements Subscriber_Interface {
 	public function add_admin_page() {
 		add_options_page(
 			$this->page->get_title(),
-			$this->page->get_title(),
+			apply_filters( 'rocket_menu_title', $this->page->get_title() ),
 			$this->page->get_capability(),
 			$this->page->get_slug(),
 			[ $this->page, 'render_page' ]

--- a/inc/Engine/Admin/Settings/Subscriber.php
+++ b/inc/Engine/Admin/Settings/Subscriber.php
@@ -83,7 +83,7 @@ class Subscriber implements Subscriber_Interface {
 	public function add_admin_page() {
 		add_options_page(
 			$this->page->get_title(),
-			apply_filters( 'rocket_menu_title', $this->page->get_title() ),
+			$this->page->get_title(),
 			$this->page->get_capability(),
 			$this->page->get_slug(),
 			[ $this->page, 'render_page' ]

--- a/inc/Engine/License/ServiceProvider.php
+++ b/inc/Engine/License/ServiceProvider.php
@@ -8,6 +8,7 @@ use WP_Rocket\Engine\License\API\Pricing;
 use WP_Rocket\Engine\License\API\UserClient;
 use WP_Rocket\Engine\License\API\User;
 use WP_Rocket\Engine\License\Upgrade;
+use WP_Rocket\Engine\License\Subscriber;
 
 /**
  * Service Provider for the License module
@@ -26,6 +27,7 @@ class ServiceProvider extends AbstractServiceProvider {
 		'pricing',
 		'user',
 		'upgrade',
+		'license_subscriber',
 	];
 
 	/**
@@ -47,5 +49,7 @@ class ServiceProvider extends AbstractServiceProvider {
 			->withArgument( $this->getContainer()->get( 'pricing' ) )
 			->withArgument( $this->getContainer()->get( 'user' ) )
 			->withArgument( $views );
+		$this->getContainer()->add( 'license_subscriber', Subscriber::class )
+			->withArgument( $this->getContainer()->get( 'upgrade' ) );
 	}
 }

--- a/inc/Engine/License/ServiceProvider.php
+++ b/inc/Engine/License/ServiceProvider.php
@@ -41,15 +41,15 @@ class ServiceProvider extends AbstractServiceProvider {
 		$this->getContainer()->add( 'pricing_client', PricingClient::class );
 		$this->getContainer()->add( 'user_client', UserClient::class )
 			->withArgument( $this->getContainer()->get( 'options' ) );
-		$this->getContainer()->add( 'pricing', Pricing::class )
+		$this->getContainer()->share( 'pricing', Pricing::class )
 			->withArgument( $this->getContainer()->get( 'pricing_client' )->get_pricing_data() );
-		$this->getContainer()->add( 'user', User::class )
+		$this->getContainer()->share( 'user', User::class )
 			->withArgument( $this->getContainer()->get( 'user_client' )->get_user_data() );
 		$this->getContainer()->add( 'upgrade', Upgrade::class )
 			->withArgument( $this->getContainer()->get( 'pricing' ) )
 			->withArgument( $this->getContainer()->get( 'user' ) )
 			->withArgument( $views );
-		$this->getContainer()->add( 'license_subscriber', Subscriber::class )
+		$this->getContainer()->share( 'license_subscriber', Subscriber::class )
 			->withArgument( $this->getContainer()->get( 'upgrade' ) );
 	}
 }

--- a/inc/Engine/License/Subscriber.php
+++ b/inc/Engine/License/Subscriber.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace WP_Rocket\Engine\License;
+
+use WP_Rocket\Event_Management\Subscriber_Interface;
+
+class Subscriber implements Subscriber_Interface {
+	private $upgrade;
+
+	public function __construct( Upgrade $upgrade ) {
+		$this->upgrade = $upgrade;
+	}
+
+	public static function get_subscribed_events() {
+		return [
+			'rocket_after_license_info'   => 'display_upgrade_section',
+			'rocket_settings_page_footer' => 'display_upgrade_popin',
+			'rocket_menu_title'           => 'add_promo_bubble',
+			'admin_footer-settings_page_wprocket' => [
+				[ 'dismiss_notification_bubble' ],
+				[ 'schedule_promo_reset' ],
+			],
+			'rocket_schedule_promo_reset' => 'reset_promo_user_meta',
+		];
+	}
+
+	public function display_upgrade_section() {
+		$this->upgrade->display_upgrade_section();
+	}
+
+	public function display_upgrade_popin() {
+		$this->upgrade->display_upgrade_popin();
+	}
+
+	public function add_promo_bubble( $menu_title ) {
+		return $this->upgrade->add_notification_bubble( $menu_title );
+	}
+
+	public function dismiss_notification_bubble() {
+		$this->upgrade->dismiss_notification_bubble();
+	}
+
+	public function schedule_promo_reset() {
+		$this->upgrade->schedule_promo_reset();
+	}
+
+	public function reset_promo_user_meta() {
+		$this->upgrade->reset_promo_user_meta();
+	}
+}

--- a/inc/Engine/License/Subscriber.php
+++ b/inc/Engine/License/Subscriber.php
@@ -5,46 +5,49 @@ namespace WP_Rocket\Engine\License;
 use WP_Rocket\Event_Management\Subscriber_Interface;
 
 class Subscriber implements Subscriber_Interface {
+	/**
+	 * Upgrade instance
+	 *
+	 * @var Upgrade
+	 */
 	private $upgrade;
 
+	/**
+	 * Instantiate the class
+	 *
+	 * @param Upgrade $upgrade Upgrade instance.
+	 */
 	public function __construct( Upgrade $upgrade ) {
 		$this->upgrade = $upgrade;
 	}
 
+	/**
+	 * Events this subscriber listens to.
+	 *
+	 * @return array
+	 */
 	public static function get_subscribed_events() {
 		return [
-			'rocket_after_license_info'   => 'display_upgrade_section',
-			'rocket_settings_page_footer' => 'display_upgrade_popin',
-			'rocket_menu_title'           => 'add_promo_bubble',
-			'admin_footer-settings_page_wprocket' => [
-				[ 'dismiss_notification_bubble' ],
-				[ 'schedule_promo_reset' ],
-			],
-			'rocket_schedule_promo_reset' => 'reset_promo_user_meta',
+			'rocket_dashboard_license_info' => 'display_upgrade_section',
+			'rocket_settings_page_footer'   => 'display_upgrade_popin',
 		];
 	}
 
+	/**
+	 * Displays the upgrade section in the license info block
+	 *
+	 * @return void
+	 */
 	public function display_upgrade_section() {
 		$this->upgrade->display_upgrade_section();
 	}
 
+	/**
+	 * Displays the upgrade popin
+	 *
+	 * @return void
+	 */
 	public function display_upgrade_popin() {
 		$this->upgrade->display_upgrade_popin();
-	}
-
-	public function add_promo_bubble( $menu_title ) {
-		return $this->upgrade->add_notification_bubble( $menu_title );
-	}
-
-	public function dismiss_notification_bubble() {
-		$this->upgrade->dismiss_notification_bubble();
-	}
-
-	public function schedule_promo_reset() {
-		$this->upgrade->schedule_promo_reset();
-	}
-
-	public function reset_promo_user_meta() {
-		$this->upgrade->reset_promo_user_meta();
 	}
 }

--- a/inc/Engine/License/Upgrade.php
+++ b/inc/Engine/License/Upgrade.php
@@ -120,7 +120,7 @@ class Upgrade extends Abstract_Render {
 		return [
 			'name'        => 'Infinite',
 			'price'       => $this->pricing->get_single_to_infinite_price(),
-			'websites'    => $this->pricing->get_infinite_websites_count(),
+			'websites'    => __( 'Unlimited', 'rocket' ),
 			'upgrade_url' => $this->user->get_upgrade_infinite_url(),
 		];
 	}
@@ -134,7 +134,7 @@ class Upgrade extends Abstract_Render {
 		return [
 			'name'        => 'Infinite',
 			'price'       => $this->pricing->get_plus_to_infinite_price(),
-			'websites'    => $this->pricing->get_infinite_websites_count(),
+			'websites'    => __( 'Unlimited', 'rocket' ),
 			'upgrade_url' => $this->user->get_upgrade_infinite_url(),
 		];
 	}

--- a/inc/Engine/License/views/upgrade-popin.php
+++ b/inc/Engine/License/views/upgrade-popin.php
@@ -32,7 +32,8 @@ defined( 'ABSPATH' ) || exit;
 				<span>$ <?php echo esc_html( $rocket_upgrade['price'] ); ?></span>
 				<span>
 				<?php
-				printf( esc_html__( '%n websites', 'rocket' ), esc_html( $rocket_upgrade['websites'] ) );
+				// translators: %s = number of websites.
+				printf( esc_html__( '%s websites', 'rocket' ),  esc_html( $rocket_upgrade['websites'] ) );
 				?>
 				</span>
 				<a href="<?php echo esc_url( $rocket_upgrade['upgrade_url'] ); ?>" target="_blank" rel="noopener noreferrer">

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -172,6 +172,7 @@ class Plugin {
 			'minify_css_admin_subscriber',
 			'admin_cache_subscriber',
 			'google_fonts_admin_subscriber',
+			'license_subscriber',
 		];
 	}
 

--- a/tests/Fixtures/inc/Engine/License/Subscriber/displayUpgradePopin.php
+++ b/tests/Fixtures/inc/Engine/License/Subscriber/displayUpgradePopin.php
@@ -1,0 +1,154 @@
+<?php
+
+return [
+	'testShouldReturnNullWhenLicenseIsInfinite' => [
+		'user'   => json_decode( json_encode( [
+			'licence_account'    => -1,
+			'licence_expiration' => strtotime( 'next year' ),
+		] ) ),
+		'pricing' => json_decode( json_encode( [] ) ),
+		'expected' => '',
+	],
+	'testShouldReturnNullWhenLicenseIsExpired' => [
+		'user'   => json_decode( json_encode( [
+			'licence_account'    => 1,
+			'licence_expiration' => strtotime( 'last month' ),
+		] ) ),
+		'pricing' => json_decode( json_encode( [] ) ),
+		'expected' => '',
+	],
+	'testShouldDisplayPopInWhenLicenseIsSingle' => [
+		'user'   => json_decode( json_encode( [
+			'licence_account'       => 1,
+			'licence_expiration'    => strtotime( 'next year' ),
+			'upgrade_plus_url'      => 'https://wp-rocket.me/checkout/upgrade/roger@wp-rocket.me /d89e18ee/plus/',
+			'upgrade_infinite_url' => 'https://wp-rocket.me/checkout/upgrade/roger@wp-rocket.me /d89e18ee/infinite/',
+		] ) ),
+		'pricing' => json_decode( json_encode( [
+			'licenses' => [
+				'single'   => [
+					'websites' => 1,
+				],
+				'plus'     => [
+					'prices'      => [
+						'from_single' => [
+							'regular' => 50,
+						],
+					],
+					'websites'    => 3,
+					
+				],
+				'infinite' => [
+					'prices'       => [
+						'from_single' => [
+							'regular' => 200,
+						],
+					],
+					'websites'    => -1,
+				],
+			],
+		] ) ),
+		'expected' => '<div class="wpr-Popin wpr-Popin-Upgrade">
+		<div class="wpr-Popin-header">
+		<h2 class="wpr-title1">
+		Speed Up More Websites</h2>
+		<button class="wpr-Popin-close wpr-Popin-Upgrade-close wpr-icon-close">
+		</button>
+		</div>
+		<div class="wpr-Popin-content">
+		<p>
+		You can use WP Rocket on more websites by upgrading your license. To upgrade, simply pay the<strong>
+		price difference</strong>
+		between your current and new licenses, as shown below.</p>
+		<p>
+		<strong>
+		N.B.</strong>
+		: Upgrading your license does not change your expiration date</p>
+		<div class="wpr-Popin-flex">
+		<div>
+		<h3>
+		Plus</h3>
+		<span>
+		$ 50</span>
+		<span>
+		3 websites</span>
+		<a href="https://wp-rocket.me/checkout/upgrade/roger@wp-rocket.me%20/d89e18ee/plus/" target="_blank" rel="noopener noreferrer">
+		Upgrade to Plus</a>
+		</div>
+		<div>
+		<h3>
+		Infinite</h3>
+		<span>
+		$ 200</span>
+		<span>
+		Unlimited websites</span>
+		<a href="https://wp-rocket.me/checkout/upgrade/roger@wp-rocket.me%20/d89e18ee/infinite/" target="_blank" rel="noopener noreferrer">
+		Upgrade to Infinite</a>
+		</div>
+		</div>
+		</div>
+		</div>',
+	],
+	'testShouldDisplayPopInWhenLicenseIsPlus' => [
+		'user'   => json_decode( json_encode( [
+			'licence_account'    => 3,
+			'licence_expiration'    => strtotime( 'next year' ),
+			'upgrade_plus_url'      => 'https://wp-rocket.me/checkout/upgrade/roger@wp-rocket.me /d89e18ee/plus/',
+			'upgrade_infinite_url' => 'https://wp-rocket.me/checkout/upgrade/roger@wp-rocket.me /d89e18ee/infinite/',
+		] ) ),
+		'pricing' => json_decode( json_encode( [
+			'licenses' => [
+				'single'   => [
+					'websites' => 1,
+				],
+				'plus'     => [
+					'prices'      => [
+						'from_single' => [
+							'regular' => 50,
+						],
+					],
+					'websites'    => 3,
+					
+				],
+				'infinite' => [
+					'prices'       => [
+						'from_plus' => [
+							'regular' => 150,
+						],
+					],
+					'websites'    => -1,
+				],
+			],
+		] ) ),
+		'expected' => '<div class="wpr-Popin wpr-Popin-Upgrade">
+		<div class="wpr-Popin-header">
+		<h2 class="wpr-title1">
+		Speed Up More Websites</h2>
+		<button class="wpr-Popin-close wpr-Popin-Upgrade-close wpr-icon-close">
+		</button>
+		</div>
+		<div class="wpr-Popin-content">
+		<p>
+		You can use WP Rocket on more websites by upgrading your license. To upgrade, simply pay the<strong>
+		price difference</strong>
+		between your current and new licenses, as shown below.</p>
+		<p>
+		<strong>
+		N.B.</strong>
+		: Upgrading your license does not change your expiration date</p>
+		<div class="wpr-Popin-flex">
+		<div>
+		<h3>
+		Infinite</h3>
+		<span>
+		$ 150</span>
+		<span>
+		Unlimited websites</span>
+		<a href="https://wp-rocket.me/checkout/upgrade/roger@wp-rocket.me%20/d89e18ee/infinite/" target="_blank" rel="noopener noreferrer">
+		Upgrade to Infinite</a>
+		</div>
+		</div>
+		</div>
+		</div>',
+	],
+];

--- a/tests/Fixtures/inc/Engine/License/Subscriber/displayUpgradeSection.php
+++ b/tests/Fixtures/inc/Engine/License/Subscriber/displayUpgradeSection.php
@@ -1,0 +1,28 @@
+<?php
+
+return [
+	'testShouldReturnNullWhenLicenseIsInfinite' => [
+		'data'   => json_decode( json_encode( [
+			'licence_account'    => -1,
+			'licence_expiration' => strtotime( 'next year' ),
+		] ) ),
+		'expected' => '',
+	],
+	'testShouldReturnNullWhenLicenseIsExpired' => [
+		'data'   => json_decode( json_encode( [
+			'licence_account'    => 1,
+			'licence_expiration' => strtotime( 'last month' ),
+		] ) ),
+		'expected' => '',
+	],
+	'testShouldDisplaySectionWhenLicenseIsNotExpiredAndNotInfinite' => [
+		'data'   => json_decode( json_encode( [
+			'licence_account'    => 1,
+			'licence_expiration' => strtotime( 'next year' ),
+		] ) ),
+		'expected' => '<p>
+		You can use WP Rocket on more websites by upgrading your license (you will only pay the price difference between your current and new licenses).
+		<button id="wpr-popin-upgrade-toggle">Upgrade Now</button>
+		</p>',
+	],
+];

--- a/tests/Fixtures/inc/Engine/License/Upgrade/displayUpgradePopin.php
+++ b/tests/Fixtures/inc/Engine/License/Upgrade/displayUpgradePopin.php
@@ -30,7 +30,7 @@ return [
 				],
 				'infinite' => [
 					'price'       => 200,
-					'websites'    => -1,
+					'websites'    => 'Unlimited',
 					'upgrade_url' => 'https://wp-rocket.me/checkout/upgrade/roger@wp-rocket.me /d89e18ee/infinite/',
 				],
 			],
@@ -46,7 +46,7 @@ return [
 				'infinite' => [
 					'name'        => 'Infinite',
 					'price'       => 200,
-					'websites'    => -1,
+					'websites'    => 'Unlimited',
 					'upgrade_url' => 'https://wp-rocket.me/checkout/upgrade/roger@wp-rocket.me /d89e18ee/infinite/',
 				],
 			],
@@ -67,7 +67,7 @@ return [
 				],
 				'infinite' => [
 					'price'       => 150,
-					'websites'    => -1,
+					'websites'    => 'Unlimited',
 					'upgrade_url' => 'https://wp-rocket.me/checkout/upgrade/roger@wp-rocket.me /d89e18ee/infinite/',
 				],
 			],
@@ -77,7 +77,7 @@ return [
 				'infinite' => [
 					'name'        => 'Infinite',
 					'price'       => 150,
-					'websites'    => -1,
+					'websites'    => 'Unlimited',
 					'upgrade_url' => 'https://wp-rocket.me/checkout/upgrade/roger@wp-rocket.me /d89e18ee/infinite/',
 				],
 			],

--- a/tests/Integration/inc/Engine/License/API/PricingClient/getPricingData.php
+++ b/tests/Integration/inc/Engine/License/API/PricingClient/getPricingData.php
@@ -12,10 +12,20 @@ use WP_Rocket\Tests\Integration\TestCase;
  * @group License
  */
 class GetPricingData extends TestCase {
+	protected static $transients = [
+		'wp_rocket_pricing',
+	];
+
 	public function tearDown() {
 		delete_transient( 'wp_rocket_pricing' );
 
 		parent::tearDown();
+	}
+
+	public function setUp() {
+		parent::setUp();
+
+		delete_transient( 'wp_rocket_pricing' );
 	}
 
 	/**

--- a/tests/Integration/inc/Engine/License/Subscriber/displayUpgradePopin.php
+++ b/tests/Integration/inc/Engine/License/Subscriber/displayUpgradePopin.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\License\Subscriber;
+
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\License\Subscriber::display_upgrade_popin
+ *
+ * @group License
+ * @group AdminOnly
+ */
+class DisplayUpgradePopin extends TestCase {
+	private static $user;
+	private static $pricing;
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		$container     = apply_filters( 'rocket_container', null );
+		self::$user    = $container->get( 'user' );
+		self::$pricing = $container->get( 'pricing' );
+	}
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->unregisterAllCallbacksExcept( 'rocket_settings_page_footer', 'display_upgrade_popin' );
+	}
+
+	public function tearDown() {
+		$this->restoreWpFilter( 'rocket_settings_page_footer' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldDisplayExpected( $user_data, $pricing_data, $expected ) {
+		$this->set_reflective_property( $user_data, 'user', self::$user );
+		$this->set_reflective_property( $pricing_data, 'pricing', self::$pricing );
+
+		$this->assertSame(
+			$this->format_the_html( $expected ),
+			$this->getActualHtml()
+		);
+	}
+
+	private function getActualHtml() {
+		ob_start();
+		do_action( 'rocket_settings_page_footer' );
+		$actual = ob_get_clean();
+
+		return empty( $actual )
+			? $actual
+			: $this->format_the_html( $actual );
+	}
+}

--- a/tests/Integration/inc/Engine/License/Subscriber/displayUpgradePopin.php
+++ b/tests/Integration/inc/Engine/License/Subscriber/displayUpgradePopin.php
@@ -13,6 +13,8 @@ use WP_Rocket\Tests\Integration\TestCase;
 class DisplayUpgradePopin extends TestCase {
 	private static $user;
 	private static $pricing;
+	private $original_user;
+	private $original_pricing;
 
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
@@ -26,10 +28,15 @@ class DisplayUpgradePopin extends TestCase {
 		parent::setUp();
 
 		$this->unregisterAllCallbacksExcept( 'rocket_settings_page_footer', 'display_upgrade_popin' );
+
+		$this->original_user    = $this->getNonPublicPropertyValue( 'user', self::$user, self::$user );
+		$this->original_pricing = $this->getNonPublicPropertyValue( 'pricing', self::$pricing, self::$pricing );
 	}
 
 	public function tearDown() {
 		$this->restoreWpFilter( 'rocket_settings_page_footer' );
+		$this->set_reflective_property( $this->original_user, 'user', self::$user );
+		$this->set_reflective_property( $this->original_pricing, 'pricing', self::$pricing );
 
 		parent::tearDown();
 	}

--- a/tests/Integration/inc/Engine/License/Subscriber/displayUpgradeSection.php
+++ b/tests/Integration/inc/Engine/License/Subscriber/displayUpgradeSection.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\License\Subscriber;
+
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\License\Subscriber::display_upgrade_section
+ *
+ * @group License
+ * @group AdminOnly
+ */
+class DisplayUpgradeSection extends TestCase {
+	private static $user;
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		$container  = apply_filters( 'rocket_container', null );
+		self::$user = $container->get( 'user' );
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldDisplayExpected( $data, $expected ) {
+		$this->set_reflective_property( $data, 'user', self::$user );
+
+		$this->assertSame(
+			$this->format_the_html( $expected ),
+			$this->getActualHtml()
+		);
+	}
+
+	private function getActualHtml() {
+		ob_start();
+		do_action( 'rocket_dashboard_license_info' );
+		$actual = ob_get_clean();
+
+		return empty( $actual )
+			? $actual
+			: $this->format_the_html( $actual );
+	}
+}

--- a/tests/Integration/inc/Engine/License/Subscriber/displayUpgradeSection.php
+++ b/tests/Integration/inc/Engine/License/Subscriber/displayUpgradeSection.php
@@ -12,12 +12,26 @@ use WP_Rocket\Tests\Integration\TestCase;
  */
 class DisplayUpgradeSection extends TestCase {
 	private static $user;
+	private $original_value;
 
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
 
-		$container  = apply_filters( 'rocket_container', null );
-		self::$user = $container->get( 'user' );
+		$container   = apply_filters( 'rocket_container', null );
+		self::$user  = $container->get( 'user' );
+		self::$value = $this->getNonPublicPropertyValue( 'user', self::$user, self::$user );
+	}
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->original_value = $this->getNonPublicPropertyValue( 'user', self::$user, self::$user );
+	}
+
+	public function tearDown() {
+		$this->set_reflective_property( $this->original_value, 'user', self::$user );
+
+		parent::tearDown();
 	}
 
 	/**

--- a/tests/Integration/inc/Engine/License/Subscriber/displayUpgradeSection.php
+++ b/tests/Integration/inc/Engine/License/Subscriber/displayUpgradeSection.php
@@ -19,7 +19,6 @@ class DisplayUpgradeSection extends TestCase {
 
 		$container   = apply_filters( 'rocket_container', null );
 		self::$user  = $container->get( 'user' );
-		self::$value = $this->getNonPublicPropertyValue( 'user', self::$user, self::$user );
 	}
 
 	public function setUp() {

--- a/tests/Unit/inc/Engine/License/Upgrade/displayUpgradePopin.php
+++ b/tests/Unit/inc/Engine/License/Upgrade/displayUpgradePopin.php
@@ -14,6 +14,8 @@ use WP_Rocket\Tests\Unit\TestCase;
  * @group License
  */
 class DisplayUpgradePopin extends TestCase {
+	protected static $mockCommonWpFunctionsInSetUp = true;
+
 	private $pricing;
 	private $user;
 	private $upgrade;
@@ -37,8 +39,6 @@ class DisplayUpgradePopin extends TestCase {
 	 * @dataProvider configTestData
 	 */
 	public function testShouldReturnExpected( $config, $expected ) {
-		protected static $mockCommonWpFunctionsInSetUp = true;
-
 		$this->user->shouldReceive( 'get_license_type' )
 			->atMost()
 			->twice()

--- a/tests/Unit/inc/Engine/License/Upgrade/displayUpgradePopin.php
+++ b/tests/Unit/inc/Engine/License/Upgrade/displayUpgradePopin.php
@@ -37,6 +37,8 @@ class DisplayUpgradePopin extends TestCase {
 	 * @dataProvider configTestData
 	 */
 	public function testShouldReturnExpected( $config, $expected ) {
+		protected static $mockCommonWpFunctionsInSetUp = true;
+
 		$this->user->shouldReceive( 'get_license_type' )
 			->atMost()
 			->twice()

--- a/tests/Unit/inc/Engine/License/Upgrade/displayUpgradeSection.php
+++ b/tests/Unit/inc/Engine/License/Upgrade/displayUpgradeSection.php
@@ -14,6 +14,8 @@ use WP_Rocket\Tests\Unit\TestCase;
  * @group License
  */
 class DisplayUpgradeSection extends TestCase {
+	protected static $mockCommonWpFunctionsInSetUp = true;
+
 	private $user;
 	private $upgrade;
 
@@ -35,8 +37,6 @@ class DisplayUpgradeSection extends TestCase {
 	 * @dataProvider configTestData
 	 */
 	public function testShouldReturnExpected( $config, $expected ) {
-		protected static $mockCommonWpFunctionsInSetUp = true;
-
 		$this->user->shouldReceive( 'get_license_type' )
 			->once()
 			->andReturn( $config['license_account'] );

--- a/tests/Unit/inc/Engine/License/Upgrade/displayUpgradeSection.php
+++ b/tests/Unit/inc/Engine/License/Upgrade/displayUpgradeSection.php
@@ -35,6 +35,8 @@ class DisplayUpgradeSection extends TestCase {
 	 * @dataProvider configTestData
 	 */
 	public function testShouldReturnExpected( $config, $expected ) {
+		protected static $mockCommonWpFunctionsInSetUp = true;
+
 		$this->user->shouldReceive( 'get_license_type' )
 			->once()
 			->andReturn( $config['license_account'] );

--- a/views/settings/page-sections/dashboard.php
+++ b/views/settings/page-sections/dashboard.php
@@ -72,6 +72,7 @@ defined( 'ABSPATH' ) || exit;
 					<div>
 						<span class="wpr-title3"><?php esc_html_e( 'License', 'rocket' ); ?></span>
 						<span class="wpr-infoAccount wpr-isValid" id="wpr-account-data"><?php echo esc_html( $data['customer_data']->licence_account ); ?></span><br>
+						<?php do_action( 'rocket_after_license_info' ); ?>
 						<span class="wpr-title3"><?php esc_html_e( 'Expiration Date', 'rocket' ); ?></span>
 						<span class="wpr-infoAccount <?php echo esc_attr( $data['customer_data']->class ); ?>" id="wpr-expiration-data"><?php echo esc_html( $data['customer_data']->licence_expiration ); ?></span>
 					</div>

--- a/views/settings/page-sections/dashboard.php
+++ b/views/settings/page-sections/dashboard.php
@@ -72,7 +72,14 @@ defined( 'ABSPATH' ) || exit;
 					<div>
 						<span class="wpr-title3"><?php esc_html_e( 'License', 'rocket' ); ?></span>
 						<span class="wpr-infoAccount wpr-isValid" id="wpr-account-data"><?php echo esc_html( $data['customer_data']->licence_account ); ?></span><br>
-						<?php do_action( 'rocket_after_license_info' ); ?>
+						<?php
+						/**
+						 * Fires when displaying the license information
+						 *
+						 * @since 3.7.3
+						 */
+						do_action( 'rocket_dashboard_license_info' );
+						?>
 						<span class="wpr-title3"><?php esc_html_e( 'Expiration Date', 'rocket' ); ?></span>
 						<span class="wpr-infoAccount <?php echo esc_attr( $data['customer_data']->class ); ?>" id="wpr-expiration-data"><?php echo esc_html( $data['customer_data']->licence_expiration ); ?></span>
 					</div>


### PR DESCRIPTION
Closes #3154 

Load and instantiate the license subscriber.

### Methods
- `display_upgrade_section()`: Displays the upgrade section in the license info block. Hooked on `rocket_dashboard_license_info` which is a new action
- `display_upgrade_popin()`: Displays the upgrade popin. Hooked on `rocket_settings_page_footer`