### PR TITLE
Guard rocket_defer_inline_exclusions filter return when used by 3rd parties

### DIFF
--- a/inc/Engine/Optimization/DeferJS/DeferJS.php
+++ b/inc/Engine/Optimization/DeferJS/DeferJS.php
@@ -294,11 +294,13 @@ class DeferJS {
 
 		$inline_exclusions = '';
 
-		if ( ! is_array( $additional_inline_exclusions_list ) ) {
-			$additional_inline_exclusions_list = explode( '|', (string) $additional_inline_exclusions_list );
+		// Check if filter return is string so convert it to array for backward compatibility.
+		if ( is_string( $additional_inline_exclusions_list ) ) {
+			$additional_inline_exclusions_list = explode( '|', $additional_inline_exclusions_list );
 		}
 
-		$inline_exclusions_list = array_merge( $inline_exclusions_list, $additional_inline_exclusions_list );
+		// Cast filter return to array.
+		$inline_exclusions_list = array_merge( $inline_exclusions_list, (array) $additional_inline_exclusions_list );
 
 		foreach ( $inline_exclusions_list as $inline_exclusions_item ) {
 			$inline_exclusions .= preg_quote( (string) $inline_exclusions_item, '#' ) . '|';

--- a/inc/Engine/Optimization/DeferJS/DeferJS.php
+++ b/inc/Engine/Optimization/DeferJS/DeferJS.php
@@ -142,7 +142,7 @@ class DeferJS {
 			}
 
 			foreach ( (array) $inline_exclusions_list as $inline_exclusions_item ) {
-				$inline_exclusions .= preg_quote( $inline_exclusions_item, '#' ) . '|';
+				$inline_exclusions .= preg_quote( (string) $inline_exclusions_item, '#' ) . '|';
 			}
 			$inline_exclusions = rtrim( $inline_exclusions, '|' );
 		}

--- a/inc/Engine/Optimization/DeferJS/DeferJS.php
+++ b/inc/Engine/Optimization/DeferJS/DeferJS.php
@@ -137,7 +137,11 @@ class DeferJS {
 
 		$inline_exclusions = '';
 		if ( ! empty( $inline_exclusions_list ) ) {
-			foreach ( $inline_exclusions_list as $inline_exclusions_item ) {
+			if ( is_string( $inline_exclusions_list ) ) {
+				$inline_exclusions_list = explode( '|', $inline_exclusions_list );
+			}
+
+			foreach ( (array) $inline_exclusions_list as $inline_exclusions_item ) {
 				$inline_exclusions .= preg_quote( $inline_exclusions_item, '#' ) . '|';
 			}
 			$inline_exclusions = rtrim( $inline_exclusions, '|' );

--- a/inc/Engine/Optimization/DeferJS/DeferJS.php
+++ b/inc/Engine/Optimization/DeferJS/DeferJS.php
@@ -294,13 +294,13 @@ class DeferJS {
 
 		$inline_exclusions = '';
 
-		if ( is_string( $additional_inline_exclusions_list ) ) {
-			$additional_inline_exclusions_list = explode( '|', $additional_inline_exclusions_list );
+		if ( ! is_array( $additional_inline_exclusions_list ) ) {
+			$additional_inline_exclusions_list = explode( '|', (string) $additional_inline_exclusions_list );
 		}
 
-		$inline_exclusions_list = array_merge( $inline_exclusions_list, (array) $additional_inline_exclusions_list );
+		$inline_exclusions_list = array_merge( $inline_exclusions_list, $additional_inline_exclusions_list );
 
-		foreach ( (array) $inline_exclusions_list as $inline_exclusions_item ) {
+		foreach ( $inline_exclusions_list as $inline_exclusions_item ) {
 			$inline_exclusions .= preg_quote( (string) $inline_exclusions_item, '#' ) . '|';
 		}
 

--- a/inc/Engine/Optimization/DeferJS/DeferJS.php
+++ b/inc/Engine/Optimization/DeferJS/DeferJS.php
@@ -126,26 +126,7 @@ class DeferJS {
 		 */
 		$jquery_patterns = apply_filters( 'rocket_defer_jquery_patterns', 'jQuery|\$\.\(|\$\(' );
 
-		/**
-		 * Filters the patterns used to find inline JS that should not be deferred
-		 *
-		 * @since 3.8
-		 *
-		 * @param array $inline_exclusions_list Array of inline JS that should not be deferred.
-		 */
-		$inline_exclusions_list = apply_filters( 'rocket_defer_inline_exclusions', $this->inline_exclusions );
-
-		$inline_exclusions = '';
-		if ( ! empty( $inline_exclusions_list ) ) {
-			if ( is_string( $inline_exclusions_list ) ) {
-				$inline_exclusions_list = explode( '|', $inline_exclusions_list );
-			}
-
-			foreach ( (array) $inline_exclusions_list as $inline_exclusions_item ) {
-				$inline_exclusions .= preg_quote( (string) $inline_exclusions_item, '#' ) . '|';
-			}
-			$inline_exclusions = rtrim( $inline_exclusions, '|' );
-		}
+		$inline_exclusions = $this->get_inline_exclusions_list_pattern();
 
 		foreach ( $matches as $inline_js ) {
 			if ( empty( $inline_js['content'] ) ) {
@@ -292,5 +273,36 @@ class DeferJS {
 		$options['exclude_defer_js'][] = '/jquery-?[0-9.]*(.min|.slim|.slim.min)?.js';
 
 		update_option( 'wp_rocket_settings', $options );
+	}
+
+	/**
+	 * Get exclusion list pattern.
+	 *
+	 * @return string
+	 */
+	private function get_inline_exclusions_list_pattern() {
+		/**
+		 * Filters the patterns used to find inline JS that should not be deferred
+		 *
+		 * @since 3.8
+		 *
+		 * @param array $inline_exclusions_list Array of inline JS that should not be deferred.
+		 */
+		$inline_exclusions_list = apply_filters( 'rocket_defer_inline_exclusions', $this->inline_exclusions );
+
+		$inline_exclusions = '';
+		if ( empty( $inline_exclusions_list ) ) {
+			$inline_exclusions_list = $this->inline_exclusions;
+		}
+
+		if ( is_string( $inline_exclusions_list ) ) {
+			$inline_exclusions_list = explode( '|', $inline_exclusions_list );
+		}
+
+		foreach ( (array) $inline_exclusions_list as $inline_exclusions_item ) {
+			$inline_exclusions .= preg_quote( (string) $inline_exclusions_item, '#' ) . '|';
+		}
+
+		return rtrim( $inline_exclusions, '|' );
 	}
 }

--- a/inc/Engine/Optimization/DeferJS/DeferJS.php
+++ b/inc/Engine/Optimization/DeferJS/DeferJS.php
@@ -298,7 +298,7 @@ class DeferJS {
 			$additional_inline_exclusions_list = explode( '|', $additional_inline_exclusions_list );
 		}
 
-		$inline_exclusions_list = array_merge( $inline_exclusions_list, (array) $additional_inline_exclusions_list);
+		$inline_exclusions_list = array_merge( $inline_exclusions_list, (array) $additional_inline_exclusions_list );
 
 		foreach ( (array) $inline_exclusions_list as $inline_exclusions_item ) {
 			$inline_exclusions .= preg_quote( (string) $inline_exclusions_item, '#' ) . '|';

--- a/inc/Engine/Optimization/DeferJS/DeferJS.php
+++ b/inc/Engine/Optimization/DeferJS/DeferJS.php
@@ -281,6 +281,8 @@ class DeferJS {
 	 * @return string
 	 */
 	private function get_inline_exclusions_list_pattern() {
+		$inline_exclusions_list = $this->inline_exclusions;
+
 		/**
 		 * Filters the patterns used to find inline JS that should not be deferred
 		 *
@@ -288,16 +290,15 @@ class DeferJS {
 		 *
 		 * @param array $inline_exclusions_list Array of inline JS that should not be deferred.
 		 */
-		$inline_exclusions_list = apply_filters( 'rocket_defer_inline_exclusions', $this->inline_exclusions );
+		$additional_inline_exclusions_list = apply_filters( 'rocket_defer_inline_exclusions', null );
 
 		$inline_exclusions = '';
-		if ( empty( $inline_exclusions_list ) ) {
-			$inline_exclusions_list = $this->inline_exclusions;
+
+		if ( is_string( $additional_inline_exclusions_list ) ) {
+			$additional_inline_exclusions_list = explode( '|', $additional_inline_exclusions_list );
 		}
 
-		if ( is_string( $inline_exclusions_list ) ) {
-			$inline_exclusions_list = explode( '|', $inline_exclusions_list );
-		}
+		$inline_exclusions_list = array_merge( $inline_exclusions_list, (array) $additional_inline_exclusions_list);
 
 		foreach ( (array) $inline_exclusions_list as $inline_exclusions_item ) {
 			$inline_exclusions .= preg_quote( (string) $inline_exclusions_item, '#' ) . '|';

--- a/tests/Fixtures/inc/Engine/Optimization/DeferJS/Subscriber/deferInlineJs.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DeferJS/Subscriber/deferInlineJs.php
@@ -143,4 +143,76 @@ return [
 		'html'     => $html,
 		'expected' => $expected,
 	],
+
+	'testShouldExcludeUsingStringFilter' => [
+		'config' => [
+			'rocket_defer_inline_exclusions_filter' => 'first_string|third_string',
+			'donotrocketoptimize' => false,
+			'post_meta'           => false,
+			'options'             => [
+				'defer_all_js'      => 1,
+				'exclude_defer_js'  => [],
+			],
+		],
+		'html'     => <<<HTML
+	<script type="text/javascript">var first_string = jQuery('#first_selector');</script>
+	<script type="text/javascript">var second_string = jQuery('#second_selector');</script>
+	<script type="text/javascript">var third_string = jQuery('#third_selector');</script>
+HTML
+		,
+		'expected' => <<<HTML
+	<script type="text/javascript">var first_string = jQuery('#first_selector');</script>
+	<script type="text/javascript">window.addEventListener('DOMContentLoaded', function() {var second_string = jQuery('#second_selector');});</script>
+	<script type="text/javascript">var third_string = jQuery('#third_selector');</script>
+HTML,
+	],
+
+	'testShouldExcludeUsingArrayFilter' => [
+		'config' => [
+			'rocket_defer_inline_exclusions_filter' => [
+				'first_string',
+				'third_string'
+			],
+			'donotrocketoptimize' => false,
+			'post_meta'           => false,
+			'options'             => [
+				'defer_all_js'      => 1,
+				'exclude_defer_js'  => [],
+			],
+		],
+		'html'     => <<<HTML
+	<script type="text/javascript">var first_string = jQuery('#first_selector');</script>
+	<script type="text/javascript">var second_string = jQuery('#second_selector');</script>
+	<script type="text/javascript">var third_string = jQuery('#third_selector');</script>
+HTML
+		,
+		'expected' => <<<HTML
+	<script type="text/javascript">var first_string = jQuery('#first_selector');</script>
+	<script type="text/javascript">window.addEventListener('DOMContentLoaded', function() {var second_string = jQuery('#second_selector');});</script>
+	<script type="text/javascript">var third_string = jQuery('#third_selector');</script>
+HTML,
+	],
+
+	'testShouldExcludeUsingObjectFilter' => [
+		'config' => [
+			'rocket_defer_inline_exclusions_filter' => new StdClass(),
+			'donotrocketoptimize' => false,
+			'post_meta'           => false,
+			'options'             => [
+				'defer_all_js'      => 1,
+				'exclude_defer_js'  => [],
+			],
+		],
+		'html'     => <<<HTML
+	<script type="text/javascript">var first_string = jQuery('#first_selector');</script>
+	<script type="text/javascript">var second_string = jQuery('#second_selector');</script>
+	<script type="text/javascript">var third_string = jQuery('#third_selector');</script>
+HTML
+		,
+		'expected' => <<<HTML
+	<script type="text/javascript">var first_string = jQuery('#first_selector');</script>
+	<script type="text/javascript">var second_string = jQuery('#second_selector');</script>
+	<script type="text/javascript">var third_string = jQuery('#third_selector');</script>
+HTML,
+	],
 ];

--- a/tests/Fixtures/inc/Engine/Optimization/DeferJS/Subscriber/deferInlineJs.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DeferJS/Subscriber/deferInlineJs.php
@@ -242,4 +242,27 @@ HTML
 	<script type="text/javascript">var third_string = jQuery('#third_selector');</script>
 HTML,
 	],
+
+	'testShouldExcludeUsingEmptyFilter' => [
+		'config' => [
+			'rocket_defer_inline_exclusions_filter' => [],
+			'donotrocketoptimize' => false,
+			'post_meta'           => false,
+			'options'             => [
+				'defer_all_js'      => 1,
+				'exclude_defer_js'  => [],
+			],
+		],
+		'html'     => <<<HTML
+	<script type="text/javascript">var first_string = jQuery('#first_selector');</script>
+	<script type="text/javascript">var second_string = jQuery('#second_selector');</script>
+	<script type="text/javascript">document.write('test');</script>
+HTML
+		,
+		'expected' => <<<HTML
+	<script type="text/javascript">window.addEventListener('DOMContentLoaded', function() {var first_string = jQuery('#first_selector');});</script>
+	<script type="text/javascript">window.addEventListener('DOMContentLoaded', function() {var second_string = jQuery('#second_selector');});</script>
+	<script type="text/javascript">document.write('test');</script>
+HTML,
+	],
 ];

--- a/tests/Fixtures/inc/Engine/Optimization/DeferJS/Subscriber/deferInlineJs.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DeferJS/Subscriber/deferInlineJs.php
@@ -222,7 +222,7 @@ HTML,
 
 	'testShouldExcludeUsingObjectFilter' => [
 		'config' => [
-			'rocket_defer_inline_exclusions_filter' => new StdClass(),
+			'rocket_defer_inline_exclusions_filter' => (object) [],
 			'donotrocketoptimize' => false,
 			'post_meta'           => false,
 			'options'             => [
@@ -263,6 +263,44 @@ HTML
 	<script type="text/javascript">window.addEventListener('DOMContentLoaded', function() {var first_string = jQuery('#first_selector');});</script>
 	<script type="text/javascript">window.addEventListener('DOMContentLoaded', function() {var second_string = jQuery('#second_selector');});</script>
 	<script type="text/javascript">document.write('test');</script>
+HTML,
+	],
+
+	'testShouldExcludeUsingBooleanFilter' => [
+		'config' => [
+			'rocket_defer_inline_exclusions_filter' => true,
+			'donotrocketoptimize' => false,
+			'post_meta'           => false,
+			'options'             => [
+				'defer_all_js'      => 1,
+				'exclude_defer_js'  => [],
+			],
+		],
+		'html'     => <<<HTML
+	<script type="text/javascript">var first_string = jQuery('#first_selector');</script>
+HTML
+		,
+		'expected' => <<<HTML
+	<script type="text/javascript">window.addEventListener('DOMContentLoaded', function() {var first_string = jQuery('#first_selector');});</script>
+HTML,
+	],
+
+	'testShouldExcludeUsingFloatFilter' => [
+		'config' => [
+			'rocket_defer_inline_exclusions_filter' => 1.568,
+			'donotrocketoptimize' => false,
+			'post_meta'           => false,
+			'options'             => [
+				'defer_all_js'      => 1,
+				'exclude_defer_js'  => [],
+			],
+		],
+		'html'     => <<<HTML
+	<script type="text/javascript">var first_string = jQuery('#first_selector');</script>
+HTML
+		,
+		'expected' => <<<HTML
+	<script type="text/javascript">window.addEventListener('DOMContentLoaded', function() {var first_string = jQuery('#first_selector');});</script>
 HTML,
 	],
 ];

--- a/tests/Fixtures/inc/Engine/Optimization/DeferJS/Subscriber/deferInlineJs.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DeferJS/Subscriber/deferInlineJs.php
@@ -167,7 +167,7 @@ HTML
 HTML,
 	],
 
-	'testShouldExcludeUsingArrayFilter' => [
+	'testShouldExcludeUsingArrayOfStringsFilter' => [
 		'config' => [
 			'rocket_defer_inline_exclusions_filter' => [
 				'first_string',
@@ -190,6 +190,33 @@ HTML
 	<script type="text/javascript">var first_string = jQuery('#first_selector');</script>
 	<script type="text/javascript">window.addEventListener('DOMContentLoaded', function() {var second_string = jQuery('#second_selector');});</script>
 	<script type="text/javascript">var third_string = jQuery('#third_selector');</script>
+HTML,
+	],
+
+	'testShouldExcludeUsingArrayOfIntegersFilter' => [
+		'config' => [
+			'rocket_defer_inline_exclusions_filter' => [
+				1,
+				2,
+				3,
+			],
+			'donotrocketoptimize' => false,
+			'post_meta'           => false,
+			'options'             => [
+				'defer_all_js'      => 1,
+				'exclude_defer_js'  => [],
+			],
+		],
+		'html'     => <<<HTML
+	<script type="text/javascript">var first_string = jQuery('#first_selector');</script>
+	<script type="text/javascript">var second_string = jQuery('#second_selector');</script>
+	<script type="text/javascript">var third_string = jQuery('#third_selector');</script>
+HTML
+		,
+		'expected' => <<<HTML
+	<script type="text/javascript">window.addEventListener('DOMContentLoaded', function() {var first_string = jQuery('#first_selector');});</script>
+	<script type="text/javascript">window.addEventListener('DOMContentLoaded', function() {var second_string = jQuery('#second_selector');});</script>
+	<script type="text/javascript">window.addEventListener('DOMContentLoaded', function() {var third_string = jQuery('#third_selector');});</script>
 HTML,
 	],
 

--- a/tests/Fixtures/inc/Engine/Optimization/DeferJS/Subscriber/deferInlineJs.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DeferJS/Subscriber/deferInlineJs.php
@@ -237,9 +237,9 @@ HTML,
 HTML
 		,
 		'expected' => <<<HTML
-	<script type="text/javascript">var first_string = jQuery('#first_selector');</script>
-	<script type="text/javascript">var second_string = jQuery('#second_selector');</script>
-	<script type="text/javascript">var third_string = jQuery('#third_selector');</script>
+	<script type="text/javascript">window.addEventListener('DOMContentLoaded', function() {var first_string = jQuery('#first_selector');});</script>
+	<script type="text/javascript">window.addEventListener('DOMContentLoaded', function() {var second_string = jQuery('#second_selector');});</script>
+	<script type="text/javascript">window.addEventListener('DOMContentLoaded', function() {var third_string = jQuery('#third_selector');});</script>
 HTML,
 	],
 

--- a/tests/Integration/inc/Engine/Optimization/DeferJS/Subscriber/deferInlineJs.php
+++ b/tests/Integration/inc/Engine/Optimization/DeferJS/Subscriber/deferInlineJs.php
@@ -15,6 +15,7 @@ class Test_DeferInlineJs extends TestCase {
 
 	private $defer_js;
 	private $exclude_defer_js;
+	private $rocket_defer_inline_exclusions_filter;
 
 	public function setUp() {
 		parent::setUp();
@@ -23,6 +24,7 @@ class Test_DeferInlineJs extends TestCase {
 	}
 
 	public function tearDown() {
+		remove_filter( 'rocket_defer_inline_exclusions', [ $this, 'add_defer_inline_exclusion' ] );
 		remove_filter( 'pre_get_rocket_option_defer_all_js', [ $this, 'set_defer_js' ] );
 		remove_filter( 'pre_get_rocket_option_exclude_defer_js', [ $this, 'set_exclude_defer_js' ] );
 		delete_post_meta( 100, '_rocket_exclude_defer_all_js' );
@@ -37,6 +39,12 @@ class Test_DeferInlineJs extends TestCase {
 		$this->donotrocketoptimize = $config['donotrocketoptimize'];
 		$this->defer_js            = $config['options']['defer_all_js'];
 		$this->exclude_defer_js    = $config['options']['exclude_defer_js'];
+
+		if ( ! empty( $config['rocket_defer_inline_exclusions_filter'] ) ) {
+			$this->rocket_defer_inline_exclusions_filter = $config['rocket_defer_inline_exclusions_filter'];
+
+			add_filter( 'rocket_defer_inline_exclusions', [ $this, 'add_defer_inline_exclusion' ] );
+		}
 
 		$this->goToContentType(
 			[
@@ -66,5 +74,9 @@ class Test_DeferInlineJs extends TestCase {
 
 	public function set_exclude_defer_js() {
 		return $this->exclude_defer_js;
+	}
+
+	public function add_defer_inline_exclusion( $exclusions ) {
+		return $this->rocket_defer_inline_exclusions_filter;
 	}
 }

--- a/tests/Integration/inc/Engine/Optimization/DeferJS/Subscriber/deferInlineJs.php
+++ b/tests/Integration/inc/Engine/Optimization/DeferJS/Subscriber/deferInlineJs.php
@@ -40,7 +40,7 @@ class Test_DeferInlineJs extends TestCase {
 		$this->defer_js            = $config['options']['defer_all_js'];
 		$this->exclude_defer_js    = $config['options']['exclude_defer_js'];
 
-		if ( ! empty( $config['rocket_defer_inline_exclusions_filter'] ) ) {
+		if ( isset( $config['rocket_defer_inline_exclusions_filter'] ) ) {
 			$this->rocket_defer_inline_exclusions_filter = $config['rocket_defer_inline_exclusions_filter'];
 
 			add_filter( 'rocket_defer_inline_exclusions', [ $this, 'add_defer_inline_exclusion' ] );


### PR DESCRIPTION
## Description

I did two things here on this PR related to the return of `rocket_defer_inline_exclusions` filter:-
1. I casted its return to be always array.
2. For backward compatibility, I checked if the return of filter is string so I converted it to array by slicing it using separator `|`

Fixes #3576 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## Is the solution different from the one proposed during the grooming?

Yes It's like groomed solution.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Add the following code into active theme `functions.php` and then clear the cache and check `error_log` or `debug.log`
```
add_filter( 'rocket_defer_inline_exclusions', function( $exclusions ){
    return 'any_parameter';
} );
```
OR
```
add_filter( 'rocket_defer_inline_exclusions', function( $exclusions ){
    return [ 'any_parameter', 'second_parameter' ];
} );
```
OR
```
add_filter( 'rocket_defer_inline_exclusions', function( $exclusions ){
    return new StdClass();
} );
```

- [x] By using ShortPixel AI plugin as in the issue description.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules