### PR TITLE
Fixes #3450 AMP Markup Incompatibilities with preload links and delay JS features

### DIFF
--- a/inc/Engine/Optimization/DelayJS/HTML.php
+++ b/inc/Engine/Optimization/DelayJS/HTML.php
@@ -76,7 +76,7 @@ class HTML {
 		 *
 		 * @param bool $do_delay_js Whether to enable preload links. Default is true.
 		 */
-		if ( ! (bool) apply_filters( 'do_rocket_delay_js', true ) ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+		if ( ! (bool) apply_filters( 'rocket_do_delay_js', true ) ) {
 			return false;
 		}
 

--- a/inc/Engine/Optimization/DelayJS/HTML.php
+++ b/inc/Engine/Optimization/DelayJS/HTML.php
@@ -69,6 +69,17 @@ class HTML {
 			return false;
 		}
 
+		/**
+		 * Filter whether to allow rocket to enable delay JS.
+		 *
+		 * @since 3.8.4
+		 *
+		 * @param bool $do_delay_js Whether to enable preload links. Default is true.
+		 */
+		if ( ! (bool) apply_filters( 'do_rocket_delay_js', true ) ) {
+			return false;
+		}
+
 		if ( rocket_get_constant( 'DONOTROCKETOPTIMIZE' ) ) {
 			return false;
 		}

--- a/inc/Engine/Optimization/DelayJS/HTML.php
+++ b/inc/Engine/Optimization/DelayJS/HTML.php
@@ -76,7 +76,7 @@ class HTML {
 		 *
 		 * @param bool $do_delay_js Whether to enable preload links. Default is true.
 		 */
-		if ( ! (bool) apply_filters( 'do_rocket_delay_js', true ) ) {
+		if ( ! (bool) apply_filters( 'do_rocket_delay_js', true ) ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 			return false;
 		}
 

--- a/inc/Engine/Preload/Links/Subscriber.php
+++ b/inc/Engine/Preload/Links/Subscriber.php
@@ -73,7 +73,7 @@ class Subscriber implements Subscriber_Interface {
 		 *
 		 * @param bool $do_preload_links Whether to enable preload links. Default is true.
 		 */
-		if ( ! (bool) apply_filters( 'do_rocket_preload_links', true ) ) { //phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+		if ( ! (bool) apply_filters( 'rocket_do_preload_links', true ) ) {
 			return;
 		}
 

--- a/inc/Engine/Preload/Links/Subscriber.php
+++ b/inc/Engine/Preload/Links/Subscriber.php
@@ -61,7 +61,19 @@ class Subscriber implements Subscriber_Interface {
 		if ( $this->is_enqueued ) {
 			return;
 		}
+
 		if ( ! (bool) $this->options->get( 'preload_links', 0 ) || rocket_bypass() ) {
+			return;
+		}
+
+		/**
+		 * Filter whether to allow rocket to enable preload links.
+		 *
+		 * @since 3.8.4
+		 *
+		 * @param bool $do_preload_links Whether to enable preload links. Default is true.
+		 */
+		if ( ! (bool) apply_filters( 'do_rocket_preload_links', true ) ) {
 			return;
 		}
 

--- a/inc/Engine/Preload/Links/Subscriber.php
+++ b/inc/Engine/Preload/Links/Subscriber.php
@@ -73,7 +73,7 @@ class Subscriber implements Subscriber_Interface {
 		 *
 		 * @param bool $do_preload_links Whether to enable preload links. Default is true.
 		 */
-		if ( ! (bool) apply_filters( 'do_rocket_preload_links', true ) ) {
+		if ( ! (bool) apply_filters( 'do_rocket_preload_links', true ) ) { //phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 			return;
 		}
 

--- a/inc/ThirdParty/Plugins/Optimization/AMP.php
+++ b/inc/ThirdParty/Plugins/Optimization/AMP.php
@@ -113,6 +113,8 @@ class AMP implements Subscriber_Interface {
 		remove_filter( 'wp_resource_hints', 'rocket_dns_prefetch', 10, 2 );
 		add_filter( 'do_rocket_lazyload', '__return_false' );
 		add_filter( 'do_rocket_lazyload_iframes', '__return_false' );
+		add_filter( 'do_rocket_delay_js', '__return_false' );
+		add_filter( 'do_rocket_preload_links', '__return_false');
 		unset( $wp_filter['rocket_buffer'] );
 
 		$options = get_option( self::AMP_OPTIONS, [] );

--- a/inc/ThirdParty/Plugins/Optimization/AMP.php
+++ b/inc/ThirdParty/Plugins/Optimization/AMP.php
@@ -113,8 +113,8 @@ class AMP implements Subscriber_Interface {
 		remove_filter( 'wp_resource_hints', 'rocket_dns_prefetch', 10, 2 );
 		add_filter( 'do_rocket_lazyload', '__return_false' );
 		add_filter( 'do_rocket_lazyload_iframes', '__return_false' );
-		add_filter( 'do_rocket_delay_js', '__return_false' );
-		add_filter( 'do_rocket_preload_links', '__return_false' );
+		add_filter( 'rocket_do_delay_js', '__return_false' );
+		add_filter( 'rocket_do_preload_links', '__return_false' );
 		unset( $wp_filter['rocket_buffer'] );
 
 		$options = get_option( self::AMP_OPTIONS, [] );

--- a/inc/ThirdParty/Plugins/Optimization/AMP.php
+++ b/inc/ThirdParty/Plugins/Optimization/AMP.php
@@ -114,7 +114,7 @@ class AMP implements Subscriber_Interface {
 		add_filter( 'do_rocket_lazyload', '__return_false' );
 		add_filter( 'do_rocket_lazyload_iframes', '__return_false' );
 		add_filter( 'do_rocket_delay_js', '__return_false' );
-		add_filter( 'do_rocket_preload_links', '__return_false');
+		add_filter( 'do_rocket_preload_links', '__return_false' );
 		unset( $wp_filter['rocket_buffer'] );
 
 		$options = get_option( self::AMP_OPTIONS, [] );

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/HTML/delayJs.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/HTML/delayJs.php
@@ -12,7 +12,7 @@ return [
 			'html'     => '<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js">',
 			'expected' => '<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js">',
 		],
-	
+
 		'shouldDoNothingWhenPostExcluded' => [
 			'config'   => [
 				'bypass'               => false,
@@ -32,6 +32,19 @@ return [
 				'do-not-delay-setting' => 0,
 				'post-excluded'        => false,
 				'allowed-scripts'      => [],
+			],
+			'html'     => '<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js">',
+			'expected' => '<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js">',
+		],
+
+		'shouldDoNothingWhenDoDelayFilterFalse' => [
+			'config'   => [
+				'bypass'               => false,
+				'donotoptimize'        => false,
+				'do-not-delay-setting' => 0,
+				'post-excluded'        => false,
+				'allowed-scripts'      => [],
+				'do-delay-filter'	   => false,
 			],
 			'html'     => '<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js">',
 			'expected' => '<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js">',

--- a/tests/Fixtures/inc/Engine/Preload/Links/Subscriber/addPreloadScript.php
+++ b/tests/Fixtures/inc/Engine/Preload/Links/Subscriber/addPreloadScript.php
@@ -20,6 +20,16 @@ return [
 			],
 			'expected' => false,
 		],
+		'testShouldDoNothingWhenDoPreloadLinksFilterFalse' => [
+			'config' => [
+				'options' => [
+					'preload_links' => 1,
+				],
+				'bypass' => false,
+				'preload_filter' => false,
+			],
+			'expected' => false,
+		],
 		'testShouldReturnPreloadScript' => [
 			'config' => [
 				'options' => [

--- a/tests/Integration/inc/Engine/Optimization/DelayJS/Subscriber/delayJs.php
+++ b/tests/Integration/inc/Engine/Optimization/DelayJS/Subscriber/delayJs.php
@@ -20,6 +20,7 @@ class Test_DelayJs extends TestCase {
 		unset( $GLOBALS['wp'] );
 		remove_filter( 'pre_get_rocket_option_delay_js', [ $this, 'set_delay_js_option' ] );
 		remove_filter( 'pre_get_rocket_option_delay_js_scripts', [ $this, 'set_delay_js_scripts_option' ] );
+		remove_filter( 'do_rocket_delay_js', '__return_false' );
 	}
 
 	/**
@@ -28,6 +29,11 @@ class Test_DelayJs extends TestCase {
 	public function testShouldProcessScriptHTML( $config, $html, $expected ) {
 		$bypass                    = isset( $config['bypass'] ) ? $config['bypass'] : false;
 		$this->donotrocketoptimize = isset( $config['donotoptimize'] ) ? $config['donotoptimize'] : false;
+
+		if ( isset ($config['do-delay-filter'] ) ) {
+			$this->set_do_rocket_delay_js_filter( $config['do-delay-filter']);
+		}
+
 		$this->options_data        = [
 			'delay_js'         => isset( $config['do-not-delay-setting'] ) ? $config['do-not-delay-setting'] : false,
 			'delay_js_scripts' => isset( $config['allowed-scripts'] ) ? $config['allowed-scripts'] : []
@@ -60,5 +66,11 @@ class Test_DelayJs extends TestCase {
 
 	public function set_delay_js_scripts_option() {
 		return isset( $this->options_data[ 'delay_js_scripts' ] ) ? $this->options_data[ 'delay_js_scripts' ] : [];
+	}
+
+	public function set_do_rocket_delay_js_filter( bool $do_delay = true ): void {
+		if ( ! $do_delay ) {
+			add_filter( 'do_rocket_delay_js', 'return_false' );
+		}
 	}
 }

--- a/tests/Integration/inc/Engine/Optimization/DelayJS/Subscriber/delayJs.php
+++ b/tests/Integration/inc/Engine/Optimization/DelayJS/Subscriber/delayJs.php
@@ -20,7 +20,7 @@ class Test_DelayJs extends TestCase {
 		unset( $GLOBALS['wp'] );
 		remove_filter( 'pre_get_rocket_option_delay_js', [ $this, 'set_delay_js_option' ] );
 		remove_filter( 'pre_get_rocket_option_delay_js_scripts', [ $this, 'set_delay_js_scripts_option' ] );
-		remove_filter( 'do_rocket_delay_js', '__return_false' );
+		remove_filter( 'rocket_do_delay_js', '__return_false' );
 	}
 
 	/**
@@ -70,7 +70,7 @@ class Test_DelayJs extends TestCase {
 
 	public function set_do_rocket_delay_js_filter( bool $do_delay = true ): void {
 		if ( ! $do_delay ) {
-			add_filter( 'do_rocket_delay_js', 'return_false' );
+			add_filter( 'rocket_do_delay_js', 'return_false' );
 		}
 	}
 }

--- a/tests/Integration/inc/Engine/Preload/Links/Subscriber/addPreloadScript.php
+++ b/tests/Integration/inc/Engine/Preload/Links/Subscriber/addPreloadScript.php
@@ -17,6 +17,7 @@ class Test_AddPreloadScript extends TestCase {
 
 		unset( $GLOBALS['wp'] );
 		remove_filter( 'pre_get_rocket_option_preload_links', [ $this, 'set_preload_links' ] );
+		remove_filter( 'do_rocket_preload_links', '__return_false' );
 
 		wp_dequeue_script('rocket-browser-checker');
 		wp_dequeue_script('rocket-preload-links');
@@ -36,6 +37,10 @@ class Test_AddPreloadScript extends TestCase {
 
 		if ( $config['bypass'] ) {
 			$GLOBALS['wp']->query_vars['nowprocket'] = 1;
+		}
+
+		if ( isset( $config['preload_filter'] ) && false === $config['preload_filter'] ) {
+			add_filter( 'do_rocket_preload_links' , '__return_false' );
 		}
 
 		$this->preload_links = $config['options']['preload_links'];

--- a/tests/Integration/inc/Engine/Preload/Links/Subscriber/addPreloadScript.php
+++ b/tests/Integration/inc/Engine/Preload/Links/Subscriber/addPreloadScript.php
@@ -17,7 +17,7 @@ class Test_AddPreloadScript extends TestCase {
 
 		unset( $GLOBALS['wp'] );
 		remove_filter( 'pre_get_rocket_option_preload_links', [ $this, 'set_preload_links' ] );
-		remove_filter( 'do_rocket_preload_links', '__return_false' );
+		remove_filter( 'rocket_do_preload_links', '__return_false' );
 
 		wp_dequeue_script('rocket-browser-checker');
 		wp_dequeue_script('rocket-preload-links');
@@ -40,7 +40,7 @@ class Test_AddPreloadScript extends TestCase {
 		}
 
 		if ( isset( $config['preload_filter'] ) && false === $config['preload_filter'] ) {
-			add_filter( 'do_rocket_preload_links' , '__return_false' );
+			add_filter( 'rocket_do_preload_links' , '__return_false' );
 		}
 
 		$this->preload_links = $config['options']['preload_links'];

--- a/tests/Integration/inc/ThirdParty/Plugins/Optimization/AMP/disableOptionsOnAmp.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Optimization/AMP/disableOptionsOnAmp.php
@@ -36,8 +36,8 @@ class Test_DisableOptionsOnAmp extends TestCase {
 			$this->assertNotFalse( has_filter( 'wp_resource_hints', 'rocket_dns_prefetch' ) );
 			$this->assertFalse( has_filter( 'do_rocket_lazyload', '__return_false' ) );
 			$this->assertFalse( has_filter( 'do_rocket_lazyload_iframes', '__return_false' ) );
-			$this->assertFalse( has_filter( 'do_rocket_delay_js', '__return_false' ) );
-			$this->assertFalse( has_filter( 'do_rocket_preload_links', '__return_false' ) );
+			$this->assertFalse( has_filter( 'rocket_do_delay_js', '__return_false' ) );
+			$this->assertFalse( has_filter( 'rocket_do_preload_links', '__return_false' ) );
 
 			$this->assertArrayHasKey( 'rocket_buffer', $wp_filter );
 
@@ -58,8 +58,8 @@ class Test_DisableOptionsOnAmp extends TestCase {
 			$this->assertFalse( has_filter( 'wp_resource_hints', 'rocket_dns_prefetch' ) );
 			$this->assertNotFalse( has_filter( 'do_rocket_lazyload', '__return_false' ) );
 			$this->assertNotFalse( has_filter( 'do_rocket_lazyload_iframes', '__return_false' ) );
-			$this->assertNotFalse( has_filter( 'do_rocket_delay_js', '__return_false' ) );
-			$this->assertNotFalse( has_filter( 'do_rocket_preload_links', '__return_false' ) );
+			$this->assertNotFalse( has_filter( 'rocket_do_delay_js', '__return_false' ) );
+			$this->assertNotFalse( has_filter( 'rocket_do_preload_links', '__return_false' ) );
 
 			if ( in_array( $config[ 'amp_options' ][ 'theme_support' ], [ 'transitional', 'reader' ], true ) ) {
 				$this->assertArrayHasKey( 'rocket_buffer', $wp_filter );

--- a/tests/Integration/inc/ThirdParty/Plugins/Optimization/AMP/disableOptionsOnAmp.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Optimization/AMP/disableOptionsOnAmp.php
@@ -36,6 +36,9 @@ class Test_DisableOptionsOnAmp extends TestCase {
 			$this->assertNotFalse( has_filter( 'wp_resource_hints', 'rocket_dns_prefetch' ) );
 			$this->assertFalse( has_filter( 'do_rocket_lazyload', '__return_false' ) );
 			$this->assertFalse( has_filter( 'do_rocket_lazyload_iframes', '__return_false' ) );
+			$this->assertFalse( has_filter( 'do_rocket_delay_js', '__return_false' ) );
+			$this->assertFalse( has_filter( 'do_rocket_preload_links', '__return_false' ) );
+
 			$this->assertArrayHasKey( 'rocket_buffer', $wp_filter );
 
 			if ( ! is_null( $config[ 'amp_options' ] ) ) {
@@ -55,6 +58,8 @@ class Test_DisableOptionsOnAmp extends TestCase {
 			$this->assertFalse( has_filter( 'wp_resource_hints', 'rocket_dns_prefetch' ) );
 			$this->assertNotFalse( has_filter( 'do_rocket_lazyload', '__return_false' ) );
 			$this->assertNotFalse( has_filter( 'do_rocket_lazyload_iframes', '__return_false' ) );
+			$this->assertNotFalse( has_filter( 'do_rocket_delay_js', '__return_false' ) );
+			$this->assertNotFalse( has_filter( 'do_rocket_preload_links', '__return_false' ) );
 
 			if ( in_array( $config[ 'amp_options' ][ 'theme_support' ], [ 'transitional', 'reader' ], true ) ) {
 				$this->assertArrayHasKey( 'rocket_buffer', $wp_filter );

--- a/tests/Unit/inc/ThirdParty/Plugins/Optimization/AMP/disableOptionsOnAmp.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/Optimization/AMP/disableOptionsOnAmp.php
@@ -53,8 +53,8 @@ class Test_DisableOptionsOnAmp extends TestCase {
 			$this->assertFalse( has_filter( 'do_rocket_lazyload', '__return_false' ) );
 			$this->assertFalse( has_filter( 'do_rocket_lazyload_iframes', '__return_false' ) );
 			$this->assertFalse( has_filter( 'do_rocket_lazyload_iframes', '__return_false' ) );
-			$this->assertFalse( has_filter( 'do_rocket_delay_js', '__return_false' ) );
-			$this->assertFalse( has_filter( 'do_rocket_preload_links', '__return_false' ) );
+			$this->assertFalse( has_filter( 'rocket_do_delay_js', '__return_false' ) );
+			$this->assertFalse( has_filter( 'rocket_do_preload_links', '__return_false' ) );
 
 			$this->assertSame(
 				PHP_INT_MAX,

--- a/tests/Unit/inc/ThirdParty/Plugins/Optimization/AMP/disableOptionsOnAmp.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/Optimization/AMP/disableOptionsOnAmp.php
@@ -52,6 +52,10 @@ class Test_DisableOptionsOnAmp extends TestCase {
 			);
 			$this->assertFalse( has_filter( 'do_rocket_lazyload', '__return_false' ) );
 			$this->assertFalse( has_filter( 'do_rocket_lazyload_iframes', '__return_false' ) );
+			$this->assertFalse( has_filter( 'do_rocket_lazyload_iframes', '__return_false' ) );
+			$this->assertFalse( has_filter( 'do_rocket_delay_js', '__return_false' ) );
+			$this->assertFalse( has_filter( 'do_rocket_preload_links', '__return_false' ) );
+
 			$this->assertSame(
 				PHP_INT_MAX,
 				has_filter( 'wp_calculate_image_srcset', 'rocket_protocol_rewrite_srcset', PHP_INT_MAX )


### PR DESCRIPTION
Closes #3450.

Add a `do_rocket_preload_links` filter to allow/disallow disable preload links feature.
Add a `do_rocket_delay_js` filter to allow/disallow delay JS feature.

Hook `return_false()` to new filters in AMP subscriber to prevent incompatible HTML.