### PR TITLE
Fix #3133 combine css/js increase cache/min size when versioning contains variable strings/timestamps

### DIFF
--- a/inc/Engine/Optimization/Minify/CSS/Combine.php
+++ b/inc/Engine/Optimization/Minify/CSS/Combine.php
@@ -121,7 +121,7 @@ class Combine extends AbstractCSSOptimization implements ProcessorInterface {
 			$this->styles[ $style['url'] ] = [
 				'type' => 'internal',
 				'tag'  => $style[0],
-				'url'  => $style['url'],
+				'url'  => strtok( $style['url'], '?' ),
 			];
 		}
 

--- a/inc/Engine/Optimization/Minify/CSS/Combine.php
+++ b/inc/Engine/Optimization/Minify/CSS/Combine.php
@@ -98,7 +98,7 @@ class Combine extends AbstractCSSOptimization implements ProcessorInterface {
 				$this->styles[ $style['url'] ] = [
 					'type' => 'external',
 					'tag'  => $style[0],
-					'url'  => rocket_add_url_protocol( $style['url'] ),
+					'url'  => rocket_add_url_protocol( strtok( $style['url'], '?' ) ),
 				];
 
 				continue;

--- a/inc/Engine/Optimization/Minify/CSS/Minify.php
+++ b/inc/Engine/Optimization/Minify/CSS/Minify.php
@@ -44,7 +44,7 @@ class Minify extends AbstractCSSOptimization implements ProcessorInterface {
 				continue;
 			}
 
-			$minify_url = $this->replace_url( $style['url'] );
+			$minify_url = $this->replace_url( strtok( $style['url'], '?' ) );
 
 			if ( ! $minify_url ) {
 				Logger::error(

--- a/inc/Engine/Optimization/Minify/JS/Combine.php
+++ b/inc/Engine/Optimization/Minify/JS/Combine.php
@@ -202,7 +202,7 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 						return;
 					}
 
-					$file_path = $this->get_file_path( $matches['url'] );
+					$file_path = $this->get_file_path( strtok( $matches['url'], '?' ) );
 
 					if ( ! $file_path ) {
 						return;

--- a/inc/Engine/Optimization/Minify/JS/Minify.php
+++ b/inc/Engine/Optimization/Minify/JS/Minify.php
@@ -79,7 +79,7 @@ class Minify extends AbstractJSOptimization implements ProcessorInterface {
 				continue;
 			}
 
-			$minify_url = $this->replace_url( $script['url'] );
+			$minify_url = $this->replace_url( strtok( $script['url'], '?' ) );
 
 			if ( ! $minify_url ) {
 				Logger::error(


### PR DESCRIPTION
Proposing a fix for [#3133](https://github.com/wp-media/wp-rocket/issues/3133). 
**Combine CSS/JS increase cache/min size when versioning contains variable strings/timestamps**

Applying Remy's proposed fix here: [#3133 (comment)](https://github.com/wp-media/wp-rocket/issues/3133#issuecomment-703837954)

The fix is applied in the minify CSS and JS files, and also in the Combine CSS and JS files

### Acceptance criteria
- An URL using a query string version number randomly generated (or with the current timestamp) should not create duplicate combine/minify files