### PR TITLE
Fixes #3232 Update sanitize for CSS/JS exclusion fields

### DIFF
--- a/inc/functions/formatting.php
+++ b/inc/functions/formatting.php
@@ -99,7 +99,7 @@ function rocket_validate_js( $file ) {
 		return $file;
 	}
 
-	return sanitize_text_field( rocket_remove_url_protocol( strtok( $file, '?' ) ) );
+	return esc_url_raw( rocket_remove_url_protocol( strtok( $file, '?' ) ) );
 }
 
 /**
@@ -112,10 +112,10 @@ function rocket_validate_js( $file ) {
  */
 function rocket_validate_css( $file ) {
 	if ( rocket_is_internal_file( $file ) ) {
-		return rocket_sanitize_css( rocket_clean_exclude_file( trim( $file ) ) );
+		return esc_url_raw( rocket_clean_exclude_file( trim( $file ) ) );
 	}
 
-	return sanitize_text_field( rocket_remove_url_protocol( strtok( $file, '?' ) ) );
+	return esc_url_raw( rocket_remove_url_protocol( strtok( $file, '?' ) ) );
 }
 
 /**
@@ -132,7 +132,7 @@ function rocket_is_internal_file( $file ) {
 	$file_host = wp_parse_url( $file, PHP_URL_HOST );
 
 	if ( empty( $file_host ) ) {
-		return false;
+		return true;
 	}
 
 	/**

--- a/inc/functions/formatting.php
+++ b/inc/functions/formatting.php
@@ -99,7 +99,7 @@ function rocket_validate_js( $file ) {
 		return $file;
 	}
 
-	return esc_url_raw( rocket_remove_url_protocol( strtok( $file, '?' ) ) );
+	return rocket_remove_url_protocol( esc_url_raw( strtok( $file, '?' ) ) );
 }
 
 /**
@@ -115,7 +115,7 @@ function rocket_validate_css( $file ) {
 		return rocket_sanitize_css( rocket_clean_exclude_file( trim( $file ) ) );
 	}
 
-	return esc_url_raw( rocket_remove_url_protocol( strtok( $file, '?' ) ) );
+	return rocket_remove_url_protocol( esc_url_raw( strtok( $file, '?' ) ) );
 }
 
 /**

--- a/inc/functions/formatting.php
+++ b/inc/functions/formatting.php
@@ -112,7 +112,7 @@ function rocket_validate_js( $file ) {
  */
 function rocket_validate_css( $file ) {
 	if ( rocket_is_internal_file( $file ) ) {
-		return esc_url_raw( rocket_clean_exclude_file( trim( $file ) ) );
+		return rocket_sanitize_css( rocket_clean_exclude_file( trim( $file ) ) );
 	}
 
 	return esc_url_raw( rocket_remove_url_protocol( strtok( $file, '?' ) ) );

--- a/tests/Unit/inc/functions/rocketValidateCss.php
+++ b/tests/Unit/inc/functions/rocketValidateCss.php
@@ -25,7 +25,7 @@ class Test_RocketValidateCss extends TestCase {
 			}
 			return parse_url( $url, PHP_URL_PATH );
 		} );
-		Functions\when( 'sanitize_text_field' )->returnArg();
+		Functions\when( 'esc_url_raw' )->returnArg();
 		Functions\when( 'rocket_remove_url_protocol' )->alias( function( $url ) {
 			return str_replace( [ 'http://', 'https://' ], '', $url );
 		} );


### PR DESCRIPTION
Fixes #3232

Sanitization on exclude from combination fields prevents from excluding certain scripts.

Applied changes: 
- returning `true` if the file is internal at [rocket_is_internal_file](https://github.com/wp-media/wp-rocket/blob/a1f95920f4e1504af6826a75d1e16294e9b133eb/inc/functions/formatting.php#L135). Props to @vmanthos on this one.

- replacing `sanitize_text_field()` by `esc_url_raw()` at  [rocket_validate_css()](https://github.com/wp-media/wp-rocket/blob/a1f95920f4e1504af6826a75d1e16294e9b133eb/inc/functions/formatting.php#L113-L118) and [rocket_validate_js()](https://github.com/wp-media/wp-rocket/blob/a1f95920f4e1504af6826a75d1e16294e9b133eb/inc/functions/formatting.php#L102)

### Acceptance criteria
- Exclusion of URLs containing encoded spaces `%20` is working correctly

