### PR TITLE
Added new external JS exclusion - kit.fontawesome.com

### DIFF
--- a/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
+++ b/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
@@ -237,6 +237,7 @@ abstract class AbstractJSOptimization extends AbstractOptimization {
 			'embed.lpcontent.net/leadboxes/current/embed.js',
 			'cc.cdn.civiccomputing.com/9/cookieControl-9.x.min.js',
 			'cse.google.com/cse.js',
+			'kit.fontawesome.com',
 		];
 
 		$excluded_external = array_merge( $defaults, $this->options->get( 'exclude_js', [] ) );


### PR DESCRIPTION
Excluded domain - kit.fontawesome.com
Related ticket - https://secure.helpscout.net/conversation/1392384936/230231/
Slack discussion - https://wp-media.slack.com/archives/C43T1AYMQ/p1610619239005300