### PR TITLE
Update the pattern used for jQuery exclusion from defer

### DIFF
--- a/inc/Engine/Admin/Beacon/Beacon.php
+++ b/inc/Engine/Admin/Beacon/Beacon.php
@@ -635,7 +635,7 @@ class Beacon extends Abstract_Render implements Subscriber_Interface {
 			],
 			'exclude_lazyload'           => [
 				'en' => [
-					'id' => '5418c792e4b0e7b8127bed99',
+					'id'  => '5418c792e4b0e7b8127bed99',
 					'url' => 'https://docs.wp-rocket.me/article/15-disabling-lazy-load-on-specific-images/?utm_source=wp_plugin&utm_medium=wp_rocket',
 				],
 			],

--- a/inc/Engine/Admin/Settings/Page.php
+++ b/inc/Engine/Admin/Settings/Page.php
@@ -1024,7 +1024,7 @@ class Page {
 						'disabled' => ! empty( $disable_youtube_lazyload ) ? 1 : 0,
 					],
 				],
-				'exclude_lazyload'  => [
+				'exclude_lazyload' => [
 					'container_class' => [
 						'wpr-Delayjs',
 					],

--- a/inc/Engine/Optimization/DeferJS/DeferJS.php
+++ b/inc/Engine/Optimization/DeferJS/DeferJS.php
@@ -234,7 +234,7 @@ class DeferJS {
 			return $excluded_files;
 		}
 
-		$excluded_files[] = 'jquery-?[0-9.]*(.min|.slim|.slim.min)?.js';
+		$excluded_files[] = '/jquery-?[0-9.]*(.min|.slim|.slim.min)?.js';
 
 		return $excluded_files;
 	}
@@ -257,7 +257,7 @@ class DeferJS {
 			return;
 		}
 
-		$options['exclude_defer_js'][] = 'jquery-?[0-9.]*(.min|.slim|.slim.min)?.js';
+		$options['exclude_defer_js'][] = '/jquery-?[0-9.]*(.min|.slim|.slim.min)?.js';
 
 		update_option( 'wp_rocket_settings', $options );
 	}

--- a/inc/Engine/Optimization/DeferJS/DeferJS.php
+++ b/inc/Engine/Optimization/DeferJS/DeferJS.php
@@ -234,7 +234,7 @@ class DeferJS {
 			return $excluded_files;
 		}
 
-		$excluded_files[] = '/jquery-*[0-9.]*(.min|.slim|.slim.min)*([^\.]*).js';
+		$excluded_files[] = 'jquery-?[0-9.]*(.min|.slim|.slim.min)?.js';
 
 		return $excluded_files;
 	}
@@ -257,7 +257,7 @@ class DeferJS {
 			return;
 		}
 
-		$options['exclude_defer_js'][] = '/jquery-*[0-9.]*(.min|.slim|.slim.min)*([^\.]*).js';
+		$options['exclude_defer_js'][] = 'jquery-?[0-9.]*(.min|.slim|.slim.min)?.js';
 
 		update_option( 'wp_rocket_settings', $options );
 	}

--- a/tests/Fixtures/inc/Engine/Optimization/DeferJS/AdminSubscriber/excludeJqueryDefer.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DeferJS/AdminSubscriber/excludeJqueryDefer.php
@@ -33,7 +33,7 @@ return [
 		'expected' => [
 			'defer_all_js_safe' => 1,
 			'exclude_defer_js'  => [
-				'/jquery-*[0-9.]*(.min|.slim|.slim.min)*([^\.]*).js',
+				'jquery-?[0-9.]*(.min|.slim|.slim.min)?.js',
 			],
 		],
 	],

--- a/tests/Fixtures/inc/Engine/Optimization/DeferJS/AdminSubscriber/excludeJqueryDefer.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DeferJS/AdminSubscriber/excludeJqueryDefer.php
@@ -33,7 +33,7 @@ return [
 		'expected' => [
 			'defer_all_js_safe' => 1,
 			'exclude_defer_js'  => [
-				'jquery-?[0-9.]*(.min|.slim|.slim.min)?.js',
+				'/jquery-?[0-9.]*(.min|.slim|.slim.min)?.js',
 			],
 		],
 	],

--- a/tests/Fixtures/inc/Engine/Optimization/DeferJS/DeferJS/excludeJqueryCombine.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DeferJS/DeferJS/excludeJqueryCombine.php
@@ -60,7 +60,7 @@ return [
 		],
 		'excluded' => [],
 		'expected' => [
-			'/jquery-*[0-9.]*(.min|.slim|.slim.min)*([^\.]*).js',
+			'jquery-?[0-9.]*(.min|.slim|.slim.min)?.js',
 		],
 	],
 ];

--- a/tests/Fixtures/inc/Engine/Optimization/DeferJS/DeferJS/excludeJqueryCombine.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DeferJS/DeferJS/excludeJqueryCombine.php
@@ -60,7 +60,7 @@ return [
 		],
 		'excluded' => [],
 		'expected' => [
-			'jquery-?[0-9.]*(.min|.slim|.slim.min)?.js',
+			'/jquery-?[0-9.]*(.min|.slim|.slim.min)?.js',
 		],
 	],
 ];

--- a/tests/Fixtures/inc/Engine/Optimization/DeferJS/DeferJS/excludeJqueryUpgrade.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DeferJS/DeferJS/excludeJqueryUpgrade.php
@@ -18,7 +18,7 @@ return [
         'expected' => [
             'defer_all_js_safe' => 1,
             'exclude_defer_js'  => [
-                'jquery-?[0-9.]*(.min|.slim|.slim.min)?.js',
+                '/jquery-?[0-9.]*(.min|.slim|.slim.min)?.js',
             ],
         ],
     ],

--- a/tests/Fixtures/inc/Engine/Optimization/DeferJS/DeferJS/excludeJqueryUpgrade.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DeferJS/DeferJS/excludeJqueryUpgrade.php
@@ -18,7 +18,7 @@ return [
         'expected' => [
             'defer_all_js_safe' => 1,
             'exclude_defer_js'  => [
-                '/jquery-*[0-9.]*(.min|.slim|.slim.min)*([^\.]*).js',
+                'jquery-?[0-9.]*(.min|.slim|.slim.min)?.js',
             ],
         ],
     ],

--- a/tests/Fixtures/inc/Engine/Optimization/DeferJS/Subscriber/excludeJqueryCombine.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DeferJS/Subscriber/excludeJqueryCombine.php
@@ -60,7 +60,7 @@ return [
 		],
 		'excluded' => [],
 		'expected' => [
-			'/jquery-*[0-9.]*(.min|.slim|.slim.min)*([^\.]*).js',
+			'jquery-?[0-9.]*(.min|.slim|.slim.min)?.js',
 		],
 	],
 ];

--- a/tests/Fixtures/inc/Engine/Optimization/DeferJS/Subscriber/excludeJqueryCombine.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DeferJS/Subscriber/excludeJqueryCombine.php
@@ -60,7 +60,7 @@ return [
 		],
 		'excluded' => [],
 		'expected' => [
-			'jquery-?[0-9.]*(.min|.slim|.slim.min)?.js',
+			'/jquery-?[0-9.]*(.min|.slim|.slim.min)?.js',
 		],
 	],
 ];

--- a/wp-rocket.php
+++ b/wp-rocket.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Rocket
  * Plugin URI: https://wp-rocket.me
  * Description: The best WordPress performance plugin.
- * Version: 3.8
+ * Version: 3.8.0.1
  * Requires at least: 5.2
  * Requires PHP: 7.0
  * Code Name: Naboo
@@ -20,7 +20,7 @@
 defined( 'ABSPATH' ) || exit;
 
 // Rocket defines.
-define( 'WP_ROCKET_VERSION',               '3.8' );
+define( 'WP_ROCKET_VERSION',               '3.8.0.1' );
 define( 'WP_ROCKET_WP_VERSION',            '5.2' );
 define( 'WP_ROCKET_WP_VERSION_TESTED',     '5.5.1' );
 define( 'WP_ROCKET_PHP_VERSION',           '7.0' );


### PR DESCRIPTION
The previous pattern could be matching unexpected files.

This new pattern has been tested against the jQuery URLs we were previously excluding, and also some of the unexpected URLs that were matching. See https://regex101.com/r/nQMi70/3