### PR TITLE
Comply with psr-4 autoload standard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,8 @@
 	"autoload": {
 		"classmap": [
 			"inc/classes",
-			"inc/vendors/classes"
+			"inc/vendors/classes",
+			"inc/deprecated"
 		],
 		"exclude-from-classmap": [
 			"inc/vendors/classes/class-rocket-mobile-detect.php",


### PR DESCRIPTION
Fixes #3182 

- [x] In `composer.json`, add to the `autoload/classmap` section the following `inc/deprecated`. This will let those classes be handled by the classmap manager instead of the PSR-4 manager in composer, and avoid the notice.
