### PR TITLE
Automatically exclude Programmable Search script from minification

### DIFF
--- a/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
+++ b/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
@@ -236,6 +236,7 @@ abstract class AbstractJSOptimization extends AbstractOptimization {
 			'loader.knack.com',
 			'embed.lpcontent.net/leadboxes/current/embed.js',
 			'cc.cdn.civiccomputing.com/9/cookieControl-9.x.min.js',
+			'cse.google.com/cse.js',
 		];
 
 		$excluded_external = array_merge( $defaults, $this->options->get( 'exclude_js', [] ) );

--- a/tests/Fixtures/inc/Engine/Optimization/Minify/JS/Minify/optimize.php
+++ b/tests/Fixtures/inc/Engine/Optimization/Minify/JS/Minify/optimize.php
@@ -278,5 +278,40 @@ EXPECTED_HTML
 			'has_integrity' => true,
 			'valid_integrity' => false
 		],
+
+		'minifyJsFilesWithGoogleCSE' => [
+			'original' => <<<ORIGINAL_HTML
+<html>
+	<head>
+		<title>Sample Page</title>
+		<script type="text/javascript" src="https://cse.google.com/cse.js?cx=xxx:xxx"></script>
+	</head>
+	<body>
+	</body>
+</html>
+ORIGINAL_HTML
+			,
+			'expected' => [
+				'html' => <<<EXPECTED_HTML
+<html>
+	<head>
+		<title>Sample Page</title>
+		<script type="text/javascript" src="https://cse.google.com/cse.js?cx=xxx:xxx"></script>
+	</head>
+	<body>
+	</body>
+</html>
+EXPECTED_HTML
+				,
+
+				'files' => [
+				],
+			],
+
+			'cdn_host' => [],
+			'cdn_url'  => 'http://example.org',
+			'site_url' => 'http://example.org',
+			'external_url' => 'https://cse.google.com/cse.js?cx=xxx:xxx',
+		],
 	],
 ];

--- a/tests/Fixtures/inc/Engine/Optimization/Minify/JS/Subscriber/process.php
+++ b/tests/Fixtures/inc/Engine/Optimization/Minify/JS/Subscriber/process.php
@@ -98,6 +98,36 @@ return [
 			],
 		],
 
+		'minifyJSFileForGoogleCSE' => [
+			// Test Data: Original JS files.
+			'original' => '<html>
+				<head>
+					<title>Sample Page</title>
+					<script type="text/javascript" src="https://cse.google.com/cse.js?cx=xxx:xxx"></script>
+				</head>
+				<body>
+				</body>
+			</html>',
+			'expected' => [
+				'html'  => '<html>
+					<head>
+						<title>Sample Page</title>
+						<script type="text/javascript" src="https://cse.google.com/cse.js?cx=xxx:xxx"></script>
+					</head>
+					<body>
+					</body>
+				</html>',
+				'files' => [],
+			],
+			'settings' => [
+				'minify_concatenate_js' => 0,
+				'cdn'                   => 0,
+				'cdn_cnames'            => [],
+				'cdn_zone'              => [],
+				'defer_all_js'          => 0,
+			],
+		],
+
 		'minifyJSFilesToCDNUrl' => [
 			'original' => '<html>
 				<head>


### PR DESCRIPTION
Fixes https://github.com/wp-media/wp-rocket/issues/3139