### PR TITLE
Start RocketCDN instead of Get RocketCDN

### DIFF
--- a/inc/Engine/CDN/RocketCDN/views/dashboard-status.php
+++ b/inc/Engine/CDN/RocketCDN/views/dashboard-status.php
@@ -29,7 +29,7 @@
 		</div>
 		<?php if ( ! $data['is_active'] ) : ?>
 		<div>
-			<a href="#page_cdn" class="wpr-button"><?php esc_html_e( 'Get RocketCDN', 'rocket' ); ?></a>
+			<a href="#page_cdn" class="wpr-button"><?php esc_html_e( 'Start RocketCDN', 'rocket' ); ?></a>
 		</div>
 		<?php endif; ?>
 	</div>


### PR DESCRIPTION
Since we fixed the token issue https://github.com/wp-media/wp-rocket/pull/3331, customer just have to relaunch the process to make it works again. Changing this string won’t prevent new users to subscribe and will indicate to existing customers that they can re-start RocketCDN from here