### PR TITLE
Closes #3234 auto enable preload links & control heartbeat options for new install

### DIFF
--- a/inc/Engine/Preload/Links/AdminSubscriber.php
+++ b/inc/Engine/Preload/Links/AdminSubscriber.php
@@ -45,7 +45,7 @@ class AdminSubscriber implements Subscriber_Interface {
 	public function add_option( $options ) {
 		$options = (array) $options;
 
-		$options['preload_links'] = 0;
+		$options['preload_links'] = 1;
 
 		return $options;
 	}

--- a/inc/admin/upgrader.php
+++ b/inc/admin/upgrader.php
@@ -225,7 +225,7 @@ function rocket_first_install() {
 				'cloudflare_protocol_rewrite' => 0,
 				'cloudflare_auto_settings'    => 0,
 				'cloudflare_old_settings'     => '',
-				'control_heartbeat'           => 0,
+				'control_heartbeat'           => 1,
 				'heartbeat_site_behavior'     => 'reduce_periodicity',
 				'heartbeat_admin_behavior'    => 'reduce_periodicity',
 				'heartbeat_editor_behavior'   => 'reduce_periodicity',

--- a/tests/Fixtures/inc/Engine/Preload/Links/AdminSubscriber/addOption.php
+++ b/tests/Fixtures/inc/Engine/Preload/Links/AdminSubscriber/addOption.php
@@ -6,13 +6,13 @@ return [
 			'options'  => 'test',
 			'expected' => [
 				0               => 'test',
-				'preload_links' => 0,
+				'preload_links' => 1,
 			],
 		],
 		'testShouldAddOptionWhenEmptyArray' => [
 			'options'  => [],
 			'expected' => [
-				'preload_links' => 0,
+				'preload_links' => 1,
 			],
 		],
 		'testShouldAddOptionWhenNotEmptyArray' => [
@@ -23,7 +23,7 @@ return [
 			'expected' => [
 				'async_css'     => 0,
 				'minify_css'    => 1,
-				'preload_links' => 0,
+				'preload_links' => 1,
 			],
 		],
 	],

--- a/tests/Fixtures/inc/Engine/Support/Data/getSupportData.php
+++ b/tests/Fixtures/inc/Engine/Support/Data/getSupportData.php
@@ -81,7 +81,7 @@ return [
 			'WP Rocket Version'        => '3.7.5',
 			'Theme'                    => 'WordPress Default',
 			'Plugins Enabled'          => 'Hello Dolly',
-			'WP Rocket Active Options' => 'Mobile Cache - Disable Emojis - Defer JS Safe - Combine Google Fonts - Preload',
+			'WP Rocket Active Options' => 'Mobile Cache - Disable Emojis - Defer JS Safe - Combine Google Fonts - Preload - Hearbeat Control',
 		],
 	],
 ];

--- a/tests/Fixtures/inc/Engine/Support/Data/getSupportData.php
+++ b/tests/Fixtures/inc/Engine/Support/Data/getSupportData.php
@@ -63,7 +63,7 @@ return [
 			'cloudflare_protocol_rewrite' => 0,
 			'cloudflare_auto_settings'    => 0,
 			'cloudflare_old_settings'     => '',
-			'control_heartbeat'           => 0,
+			'control_heartbeat'           => 1,
 			'heartbeat_site_behavior'     => 'reduce_periodicity',
 			'heartbeat_admin_behavior'    => 'reduce_periodicity',
 			'heartbeat_editor_behavior'   => 'reduce_periodicity',

--- a/tests/Fixtures/inc/admin/rocketFirstInstall.php
+++ b/tests/Fixtures/inc/admin/rocketFirstInstall.php
@@ -61,7 +61,7 @@ $default = [
 	'cloudflare_protocol_rewrite' => 0,
 	'cloudflare_auto_settings'    => 0,
 	'cloudflare_old_settings'     => '',
-	'control_heartbeat'           => 0,
+	'control_heartbeat'           => 1,
 	'heartbeat_site_behavior'     => 'reduce_periodicity',
 	'heartbeat_admin_behavior'    => 'reduce_periodicity',
 	'heartbeat_editor_behavior'   => 'reduce_periodicity',
@@ -122,7 +122,7 @@ $integration[ 'delay_js_scripts' ] = [
 	'olark',
 	'pixel-caffeine/build/frontend.js',
 ];
-$integration[ 'preload_links' ]    = 0;
+$integration[ 'preload_links' ]    = 1;
 
 return [
 	'test_data' => [


### PR DESCRIPTION
Closes #3234 

- Change the default values for preload links and control heartbeat from `0` to `1`
- Update fixtures for related tests

### Acceptance criteria
- On new installs, Heartbeat control & preload links are enabled by default
- On update, the previous values are preserved