### PR TITLE
Closes #3113 Stop removing empty lines in the .htaccess

### DIFF
--- a/inc/functions/htaccess.php
+++ b/inc/functions/htaccess.php
@@ -18,7 +18,6 @@ function flush_rocket_htaccess( $remove_rules = false ) { // phpcs:ignore WordPr
 	 * Filters disabling of WP Rocket htaccess rules
 	 *
 	 * @since 3.2.5
-	 * @author Remy Perona
 	 *
 	 * @param bool $disable True to disable, false otherwise.
 	 */
@@ -54,18 +53,6 @@ function flush_rocket_htaccess( $remove_rules = false ) { // phpcs:ignore WordPr
 
 	if ( ! $remove_rules ) {
 		$ftmp = get_rocket_htaccess_marker() . PHP_EOL . $ftmp;
-	}
-
-	/**
-	 * Determine if empty lines should be removed in the .htaccess file.
-	 *
-	 * @since  2.10.7
-	 * @author Remy Perona
-	 *
-	 * @param boolean $remove_empty_lines True to remove, false otherwise.
-	 */
-	if ( apply_filters( 'rocket_remove_empty_lines', true ) ) {
-		$ftmp = preg_replace( "/\n+/", "\n", $ftmp );
 	}
 
 	// Make sure the WP rules are still there.

--- a/tests/Fixtures/content/htaccessContent.php
+++ b/tests/Fixtures/content/htaccessContent.php
@@ -10,6 +10,7 @@ AddDefaultCharset UTF-8
 <IfModule mod_mime.c>
 AddCharset UTF-8 .atom .css .js .json .rss .vtt .xml
 </IfModule>
+
 # FileETag None is not enough for every server.
 <IfModule mod_headers.c>
 Header unset ETag
@@ -18,6 +19,7 @@ Header unset ETag
 HTACCESS;
 
 $fileETag = <<<HTACCESS
+
 # Since we’re sending far-future expires, we don’t need ETags for static content.
 # developer.yahoo.com/performance/rules.html#etags
 FileETag None
@@ -35,12 +37,14 @@ Header set Access-Control-Allow-Origin "*" env=IS_CORS
 </FilesMatch>
 </IfModule>
 </IfModule>
+
 # Allow access to web fonts from all domains.
 <FilesMatch "\.(eot|otf|tt[cf]|woff2?)$">
 <IfModule mod_headers.c>
 Header set Access-Control-Allow-Origin "*"
 </IfModule>
 </FilesMatch>
+
 
 HTACCESS;
 
@@ -179,6 +183,7 @@ HTACCESS;
 
 $end = <<<HTACCESS
 # END WP Rocket
+
 # Random
 # add a trailing slash to /wp-admin# BEGIN WordPress
 


### PR DESCRIPTION
## Description

Removed the lines controlling the removal of the empty lines in the `.htaccess` file. Also removed the associated filter.

Fixes #3113

## Type of change

- [x] Enhancement (non-breaking change which adds functionality)

## Is the solution different from the one proposed during the grooming?

No

## How Has This Been Tested?

- [x] Tested by updating settings that impact the `.htaccess` content. Empty lines are correctly preserved

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings