### PR TITLE
Closes #3283 Exclude defer JS: Admin

### DIFF
--- a/inc/Engine/Admin/Settings/Page.php
+++ b/inc/Engine/Admin/Settings/Page.php
@@ -801,6 +801,20 @@ class Page {
 					'default'           => 0,
 					'sanitize_callback' => 'sanitize_checkbox',
 				],
+				'exclude_defer_js'       => [
+					'container_class'   => [
+						'wpr-field--children',
+					],
+					'type'              => 'textarea',
+					'label'             => __( 'Excluded JavaScript Files', 'rocket' ),
+					'description'       => __( 'Specify URLs of JavaScript files to be excluded from defer (one per line).', 'rocket' ),
+					'placeholder'       => '/wp-content/themes/some-theme/(.*).js',
+					'parent'            => 'defer_all_js',
+					'section'           => 'js',
+					'page'              => 'file_optimization',
+					'default'           => [],
+					'sanitize_callback' => 'sanitize_textarea',
+				],
 				'defer_all_js_safe'      => [
 					'container_class'   => [
 						'wpr-field--children',

--- a/inc/Engine/Admin/Settings/Settings.php
+++ b/inc/Engine/Admin/Settings/Settings.php
@@ -222,6 +222,7 @@ class Settings {
 		$input['minify_concatenate_js']  = ! empty( $input['minify_concatenate_js'] ) ? 1 : 0;
 
 		$input['defer_all_js']      = ! empty( $input['defer_all_js'] ) ? 1 : 0;
+		$input['exclude_defer_js']  = ! empty( $input['exclude_defer_js'] ) ? rocket_sanitize_textarea_field( 'exclude_defer_js', $input['exclude_defer_js'] ) : [];
 		$input['defer_all_js_safe'] = ! empty( $input['defer_all_js_safe'] ) ? 1 : 0;
 		$input['delay_js']          = $this->sanitize_checkbox( $input, 'delay_js' );
 		$input['delay_js_scripts']  = ! empty( $input['delay_js_scripts'] ) ? rocket_sanitize_textarea_field( 'delay_js_scripts', $input['delay_js_scripts'] ) : [];

--- a/inc/Engine/Optimization/DeferJS/AdminSubscriber.php
+++ b/inc/Engine/Optimization/DeferJS/AdminSubscriber.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Engine\Optimization\DeferJS;
+
+use WP_Rocket\Event_Management\Subscriber_Interface;
+
+class AdminSubscriber implements Subscriber_Interface {
+	/**
+	 * DeferJS instance
+	 *
+	 * @var DeferJS
+	 */
+	private $defer_js;
+
+	/**
+	 * Instantiate the class
+	 *
+	 * @param DeferJS $defer_js DeferJS instance.
+	 */
+	public function __construct( DeferJS $defer_js ) {
+		$this->defer_js = $defer_js;
+	}
+
+	/**
+	 * Returns array of events this listen to.
+	 *
+	 * @return array
+	 */
+	public static function get_subscribed_events() : array {
+		return [
+			'rocket_first_install_options' => 'add_defer_js_option',
+		];
+	}
+
+	/**
+	 * Adds defer js option to WP Rocket options array
+	 *
+	 * @since 3.8
+	 *
+	 * @param array $options WP Rocket options array.
+	 * @return array
+	 */
+	public function add_defer_js_option( array $options ) : array {
+		return $this->defer_js->add_option( $options );
+	}
+}

--- a/inc/Engine/Optimization/DeferJS/DeferJS.php
+++ b/inc/Engine/Optimization/DeferJS/DeferJS.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Engine\Optimization\DeferJS;
+
+use WP_Rocket\Admin\Options_Data;
+
+class DeferJS {
+	/**
+	 * Options instance
+	 *
+	 * @var Options_Data
+	 */
+	private $options;
+
+	/**
+	 * Instantiate the class
+	 *
+	 * @param Options_Data $options Options instance.
+	 */
+	public function __construct( Options_Data $options ) {
+		$this->options = $options;
+	}
+
+	/**
+	 * Add the exclude defer JS option in WP Rocket options array
+	 *
+	 * @since 3.8
+	 *
+	 * @param array $options WP Rocket options array.
+	 * @return array
+	 */
+	public function add_option( array $options ) : array {
+		$options['exclude_defer_js'] = [];
+
+		return $options;
+	}
+}

--- a/inc/Engine/Optimization/DeferJS/ServiceProvider.php
+++ b/inc/Engine/Optimization/DeferJS/ServiceProvider.php
@@ -1,0 +1,38 @@
+<?php
+namespace WP_Rocket\Engine\Optimization\DeferJS;
+
+use WP_Rocket\Engine\Container\ServiceProvider\AbstractServiceProvider;
+
+/**
+ * Service provider for the WP Rocket Defer JS
+ *
+ * @since 3.7
+ */
+class ServiceProvider extends AbstractServiceProvider {
+
+	/**
+	 * The provides array is a way to let the container
+	 * know that a service is provided by this service
+	 * provider. Every service that is registered via
+	 * this service provider must have an alias added
+	 * to this array or it will be ignored.
+	 *
+	 * @var array
+	 */
+	protected $provides = [
+		'defer_js',
+		'defer_js_admin_subscriber',
+	];
+
+	/**
+	 * Registers the option array in the container
+	 *
+	 * @return void
+	 */
+	public function register() {
+		$this->getContainer()->add( 'defer_js', 'WP_Rocket\Engine\Optimization\DeferJS\DeferJS' )
+			->withArgument( $this->getContainer()->get( 'options' ) );
+		$this->getContainer()->share( 'defer_js_admin_subscriber', 'WP_Rocket\Engine\Optimization\DeferJS\AdminSubscriber' )
+			->withArgument( $this->getContainer()->get( 'defer_js' ) );
+	}
+}

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -106,6 +106,7 @@ class Plugin {
 		$this->container->addServiceProvider( 'WP_Rocket\Engine\Cache\ServiceProvider' );
 		$this->container->addServiceProvider( 'WP_Rocket\Engine\CriticalPath\ServiceProvider' );
 		$this->container->addServiceProvider( 'WP_Rocket\Engine\HealthCheck\ServiceProvider' );
+		$this->container->addServiceProvider( 'WP_Rocket\Engine\Optimization\DeferJS\ServiceProvider' );
 
 		$this->is_valid_key = rocket_valid_key();
 
@@ -174,6 +175,7 @@ class Plugin {
 			'admin_cache_subscriber',
 			'google_fonts_admin_subscriber',
 			'license_subscriber',
+			'defer_js_admin_subscriber',
 		];
 	}
 

--- a/inc/functions/formatting.php
+++ b/inc/functions/formatting.php
@@ -186,6 +186,7 @@ function rocket_sanitize_textarea_field( $field, $value ) {
 		'cdn_reject_files'     => [ 'rocket_clean_exclude_file', 'rocket_clean_wildcards' ], // Pattern.
 		'exclude_css'          => [ 'rocket_validate_css', 'rocket_clean_wildcards' ], // Pattern.
 		'exclude_inline_js'    => [ 'sanitize_text_field' ], // Pattern.
+		'exclude_defer_js'     => [ 'rocket_validate_js', 'rocket_clean_wildcards' ], // Pattern.
 		'exclude_js'           => [ 'rocket_validate_js', 'rocket_clean_wildcards' ], // Pattern.
 		'delay_js_scripts'     => [ 'rocket_validate_js' ],
 	];

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -26,8 +26,8 @@
 
 	<!-- Rules: Check PHP version compatibility - see https://github.com/PHPCompatibility/PHPCompatibilityWP -->
 	<rule ref="PHPCompatibility"/>
-	<config name="testVersion" value="5.6-"/>
-	<config name="minimum_supported_wp_version" value="4.7"/>
+	<config name="testVersion" value="7.0-"/>
+	<config name="minimum_supported_wp_version" value="5.2"/>
 
 	<rule ref="WordPress">
         <exclude name="Generic.Functions.FunctionCallArgumentSpacing.TooMuchSpaceAfterComma"/>

--- a/tests/Fixtures/inc/Engine/Optimization/DeferJS/AdminSubscriber/addDeferJsOption.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DeferJS/AdminSubscriber/addDeferJsOption.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+	'shouldReturnValidOptionsWithEmptyOptions' => [
+		'input' => [
+			'options' => [],
+		],
+		'expected' => [
+			'exclude_defer_js' => [],
+		]
+	],
+	'shouldNotOverrideOtherOptions' => [
+		'input' => [
+			'options' => [
+				'test_option' => 1,
+			],
+		],
+		'expected' => [
+			'test_option'      => 1,
+			'exclude_defer_js' => [],
+		]
+	],
+];

--- a/tests/Fixtures/inc/Engine/Optimization/DeferJS/DeferJS/addOption.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DeferJS/DeferJS/addOption.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+	'shouldReturnValidOptionsWithEmptyOptions' => [
+		'input' => [
+			'options' => [],
+		],
+		'expected' => [
+			'exclude_defer_js' => [],
+		]
+	],
+	'shouldNotOverrideOtherOptions' => [
+		'input' => [
+			'options' => [
+				'test_option' => 1,
+			],
+		],
+		'expected' => [
+			'test_option'      => 1,
+			'exclude_defer_js' => [],
+		]
+	],
+];

--- a/tests/Fixtures/inc/admin/rocketFirstInstall.php
+++ b/tests/Fixtures/inc/admin/rocketFirstInstall.php
@@ -76,6 +76,7 @@ $default = [
 
 $integration = $default;
 $integration[ 'async_css_mobile' ] = 1;
+$integration[ 'exclude_defer_js' ] = [];
 $integration[ 'delay_js' ]         = 1;
 $integration[ 'delay_js_scripts' ] = [
 	'getbutton.io',

--- a/tests/Integration/inc/Engine/Optimization/DeferJS/AdminSubscriber/addDeferJsOption.php
+++ b/tests/Integration/inc/Engine/Optimization/DeferJS/AdminSubscriber/addDeferJsOption.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\Optimization\DeferJS\DeferJS;
+
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Optimization\DeferJS\DeferJS::add_defer_js_option
+ *
+ * @group  DeferJS
+ */
+class Test_AddDeferJsOption extends TestCase {
+	public function setUp() {
+		parent::setUp();
+
+		$this->unregisterAllCallbacksExcept( 'rocket_first_install_options', 'add_defer_js_option' );
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+
+		$this->restoreWpFilter( 'rocket_first_install_options' );
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldDoExpectedForFirstInstallOptions( $input, $expected ) {
+		$options  = isset( $input['options'] )  ? $input['options']  : [];
+
+		$actual = apply_filters( 'rocket_first_install_options', $options );
+
+		$this->assertSame( $expected, $actual );
+
+	}
+}

--- a/tests/Integration/inc/Engine/Optimization/DeferJS/AdminSubscriber/addDeferJsOption.php
+++ b/tests/Integration/inc/Engine/Optimization/DeferJS/AdminSubscriber/addDeferJsOption.php
@@ -1,12 +1,13 @@
 <?php
 
-namespace WP_Rocket\Tests\Integration\inc\Engine\Optimization\DeferJS\DeferJS;
+namespace WP_Rocket\Tests\Integration\inc\Engine\Optimization\DeferJS\AdminSubscriber;
 
 use WP_Rocket\Tests\Integration\TestCase;
 
 /**
- * @covers \WP_Rocket\Engine\Optimization\DeferJS\DeferJS::add_defer_js_option
+ * @covers \WP_Rocket\Engine\Optimization\DeferJS\AdminSubscriber::add_defer_js_option
  *
+ * @group  AdminOnly
  * @group  DeferJS
  */
 class Test_AddDeferJsOption extends TestCase {

--- a/tests/Unit/inc/Engine/Optimization/DeferJS/DeferJS/addOption.php
+++ b/tests/Unit/inc/Engine/Optimization/DeferJS/DeferJS/addOption.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\DeferJS\DeferJS;
+
+use Mockery;
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Engine\Optimization\DeferJS\DeferJS;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Optimization\DeferJS\DeferJS::add_option
+ *
+ * @group  DeferJS
+ */
+class Test_AddOption extends TestCase{
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldDoExpected( $input, $expected ){
+		$options  = isset( $input['options'] )  ? $input['options']  : [];
+		$defer_js = new DeferJS( Mockery::mock( Options_Data::class ) );
+
+		$this->assertSame(
+			$expected,
+			$defer_js->add_option( $options )
+		);
+	}
+}


### PR DESCRIPTION
Closes #3283

### Code changes
#### Create class `WP_Rocket\Engine\Optimization\DeferJS\DeferJS`
- Add a method `add_option()` to register `exclude_defer_js` as an option index, with a default value of empty array
- Write tests

#### Create class `WP_Rocket\Engine\Optimization\DeferJS\AdminSubscriber`
- Add `DeferJS` as a dependency
- Register an event on `rocket_first_install_options`, with the callback being `DeferJS::add_option()`
- Write tests

#### Create class `WP_Rocket\Engine\Optimization\DeferJS\ServiceProvider`
- Register the 2 classes above with the service provider

#### Update class `WP_Rocket\Engine\Admin\Settings\Page`
- Update method `assets_section()`, to register the new field `exclude_defer_js`
- The field is a child of the `defer_all_js` field
- Field data is available in the parent issue

#### Update class `WP_Rocket\Engine\Admin\Settings\Settings`
- Sanitize the new `exclude_defer_js` field, using the same method as the minify JS exclusion

#### Update class `WP_Rocket\Plugin`
- Load the DeferJS service provider in the `load()` method
- Add the DeferJS admin subscriber in the `init_admin_subscribers()` subscribers array
