### PR TITLE
Closes #3423 Add preconnect tag for CDN URLs

### DIFF
--- a/inc/Engine/CDN/Subscriber.php
+++ b/inc/Engine/CDN/Subscriber.php
@@ -271,20 +271,20 @@ class Subscriber implements Subscriber_Interface {
 			return $urls;
 		}
 
-		$cdn_urls = $this->cdn->get_cdn_urls([ 'all', 'images', 'css_and_js', 'css', 'js' ]);
+		$cdn_urls = $this->cdn->get_cdn_urls( [ 'all', 'images', 'css_and_js', 'css', 'js' ] );
 
 		if ( empty( $cdn_urls ) ) {
 			return $urls;
 		}
 
 		foreach ( $cdn_urls as $cdn_url ) {
-			//Note: As of 22 Feb, 2021 we cannot add more than one instance of a domain url
-			//on the wp_resource_hint() hook -- wp_resource_hint() will
-			//only actually print the first one.
-			//Ideally, we want both because CSS resources will use the crossorigin version,
-			//But JS resources will not.
-			//Jonathan has submitted a ticket to change this behavior:
-			//@see https://core.trac.wordpress.org/ticket/52465
+			// Note: As of 22 Feb, 2021 we cannot add more than one instance of a domain url
+			// on the wp_resource_hint() hook -- wp_resource_hint() will
+			// only actually print the first one.
+			// Ideally, we want both because CSS resources will use the crossorigin version,
+			// But JS resources will not.
+			// Jonathan has submitted a ticket to change this behavior:
+			// @see https://core.trac.wordpress.org/ticket/52465
 			// Until then, we order these to prefer/print the non-crossorigin version.
 			$urls[] = [ 'href' => $cdn_url ];
 			$urls[] = [

--- a/inc/Engine/CDN/Subscriber.php
+++ b/inc/Engine/CDN/Subscriber.php
@@ -270,6 +270,7 @@ class Subscriber implements Subscriber_Interface {
 		) {
 			return $urls;
 		}
+
 		$cdn_urls = $this->get_cdn_hosts();
 
 		if ( empty( $cdn_urls ) ) {
@@ -277,14 +278,19 @@ class Subscriber implements Subscriber_Interface {
 		}
 
 		foreach ( $cdn_urls as $cdn_url ) {
-			//Todo: We cannot add more than one instance of a domain url
+			//Note: As of 22 Feb, 2021 we cannot add more than one instance of a domain url
 			//on the wp_resource_hint() hook -- wp_resource_hint() will
 			//only actually print the first one.
-			$urls[] = '//123456.rocketcdn.me';
+			//Ideally, we want both because CSS resources will use the crossorigin version,
+			//But JS resources will not.
+			//Jonathan has submitted a ticket to change this behavior:
+			//@see https://core.trac.wordpress.org/ticket/52465
+			// Until then, we order these to prefer/print the non-crossorigin version.
 			$urls[] = [
-				'href' => '//123456.rocketcdn.me',
-				'crossorigin',
+				'href'        => $cdn_url,
+				'crossorigin' => 'anonymous',
 			];
+			$urls[] = [ 'href' => $cdn_url ];
 		}
 
 		return $urls;

--- a/inc/Engine/CDN/Subscriber.php
+++ b/inc/Engine/CDN/Subscriber.php
@@ -281,6 +281,10 @@ class Subscriber implements Subscriber_Interface {
 			$url_parts = get_rocket_parse_url( $url );
 
 			if ( empty( $url_parts['scheme'] ) ) {
+				if ( preg_match( '/^(?![\/])(?=[^\.]+\/).+/i', $url ) ) {
+					continue;
+				}
+
 				$url       = '//' . $url;
 				$url_parts = get_rocket_parse_url( $url );
 			}

--- a/inc/Engine/CDN/Subscriber.php
+++ b/inc/Engine/CDN/Subscriber.php
@@ -277,7 +277,18 @@ class Subscriber implements Subscriber_Interface {
 			return $urls;
 		}
 
-		foreach ( $cdn_urls as $cdn_url ) {
+		foreach ( $cdn_urls as $url ) {
+			$url_parts = get_rocket_parse_url( $url );
+
+			if ( empty( $url_parts['scheme'] ) ) {
+				$url       =  '//' . $url ;
+				$url_parts = get_rocket_parse_url( $url );
+			}
+
+			$domain = empty($url_parts['scheme'])
+				? '//' . $url_parts['host']
+				: $url_parts['scheme'] . '://' . $url_parts['host'];
+
 			// Note: As of 22 Feb, 2021 we cannot add more than one instance of a domain url
 			// on the wp_resource_hint() hook -- wp_resource_hint() will
 			// only actually print the first one.
@@ -286,9 +297,9 @@ class Subscriber implements Subscriber_Interface {
 			// Jonathan has submitted a ticket to change this behavior:
 			// @see https://core.trac.wordpress.org/ticket/52465
 			// Until then, we order these to prefer/print the non-crossorigin version.
-			$urls[] = [ 'href' => $cdn_url ];
+			$urls[] = [ 'href' => $domain ];
 			$urls[] = [
-				'href'        => $cdn_url,
+				'href'        => $domain,
 				'crossorigin' => 'anonymous',
 			];
 		}
@@ -303,7 +314,8 @@ class Subscriber implements Subscriber_Interface {
 	 *
 	 * @return boolean
 	 */
-	private function is_allowed() {
+	private
+	function is_allowed() {
 		if ( rocket_get_constant( 'DONOTROCKETOPTIMIZE' ) ) {
 			return false;
 		}
@@ -326,7 +338,8 @@ class Subscriber implements Subscriber_Interface {
 	 *
 	 * @return bool
 	 */
-	private function is_cdn_enabled() {
+	private
+	function is_cdn_enabled() {
 		return (bool) $this->options->get( 'cdn', 0 );
 	}
 }

--- a/inc/Engine/CDN/Subscriber.php
+++ b/inc/Engine/CDN/Subscriber.php
@@ -28,7 +28,7 @@ class Subscriber implements Subscriber_Interface {
 	 * Constructor
 	 *
 	 * @param Options_Data $options WP Rocket Options instance.
-	 * @param CDN          $cdn CDN instance.
+	 * @param CDN          $cdn     CDN instance.
 	 */
 	public function __construct( Options_Data $options, CDN $cdn ) {
 		$this->options = $options;
@@ -55,6 +55,7 @@ class Subscriber implements Subscriber_Interface {
 			'rocket_css_url'          => [ 'add_cdn_url', 10, 2 ],
 			'rocket_js_url'           => [ 'add_cdn_url', 10, 2 ],
 			'rocket_asset_url'        => [ 'maybe_replace_url', 10, 2 ],
+			'wp_resource_hints'       => [ 'add_preconnect_cdn', 10, 2 ],
 		];
 	}
 
@@ -64,6 +65,7 @@ class Subscriber implements Subscriber_Interface {
 	 * @since 3.4
 	 *
 	 * @param string $html HTML content.
+	 *
 	 * @return string
 	 */
 	public function rewrite( $html ) {
@@ -80,6 +82,7 @@ class Subscriber implements Subscriber_Interface {
 	 * @since 3.4.0.4
 	 *
 	 * @param string $html HTML content.
+	 *
 	 * @return string
 	 */
 	public function rewrite_srcset( $html ) {
@@ -96,6 +99,7 @@ class Subscriber implements Subscriber_Interface {
 	 * @since 3.4
 	 *
 	 * @param string $content CSS content.
+	 *
 	 * @return string
 	 */
 	public function rewrite_css_properties( $content ) {
@@ -155,6 +159,7 @@ class Subscriber implements Subscriber_Interface {
 	 * @since 3.4
 	 *
 	 * @param array $domains Domain names to DNS prefetch.
+	 *
 	 * @return array
 	 */
 	public function add_dns_prefetch_cdn( $domains ) {
@@ -176,8 +181,9 @@ class Subscriber implements Subscriber_Interface {
 	 *
 	 * @since 3.4
 	 *
-	 * @param string $url URL to rewrite.
+	 * @param string $url          URL to rewrite.
 	 * @param string $original_url Original URL for this URL. Optional.
+	 *
 	 * @return string
 	 */
 	public function add_cdn_url( $url, $original_url = '' ) {
@@ -195,8 +201,9 @@ class Subscriber implements Subscriber_Interface {
 	 *
 	 * @since 3.5.3
 	 *
-	 * @param string $url URL of the asset.
+	 * @param string $url   URL of the asset.
 	 * @param array  $zones Array of corresponding zones for the asset.
+	 *
 	 * @return string
 	 */
 	public function maybe_replace_url( $url, array $zones = [ 'all' ] ) {
@@ -239,6 +246,43 @@ class Subscriber implements Subscriber_Interface {
 		}
 
 		return $url;
+	}
+
+	/**
+	 * Add a preconnect tag for the CDN.
+	 *
+	 * @since 3.8.3
+	 *
+	 * @param array  $urls The initial array of wp_resource_hint urls.
+	 * @param string $relation_type The relation type for the hint: eg., 'preconnect', 'prerender', etc.
+	 *
+	 * @return array The filtered urls.
+	 */
+	public function add_preconnect_cdn( array $urls, string $relation_type ): array {
+		if (
+			'preconnect' !== $relation_type
+			||
+			rocket_bypass()
+			||
+			! $this->is_allowed()
+			||
+			! $this->is_cdn_enabled()
+		) {
+			return $urls;
+		}
+
+		$cdn_urls = $this->get_cdn_hosts();
+
+		if ( empty( $cdn_urls) ) {
+			return $urls;
+		}
+
+		foreach ( $cdn_urls as $cdn_url ) {
+			$urls[] = $cdn_url;
+			$urls[] = [ 'href' => $cdn_url, 'crossorigin' => 'crossorigin' ];
+		}
+
+		return $urls;
 	}
 
 	/**

--- a/inc/Engine/CDN/Subscriber.php
+++ b/inc/Engine/CDN/Subscriber.php
@@ -271,7 +271,7 @@ class Subscriber implements Subscriber_Interface {
 			return $urls;
 		}
 
-		$cdn_urls = $this->get_cdn_hosts();
+		$cdn_urls = $this->cdn->get_cdn_urls([ 'all', 'images', 'css_and_js', 'css', 'js' ]);
 
 		if ( empty( $cdn_urls ) ) {
 			return $urls;
@@ -286,11 +286,11 @@ class Subscriber implements Subscriber_Interface {
 			//Jonathan has submitted a ticket to change this behavior:
 			//@see https://core.trac.wordpress.org/ticket/52465
 			// Until then, we order these to prefer/print the non-crossorigin version.
+			$urls[] = [ 'href' => $cdn_url ];
 			$urls[] = [
 				'href'        => $cdn_url,
 				'crossorigin' => 'anonymous',
 			];
-			$urls[] = [ 'href' => $cdn_url ];
 		}
 
 		return $urls;

--- a/inc/Engine/CDN/Subscriber.php
+++ b/inc/Engine/CDN/Subscriber.php
@@ -253,7 +253,7 @@ class Subscriber implements Subscriber_Interface {
 	 *
 	 * @since 3.8.3
 	 *
-	 * @param array  $urls The initial array of wp_resource_hint urls.
+	 * @param array  $urls          The initial array of wp_resource_hint urls.
 	 * @param string $relation_type The relation type for the hint: eg., 'preconnect', 'prerender', etc.
 	 *
 	 * @return array The filtered urls.
@@ -270,16 +270,21 @@ class Subscriber implements Subscriber_Interface {
 		) {
 			return $urls;
 		}
-
 		$cdn_urls = $this->get_cdn_hosts();
 
-		if ( empty( $cdn_urls) ) {
+		if ( empty( $cdn_urls ) ) {
 			return $urls;
 		}
 
 		foreach ( $cdn_urls as $cdn_url ) {
-			$urls[] = $cdn_url;
-			$urls[] = [ 'href' => $cdn_url, 'crossorigin' => 'crossorigin' ];
+			//Todo: We cannot add more than one instance of a domain url
+			//on the wp_resource_hint() hook -- wp_resource_hint() will
+			//only actually print the first one.
+			$urls[] = '//123456.rocketcdn.me';
+			$urls[] = [
+				'href' => '//123456.rocketcdn.me',
+				'crossorigin',
+			];
 		}
 
 		return $urls;

--- a/inc/Engine/CDN/Subscriber.php
+++ b/inc/Engine/CDN/Subscriber.php
@@ -281,11 +281,11 @@ class Subscriber implements Subscriber_Interface {
 			$url_parts = get_rocket_parse_url( $url );
 
 			if ( empty( $url_parts['scheme'] ) ) {
-				$url       =  '//' . $url ;
+				$url       = '//' . $url;
 				$url_parts = get_rocket_parse_url( $url );
 			}
 
-			$domain = empty($url_parts['scheme'])
+			$domain = empty( $url_parts['scheme'] )
 				? '//' . $url_parts['host']
 				: $url_parts['scheme'] . '://' . $url_parts['host'];
 
@@ -314,8 +314,7 @@ class Subscriber implements Subscriber_Interface {
 	 *
 	 * @return boolean
 	 */
-	private
-	function is_allowed() {
+	private function is_allowed() {
 		if ( rocket_get_constant( 'DONOTROCKETOPTIMIZE' ) ) {
 			return false;
 		}
@@ -338,8 +337,7 @@ class Subscriber implements Subscriber_Interface {
 	 *
 	 * @return bool
 	 */
-	private
-	function is_cdn_enabled() {
+	private function is_cdn_enabled() {
 		return (bool) $this->options->get( 'cdn', 0 );
 	}
 }

--- a/tests/Fixtures/inc/Engine/CDN/Subscriber/add-preconnect-cdn.php
+++ b/tests/Fixtures/inc/Engine/CDN/Subscriber/add-preconnect-cdn.php
@@ -12,11 +12,6 @@ return [
 		],
 		'expected-html' => <<<HTML
 <link rel='dns-prefetch' href='//s.w.org' />
-<link rel='dns-prefetch' href='//123456.rocketcdn.me' />
-<link rel='dns-prefetch' href='//my-cdn.cdnservice.com' />
-<link rel='dns-prefetch' href='//cdn.example.com' />
-<link rel='dns-prefetch' href='//8901.wicked-fast-cdn.com' />
-<link rel='dns-prefetch' href='//another.cdn.com' />
 <link href='//123456.rocketcdn.me' rel='preconnect' />
 <link href='https://my-cdn.cdnservice.com' rel='preconnect' />
 <link href='http://cdn.example.com' rel='preconnect' />

--- a/tests/Fixtures/inc/Engine/CDN/Subscriber/add-preconnect-cdn.php
+++ b/tests/Fixtures/inc/Engine/CDN/Subscriber/add-preconnect-cdn.php
@@ -3,15 +3,25 @@
 return [
 	'shouldAddPreconnectLinkForCdn' => [
 		'cdn-cnames'    => [
-			'https://123456.rocketcdn.me',
-			'https://my-cdn.cdnservice.com',
+			'123456.rocketcdn.me',
+			'https://my-cdn.cdnservice.com/',
+			'http://cdn.example.com',
+			'/some/path/with/no/domain',
+			'8901.wicked-fast-cdn.com/path/to/my/files',
+			'https://another.cdn.com/with/a/path',
 		],
 		'expected-html' => <<<HTML
 <link rel='dns-prefetch' href='//s.w.org' />
 <link rel='dns-prefetch' href='//123456.rocketcdn.me' />
 <link rel='dns-prefetch' href='//my-cdn.cdnservice.com' />
-<link href='https://123456.rocketcdn.me' rel='preconnect' />
+<link rel='dns-prefetch' href='//cdn.example.com' />
+<link rel='dns-prefetch' href='//8901.wicked-fast-cdn.com' />
+<link rel='dns-prefetch' href='//another.cdn.com' />
+<link href='//123456.rocketcdn.me' rel='preconnect' />
 <link href='https://my-cdn.cdnservice.com' rel='preconnect' />
+<link href='http://cdn.example.com' rel='preconnect' />
+<link href='//8901.wicked-fast-cdn.com' rel='preconnect' />
+<link href='https://another.cdn.com' rel='preconnect' />
 HTML
 	],
 ];

--- a/tests/Fixtures/inc/Engine/CDN/Subscriber/add-preconnect-cdn.php
+++ b/tests/Fixtures/inc/Engine/CDN/Subscriber/add-preconnect-cdn.php
@@ -7,6 +7,7 @@ return [
 			'https://my-cdn.cdnservice.com/',
 			'http://cdn.example.com',
 			'/some/path/with/no/domain',
+			'test/tests',
 			'8901.wicked-fast-cdn.com/path/to/my/files',
 			'https://another.cdn.com/with/a/path',
 		],

--- a/tests/Fixtures/inc/Engine/CDN/Subscriber/add-preconnect-cdn.php
+++ b/tests/Fixtures/inc/Engine/CDN/Subscriber/add-preconnect-cdn.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+	'shouldAddPreconnectLinkForCdn' => [
+		'cdn-cnames'    => [
+			'https://123456.rocketcdn.me',
+			'https://my-cdn.cdnservice.com',
+		],
+		'expected-html' => <<<HTML
+<link rel='dns-prefetch' href='//s.w.org' />
+<link rel='dns-prefetch' href='//123456.rocketcdn.me' />
+<link rel='dns-prefetch' href='//my-cdn.cdnservice.com' />
+<link href='https://123456.rocketcdn.me' rel='preconnect' />
+<link href='https://my-cdn.cdnservice.com' rel='preconnect' />
+HTML
+	],
+];

--- a/tests/Integration/inc/Engine/CDN/Subscriber/TestCase.php
+++ b/tests/Integration/inc/Engine/CDN/Subscriber/TestCase.php
@@ -2,7 +2,7 @@
 
 namespace WP_Rocket\Tests\Integration\inc\Engine\CDN\Subscriber;
 
-use WPMedia\PHPUnit\Integration\TestCase as BaseTestCase;
+use WP_Rocket\Tests\Integration\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase {
 	protected $cnames;

--- a/tests/Integration/inc/Engine/CDN/Subscriber/addPreconnectCdn.php
+++ b/tests/Integration/inc/Engine/CDN/Subscriber/addPreconnectCdn.php
@@ -14,16 +14,6 @@ class Test_addPreconnectCdn extends TestCase {
 	 */
 	public function testShouldAddPreconnectCdn($cnames, $expected) {
 		$this->cnames = $cnames;
-//		$this->cnames = [
-//			'https://123456.rocketcdn.me',
-//		];
-
-//		$html = <<<HTML
-//<link rel='dns-prefetch' href='//s.w.org' />
-//<link rel='dns-prefetch' href='//123456.rocketcdn.me' />
-//<link href='https://123456.rocketcdn.me' rel='preconnect' />
-//HTML;
-
 
 		add_filter( 'pre_get_rocket_option_cdn', [ $this, 'return_true'] );
 		add_filter( 'rocket_cdn_cnames', [ $this, 'setCnames' ] );

--- a/tests/Integration/inc/Engine/CDN/Subscriber/addPreconnectCdn.php
+++ b/tests/Integration/inc/Engine/CDN/Subscriber/addPreconnectCdn.php
@@ -9,17 +9,20 @@ namespace WP_Rocket\Tests\Integration\inc\Engine\CDN\Subscriber;
  */
 class Test_addPreconnectCdn extends TestCase {
 
-	public function testShouldAddPreconnectCdn() {
-		$this->cnames = [
-			'https://123456.rocketcdn.me',
-		];
+	/**
+	 * @dataProvider providerTestData
+	 */
+	public function testShouldAddPreconnectCdn($cnames, $expected) {
+		$this->cnames = $cnames;
+//		$this->cnames = [
+//			'https://123456.rocketcdn.me',
+//		];
 
-		$html = <<<HTML
-<link rel='dns-prefetch' href='//s.w.org' />
-<link rel='dns-prefetch' href='//123456.rocketcdn.me' />
-<link rel='preconnect' href='//123456.rocketcdn.me' />
-<link href='//123456.rocketcdn.me' crossorigin rel='preconnect' />
-HTML;
+//		$html = <<<HTML
+//<link rel='dns-prefetch' href='//s.w.org' />
+//<link rel='dns-prefetch' href='//123456.rocketcdn.me' />
+//<link href='https://123456.rocketcdn.me' rel='preconnect' />
+//HTML;
 
 
 		add_filter( 'pre_get_rocket_option_cdn', [ $this, 'return_true'] );
@@ -29,13 +32,12 @@ HTML;
 		wp_resource_hints();
 
 		$this->assertSame(
-			$this->format_the_html($html),
+			$this->format_the_html($expected),
 			$this->format_the_html(ob_get_clean())
 		);
 	}
 
-	// Todo: get data from an actual dataproider fixture
 	public function providerTestData() {
-		return $this->getTestData( __DIR__, 'addPreconnectCdn' );
+		return $this->getTestData( __DIR__, 'add-preconnect-cdn' );
 	}
 }

--- a/tests/Integration/inc/Engine/CDN/Subscriber/addPreconnectCdn.php
+++ b/tests/Integration/inc/Engine/CDN/Subscriber/addPreconnectCdn.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\CDN\Subscriber;
+
+/**
+ * @covers \WP_Rocket\Engine\CDN\Subscriber::add_preconnect_cdn
+ * @uses   \WP_Rocket\Engine\CDN\CDN::get_cdn_urls
+ * @group  CDN
+ */
+class Test_addPreconnectCdn extends TestCase {
+
+	public function testShouldAddPreconnectCdn() {
+		$this->cnames = [
+			'https://123456.rocketcdn.me',
+		];
+
+		$html = <<<HTML
+<link rel='dns-prefetch' href='//s.w.org' />
+<link rel='dns-prefetch' href='//123456.rocketcdn.me' />
+<link rel='preconnect' href='//123456.rocketcdn.me' />
+<link href='//123456.rocketcdn.me' crossorigin rel='preconnect' />
+HTML;
+
+
+		add_filter( 'pre_get_rocket_option_cdn', [ $this, 'return_true'] );
+		add_filter( 'rocket_cdn_cnames', [ $this, 'setCnames' ] );
+
+		ob_start();
+		wp_resource_hints();
+
+		$this->assertSame(
+			$this->format_the_html($html),
+			$this->format_the_html(ob_get_clean())
+		);
+	}
+
+	// Todo: get data from an actual dataproider fixture
+	public function providerTestData() {
+		return $this->getTestData( __DIR__, 'addPreconnectCdn' );
+	}
+}

--- a/tests/Integration/inc/Engine/CDN/Subscriber/addPreconnectCdn.php
+++ b/tests/Integration/inc/Engine/CDN/Subscriber/addPreconnectCdn.php
@@ -9,6 +9,18 @@ namespace WP_Rocket\Tests\Integration\inc\Engine\CDN\Subscriber;
  */
 class Test_addPreconnectCdn extends TestCase {
 
+	public function setUp() {
+		$this->unregisterAllCallbacksExcept( 'wp_resource_hints', 'add_preconnect_cdn', 10 );
+
+		parent::setUp();
+	}
+
+	public function tearDown() {
+		$this->restoreWpFilter( 'wp_resource_hints' );
+
+		parent::tearDown();
+	}
+
 	/**
 	 * @dataProvider providerTestData
 	 */


### PR DESCRIPTION
Closes #3423 

- [x] Add `add_precnnect_cdn()` method to `wp_resource_hints` filter.
- [X] Add integration tests for new method.