### PR TITLE
Closes #3306 Add missing dimensions to images: admin side

### DIFF
--- a/inc/Engine/Admin/Settings/Page.php
+++ b/inc/Engine/Admin/Settings/Page.php
@@ -928,6 +928,12 @@ class Page {
 					// translators: %1$s = “WP Rocket”, %2$s = a list of plugin names.
 					'helper'      => ! empty( $disable_lazyload ) ? sprintf( __( 'LazyLoad is currently activated in %2$s. If you want to use WP Rocket’s LazyLoad, disable this option in %2$s.', 'rocket' ), WP_ROCKET_PLUGIN_NAME, $disable_lazyload ) : '',
 				],
+				'dimensions_section' => [
+					'title' => __( 'Images dimensions', 'rocket' ),
+					'type'  => 'fields_container',
+					'description' => __( 'Add missing width and height attributes to images. Helps prevent layout shifts and improve the reading experience for your visitors. More info', 'rocket' ),
+					'page' => 'media',
+				],
 				'embeds_section'   => [
 					'title'       => __( 'Embeds', 'rocket' ),
 					'type'        => 'fields_container',
@@ -1013,6 +1019,14 @@ class Page {
 					],
 					// translators: %1$s = “WP Rocket”, %2$s = a list of plugin or themes names.
 					'description'       => ! empty( $disable_youtube_lazyload ) ? sprintf( __( 'Replace YouTube iframe with preview image is not compatible with %2$s.', 'rocket' ), WP_ROCKET_PLUGIN_NAME, $disable_youtube_lazyload ) : '',
+				],
+				'images_dimensions' => [
+					'type'              => 'checkbox',
+					'label'             => __( 'Add missing image dimensions', 'rocket' ),
+					'section'           => 'dimensions_section',
+					'page'              => 'media',
+					'default'           => 0,
+					'sanitize_callback' => 'sanitize_checkbox',
 				],
 				'embeds'           => [
 					'type'              => 'checkbox',

--- a/inc/Engine/Admin/Settings/Page.php
+++ b/inc/Engine/Admin/Settings/Page.php
@@ -929,10 +929,10 @@ class Page {
 					'helper'      => ! empty( $disable_lazyload ) ? sprintf( __( 'LazyLoad is currently activated in %2$s. If you want to use WP Rocket’s LazyLoad, disable this option in %2$s.', 'rocket' ), WP_ROCKET_PLUGIN_NAME, $disable_lazyload ) : '',
 				],
 				'dimensions_section' => [
-					'title' => __( 'Images dimensions', 'rocket' ),
-					'type'  => 'fields_container',
+					'title'       => __( 'Images dimensions', 'rocket' ),
+					'type'        => 'fields_container',
 					'description' => __( 'Add missing width and height attributes to images. Helps prevent layout shifts and improve the reading experience for your visitors. More info', 'rocket' ),
-					'page' => 'media',
+					'page'        => 'media',
 				],
 				'embeds_section'     => [
 					'title'       => __( 'Embeds', 'rocket' ),

--- a/inc/Engine/Admin/Settings/Page.php
+++ b/inc/Engine/Admin/Settings/Page.php
@@ -915,7 +915,7 @@ class Page {
 
 		$this->settings->add_settings_sections(
 			[
-				'lazyload_section' => [
+				'lazyload_section'   => [
 					'title'       => __( 'LazyLoad', 'rocket' ),
 					'type'        => 'fields_container',
 					// translators: %1$s = opening <a> tag, %2$s = closing </a> tag.
@@ -934,13 +934,13 @@ class Page {
 					'description' => __( 'Add missing width and height attributes to images. Helps prevent layout shifts and improve the reading experience for your visitors. More info', 'rocket' ),
 					'page' => 'media',
 				],
-				'embeds_section'   => [
+				'embeds_section'     => [
 					'title'       => __( 'Embeds', 'rocket' ),
 					'type'        => 'fields_container',
 					'description' => __( 'Prevents others from embedding content from your site, prevents you from embedding content from other (non-allowed) sites, and removes JavaScript requests related to WordPress embeds', 'rocket' ),
 					'page'        => 'media',
 				],
-				'webp_section'     => [
+				'webp_section'       => [
 					'title'       => __( 'WebP compatibility', 'rocket' ),
 					'type'        => 'fields_container',
 					'description' => sprintf(
@@ -970,7 +970,7 @@ class Page {
 
 		$this->settings->add_settings_fields(
 			[
-				'lazyload'         => [
+				'lazyload'          => [
 					'type'              => 'checkbox',
 					'label'             => __( 'Enable for images', 'rocket' ),
 					'section'           => 'lazyload_section',
@@ -986,7 +986,7 @@ class Page {
 					// translators: %1$s = “WP Rocket”, %2$s = a list of plugin names.
 					'description'       => ! empty( $disable_images_lazyload ) ? sprintf( __( 'LazyLoad for images is currently activated in %2$s. If you want to use %1$s’s LazyLoad, disable this option in %2$s.', 'rocket' ), WP_ROCKET_PLUGIN_NAME, $disable_images_lazyload ) : '',
 				],
-				'lazyload_iframes' => [
+				'lazyload_iframes'  => [
 					'container_class'   => [
 						! empty( $disable_iframes_lazyload ) ? 'wpr-isDisabled' : '',
 						'wpr-isParent',
@@ -1001,7 +1001,7 @@ class Page {
 						'disabled' => ! empty( $disable_iframes_lazyload ) ? 1 : 0,
 					],
 				],
-				'lazyload_youtube' => [
+				'lazyload_youtube'  => [
 					'container_class'   => [
 						! empty( $disable_youtube_lazyload ) ? 'wpr-isDisabled' : '',
 						'wpr-field--children',
@@ -1028,7 +1028,7 @@ class Page {
 					'default'           => 0,
 					'sanitize_callback' => 'sanitize_checkbox',
 				],
-				'embeds'           => [
+				'embeds'            => [
 					'type'              => 'checkbox',
 					'label'             => __( 'Disable WordPress embeds', 'rocket' ),
 					'section'           => 'embeds_section',
@@ -1036,7 +1036,7 @@ class Page {
 					'default'           => 1,
 					'sanitize_callback' => 'sanitize_checkbox',
 				],
-				'cache_webp'       => array_merge(
+				'cache_webp'        => array_merge(
 					$cache_webp_field,
 					[
 						'type'              => 'checkbox',

--- a/inc/Engine/Admin/Settings/Settings.php
+++ b/inc/Engine/Admin/Settings/Settings.php
@@ -492,7 +492,13 @@ class Settings {
 
 		unset( $input['ignore'] );
 
-		return apply_filters( 'rocket_input_sanitize', $input );
+		/**
+		 * Filters the sanitized input before returning the array
+		 *
+		 * @param array    $input    Array of sanitized values after being submitted by the form.
+		 * @param Settings $settings Current class instance.
+		 */
+		return apply_filters( 'rocket_input_sanitize', $input, $this );
 	}
 
 	/**

--- a/inc/Engine/Media/ImagesDimensions/AdminSubscriber.php
+++ b/inc/Engine/Media/ImagesDimensions/AdminSubscriber.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace WP_Rocket\Engine\Media\ImagesDimensions;
+
+use WP_Rocket\Event_Management\Subscriber_Interface;
+
+class AdminSubscriber implements Subscriber_Interface {
+	/**
+	 * ImagesDimensions instance
+	 *
+	 * @var ImagesDimensions
+	 */
+	private $dimensions;
+
+	/**
+	 * Instantiate the class
+	 *
+	 * @param ImagesDimensions $dimensions ImageDimensions instance.
+	 */
+	public function __construct( ImagesDimensions $dimensions ) {
+		$this->dimensions = $dimensions;
+	}
+
+	/**
+	 * Returns an array of events this listens to
+	 *
+	 * @return array
+	 */
+	public static function get_subscribed_events() : array {
+		return [
+			'rocket_first_install_options' => [ 'add_option', 14 ],
+		];
+	}
+
+	/**
+	 * Add the images dimensions option to the WP Rocket options array
+	 *
+	 * @param array $options WP Rocket options array.
+	 * @return array
+	 */
+	public function add_option( array $options ) : array {
+		return $this->dimensions->add_option( $options );
+	}
+}

--- a/inc/Engine/Media/ImagesDimensions/AdminSubscriber.php
+++ b/inc/Engine/Media/ImagesDimensions/AdminSubscriber.php
@@ -2,6 +2,7 @@
 
 namespace WP_Rocket\Engine\Media\ImagesDimensions;
 
+use WP_Rocket\Engine\Admin\Settings\Settings;
 use WP_Rocket\Event_Management\Subscriber_Interface;
 
 class AdminSubscriber implements Subscriber_Interface {
@@ -29,6 +30,7 @@ class AdminSubscriber implements Subscriber_Interface {
 	public static function get_subscribed_events() : array {
 		return [
 			'rocket_first_install_options' => [ 'add_option', 14 ],
+			'rocket_input_sanitize'        => [ 'sanitize_option', 10, 2 ],
 		];
 	}
 
@@ -40,5 +42,18 @@ class AdminSubscriber implements Subscriber_Interface {
 	 */
 	public function add_option( array $options ) : array {
 		return $this->dimensions->add_option( $options );
+	}
+
+	/**
+	 * Sanitizes the option value when saving from the settings page
+	 *
+	 * @since 3.8
+	 *
+	 * @param array    $input    Array of sanitized values after being submitted by the form.
+	 * @param Settings $settings Settings class instance.
+	 * @return array
+	 */
+	public function sanitize_option( array $input, Settings $settings ) : array {
+		return $this->dimensions->sanitize_option_value( $input, $settings );
 	}
 }

--- a/inc/Engine/Media/ImagesDimensions/ImagesDimensions.php
+++ b/inc/Engine/Media/ImagesDimensions/ImagesDimensions.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace WP_Rocket\Engine\Media\ImagesDimensions;
+
+class ImagesDimensions {
+	/**
+	 * Adds the images dimensions option to WP Rocket options array
+	 *
+	 * @param array $options WP Rocket options array.
+	 * @return array
+	 */
+	public function add_option( array $options ) : array {
+		$options['images_dimensions'] = 0;
+
+		return $options;
+	}
+}

--- a/inc/Engine/Media/ImagesDimensions/ImagesDimensions.php
+++ b/inc/Engine/Media/ImagesDimensions/ImagesDimensions.php
@@ -2,9 +2,13 @@
 
 namespace WP_Rocket\Engine\Media\ImagesDimensions;
 
+use WP_Rocket\Engine\Admin\Settings\Settings;
+
 class ImagesDimensions {
 	/**
 	 * Adds the images dimensions option to WP Rocket options array
+	 *
+	 * @since 3.8
 	 *
 	 * @param array $options WP Rocket options array.
 	 * @return array
@@ -13,5 +17,20 @@ class ImagesDimensions {
 		$options['images_dimensions'] = 0;
 
 		return $options;
+	}
+
+	/**
+	 * Sanitizes the option value when saving from the settings page
+	 *
+	 * @since 3.8
+	 *
+	 * @param array    $input    Array of sanitized values after being submitted by the form.
+	 * @param Settings $settings Settings class instance.
+	 * @return array
+	 */
+	public function sanitize_option_value( array $input, Settings $settings ) : array {
+		$input['images_dimensions'] = $settings->sanitize_checkbox( $input, 'images_dimensions' );
+
+		return $input;
 	}
 }

--- a/inc/Engine/Media/ServiceProvider.php
+++ b/inc/Engine/Media/ServiceProvider.php
@@ -26,6 +26,8 @@ class ServiceProvider extends AbstractServiceProvider {
 		'lazyload_subscriber',
 		'embeds_subscriber',
 		'emojis_subscriber',
+		'images_dimensions',
+		'dimensions_admin_subscriber',
 	];
 
 	/**
@@ -50,5 +52,9 @@ class ServiceProvider extends AbstractServiceProvider {
 			->withArgument( $options );
 		$this->getContainer()->share( 'emojis_subscriber', 'WP_Rocket\Engine\Media\Emojis\EmojisSubscriber' )
 			->withArgument( $options );
+
+		$this->getContainer()->add( 'images_dimensions', 'WP_Rocket\Engine\Media\ImagesDimensions\ImagesDimensions' );
+		$this->getContainer()->share( 'dimensions_admin_subscriber', 'WP_Rocket\Engine\Media\ImagesDimensions\AdminSubscriber' )
+			->withArgument( $this->getContainer()->get( 'images_dimensions' ) );
 	}
 }

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -106,6 +106,7 @@ class Plugin {
 		$this->container->addServiceProvider( 'WP_Rocket\Engine\Cache\ServiceProvider' );
 		$this->container->addServiceProvider( 'WP_Rocket\Engine\CriticalPath\ServiceProvider' );
 		$this->container->addServiceProvider( 'WP_Rocket\Engine\HealthCheck\ServiceProvider' );
+		$this->container->addServiceProvider( 'WP_Rocket\Engine\Media\ServiceProvider' );
 
 		$this->is_valid_key = rocket_valid_key();
 
@@ -174,6 +175,7 @@ class Plugin {
 			'admin_cache_subscriber',
 			'google_fonts_admin_subscriber',
 			'license_subscriber',
+			'dimensions_admin_subscriber',
 		];
 	}
 
@@ -185,7 +187,6 @@ class Plugin {
 	 * @return array array of subscribers.
 	 */
 	private function init_valid_key_subscribers() {
-		$this->container->addServiceProvider( 'WP_Rocket\Engine\Media\ServiceProvider' );
 		$this->container->addServiceProvider( 'WP_Rocket\Engine\Optimization\ServiceProvider' );
 
 		$subscribers = [

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -26,8 +26,8 @@
 
 	<!-- Rules: Check PHP version compatibility - see https://github.com/PHPCompatibility/PHPCompatibilityWP -->
 	<rule ref="PHPCompatibility"/>
-	<config name="testVersion" value="5.6-"/>
-	<config name="minimum_supported_wp_version" value="4.7"/>
+	<config name="testVersion" value="7.0-"/>
+	<config name="minimum_supported_wp_version" value="5.2"/>
 
 	<rule ref="WordPress">
         <exclude name="Generic.Functions.FunctionCallArgumentSpacing.TooMuchSpaceAfterComma"/>

--- a/tests/Fixtures/inc/Engine/Media/ImagesDimensions/AdminSubscriber/addOption.php
+++ b/tests/Fixtures/inc/Engine/Media/ImagesDimensions/AdminSubscriber/addOption.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+	'shouldReturnValidOptionsWithEmptyOptions' => [
+		'input' => [
+			'options' => [],
+		],
+		'expected' => [
+			'images_dimensions' => 0,
+		]
+	],
+	'shouldNotOverrideOtherOptions' => [
+		'input' => [
+			'options' => [
+				'test_option' => 1,
+			],
+		],
+		'expected' => [
+			'test_option'       => 1,
+			'images_dimensions' => 0,
+		]
+	],
+];

--- a/tests/Fixtures/inc/Engine/Media/ImagesDimensions/ImagesDimensions/addOption.php
+++ b/tests/Fixtures/inc/Engine/Media/ImagesDimensions/ImagesDimensions/addOption.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+	'shouldReturnValidOptionsWithEmptyOptions' => [
+		'input' => [
+			'options' => [],
+		],
+		'expected' => [
+			'images_dimensions' => 0,
+		]
+	],
+	'shouldNotOverrideOtherOptions' => [
+		'input' => [
+			'options' => [
+				'test_option' => 1,
+			],
+		],
+		'expected' => [
+			'test_option'       => 1,
+			'images_dimensions' => 0,
+		]
+	],
+];

--- a/tests/Fixtures/inc/admin/rocketFirstInstall.php
+++ b/tests/Fixtures/inc/admin/rocketFirstInstall.php
@@ -121,7 +121,8 @@ $integration[ 'delay_js_scripts' ] = [
 	'olark',
 	'pixel-caffeine/build/frontend.js',
 ];
-$integration[ 'preload_links' ]    = 1;
+$integration[ 'preload_links' ]     = 1;
+$integration[ 'images_dimensions' ] = 0;
 
 return [
 	'test_data' => [

--- a/tests/Integration/inc/Engine/Media/ImagesDimensions/AdminSubscriber/addOption.php
+++ b/tests/Integration/inc/Engine/Media/ImagesDimensions/AdminSubscriber/addOption.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\Media\ImagesDimensions\AdminSubscriber;
+
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Media\ImagesDimensions\AdminSubscriber::add_option
+ *
+ * @group  AdminOnly
+ * @group  ImagesDimensions
+ */
+class Test_AddOption extends TestCase {
+	public function setUp() {
+		parent::setUp();
+
+		$this->unregisterAllCallbacksExcept( 'rocket_first_install_options', 'add_option', 14 );
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+
+		$this->restoreWpFilter( 'rocket_first_install_options' );
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldDoExpectedForFirstInstallOptions( $input, $expected ) {
+		$options = isset( $input['options'] )  ? $input['options']  : [];
+
+		$this->assertSame(
+			$expected,
+			apply_filters( 'rocket_first_install_options', $options )
+		);
+
+	}
+}

--- a/tests/Unit/inc/Engine/Media/ImagesDimensions/ImagesDimensions/addOption.php
+++ b/tests/Unit/inc/Engine/Media/ImagesDimensions/ImagesDimensions/addOption.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\Media\ImagesDimensions\ImagesDimensions;
+
+use WP_Rocket\Engine\Media\ImagesDimensions\ImagesDimensions;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Media\ImagesDimensions\ImagesDimensions::add_option
+ *
+ * @group  ImagesDimensions
+ */
+class Test_AddOption extends TestCase{
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldDoExpected( $input, $expected ){
+		$options    = isset( $input['options'] )  ? $input['options']  : [];
+		$dimensions = new ImagesDimensions();
+
+		$this->assertSame(
+			$expected,
+			$dimensions->add_option( $options )
+		);
+	}
+}


### PR DESCRIPTION
Closes #3306 

- Add the new `images_dimensions` option to WP Rocket options array
- Add the new UI element to the media tab
- Instantiate, load and register the new classes into the plugin initialization process
- Add unit/integration tests