### PR TITLE
Fix #3209 avada lazyload is detected as always active

### DIFF
--- a/inc/3rd-party/themes/avada.php
+++ b/inc/3rd-party/themes/avada.php
@@ -18,9 +18,12 @@ if ( 'Avada' === $current_theme->get( 'Name' ) ) {
 	 * @param string $value New Avada option value.
 	 * @return void
 	 */
-	function rocket_avada_maybe_deactivate_lazyload( $old_value, $value ) {
-		if ( empty( $old_value['lazy_load'] ) && ! empty( $value['lazy_load'] ) ) {
+	 function rocket_avada_maybe_deactivate_lazyload( $old_value, $value ) {
+		if ( (empty( $old_value['lazy_load'] ) && ! empty( $value['lazy_load'] ) ) 
+			|| ( 'none' === $old_value['lazy_load'] && 'none' !== $value['lazy_load'] ) ) {
+			
 			update_rocket_option( 'lazyload', 0 );
+			
 		}
 	}
 	add_action( 'update_option_fusion_options', 'rocket_avada_maybe_deactivate_lazyload', 10, 2 );
@@ -37,12 +40,14 @@ if ( 'Avada' === $current_theme->get( 'Name' ) ) {
 function rocket_avada_maybe_disable_lazyload() {
 	$avada_options = get_option( 'fusion_options' );
 	$current_theme = wp_get_theme();
-
-	if ( 'Avada' === $current_theme->get( 'Name' ) && ! empty( $avada_options['lazy_load'] ) ) {
-		return true;
+ 
+  
+	if ( 'Avada' === $current_theme->get( 'Name' ) 	&&  ( empty( $avada_options['lazy_load'] )  || 'none' === $avada_options['lazy_load'] ) ) {
+				
+		return false;
 	}
 
-	return false;
+	return true;
 }
 
 /**

--- a/inc/3rd-party/themes/avada.php
+++ b/inc/3rd-party/themes/avada.php
@@ -18,12 +18,9 @@ if ( 'Avada' === $current_theme->get( 'Name' ) ) {
 	 * @param string $value New Avada option value.
 	 * @return void
 	 */
-	 function rocket_avada_maybe_deactivate_lazyload( $old_value, $value ) {
-		if ( (empty( $old_value['lazy_load'] ) && ! empty( $value['lazy_load'] ) ) 
-			|| ( 'none' === $old_value['lazy_load'] && 'none' !== $value['lazy_load'] ) ) {
-			
+	function rocket_avada_maybe_deactivate_lazyload( $old_value, $value ) {
+		if ( ( empty( $old_value['lazy_load'] ) && ! empty( $value['lazy_load'] ) ) || ( 'avada' === $value['lazy_load'] ) ) {
 			update_rocket_option( 'lazyload', 0 );
-			
 		}
 	}
 	add_action( 'update_option_fusion_options', 'rocket_avada_maybe_deactivate_lazyload', 10, 2 );
@@ -40,9 +37,8 @@ if ( 'Avada' === $current_theme->get( 'Name' ) ) {
 function rocket_avada_maybe_disable_lazyload() {
 	$avada_options = get_option( 'fusion_options' );
 	$current_theme = wp_get_theme();
-  
-	if ( 'Avada' === $current_theme->get( 'Name' ) 	&&  ( empty( $avada_options['lazy_load'] )  || 'none' === $avada_options['lazy_load'] ) ) {
-				
+
+	if  ( ( 'Avada' === $current_theme->get( 'Name' ) ) && ( empty( $avada_options['lazy_load'] ) || 'avada' !== $avada_options['lazy_load']  ) ) {
 		return false;
 	}
 

--- a/inc/3rd-party/themes/avada.php
+++ b/inc/3rd-party/themes/avada.php
@@ -19,7 +19,7 @@ if ( 'Avada' === $current_theme->get( 'Name' ) ) {
 	 * @return void
 	 */
 	function rocket_avada_maybe_deactivate_lazyload( $old_value, $value ) {
-		if ( ( empty( $old_value['lazy_load'] ) && ! empty( $value['lazy_load'] ) ) || ( 'avada' === $value['lazy_load'] ) ) {
+		if ( ( empty( $old_value['lazy_load'] ) || ( ! empty( $value['lazy_load'] ) && ( 'avada' === $value['lazy_load'] ) ) {
 			update_rocket_option( 'lazyload', 0 );
 		}
 	}

--- a/inc/3rd-party/themes/avada.php
+++ b/inc/3rd-party/themes/avada.php
@@ -38,7 +38,15 @@ function rocket_avada_maybe_disable_lazyload() {
 	$avada_options = get_option( 'fusion_options' );
 	$current_theme = wp_get_theme();
 
-	if  ( ( 'Avada' === $current_theme->get( 'Name' ) ) && ( empty( $avada_options['lazy_load'] ) || 'avada' !== $avada_options['lazy_load']  ) ) {
+	if ( ( 'Avada' !== $current_theme->get( 'Name' ) ) {
+		return false;
+	}
+
+	if ( empty( $avada_options['lazy_load'] ) ) {
+		return false;
+	}
+
+	if ( ! empty( $avada_options['lazy_load'] && 'avada' !== $avada_options['lazy_load'] ) ) {
 		return false;
 	}
 

--- a/inc/3rd-party/themes/avada.php
+++ b/inc/3rd-party/themes/avada.php
@@ -40,7 +40,6 @@ if ( 'Avada' === $current_theme->get( 'Name' ) ) {
 function rocket_avada_maybe_disable_lazyload() {
 	$avada_options = get_option( 'fusion_options' );
 	$current_theme = wp_get_theme();
- 
   
 	if ( 'Avada' === $current_theme->get( 'Name' ) 	&&  ( empty( $avada_options['lazy_load'] )  || 'none' === $avada_options['lazy_load'] ) ) {
 				

--- a/inc/3rd-party/themes/avada.php
+++ b/inc/3rd-party/themes/avada.php
@@ -12,14 +12,17 @@ if ( 'Avada' === $current_theme->get( 'Name' ) ) {
 	 * Deactivate WP Rocket lazyload if Avada lazyload is enabled
 	 *
 	 * @since 3.3.4
-	 * @author Remy Perona
 	 *
 	 * @param string $old_value Previous Avada option value.
 	 * @param string $value New Avada option value.
 	 * @return void
 	 */
 	function rocket_avada_maybe_deactivate_lazyload( $old_value, $value ) {
-		if ( ( empty( $old_value['lazy_load'] ) || ( ! empty( $value['lazy_load'] ) && ( 'avada' === $value['lazy_load'] ) ) {
+		if (
+			empty( $old_value['lazy_load'] )
+			||
+			( ! empty( $value['lazy_load'] ) && 'avada' === $value['lazy_load'] )
+		) {
 			update_rocket_option( 'lazyload', 0 );
 		}
 	}
@@ -30,7 +33,6 @@ if ( 'Avada' === $current_theme->get( 'Name' ) ) {
  * Disable WP Rocket lazyload field if Avada lazyload is enabled
  *
  * @since 3.3.4
- * @author Remy Perona
  *
  * @return bool
  */
@@ -38,7 +40,7 @@ function rocket_avada_maybe_disable_lazyload() {
 	$avada_options = get_option( 'fusion_options' );
 	$current_theme = wp_get_theme();
 
-	if ( ( 'Avada' !== $current_theme->get( 'Name' ) ) {
+	if ( 'Avada' !== $current_theme->get( 'Name' ) ) {
 		return false;
 	}
 
@@ -57,7 +59,8 @@ function rocket_avada_maybe_disable_lazyload() {
  * Clears WP Rocket's cache after Avada's Fusion Patcher flushes their caches
  *
  * @since 3.3.5
- * @author Vasilis Manthos
+ *
+ * @return void
  */
 function rocket_avada_clear_cache_fusion_patcher() {
 	rocket_clean_domain();


### PR DESCRIPTION
Proposing a fix for [#3209](https://github.com/wp-media/wp-rocket/issues/3209)
(thank you @engahmeds3ed for the help!)

starting from Avada 7.2 version the `lazy_load` value is never empty, it’d be one of:
- none
- wordpress
- avada

Added verifications for the "none" value to deactivate and disable our LazyLoad option, while keeping the "empty" value verification for backward compatibility