### PR TITLE
Exclude aepc_pixel inline scripts

### DIFF
--- a/inc/Engine/Optimization/Minify/JS/Combine.php
+++ b/inc/Engine/Optimization/Minify/JS/Combine.php
@@ -652,6 +652,7 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 			'aepro',
 			'cdn.jst.ai',
 			'w2dc_fields_in_categories',
+			'aepc_pixel',
 		];
 
 		$excluded_inline = array_merge( $defaults, $this->options->get( 'exclude_inline_js', [] ) );


### PR DESCRIPTION
Excluding `aepc_pixel` inline scripts from js combination to prevent a JS error. 

Per Lucy's note: 
> there are multiple inline scripts with aepc_pixel
> one of them is excluded automatically from combine js due to a fbq related exclusion, but others are not.
> console error: Uncaught ReferenceError: aepc_pixel is not defined

related ticket: 
https://secure.helpscout.net/conversation/1303694885/200677?folderId=2683093