### PR TITLE
Fixes #3238 Remove empty values in $purge_urls array

### DIFF
--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -140,7 +140,10 @@ function rocket_get_purge_urls( $post_id, $post ) {
 			$purge_urls[] = get_permalink( $parent_id );
 		}
 	}
-
+	
+	// Remove entries with empty values in array
+	$purge_urls = array_filter( $purge_urls );
+	
 	return array_flip( array_flip( $purge_urls ) );
 }
 

--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -142,7 +142,7 @@ function rocket_get_purge_urls( $post_id, $post ) {
 	}
 
 	// Remove entries with empty values in array.
-	$purge_urls = array_filter( $purge_urls );
+	$purge_urls = array_filter( $purge_urls, 'is_string' );
 
 	return array_flip( array_flip( $purge_urls ) );
 }

--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -140,10 +140,10 @@ function rocket_get_purge_urls( $post_id, $post ) {
 			$purge_urls[] = get_permalink( $parent_id );
 		}
 	}
-	
-	// Remove entries with empty values in array
+
+	// Remove entries with empty values in array.
 	$purge_urls = array_filter( $purge_urls );
-	
+
 	return array_flip( array_flip( $purge_urls ) );
 }
 

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -537,21 +537,19 @@ function rocket_clean_files( $urls, $filesystem = null ) {
 
 		$parsed_url = get_rocket_parse_url( $url );
 
-		if ( empty( $parsed_url['host'] ) ) {
-			continue;
-		}
-
-		foreach ( _rocket_get_cache_dirs( $parsed_url['host'], $cache_path ) as $dir ) {
-			$entry = $dir . $parsed_url['path'];
-			// Skip if the dir/file does not exist.
-			if ( ! $filesystem->exists( $entry ) ) {
-				continue;
-			}
-
-			if ( $filesystem->is_dir( $entry ) ) {
-				rocket_rrmdir( $entry, [], $filesystem );
-			} else {
-				$filesystem->delete( $entry );
+		if ( ! empty( $parsed_url['host'] ) ) {
+			foreach ( _rocket_get_cache_dirs( $parsed_url['host'], $cache_path ) as $dir ) {
+				$entry = $dir . $parsed_url['path'];
+				// Skip if the dir/file does not exist.
+				if ( ! $filesystem->exists( $entry ) ) {
+					continue;
+				}
+	
+				if ( $filesystem->is_dir( $entry ) ) {
+					rocket_rrmdir( $entry, [], $filesystem );
+				} else {
+					$filesystem->delete( $entry );
+				}
 			}
 		}
 

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -544,7 +544,7 @@ function rocket_clean_files( $urls, $filesystem = null ) {
 				if ( ! $filesystem->exists( $entry ) ) {
 					continue;
 				}
-	
+
 				if ( $filesystem->is_dir( $entry ) ) {
 					rocket_rrmdir( $entry, [], $filesystem );
 				} else {

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -537,6 +537,10 @@ function rocket_clean_files( $urls, $filesystem = null ) {
 
 		$parsed_url = get_rocket_parse_url( $url );
 
+		if ( empty( $parsed_url['host'] ) ) {
+			continue;
+		}
+
 		foreach ( _rocket_get_cache_dirs( $parsed_url['host'], $cache_path ) as $dir ) {
 			$entry = $dir . $parsed_url['path'];
 			// Skip if the dir/file does not exist.

--- a/tests/Fixtures/inc/functions/rocketCleanFiles.php
+++ b/tests/Fixtures/inc/functions/rocketCleanFiles.php
@@ -12,6 +12,14 @@ return [
 				'cleaned' => [],
 			],
 		],
+		'shouldBailOutWhenInvalidURLsToClean'                        => [
+			'urls'     => [
+				'test',
+			],
+			'expected' => [
+				'cleaned' => [],
+			],
+		],
 		'shouldDeleteSingleDirUrl'                              => [
 			'urls'     => [
 				'http://baz.example.org/',


### PR DESCRIPTION
## Description

Use `array_filter` to remove invalid values from the `$purge_urls` array.

All the values that didn't return`false` (such as random strings, integers, `true` boolean) and were passed into the $purge_urls array caused PHP notices regardless of the method `array_flip()` or `array_unique()` is used, but didn't cause the Warning from the GH issue.

Example: `PHP Notice: Trying to access array offset on value of type null in .../wp-content/plugins/wp-rocket/inc/functions/files.php on line 540`

Fixes #3238

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested with a variety of values passed into the $purge_urls array. Tests and notes added in the ticket: https://secure.helpscout.net/conversation/1413525677/236164/

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes