### PR TITLE
Closes #3322 Exclude from lazyload: admin

### DIFF
--- a/inc/Engine/Admin/Settings/Page.php
+++ b/inc/Engine/Admin/Settings/Page.php
@@ -1027,6 +1027,18 @@ class Page {
 					// translators: %1$s = “WP Rocket”, %2$s = a list of plugin or themes names.
 					'description'       => ! empty( $disable_youtube_lazyload ) ? sprintf( __( 'Replace YouTube iframe with preview image is not compatible with %2$s.', 'rocket' ), WP_ROCKET_PLUGIN_NAME, $disable_youtube_lazyload ) : '',
 				],
+				'exclude_lazyload' => [
+					'container_class' => [
+						'wpr-Delayjs',
+					],
+					'type'            => 'textarea',
+					'label'           => __( 'Excluded images or iframes', 'rocket' ),
+					'description'     => __( 'Specify keywords (e.g. image filename, CSS class, domain) from the image or iframe code to be excluded (one per line).' ),
+					'section'         => 'lazyload_section',
+					'page'            => 'media',
+					'default'         => [],
+					'placeholder'     => 'example-image.jpg',
+				],
 				'embeds'           => [
 					'type'              => 'checkbox',
 					'label'             => __( 'Disable WordPress embeds', 'rocket' ),

--- a/inc/Engine/Media/Lazyload/AdminSubscriber.php
+++ b/inc/Engine/Media/Lazyload/AdminSubscriber.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace WP_Rocket\Engine\Media\Lazyload;
+
+use WP_Rocket\Event_Management\Subscriber_Interface;
+
+class AdminSubscriber implements Subscriber_Interface {
+	/**
+	 * Returns an array of events this listens to
+	 *
+	 * @return array
+	 */
+	public static function get_subscribed_events() : array {
+		return [
+			'rocket_first_install_options' => [ 'add_option', 15 ],
+			'rocket_sanitize_input'        => 'sanitize_exclude_lazyload',
+		];
+	}
+
+	/**
+	 * Adds the exclude lazyload option to WP Rocket options array
+	 *
+	 * @since 3.8
+	 *
+	 * @param array $options WP Rocket options array.
+	 * @return array
+	 */
+	public function add_option( array $options ) : array {
+		$options['exclude_lazyload'] = [];
+
+		return $options;
+	}
+
+	/**
+	 * Sanitizes the exclude lazyload input when saving the option
+	 *
+	 * @since 3.8
+	 *
+	 * @param array $input Input array.
+	 * @return array
+	 */
+	public function sanitize_exclude_lazyload( array $input ) : array {
+		if ( empty( $input['exclude_lazyload'] ) ) {
+			$input['exclude_lazyload'] = [];
+		}
+
+		$input['exclude_lazyload'] = rocket_sanitize_textarea_field( 'exclude_lazyload', $input['exclude_lazyload'] );
+
+		return $input;
+	}
+}

--- a/inc/Engine/Media/ServiceProvider.php
+++ b/inc/Engine/Media/ServiceProvider.php
@@ -24,6 +24,7 @@ class ServiceProvider extends AbstractServiceProvider {
 		'lazyload_image',
 		'lazyload_iframe',
 		'lazyload_subscriber',
+		'lazyload_admin_subscriber',
 		'embeds_subscriber',
 		'emojis_subscriber',
 	];
@@ -46,6 +47,7 @@ class ServiceProvider extends AbstractServiceProvider {
 			->withArgument( $this->getContainer()->get( 'lazyload_assets' ) )
 			->withArgument( $this->getContainer()->get( 'lazyload_image' ) )
 			->withArgument( $this->getContainer()->get( 'lazyload_iframe' ) );
+		$this->getContainer()->share( 'lazyload_admin_subscriber', 'WP_Rocket\Engine\Media\Lazyload\AdminSubscriber' );
 		$this->getContainer()->share( 'embeds_subscriber', 'WP_Rocket\Engine\Media\Embeds\EmbedsSubscriber' )
 			->withArgument( $options );
 		$this->getContainer()->share( 'emojis_subscriber', 'WP_Rocket\Engine\Media\Emojis\EmojisSubscriber' )

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -106,6 +106,7 @@ class Plugin {
 		$this->container->addServiceProvider( 'WP_Rocket\Engine\Cache\ServiceProvider' );
 		$this->container->addServiceProvider( 'WP_Rocket\Engine\CriticalPath\ServiceProvider' );
 		$this->container->addServiceProvider( 'WP_Rocket\Engine\HealthCheck\ServiceProvider' );
+		$this->container->addServiceProvider( 'WP_Rocket\Engine\Media\ServiceProvider' );
 		$this->container->addServiceProvider( 'WP_Rocket\Engine\Optimization\DeferJS\ServiceProvider' );
 
 		$this->is_valid_key = rocket_valid_key();
@@ -176,6 +177,7 @@ class Plugin {
 			'google_fonts_admin_subscriber',
 			'license_subscriber',
 			'defer_js_admin_subscriber',
+			'lazyload_admin_subscriber',
 		];
 	}
 
@@ -187,7 +189,6 @@ class Plugin {
 	 * @return array array of subscribers.
 	 */
 	private function init_valid_key_subscribers() {
-		$this->container->addServiceProvider( 'WP_Rocket\Engine\Media\ServiceProvider' );
 		$this->container->addServiceProvider( 'WP_Rocket\Engine\Optimization\ServiceProvider' );
 
 		$subscribers = [

--- a/inc/functions/formatting.php
+++ b/inc/functions/formatting.php
@@ -185,6 +185,7 @@ function rocket_sanitize_textarea_field( $field, $value ) {
 		'exclude_defer_js'     => [ 'rocket_validate_js', 'rocket_clean_wildcards' ], // Pattern.
 		'exclude_js'           => [ 'rocket_validate_js', 'rocket_clean_wildcards' ], // Pattern.
 		'delay_js_scripts'     => [ 'rocket_validate_js' ],
+		'exclude_lazyload'     => [ 'sanitize_text_field' ],
 	];
 
 	if ( ! isset( $fields[ $field ] ) ) {

--- a/tests/Fixtures/inc/Engine/Media/Lazyload/AdminSubscriber/addOption.php
+++ b/tests/Fixtures/inc/Engine/Media/Lazyload/AdminSubscriber/addOption.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+	'shouldReturnValidOptionsWithEmptyOptions' => [
+		'input' => [
+			'options' => [],
+		],
+		'expected' => [
+			'exclude_lazyload' => [],
+		]
+	],
+	'shouldNotOverrideOtherOptions' => [
+		'input' => [
+			'options' => [
+				'test_option' => 1,
+			],
+		],
+		'expected' => [
+			'test_option'       => 1,
+			'exclude_lazyload' => [],
+		]
+	],
+];

--- a/tests/Fixtures/inc/Engine/Media/Lazyload/AdminSubscriber/sanitizeExcludeLazyload.php
+++ b/tests/Fixtures/inc/Engine/Media/Lazyload/AdminSubscriber/sanitizeExcludeLazyload.php
@@ -1,0 +1,28 @@
+<?php
+
+return [
+	'shouldReturnInputWithEmptyExcludeLazyload' => [
+		'input' => [
+            'minify_css' => 0,
+        ],
+		'expected' => [
+            'minify_css'       => 0,
+			'exclude_lazyload' => [],
+		]
+	],
+	'shouldReturnInputWithSanitizedExcludeLazyload' => [
+		'input' => [
+            'minify_css'       => 0,
+			'exclude_lazyload' => "lazy\nexample.org\n/wp-content/plugins/test/test.jpg\ndata-image",
+		],
+		'expected' => [
+            'minify_css'       => 0,
+			'exclude_lazyload' => [
+                'lazy',
+                'example.org',
+                '/wp-content/plugins/test/test.jpg',
+                'data-image',
+            ],
+		]
+	],
+];

--- a/tests/Fixtures/inc/admin/rocketFirstInstall.php
+++ b/tests/Fixtures/inc/admin/rocketFirstInstall.php
@@ -123,6 +123,7 @@ $integration[ 'delay_js_scripts' ] = [
 	'pixel-caffeine/build/frontend.js',
 ];
 $integration[ 'preload_links' ]    = 1;
+$integration[ 'exclude_lazyload' ] = [];
 
 return [
 	'test_data' => [

--- a/tests/Integration/inc/Engine/Media/Lazyload/AdminSubscriber/addOption.php
+++ b/tests/Integration/inc/Engine/Media/Lazyload/AdminSubscriber/addOption.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\Media\Lazyload\AdminSubscriber;
+
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Media\Lazyload\AdminSubscriber::add_option
+ *
+ * @group  AdminOnly
+ * @group  Lazyload
+ */
+class Test_AddOption extends TestCase {
+	public function setUp() {
+		parent::setUp();
+
+		$this->unregisterAllCallbacksExcept( 'rocket_first_install_options', 'add_option', 15 );
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+
+		$this->restoreWpFilter( 'rocket_first_install_options' );
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldDoExpectedForFirstInstallOptions( $input, $expected ) {
+		$options = isset( $input['options'] )  ? $input['options']  : [];
+
+		$this->assertSame(
+			$expected,
+			apply_filters( 'rocket_first_install_options', $options )
+		);
+
+	}
+}

--- a/tests/Integration/inc/Engine/Media/Lazyload/AdminSubscriber/sanitizeExcludeLazyload.php
+++ b/tests/Integration/inc/Engine/Media/Lazyload/AdminSubscriber/sanitizeExcludeLazyload.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\Media\Lazyload\AdminSubscriber;
+
+use WP_Rocket\Engine\Media\Lazyload\AdminSubscriber;
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Media\Lazyload\AdminSubscriber::sanitize_exclude_lazyload
+ *
+ * @group AdminOnly
+ * @group Media
+ * @group Lazyload
+ */
+class Test_SanitizeExcludeLazyload extends TestCase {
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnExpected( $input, $expected ) {
+		$this->assertSame(
+			$expected,
+			apply_filters( 'rocket_sanitize_input', $input )
+		);
+	}
+}

--- a/tests/Unit/inc/Engine/Media/Lazyload/AdminSubscriber/addOption.php
+++ b/tests/Unit/inc/Engine/Media/Lazyload/AdminSubscriber/addOption.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\Media\Lazyload\AdminSubscriber;
+
+use WP_Rocket\Engine\Media\Lazyload\AdminSubscriber;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Media\Lazyload\AdminSubscriber::add_option
+ *
+ * @group Media
+ * @group Lazyload
+ */
+class Test_AddOption extends TestCase {
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnExpected( $input, $expected ) {
+		$options    = isset( $input['options'] )  ? $input['options']  : [];
+		$subscriber = new AdminSubscriber();
+
+		$this->assertSame(
+			$expected,
+			$subscriber->add_option( $options )
+		);
+	}
+}


### PR DESCRIPTION
Closes #3322 

- Add the `Lazyload\AdminSubscriber class`
- Register and load it in the service provider and the main plugin file
- Add the UI field on the settings page
- Add tests