### PR TITLE
Fixes delay JS scripts textarea sanitization

### DIFF
--- a/inc/Engine/Admin/Settings/Settings.php
+++ b/inc/Engine/Admin/Settings/Settings.php
@@ -224,7 +224,7 @@ class Settings {
 		$input['defer_all_js']      = ! empty( $input['defer_all_js'] ) ? 1 : 0;
 		$input['defer_all_js_safe'] = ! empty( $input['defer_all_js_safe'] ) ? 1 : 0;
 		$input['delay_js']          = $this->sanitize_checkbox( $input, 'delay_js' );
-		$input['delay_js_scripts']  = ! empty( $input['delay_js_scripts'] ) ? rocket_sanitize_textarea_field( 'cdn_reject_files', $input['delay_js_scripts'] ) : [];
+		$input['delay_js_scripts']  = ! empty( $input['delay_js_scripts'] ) ? rocket_sanitize_textarea_field( 'delay_js_scripts', $input['delay_js_scripts'] ) : [];
 
 		// If Defer JS is deactivated, set Safe Mode for Jquery to active.
 		if ( 0 === $input['defer_all_js'] ) {


### PR DESCRIPTION
The value passed to `rocket_sanitize_textarea_field()` was incorrect, and caused some of the default list to be stripped of the appropriate values.

The new value passed fixes the issue.