### PR TITLE
GH-3540 Adds Combine JS exception for AMP mobile redirection script.

### DIFF
--- a/inc/Engine/Optimization/Minify/JS/Combine.php
+++ b/inc/Engine/Optimization/Minify/JS/Combine.php
@@ -684,7 +684,7 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 			'tagGroupsTabstaggroupscloudtabs',
 			'jrRelatedWidgets',
 			'UNCODE.initRow',
-			'ampUrl',
+			'amp_mobile_redirect_disabled',
 		];
 
 		$excluded_inline = array_merge( $defaults, $this->options->get( 'exclude_inline_js', [] ) );

--- a/inc/Engine/Optimization/Minify/JS/Combine.php
+++ b/inc/Engine/Optimization/Minify/JS/Combine.php
@@ -684,6 +684,7 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 			'tagGroupsTabstaggroupscloudtabs',
 			'jrRelatedWidgets',
 			'UNCODE.initRow',
+			'ampUrl',
 		];
 
 		$excluded_inline = array_merge( $defaults, $this->options->get( 'exclude_inline_js', [] ) );


### PR DESCRIPTION
My PR addresses #3540 
Adds AMP plugin's inline script for mobile redirection to exclusion list (`amp_mobile_redirect_disabled` ). So it will redirect without delay.

