### PR TITLE
Prevent combination of excluded files from defer JS

### DIFF
--- a/inc/Engine/Optimization/DeferJS/DeferJS.php
+++ b/inc/Engine/Optimization/DeferJS/DeferJS.php
@@ -101,7 +101,7 @@ class DeferJS {
 	 *
 	 * @return array
 	 */
-	private function get_excluded() : array {
+	public function get_excluded() : array {
 		$exclude_defer_js = [
 			'gist.github.com',
 			'content.jwplatform.com',

--- a/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
+++ b/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
@@ -49,11 +49,6 @@ abstract class AbstractJSOptimization extends AbstractOptimization {
 	protected function get_excluded_files() {
 		$excluded_files   = $this->options->get( 'exclude_js', [] );
 		$excluded_files[] = '/wp-includes/js/dist/i18n.min.js';
-		$jquery_urls      = $this->get_jquery_urls();
-
-		if ( ! empty( $jquery_urls ) ) {
-			$excluded_files = array_merge( $excluded_files, $jquery_urls );
-		}
 
 		/**
 		 * Filter JS files to exclude from minification/concatenation.
@@ -149,37 +144,6 @@ abstract class AbstractJSOptimization extends AbstractOptimization {
 		 * @param string $original_url Original URL for this file.
 		 */
 		return apply_filters( 'rocket_js_url', $minify_url, $original_url );
-	}
-
-	/**
-	 * Gets jQuery URL if defer JS safe mode is active.
-	 *
-	 * @since  3.1
-	 *
-	 * @return array
-	 */
-	protected function get_jquery_urls() {
-		if ( ! $this->options->get( 'defer_all_js', 0 ) || ! $this->options->get( 'defer_all_js_safe', 0 ) ) {
-			return [];
-		}
-
-		$exclude_jquery = [];
-		$jquery         = wp_scripts()->registered['jquery-core']->src;
-
-		if ( isset( $jquery ) ) {
-			if ( empty( wp_parse_url( $jquery, PHP_URL_HOST ) ) ) {
-				$exclude_jquery[] = wp_parse_url( site_url( $jquery ), PHP_URL_PATH );
-			} else {
-				$exclude_jquery[] = $jquery;
-			}
-		}
-
-		$exclude_jquery[] = 'c0.wp.com/c/(?:.+)/wp-includes/js/jquery/jquery.js';
-		$exclude_jquery[] = 'ajax.googleapis.com/ajax/libs/jquery/(?:.+)/jquery(?:\.min)?.js';
-		$exclude_jquery[] = 'cdnjs.cloudflare.com/ajax/libs/jquery/(?:.+)/jquery(?:\.min)?.js';
-		$exclude_jquery[] = 'code.jquery.com/jquery-.*(?:\.min|slim)?.js';
-
-		return $exclude_jquery;
 	}
 
 	/**

--- a/inc/Engine/Optimization/Minify/JS/Combine.php
+++ b/inc/Engine/Optimization/Minify/JS/Combine.php
@@ -178,18 +178,7 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 							}
 						}
 
-						if (
-							! empty( $this->excluded_defer_js )
-							&&
-							preg_match( '#(' . $this->excluded_defer_js . ')#i', $matches['url'] )
-						) {
-							Logger::debug(
-								'Script is excluded from defer JS.',
-								[
-									'js combine process',
-									'tag' => $matches[0],
-								]
-							);
+						if ( $this->is_defer_excluded( $matches['url'] ) ) {
 							return;
 						}
 
@@ -212,18 +201,7 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 						return;
 					}
 
-					if (
-						! empty( $this->excluded_defer_js )
-						&&
-						preg_match( '#(' . $this->excluded_defer_js . ')#i', $matches['url'] )
-					) {
-						Logger::debug(
-							'Script is excluded from defer JS.',
-							[
-								'js combine process',
-								'tag' => $matches[0],
-							]
-						);
+					if ( $this->is_defer_excluded( $matches['url'] ) ) {
 						return;
 					}
 
@@ -873,4 +851,30 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 		return false !== strpos( $script_attributes, 'data-rocketlazyloadscript=' );
 	}
 
+	/**
+	 * Checks if the current URL is excluded from defer JS
+	 *
+	 * @since 3.8
+	 *
+	 * @param string $url URL to check.
+	 * @return boolean
+	 */
+	private function is_defer_excluded( string $url ) : bool {
+		if (
+			! empty( $this->excluded_defer_js )
+			&&
+			preg_match( '#(' . $this->excluded_defer_js . ')#i', $url )
+		) {
+			Logger::debug(
+				'Script is excluded from defer JS.',
+				[
+					'js combine process',
+					'url' => $url,
+				]
+			);
+			return true;
+		}
+
+		return false;
+	}
 }

--- a/inc/Engine/Optimization/Minify/JS/Combine.php
+++ b/inc/Engine/Optimization/Minify/JS/Combine.php
@@ -179,7 +179,7 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 						}
 
 						if (
-							!empty( $this->excluded_defer_js )
+							! empty( $this->excluded_defer_js )
 							&&
 							preg_match( '#(' . $this->excluded_defer_js . ')#i', $matches['url'] )
 						) {
@@ -213,7 +213,7 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 					}
 
 					if (
-						!empty( $this->excluded_defer_js )
+						! empty( $this->excluded_defer_js )
 						&&
 						preg_match( '#(' . $this->excluded_defer_js . ')#i', $matches['url'] )
 					) {

--- a/inc/Engine/Optimization/Minify/JS/Combine.php
+++ b/inc/Engine/Optimization/Minify/JS/Combine.php
@@ -178,7 +178,11 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 							}
 						}
 
-						if ( preg_match( '#(' .  $this->excluded_defer_js . ')#i', $matches['url'] ) ) {
+						if (
+							!empty( $this->excluded_defer_js )
+						   &&
+						   preg_match( '#(' . $this->excluded_defer_js . ')#i', $matches['url'] )
+					   ) {
 							Logger::debug(
 								'Script is excluded from defer JS.',
 								[
@@ -208,7 +212,11 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 						return;
 					}
 
-					if ( preg_match( '#(' .  $this->excluded_defer_js . ')#i', $matches['url'] ) ) {
+					if (
+						 !empty( $this->excluded_defer_js )
+						&&
+						preg_match( '#(' . $this->excluded_defer_js . ')#i', $matches['url'] )
+					) {
 						Logger::debug(
 							'Script is excluded from defer JS.',
 							[

--- a/inc/Engine/Optimization/Minify/JS/Combine.php
+++ b/inc/Engine/Optimization/Minify/JS/Combine.php
@@ -180,9 +180,9 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 
 						if (
 							!empty( $this->excluded_defer_js )
-						   &&
-						   preg_match( '#(' . $this->excluded_defer_js . ')#i', $matches['url'] )
-					   ) {
+							&&
+							preg_match( '#(' . $this->excluded_defer_js . ')#i', $matches['url'] )
+						) {
 							Logger::debug(
 								'Script is excluded from defer JS.',
 								[
@@ -213,7 +213,7 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 					}
 
 					if (
-						 !empty( $this->excluded_defer_js )
+						!empty( $this->excluded_defer_js )
 						&&
 						preg_match( '#(' . $this->excluded_defer_js . ')#i', $matches['url'] )
 					) {

--- a/inc/Engine/Optimization/Minify/JS/Subscriber.php
+++ b/inc/Engine/Optimization/Minify/JS/Subscriber.php
@@ -3,6 +3,7 @@ namespace WP_Rocket\Engine\Optimization\Minify\JS;
 
 use WP_Rocket\Dependencies\Minify\JS as MinifyJS;
 use WP_Rocket\Engine\Optimization\AssetsLocalCache;
+use WP_Rocket\Engine\Optimization\DeferJS\DeferJS;
 use WP_Rocket\Engine\Optimization\Minify\AbstractMinifySubscriber;
 
 /**
@@ -46,7 +47,7 @@ class Subscriber extends AbstractMinifySubscriber {
 		$assets_local_cache = new AssetsLocalCache( rocket_get_constant( 'WP_ROCKET_MINIFY_CACHE_PATH' ), $this->filesystem );
 
 		if ( $this->options->get( 'minify_js' ) && $this->options->get( 'minify_concatenate_js' ) ) {
-			$this->set_processor_type( new Combine( $this->options, new MinifyJS(), $assets_local_cache ) );
+			$this->set_processor_type( new Combine( $this->options, new MinifyJS(), $assets_local_cache, new DeferJS( $this->options ) ) );
 		} elseif ( $this->options->get( 'minify_js' ) && ! $this->options->get( 'minify_concatenate_js' ) ) {
 			$this->set_processor_type( new Minify( $this->options, $assets_local_cache ) );
 		}

--- a/tests/Fixtures/inc/Engine/Optimization/Minify/JS/Combine/combine.php
+++ b/tests/Fixtures/inc/Engine/Optimization/Minify/JS/Combine/combine.php
@@ -54,6 +54,7 @@ EXPECTED_HTML
 				'site_url'          => 'http://example.org',
 				'defer_all_js'      => false,
 				'defer_all_js_safe' => false,
+				'exclude_defer_js'  => [],
 			],
 		],
 
@@ -107,6 +108,9 @@ EXPECTED_HTML
 				'site_url'          => 'http://example.org',
 				'defer_all_js'      => true,
 				'defer_all_js_safe' => true,
+				'exclude_defer_js'  => [
+					'/wp-includes/js/jquery/jquery.js',
+				],
 			],
 		],
 
@@ -159,6 +163,7 @@ EXPECTED_HTML
 				'site_url'          => 'http://example.org',
 				'defer_all_js'      => false,
 				'defer_all_js_safe' => false,
+				'exclude_defer_js'  => [],
 			],
 		],
 
@@ -214,6 +219,7 @@ EXPECTED_HTML
 				'site_url'          => 'http://example.org',
 				'defer_all_js'      => false,
 				'defer_all_js_safe' => false,
+				'exclude_defer_js'  => [],
 			],
 		],
 
@@ -266,6 +272,7 @@ EXPECTED_HTML
 				'site_url' => 'http://example.org',
 				'defer_all_js'      => false,
 				'defer_all_js_safe' => false,
+				'exclude_defer_js'  => [],
 			],
 		],
 
@@ -317,6 +324,7 @@ EXPECTED_HTML
 				'site_url' => 'http://example.org',
 				'defer_all_js'      => false,
 				'defer_all_js_safe' => false,
+				'exclude_defer_js'  => [],
 			],
 		],
 
@@ -368,6 +376,7 @@ EXPECTED_HTML
 				'site_url' => 'http://example.org',
 				'defer_all_js'      => false,
 				'defer_all_js_safe' => false,
+				'exclude_defer_js'  => [],
 			],
 		],
 	],

--- a/tests/Unit/inc/Engine/Optimization/Minify/JS/Combine/optimize.php
+++ b/tests/Unit/inc/Engine/Optimization/Minify/JS/Combine/optimize.php
@@ -7,6 +7,7 @@ use Brain\Monkey\Functions;
 use WP_Rocket\Dependencies\Minify;
 use Mockery;
 use WP_Rocket\Engine\Optimization\AssetsLocalCache;
+use WP_Rocket\Engine\Optimization\DeferJS\DeferJS;
 use WP_Rocket\Engine\Optimization\Minify\JS\Combine;
 use WP_Rocket\Tests\Unit\inc\Engine\Optimization\TestCase;
 
@@ -21,6 +22,7 @@ use WP_Rocket\Tests\Unit\inc\Engine\Optimization\TestCase;
 class Test_Optimize extends TestCase {
 	protected $path_to_test_data = '/inc/Engine/Optimization/Minify/JS/Combine/combine.php';
 	private   $minify;
+	private   $defer_js;
 
 	public function setUp() {
 		parent::setUp();
@@ -28,7 +30,9 @@ class Test_Optimize extends TestCase {
 		$this->minify = Mockery::mock( Minify\JS::class );
 		$this->minify->shouldReceive( 'add' );
 		$this->minify->shouldReceive( 'minify' )
-		             ->andReturn( 'minified JS' );
+					 ->andReturn( 'minified JS' );
+
+		$this->defer_js = Mockery::mock( DeferJS::class );
 
 		Functions\when( 'esc_url' )->returnArg();
 		Functions\when( 'wp_scripts' )->alias( function () {
@@ -61,14 +65,10 @@ class Test_Optimize extends TestCase {
 			->with( 'exclude_inline_js', [] )
 			->andReturn( [] );
 		$this->options->shouldReceive( 'get' )
-			->with( 'defer_all_js', 0 )
-			->andReturn( $config['defer_all_js'] );
-		$this->options->shouldReceive( 'get' )
-			->with( 'defer_all_js_safe', 0 )
-			->andReturn( $config['defer_all_js_safe'] );
-		$this->options->shouldReceive( 'get' )
 			->with( 'exclude_js', [] )
 			->andReturn( [] );
+		$this->defer_js->shouldReceive( 'get_excluded' )
+			->andReturn( $config['exclude_defer_js'] );
 
 		Filters\expectApplied( 'rocket_cdn_hosts' )
 			->zeroOrMoreTimes()
@@ -87,7 +87,7 @@ class Test_Optimize extends TestCase {
 				return str_replace( 'http://example.org', $config['cdn_url'], $url );
 			} );
 
-		$combine = new Combine( $this->options, $this->minify, Mockery::mock( AssetsLocalCache::class ) );
+		$combine = new Combine( $this->options, $this->minify, Mockery::mock( AssetsLocalCache::class ), $this->defer_js );
 
 		$this->assertSame(
 			$this->format_the_html( $expected['html'] ),


### PR DESCRIPTION
With this changes, files excluded from defer JS are also excluded from combine JS, to make sure the exclusion is preserved.

Previously, only jQuery files were excluded from combine JS. Now, all files in defer JS exclusion will be.