### PR TITLE
Fixes #3521 Add position configuration for Beacon display

### DIFF
--- a/inc/Engine/Admin/Beacon/Beacon.php
+++ b/inc/Engine/Admin/Beacon/Beacon.php
@@ -41,7 +41,7 @@ class Beacon extends Abstract_Render implements Subscriber_Interface {
 	/**
 	 * Constructor
 	 *
-	 * @since  3.2
+	 * @since 3.2
 	 *
 	 * @param Options_Data $options       Options instance.
 	 * @param string       $template_path Absolute path to the views/settings.
@@ -93,6 +93,7 @@ class Beacon extends Abstract_Render implements Subscriber_Interface {
 			'identify' => wp_json_encode( $this->identify_data() ),
 			'session'  => wp_json_encode( $this->support_data->get_support_data() ),
 			'prefill'  => wp_json_encode( $this->prefill_data() ),
+			'config'   => wp_json_encode( $this->config_data() ),
 		];
 
 		echo $this->generate( 'beacon', $data ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -176,6 +177,21 @@ class Beacon extends Abstract_Render implements Subscriber_Interface {
 		}
 
 		return $prefill_data;
+	}
+
+	/**
+	 * Returns config data to pass to Beacon
+	 *
+	 * @since 3.8.5
+	 *
+	 * @return array
+	 */
+	private function config_data() : array {
+		return [
+			'display' => [
+				'position' => is_rtl() ? 'left' : 'right',
+			],
+		];
 	}
 
 	/**

--- a/tests/Fixtures/inc/Engine/Admin/Beacon/Beacon/insertScript.php
+++ b/tests/Fixtures/inc/Engine/Admin/Beacon/Beacon/insertScript.php
@@ -5,6 +5,7 @@ return [
 		'testShouldEchoDefaultWithNulledLicense' => [
 			'config'   => [
 				'locale'        => 'en_US',
+				'rtl'           => false,
 				'customer_data' => false,
 			],
 			'expected' => [
@@ -13,6 +14,7 @@ return [
 					'identify' => '{"email":"dummy@wp-rocket.me","Website":"http:\/\/example.org"}',
 					'session'  => '{"Website":"http:\/\/example.org","WordPress Version":"5.4","WP Rocket Version":"3.6","Theme":"WordPress Default","Plugins Enabled":"","WP Rocket Active Options":""}',
 					'prefill'  => '{"fields":[{"id":21728,"value":108003}]}',
+					'config' => '{"display":{"position":"right"}}',
 				],
 				'script' => <<<SCRIPT
 <script>!function(e,t,n){function a(){var e=t.getElementsByTagName("script")[0],n=t.createElement("script");n.type="text/javascript",n.async=!0,n.src="https://beacon-v2.helpscout.net",e.parentNode.insertBefore(n,e)}if(e.Beacon=n=function(t,n,a){e.Beacon.readyQueue.push({method:t,options:n,data:a})},n.readyQueue=[],"complete"===t.readyState)return a();e.attachEvent?e.attachEvent("onload",a):e.addEventListener("load",a,!1)}(window,document,window.Beacon||function(){});
@@ -20,6 +22,7 @@ window.Beacon('init', '44cc73fb-7636-4206-b115-c7b33823551b')
 window.Beacon("identify", {"email":"dummy@wp-rocket.me","Website":"http:\/\/example.org"});
 window.Beacon("session-data", {"Website":"http:\/\/example.org","WordPress Version":"5.4","WP Rocket Version":"3.6","Theme":"WordPress Default","Plugins Enabled":"","WP Rocket Active Options":""});
 window.Beacon("prefill", {"fields":[{"id":21728,"value":108003}]});
+window.Beacon("config", {"display":{"position":"right"}});
 window.addEventListener("hashchange", function () {
 	window.Beacon("suggest");
 }, false);</script>
@@ -30,6 +33,7 @@ SCRIPT
 		'testShouldEchoDefaultWithUnavailableLicense' => [
 			'config'   => [
 				'locale'        => 'en_US',
+				'rtl'           => false,
 				'customer_data' => (object) [
 					'licence_account' => 'Unavailable',
 				],
@@ -40,6 +44,7 @@ SCRIPT
 					'identify' => '{"email":"dummy@wp-rocket.me","Website":"http:\/\/example.org"}',
 					'session'  => '{"Website":"http:\/\/example.org","WordPress Version":"5.4","WP Rocket Version":"3.6","Theme":"WordPress Default","Plugins Enabled":"","WP Rocket Active Options":""}',
 					'prefill'  => '{"fields":[{"id":21728,"value":108003}]}',
+					'config' => '{"display":{"position":"right"}}',
 				],
 				'script' => <<<SCRIPT
 <script>!function(e,t,n){function a(){var e=t.getElementsByTagName("script")[0],n=t.createElement("script");n.type="text/javascript",n.async=!0,n.src="https://beacon-v2.helpscout.net",e.parentNode.insertBefore(n,e)}if(e.Beacon=n=function(t,n,a){e.Beacon.readyQueue.push({method:t,options:n,data:a})},n.readyQueue=[],"complete"===t.readyState)return a();e.attachEvent?e.attachEvent("onload",a):e.addEventListener("load",a,!1)}(window,document,window.Beacon||function(){});
@@ -47,6 +52,7 @@ window.Beacon('init', '44cc73fb-7636-4206-b115-c7b33823551b')
 window.Beacon("identify", {"email":"dummy@wp-rocket.me","Website":"http:\/\/example.org"});
 window.Beacon("session-data", {"Website":"http:\/\/example.org","WordPress Version":"5.4","WP Rocket Version":"3.6","Theme":"WordPress Default","Plugins Enabled":"","WP Rocket Active Options":""});
 window.Beacon("prefill", {"fields":[{"id":21728,"value":108003}]});
+window.Beacon("config", {"display":{"position":"right"}});
 window.addEventListener("hashchange", function () {
 	window.Beacon("suggest");
 }, false);</script>
@@ -57,6 +63,7 @@ SCRIPT
 		'testShouldEchoDefaultWithSingleLicense' => [
 			'config'   => [
 				'locale'        => 'en_US',
+				'rtl'           => false,
 				'customer_data' => (object) [
 					'licence_account' => 'Single',
 				],
@@ -67,6 +74,7 @@ SCRIPT
 					'identify' => '{"email":"dummy@wp-rocket.me","Website":"http:\/\/example.org"}',
 					'session'  => '{"Website":"http:\/\/example.org","WordPress Version":"5.4","WP Rocket Version":"3.6","Theme":"WordPress Default","Plugins Enabled":"","WP Rocket Active Options":""}',
 					'prefill'  => '{"fields":[{"id":21728,"value":108000}]}',
+					'config' => '{"display":{"position":"right"}}',
 				],
 				'script' => <<<SCRIPT
 <script>!function(e,t,n){function a(){var e=t.getElementsByTagName("script")[0],n=t.createElement("script");n.type="text/javascript",n.async=!0,n.src="https://beacon-v2.helpscout.net",e.parentNode.insertBefore(n,e)}if(e.Beacon=n=function(t,n,a){e.Beacon.readyQueue.push({method:t,options:n,data:a})},n.readyQueue=[],"complete"===t.readyState)return a();e.attachEvent?e.attachEvent("onload",a):e.addEventListener("load",a,!1)}(window,document,window.Beacon||function(){});
@@ -74,6 +82,7 @@ window.Beacon('init', '44cc73fb-7636-4206-b115-c7b33823551b')
 window.Beacon("identify", {"email":"dummy@wp-rocket.me","Website":"http:\/\/example.org"});
 window.Beacon("session-data", {"Website":"http:\/\/example.org","WordPress Version":"5.4","WP Rocket Version":"3.6","Theme":"WordPress Default","Plugins Enabled":"","WP Rocket Active Options":""});
 window.Beacon("prefill", {"fields":[{"id":21728,"value":108000}]});
+window.Beacon("config", {"display":{"position":"right"}});
 window.addEventListener("hashchange", function () {
 	window.Beacon("suggest");
 }, false);</script>
@@ -84,6 +93,7 @@ SCRIPT
 		'testShouldEchoDefaultWithPlusLicense' => [
 			'config'   => [
 				'locale'        => 'en_US',
+				'rtl'           => false,
 				'customer_data' => (object) [
 					'licence_account' => 'Plus',
 				],
@@ -94,6 +104,7 @@ SCRIPT
 					'identify' => '{"email":"dummy@wp-rocket.me","Website":"http:\/\/example.org"}',
 					'session'  => '{"Website":"http:\/\/example.org","WordPress Version":"5.4","WP Rocket Version":"3.6","Theme":"WordPress Default","Plugins Enabled":"","WP Rocket Active Options":""}',
 					'prefill'  => '{"fields":[{"id":21728,"value":108001}]}',
+					'config' => '{"display":{"position":"right"}}',
 				],
 				'script' => <<<SCRIPT
 <script>!function(e,t,n){function a(){var e=t.getElementsByTagName("script")[0],n=t.createElement("script");n.type="text/javascript",n.async=!0,n.src="https://beacon-v2.helpscout.net",e.parentNode.insertBefore(n,e)}if(e.Beacon=n=function(t,n,a){e.Beacon.readyQueue.push({method:t,options:n,data:a})},n.readyQueue=[],"complete"===t.readyState)return a();e.attachEvent?e.attachEvent("onload",a):e.addEventListener("load",a,!1)}(window,document,window.Beacon||function(){});
@@ -101,6 +112,7 @@ window.Beacon('init', '44cc73fb-7636-4206-b115-c7b33823551b')
 window.Beacon("identify", {"email":"dummy@wp-rocket.me","Website":"http:\/\/example.org"});
 window.Beacon("session-data", {"Website":"http:\/\/example.org","WordPress Version":"5.4","WP Rocket Version":"3.6","Theme":"WordPress Default","Plugins Enabled":"","WP Rocket Active Options":""});
 window.Beacon("prefill", {"fields":[{"id":21728,"value":108001}]});
+window.Beacon("config", {"display":{"position":"right"}});
 window.addEventListener("hashchange", function () {
 	window.Beacon("suggest");
 }, false);</script>
@@ -111,6 +123,7 @@ SCRIPT
 		'testShouldEchoDefaultWithInfiniteLicense' => [
 			'config'   => [
 				'locale'        => 'en_US',
+				'rtl'           => false,
 				'customer_data' => (object) [
 					'licence_account' => 'Infinite',
 				],
@@ -121,6 +134,7 @@ SCRIPT
 					'identify' => '{"email":"dummy@wp-rocket.me","Website":"http:\/\/example.org"}',
 					'session'  => '{"Website":"http:\/\/example.org","WordPress Version":"5.4","WP Rocket Version":"3.6","Theme":"WordPress Default","Plugins Enabled":"","WP Rocket Active Options":""}',
 					'prefill'  => '{"fields":[{"id":21728,"value":108002}]}',
+					'config' => '{"display":{"position":"right"}}',
 				],
 				'script' => <<<SCRIPT
 <script>!function(e,t,n){function a(){var e=t.getElementsByTagName("script")[0],n=t.createElement("script");n.type="text/javascript",n.async=!0,n.src="https://beacon-v2.helpscout.net",e.parentNode.insertBefore(n,e)}if(e.Beacon=n=function(t,n,a){e.Beacon.readyQueue.push({method:t,options:n,data:a})},n.readyQueue=[],"complete"===t.readyState)return a();e.attachEvent?e.attachEvent("onload",a):e.addEventListener("load",a,!1)}(window,document,window.Beacon||function(){});
@@ -128,6 +142,7 @@ window.Beacon('init', '44cc73fb-7636-4206-b115-c7b33823551b')
 window.Beacon("identify", {"email":"dummy@wp-rocket.me","Website":"http:\/\/example.org"});
 window.Beacon("session-data", {"Website":"http:\/\/example.org","WordPress Version":"5.4","WP Rocket Version":"3.6","Theme":"WordPress Default","Plugins Enabled":"","WP Rocket Active Options":""});
 window.Beacon("prefill", {"fields":[{"id":21728,"value":108002}]});
+window.Beacon("config", {"display":{"position":"right"}});
 window.addEventListener("hashchange", function () {
 	window.Beacon("suggest");
 }, false);</script>
@@ -138,6 +153,7 @@ SCRIPT
 		'testShouldEchoFR' => [
 			'config'   => [
 				'locale'        => 'fr_FR',
+				'rtl'           => false,
 				'customer_data' => false,
 			],
 			'expected' => [
@@ -146,6 +162,7 @@ SCRIPT
 					'identify' => '{"email":"dummy@wp-rocket.me","Website":"http:\/\/example.org"}',
 					'session'  => '{"Website":"http:\/\/example.org","WordPress Version":"5.4","WP Rocket Version":"3.6","Theme":"WordPress Default","Plugins Enabled":"","WP Rocket Active Options":""}',
 					'prefill'  => '{"fields":[{"id":21728,"value":108003}]}',
+					'config' => '{"display":{"position":"right"}}',
 				],
 				'script' => <<<SCRIPT
 <script>!function(e,t,n){function a(){var e=t.getElementsByTagName("script")[0],n=t.createElement("script");n.type="text/javascript",n.async=!0,n.src="https://beacon-v2.helpscout.net",e.parentNode.insertBefore(n,e)}if(e.Beacon=n=function(t,n,a){e.Beacon.readyQueue.push({method:t,options:n,data:a})},n.readyQueue=[],"complete"===t.readyState)return a();e.attachEvent?e.attachEvent("onload",a):e.addEventListener("load",a,!1)}(window,document,window.Beacon||function(){});
@@ -153,6 +170,35 @@ window.Beacon('init', '9db9417a-5e2f-41dd-8857-1421d5112aea')
 window.Beacon("identify", {"email":"dummy@wp-rocket.me","Website":"http:\/\/example.org"});
 window.Beacon("session-data", {"Website":"http:\/\/example.org","WordPress Version":"5.4","WP Rocket Version":"3.6","Theme":"WordPress Default","Plugins Enabled":"","WP Rocket Active Options":""});
 window.Beacon("prefill", {"fields":[{"id":21728,"value":108003}]});
+window.Beacon("config", {"display":{"position":"right"}});
+window.addEventListener("hashchange", function () {
+	window.Beacon("suggest");
+}, false);</script>
+SCRIPT
+				,
+			],
+		],
+		'testShouldEchoBeaconOnLeftSide' => [
+			'config'   => [
+				'locale'        => 'ar',
+				'rtl'           => true,
+				'customer_data' => false,
+			],
+			'expected' => [
+				'data'   => [
+					'form_id'  => '44cc73fb-7636-4206-b115-c7b33823551b',
+					'identify' => '{"email":"dummy@wp-rocket.me","Website":"http:\/\/example.org"}',
+					'session'  => '{"Website":"http:\/\/example.org","WordPress Version":"5.4","WP Rocket Version":"3.6","Theme":"WordPress Default","Plugins Enabled":"","WP Rocket Active Options":""}',
+					'prefill'  => '{"fields":[{"id":21728,"value":108003}]}',
+					'config' => '{"display":{"position":"left"}}',
+				],
+				'script' => <<<SCRIPT
+<script>!function(e,t,n){function a(){var e=t.getElementsByTagName("script")[0],n=t.createElement("script");n.type="text/javascript",n.async=!0,n.src="https://beacon-v2.helpscout.net",e.parentNode.insertBefore(n,e)}if(e.Beacon=n=function(t,n,a){e.Beacon.readyQueue.push({method:t,options:n,data:a})},n.readyQueue=[],"complete"===t.readyState)return a();e.attachEvent?e.attachEvent("onload",a):e.addEventListener("load",a,!1)}(window,document,window.Beacon||function(){});
+window.Beacon('init', '44cc73fb-7636-4206-b115-c7b33823551b')
+window.Beacon("identify", {"email":"dummy@wp-rocket.me","Website":"http:\/\/example.org"});
+window.Beacon("session-data", {"Website":"http:\/\/example.org","WordPress Version":"5.4","WP Rocket Version":"3.6","Theme":"WordPress Default","Plugins Enabled":"","WP Rocket Active Options":""});
+window.Beacon("prefill", {"fields":[{"id":21728,"value":108003}]});
+window.Beacon("config", {"display":{"position":"left"}});
 window.addEventListener("hashchange", function () {
 	window.Beacon("suggest");
 }, false);</script>

--- a/tests/Integration/inc/Engine/Admin/Beacon/Beacon/insertScript.php
+++ b/tests/Integration/inc/Engine/Admin/Beacon/Beacon/insertScript.php
@@ -14,22 +14,28 @@ use WP_Rocket\Tests\Integration\TestCase;
  */
 class Test_InsertScript extends TestCase {
 	private $locale;
+	private $text_direction;
+
 	protected static $transients = [
 		'wp_rocket_customer_data' => null,
 	];
 
 	public function setUp() {
+		global $wp_locale;
+
 		parent::setUp();
 
 		set_current_screen( 'settings_page_wprocket' );
 		Functions\when( 'get_bloginfo' )->justReturn( '5.4' );
+
+		$this->text_direction = $wp_locale->text_direction;
 	}
 
 	public function tearDown() {
 		global $wp_locale;
 		set_current_screen( 'front' );
 
-		$wp_locale->text_direction = 'ltr';
+		$wp_locale->text_direction = $this->text_direction;
 
 		remove_filter( 'rocket_beacon_locale', [ $this, 'locale_cb' ] );
 		remove_filter( 'pre_get_rocket_option_consumer_email', [ $this, 'consumer_email' ] );

--- a/tests/Integration/inc/Engine/Admin/Beacon/Beacon/insertScript.php
+++ b/tests/Integration/inc/Engine/Admin/Beacon/Beacon/insertScript.php
@@ -26,12 +26,15 @@ class Test_InsertScript extends TestCase {
 	}
 
 	public function tearDown() {
-		parent::tearDown();
-
+		global $wp_locale;
 		set_current_screen( 'front' );
+
+		$wp_locale->text_direction = 'ltr';
 
 		remove_filter( 'rocket_beacon_locale', [ $this, 'locale_cb' ] );
 		remove_filter( 'pre_get_rocket_option_consumer_email', [ $this, 'consumer_email' ] );
+
+		parent::tearDown();
 	}
 
 	public function testCallbackIsRegistered() {
@@ -56,11 +59,17 @@ class Test_InsertScript extends TestCase {
 	 * @dataProvider configTestData
 	 */
 	public function testShouldReturnBeaconScript( $config, $expected ) {
+		global $wp_locale;
+
 		$this->createUser( 'administrator' );
 		$this->assertTrue( current_user_can( 'rocket_manage_options' ) );
 
 		$this->locale         = $config['locale'];
 		$this->rocket_version = '3.6';
+
+		if ( $config['rtl'] ) {
+			$wp_locale->text_direction = 'rtl';
+		}
 
 		if ( false !== $config['customer_data'] ) {
 			set_transient( 'wp_rocket_customer_data', $config['customer_data'] );

--- a/tests/Unit/inc/Engine/Admin/Beacon/Beacon/insertScript.php
+++ b/tests/Unit/inc/Engine/Admin/Beacon/Beacon/insertScript.php
@@ -2,13 +2,13 @@
 
 namespace WP_Rocket\Tests\Unit\inc\Engine\Admin\Beacon\Beacon;
 
-use Mockery;
-use WP_Theme;
 use Brain\Monkey\Functions;
+use Mockery;
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\Admin\Beacon\Beacon;
 use WP_Rocket\Engine\Support\Data;
 use WP_Rocket\Tests\Unit\TestCase;
+use WP_Theme;
 
 /**
  * @covers \WP_Rocket\Engine\Admin\Beacon\Beacon::insert_script
@@ -53,6 +53,7 @@ class Test_InsertScript extends TestCase {
 		Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
 		Functions\when( 'home_url' )->justReturn( 'http://example.org' );
 		Functions\when( 'get_transient' )->justReturn( $config['customer_data'] );
+		Functions\when( 'is_rtl' )->justReturn( $config['rtl'] );
 
 		$this->options->shouldReceive( 'get' )
 			->with( 'consumer_email' )

--- a/views/settings/beacon.php
+++ b/views/settings/beacon.php
@@ -9,6 +9,7 @@
  *      @type string $identify Identify data to send to Helpscout.
  *      @type string $session  Session data to send to Helpscout.
  *      @type string $prefill  Prefill data to send to Helpscout.
+ *      @type string $config   Config data to send to Helpscout.
  * }
  */
 
@@ -20,6 +21,7 @@ window.Beacon('init', '<?php echo esc_js( $data['form_id'] ); ?>')
 window.Beacon("identify", <?php echo $data['identify']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>);
 window.Beacon("session-data", <?php echo $data['session']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>);
 window.Beacon("prefill", <?php echo $data['prefill']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>);
+window.Beacon("config", <?php echo $data['config']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>);
 window.addEventListener("hashchange", function () {
 	window.Beacon("suggest");
 }, false);</script>


### PR DESCRIPTION
## Description

This PR adds support for RTL languages when displaying the HS Beacon on our settings page.

Instead of always being displayed on the right hand side, it's now displayed on the left hand side for RTL languages.

Fixes #3521

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Tested on LTR language with english set as the website language in WP settings
- [x] Tested on RTL language with arabic  set as the website language in WP settings
- [x] Unit/Integration tests updated to validate the Beacon configuration

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes