### PR TITLE
Update branch name from master to trunk in actions

### DIFF
--- a/.github/workflows/licence_data.yml
+++ b/.github/workflows/licence_data.yml
@@ -2,9 +2,9 @@ name: Rebuild Licence data file
 
 on:
   push:
-    branches: [ master, develop ]
+    branches: [ trunk, develop ]
   pull_request:
-    branches: [ master, develop ]
+    branches: [ trunk, develop ]
 
 jobs:
   licence:

--- a/.github/workflows/lint_phpcs.yml
+++ b/.github/workflows/lint_phpcs.yml
@@ -3,7 +3,7 @@ name: PHP CodeSniffer lint
 on:
   pull_request:
     branches:
-      - master
+      - trunk
       - develop
       - branch-*
       - feature/*

--- a/.github/workflows/lint_phpstan.yml
+++ b/.github/workflows/lint_phpstan.yml
@@ -3,7 +3,7 @@ name: PHPStan lint
 on:
   pull_request:
     branches:
-      - master
+      - trunk
       - develop
       - branch-*
       - feature/*

--- a/.github/workflows/test_wprocket.yml
+++ b/.github/workflows/test_wprocket.yml
@@ -3,7 +3,7 @@ name: WPRocket Test
 on:
   pull_request:
     branches:
-      - master
+      - trunk
       - develop
       - branch-*
       - feature/*

--- a/.github/workflows/test_wprocket_legacy.yml
+++ b/.github/workflows/test_wprocket_legacy.yml
@@ -3,7 +3,7 @@ name: WPRocket Test - Legacy
 on:
   pull_request:
     branches:
-      - master
+      - trunk
       - develop
       - branch-*
       - feature/*


### PR DESCRIPTION
We renamed the `master` branch to `trunk` recently. This change needs to be reflected in our Github Actions to make sure they are correctly triggered again.