### PR TITLE
Fixes #3437 Exclude image inside a picture element from lazyload

### DIFF
--- a/inc/Dependencies/RocketLazyload/Image.php
+++ b/inc/Dependencies/RocketLazyload/Image.php
@@ -253,6 +253,16 @@ class Image {
 
 		foreach ( $pictures as $picture ) {
 			if ( $this->isExcluded( $picture[0], $excluded ) ) {
+				if ( ! preg_match( '#<img(?<atts>\s.+)\s?/?>#iUs', $picture[0], $img ) ) {
+					continue;
+				}
+	
+				$img = $this->canLazyload( $img );
+	
+				if ( ! $img ) {
+					continue;
+				}
+
 				$nolazy_picture = str_replace( '<img', '<img data-skip-lazy=""', $picture[0] );
 				$html           = str_replace( $picture[0], $nolazy_picture, $html );
 

--- a/inc/Dependencies/RocketLazyload/Image.php
+++ b/inc/Dependencies/RocketLazyload/Image.php
@@ -253,25 +253,30 @@ class Image {
 
 		foreach ( $pictures as $picture ) {
 			if ( $this->isExcluded( $picture[0], $excluded ) ) {
+				$nolazy_picture = str_replace( '<img', '<img data-skip-lazy=""', $picture[0] );
+				$html           = str_replace( $picture[0], $nolazy_picture, $html );
+
 				continue;
 			}
 
-			$lazy_sources = 0;
-
 			if ( preg_match_all( '#<source(?<atts>\s.+)>#iUs', $picture['sources'], $sources, PREG_SET_ORDER ) ) {
-				$sources = array_unique( $sources, SORT_REGULAR );
+				$lazy_sources = 0;
+				$sources      = array_unique( $sources, SORT_REGULAR );
+				$lazy_picture = $picture[0];
 
 				foreach ( $sources as $source ) {
 					$lazyload_srcset = preg_replace( '/([\s"\'])srcset/i', '\1data-lazy-srcset', $source[0] );
-					$html            = str_replace( $source[0], $lazyload_srcset, $html );
+					$lazy_picture    = str_replace( $source[0], $lazyload_srcset, $lazy_picture );
 
 					unset( $lazyload_srcset );
 					$lazy_sources++;
 				}
-			}
 
-			if ( 0 === $lazy_sources ) {
-				continue;
+				if ( 0 === $lazy_sources ) {
+					continue;
+				}
+
+				$html = str_replace( $picture[0], $lazy_picture, $html );
 			}
 
 			if ( ! preg_match( '#<img(?<atts>\s.+)\s?/?>#iUs', $picture[0], $img ) ) {


### PR DESCRIPTION
## Description

This PR adds the `data-skip-lazy` attribute to `img` inside a `picture`, when the picture is excluded from lazyload.

It also fixes a bug that would set the `data-lazy-srcset` on `source` when it should not.

Fixes https://github.com/wp-media/wp-rocket/issues/3437

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests updated to validate the code update on the upstream repository

## Is there any change compared to the proposed solution during grooming?

Yes, the proposed solution was to ignore `picture` elements in the html when doing the lazyload for images, by changing the buffer value.

I took a different approach, to propose a self-contained solution, where we directly add an excluded attribute to the `img` inside a `picture`. That way, this `img` will be skipped by the lazyload for images.

It also avoids modifying the buffer, which can have unexpected side-effects.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes