### PR TITLE
Fix wp version tests

### DIFF
--- a/.github/workflows/test_wprocket.yml
+++ b/.github/workflows/test_wprocket.yml
@@ -69,7 +69,7 @@ jobs:
       run: composer install --prefer-dist --no-interaction --no-scripts
 
     - name: Install tests
-      run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1:3306 $WP_VERSION
+      run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1:3306 ${{ matrix.wp-versions }}
 
     - name: Test
       run: composer run-tests

--- a/.github/workflows/test_wprocket_legacy.yml
+++ b/.github/workflows/test_wprocket_legacy.yml
@@ -73,7 +73,7 @@ jobs:
       run: composer install --prefer-dist --no-interaction --no-scripts
 
     - name: Install tests
-      run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1:3306 $WP_VERSION
+      run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1:3306 ${{ matrix.wp-versions }}
 
     - name: Test
       run: composer run-tests


### PR DESCRIPTION
Fix the WP version in our automated tests to correctly use the version defined in the configuration