### PR TITLE
Increase pricing data transient expiration time

### DIFF
--- a/inc/Engine/License/API/PricingClient.php
+++ b/inc/Engine/License/API/PricingClient.php
@@ -27,7 +27,7 @@ class PricingClient {
 			return false;
 		}
 
-		set_transient( 'wp_rocket_pricing', $data, 6 * HOUR_IN_SECONDS );
+		set_transient( 'wp_rocket_pricing', $data, 12 * HOUR_IN_SECONDS );
 
 		return $data;
 	}

--- a/tests/Unit/inc/Engine/License/API/PricingClient/getPricingData.php
+++ b/tests/Unit/inc/Engine/License/API/PricingClient/getPricingData.php
@@ -54,7 +54,7 @@ class GetPricingData extends TestCase {
 		) {
 			Functions\expect( 'set_transient' )
 				->once()
-				->with( 'wp_rocket_pricing', Mockery::type( 'object' ), 6 * HOUR_IN_SECONDS );
+				->with( 'wp_rocket_pricing', Mockery::type( 'object' ), 12 * HOUR_IN_SECONDS );
 		} else {
 			Functions\expect( 'set_transient' )->never();
 		}


### PR DESCRIPTION
Fixes https://github.com/wp-media/wp-rocket/issues/3441
By increasing wp_rocket_pricing transient TTL to 12 hours