### PR TITLE
Fixes #3083 Update delay JS RegEx to ignore space inside script tags

### DIFF
--- a/inc/Engine/Optimization/DelayJS/HTML.php
+++ b/inc/Engine/Optimization/DelayJS/HTML.php
@@ -88,7 +88,7 @@ class HTML {
 	 * @return string
 	 */
 	private function parse( $html ) {
-		$replaced_html = preg_replace_callback( '/<\s*script\s*(?<attr>[^>]*)?>(?<content>.*)?<\s*\/\s*script\s*>/Uims', [ $this, 'replace_scripts' ], $html );
+		$replaced_html = preg_replace_callback( '/<\s*script\s*(?<attr>.*)?>(?<content>.*)?<\s*\/\s*script\s*>/Uims', [ $this, 'replace_scripts' ], $html );
 
 		if ( empty( $replaced_html ) ) {
 			return $html;

--- a/inc/Engine/Optimization/DelayJS/HTML.php
+++ b/inc/Engine/Optimization/DelayJS/HTML.php
@@ -88,7 +88,7 @@ class HTML {
 	 * @return string
 	 */
 	private function parse( $html ) {
-		$replaced_html = preg_replace_callback( '/<\s*script\s*(?<attr>.*)?>(?<content>.*)?<\s*\/\s*script\s*>/Uims', [ $this, 'replace_scripts' ], $html );
+		$replaced_html = preg_replace_callback( '/<\s*script\s*(?<attr>[^>]*?)?>(?<content>.*?)?<\s*\/\s*script\s*>/ims', [ $this, 'replace_scripts' ], $html );
 
 		if ( empty( $replaced_html ) ) {
 			return $html;

--- a/inc/Engine/Optimization/DelayJS/HTML.php
+++ b/inc/Engine/Optimization/DelayJS/HTML.php
@@ -88,7 +88,7 @@ class HTML {
 	 * @return string
 	 */
 	private function parse( $html ) {
-		$replaced_html = preg_replace_callback( '/<script\s*(?<attr>[^>]*)?>(?<content>.*)?<\/script>/Uims', [ $this, 'replace_scripts' ], $html );
+		$replaced_html = preg_replace_callback( '/<\s*script\s*(?<attr>[^>]*)?>(?<content>.*)?<\s*\/\s*script\s*>/Uims', [ $this, 'replace_scripts' ], $html );
 
 		if ( empty( $replaced_html ) ) {
 			return $html;

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/HTML/delayJs.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/HTML/delayJs.php
@@ -103,7 +103,7 @@ return [
 <script data-ignore-me="this script should be ignored!" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js"></script>
 <script data-rocketlazyloadscript=\'//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js\' type="text/javascript" ></script>',
 		],
-		'shouldIgnoreScriptsWithSpaces' => [
+		'shouldProcessScriptsWithSpaces' => [
 			'config'   => [
 				'bypass'               => false,
 				'donotoptimize'        => false,
@@ -113,7 +113,7 @@ return [
 			],
 			'html'     => '<script src="https://ck239.infusionsoft.com/app/webTracking/getTrackingCode"></script >
 <style>.tcm-color-ac span { color: #03a9f4;}</style>',
-			'expected' => '<script data-rocketlazyloadscript=\'https://ck239.infusionsoft.com/app/webTracking/getTrackingCode\'></script>
+			'expected' => '<script data-rocketlazyloadscript=\'https://ck239.infusionsoft.com/app/webTracking/getTrackingCode\' ></script>
 <style>.tcm-color-ac span { color: #03a9f4;}</style>',
 		],
 	]

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/HTML/delayJs.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/HTML/delayJs.php
@@ -103,5 +103,18 @@ return [
 <script data-ignore-me="this script should be ignored!" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js"></script>
 <script data-rocketlazyloadscript=\'//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js\' type="text/javascript" ></script>',
 		],
+		'shouldIgnoreScriptsWithSpaces' => [
+			'config'   => [
+				'bypass'               => false,
+				'donotoptimize'        => false,
+				'do-not-delay-setting' => 1,
+				'post-excluded'        => false,
+				'allowed-scripts'      => [ 'ck239.infusionsoft.com/app/webTracking/getTrackingCode' ],
+			],
+			'html'     => '<script src="https://ck239.infusionsoft.com/app/webTracking/getTrackingCode"></script >
+<style>.tcm-color-ac span { color: #03a9f4;}</style>',
+			'expected' => '<script data-rocketlazyloadscript=\'https://ck239.infusionsoft.com/app/webTracking/getTrackingCode\'></script>
+<style>.tcm-color-ac span { color: #03a9f4;}</style>',
+		],
 	]
 ];

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/Subscriber/delayJs.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/Subscriber/delayJs.php
@@ -84,5 +84,18 @@ return [
 <script data-ignore-me="this script should be ignored!" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js"></script>
 <script data-rocketlazyloadscript=\'//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js\' type="text/javascript" ></script>',
 		],
+		'shouldProcessScriptsWithSpaces' => [
+			'config'   => [
+				'bypass'               => false,
+				'donotoptimize'        => false,
+				'do-not-delay-setting' => 1,
+				'post-excluded'        => false,
+				'allowed-scripts'      => [ 'ck239.infusionsoft.com/app/webTracking/getTrackingCode' ],
+			],
+			'html'     => '<script src="https://ck239.infusionsoft.com/app/webTracking/getTrackingCode"></script >
+<style>.tcm-color-ac span { color: #03a9f4;}</style>',
+			'expected' => '<script data-rocketlazyloadscript=\'https://ck239.infusionsoft.com/app/webTracking/getTrackingCode\' ></script>
+<style>.tcm-color-ac span { color: #03a9f4;}</style>',
+		],
 	]
 ];


### PR DESCRIPTION
## Description

I've updated the RegEx to ignore spaces either in the opening or closing `script` tag.

Fixes #3083.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

Yes, it is. I've added extra checks for spaces in the opening `<script>` tag, as well as the closing tag, to cover all cases.

## How Has This Been Tested?

A test run against the breaking sample:
https://regex101.com/r/hZiXud/1/

Which is working fine with the new RegEx: https://regex101.com/r/5RWVBd/1

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes