### PR TITLE
Fixes fragile tests related to the license and pricing API

### DIFF
--- a/tests/Fixtures/inc/Engine/License/API/UserClient/getUserData.php
+++ b/tests/Fixtures/inc/Engine/License/API/UserClient/getUserData.php
@@ -37,5 +37,15 @@ return [
 		],
 		'expected' => $data,
 	],
+	'testShouldReturnDataWhenSuccess'  => [
+		'config'   => [
+			'transient' => false,
+			'response'  => [
+				'code' => 200,
+				'body' => $json,
+			],
+		],
+		'expected' => $data,
+	],
 ];
 

--- a/tests/Integration/inc/Engine/License/API/PricingClient/getPricingData.php
+++ b/tests/Integration/inc/Engine/License/API/PricingClient/getPricingData.php
@@ -43,22 +43,20 @@ class GetPricingData extends TestCase {
 			->once()
 			->with( PricingClient::PRICING_ENDPOINT )
 			->andReturn( $config['response'] );
-		}
 
-		$this->assertEquals(
-			$expected,
-			$client->get_pricing_data()
-		);
-
-		if (
-			false === $config['transient']
-			&&
-			false !== $expected
-		) {
+			$this->assertFalse( $client->get_pricing_data() );
+		} else {
 			$this->assertEquals(
-				$expected,
-				get_transient( 'wp_rocket_pricing' )
+				array_keys( (array) $expected ),
+				array_keys( (array) $client->get_pricing_data() )
 			);
+
+			if ( false === $config['transient'] ) {
+				$this->assertEquals(
+					array_keys( (array) $expected ),
+					array_keys( (array) get_transient( 'wp_rocket_pricing' ) )
+				);
+			}
 		}
 	}
 }

--- a/tests/Integration/inc/Engine/License/API/UserClient/getUserData.php
+++ b/tests/Integration/inc/Engine/License/API/UserClient/getUserData.php
@@ -62,22 +62,20 @@ class GetUserData extends TestCase {
 				]
 			)
 			->andReturn( $config['response'] );
-		}
 
-		$this->assertEquals(
-			$expected,
-			self::$client->get_user_data()
-		);
-
-		if (
-			false === $config['transient']
-			&&
-			false !== $expected
-		) {
+			$this->assertFalse( self::$client->get_user_data() );
+		} else {
 			$this->assertEquals(
-				$expected,
-				get_transient( 'wp_rocket_customer_data' )
+				array_keys( (array) $expected ),
+				array_keys( (array) self::$client->get_user_data() )
 			);
+
+			if ( false === $config['transient'] ) {
+				$this->assertEquals(
+					array_keys( (array) $expected ),
+					array_keys( (array) get_transient( 'wp_rocket_customer_data' ) )
+				);
+			}
 		}
 	}
 


### PR DESCRIPTION
Those tests were failing any time the API responses change, because the values are different.

To fix it, We only check for the response keys instead of the full response.