### PR TITLE
#3450 Rewrite AMP Compat fixes using generic filters

### DIFF
--- a/inc/Engine/Optimization/DelayJS/HTML.php
+++ b/inc/Engine/Optimization/DelayJS/HTML.php
@@ -69,17 +69,6 @@ class HTML {
 			return false;
 		}
 
-		/**
-		 * Filter whether to allow rocket to enable delay JS.
-		 *
-		 * @since 3.8.4
-		 *
-		 * @param bool $do_delay_js Whether to enable preload links. Default is true.
-		 */
-		if ( ! (bool) apply_filters( 'rocket_do_delay_js', true ) ) {
-			return false;
-		}
-
 		if ( rocket_get_constant( 'DONOTROCKETOPTIMIZE' ) ) {
 			return false;
 		}

--- a/inc/Engine/Preload/Links/Subscriber.php
+++ b/inc/Engine/Preload/Links/Subscriber.php
@@ -66,17 +66,6 @@ class Subscriber implements Subscriber_Interface {
 			return;
 		}
 
-		/**
-		 * Filter whether to allow rocket to enable preload links.
-		 *
-		 * @since 3.8.4
-		 *
-		 * @param bool $do_preload_links Whether to enable preload links. Default is true.
-		 */
-		if ( ! (bool) apply_filters( 'rocket_do_preload_links', true ) ) {
-			return;
-		}
-
 		$js_assets_path = rocket_get_constant( 'WP_ROCKET_PATH' ) . 'assets/js/';
 
 		if ( ! wp_script_is( 'rocket-browser-checker' ) ) {

--- a/inc/ThirdParty/Plugins/Optimization/AMP.php
+++ b/inc/ThirdParty/Plugins/Optimization/AMP.php
@@ -4,6 +4,7 @@ namespace WP_Rocket\ThirdParty\Plugins\Optimization;
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\CDN\Subscriber;
 use WP_Rocket\Event_Management\Subscriber_Interface;
+use function Sodium\add;
 
 /**
  * Subscriber for compatibility with AMP
@@ -113,8 +114,10 @@ class AMP implements Subscriber_Interface {
 		remove_filter( 'wp_resource_hints', 'rocket_dns_prefetch', 10, 2 );
 		add_filter( 'do_rocket_lazyload', '__return_false' );
 		add_filter( 'do_rocket_lazyload_iframes', '__return_false' );
-		add_filter( 'rocket_do_delay_js', '__return_false' );
-		add_filter( 'rocket_do_preload_links', '__return_false' );
+		add_filter( 'pre_get_rocket_option_async_css', '__return_false' );
+		add_filter( 'pre_get_rocket_option_delay_js', '__return_false' );
+		add_filter( 'pre_get_rocket_option_preload_links', '__return_false' );
+
 		unset( $wp_filter['rocket_buffer'] );
 
 		$options = get_option( self::AMP_OPTIONS, [] );

--- a/inc/ThirdParty/Plugins/Optimization/AMP.php
+++ b/inc/ThirdParty/Plugins/Optimization/AMP.php
@@ -4,7 +4,6 @@ namespace WP_Rocket\ThirdParty\Plugins\Optimization;
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\CDN\Subscriber;
 use WP_Rocket\Event_Management\Subscriber_Interface;
-use function Sodium\add;
 
 /**
  * Subscriber for compatibility with AMP

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/HTML/delayJs.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/HTML/delayJs.php
@@ -37,19 +37,6 @@ return [
 			'expected' => '<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js">',
 		],
 
-		'shouldDoNothingWhenDoDelayFilterFalse' => [
-			'config'   => [
-				'bypass'               => false,
-				'donotoptimize'        => false,
-				'do-not-delay-setting' => 0,
-				'post-excluded'        => false,
-				'allowed-scripts'      => [],
-				'do-delay-filter'	   => false,
-			],
-			'html'     => '<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js">',
-			'expected' => '<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js">',
-		],
-
 		'shouldNotProcessDelayJsScriptWhenBypass' => [
 			'config'   => [
 				'donotoptimize'      => false,

--- a/tests/Fixtures/inc/Engine/Preload/Links/Subscriber/addPreloadScript.php
+++ b/tests/Fixtures/inc/Engine/Preload/Links/Subscriber/addPreloadScript.php
@@ -20,16 +20,6 @@ return [
 			],
 			'expected' => false,
 		],
-		'testShouldDoNothingWhenDoPreloadLinksFilterFalse' => [
-			'config' => [
-				'options' => [
-					'preload_links' => 1,
-				],
-				'bypass' => false,
-				'preload_filter' => false,
-			],
-			'expected' => false,
-		],
 		'testShouldReturnPreloadScript' => [
 			'config' => [
 				'options' => [

--- a/tests/Integration/inc/Engine/Optimization/DelayJS/Subscriber/delayJs.php
+++ b/tests/Integration/inc/Engine/Optimization/DelayJS/Subscriber/delayJs.php
@@ -20,7 +20,6 @@ class Test_DelayJs extends TestCase {
 		unset( $GLOBALS['wp'] );
 		remove_filter( 'pre_get_rocket_option_delay_js', [ $this, 'set_delay_js_option' ] );
 		remove_filter( 'pre_get_rocket_option_delay_js_scripts', [ $this, 'set_delay_js_scripts_option' ] );
-		remove_filter( 'rocket_do_delay_js', '__return_false' );
 	}
 
 	/**
@@ -29,10 +28,6 @@ class Test_DelayJs extends TestCase {
 	public function testShouldProcessScriptHTML( $config, $html, $expected ) {
 		$bypass                    = isset( $config['bypass'] ) ? $config['bypass'] : false;
 		$this->donotrocketoptimize = isset( $config['donotoptimize'] ) ? $config['donotoptimize'] : false;
-
-		if ( isset ($config['do-delay-filter'] ) ) {
-			$this->set_do_rocket_delay_js_filter( $config['do-delay-filter']);
-		}
 
 		$this->options_data        = [
 			'delay_js'         => isset( $config['do-not-delay-setting'] ) ? $config['do-not-delay-setting'] : false,
@@ -66,11 +61,5 @@ class Test_DelayJs extends TestCase {
 
 	public function set_delay_js_scripts_option() {
 		return isset( $this->options_data[ 'delay_js_scripts' ] ) ? $this->options_data[ 'delay_js_scripts' ] : [];
-	}
-
-	public function set_do_rocket_delay_js_filter( bool $do_delay = true ): void {
-		if ( ! $do_delay ) {
-			add_filter( 'rocket_do_delay_js', 'return_false' );
-		}
 	}
 }

--- a/tests/Integration/inc/Engine/Preload/Links/Subscriber/addPreloadScript.php
+++ b/tests/Integration/inc/Engine/Preload/Links/Subscriber/addPreloadScript.php
@@ -17,7 +17,6 @@ class Test_AddPreloadScript extends TestCase {
 
 		unset( $GLOBALS['wp'] );
 		remove_filter( 'pre_get_rocket_option_preload_links', [ $this, 'set_preload_links' ] );
-		remove_filter( 'rocket_do_preload_links', '__return_false' );
 
 		wp_dequeue_script('rocket-browser-checker');
 		wp_dequeue_script('rocket-preload-links');
@@ -37,10 +36,6 @@ class Test_AddPreloadScript extends TestCase {
 
 		if ( $config['bypass'] ) {
 			$GLOBALS['wp']->query_vars['nowprocket'] = 1;
-		}
-
-		if ( isset( $config['preload_filter'] ) && false === $config['preload_filter'] ) {
-			add_filter( 'rocket_do_preload_links' , '__return_false' );
 		}
 
 		$this->preload_links = $config['options']['preload_links'];

--- a/tests/Integration/inc/ThirdParty/Plugins/Optimization/AMP/disableOptionsOnAmp.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Optimization/AMP/disableOptionsOnAmp.php
@@ -36,8 +36,9 @@ class Test_DisableOptionsOnAmp extends TestCase {
 			$this->assertNotFalse( has_filter( 'wp_resource_hints', 'rocket_dns_prefetch' ) );
 			$this->assertFalse( has_filter( 'do_rocket_lazyload', '__return_false' ) );
 			$this->assertFalse( has_filter( 'do_rocket_lazyload_iframes', '__return_false' ) );
-			$this->assertFalse( has_filter( 'rocket_do_delay_js', '__return_false' ) );
-			$this->assertFalse( has_filter( 'rocket_do_preload_links', '__return_false' ) );
+			$this->assertFalse( has_filter( 'pre_get_rocket_option_async_css', '__return_false' ) );
+			$this->assertFalse( has_filter( 'pre_get_rocket_option_delay_js', '__return_false' ) );
+			$this->assertFalse( has_filter( 'pre_get_rocket_option_preload_links', '__return_false' ) );
 
 			$this->assertArrayHasKey( 'rocket_buffer', $wp_filter );
 
@@ -58,8 +59,9 @@ class Test_DisableOptionsOnAmp extends TestCase {
 			$this->assertFalse( has_filter( 'wp_resource_hints', 'rocket_dns_prefetch' ) );
 			$this->assertNotFalse( has_filter( 'do_rocket_lazyload', '__return_false' ) );
 			$this->assertNotFalse( has_filter( 'do_rocket_lazyload_iframes', '__return_false' ) );
-			$this->assertNotFalse( has_filter( 'rocket_do_delay_js', '__return_false' ) );
-			$this->assertNotFalse( has_filter( 'rocket_do_preload_links', '__return_false' ) );
+			$this->assertNotFalse( has_filter( 'pre_get_rocket_option_async_css', '__return_false' ) );
+			$this->assertNotFalse( has_filter( 'pre_get_rocket_option_delay_js', '__return_false' ) );
+			$this->assertNotFalse( has_filter( 'pre_get_rocket_option_preload_links', '__return_false' ) );
 
 			if ( in_array( $config[ 'amp_options' ][ 'theme_support' ], [ 'transitional', 'reader' ], true ) ) {
 				$this->assertArrayHasKey( 'rocket_buffer', $wp_filter );

--- a/tests/Unit/inc/ThirdParty/Plugins/Optimization/AMP/disableOptionsOnAmp.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/Optimization/AMP/disableOptionsOnAmp.php
@@ -52,9 +52,9 @@ class Test_DisableOptionsOnAmp extends TestCase {
 			);
 			$this->assertFalse( has_filter( 'do_rocket_lazyload', '__return_false' ) );
 			$this->assertFalse( has_filter( 'do_rocket_lazyload_iframes', '__return_false' ) );
-			$this->assertFalse( has_filter( 'do_rocket_lazyload_iframes', '__return_false' ) );
-			$this->assertFalse( has_filter( 'rocket_do_delay_js', '__return_false' ) );
-			$this->assertFalse( has_filter( 'rocket_do_preload_links', '__return_false' ) );
+			$this->assertFalse( has_filter( 'pre_get_rocket_option_async_css', '__return_false' ) );
+			$this->assertFalse( has_filter( 'pre_get_rocket_option_delay_js', '__return_false' ) );
+			$this->assertFalse( has_filter( 'pre_get_rocket_option_preload_links', '__return_false' ) );
 
 			$this->assertSame(
 				PHP_INT_MAX,


### PR DESCRIPTION
After #3508 merged, a new more direct approach came to light -- using `pre_get_rocket_option_xxx` directly in the AMP compat file rather than creating new specific filters.

Also, previous solution did not adequately cover the Optimize CSS delivery option, appearing only on activation. Therefore we add `pre_get_rocket_option_async_css` filter here as well.