### PR TITLE
Fix/set proper non grandfathered create date

### DIFF
--- a/inc/Engine/License/API/User.php
+++ b/inc/Engine/License/API/User.php
@@ -61,10 +61,12 @@ class User {
 	 */
 	public function get_creation_date() {
 		if ( ! isset( $this->user->date_created ) ) {
-			return 0;
+			return time();
 		}
 
-		return (int) $this->user->date_created;
+		return (int) $this->user->date_created > 0
+			? (int) $this->user->date_created
+			: time();
 	}
 
 	/**

--- a/tests/Fixtures/inc/Engine/License/API/User/getCreationDate.php
+++ b/tests/Fixtures/inc/Engine/License/API/User/getCreationDate.php
@@ -1,15 +1,22 @@
 <?php
 
 return [
-	'testShouldReturnZeroWhenNotObject' => [
+	'testShouldReturnCurrentTimeWhenNotObject' => [
 		'data'     => [],
-		'expected' => 0,
+		'expected' => time(),
 	],
-	'testShouldReturnZeroWhenPropertyNotSet' => [
+	'testShouldReturnCurrentTimeWhenPropertyNotSet' => [
 		'data'     => json_decode( json_encode( [
 			'ID' => 1,
 		] ) ),
-		'expected' => 0,
+		'expected' => time(),
+	],
+	'testShouldReturnCurrentTimeWhenPropertyZero' => [
+		'data' => json_decode( json_encode( [
+			'ID' => 1,
+			'date_created' => 0,
+		] ) ),
+		'expected' => time(),
 	],
 	'testShouldReturnValueWhenPropertySet' => [
 		'data'     => json_decode( json_encode( [

--- a/tests/Unit/inc/Engine/License/API/User/getCreationDate.php
+++ b/tests/Unit/inc/Engine/License/API/User/getCreationDate.php
@@ -8,7 +8,7 @@ use WP_Rocket\Tests\Unit\TestCase;
 /**
  * @covers \WP_Rocket\Engine\License\API\User::get_creation_date
  *
- * @group License
+ * @group  License
  */
 class GetCreationDate extends TestCase {
 	/**
@@ -16,10 +16,8 @@ class GetCreationDate extends TestCase {
 	 */
 	public function testShouldReturnExpected( $data, $expected ) {
 		$user = new User( $data );
+		$time_match = $expected - $user->get_creation_date();
 
-		$this->assertEquals(
-			$expected,
-			$user->get_creation_date()
-		);
+		$this->assertLessThan( 2, $time_match );
 	}
 }


### PR DESCRIPTION
Fixes #3388 

- Checks for both unset create_date and `0` create_date, returning current `time()` in either case instead of `0`.
- Updates unit test and fixtures for `Engine/Licence/API/User::get_creation_date()`
