### PR TITLE
Fixes #3035 Prevent WP_CACHE from being defined multiple times in wp-config.php

### DIFF
--- a/inc/Engine/Cache/WPCache.php
+++ b/inc/Engine/Cache/WPCache.php
@@ -156,7 +156,7 @@ class WPCache implements ActivationInterface, DeactivationInterface {
 		$constant = $this->get_wp_cache_content( $value );
 
 		if ( ! $wp_cache_found ) {
-			$config_file_contents = preg_replace( '/(<\?php)/i', "<?php\r\n{$constant}\r\n", $config_file_contents );
+			$config_file_contents = preg_replace( '/(<\?php)/i', "<?php\r\n{$constant}\r\n", $config_file_contents, 1 );
 		} elseif ( ! empty( $matches['value'] ) && $matches['value'] !== $value ) {
 			$config_file_contents = preg_replace( '/^\s*define\(\s*\'WP_CACHE\'\s*,\s*([^\s\)]*)\s*\).+/m', $constant, $config_file_contents );
 		}


### PR DESCRIPTION
## Description

like proposed by @Tabrisrp added the limit paramater to preg_replace to assure the WP_CACHE constant only will be set once no matter how often `<?php` is found.

Fixes #3035

## Type of change

- [X] Bugfix

## Is the solution different from the one proposed during the grooming?

No

## How Has This Been Tested?

tested using an online PHP tool

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules