### PR TITLE
Exclude JS files for 3D FlipBook – PDF Flipbook Viewer, Flipbook Imag…

### DIFF
--- a/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
+++ b/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
@@ -268,6 +268,10 @@ abstract class AbstractJSOptimization extends AbstractOptimization {
 			'loader.knack.com',
 			'embed.lpcontent.net/leadboxes/current/embed.js',
 			'cc.cdn.civiccomputing.com/9/cookieControl-9.x.min.js',
+			'/wp-content/plugins/interactive-3d-flipbook-powered-physics-engine/assets/js/html2canvas.min.js',
+			'/wp-content/plugins/interactive-3d-flipbook-powered-physics-engine/assets/js/pdf.min.js',
+			'/wp-content/plugins/interactive-3d-flipbook-powered-physics-engine/assets/js/three.min.js',
+			'/wp-content/plugins/interactive-3d-flipbook-powered-physics-engine/assets/js/3d-flip-book.min.js',
 		];
 
 		$excluded_external = array_merge( $defaults, $this->options->get( 'exclude_js', [] ) );


### PR DESCRIPTION
Exclude JavaScript files for the following plugin to work properly:
[3D FlipBook – PDF Flipbook Viewer, Flipbook Image Gallery](https://wordpress.org/plugins/interactive-3d-flipbook-powered-physics-engine/)

**Related ticket:** https://secure.helpscout.net/conversation/1340530176/212865/