### PR TITLE
Remove referer check from support REST endpoint

### DIFF
--- a/inc/Engine/Support/Rest.php
+++ b/inc/Engine/Support/Rest.php
@@ -69,18 +69,6 @@ class Rest {
 	 * @return WP_REST_Response
 	 */
 	public function get_support_data() {
-		if ( false === strpos( wp_get_raw_referer(), 'wp-rocket.me' ) ) {
-			return rest_ensure_response(
-				[
-					'code'    => 'rest_invalid_referer',
-					'message' => 'Invalid referer',
-					'data'    => [
-						'status' => 400,
-					],
-				]
-			);
-		}
-
 		return rest_ensure_response(
 			[
 				'code'    => 'rest_support_data_success',

--- a/tests/Fixtures/inc/Engine/Support/Rest/getSupportData.php
+++ b/tests/Fixtures/inc/Engine/Support/Rest/getSupportData.php
@@ -1,25 +1,6 @@
 <?php
 
 return [
-	'testShouldReturnEmptyArrayWhenWrongReferer' => [
-		'support_data' => [
-			'Website'                  => 'http://example.org',
-			'WordPress Version'        => '5.5',
-			'WP Rocket Version'        => '3.7.5',
-			'Theme'                    => 'WordPress Default',
-			'Plugins Enabled'          => 'Hello Dolly',
-			'WP Rocket Active Options' => 'Mobile Cache - Disable Emojis - Defer JS Safe - Combine Google Fonts - Preload',
-		],
-		'referer' => 'http://google.com',
-		'expected' => [
-			'code'    => 'rest_invalid_referer',
-			'message' => 'Invalid referer',
-			'data'    => [
-				'status' => 400,
-			],
-		],
-	],
-
 	'testShouldReturnSupportArrayWhenCorrectReferer' => [
 		'support_data' => [
 			'Website'                  => 'http://example.org',
@@ -29,7 +10,6 @@ return [
 			'Plugins Enabled'          => 'Hello Dolly',
 			'WP Rocket Active Options' => 'Mobile Cache - Disable Emojis - Defer JS Safe - Combine Google Fonts - Preload',
 		],
-		'referer' => 'https://wp-rocket.me',
 		'expected' => [
 			'code'    => 'rest_support_data_success',
 			'message' => 'Support data request successful',

--- a/tests/Fixtures/inc/Engine/Support/Subscriber/registerSupportRoute.php
+++ b/tests/Fixtures/inc/Engine/Support/Subscriber/registerSupportRoute.php
@@ -6,7 +6,6 @@ return [
 			'key'   => false,
 			'email' => false,
 		],
-		'referer'  => 'https://wp-rocket.me',
 		'expected' => [
 			'code' => 'rest_invalid_param',
 			'message' => 'Invalid parameter(s): email, key',
@@ -24,7 +23,6 @@ return [
 			'key'   => false,
 			'email' => true,
 		],
-		'referer'  => 'https://wp-rocket.me',
 		'expected' => [
 			'code' => 'rest_invalid_param',
 			'message' => 'Invalid parameter(s): key',
@@ -41,7 +39,6 @@ return [
 			'key'   => true,
 			'email' => false,
 		],
-		'referer'  => 'https://wp-rocket.me',
 		'expected' => [
 			'code' => 'rest_invalid_param',
 			'message' => 'Invalid parameter(s): email',
@@ -53,26 +50,11 @@ return [
 			],
 		],
 	],
-	'testShouldReturnEmptyDataWhenWrongReferer' => [
-		'params'   => [
-			'key'   => true,
-			'email' => true,
-		],
-		'referer'  => 'https://google.com',
-		'expected' => [
-			'code'    => 'rest_invalid_referer',
-			'message' => 'Invalid referer',
-			'data'    => [
-				'status' => 400,
-			],
-		],
-	],
 	'testShouldReturnSupportDataWhenValid' => [
 		'params'   => [
 			'key'   => true,
 			'email' => true,
 		],
-		'referer'  => 'https://wp-rocket.me',
 		'expected' => [
 			'code'    => 'rest_support_data_success',
 			'message' => 'Support data request successful',

--- a/tests/Integration/inc/Engine/Support/Subscriber/registerSupportRoute.php
+++ b/tests/Integration/inc/Engine/Support/Subscriber/registerSupportRoute.php
@@ -63,13 +63,11 @@ class Test_RegisterSupportRoute extends WPMediaRESTfulTestCase {
 	/**
 	 * @dataProvider configTestData
 	 */
-	public function testShouldReturnExpected( $params, $referer, $expected ) {
+	public function testShouldReturnExpected( $params, $expected ) {
 		global $wp_version;
 
 		$this->rocket_version = '3.7.5';
-
-		$wp_version              = '5.5';
-		$_SERVER['HTTP_REFERER'] = $referer;
+		$wp_version           = '5.5';
 
 		$body = [
 			'email' => $params['email'] ? self::getApiCredential( 'ROCKET_EMAIL' ) : '',

--- a/tests/Unit/inc/Engine/Support/Rest/getSupportData.php
+++ b/tests/Unit/inc/Engine/Support/Rest/getSupportData.php
@@ -18,7 +18,7 @@ class Test_GetSupportData extends TestCase {
 	/**
 	 * @dataProvider configTestData
 	 */
-	public function testShouldReturnExpected( $support_data, $referer, $expected ) {
+	public function testShouldReturnExpected( $support_data, $expected ) {
 		$data = Mockery::mock( Data::class );
 		$rest = new Rest( $data, Mockery::mock( Options_Data::class ) );
 
@@ -26,9 +26,6 @@ class Test_GetSupportData extends TestCase {
 			->atMost()
 			->once()
 			->andReturn( $support_data );
-
-		Functions\when( 'wp_get_raw_referer' )
-			->justReturn( $referer );
 
 		Functions\expect( 'rest_ensure_response' )
 			->once()


### PR DESCRIPTION
The referer check is too unreliable to be used there. We already use the consumer key and email to validate the request, and no sensitive data are sent back, so it's an acceptable trade-off to remove it.