### PR TITLE
Fixes #3498 Turn off "Delay JS" option when Safe Mode is activated

### DIFF
--- a/inc/Engine/Admin/Deactivation/DeactivationIntent.php
+++ b/inc/Engine/Admin/Deactivation/DeactivationIntent.php
@@ -139,7 +139,6 @@ mixpanel.init("a36067b00a263cce0299cfd960e26ecf", {
 			'rocket_safe_mode_reset_options',
 			[
 				'embeds'                 => 0,
-				'defer_all_js'           => 0,
 				'async_css'              => 0,
 				'lazyload'               => 0,
 				'lazyload_iframes'       => 0,
@@ -148,6 +147,8 @@ mixpanel.init("a36067b00a263cce0299cfd960e26ecf", {
 				'minify_concatenate_css' => 0,
 				'minify_js'              => 0,
 				'minify_concatenate_js'  => 0,
+				'defer_all_js'           => 0,
+				'delay_js'               => 0,
 				'minify_google_fonts'    => 0,
 				'cdn'                    => 0,
 			]

--- a/inc/Engine/Optimization/DelayJS/Admin/Subscriber.php
+++ b/inc/Engine/Optimization/DelayJS/Admin/Subscriber.php
@@ -41,7 +41,6 @@ class Subscriber extends Abstract_Render implements Subscriber_Interface {
 				[ 'option_update_3_7_6_1', 13, 2 ],
 			],
 			'wp_ajax_rocket_restore_delay_js_defaults'     => 'restore_defaults',
-			'rocket_safe_mode_reset_options'               => 'add_options',
 		];
 	}
 

--- a/tests/Fixtures/inc/Engine/Admin/Deactivation/DeactivationIntent/activateSafeMode.php
+++ b/tests/Fixtures/inc/Engine/Admin/Deactivation/DeactivationIntent/activateSafeMode.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+	'testShouldResetOptions' => [
+		'expected' => [
+			'embeds'                 => 0,
+			'async_css'              => 0,
+			'lazyload'               => 0,
+			'lazyload_iframes'       => 0,
+			'lazyload_youtube'       => 0,
+			'minify_css'             => 0,
+			'minify_concatenate_css' => 0,
+			'minify_js'              => 0,
+			'minify_concatenate_js'  => 0,
+			'defer_all_js'           => 0,
+			'delay_js'               => 0,
+			'minify_google_fonts'    => 0,
+			'cdn'                    => 0,
+		],
+	],
+];

--- a/tests/Integration/inc/Engine/Admin/Deactivation/DeactivationIntent/activateSafeMode.php
+++ b/tests/Integration/inc/Engine/Admin/Deactivation/DeactivationIntent/activateSafeMode.php
@@ -41,7 +41,10 @@ class Test_ActivateSafeMode extends AjaxTestCase {
 		$this->assertFalse( $response->success );
 	}
 
-	public function testShouldResetOptions() {
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldResetOptions( $expected ) {
 		CapTrait::setAdminCap();
 
 		$this->_setRole( 'administrator' );
@@ -53,25 +56,9 @@ class Test_ActivateSafeMode extends AjaxTestCase {
 		$this->assertObjectHasAttribute( 'success', $response );
 		$this->assertTrue( $response->success );
 
-		$expected_subset = [
-			'embeds'                 => 0,
-			'async_css'              => 0,
-			'lazyload'               => 0,
-			'lazyload_iframes'       => 0,
-			'lazyload_youtube'       => 0,
-			'minify_css'             => 0,
-			'minify_concatenate_css' => 0,
-			'minify_js'              => 0,
-			'minify_concatenate_js'  => 0,
-			'defer_all_js'           => 0,
-			'delay_js'               => 0,
-			'minify_google_fonts'    => 0,
-			'cdn'                    => 0,
-		];
-
 		$options = get_option( 'wp_rocket_settings' );
 
-		foreach ( $expected_subset as $key => $value ) {
+		foreach ( $expected as $key => $value ) {
 			$this->assertArrayHasKey( $key, $options );
 			$this->assertSame( $value, $options[$key] );
 		}

--- a/tests/Integration/inc/Engine/Admin/Deactivation/DeactivationIntent/activateSafeMode.php
+++ b/tests/Integration/inc/Engine/Admin/Deactivation/DeactivationIntent/activateSafeMode.php
@@ -55,7 +55,6 @@ class Test_ActivateSafeMode extends AjaxTestCase {
 
 		$expected_subset = [
 			'embeds'                 => 0,
-			'defer_all_js'           => 0,
 			'async_css'              => 0,
 			'lazyload'               => 0,
 			'lazyload_iframes'       => 0,
@@ -64,6 +63,8 @@ class Test_ActivateSafeMode extends AjaxTestCase {
 			'minify_concatenate_css' => 0,
 			'minify_js'              => 0,
 			'minify_concatenate_js'  => 0,
+			'defer_all_js'           => 0,
+			'delay_js'               => 0,
 			'minify_google_fonts'    => 0,
 			'cdn'                    => 0,
 		];

--- a/tests/Integration/inc/Engine/Optimization/DelayJS/Admin/Subscriber/addOptions.php
+++ b/tests/Integration/inc/Engine/Optimization/DelayJS/Admin/Subscriber/addOptions.php
@@ -33,17 +33,4 @@ class Test_AddOptions extends TestCase {
 		$this->assertSame( $expected, $actual );
 
 	}
-
-	/**
-	 * @dataProvider configTestData
-	 */
-	public function testShouldDoExpectedForSafeModeResetOptions( $input, $expected ) {
-		$options  = isset( $input['options'] )  ? $input['options']  : [];
-
-		$actual = apply_filters( 'rocket_safe_mode_reset_options', $options );
-
-		$this->assertSame( $expected, $actual );
-
-	}
-
 }

--- a/tests/Unit/inc/Engine/Admin/Deactivation/DeactivationIntent/activateSafeMode.php
+++ b/tests/Unit/inc/Engine/Admin/Deactivation/DeactivationIntent/activateSafeMode.php
@@ -37,7 +37,6 @@ class Test_ActivateSafeMode extends TestCase {
 	public function testShouldResetOptions() {
 		$options = [
 			'embeds'                 => 0,
-			'defer_all_js'           => 0,
 			'async_css'              => 0,
 			'lazyload'               => 0,
 			'lazyload_iframes'       => 0,
@@ -46,6 +45,8 @@ class Test_ActivateSafeMode extends TestCase {
 			'minify_concatenate_css' => 0,
 			'minify_js'              => 0,
 			'minify_concatenate_js'  => 0,
+			'defer_all_js'           => 0,
+			'delay_js'               => 0,
 			'minify_google_fonts'    => 0,
 			'cdn'                    => 0,
 		];

--- a/tests/Unit/inc/Engine/Admin/Deactivation/DeactivationIntent/activateSafeMode.php
+++ b/tests/Unit/inc/Engine/Admin/Deactivation/DeactivationIntent/activateSafeMode.php
@@ -4,7 +4,7 @@ namespace WP_Rocket\Tests\Unit\inc\Engine\Admin\Deactivation\DeactivationIntent;
 
 use Mockery;
 use Brain\Monkey\Functions;
-use WPMedia\PHPUnit\Unit\TestCase;
+use WP_Rocket\Tests\Unit\TestCase;
 use WP_Rocket\Engine\Admin\Deactivation\DeactivationIntent;
 
 /**
@@ -34,34 +34,21 @@ class Test_ActivateSafeMode extends TestCase {
 		$this->deactivation->activate_safe_mode();
 	}
 
-	public function testShouldResetOptions() {
-		$options = [
-			'embeds'                 => 0,
-			'async_css'              => 0,
-			'lazyload'               => 0,
-			'lazyload_iframes'       => 0,
-			'lazyload_youtube'       => 0,
-			'minify_css'             => 0,
-			'minify_concatenate_css' => 0,
-			'minify_js'              => 0,
-			'minify_concatenate_js'  => 0,
-			'defer_all_js'           => 0,
-			'delay_js'               => 0,
-			'minify_google_fonts'    => 0,
-			'cdn'                    => 0,
-		];
-
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldResetOptions( $expected ) {
 		Functions\when( 'current_user_can' )->justReturn( true );
 
 		$this->options->shouldReceive( 'set_values' )
 			->once()
-			->with( $options );
+			->with( $expected );
 		$this->options->shouldReceive( 'get_options' )
 			->once()
-			->andReturn( $options );
+			->andReturn( $expected );
 		$this->options_api->shouldReceive( 'set' )
 			->once()
-			->with( 'settings', $options );
+			->with( 'settings', $expected );
 
 		Functions\expect( 'wp_send_json_success' )->once();
 


### PR DESCRIPTION
## Description

Add delay JS to the list of options to turn off when safe mode is enabled.

Closes #3498

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Is the solution different from the one proposed during the grooming?

No

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes