### PR TITLE
Fixes #3440 Add Pricing Client API timeout transients

### DIFF
--- a/inc/Engine/License/API/PricingClient.php
+++ b/inc/Engine/License/API/PricingClient.php
@@ -62,8 +62,8 @@ class PricingClient {
 			return false;
 		}
 
-		set_transient( 'wp_rocket_pricing_timeout', 0 );
-		set_transient( 'wp_rocket_pricing_timeout_active', 0 );
+		delete_transient( 'wp_rocket_pricing_timeout' );
+		delete_transient( 'wp_rocket_pricing_timeout_active' );
 
 		return json_decode( $body );
 	}
@@ -84,7 +84,7 @@ class PricingClient {
 				DAY_IN_SECONDS
 			);
 
-		set_transient( 'wp_rocket_pricing_timeout', $timeout );
-		set_transient( 'wp_rocket_pricing_timeout_active', true );
+		set_transient( 'wp_rocket_pricing_timeout', $timeout, WEEK_IN_SECONDS );
+		set_transient( 'wp_rocket_pricing_timeout_active', true, WEEK_IN_SECONDS );
 	}
 }

--- a/inc/Engine/License/API/PricingClient.php
+++ b/inc/Engine/License/API/PricingClient.php
@@ -40,20 +40,51 @@ class PricingClient {
 	 * @return bool|object
 	 */
 	private function get_raw_pricing_data() {
+		if ( (bool) get_transient( 'wp_rocket_pricing_timeout_active' ) ) {
+			return false;
+		}
+
 		$response = wp_safe_remote_get(
 			self::PRICING_ENDPOINT
 		);
 
 		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			$this->set_timeout_transients();
+
 			return false;
 		}
 
 		$body = wp_remote_retrieve_body( $response );
 
 		if ( empty( $body ) ) {
+			$this->set_timeout_transients();
+
 			return false;
 		}
 
+		set_transient( 'wp_rocket_pricing_timeout', 0 );
+		set_transient( 'wp_rocket_pricing_timeout_active', 0 );
+
 		return json_decode( $body );
+	}
+
+	/**
+	 * Set pricing timeout transients.
+	 *
+	 * @since 3.8.4
+	 *
+	 * @return void
+	 */
+	private function set_timeout_transients(): void {
+		$timeout = (int) get_transient( 'wp_rocket_pricing_timeout' );
+		$timeout = ( 0 === $timeout )
+			? 300
+			: ( 2 * $timeout < DAY_IN_SECONDS
+				? 2 * $timeout :
+				DAY_IN_SECONDS
+			);
+
+		set_transient( 'wp_rocket_pricing_timeout', $timeout );
+		set_transient( 'wp_rocket_pricing_timeout_active', true );
 	}
 }

--- a/inc/Engine/License/API/PricingClient.php
+++ b/inc/Engine/License/API/PricingClient.php
@@ -75,7 +75,7 @@ class PricingClient {
 	 *
 	 * @return void
 	 */
-	private function set_timeout_transients(): void {
+	private function set_timeout_transients() {
 		$timeout = (int) get_transient( 'wp_rocket_pricing_timeout' );
 		$timeout = ( 0 === $timeout )
 			? 300

--- a/inc/Engine/License/API/PricingClient.php
+++ b/inc/Engine/License/API/PricingClient.php
@@ -79,7 +79,7 @@ class PricingClient {
 		$timeout = (int) get_transient( 'wp_rocket_pricing_timeout' );
 		$timeout = ( 0 === $timeout )
 			? 300
-			: ( 2 * $timeout < DAY_IN_SECONDS
+			: ( 2 * $timeout <= DAY_IN_SECONDS
 				? 2 * $timeout :
 				DAY_IN_SECONDS
 			);

--- a/tests/Fixtures/inc/Engine/License/API/PricingClient/getPricingData.php
+++ b/tests/Fixtures/inc/Engine/License/API/PricingClient/getPricingData.php
@@ -8,6 +8,8 @@ return [
 	'testShouldReturnDataWhenCached' => [
 		'config'   => [
 			'pricing-transient' => true,
+			'timeout-active'    => false,
+			'timeout-duration'  => false,
 			'response'          => false,
 		],
 		'expected' => [
@@ -19,6 +21,7 @@ return [
 		'config'   => [
 			'pricing-transient' => false,
 			'timeout-active'    => true,
+			'timeout-duration'  => false,
 			'response'          => false,
 		],
 		'expected' => [
@@ -79,6 +82,33 @@ return [
 		],
 		'expected' => [
 			'result' => $data,
+		],
+	],
+
+	'testShouldDoubleTimeoutDurationFromPreviousDuration' => [
+		'config'   => [
+			'pricing-transient' => false,
+			'timeout-active'    => false,
+			'timeout-duration'  => 300,
+			'response'          => false,
+		],
+		'expected' => [
+			'result'           => false,
+			'timeout-duration' => 600
+		],
+	],
+
+	'testShouldNotSetTimeoutDurationLongerThanADay' => [
+		'config'   => [
+			'pricing-transient' => false,
+			'timeout-active'    => false,
+			'timeout-duration'  => rocket_get_constant( 'DAY_IN_SECONDS' )
+								   - rocket_get_constant( 'HOuR_IN_SECONDS' ),
+			'response'          => false,
+		],
+		'expected' => [
+			'result'           => false,
+			'timeout-duration' => rocket_get_constant( 'DAY_IN_SECONDS' ),
 		],
 	],
 ];

--- a/tests/Fixtures/inc/Engine/License/API/PricingClient/getPricingData.php
+++ b/tests/Fixtures/inc/Engine/License/API/PricingClient/getPricingData.php
@@ -7,14 +7,14 @@ $data = json_decode( $json );
 return [
 	'testShouldReturnFalseWhenWPError' => [
 		'config'   => [
-			'transient' => false,
+			'pricing-transient' => false,
 			'response'  => new WP_Error( 'http_request_failed', 'error' ),
 		],
 		'expected' => false,
 	],
 	'testShouldReturnFalseWhenNot200'  => [
 		'config'   => [
-			'transient' => false,
+			'pricing-transient' => false,
 			'response'  => [
 				'code' => 404,
 				'body' => false,
@@ -24,7 +24,7 @@ return [
 	],
 	'testShouldReturnFalseWhenNoBody'  => [
 		'config'   => [
-			'transient' => false,
+			'pricing-transient' => false,
 			'response'  => [
 				'code' => 200,
 			],
@@ -33,14 +33,14 @@ return [
 	],
 	'testShouldReturnDataWhenCached'   => [
 		'config'   => [
-			'transient' => true,
+			'pricing-transient' => true,
 			'response'  => false,
 		],
 		'expected' => $data,
 	],
 	'testShouldReturnDataWhenSuccess'  => [
 		'config'   => [
-			'transient' => false,
+			'pricing-transient' => false,
 			'response'  => [
 				'code' => 200,
 				'body' => $json,

--- a/tests/Fixtures/inc/Engine/License/API/PricingClient/getPricingData.php
+++ b/tests/Fixtures/inc/Engine/License/API/PricingClient/getPricingData.php
@@ -5,47 +5,80 @@ $json = '{"licenses":{"single":{"prices":{"regular":49,"sale":39.2,"renewal":{"i
 $data = json_decode( $json );
 
 return [
-	'testShouldReturnFalseWhenWPError' => [
+	'testShouldReturnDataWhenCached' => [
 		'config'   => [
-			'pricing-transient' => false,
-			'response'  => new WP_Error( 'http_request_failed', 'error' ),
+			'pricing-transient' => true,
+			'response'          => false,
 		],
-		'expected' => false,
+		'expected' => [
+			'result' => $data,
+		]
 	],
-	'testShouldReturnFalseWhenNot200'  => [
+
+	'testShouldReturnFalseWhenTimeoutActive' => [
 		'config'   => [
 			'pricing-transient' => false,
-			'response'  => [
+			'timeout-active'    => true,
+			'response'          => false,
+		],
+		'expected' => [
+			'result' => false,
+		],
+	],
+
+	'testReturnFalseWhenWPError' => [
+		'config'   => [
+			'pricing-transient' => false,
+			'timeout-active'    => false,
+			'timeout-duration'  => false,
+			'response'          => new WP_Error( 'http_request_failed', 'error' ),
+		],
+		'expected' => [
+			'result' => false,
+		],
+	],
+
+	'testShouldReturnFalseWhenNot200' => [
+		'config'   => [
+			'pricing-transient' => false,
+			'timeout-active'    => false,
+			'timeout-duration'  => false,
+			'response'          => [
 				'code' => 404,
 				'body' => false,
 			],
 		],
-		'expected' => false,
+		'expected' => [
+			'result' => false,
+		],
 	],
-	'testShouldReturnFalseWhenNoBody'  => [
+
+	'testShouldReturnFalseWhenNoBody' => [
 		'config'   => [
 			'pricing-transient' => false,
-			'response'  => [
+			'timeout-active'    => false,
+			'timeout-duration'  => false,
+			'response'          => [
 				'code' => 200,
 			],
 		],
-		'expected' => false,
-	],
-	'testShouldReturnDataWhenCached'   => [
-		'config'   => [
-			'pricing-transient' => true,
-			'response'  => false,
+		'expected' => [
+			'result' => false,
 		],
-		'expected' => $data,
 	],
-	'testShouldReturnDataWhenSuccess'  => [
+
+	'testShouldReturnDataWhenSuccess' => [
 		'config'   => [
 			'pricing-transient' => false,
-			'response'  => [
+			'timeout-active'    => false,
+			'timeout-duration'  => false,
+			'response'          => [
 				'code' => 200,
 				'body' => $json,
 			],
 		],
-		'expected' => $data,
+		'expected' => [
+			'result' => $data,
+		],
 	],
 ];

--- a/tests/Fixtures/inc/Engine/License/API/PricingClient/getPricingData.php
+++ b/tests/Fixtures/inc/Engine/License/API/PricingClient/getPricingData.php
@@ -90,7 +90,7 @@ return [
 			'pricing-transient' => false,
 			'timeout-active'    => false,
 			'timeout-duration'  => 300,
-			'response'          => false,
+			'response'          => [ 'code' => 404 ],
 		],
 		'expected' => [
 			'result'           => false,
@@ -104,7 +104,7 @@ return [
 			'timeout-active'    => false,
 			'timeout-duration'  => rocket_get_constant( 'DAY_IN_SECONDS' )
 								   - rocket_get_constant( 'HOuR_IN_SECONDS' ),
-			'response'          => false,
+			'response'          => [ 'code' => 404 ],
 		],
 		'expected' => [
 			'result'           => false,

--- a/tests/Integration/inc/Engine/License/API/PricingClient/getPricingData.php
+++ b/tests/Integration/inc/Engine/License/API/PricingClient/getPricingData.php
@@ -9,23 +9,29 @@ use WP_Rocket\Tests\Integration\TestCase;
 /**
  * @covers \WP_Rocket\Engine\License\API\PricingClient::get_pricing_data
  *
- * @group License
+ * @group  License
  */
 class GetPricingData extends TestCase {
 	protected static $transients = [
 		'wp_rocket_pricing',
+		'wp_rocket_pricing_timeout',
+		'wp_rocket_pricing_timeout_active'
 	];
-
-	public function tearDown() {
-		delete_transient( 'wp_rocket_pricing' );
-
-		parent::tearDown();
-	}
 
 	public function setUp() {
 		parent::setUp();
 
 		delete_transient( 'wp_rocket_pricing' );
+		delete_transient( 'wp_rocket_pricing_timeout' );
+		delete_transient( 'wp_rocket_pricing_timeout_active' );
+	}
+
+	public function tearDown() {
+		delete_transient( 'wp_rocket_pricing' );
+		delete_transient( 'wp_rocket_pricing_timeout' );
+		delete_transient( 'wp_rocket_pricing_timeout_active' );
+
+		parent::tearDown();
 	}
 
 	/**
@@ -34,29 +40,44 @@ class GetPricingData extends TestCase {
 	public function testShouldReturnExpected( $config, $expected ) {
 		$client = new PricingClient();
 
-		if ( true === $config['transient'] ) {
-			set_transient( 'wp_rocket_pricing', $expected );
+		if ( true === $config['pricing-transient'] ) {
+			set_transient( 'wp_rocket_pricing', $expected['result'] );
 		}
 
-		if ( false === $expected ) {
+		if ( false !== $config['timeout-duration'] ) {
+			set_transient( 'wp_rocket_pricing_timeout', $config['timeout-duration'], WEEK_IN_SECONDS );
+		}
+
+		if ( true === $config['timeout-active'] ) {
+			set_transient( 'wp_rocket_pricing_timeout_active', true, WEEK_IN_SECONDS );
+		}
+
+		if ( false === $config['timeout-active'] && false === $expected['result'] ) {
 			Functions\expect( 'wp_safe_remote_get' )
-			->once()
-			->with( PricingClient::PRICING_ENDPOINT )
-			->andReturn( $config['response'] );
+				->once()
+				->with( PricingClient::PRICING_ENDPOINT )
+				->andReturn( $config['response'] );
 
 			$this->assertFalse( $client->get_pricing_data() );
 		} else {
 			$this->assertEquals(
-				array_keys( (array) $expected ),
+				array_keys( (array) $expected['result'] ),
 				array_keys( (array) $client->get_pricing_data() )
 			);
 
-			if ( false === $config['transient'] ) {
+			if ( false === $config['pricing-transient'] ) {
 				$this->assertEquals(
-					array_keys( (array) $expected ),
+					array_keys( (array) $expected['result'] ),
 					array_keys( (array) get_transient( 'wp_rocket_pricing' ) )
 				);
 			}
+		}
+
+		if ( false !== $config['timeout-duration'] ) {
+			$this->assertEquals(
+				$expected['timeout-duration'],
+				get_transient( 'wp_rocket_pricing_timeout' )
+			);
 		}
 	}
 }

--- a/tests/Unit/inc/Engine/License/API/PricingClient/getPricingData.php
+++ b/tests/Unit/inc/Engine/License/API/PricingClient/getPricingData.php
@@ -10,7 +10,7 @@ use WP_Rocket\Tests\Unit\TestCase;
 /**
  * @covers \WP_Rocket\Engine\License\API\PricingClient::get_pricing_data
  *
- * @group License
+ * @group  License
  */
 class GetPricingData extends TestCase {
 	/**
@@ -22,7 +22,7 @@ class GetPricingData extends TestCase {
 		Functions\expect( 'get_transient' )
 			->once()
 			->with( 'wp_rocket_pricing' )
-			->andReturn( true === $config['transient'] ? $expected : false );
+			->andReturn( true === $config['pricing-transient'] ? $expected : false );
 
 		if ( false !== $config['response'] ) {
 			Functions\expect( 'wp_safe_remote_get' )
@@ -30,31 +30,44 @@ class GetPricingData extends TestCase {
 				->with( PricingClient::PRICING_ENDPOINT )
 				->andReturn( $config['response'] );
 
-				Functions\when( 'wp_remote_retrieve_response_code' )
+			Functions\when( 'wp_remote_retrieve_response_code' )
 				->justReturn(
 					is_array( $config['response'] ) && isset( $config['response']['code'] )
-					? $config['response']['code']
-					: ''
+						? $config['response']['code']
+						: ''
 				);
 
-				Functions\when( 'wp_remote_retrieve_body' )
+			Functions\when( 'wp_remote_retrieve_body' )
 				->justReturn(
 					is_array( $config['response'] ) && isset( $config['response']['body'] )
-					? $config['response']['body']
-					: ''
+						? $config['response']['body']
+						: ''
 				);
+
+			if ( is_array( $config['response'] ) && ! $config['response']['body'] ) {
+				Functions\expect( 'set_transient' )->twice();
+			}
+
 		} else {
-			Functions\expect( 'wp_safe_remote_get' )->never();
+			 if ( is_array( $config['response'] ) && isset( $config['response']['body'] ) ) {
+			 	Functions\expect( 'set_transient' )
+					->with( 'wp_rocket_pricing_timeout' )
+					->andAlsoExpectIt()
+					->with( 'wp_rocket_pricing_timeout_active' );
+			 }
+
+			 Functions\expect( 'wp_safe_remote_get' )->never();
 		}
 
 		if (
-			false === $config['transient']
+			false === $config['pricing-transient']
 			&&
 			false !== $expected
 		) {
 			Functions\expect( 'set_transient' )
 				->once()
 				->with( 'wp_rocket_pricing', Mockery::type( 'object' ), 12 * HOUR_IN_SECONDS );
+			Functions\expect( 'delete_transient' )->twice();
 		} else {
 			Functions\expect( 'set_transient' )->never();
 		}

--- a/tests/Unit/inc/Engine/License/API/PricingClient/getPricingData.php
+++ b/tests/Unit/inc/Engine/License/API/PricingClient/getPricingData.php
@@ -62,7 +62,15 @@ class GetPricingData extends TestCase {
 					->andReturn( (int) $config['timeout-duration'] );
 
 				Functions\expect( 'set_transient' )
-					->with( 'wp_rocket_pricing_timeout', 300, rocket_get_constant('WEEK_IN_SECONDS' ) )
+					->with(
+						'wp_rocket_pricing_timeout',
+						$config['timeout-duration']
+							? min( [
+							2 * $config['timeout-duration'],
+							rocket_get_constant( 'DAY_IN_SECONDS' )
+						] )
+							: 300,
+						rocket_get_constant( 'WEEK_IN_SECONDS' ) )
 					->andAlsoExpectIt()
 					->with( 'wp_rocket_pricing_timeout_active', true, WEEK_IN_SECONDS );
 			} else {

--- a/tests/Unit/inc/Engine/License/API/PricingClient/getPricingData.php
+++ b/tests/Unit/inc/Engine/License/API/PricingClient/getPricingData.php
@@ -22,7 +22,28 @@ class GetPricingData extends TestCase {
 		Functions\expect( 'get_transient' )
 			->once()
 			->with( 'wp_rocket_pricing' )
-			->andReturn( true === $config['pricing-transient'] ? $expected : false );
+			->andReturn( true === $config['pricing-transient'] ? $expected['result'] : false );
+
+		Functions\when( 'wp_remote_retrieve_response_code' )
+			->justReturn(
+				is_array( $config['response'] ) && isset( $config['response']['code'] )
+					? $config['response']['code']
+					: ''
+			);
+
+		Functions\when( 'wp_remote_retrieve_body' )
+			->justReturn(
+				is_array( $config['response'] ) && isset( $config['response']['body'] )
+					? $config['response']['body']
+					: ''
+			);
+
+		if ( false === $config['pricing-transient'] ) {
+			Functions\expect( 'get_transient' )
+				->once()
+				->with( 'wp_rocket_pricing_timeout_active' )
+				->andReturn( $config['timeout-active'] );
+		}
 
 		if ( false !== $config['response'] ) {
 			Functions\expect( 'wp_safe_remote_get' )
@@ -30,51 +51,28 @@ class GetPricingData extends TestCase {
 				->with( PricingClient::PRICING_ENDPOINT )
 				->andReturn( $config['response'] );
 
-			Functions\when( 'wp_remote_retrieve_response_code' )
-				->justReturn(
-					is_array( $config['response'] ) && isset( $config['response']['code'] )
-						? $config['response']['code']
-						: ''
-				);
-
-			Functions\when( 'wp_remote_retrieve_body' )
-				->justReturn(
-					is_array( $config['response'] ) && isset( $config['response']['body'] )
-						? $config['response']['body']
-						: ''
-				);
-
-			if ( is_array( $config['response'] ) && ! $config['response']['body'] ) {
-				Functions\expect( 'set_transient' )->twice();
-			}
-
-		} else {
-			 if ( is_array( $config['response'] ) && isset( $config['response']['body'] ) ) {
-			 	Functions\expect( 'set_transient' )
+			if (
+				! is_array( $config['response'] ) ||
+				200 !== $config['response']['code'] ||
+				! isset( $config['response']['body'] )
+			) {
+				Functions\expect( 'get_transient' )
+					->once()
 					->with( 'wp_rocket_pricing_timeout' )
+					->andReturn( (int) $config['timeout-duration'] );
+
+				Functions\expect( 'set_transient' )
+					->with( 'wp_rocket_pricing_timeout', 300, rocket_get_constant('WEEK_IN_SECONDS' ) )
 					->andAlsoExpectIt()
-					->with( 'wp_rocket_pricing_timeout_active' );
-			 }
-
-			 Functions\expect( 'wp_safe_remote_get' )->never();
+					->with( 'wp_rocket_pricing_timeout_active', true, WEEK_IN_SECONDS );
+			} else {
+				Functions\expect( 'set_transient' )
+					->once()
+					->with( 'wp_rocket_pricing', Mockery::type( 'object' ), 12 * HOUR_IN_SECONDS );
+				Functions\expect( 'delete_transient' )->twice();
+			}
 		}
 
-		if (
-			false === $config['pricing-transient']
-			&&
-			false !== $expected
-		) {
-			Functions\expect( 'set_transient' )
-				->once()
-				->with( 'wp_rocket_pricing', Mockery::type( 'object' ), 12 * HOUR_IN_SECONDS );
-			Functions\expect( 'delete_transient' )->twice();
-		} else {
-			Functions\expect( 'set_transient' )->never();
-		}
-
-		$this->assertEquals(
-			$expected,
-			$client->get_pricing_data()
-		);
+		$this->assertEquals( $expected['result'], $client->get_pricing_data() );
 	}
 }


### PR DESCRIPTION
Closes #3440

Adds 2 transients
1. `wp_rocket_pricing_timeout` saves the current duration of the pricing API timeout, and
2. `wp_rocket_pricing_timeout_active` saves whether a pricing API timeout is currently active
 
Using 2 transients here, because using the transient expiration for duration causes the duration to be lost between admin page loads when the current transient expires.

Needs: Unit/Integration tests for transient behavior in `PricingClient::get_pricing_data()`