### PR TITLE
Fixes #3332 Add missing filter parameter in get_rocket_cdn_cnames()

### DIFF
--- a/inc/functions/api.php
+++ b/inc/functions/api.php
@@ -66,7 +66,7 @@ function get_rocket_cdn_cnames( $zone = 'all' ) { // phpcs:ignore WordPress.Nami
 	 *
 	 * @param array $hosts List of CNAMES.
 	 */
-	$hosts = (array) apply_filters( 'rocket_cdn_cnames', $hosts );
+	$hosts = (array) apply_filters( 'rocket_cdn_cnames', $hosts, $zone );
 	$hosts = array_filter( $hosts );
 	$hosts = array_flip( array_flip( $hosts ) );
 	$hosts = array_values( $hosts );

--- a/inc/functions/api.php
+++ b/inc/functions/api.php
@@ -65,6 +65,7 @@ function get_rocket_cdn_cnames( $zone = 'all' ) { // phpcs:ignore WordPress.Nami
 	 * @since 2.7
 	 *
 	 * @param array $hosts List of CNAMES.
+	 * @param array $zone  Array of CDN zones.
 	 */
 	$hosts = (array) apply_filters( 'rocket_cdn_cnames', $hosts, $zone );
 	$hosts = array_filter( $hosts );


### PR DESCRIPTION
## Description

This PR adds a missing filter parameter in the function `get_rocket_cdn_cnames()`.

This missing parameter created a fatal error when the above function is used in conjunction with the EWWW plugin enabled, because of our EWWW compatibility file, which requires the 2 parameters.

Fixes #3332

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
