### PR TITLE
Closes #3564 Update minified filename structure to use query string instead of version in filename

### DIFF
--- a/inc/Engine/Optimization/AbstractOptimization.php
+++ b/inc/Engine/Optimization/AbstractOptimization.php
@@ -214,4 +214,20 @@ abstract class AbstractOptimization {
 
 		return $html;
 	}
+
+	/**
+	 * Get full minified url with ?ver query string.
+	 *
+	 * @param string $minified_path Path of minified file.
+	 * @param string $minified_url Url of minified file.
+	 *
+	 * @return string
+	 */
+	protected function get_full_minified_url( $minified_path, $minified_url ) {
+		$file_mtime = rocket_direct_filesystem()->mtime( $minified_path );
+
+		$version = $file_mtime ? $file_mtime : md5( $minified_url . $this->minify_key );
+
+		return add_query_arg( 'ver', $version, $minified_url );
+	}
 }

--- a/inc/Engine/Optimization/Minify/CSS/Minify.php
+++ b/inc/Engine/Optimization/Minify/CSS/Minify.php
@@ -137,7 +137,7 @@ class Minify extends AbstractCSSOptimization implements ProcessorInterface {
 
 		$filename      = ltrim( rocket_realpath( $parsed_url['path'] ), '/' );
 		$minified_file = rawurldecode( $this->minify_base_path . $filename );
-		$minify_url    = $this->get_minify_url( $filename, $url ) . "?ver=" . rocket_direct_filesystem()->mtime( $minified_file );
+		$minify_url    = $this->get_minify_url( $filename, $url ) . '?ver=' . rocket_direct_filesystem()->mtime( $minified_file );
 
 		if ( rocket_direct_filesystem()->exists( $minified_file ) ) {
 			Logger::debug(

--- a/inc/Engine/Optimization/Minify/CSS/Minify.php
+++ b/inc/Engine/Optimization/Minify/CSS/Minify.php
@@ -135,10 +135,9 @@ class Minify extends AbstractCSSOptimization implements ProcessorInterface {
 			$url = rocket_add_url_protocol( $url );
 		}
 
-		$unique_id     = md5( $url . $this->minify_key );
-		$filename      = preg_replace( '/\.(css)$/', '-' . $unique_id . '.css', ltrim( rocket_realpath( $parsed_url['path'] ), '/' ) );
+		$filename      = ltrim( rocket_realpath( $parsed_url['path'] ), '/' );
 		$minified_file = rawurldecode( $this->minify_base_path . $filename );
-		$minify_url    = $this->get_minify_url( $filename, $url );
+		$minify_url    = $this->get_minify_url( $filename, $url ) . "?ver=" . rocket_direct_filesystem()->mtime( $minified_file );
 
 		if ( rocket_direct_filesystem()->exists( $minified_file ) ) {
 			Logger::debug(

--- a/inc/Engine/Optimization/Minify/CSS/Minify.php
+++ b/inc/Engine/Optimization/Minify/CSS/Minify.php
@@ -138,7 +138,7 @@ class Minify extends AbstractCSSOptimization implements ProcessorInterface {
 		$filename            = ltrim( rocket_realpath( $parsed_url['path'] ), '/' );
 		$minified_file       = rawurldecode( $this->minify_base_path . $filename );
 		$minified_file_mtime = rocket_direct_filesystem()->mtime( $minified_file );
-		$minify_url          = add_query_arg( 'ver', $minified_file_mtime ? $minified_file_mtime : '', $this->get_minify_url( $filename, $url ) );
+		$minify_url          = add_query_arg( 'ver', $minified_file_mtime ? $minified_file_mtime : md5( $url . $this->minify_key ), $this->get_minify_url( $filename, $url ) );
 
 		if ( rocket_direct_filesystem()->exists( $minified_file ) ) {
 			Logger::debug(

--- a/inc/Engine/Optimization/Minify/CSS/Minify.php
+++ b/inc/Engine/Optimization/Minify/CSS/Minify.php
@@ -135,10 +135,8 @@ class Minify extends AbstractCSSOptimization implements ProcessorInterface {
 			$url = rocket_add_url_protocol( $url );
 		}
 
-		$filename            = ltrim( rocket_realpath( $parsed_url['path'] ), '/' );
-		$minified_file       = rawurldecode( $this->minify_base_path . $filename );
-		$minified_file_mtime = rocket_direct_filesystem()->mtime( $minified_file );
-		$minify_url          = add_query_arg( 'ver', $minified_file_mtime ? $minified_file_mtime : md5( $url . $this->minify_key ), $this->get_minify_url( $filename, $url ) );
+		$filename      = ltrim( rocket_realpath( $parsed_url['path'] ), '/' );
+		$minified_file = rawurldecode( $this->minify_base_path . $filename );
 
 		if ( rocket_direct_filesystem()->exists( $minified_file ) ) {
 			Logger::debug(
@@ -149,7 +147,7 @@ class Minify extends AbstractCSSOptimization implements ProcessorInterface {
 				]
 			);
 
-			return $minify_url;
+			return $this->get_full_minified_url( $minified_file, $this->get_minify_url( $filename, $url ) );
 		}
 
 		$external_url = $this->is_external_file( $url );
@@ -199,7 +197,7 @@ class Minify extends AbstractCSSOptimization implements ProcessorInterface {
 			return false;
 		}
 
-		return $minify_url;
+		return $this->get_full_minified_url( $minified_file, $this->get_minify_url( $filename, $url ) );
 	}
 
 	/**

--- a/inc/Engine/Optimization/Minify/CSS/Minify.php
+++ b/inc/Engine/Optimization/Minify/CSS/Minify.php
@@ -135,9 +135,10 @@ class Minify extends AbstractCSSOptimization implements ProcessorInterface {
 			$url = rocket_add_url_protocol( $url );
 		}
 
-		$filename      = ltrim( rocket_realpath( $parsed_url['path'] ), '/' );
-		$minified_file = rawurldecode( $this->minify_base_path . $filename );
-		$minify_url    = $this->get_minify_url( $filename, $url ) . '?ver=' . rocket_direct_filesystem()->mtime( $minified_file );
+		$filename            = ltrim( rocket_realpath( $parsed_url['path'] ), '/' );
+		$minified_file       = rawurldecode( $this->minify_base_path . $filename );
+		$minified_file_mtime = rocket_direct_filesystem()->mtime( $minified_file );
+		$minify_url          = add_query_arg( 'ver', $minified_file_mtime ? $minified_file_mtime : '', $this->get_minify_url( $filename, $url ) );
 
 		if ( rocket_direct_filesystem()->exists( $minified_file ) ) {
 			Logger::debug(

--- a/inc/Engine/Optimization/Minify/JS/Minify.php
+++ b/inc/Engine/Optimization/Minify/JS/Minify.php
@@ -184,11 +184,9 @@ class Minify extends AbstractJSOptimization implements ProcessorInterface {
 
 		// This filter is documented in /inc/classes/optimization/class-abstract-optimization.php.
 		$url       = apply_filters( 'rocket_asset_url', $url, $this->get_zones() );
-		$unique_id = md5( $url . $this->minify_key );
-		$filename  = preg_replace( '/\.js$/', '-' . $unique_id . '.js', ltrim( rocket_realpath( wp_parse_url( $url, PHP_URL_PATH ) ), '/' ) );
-
+		$filename      = ltrim( rocket_realpath( wp_parse_url( $url, PHP_URL_PATH ) ), '/' );
 		$minified_file = rawurldecode( $this->minify_base_path . $filename );
-		$minified_url  = $this->get_minify_url( $filename, $url );
+		$minified_url    = $this->get_minify_url( $filename, $url ) . "?ver=" . rocket_direct_filesystem()->mtime( $minified_file );
 
 		if ( rocket_direct_filesystem()->exists( $minified_file ) ) {
 			Logger::debug(

--- a/inc/Engine/Optimization/Minify/JS/Minify.php
+++ b/inc/Engine/Optimization/Minify/JS/Minify.php
@@ -183,8 +183,19 @@ class Minify extends AbstractJSOptimization implements ProcessorInterface {
 		}
 
 		// This filter is documented in /inc/classes/optimization/class-abstract-optimization.php.
-		$url                 = apply_filters( 'rocket_asset_url', $url, $this->get_zones() );
-		$filename            = ltrim( rocket_realpath( wp_parse_url( $url, PHP_URL_PATH ) ), '/' );
+		$url = apply_filters( 'rocket_asset_url', $url, $this->get_zones() );
+
+		$parsed_url = wp_parse_url( $url );
+
+		if ( empty( $parsed_url['path'] ) ) {
+			return false;
+		}
+
+		if ( ! empty( $parsed_url['host'] ) ) {
+			$url = rocket_add_url_protocol( $url );
+		}
+
+		$filename            = ltrim( rocket_realpath( $parsed_url['path'] ), '/' );
 		$minified_file       = rawurldecode( $this->minify_base_path . $filename );
 		$minified_file_mtime = rocket_direct_filesystem()->mtime( $minified_file );
 		$minified_url        = add_query_arg( 'ver', $minified_file_mtime ? $minified_file_mtime : '', $this->get_minify_url( $filename, $url ) );

--- a/inc/Engine/Optimization/Minify/JS/Minify.php
+++ b/inc/Engine/Optimization/Minify/JS/Minify.php
@@ -183,10 +183,11 @@ class Minify extends AbstractJSOptimization implements ProcessorInterface {
 		}
 
 		// This filter is documented in /inc/classes/optimization/class-abstract-optimization.php.
-		$url           = apply_filters( 'rocket_asset_url', $url, $this->get_zones() );
-		$filename      = ltrim( rocket_realpath( wp_parse_url( $url, PHP_URL_PATH ) ), '/' );
-		$minified_file = rawurldecode( $this->minify_base_path . $filename );
-		$minified_url  = $this->get_minify_url( $filename, $url ) . '?ver=' . rocket_direct_filesystem()->mtime( $minified_file );
+		$url                 = apply_filters( 'rocket_asset_url', $url, $this->get_zones() );
+		$filename            = ltrim( rocket_realpath( wp_parse_url( $url, PHP_URL_PATH ) ), '/' );
+		$minified_file       = rawurldecode( $this->minify_base_path . $filename );
+		$minified_file_mtime = rocket_direct_filesystem()->mtime( $minified_file );
+		$minified_url        = add_query_arg( 'ver', $minified_file_mtime ? $minified_file_mtime : '', $this->get_minify_url( $filename, $url ) );
 
 		if ( rocket_direct_filesystem()->exists( $minified_file ) ) {
 			Logger::debug(

--- a/inc/Engine/Optimization/Minify/JS/Minify.php
+++ b/inc/Engine/Optimization/Minify/JS/Minify.php
@@ -198,7 +198,7 @@ class Minify extends AbstractJSOptimization implements ProcessorInterface {
 		$filename            = ltrim( rocket_realpath( $parsed_url['path'] ), '/' );
 		$minified_file       = rawurldecode( $this->minify_base_path . $filename );
 		$minified_file_mtime = rocket_direct_filesystem()->mtime( $minified_file );
-		$minified_url        = add_query_arg( 'ver', $minified_file_mtime ? $minified_file_mtime : '', $this->get_minify_url( $filename, $url ) );
+		$minified_url        = add_query_arg( 'ver', $minified_file_mtime ? $minified_file_mtime : md5( $url . $this->minify_key ), $this->get_minify_url( $filename, $url ) );
 
 		if ( rocket_direct_filesystem()->exists( $minified_file ) ) {
 			Logger::debug(

--- a/inc/Engine/Optimization/Minify/JS/Minify.php
+++ b/inc/Engine/Optimization/Minify/JS/Minify.php
@@ -183,10 +183,10 @@ class Minify extends AbstractJSOptimization implements ProcessorInterface {
 		}
 
 		// This filter is documented in /inc/classes/optimization/class-abstract-optimization.php.
-		$url       = apply_filters( 'rocket_asset_url', $url, $this->get_zones() );
+		$url           = apply_filters( 'rocket_asset_url', $url, $this->get_zones() );
 		$filename      = ltrim( rocket_realpath( wp_parse_url( $url, PHP_URL_PATH ) ), '/' );
 		$minified_file = rawurldecode( $this->minify_base_path . $filename );
-		$minified_url    = $this->get_minify_url( $filename, $url ) . "?ver=" . rocket_direct_filesystem()->mtime( $minified_file );
+		$minified_url  = $this->get_minify_url( $filename, $url ) . '?ver=' . rocket_direct_filesystem()->mtime( $minified_file );
 
 		if ( rocket_direct_filesystem()->exists( $minified_file ) ) {
 			Logger::debug(

--- a/inc/Engine/Optimization/Minify/JS/Minify.php
+++ b/inc/Engine/Optimization/Minify/JS/Minify.php
@@ -195,10 +195,8 @@ class Minify extends AbstractJSOptimization implements ProcessorInterface {
 			$url = rocket_add_url_protocol( $url );
 		}
 
-		$filename            = ltrim( rocket_realpath( $parsed_url['path'] ), '/' );
-		$minified_file       = rawurldecode( $this->minify_base_path . $filename );
-		$minified_file_mtime = rocket_direct_filesystem()->mtime( $minified_file );
-		$minified_url        = add_query_arg( 'ver', $minified_file_mtime ? $minified_file_mtime : md5( $url . $this->minify_key ), $this->get_minify_url( $filename, $url ) );
+		$filename      = ltrim( rocket_realpath( $parsed_url['path'] ), '/' );
+		$minified_file = rawurldecode( $this->minify_base_path . $filename );
 
 		if ( rocket_direct_filesystem()->exists( $minified_file ) ) {
 			Logger::debug(
@@ -208,7 +206,7 @@ class Minify extends AbstractJSOptimization implements ProcessorInterface {
 					'path' => $minified_file,
 				]
 			);
-			return $minified_url;
+			return $this->get_full_minified_url( $minified_file, $this->get_minify_url( $filename, $url ) );
 		}
 
 		$is_external_url = $this->is_external_file( $url );
@@ -258,7 +256,7 @@ class Minify extends AbstractJSOptimization implements ProcessorInterface {
 			return false;
 		}
 
-		return $minified_url;
+		return $this->get_full_minified_url( $minified_file, $this->get_minify_url( $filename, $url ) );
 	}
 
 	/**

--- a/tests/Fixtures/inc/Engine/Optimization/Minify/CSS/Minify/optimize.php
+++ b/tests/Fixtures/inc/Engine/Optimization/Minify/CSS/Minify/optimize.php
@@ -27,10 +27,10 @@ return [
 <html>
 	<head>
 		<title>Sample Page</title>
-		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=" type="text/css" media="all">
-		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=">
+		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver" type="text/css" media="all">
+		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver">
 		<link rel="stylesheet" href="http://example.org/wp-includes/css/dashicons.min.css">
-		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=">
+		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver">
 	</head>
 	<body>
 	</body>
@@ -73,10 +73,10 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=" type="text/css" media="all">
-		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=">
+		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver" type="text/css" media="all">
+		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver">
 		<link rel="stylesheet" href="/wp-includes/css/dashicons.min.css">
-		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=">
+		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver">
 	</head>
 	<body>
 	</body>
@@ -106,10 +106,10 @@ EXPECTED_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=" type="text/css" media="all">
-		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=">
+		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver" type="text/css" media="all">
+		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver">
 		<link rel="stylesheet" href="http://example.org/wp-includes/css/dashicons.min.css">
-		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=">
+		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver">
 	</head>
 	<body>
 	</body>
@@ -153,10 +153,10 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=" type="text/css" media="all">
-		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=">
+		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver" type="text/css" media="all">
+		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver">
 		<link rel="stylesheet" href="https://123456.rocketcdn.me/wp-includes/css/dashicons.min.css">
-		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=">
+		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver">
 	</head>
 	<body>
 	</body>
@@ -200,10 +200,10 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=" type="text/css" media="all">
-		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=">
+		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver" type="text/css" media="all">
+		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver">
 		<link rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-includes/css/dashicons.min.css">
-		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=">
+		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver">
 	</head>
 	<body>
 	</body>
@@ -243,7 +243,7 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/path/to/style.css?ver=" type="text/css" media="all">
+		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/path/to/style.css?ver" type="text/css" media="all">
 	</head>
 	<body>
 	</body>
@@ -279,7 +279,7 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/path/to/style.css?ver=" type="text/css" media="all">
+		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/path/to/style.css?ver" type="text/css" media="all">
 	</head>
 	<body>
 	</body>

--- a/tests/Fixtures/inc/Engine/Optimization/Minify/CSS/Minify/optimize.php
+++ b/tests/Fixtures/inc/Engine/Optimization/Minify/CSS/Minify/optimize.php
@@ -27,10 +27,10 @@ return [
 <html>
 	<head>
 		<title>Sample Page</title>
-		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-dcd1a95e5d432b5d300d7c2f216d7150.css" type="text/css" media="all">
-		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style-b35546733b0295036e79cc1f700b1efd.css">
+		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=" type="text/css" media="all">
+		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=">
 		<link rel="stylesheet" href="http://example.org/wp-includes/css/dashicons.min.css">
-		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min-73003a856907a7e09cca97c586493ed7.css">
+		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=">
 	</head>
 	<body>
 	</body>
@@ -38,12 +38,12 @@ return [
 EXPECTED_HTML
 				,
 				'files' => [
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-dcd1a95e5d432b5d300d7c2f216d7150.css',
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-dcd1a95e5d432b5d300d7c2f216d7150.css.gz',
-					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style-b35546733b0295036e79cc1f700b1efd.css',
-					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style-b35546733b0295036e79cc1f700b1efd.css.gz',
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min-73003a856907a7e09cca97c586493ed7.css',
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min-73003a856907a7e09cca97c586493ed7.css.gz',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css.gz',
+					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css',
+					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css.gz',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css.gz',
 				],
 			],
 
@@ -73,10 +73,10 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-81368ec770e103151d0a6b86fb40c04b.css" type="text/css" media="all">
-		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style-dd6c273e12758644d0d561ae5eb1792c.css">
+		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=" type="text/css" media="all">
+		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=">
 		<link rel="stylesheet" href="/wp-includes/css/dashicons.min.css">
-		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min-dae742d87623d4edfaef3856b672fab7.css">
+		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=">
 	</head>
 	<body>
 	</body>
@@ -84,12 +84,12 @@ ORIGINAL_HTML
 EXPECTED_HTML
 				,
 				'files' => [
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-81368ec770e103151d0a6b86fb40c04b.css',
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-81368ec770e103151d0a6b86fb40c04b.css.gz',
-					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style-dd6c273e12758644d0d561ae5eb1792c.css',
-					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style-dd6c273e12758644d0d561ae5eb1792c.css.gz',
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min-dae742d87623d4edfaef3856b672fab7.css',
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min-dae742d87623d4edfaef3856b672fab7.css.gz',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css.gz',
+					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css',
+					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css.gz',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css.gz',
 				],
 			],
 
@@ -106,10 +106,10 @@ EXPECTED_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-dcd1a95e5d432b5d300d7c2f216d7150.css" type="text/css" media="all">
-		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style-b35546733b0295036e79cc1f700b1efd.css">
+		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=" type="text/css" media="all">
+		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=">
 		<link rel="stylesheet" href="http://example.org/wp-includes/css/dashicons.min.css">
-		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min-73003a856907a7e09cca97c586493ed7.css">
+		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=">
 	</head>
 	<body>
 	</body>
@@ -118,12 +118,12 @@ EXPECTED_HTML
 				,
 
 				'files' => [
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-dcd1a95e5d432b5d300d7c2f216d7150.css',
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-dcd1a95e5d432b5d300d7c2f216d7150.css.gz',
-					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style-b35546733b0295036e79cc1f700b1efd.css',
-					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style-b35546733b0295036e79cc1f700b1efd.css.gz',
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min-73003a856907a7e09cca97c586493ed7.css',
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min-73003a856907a7e09cca97c586493ed7.css.gz',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css.gz',
+					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css',
+					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css.gz',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css.gz',
 				],
 			],
 
@@ -153,10 +153,10 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-dcd1a95e5d432b5d300d7c2f216d7150.css" type="text/css" media="all">
-		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style-b35546733b0295036e79cc1f700b1efd.css">
+		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=" type="text/css" media="all">
+		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=">
 		<link rel="stylesheet" href="https://123456.rocketcdn.me/wp-includes/css/dashicons.min.css">
-		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min-73003a856907a7e09cca97c586493ed7.css">
+		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=">
 	</head>
 	<body>
 	</body>
@@ -165,12 +165,12 @@ EXPECTED_HTML
 				,
 
 				'files' => [
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-dcd1a95e5d432b5d300d7c2f216d7150.css',
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-dcd1a95e5d432b5d300d7c2f216d7150.css.gz',
-					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style-b35546733b0295036e79cc1f700b1efd.css',
-					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style-b35546733b0295036e79cc1f700b1efd.css.gz',
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min-73003a856907a7e09cca97c586493ed7.css',
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min-73003a856907a7e09cca97c586493ed7.css.gz',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css.gz',
+					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css',
+					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css.gz',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css.gz',
 				],
 			],
 
@@ -200,10 +200,10 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-dcd1a95e5d432b5d300d7c2f216d7150.css" type="text/css" media="all">
-		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style-b35546733b0295036e79cc1f700b1efd.css">
+		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=" type="text/css" media="all">
+		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=">
 		<link rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-includes/css/dashicons.min.css">
-		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min-73003a856907a7e09cca97c586493ed7.css">
+		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=">
 	</head>
 	<body>
 	</body>
@@ -211,12 +211,12 @@ ORIGINAL_HTML
 EXPECTED_HTML
 				,
 				'files' => [
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-dcd1a95e5d432b5d300d7c2f216d7150.css',
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-dcd1a95e5d432b5d300d7c2f216d7150.css.gz',
-					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style-b35546733b0295036e79cc1f700b1efd.css',
-					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style-b35546733b0295036e79cc1f700b1efd.css.gz',
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min-73003a856907a7e09cca97c586493ed7.css',
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min-73003a856907a7e09cca97c586493ed7.css.gz',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css.gz',
+					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css',
+					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css.gz',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css.gz',
 				],
 			],
 
@@ -243,7 +243,7 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/path/to/style-83936e8415166d4e08a1d8998b5990cd.css" type="text/css" media="all">
+		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/path/to/style.css?ver=" type="text/css" media="all">
 	</head>
 	<body>
 	</body>
@@ -251,8 +251,8 @@ ORIGINAL_HTML
 EXPECTED_HTML
 				,
 				'files' => [
-					'wp-content/cache/min/1/path/to/style-83936e8415166d4e08a1d8998b5990cd.css',
-					'wp-content/cache/min/1/path/to/style-83936e8415166d4e08a1d8998b5990cd.css.gz',
+					'wp-content/cache/min/1/path/to/style.css',
+					'wp-content/cache/min/1/path/to/style.css.gz',
 				],
 			],
 
@@ -279,7 +279,7 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/path/to/style-83936e8415166d4e08a1d8998b5990cd.css" type="text/css" media="all">
+		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/path/to/style.css?ver=" type="text/css" media="all">
 	</head>
 	<body>
 	</body>
@@ -287,8 +287,8 @@ ORIGINAL_HTML
 EXPECTED_HTML
 				,
 				'files' => [
-					'wp-content/cache/min/1/path/to/style-83936e8415166d4e08a1d8998b5990cd.css',
-					'wp-content/cache/min/1/path/to/style-83936e8415166d4e08a1d8998b5990cd.css.gz',
+					'wp-content/cache/min/1/path/to/style.css',
+					'wp-content/cache/min/1/path/to/style.css.gz',
 				],
 			],
 

--- a/tests/Fixtures/inc/Engine/Optimization/Minify/CSS/Minify/optimize.php
+++ b/tests/Fixtures/inc/Engine/Optimization/Minify/CSS/Minify/optimize.php
@@ -27,10 +27,10 @@ return [
 <html>
 	<head>
 		<title>Sample Page</title>
-		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=dcd1a95e5d432b5d300d7c2f216d7150" type="text/css" media="all">
-		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=b35546733b0295036e79cc1f700b1efd">
+		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver={{mtime}}" type="text/css" media="all">
+		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver={{mtime}}">
 		<link rel="stylesheet" href="http://example.org/wp-includes/css/dashicons.min.css">
-		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=73003a856907a7e09cca97c586493ed7">
+		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver={{mtime}}">
 	</head>
 	<body>
 	</body>
@@ -73,10 +73,10 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=81368ec770e103151d0a6b86fb40c04b" type="text/css" media="all">
-		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=dd6c273e12758644d0d561ae5eb1792c">
+		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver={{mtime}}" type="text/css" media="all">
+		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver={{mtime}}">
 		<link rel="stylesheet" href="/wp-includes/css/dashicons.min.css">
-		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=dae742d87623d4edfaef3856b672fab7">
+		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver={{mtime}}">
 	</head>
 	<body>
 	</body>
@@ -106,10 +106,10 @@ EXPECTED_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=dcd1a95e5d432b5d300d7c2f216d7150" type="text/css" media="all">
-		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=b35546733b0295036e79cc1f700b1efd">
+		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver={{mtime}}" type="text/css" media="all">
+		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver={{mtime}}">
 		<link rel="stylesheet" href="http://example.org/wp-includes/css/dashicons.min.css">
-		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=73003a856907a7e09cca97c586493ed7">
+		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver={{mtime}}">
 	</head>
 	<body>
 	</body>
@@ -153,10 +153,10 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=dcd1a95e5d432b5d300d7c2f216d7150" type="text/css" media="all">
-		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=b35546733b0295036e79cc1f700b1efd">
+		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver={{mtime}}" type="text/css" media="all">
+		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver={{mtime}}">
 		<link rel="stylesheet" href="https://123456.rocketcdn.me/wp-includes/css/dashicons.min.css">
-		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=73003a856907a7e09cca97c586493ed7">
+		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver={{mtime}}">
 	</head>
 	<body>
 	</body>
@@ -200,10 +200,10 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=dcd1a95e5d432b5d300d7c2f216d7150" type="text/css" media="all">
-		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=b35546733b0295036e79cc1f700b1efd">
+		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver={{mtime}}" type="text/css" media="all">
+		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver={{mtime}}">
 		<link rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-includes/css/dashicons.min.css">
-		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=73003a856907a7e09cca97c586493ed7">
+		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver={{mtime}}">
 	</head>
 	<body>
 	</body>
@@ -243,7 +243,7 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/path/to/style.css?ver=83936e8415166d4e08a1d8998b5990cd" type="text/css" media="all">
+		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/path/to/style.css?ver={{mtime}}" type="text/css" media="all">
 	</head>
 	<body>
 	</body>
@@ -279,7 +279,7 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/path/to/style.css?ver=83936e8415166d4e08a1d8998b5990cd" type="text/css" media="all">
+		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/path/to/style.css?ver={{mtime}}" type="text/css" media="all">
 	</head>
 	<body>
 	</body>

--- a/tests/Fixtures/inc/Engine/Optimization/Minify/CSS/Minify/optimize.php
+++ b/tests/Fixtures/inc/Engine/Optimization/Minify/CSS/Minify/optimize.php
@@ -27,10 +27,10 @@ return [
 <html>
 	<head>
 		<title>Sample Page</title>
-		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver" type="text/css" media="all">
-		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver">
+		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=dcd1a95e5d432b5d300d7c2f216d7150" type="text/css" media="all">
+		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=b35546733b0295036e79cc1f700b1efd">
 		<link rel="stylesheet" href="http://example.org/wp-includes/css/dashicons.min.css">
-		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver">
+		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=73003a856907a7e09cca97c586493ed7">
 	</head>
 	<body>
 	</body>
@@ -73,10 +73,10 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver" type="text/css" media="all">
-		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver">
+		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=81368ec770e103151d0a6b86fb40c04b" type="text/css" media="all">
+		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=dd6c273e12758644d0d561ae5eb1792c">
 		<link rel="stylesheet" href="/wp-includes/css/dashicons.min.css">
-		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver">
+		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=dae742d87623d4edfaef3856b672fab7">
 	</head>
 	<body>
 	</body>
@@ -106,10 +106,10 @@ EXPECTED_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver" type="text/css" media="all">
-		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver">
+		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=dcd1a95e5d432b5d300d7c2f216d7150" type="text/css" media="all">
+		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=b35546733b0295036e79cc1f700b1efd">
 		<link rel="stylesheet" href="http://example.org/wp-includes/css/dashicons.min.css">
-		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver">
+		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=73003a856907a7e09cca97c586493ed7">
 	</head>
 	<body>
 	</body>
@@ -153,10 +153,10 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver" type="text/css" media="all">
-		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver">
+		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=dcd1a95e5d432b5d300d7c2f216d7150" type="text/css" media="all">
+		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=b35546733b0295036e79cc1f700b1efd">
 		<link rel="stylesheet" href="https://123456.rocketcdn.me/wp-includes/css/dashicons.min.css">
-		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver">
+		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=73003a856907a7e09cca97c586493ed7">
 	</head>
 	<body>
 	</body>
@@ -200,10 +200,10 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver" type="text/css" media="all">
-		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver">
+		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=dcd1a95e5d432b5d300d7c2f216d7150" type="text/css" media="all">
+		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=b35546733b0295036e79cc1f700b1efd">
 		<link rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-includes/css/dashicons.min.css">
-		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver">
+		<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=73003a856907a7e09cca97c586493ed7">
 	</head>
 	<body>
 	</body>
@@ -243,7 +243,7 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/path/to/style.css?ver" type="text/css" media="all">
+		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/path/to/style.css?ver=83936e8415166d4e08a1d8998b5990cd" type="text/css" media="all">
 	</head>
 	<body>
 	</body>
@@ -279,7 +279,7 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/path/to/style.css?ver" type="text/css" media="all">
+		<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/path/to/style.css?ver=83936e8415166d4e08a1d8998b5990cd" type="text/css" media="all">
 	</head>
 	<body>
 	</body>

--- a/tests/Fixtures/inc/Engine/Optimization/Minify/CSS/Subscriber/process.php
+++ b/tests/Fixtures/inc/Engine/Optimization/Minify/CSS/Subscriber/process.php
@@ -31,11 +31,11 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=5360e3be2666897518a1821fbecc9d28" type="text/css" media="all">
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=4a16b4cd55f600cc39947847baa15308">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver={{mtime}}" type="text/css" media="all">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver={{mtime}}">
 						<link rel="stylesheet" href="http://example.org/wp-includes/css/dashicons.min.css">
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=810497c120aacb0db0d64737badecd9c">
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/font-awesome/4.7.0/css/font-awesome.min.css?ver=8f298935317a465eea8c736e75f1b935">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver={{mtime}}">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/font-awesome/4.7.0/css/font-awesome.min.css?ver={{mtime}}">
 					</head>
 					<body>
 					</body>
@@ -47,7 +47,8 @@ return [
 					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css.gz',
 					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css',
 					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css.gz',
-					'wp-content/cache/min/3rd-party/stackpath.bootstrapcdn.com-font-awesome-4.7.0-css-font-awesome.min.css',
+					'wp-content/cache/min/1/font-awesome/4.7.0/css/font-awesome.min.css',
+					'wp-content/cache/min/1/font-awesome/4.7.0/css/font-awesome.min.css.gz',
 				],
 			],
 
@@ -76,16 +77,19 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/font-awesome/4.7.0/css/font-awesome.css?ver=f0a49cb1d696cc10278bb729970847c9" integrity="notvalid" type="text/css" media="all">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/font-awesome/4.7.0/css/font-awesome.css?ver={{mtime}}" integrity="notvalid" type="text/css" media="all">
 						<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.css" integrity="notvalidalgorithm-hashed">
 						<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.css" integrity="sha384-notvalidhash">
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/ajax/libs/font-awesome/5.15.2/css/fontawesome.css?ver=1f62604cfce89df4f94b128b68e13771">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/ajax/libs/font-awesome/5.15.2/css/fontawesome.css?ver={{mtime}}">
 					</head>
 					<body>
 					</body>
 				</html>',
 				'files' => [
-					'wp-content/cache/min/1/font-awesome/4.7.0/css/font-awesome-f0a49cb1d696cc10278bb729970847c9.css'
+					'wp-content/cache/min/1/font-awesome/4.7.0/css/font-awesome.css',
+					'wp-content/cache/min/1/font-awesome/4.7.0/css/font-awesome.css.gz',
+					'wp-content/cache/min/1/ajax/libs/font-awesome/5.15.2/css/fontawesome.css',
+					'wp-content/cache/min/1/ajax/libs/font-awesome/5.15.2/css/fontawesome.css.gz',
 				],
 			],
 
@@ -115,11 +119,11 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=36f730a00bbaa4bb81d6a9dac005155f" type="text/css" media="all">
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=3b71a3cb9b14d657f0cb8365af32e4c8">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver={{mtime}}" type="text/css" media="all">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver={{mtime}}">
 						<link rel="stylesheet" href="/wp-includes/css/dashicons.min.css">
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=28df9696b00052d455b668898ba0aef4">
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/font-awesome/4.7.0/css/font-awesome.min.css?ver=8f298935317a465eea8c736e75f1b935">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver={{mtime}}">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/font-awesome/4.7.0/css/font-awesome.min.css?ver={{mtime}}">
 					</head>
 					<body>
 					</body>
@@ -131,7 +135,8 @@ return [
 					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css.gz',
 					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css',
 					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css.gz',
-					'wp-content/cache/min/3rd-party/stackpath.bootstrapcdn.com-font-awesome-4.7.0-css-font-awesome.min.css',
+					'wp-content/cache/min/1/font-awesome/4.7.0/css/font-awesome.min.css',
+					'wp-content/cache/min/1/font-awesome/4.7.0/css/font-awesome.min.css.gz',
 				],
 			],
 
@@ -160,10 +165,10 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=5360e3be2666897518a1821fbecc9d28" type="text/css" media="all">
-						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=4a16b4cd55f600cc39947847baa15308">
+						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver={{mtime}}" type="text/css" media="all">
+						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver={{mtime}}">
 						<link rel="stylesheet" href="https://123456.rocketcdn.me/wp-includes/css/dashicons.min.css">
-						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=810497c120aacb0db0d64737badecd9c">
+						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver={{mtime}}">
 
 					</head>
 					<body>
@@ -208,10 +213,10 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=5360e3be2666897518a1821fbecc9d28" type="text/css" media="all">
-						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=4a16b4cd55f600cc39947847baa15308">
+						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver={{mtime}}" type="text/css" media="all">
+						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver={{mtime}}">
 						<link rel="stylesheet" href="https://123456.rocketcdn.me/wp-includes/css/dashicons.min.css">
-						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=810497c120aacb0db0d64737badecd9c">
+						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver={{mtime}}">
 
 					</head>
 					<body>
@@ -253,10 +258,10 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=5360e3be2666897518a1821fbecc9d28" type="text/css" media="all">
-						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=4a16b4cd55f600cc39947847baa15308">
+						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver={{mtime}}" type="text/css" media="all">
+						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver={{mtime}}">
 						<link rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-includes/css/dashicons.min.css">
-						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=810497c120aacb0db0d64737badecd9c">
+						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver={{mtime}}">
 
 					</head>
 					<body>

--- a/tests/Fixtures/inc/Engine/Optimization/Minify/CSS/Subscriber/process.php
+++ b/tests/Fixtures/inc/Engine/Optimization/Minify/CSS/Subscriber/process.php
@@ -66,7 +66,7 @@ return [
 					<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.css" integrity="notvalid" type="text/css" media="all">
 					<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.css" integrity="notvalidalgorithm-hashed">
 					<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.css" integrity="sha384-notvalidhash">
-					<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.1/css/font-awesome.css" integrity="sha384-/TCrTtA4HcJvf4j70IDxw88HLaJNQ86jM0UFg9q6wTlTb1TPNXRkZC7WhiRZQVOa">
+					<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.2/css/fontawesome.css" integrity="sha384-kru28UjhynaepLMcLGIBjkuOAHbhva6Xuk0nZStgRk733F+oTf2JKejiH/TslLhR">
 		</head>
 				<body>
 				</body>
@@ -79,7 +79,7 @@ return [
 						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/font-awesome/4.7.0/css/font-awesome.css?ver=" integrity="notvalid" type="text/css" media="all">
 						<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.css" integrity="notvalidalgorithm-hashed">
 						<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.css" integrity="sha384-notvalidhash">
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/font-awesome/4.7.1/css/font-awesome.css?ver=">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/ajax/libs/font-awesome/5.15.2/css/fontawesome.css?ver=">
 					</head>
 					<body>
 					</body>

--- a/tests/Fixtures/inc/Engine/Optimization/Minify/CSS/Subscriber/process.php
+++ b/tests/Fixtures/inc/Engine/Optimization/Minify/CSS/Subscriber/process.php
@@ -31,22 +31,22 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-5360e3be2666897518a1821fbecc9d28.css" type="text/css" media="all">
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style-4a16b4cd55f600cc39947847baa15308.css">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=" type="text/css" media="all">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=">
 						<link rel="stylesheet" href="http://example.org/wp-includes/css/dashicons.min.css">
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min-810497c120aacb0db0d64737badecd9c.css">
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/font-awesome/4.7.0/css/font-awesome.min-8f298935317a465eea8c736e75f1b935.css">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/font-awesome/4.7.0/css/font-awesome.min.css?ver=">
 					</head>
 					<body>
 					</body>
 				</html>',
 				'files' => [
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-5360e3be2666897518a1821fbecc9d28.css',
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-5360e3be2666897518a1821fbecc9d28.css.gz',
-					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style-4a16b4cd55f600cc39947847baa15308.css',
-					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style-4a16b4cd55f600cc39947847baa15308.css.gz',
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min-810497c120aacb0db0d64737badecd9c.css',
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min-810497c120aacb0db0d64737badecd9c.css.gz',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css.gz',
+					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css',
+					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css.gz',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css.gz',
 					'wp-content/cache/min/3rd-party/stackpath.bootstrapcdn.com-font-awesome-4.7.0-css-font-awesome.min.css',
 				],
 			],
@@ -66,7 +66,7 @@ return [
 					<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.css" integrity="notvalid" type="text/css" media="all">
 					<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.css" integrity="notvalidalgorithm-hashed">
 					<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.css" integrity="sha384-notvalidhash">
-					<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.css" integrity="sha384-FckWOBo7yuyMS7In0aXZ0aoVvnInlnFMwCv77x9sZpFgOonQgnBj1uLwenWVtsEj">
+					<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.1/css/font-awesome.css" integrity="sha384-/TCrTtA4HcJvf4j70IDxw88HLaJNQ86jM0UFg9q6wTlTb1TPNXRkZC7WhiRZQVOa">
 		</head>
 				<body>
 				</body>
@@ -76,10 +76,10 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/font-awesome/4.7.0/css/font-awesome-f0a49cb1d696cc10278bb729970847c9.css" integrity="notvalid" type="text/css" media="all">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/font-awesome/4.7.0/css/font-awesome.css?ver=" integrity="notvalid" type="text/css" media="all">
 						<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.css" integrity="notvalidalgorithm-hashed">
 						<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.css" integrity="sha384-notvalidhash">
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/font-awesome/4.7.0/css/font-awesome-f0a49cb1d696cc10278bb729970847c9.css">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/font-awesome/4.7.1/css/font-awesome.css?ver=">
 					</head>
 					<body>
 					</body>
@@ -115,22 +115,22 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-36f730a00bbaa4bb81d6a9dac005155f.css" type="text/css" media="all">
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style-3b71a3cb9b14d657f0cb8365af32e4c8.css">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=" type="text/css" media="all">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=">
 						<link rel="stylesheet" href="/wp-includes/css/dashicons.min.css">
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min-28df9696b00052d455b668898ba0aef4.css">
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/font-awesome/4.7.0/css/font-awesome.min-8f298935317a465eea8c736e75f1b935.css">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/font-awesome/4.7.0/css/font-awesome.min.css?ver=">
 					</head>
 					<body>
 					</body>
 				</html>',
 				'files' => [
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-36f730a00bbaa4bb81d6a9dac005155f.css',
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-36f730a00bbaa4bb81d6a9dac005155f.css.gz',
-					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style-3b71a3cb9b14d657f0cb8365af32e4c8.css',
-					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style-3b71a3cb9b14d657f0cb8365af32e4c8.css.gz',
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min-28df9696b00052d455b668898ba0aef4.css',
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min-28df9696b00052d455b668898ba0aef4.css.gz',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css.gz',
+					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css',
+					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css.gz',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css.gz',
 					'wp-content/cache/min/3rd-party/stackpath.bootstrapcdn.com-font-awesome-4.7.0-css-font-awesome.min.css',
 				],
 			],
@@ -160,22 +160,22 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-5360e3be2666897518a1821fbecc9d28.css" type="text/css" media="all">
-						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style-4a16b4cd55f600cc39947847baa15308.css">
+						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=" type="text/css" media="all">
+						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=">
 						<link rel="stylesheet" href="https://123456.rocketcdn.me/wp-includes/css/dashicons.min.css">
-						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min-810497c120aacb0db0d64737badecd9c.css">
+						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=">
 
 					</head>
 					<body>
 					</body>
 				</html>',
 				'files' => [
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-5360e3be2666897518a1821fbecc9d28.css',
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-5360e3be2666897518a1821fbecc9d28.css.gz',
-					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style-4a16b4cd55f600cc39947847baa15308.css',
-					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style-4a16b4cd55f600cc39947847baa15308.css.gz',
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min-810497c120aacb0db0d64737badecd9c.css',
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min-810497c120aacb0db0d64737badecd9c.css.gz',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css.gz',
+					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css',
+					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css.gz',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css.gz',
 				],
 			],
 
@@ -208,22 +208,22 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-5360e3be2666897518a1821fbecc9d28.css" type="text/css" media="all">
-						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style-4a16b4cd55f600cc39947847baa15308.css">
+						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=" type="text/css" media="all">
+						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=">
 						<link rel="stylesheet" href="https://123456.rocketcdn.me/wp-includes/css/dashicons.min.css">
-						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min-810497c120aacb0db0d64737badecd9c.css">
+						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=">
 
 					</head>
 					<body>
 					</body>
 				</html>',
 				'files' => [
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-5360e3be2666897518a1821fbecc9d28.css',
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-5360e3be2666897518a1821fbecc9d28.css.gz',
-					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style-4a16b4cd55f600cc39947847baa15308.css',
-					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style-4a16b4cd55f600cc39947847baa15308.css.gz',
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min-810497c120aacb0db0d64737badecd9c.css',
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min-810497c120aacb0db0d64737badecd9c.css.gz',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css.gz',
+					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css',
+					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css.gz',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css.gz',
 				],
 			],
 
@@ -253,22 +253,22 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-5360e3be2666897518a1821fbecc9d28.css" type="text/css" media="all">
-						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style-4a16b4cd55f600cc39947847baa15308.css">
+						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=" type="text/css" media="all">
+						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=">
 						<link rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-includes/css/dashicons.min.css">
-						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min-810497c120aacb0db0d64737badecd9c.css">
+						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=">
 
 					</head>
 					<body>
 					</body>
 				</html>',
 				'files' => [
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-5360e3be2666897518a1821fbecc9d28.css',
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-5360e3be2666897518a1821fbecc9d28.css.gz',
-					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style-4a16b4cd55f600cc39947847baa15308.css',
-					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style-4a16b4cd55f600cc39947847baa15308.css.gz',
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min-810497c120aacb0db0d64737badecd9c.css',
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min-810497c120aacb0db0d64737badecd9c.css.gz',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css.gz',
+					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css',
+					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css.gz',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css.gz',
 				],
 			],
 

--- a/tests/Fixtures/inc/Engine/Optimization/Minify/CSS/Subscriber/process.php
+++ b/tests/Fixtures/inc/Engine/Optimization/Minify/CSS/Subscriber/process.php
@@ -31,11 +31,11 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=" type="text/css" media="all">
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver" type="text/css" media="all">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver">
 						<link rel="stylesheet" href="http://example.org/wp-includes/css/dashicons.min.css">
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=">
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/font-awesome/4.7.0/css/font-awesome.min.css?ver=">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/font-awesome/4.7.0/css/font-awesome.min.css?ver">
 					</head>
 					<body>
 					</body>
@@ -76,10 +76,10 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/font-awesome/4.7.0/css/font-awesome.css?ver=" integrity="notvalid" type="text/css" media="all">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/font-awesome/4.7.0/css/font-awesome.css?ver" integrity="notvalid" type="text/css" media="all">
 						<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.css" integrity="notvalidalgorithm-hashed">
 						<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.css" integrity="sha384-notvalidhash">
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/ajax/libs/font-awesome/5.15.2/css/fontawesome.css?ver=">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/ajax/libs/font-awesome/5.15.2/css/fontawesome.css?ver">
 					</head>
 					<body>
 					</body>
@@ -115,11 +115,11 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=" type="text/css" media="all">
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver" type="text/css" media="all">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver">
 						<link rel="stylesheet" href="/wp-includes/css/dashicons.min.css">
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=">
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/font-awesome/4.7.0/css/font-awesome.min.css?ver=">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/font-awesome/4.7.0/css/font-awesome.min.css?ver">
 					</head>
 					<body>
 					</body>
@@ -160,10 +160,10 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=" type="text/css" media="all">
-						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=">
+						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver" type="text/css" media="all">
+						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver">
 						<link rel="stylesheet" href="https://123456.rocketcdn.me/wp-includes/css/dashicons.min.css">
-						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=">
+						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver">
 
 					</head>
 					<body>
@@ -208,10 +208,10 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=" type="text/css" media="all">
-						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=">
+						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver" type="text/css" media="all">
+						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver">
 						<link rel="stylesheet" href="https://123456.rocketcdn.me/wp-includes/css/dashicons.min.css">
-						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=">
+						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver">
 
 					</head>
 					<body>
@@ -253,10 +253,10 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=" type="text/css" media="all">
-						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=">
+						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver" type="text/css" media="all">
+						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver">
 						<link rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-includes/css/dashicons.min.css">
-						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=">
+						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver">
 
 					</head>
 					<body>

--- a/tests/Fixtures/inc/Engine/Optimization/Minify/CSS/Subscriber/process.php
+++ b/tests/Fixtures/inc/Engine/Optimization/Minify/CSS/Subscriber/process.php
@@ -31,11 +31,11 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver" type="text/css" media="all">
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=5360e3be2666897518a1821fbecc9d28" type="text/css" media="all">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=4a16b4cd55f600cc39947847baa15308">
 						<link rel="stylesheet" href="http://example.org/wp-includes/css/dashicons.min.css">
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver">
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/font-awesome/4.7.0/css/font-awesome.min.css?ver">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=810497c120aacb0db0d64737badecd9c">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/font-awesome/4.7.0/css/font-awesome.min.css?ver=8f298935317a465eea8c736e75f1b935">
 					</head>
 					<body>
 					</body>
@@ -76,10 +76,10 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/font-awesome/4.7.0/css/font-awesome.css?ver" integrity="notvalid" type="text/css" media="all">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/font-awesome/4.7.0/css/font-awesome.css?ver=f0a49cb1d696cc10278bb729970847c9" integrity="notvalid" type="text/css" media="all">
 						<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.css" integrity="notvalidalgorithm-hashed">
 						<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.css" integrity="sha384-notvalidhash">
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/ajax/libs/font-awesome/5.15.2/css/fontawesome.css?ver">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/ajax/libs/font-awesome/5.15.2/css/fontawesome.css?ver=1f62604cfce89df4f94b128b68e13771">
 					</head>
 					<body>
 					</body>
@@ -115,11 +115,11 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver" type="text/css" media="all">
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=36f730a00bbaa4bb81d6a9dac005155f" type="text/css" media="all">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=3b71a3cb9b14d657f0cb8365af32e4c8">
 						<link rel="stylesheet" href="/wp-includes/css/dashicons.min.css">
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver">
-						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/font-awesome/4.7.0/css/font-awesome.min.css?ver">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=28df9696b00052d455b668898ba0aef4">
+						<link data-minify="1" rel="stylesheet" href="http://example.org/wp-content/cache/min/1/font-awesome/4.7.0/css/font-awesome.min.css?ver=8f298935317a465eea8c736e75f1b935">
 					</head>
 					<body>
 					</body>
@@ -160,10 +160,10 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver" type="text/css" media="all">
-						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver">
+						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=5360e3be2666897518a1821fbecc9d28" type="text/css" media="all">
+						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=4a16b4cd55f600cc39947847baa15308">
 						<link rel="stylesheet" href="https://123456.rocketcdn.me/wp-includes/css/dashicons.min.css">
-						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver">
+						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=810497c120aacb0db0d64737badecd9c">
 
 					</head>
 					<body>
@@ -208,10 +208,10 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver" type="text/css" media="all">
-						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver">
+						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=5360e3be2666897518a1821fbecc9d28" type="text/css" media="all">
+						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=4a16b4cd55f600cc39947847baa15308">
 						<link rel="stylesheet" href="https://123456.rocketcdn.me/wp-includes/css/dashicons.min.css">
-						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver">
+						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=810497c120aacb0db0d64737badecd9c">
 
 					</head>
 					<body>
@@ -253,10 +253,10 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver" type="text/css" media="all">
-						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver">
+						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/style.css?ver=5360e3be2666897518a1821fbecc9d28" type="text/css" media="all">
+						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/plugins/hello-dolly/style.css?ver=4a16b4cd55f600cc39947847baa15308">
 						<link rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-includes/css/dashicons.min.css">
-						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver">
+						<link data-minify="1" rel="stylesheet" href="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/style-font-face.min.css?ver=810497c120aacb0db0d64737badecd9c">
 
 					</head>
 					<body>

--- a/tests/Fixtures/inc/Engine/Optimization/Minify/JS/Minify/optimize.php
+++ b/tests/Fixtures/inc/Engine/Optimization/Minify/JS/Minify/optimize.php
@@ -26,8 +26,8 @@ return [
 <html>
 	<head>
 		<title>Sample Page</title>
-		<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver="></script>
-		<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver="></script>
+		<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver"></script>
+		<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver"></script>
 		<script type="text/javascript" src="http://example.org/wp-includes/js/jquery/jquery.js"></script>
 	</head>
 	<body>
@@ -56,8 +56,8 @@ EXPECTED_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver="></script>
-		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver="></script>
+		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver"></script>
+		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver"></script>
 		<script type="text/javascript" src="http://example.org/wp-includes/js/jquery/jquery.js"></script>
 	</head>
 	<body>
@@ -99,8 +99,8 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver="></script>
-		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver="></script>
+		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver"></script>
+		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver"></script>
 		<script type="text/javascript" src="https://123456.rocketcdn.me/wp-includes/js/jquery/jquery.js"></script>
 	</head>
 	<body>
@@ -142,8 +142,8 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver="></script>
-		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver="></script>
+		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver"></script>
+		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver"></script>
 		<script type="text/javascript" src="https://123456.rocketcdn.me/cdnpath/wp-includes/js/jquery/jquery.js"></script>
 	</head>
 	<body>
@@ -183,7 +183,7 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/path/to/external-script.js?ver="></script>
+		<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/path/to/external-script.js?ver"></script>
 	</head>
 	<body>
 	</body>
@@ -220,7 +220,7 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/path/to/external-script.js?ver="></script>
+		<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/path/to/external-script.js?ver"></script>
 	</head>
 	<body>
 	</body>

--- a/tests/Fixtures/inc/Engine/Optimization/Minify/JS/Minify/optimize.php
+++ b/tests/Fixtures/inc/Engine/Optimization/Minify/JS/Minify/optimize.php
@@ -26,8 +26,8 @@ return [
 <html>
 	<head>
 		<title>Sample Page</title>
-		<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver"></script>
-		<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver"></script>
+		<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver=09b5ce74889313bd51265ef983880c47"></script>
+		<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver=796977248f632116e0145a488743a3d2"></script>
 		<script type="text/javascript" src="http://example.org/wp-includes/js/jquery/jquery.js"></script>
 	</head>
 	<body>
@@ -56,8 +56,8 @@ EXPECTED_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver"></script>
-		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver"></script>
+		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver=09b5ce74889313bd51265ef983880c47"></script>
+		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver=796977248f632116e0145a488743a3d2"></script>
 		<script type="text/javascript" src="http://example.org/wp-includes/js/jquery/jquery.js"></script>
 	</head>
 	<body>
@@ -99,8 +99,8 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver"></script>
-		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver"></script>
+		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver=09b5ce74889313bd51265ef983880c47"></script>
+		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver=796977248f632116e0145a488743a3d2"></script>
 		<script type="text/javascript" src="https://123456.rocketcdn.me/wp-includes/js/jquery/jquery.js"></script>
 	</head>
 	<body>
@@ -142,8 +142,8 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver"></script>
-		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver"></script>
+		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver=09b5ce74889313bd51265ef983880c47"></script>
+		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver=796977248f632116e0145a488743a3d2"></script>
 		<script type="text/javascript" src="https://123456.rocketcdn.me/cdnpath/wp-includes/js/jquery/jquery.js"></script>
 	</head>
 	<body>
@@ -183,7 +183,7 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/path/to/external-script.js?ver"></script>
+		<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/path/to/external-script.js?ver=be0e316c7ba17da1873da5ede49f7ac9"></script>
 	</head>
 	<body>
 	</body>
@@ -220,7 +220,7 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/path/to/external-script.js?ver"></script>
+		<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/path/to/external-script.js?ver=be0e316c7ba17da1873da5ede49f7ac9"></script>
 	</head>
 	<body>
 	</body>

--- a/tests/Fixtures/inc/Engine/Optimization/Minify/JS/Minify/optimize.php
+++ b/tests/Fixtures/inc/Engine/Optimization/Minify/JS/Minify/optimize.php
@@ -26,8 +26,8 @@ return [
 <html>
 	<head>
 		<title>Sample Page</title>
-		<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script-09b5ce74889313bd51265ef983880c47.js"></script>
-		<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script-796977248f632116e0145a488743a3d2.js"></script>
+		<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver="></script>
+		<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver="></script>
 		<script type="text/javascript" src="http://example.org/wp-includes/js/jquery/jquery.js"></script>
 	</head>
 	<body>
@@ -36,10 +36,10 @@ return [
 EXPECTED_HTML
 				,
 				'files' => [
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script-09b5ce74889313bd51265ef983880c47.js',
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script-09b5ce74889313bd51265ef983880c47.js.gz',
-					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/script-796977248f632116e0145a488743a3d2.js',
-					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/script-796977248f632116e0145a488743a3d2.js.gz',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js.gz',
+					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js',
+					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js.gz',
 				],
 			],
 
@@ -56,8 +56,8 @@ EXPECTED_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script-09b5ce74889313bd51265ef983880c47.js"></script>
-		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script-796977248f632116e0145a488743a3d2.js"></script>
+		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver="></script>
+		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver="></script>
 		<script type="text/javascript" src="http://example.org/wp-includes/js/jquery/jquery.js"></script>
 	</head>
 	<body>
@@ -67,10 +67,10 @@ EXPECTED_HTML
 				,
 
 				'files' => [
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script-09b5ce74889313bd51265ef983880c47.js',
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script-09b5ce74889313bd51265ef983880c47.js.gz',
-					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/script-796977248f632116e0145a488743a3d2.js',
-					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/script-796977248f632116e0145a488743a3d2.js.gz',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js.gz',
+					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js',
+					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js.gz',
 				],
 			],
 
@@ -99,8 +99,8 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script-09b5ce74889313bd51265ef983880c47.js"></script>
-		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script-796977248f632116e0145a488743a3d2.js"></script>
+		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver="></script>
+		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver="></script>
 		<script type="text/javascript" src="https://123456.rocketcdn.me/wp-includes/js/jquery/jquery.js"></script>
 	</head>
 	<body>
@@ -110,10 +110,10 @@ EXPECTED_HTML
 				,
 
 				'files' => [
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script-09b5ce74889313bd51265ef983880c47.js',
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script-09b5ce74889313bd51265ef983880c47.js.gz',
-					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/script-796977248f632116e0145a488743a3d2.js',
-					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/script-796977248f632116e0145a488743a3d2.js.gz',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js.gz',
+					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js',
+					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js.gz',
 				],
 			],
 
@@ -142,8 +142,8 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script-09b5ce74889313bd51265ef983880c47.js"></script>
-		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script-796977248f632116e0145a488743a3d2.js"></script>
+		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver="></script>
+		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver="></script>
 		<script type="text/javascript" src="https://123456.rocketcdn.me/cdnpath/wp-includes/js/jquery/jquery.js"></script>
 	</head>
 	<body>
@@ -153,10 +153,10 @@ EXPECTED_HTML
 				,
 
 				'files' => [
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script-09b5ce74889313bd51265ef983880c47.js',
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script-09b5ce74889313bd51265ef983880c47.js.gz',
-					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/script-796977248f632116e0145a488743a3d2.js',
-					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/script-796977248f632116e0145a488743a3d2.js.gz',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js.gz',
+					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js',
+					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js.gz',
 				],
 			],
 
@@ -183,7 +183,7 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/path/to/external-script-be0e316c7ba17da1873da5ede49f7ac9.js"></script>
+		<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/path/to/external-script.js?ver="></script>
 	</head>
 	<body>
 	</body>
@@ -192,8 +192,8 @@ EXPECTED_HTML
 				,
 
 				'files' => [
-					'wp-content/cache/min/1/path/to/external-script-be0e316c7ba17da1873da5ede49f7ac9.js',
-					'wp-content/cache/min/1/path/to/external-script-be0e316c7ba17da1873da5ede49f7ac9.js.gz',
+					'wp-content/cache/min/1/path/to/external-script.js',
+					'wp-content/cache/min/1/path/to/external-script.js.gz',
 				],
 			],
 
@@ -220,7 +220,7 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/path/to/external-script-be0e316c7ba17da1873da5ede49f7ac9.js"></script>
+		<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/path/to/external-script.js?ver="></script>
 	</head>
 	<body>
 	</body>
@@ -229,8 +229,8 @@ EXPECTED_HTML
 				,
 
 				'files' => [
-					'wp-content/cache/min/1/path/to/external-script-be0e316c7ba17da1873da5ede49f7ac9.js',
-					'wp-content/cache/min/1/path/to/external-script-be0e316c7ba17da1873da5ede49f7ac9.js.gz',
+					'wp-content/cache/min/1/path/to/external-script.js',
+					'wp-content/cache/min/1/path/to/external-script.js.gz',
 				],
 			],
 

--- a/tests/Fixtures/inc/Engine/Optimization/Minify/JS/Minify/optimize.php
+++ b/tests/Fixtures/inc/Engine/Optimization/Minify/JS/Minify/optimize.php
@@ -26,8 +26,8 @@ return [
 <html>
 	<head>
 		<title>Sample Page</title>
-		<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver=09b5ce74889313bd51265ef983880c47"></script>
-		<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver=796977248f632116e0145a488743a3d2"></script>
+		<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver={{mtime}}"></script>
+		<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver={{mtime}}"></script>
 		<script type="text/javascript" src="http://example.org/wp-includes/js/jquery/jquery.js"></script>
 	</head>
 	<body>
@@ -56,8 +56,8 @@ EXPECTED_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver=09b5ce74889313bd51265ef983880c47"></script>
-		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver=796977248f632116e0145a488743a3d2"></script>
+		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver={{mtime}}"></script>
+		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver={{mtime}}"></script>
 		<script type="text/javascript" src="http://example.org/wp-includes/js/jquery/jquery.js"></script>
 	</head>
 	<body>
@@ -99,8 +99,8 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver=09b5ce74889313bd51265ef983880c47"></script>
-		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver=796977248f632116e0145a488743a3d2"></script>
+		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver={{mtime}}"></script>
+		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver={{mtime}}"></script>
 		<script type="text/javascript" src="https://123456.rocketcdn.me/wp-includes/js/jquery/jquery.js"></script>
 	</head>
 	<body>
@@ -142,8 +142,8 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver=09b5ce74889313bd51265ef983880c47"></script>
-		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver=796977248f632116e0145a488743a3d2"></script>
+		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver={{mtime}}"></script>
+		<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver={{mtime}}"></script>
 		<script type="text/javascript" src="https://123456.rocketcdn.me/cdnpath/wp-includes/js/jquery/jquery.js"></script>
 	</head>
 	<body>
@@ -183,7 +183,7 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/path/to/external-script.js?ver=be0e316c7ba17da1873da5ede49f7ac9"></script>
+		<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/path/to/external-script.js?ver={{mtime}}"></script>
 	</head>
 	<body>
 	</body>
@@ -220,7 +220,7 @@ ORIGINAL_HTML
 <html>
 	<head>
 		<title>Sample Page</title>
-		<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/path/to/external-script.js?ver=be0e316c7ba17da1873da5ede49f7ac9"></script>
+		<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/path/to/external-script.js?ver={{mtime}}"></script>
 	</head>
 	<body>
 	</body>

--- a/tests/Fixtures/inc/Engine/Optimization/Minify/JS/Subscriber/process.php
+++ b/tests/Fixtures/inc/Engine/Optimization/Minify/JS/Subscriber/process.php
@@ -36,10 +36,10 @@ return [
 				'html' => '<html>
 					<head>
 						<title>Sample Page</title>
-						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver"></script>
-						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver"></script>
+						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver=cdcfd4a96e52edbc4d3e7d5e887dbd11"></script>
+						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver=82c5174e342f25861cb20cab85ecb625"></script>
 						<script type="text/javascript" src="http://example.org' . $jquery_path . '"></script>
-						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js?ver"></script>
+						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js?ver=2d51e1a9b3d408c46ab0057b69063753"></script>
 					</head>
 					<body>
 					</body>
@@ -78,10 +78,10 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js?ver" integrity="notvalid"></script>
+						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js?ver=2d51e1a9b3d408c46ab0057b69063753" integrity="notvalid"></script>
 						<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js" integrity="notvalidalgorithm-hashed"></script>
 						<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js" integrity="sha384-notvalidhash"></script>
-						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/ajax/libs/twitter-bootstrap/4.5.1/js/bootstrap.js?ver"></script>
+						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/ajax/libs/twitter-bootstrap/4.5.1/js/bootstrap.js?ver=a4fa5fe2f754976b8d54f283a3962b95"></script>
 					</head>
 					<body>
 					</body>
@@ -144,8 +144,8 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver"></script>
-						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver"></script>
+						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver=cdcfd4a96e52edbc4d3e7d5e887dbd11"></script>
+						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver=82c5174e342f25861cb20cab85ecb625"></script>
 						<script type="text/javascript" src="https://123456.rocketcdn.me' . $jquery_path . '"></script>
 					</head>
 					<body>
@@ -183,8 +183,8 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver"></script>
-						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver"></script>
+						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver=cdcfd4a96e52edbc4d3e7d5e887dbd11"></script>
+						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver=82c5174e342f25861cb20cab85ecb625"></script>
 						<script type="text/javascript" src="https://123456.rocketcdn.me' . $jquery_path . '"></script>
 					</head>
 					<body>
@@ -221,8 +221,8 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver"></script>
-						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver"></script>
+						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver=cdcfd4a96e52edbc4d3e7d5e887dbd11"></script>
+						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver=82c5174e342f25861cb20cab85ecb625"></script>
 						<script type="text/javascript" src="https://123456.rocketcdn.me/cdnpath' . $jquery_path . '"></script>
 					</head>
 					<body>

--- a/tests/Fixtures/inc/Engine/Optimization/Minify/JS/Subscriber/process.php
+++ b/tests/Fixtures/inc/Engine/Optimization/Minify/JS/Subscriber/process.php
@@ -36,10 +36,10 @@ return [
 				'html' => '<html>
 					<head>
 						<title>Sample Page</title>
-						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver=cdcfd4a96e52edbc4d3e7d5e887dbd11"></script>
-						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver=82c5174e342f25861cb20cab85ecb625"></script>
+						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver={{mtime}}"></script>
+						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver={{mtime}}"></script>
 						<script type="text/javascript" src="http://example.org' . $jquery_path . '"></script>
-						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js?ver=2d51e1a9b3d408c46ab0057b69063753"></script>
+						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js?ver={{mtime}}"></script>
 					</head>
 					<body>
 					</body>
@@ -49,7 +49,8 @@ return [
 					'wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js.gz',
 					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js',
 					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js.gz',
-					'wp-content/cache/min/3rd-party/cdnjs.cloudflare.com-ajax-libs-twitter-bootstrap-4.5.0-js-bootstrap.js',
+					'wp-content/cache/min/1/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js',
+					'wp-content/cache/min/1/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js.gz',
 				],
 			],
 			'settings' => [
@@ -78,16 +79,19 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js?ver=2d51e1a9b3d408c46ab0057b69063753" integrity="notvalid"></script>
+						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js?ver={{mtime}}" integrity="notvalid"></script>
 						<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js" integrity="notvalidalgorithm-hashed"></script>
 						<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js" integrity="sha384-notvalidhash"></script>
-						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/ajax/libs/twitter-bootstrap/4.5.1/js/bootstrap.js?ver=a4fa5fe2f754976b8d54f283a3962b95"></script>
+						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/ajax/libs/twitter-bootstrap/4.5.1/js/bootstrap.js?ver={{mtime}}"></script>
 					</head>
 					<body>
 					</body>
 				</html>',
 				'files' => [
-					'wp-content/cache/min/1/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js'
+					'wp-content/cache/min/1/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js',
+					'wp-content/cache/min/1/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js.gz',
+					'wp-content/cache/min/1/ajax/libs/twitter-bootstrap/4.5.1/js/bootstrap.js',
+					'wp-content/cache/min/1/ajax/libs/twitter-bootstrap/4.5.1/js/bootstrap.js.gz',
 				],
 			],
 			'settings' => [
@@ -144,8 +148,8 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver=cdcfd4a96e52edbc4d3e7d5e887dbd11"></script>
-						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver=82c5174e342f25861cb20cab85ecb625"></script>
+						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver={{mtime}}"></script>
+						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver={{mtime}}"></script>
 						<script type="text/javascript" src="https://123456.rocketcdn.me' . $jquery_path . '"></script>
 					</head>
 					<body>
@@ -183,8 +187,8 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver=cdcfd4a96e52edbc4d3e7d5e887dbd11"></script>
-						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver=82c5174e342f25861cb20cab85ecb625"></script>
+						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver={{mtime}}"></script>
+						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver={{mtime}}"></script>
 						<script type="text/javascript" src="https://123456.rocketcdn.me' . $jquery_path . '"></script>
 					</head>
 					<body>
@@ -221,8 +225,8 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver=cdcfd4a96e52edbc4d3e7d5e887dbd11"></script>
-						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver=82c5174e342f25861cb20cab85ecb625"></script>
+						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver={{mtime}}"></script>
+						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver={{mtime}}"></script>
 						<script type="text/javascript" src="https://123456.rocketcdn.me/cdnpath' . $jquery_path . '"></script>
 					</head>
 					<body>

--- a/tests/Fixtures/inc/Engine/Optimization/Minify/JS/Subscriber/process.php
+++ b/tests/Fixtures/inc/Engine/Optimization/Minify/JS/Subscriber/process.php
@@ -3,6 +3,7 @@
 global $wp_scripts;
 
 $jquery_path = $wp_scripts->registered['jquery-core']->src;
+$timenow = time();
 
 return [
 	'vfs_dir' => 'wp-content/',
@@ -35,19 +36,19 @@ return [
 				'html' => '<html>
 					<head>
 						<title>Sample Page</title>
-						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script-cdcfd4a96e52edbc4d3e7d5e887dbd11.js"></script>
-						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script-82c5174e342f25861cb20cab85ecb625.js"></script>
+						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver="></script>
+						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver="></script>
 						<script type="text/javascript" src="http://example.org' . $jquery_path . '"></script>
-						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap-2d51e1a9b3d408c46ab0057b69063753.js"></script>
+						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js?ver="></script>
 					</head>
 					<body>
 					</body>
 				</html>',
 				'files' => [
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script-cdcfd4a96e52edbc4d3e7d5e887dbd11.js',
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script-cdcfd4a96e52edbc4d3e7d5e887dbd11.js.gz',
-					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/script-82c5174e342f25861cb20cab85ecb625.js',
-					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/script-82c5174e342f25861cb20cab85ecb625.js.gz',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js.gz',
+					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js',
+					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js.gz',
 					'wp-content/cache/min/3rd-party/cdnjs.cloudflare.com-ajax-libs-twitter-bootstrap-4.5.0-js-bootstrap.js',
 				],
 			],
@@ -68,7 +69,7 @@ return [
 					<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js" integrity="notvalid"></script>
 					<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js" integrity="notvalidalgorithm-hashed"></script>
 					<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js" integrity="sha384-notvalidhash"></script>
-					<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js" integrity="sha384-7emZq+z4THDbp1s8SKlmK0zlENQgT+twJBBAcJCe8c+mastOWEfHflsBcz9t1ste"></script>
+					<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.1/js/bootstrap.js" integrity="sha384-DCTGxr1MNV4fD9E8fGEPvxOCqu7hIyBSUrSwiSFtEloMCudWDuD8X75eb1x9b8eJ"></script>
 				</head>
 				<body>
 				</body>
@@ -77,16 +78,16 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap-2d51e1a9b3d408c46ab0057b69063753.js" integrity="notvalid"></script>
+						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js?ver=" integrity="notvalid"></script>
 						<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js" integrity="notvalidalgorithm-hashed"></script>
 						<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js" integrity="sha384-notvalidhash"></script>
-						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap-2d51e1a9b3d408c46ab0057b69063753.js"></script>
+						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/ajax/libs/twitter-bootstrap/4.5.1/js/bootstrap.js?ver="></script>
 					</head>
 					<body>
 					</body>
 				</html>',
 				'files' => [
-					'wp-content/cache/min/1/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap-2d51e1a9b3d408c46ab0057b69063753.js'
+					'wp-content/cache/min/1/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js'
 				],
 			],
 			'settings' => [
@@ -143,18 +144,18 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script-cdcfd4a96e52edbc4d3e7d5e887dbd11.js"></script>
-						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script-82c5174e342f25861cb20cab85ecb625.js"></script>
+						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver="></script>
+						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver="></script>
 						<script type="text/javascript" src="https://123456.rocketcdn.me' . $jquery_path . '"></script>
 					</head>
 					<body>
 					</body>
 				</html>',
 				'files'   => [
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script-cdcfd4a96e52edbc4d3e7d5e887dbd11.js',
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script-cdcfd4a96e52edbc4d3e7d5e887dbd11.js.gz',
-					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/script-82c5174e342f25861cb20cab85ecb625.js',
-					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/script-82c5174e342f25861cb20cab85ecb625.js.gz',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js.gz',
+					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js',
+					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js.gz',
 				],
 			],
 			'settings' => [
@@ -182,18 +183,18 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script-cdcfd4a96e52edbc4d3e7d5e887dbd11.js"></script>
-						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script-82c5174e342f25861cb20cab85ecb625.js"></script>
+						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver="></script>
+						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver="></script>
 						<script type="text/javascript" src="https://123456.rocketcdn.me' . $jquery_path . '"></script>
 					</head>
 					<body>
 					</body>
 				</html>',
 				'files' => [
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script-cdcfd4a96e52edbc4d3e7d5e887dbd11.js',
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script-cdcfd4a96e52edbc4d3e7d5e887dbd11.js.gz',
-					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/script-82c5174e342f25861cb20cab85ecb625.js',
-					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/script-82c5174e342f25861cb20cab85ecb625.js.gz',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js.gz',
+					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js',
+					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js.gz',
 				],
 			],
 			'settings' => [
@@ -220,18 +221,18 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script-cdcfd4a96e52edbc4d3e7d5e887dbd11.js"></script>
-						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script-82c5174e342f25861cb20cab85ecb625.js"></script>
+						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver="></script>
+						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver="></script>
 						<script type="text/javascript" src="https://123456.rocketcdn.me/cdnpath' . $jquery_path . '"></script>
 					</head>
 					<body>
 					</body>
 				</html>',
 				'files' => [
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script-cdcfd4a96e52edbc4d3e7d5e887dbd11.js',
-					'wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script-cdcfd4a96e52edbc4d3e7d5e887dbd11.js.gz',
-					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/script-82c5174e342f25861cb20cab85ecb625.js',
-					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/script-82c5174e342f25861cb20cab85ecb625.js.gz',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js',
+					'wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js.gz',
+					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js',
+					'wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js.gz',
 				],
 			],
 			[

--- a/tests/Fixtures/inc/Engine/Optimization/Minify/JS/Subscriber/process.php
+++ b/tests/Fixtures/inc/Engine/Optimization/Minify/JS/Subscriber/process.php
@@ -36,10 +36,10 @@ return [
 				'html' => '<html>
 					<head>
 						<title>Sample Page</title>
-						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver="></script>
-						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver="></script>
+						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver"></script>
+						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver"></script>
 						<script type="text/javascript" src="http://example.org' . $jquery_path . '"></script>
-						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js?ver="></script>
+						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js?ver"></script>
 					</head>
 					<body>
 					</body>
@@ -78,10 +78,10 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js?ver=" integrity="notvalid"></script>
+						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js?ver" integrity="notvalid"></script>
 						<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js" integrity="notvalidalgorithm-hashed"></script>
 						<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js" integrity="sha384-notvalidhash"></script>
-						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/ajax/libs/twitter-bootstrap/4.5.1/js/bootstrap.js?ver="></script>
+						<script data-minify="1" type="text/javascript" src="http://example.org/wp-content/cache/min/1/ajax/libs/twitter-bootstrap/4.5.1/js/bootstrap.js?ver"></script>
 					</head>
 					<body>
 					</body>
@@ -144,8 +144,8 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver="></script>
-						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver="></script>
+						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver"></script>
+						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver"></script>
 						<script type="text/javascript" src="https://123456.rocketcdn.me' . $jquery_path . '"></script>
 					</head>
 					<body>
@@ -183,8 +183,8 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver="></script>
-						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver="></script>
+						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver"></script>
+						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver"></script>
 						<script type="text/javascript" src="https://123456.rocketcdn.me' . $jquery_path . '"></script>
 					</head>
 					<body>
@@ -221,8 +221,8 @@ return [
 				'html'  => '<html>
 					<head>
 						<title>Sample Page</title>
-						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver="></script>
-						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver="></script>
+						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/themes/twentytwenty/assets/script.js?ver"></script>
+						<script data-minify="1" type="text/javascript" src="https://123456.rocketcdn.me/cdnpath/wp-content/cache/min/1/wp-content/plugins/hello-dolly/script.js?ver"></script>
 						<script type="text/javascript" src="https://123456.rocketcdn.me/cdnpath' . $jquery_path . '"></script>
 					</head>
 					<body>

--- a/tests/Integration/inc/Engine/Optimization/Minify/CSS/Subscriber/process.php
+++ b/tests/Integration/inc/Engine/Optimization/Minify/CSS/Subscriber/process.php
@@ -47,6 +47,13 @@ class Test_Process extends TestCase {
 
 		$actual = apply_filters( 'rocket_buffer', $original );
 
+		foreach ($expected['files'] as $file) {
+			$file_mtime = $this->filesystem->mtime( $file );
+			if ( $file_mtime ) {
+				$expected['html'] = str_replace( $file."?ver={{mtime}}", $file."?ver=".$file_mtime, $expected['html'] );
+			}
+		}
+
 		$this->assertSame(
 			$this->format_the_html( $expected['html'] ),
 			$this->format_the_html( $actual )

--- a/tests/Integration/inc/Engine/Optimization/Minify/JS/Subscriber/process.php
+++ b/tests/Integration/inc/Engine/Optimization/Minify/JS/Subscriber/process.php
@@ -46,9 +46,18 @@ class Test_Process extends TestCase {
 		$this->settings = $settings;
 		$this->setSettings();
 
+		$actual = apply_filters( 'rocket_buffer', $original );
+
+		foreach ($expected['files'] as $file) {
+			$file_mtime = $this->filesystem->mtime( $file );
+			if ( $file_mtime ) {
+				$expected['html'] = str_replace( $file."?ver={{mtime}}", $file."?ver=".$file_mtime, $expected['html'] );
+			}
+		}
+
 		$this->assertSame(
 			$this->format_the_html( $expected['html'] ),
-			$this->format_the_html( apply_filters( 'rocket_buffer', $original ) )
+			$this->format_the_html( $actual )
 		);
 
 		$this->assertFilesExists( $expected['files'] );

--- a/tests/Unit/inc/Engine/Optimization/Minify/CSS/Minify/optimize.php
+++ b/tests/Unit/inc/Engine/Optimization/Minify/CSS/Minify/optimize.php
@@ -114,7 +114,7 @@ class Test_Optimize extends TestCase {
 		}
 
 		Functions\expect( 'add_query_arg' )->andReturnUsing( function ( $key, $value, $url ) {
-			return $url . '?' . $key;
+			return $url . '?' . $key . '=' . $value;
 		} );
 
 		$this->minify = new Minify( $this->options, $this->local_cache );

--- a/tests/Unit/inc/Engine/Optimization/Minify/CSS/Minify/optimize.php
+++ b/tests/Unit/inc/Engine/Optimization/Minify/CSS/Minify/optimize.php
@@ -113,6 +113,10 @@ class Test_Optimize extends TestCase {
 				->andReturnArg( 1 );
 		}
 
+		Functions\expect( 'add_query_arg' )->andReturnUsing( function ( $key, $value, $url ) {
+			return $url . '?' . $key;
+		} );
+
 		$this->minify = new Minify( $this->options, $this->local_cache );
 
 		$this->assertSame(

--- a/tests/Unit/inc/Engine/Optimization/Minify/CSS/Minify/optimize.php
+++ b/tests/Unit/inc/Engine/Optimization/Minify/CSS/Minify/optimize.php
@@ -119,9 +119,18 @@ class Test_Optimize extends TestCase {
 
 		$this->minify = new Minify( $this->options, $this->local_cache );
 
+		$optimized_html = $this->minify->optimize( $original );
+
+		foreach ($expected['files'] as $file) {
+			$file_mtime = $this->filesystem->mtime( $file );
+			if ( $file_mtime ) {
+				$expected['html'] = str_replace( $file."?ver={{mtime}}", $file."?ver=".$file_mtime, $expected['html'] );
+			}
+		}
+
 		$this->assertSame(
 			$this->format_the_html( $expected['html'] ),
-			$this->format_the_html( $this->minify->optimize( $original ) )
+			$this->format_the_html( $optimized_html )
 		);
 
 		$this->assertFilesExists( $expected['files'] );

--- a/tests/Unit/inc/Engine/Optimization/Minify/JS/Minify/optimize.php
+++ b/tests/Unit/inc/Engine/Optimization/Minify/JS/Minify/optimize.php
@@ -95,9 +95,18 @@ class Test_Optimize extends TestCase {
 			return $url . '?' . $key . '=' . $value;
 		} );
 
+		$optimized_html = $this->minify->optimize( $original );
+
+		foreach ($expected['files'] as $file) {
+			$file_mtime = $this->filesystem->mtime( $file );
+			if ( $file_mtime ) {
+				$expected['html'] = str_replace( $file."?ver={{mtime}}", $file."?ver=".$file_mtime, $expected['html'] );
+			}
+		}
+
 		$this->assertSame(
 			$this->format_the_html( $expected['html'] ),
-			$this->format_the_html( $this->minify->optimize( $original ) )
+			$this->format_the_html( $optimized_html )
 		);
 
 		$this->assertFilesExists( $expected['files'] );

--- a/tests/Unit/inc/Engine/Optimization/Minify/JS/Minify/optimize.php
+++ b/tests/Unit/inc/Engine/Optimization/Minify/JS/Minify/optimize.php
@@ -2,6 +2,7 @@
 
 namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\Minify\JS\Minify;
 
+use Brain\Monkey\Functions;
 use Brain\Monkey\Filters;
 use Mockery;
 use WP_Rocket\Engine\Optimization\AssetsLocalCache;
@@ -89,6 +90,10 @@ class Test_Optimize extends TestCase {
 				}
 				return $asset_match[0];
 			} );
+
+		Functions\expect( 'add_query_arg' )->andReturnUsing( function ( $key, $value, $url ) {
+			return $url . '?' . $key;
+		} );
 
 		$this->assertSame(
 			$this->format_the_html( $expected['html'] ),

--- a/tests/Unit/inc/Engine/Optimization/Minify/JS/Minify/optimize.php
+++ b/tests/Unit/inc/Engine/Optimization/Minify/JS/Minify/optimize.php
@@ -92,7 +92,7 @@ class Test_Optimize extends TestCase {
 			} );
 
 		Functions\expect( 'add_query_arg' )->andReturnUsing( function ( $key, $value, $url ) {
-			return $url . '?' . $key;
+			return $url . '?' . $key . '=' . $value;
 		} );
 
 		$this->assertSame(


### PR DESCRIPTION
## Description

As mentioned in the issue itself we will add a query string (?ver=) with the last modified time of the CSS or JS files. It means we won't rely anymore on the minify key and the filename of the minified file won't contain it too.

Fixes #3564 

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Is the solution different from the one proposed during the grooming?

No

## How Has This Been Tested?

- [x] Create page template and add some css/js files into it then enable minify css and minify js ( uncheck combine css/js ) and you will find the minified file structre changed to be the same filename with suffix `?ver=`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules