### PR TITLE
Fixes #3178 Correctly minify/combine CSS/JS when the URL contains encoded characters

### DIFF
--- a/inc/functions/formatting.php
+++ b/inc/functions/formatting.php
@@ -492,6 +492,7 @@ function rocket_url_to_path( $url, array $zones = [ 'all' ] ) {
 	 */
 	$url = apply_filters( 'rocket_asset_url', $url, $zones );
 
+	$url      = str_replace( '%20', ' ', $url );
 	$root_url = preg_replace( '/^https?:/', '', $root_url );
 	$url      = preg_replace( '/^https?:/', '', $url );
 	$file     = str_replace( $root_url, $root_dir, $url );

--- a/inc/functions/formatting.php
+++ b/inc/functions/formatting.php
@@ -492,7 +492,7 @@ function rocket_url_to_path( $url, array $zones = [ 'all' ] ) {
 	 */
 	$url = apply_filters( 'rocket_asset_url', $url, $zones );
 
-	$url      = str_replace( '%20', ' ', $url );
+	$url      = rawurldecode( $url );
 	$root_url = preg_replace( '/^https?:/', '', $root_url );
 	$url      = preg_replace( '/^https?:/', '', $url );
 	$file     = str_replace( $root_url, $root_dir, $url );


### PR DESCRIPTION
Fixes #3178

### Acceptance criteria
- assets URLs containing spaces or other encoded characters are correctly minified/combined