### PR TITLE
Add filters to set file name externally and force page loading

### DIFF
--- a/inc/Engine/Optimization/Minify/CSS/Combine.php
+++ b/inc/Engine/Optimization/Minify/CSS/Combine.php
@@ -199,6 +199,14 @@ class Combine extends AbstractCSSOptimization implements ProcessorInterface {
 
 		$file_hash      = implode( ',', array_column( $this->styles, 'url' ) );
 		$this->filename = md5( $file_hash . $this->minify_key ) . '.css';
+		
+		/**
+		 * Allow overwriting file name to be saved.
+		 *
+		 * @since 3.8.9
+		 *
+		 * @param string $filename The file name already generated.
+		 */
 		$this->filename      = apply_filters( 'rocket_minified_css_file_name', $this->filename );
 
 		$combined_file = $this->minify_base_path . $this->filename;
@@ -276,6 +284,13 @@ class Combine extends AbstractCSSOptimization implements ProcessorInterface {
 			]
 		);
 
+		/**
+		 * Filters file URL before inserting as stylesheet source.
+		 *
+		 * @since 3.8.9
+		 *
+		 * @param string $minify_url URL of minified file to be served.
+		 */
 		$minify_url = apply_filters( 'rocket_minified_css_url', $minify_url );
 		// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 		return preg_replace( '/<\/title>/i', '$0<link rel="stylesheet" href="' . esc_url( $minify_url ) . '" media="all" data-minify="1" />', $html, 1 );

--- a/inc/Engine/Optimization/Minify/CSS/Combine.php
+++ b/inc/Engine/Optimization/Minify/CSS/Combine.php
@@ -199,6 +199,7 @@ class Combine extends AbstractCSSOptimization implements ProcessorInterface {
 
 		$file_hash      = implode( ',', array_column( $this->styles, 'url' ) );
 		$this->filename = md5( $file_hash . $this->minify_key ) . '.css';
+		$this->filename      = apply_filters( 'rocket_minified_css_file_name', $this->filename );
 
 		$combined_file = $this->minify_base_path . $this->filename;
 
@@ -275,6 +276,7 @@ class Combine extends AbstractCSSOptimization implements ProcessorInterface {
 			]
 		);
 
+		$minify_url = apply_filters( 'rocket_minified_css_url', $minify_url );
 		// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 		return preg_replace( '/<\/title>/i', '$0<link rel="stylesheet" href="' . esc_url( $minify_url ) . '" media="all" data-minify="1" />', $html, 1 );
 	}

--- a/inc/Engine/Optimization/Minify/JS/Combine.php
+++ b/inc/Engine/Optimization/Minify/JS/Combine.php
@@ -133,6 +133,14 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 		}
 
 
+
+		/**
+		 * Filters file URL before inserting as script source.
+		 *
+		 * @since 3.8.9
+		 *
+		 * @param string $minify_url URL of minified file to be served.
+		 */
 		$minify_url = apply_filters( 'rocket_minified_js_url', $minify_url );
 		// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 		$html = str_replace( '</body>', '<script src="' . esc_url( $minify_url ) . '" data-minify="1"></script>' . $move_after . '</body>', $html );
@@ -357,6 +365,15 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 
 		$filename      = md5( $content . $this->minify_key ) . '.js';
 		$minified_file = $this->minify_base_path . $filename;
+
+
+		/**
+		 * Allow overwriting file name to be saved.
+		 *
+		 * @since 3.8.9
+		 *
+		 * @param string $filename The file name already generated.
+		 */
 		$filename      = apply_filters( 'rocket_minified_js_file_name', $filename );
 
 		if ( ! rocket_direct_filesystem()->is_readable( $minified_file ) ) {

--- a/inc/Engine/Optimization/Minify/JS/Combine.php
+++ b/inc/Engine/Optimization/Minify/JS/Combine.php
@@ -132,6 +132,8 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 			}
 		}
 
+
+		$minify_url = apply_filters( 'rocket_minified_js_url', $minify_url );
 		// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 		$html = str_replace( '</body>', '<script src="' . esc_url( $minify_url ) . '" data-minify="1"></script>' . $move_after . '</body>', $html );
 
@@ -355,6 +357,8 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 
 		$filename      = md5( $content . $this->minify_key ) . '.js';
 		$minified_file = $this->minify_base_path . $filename;
+		$filename      = apply_filters( 'rocket_minified_js_file_name', $filename );
+
 		if ( ! rocket_direct_filesystem()->is_readable( $minified_file ) ) {
 			$minified_content = $this->minify();
 

--- a/inc/classes/Buffer/class-cache.php
+++ b/inc/classes/Buffer/class-cache.php
@@ -94,12 +94,14 @@ class Cache extends Abstract_Buffer {
 		$accept_encoding     = $this->config->get_server_input( 'HTTP_ACCEPT_ENCODING' );
 		$accept_gzip         = $accept_encoding && false !== strpos( $accept_encoding, 'gzip' );
 
+		$force_no_cache = apply_filters( 'rocket_force_no_cache', false );
+
 		// Check if cache file exist.
-		if ( $accept_gzip && is_readable( $cache_filepath_gzip ) ) {
+		if ( ! $force_no_cache && $accept_gzip && is_readable( $cache_filepath_gzip ) ) {
 			$this->serve_gzip_cache_file( $cache_filepath_gzip );
 		}
 
-		if ( is_readable( $cache_filepath ) ) {
+		if ( ! $force_no_cache && is_readable( $cache_filepath ) ) {
 			$this->serve_cache_file( $cache_filepath );
 		}
 

--- a/inc/classes/Buffer/class-cache.php
+++ b/inc/classes/Buffer/class-cache.php
@@ -94,14 +94,12 @@ class Cache extends Abstract_Buffer {
 		$accept_encoding     = $this->config->get_server_input( 'HTTP_ACCEPT_ENCODING' );
 		$accept_gzip         = $accept_encoding && false !== strpos( $accept_encoding, 'gzip' );
 
-		$force_no_cache = apply_filters( 'rocket_force_no_cache', false );
-
 		// Check if cache file exist.
-		if ( ! $force_no_cache && $accept_gzip && is_readable( $cache_filepath_gzip ) ) {
+		if ( $accept_gzip && is_readable( $cache_filepath_gzip ) ) {
 			$this->serve_gzip_cache_file( $cache_filepath_gzip );
 		}
 
-		if ( ! $force_no_cache && is_readable( $cache_filepath ) ) {
+		if ( is_readable( $cache_filepath ) ) {
 			$this->serve_cache_file( $cache_filepath );
 		}
 


### PR DESCRIPTION
This pull request adds two filters:
1, a filter to change the file name at the point where it's generated for minified JS and CSS files.  This will let other plugins implement logic for determining the minified file name before the page is loaded. 
2, a filter to allow changing the URL inserted into the HTML of the page.  This will let other plugins modify the URL if needed, such as to add a cache busting query parameter.