### PR TITLE
Prevent duplicate addition of inline JS on multiple wp_enqueue_script calls

### DIFF
--- a/inc/Engine/Optimization/DelayJS/Subscriber.php
+++ b/inc/Engine/Optimization/DelayJS/Subscriber.php
@@ -23,6 +23,14 @@ class Subscriber implements Subscriber_Interface {
 	 * @var \WP_Filesystem_Direct
 	 */
 	private $filesystem;
+	
+	/**
+	 * Script enqueued status.
+	 *
+	 * @since 3.7
+	 *
+	 */
+	private $is_enqueued = false;
 
 	/**
 	 * Subscriber constructor.
@@ -70,6 +78,9 @@ class Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function add_delay_js_script() {
+		if ( $this->is_enqueued ) {
+			return;
+		}
 		if ( ! $this->html->is_allowed() ) {
 			return;
 		}
@@ -113,5 +124,7 @@ class Subscriber implements Subscriber_Interface {
 			'rocket-delay-js',
 			$this->filesystem->get_contents( "{$js_assets_path}{$script_filename}" )
 		);
+		
+		$this->is_enqueued = true;
 	}
 }

--- a/inc/Engine/Optimization/DelayJS/Subscriber.php
+++ b/inc/Engine/Optimization/DelayJS/Subscriber.php
@@ -23,12 +23,12 @@ class Subscriber implements Subscriber_Interface {
 	 * @var \WP_Filesystem_Direct
 	 */
 	private $filesystem;
-	
+
 	/**
 	 * Script enqueued status.
 	 *
 	 * @since 3.7
-	 *
+	 * @var bool
 	 */
 	private $is_enqueued = false;
 
@@ -124,7 +124,7 @@ class Subscriber implements Subscriber_Interface {
 			'rocket-delay-js',
 			$this->filesystem->get_contents( "{$js_assets_path}{$script_filename}" )
 		);
-		
+
 		$this->is_enqueued = true;
 	}
 }

--- a/inc/Engine/Preload/Links/Subscriber.php
+++ b/inc/Engine/Preload/Links/Subscriber.php
@@ -20,10 +20,11 @@ class Subscriber implements Subscriber_Interface {
 	 * @var WP_Filesystem_Direct
 	 */
 	private $filesystem;
-	
+
 	/**
 	 * Script enqueued status.
 	 *
+	 * @var bool
 	 */
 	private $is_enqueued = false;
 
@@ -107,7 +108,7 @@ class Subscriber implements Subscriber_Interface {
 			'RocketPreloadLinksConfig',
 			$this->get_preload_links_config()
 		);
-		
+
 		$this->is_enqueued = true;
 	}
 

--- a/inc/Engine/Preload/Links/Subscriber.php
+++ b/inc/Engine/Preload/Links/Subscriber.php
@@ -20,6 +20,12 @@ class Subscriber implements Subscriber_Interface {
 	 * @var WP_Filesystem_Direct
 	 */
 	private $filesystem;
+	
+	/**
+	 * Script enqueued status.
+	 *
+	 */
+	private $is_enqueued = false;
 
 	/**
 	 * Instantiate the class.
@@ -51,6 +57,9 @@ class Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function add_preload_script() {
+		if ( $this->is_enqueued ) {
+			return;
+		}
 		if ( ! (bool) $this->options->get( 'preload_links', 0 ) || rocket_bypass() ) {
 			return;
 		}
@@ -98,6 +107,8 @@ class Subscriber implements Subscriber_Interface {
 			'RocketPreloadLinksConfig',
 			$this->get_preload_links_config()
 		);
+		
+		$this->is_enqueued = true;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #3125 

Use a private property `is_enqueued` to check if the method has already been called once, in the delay JS and preload links subscribers.

### Acceptance criteria
- The inline JS scripts from delay JS and preload links are not inserted multiple times if `wp_enqueue_scripts` is called more than once