### PR TITLE
Closes #3318 - GF-API2 Modify process() to use both Combine classes (3/4)

### DIFF
--- a/inc/Engine/Optimization/GoogleFonts/AbstractGFOptimization.php
+++ b/inc/Engine/Optimization/GoogleFonts/AbstractGFOptimization.php
@@ -48,8 +48,7 @@ abstract class AbstractGFOptimization extends AbstractOptimization {
 
 		$display     = $this->get_font_display_value();
 		$parsed_font = wp_parse_args( $query );
-
-		$font_url = ! empty( $parsed_font['display'] )
+		$font_url    = ! empty( $parsed_font['display'] )
 			? str_replace( "&display={$parsed_font['display']}", "&display={$display}", $font_url )
 			: "{$font_url}&display={$display}";
 

--- a/inc/Engine/Optimization/GoogleFonts/CombineV2.php
+++ b/inc/Engine/Optimization/GoogleFonts/CombineV2.php
@@ -119,7 +119,7 @@ class CombineV2 extends AbstractGFOptimization {
 
 		$url_pattern     = '#^(family=[A-Za-z0-9;:,=%&\+\@\.]+)$#';
 		$display_pattern = '#&display=(?:swap|auto|block|fallback|optional)#';
-		$decoded_url     = html_entity_decode( $tag['url'] ); //return $decoded_url;
+		$decoded_url     = html_entity_decode( $tag['url'] );
 		$query           = wp_parse_url( $decoded_url, PHP_URL_QUERY );
 
 		if ( empty( $query ) ) {

--- a/inc/Engine/Optimization/GoogleFonts/Subscriber.php
+++ b/inc/Engine/Optimization/GoogleFonts/Subscriber.php
@@ -34,9 +34,9 @@ class Subscriber implements Subscriber_Interface {
 	/**
 	 * Instantiate the subscriber.
 	 *
-	 * @param AbstractGFOptimization      $combine Combine instance.
+	 * @param AbstractGFOptimization $combine Combine instance.
 	 * @param AbstractGFOptimization $combine_v2 Combine V2 instance.
-	 * @param Options_Data $options Options_Data instance.
+	 * @param Options_Data           $options Options_Data instance.
 	 */
 	public function __construct( AbstractGFOptimization $combine, AbstractGFOptimization $combine_v2, Options_Data $options ) {
 		$this->combine    = $combine;
@@ -85,7 +85,8 @@ class Subscriber implements Subscriber_Interface {
 	}
 
 	/**
-	 * Processes the HTML to combine found Google fonts
+	 * Processes the HTML to combine found Google fonts.
+	 * Handles both Google Fonts API v2 and v1.
 	 *
 	 * @since 3.1
 	 *
@@ -97,8 +98,9 @@ class Subscriber implements Subscriber_Interface {
 			return $html;
 		}
 
-		// Todo: Integrate both combine processes, maybe with html comment, here
-		// $html = $this->combine_v2->optimize( $html );
+		// Combine Google Font API V2.
+		$html = $this->combine_v2->optimize( $html );
+		// Combine Google Font API V1.
 		return $this->combine->optimize( $html );
 	}
 


### PR DESCRIPTION
Closes https://github.com/wp-media/wp-rocket/issues/3318

Subtask of https://github.com/wp-media/wp-rocket/issues/3264.

- [x] Modify `Optimization\GoogleFonts\Subscriber::process() to run both optimizations and add html comment when both return a tag.
~- [ ] Modify original Combine class to prevent it's processing API2 tags.~ (Done in Part 2)


