### PR TITLE
Support custom filesystem implementations

### DIFF
--- a/inc/classes/Buffer/class-cache.php
+++ b/inc/classes/Buffer/class-cache.php
@@ -187,7 +187,7 @@ class Cache extends Abstract_Buffer {
 		}
 
 		// Serve the cache if file isn't store in the client browser cache.
-		readfile( $cache_filepath );
+		$this->fs->readfile( $cache_filepath );
 
 		$this->log(
 			'Serving cache file.',
@@ -231,7 +231,7 @@ class Cache extends Abstract_Buffer {
 		}
 
 		// Serve the cache if file isn't store in the client browser cache.
-		readgzfile( $cache_filepath );
+		$this->fs->readgzfile( $cache_filepath );
 
 		$this->log(
 			'Serving gzip cache file.',

--- a/inc/classes/Buffer/class-cache.php
+++ b/inc/classes/Buffer/class-cache.php
@@ -171,6 +171,8 @@ class Cache extends Abstract_Buffer {
 		require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-base.php';
 		require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-direct.php';
 
+		// TODO: load storage implementation based on config/constant
+
 		return new FilesystemDirect(
 			new WP_Filesystem_Direct( null )
 		);

--- a/inc/classes/Buffer/class-cache.php
+++ b/inc/classes/Buffer/class-cache.php
@@ -1,6 +1,9 @@
 <?php
 namespace WP_Rocket\Buffer;
 
+use WP_Filesystem_Direct;
+use WP_Rocket\Storage\FilesystemDirect;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -86,7 +89,7 @@ class Cache extends Abstract_Buffer {
 			return;
 		}
 
-		$this->storage = rocket_direct_filesystem();
+		$this->storage = $this->init_storage();
 
 		/**
 		 * Serve the cache file if it exists.
@@ -154,6 +157,23 @@ class Cache extends Abstract_Buffer {
 		);
 
 		ob_start( [ $this, 'maybe_process_buffer' ] );
+	}
+
+	/**
+	 * Instanciate the filesystem class.
+	 *
+	 * @since  3.9
+	 */
+	public function init_storage() {
+		require_once __DIR__ . '/../Storage/class-abstract-storage.php';
+		require_once __DIR__ . '/../Storage/class-filesystem-direct.php';
+
+		require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-base.php';
+		require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-direct.php';
+
+		return new FilesystemDirect(
+			new WP_Filesystem_Direct( null )
+		);
 	}
 
 	/**

--- a/inc/classes/Storage/class-abstract-storage.php
+++ b/inc/classes/Storage/class-abstract-storage.php
@@ -1,0 +1,50 @@
+<?php
+namespace WP_Rocket\Storage;
+
+use WP_Filesystem_Base;
+
+/**
+ * Abstract storage implementation.
+ *
+ * @since  3.9
+ */
+abstract class Abstract_Storage {
+
+	/**
+	 * The filesystem implementation.
+	 *
+	 * @var    WP_Filesystem_Base
+	 * @since  3.9
+	 */
+	private $fs;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since  3.9
+	 */
+	final public function __construct( WP_Filesystem_Base $fs ) {
+		$this->fs = $fs;
+	}
+
+	/**
+	 * Outputs a file.
+	 *
+	 * @since  3.9
+	 */
+	abstract public function readfile( $filename, $use_include_path = false, $context = null );
+
+	/**
+	 * Output a gz-file.
+	 *
+	 * @since  3.9
+	 */
+	abstract public function readgzfile( $filename, $use_include_path = 0 );
+
+	/**
+	 * Proxy calls to `$fs` implementation.
+	 */
+	public function __call( $name, $arguments) {
+		return $this->fs->{$name}(...$arguments);
+	}
+}

--- a/inc/classes/Storage/class-filesystem-direct.php
+++ b/inc/classes/Storage/class-filesystem-direct.php
@@ -1,0 +1,28 @@
+<?php
+namespace WP_Rocket\Storage;
+
+/**
+ * Handle page cache.
+ *
+ * @since  3.9
+ */
+class FilesystemDirect extends Abstract_Storage {
+
+	/**
+	 * Outputs a file.
+	 *
+	 * @since  3.9
+	 */
+	public function readfile( $filename, $use_include_path = false, $context = null ) {
+		return readfile( $filename, $use_include_path, $context );
+	}
+
+	/**
+	 * Output a gz-file.
+	 *
+	 * @since  3.9
+	 */
+	public function readgzfile( $filename, $use_include_path = 0 ) {
+		return readgzfile( $filename, $use_include_path );
+	}
+}

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -1064,6 +1064,8 @@ function rocket_direct_filesystem() {
 	require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-base.php';
 	require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-direct.php';
 
+	// TODO: load storage implementation based on config/constant
+
 	return new FilesystemDirect(
 		new WP_Filesystem_Direct( null )
 	);

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -1059,6 +1059,9 @@ function rocket_rrmdir( $dir, array $dirs_to_preserve = [], $filesystem = null )
 function rocket_direct_filesystem() {
 	require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-base.php';
 	require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-direct.php';
+
+	// TODO: support custom filesystem classes
+	// TODO: add `readfile()` and `readgzfile()` on top
 	return new WP_Filesystem_Direct( new StdClass() );
 }
 

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -1,6 +1,7 @@
 <?php
 
 use WP_Rocket\Logger\Logger;
+use WP_Rocket\Storage\FilesystemDirect;
 use WP_Rocket\Engine\Cache\AdvancedCache;
 
 defined( 'ABSPATH' ) || exit;
@@ -1057,12 +1058,15 @@ function rocket_rrmdir( $dir, array $dirs_to_preserve = [], $filesystem = null )
  * @return object WP_Filesystem_Direct instance
  */
 function rocket_direct_filesystem() {
+	require_once WP_ROCKET_INC_PATH . 'classes/Storage/class-abstract-storage.php';
+	require_once WP_ROCKET_INC_PATH . 'classes/Storage/class-filesystem-direct.php';
+
 	require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-base.php';
 	require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-direct.php';
 
-	// TODO: support custom filesystem classes
-	// TODO: add `readfile()` and `readgzfile()` on top
-	return new WP_Filesystem_Direct( new StdClass() );
+	return new FilesystemDirect(
+		new WP_Filesystem_Direct( null )
+	);
 }
 
 /**


### PR DESCRIPTION
Resolves #3231.

We'd like to support storing cache files in Redis (Object Cache) instead of the filesystem.

The easiest way to support custom file storage implementations seems be to decorate the `rocket_direct_filesystem()` method and direct all calls to the local filesystem to it.

This PR is just a POC and requires further work.

- [x] Rename `fs` to storage
- [x] Create new `Storage` interface
- [x] Wrap `WP_Filesystem_Direct`
- [x] Handle loading of storage in `advanced-cache.php`
- [ ] Load storage based on config/constant
