### PR TITLE
Fixes #3323 High CPU usage when combining CSS

### DIFF
--- a/inc/Engine/Optimization/Minify/CSS/Combine.php
+++ b/inc/Engine/Optimization/Minify/CSS/Combine.php
@@ -276,7 +276,7 @@ class Combine extends AbstractCSSOptimization implements ProcessorInterface {
 	 * @return string
 	 */
 	private function get_content( $combined_file ) {
-		$content = '';
+		$minifier = new MinifyCSS();
 
 		foreach ( $this->styles as $key => $style ) {
 			if ( 'internal' === $style['type'] ) {
@@ -294,29 +294,15 @@ class Combine extends AbstractCSSOptimization implements ProcessorInterface {
 				continue;
 			}
 
-			$content .= $file_content;
+			$minifier->add( $file_content );
 		}
 
-		$content = $this->minify( $content );
+		$content = $minifier->minify();
 
 		if ( empty( $content ) ) {
 			Logger::debug( 'No CSS content.', [ 'css combine process' ] );
 		}
 
 		return $content;
-	}
-
-	/**
-	 * Minifies the content
-	 *
-	 * @since 3.1
-	 *
-	 * @param string $content Content to minify.
-	 * @return string
-	 */
-	protected function minify( $content ) {
-		$minifier = new MinifyCSS( $content );
-
-		return $minifier->minify();
 	}
 }

--- a/tests/Fixtures/inc/Engine/License/API/UserClient/getUserData.php
+++ b/tests/Fixtures/inc/Engine/License/API/UserClient/getUserData.php
@@ -37,15 +37,5 @@ return [
 		],
 		'expected' => $data,
 	],
-	'testShouldReturnDataWhenSuccess'  => [
-		'config'   => [
-			'transient' => false,
-			'response'  => [
-				'code' => 200,
-				'body' => $json,
-			],
-		],
-		'expected' => $data,
-	],
 ];
 


### PR DESCRIPTION
Fixes #3323 

Changes the way the content is passed to the minify library: instead of passing the whole content at once, add it in smaller data chunk, and let the library handle combining.

This should prevent the high CPU usage reported in the issue, as the library's regex will process smaller data chunks instead of one big.