### PR TITLE
Exclude JetPack Compare Images from lazyload

### DIFF
--- a/inc/Dependencies/RocketLazyload/Image.php
+++ b/inc/Dependencies/RocketLazyload/Image.php
@@ -394,6 +394,7 @@ class Image {
 				'avia-bg-style-fixed',
 				'data-skip-lazy',
 				'skip-lazy',
+				'image-compare__',
 			]
 		);
 	}


### PR DESCRIPTION
Closes https://github.com/wp-media/wp-rocket/issues/3383