### PR TITLE
Fixes #2777 Update text formatting in Rocket Analytics modal

### DIFF
--- a/views/settings/page.php
+++ b/views/settings/page.php
@@ -73,7 +73,12 @@ settings_errors( $data['slug'] ); ?>
 			<button class="wpr-Popin-close wpr-Popin-Analytics-close wpr-icon-close"></button>
 		</div>
 		<div class="wpr-Popin-content">
-			<p><?php esc_html_e( 'Below is a detailed view of all data WP Rocket will collect <strong>if granted permission.</strong>', 'rocket' ); ?></p>
+			<p>
+			<?php
+				// translators: %1$s = <strong>, %2$s = </strong>.
+				printf( esc_html__( 'Below is a detailed view of all data WP Rocket will collect %1$sif granted permission.%2$s', 'rocket' ), '<strong>', '</strong>' );
+			?>
+			</p>
 			<?php echo rocket_data_collection_preview_table(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Dynamic content is properly escaped in the view. ?>
 			<div class="wpr-Popin-flex">
 				<p><?php esc_html_e( 'WP Rocket will never transmit any domain names or email addresses (except for license validation), IP addresses, or third-party API keys.', 'rocket' ); ?></p>


### PR DESCRIPTION
## Description

Update the text formatting in the rocket analytics modal, to prevent escaped HTML being displayed.

Fixes #2777

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

It's a bit different, using `printf` to insert the HTML tags, instead of splitting the sentence in 2 parts.

## How Has This Been Tested?

- [x] Checked the modal window text after doing the change, it's now correctly in bold instead of showing the HTML tags.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings