### PR TITLE
Closes #1744 Show warning when PageSpeed Ninja is active

### DIFF
--- a/inc/admin/ui/notices.php
+++ b/inc/admin/ui/notices.php
@@ -142,6 +142,7 @@ function rocket_plugins_to_deactivate() {
 		'leverage-browser-caching'                   => 'leverage-browser-caching/leverage-browser-caching.php',
 		'add-expires-headers'                        => 'add-expires-headers/add-expires-headers.php',
 		'page-optimize'                              => 'page-optimize/page-optimize.php',
+		'psn-pagespeed-ninja'                        => 'psn-pagespeed-ninja/pagespeedninja.php',
 	];
 
 	if ( get_rocket_option( 'lazyload' ) ) {


### PR DESCRIPTION
## Description

Show a warning when the plugin PageSpeed ninja is active at the same time as WP Rocket.

Closes #1744 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings