### PR TITLE
Add nonce action for WooCommerce Additional Variation Images

### DIFF
--- a/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber.php
+++ b/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber.php
@@ -478,6 +478,7 @@ class WooCommerceSubscriber implements Event_Manager_Aware_Subscriber_Interface 
 			'filter-nonce', // Rehub theme filter.
 			'log-out', // WordPress's log-out action (wp_nonce_ays() function).
 			'ybws123456', // Custom Bookly form.
+			'_wc_additional_variation_images_nonce', // WooCommerce Additional Variation Images.
 		];
 	}
 }


### PR DESCRIPTION
**Related ticket:** https://secure.helpscout.net/conversation/1335093437/210973?folderId=273766

It's for the following plugin: [WooCommerce Additional Variation Images](https://woocommerce.com/products/woocommerce-additional-variation-images/)