### PR TITLE
Closes #3539 Combine @import rules into the minified CSS files

### DIFF
--- a/inc/Engine/Optimization/CSSTrait.php
+++ b/inc/Engine/Optimization/CSSTrait.php
@@ -387,53 +387,53 @@ trait CSSTrait {
 	 * @param string $url URL of the file.
 	 * @return bool True if external, false otherwise.
 	 */
-	 function is_external_path( $url ) {
-		 $file = get_rocket_parse_url( $url );
+	protected function is_external_path( $url ) {
+		$file = get_rocket_parse_url( $url );
 
-		 if ( empty( $file['path'] ) ) {
-			 return true;
-		 }
+		if ( empty( $file['path'] ) ) {
+			return true;
+		}
 
-		 $parsed_site_url = wp_parse_url( site_url() );
+		$parsed_site_url = wp_parse_url( site_url() );
 
-		 if ( empty( $parsed_site_url['host'] ) ) {
-			 return true;
-		 }
+		if ( empty( $parsed_site_url['host'] ) ) {
+			return true;
+		}
 
-		 // This filter is documented in inc/Engine/Admin/Settings/Settings.php.
-		 $hosts   = (array) apply_filters( 'rocket_cdn_hosts', [], [ 'all' ] );
-		 $hosts[] = $parsed_site_url['host'];
-		 $langs   = get_rocket_i18n_uri();
+		// This filter is documented in inc/Engine/Admin/Settings/Settings.php.
+		$hosts   = (array) apply_filters( 'rocket_cdn_hosts', [], [ 'all' ] );
+		$hosts[] = $parsed_site_url['host'];
+		$langs   = get_rocket_i18n_uri();
 
-		 // Get host for all langs.
-		 foreach ( $langs as $lang ) {
-			 $url_host = wp_parse_url( $lang, PHP_URL_HOST );
+		// Get host for all langs.
+		foreach ( $langs as $lang ) {
+			$url_host = wp_parse_url( $lang, PHP_URL_HOST );
 
-			 if ( ! isset( $url_host ) ) {
-				 continue;
-			 }
+			if ( ! isset( $url_host ) ) {
+				continue;
+			}
 
-			 $hosts[] = $url_host;
-		 }
+			$hosts[] = $url_host;
+		}
 
-		 $hosts = array_unique( $hosts );
+		$hosts = array_unique( $hosts );
 
-		 if ( empty( $hosts ) ) {
-			 return true;
-		 }
+		if ( empty( $hosts ) ) {
+			return true;
+		}
 
-		 // URL has domain and domain is part of the internal domains.
-		 if ( ! empty( $file['host'] ) ) {
-			 foreach ( $hosts as $host ) {
-				 if ( false !== strpos( $url, $host ) ) {
-					 return false;
-				 }
-			 }
+		// URL has domain and domain is part of the internal domains.
+		if ( ! empty( $file['host'] ) ) {
+			foreach ( $hosts as $host ) {
+				if ( false !== strpos( $url, $host ) ) {
+					return false;
+				}
+			}
 
-			 return true;
-		 }
+			return true;
+		}
 
-		 return false;
+		return false;
 	}
 
 	/**

--- a/inc/Engine/Optimization/CSSTrait.php
+++ b/inc/Engine/Optimization/CSSTrait.php
@@ -371,18 +371,6 @@ trait CSSTrait {
 	 */
 	private function get_internal_file_contents( $file, $base_path ) {
 		if ( $this->is_external_path( $file ) && wp_http_validate_url( $file ) ) {
-			/**
-			 * Filter Import external urls.
-			 *
-			 * @since 3.8.6
-			 *
-			 * @param bool Allow status.
-			 * @param string $file File path/URL.
-			 */
-			if ( (bool) apply_filters( 'rocket_allow_import_externals', false, $file ) ) {
-				return [ $file, rocket_direct_filesystem()->get_contents( $file ) ];
-			}
-
 			return [ $file, false ];
 		}
 

--- a/inc/Engine/Optimization/CSSTrait.php
+++ b/inc/Engine/Optimization/CSSTrait.php
@@ -198,6 +198,8 @@ trait CSSTrait {
 	/**
 	 * Replace local imports with their contents recursively.
 	 *
+	 * @since 3.8.6
+	 *
 	 * @param string $content CSS Content.
 	 * @param string $target Target CSS file path.
 	 *
@@ -347,6 +349,8 @@ trait CSSTrait {
 	/**
 	 * Get internal file full path and contents.
 	 *
+	 * @since 3.8.6
+	 *
 	 * @param string $file Internal file path (maybe external url or relative path).
 	 * @param string $base_path Base path as reference for relative paths.
 	 *
@@ -357,7 +361,7 @@ trait CSSTrait {
 			/**
 			 * Filter Import external urls.
 			 *
-			 * @since 3.6.8
+			 * @since 3.8.6
 			 *
 			 * @param bool Allow status.
 			 * @param string $file File path/URL.
@@ -369,6 +373,7 @@ trait CSSTrait {
 			return [ $file, false ];
 		}
 
+		// Check if this file is readable or it's relative path so we add base_path at it's start.
 		if ( ! rocket_direct_filesystem()->is_readable( $this->get_local_path( $file ) ) ) {
 			$ds   = rocket_get_constant( 'DIRECTORY_SEPARATOR' );
 			$file = $base_path . $ds . str_replace( '/', $ds, $file );
@@ -382,7 +387,7 @@ trait CSSTrait {
 	/**
 	 * Determines if the file is external.
 	 *
-	 * @since 3.8
+	 * @since 3.8.6
 	 *
 	 * @param string $url URL of the file.
 	 * @return bool True if external, false otherwise.
@@ -439,6 +444,8 @@ trait CSSTrait {
 	/**
 	 * Get local absolute path for image.
 	 *
+	 * @since 3.8.6
+	 *
 	 * @param string $url Image url.
 	 *
 	 * @return string Image absolute local path.
@@ -460,6 +467,8 @@ trait CSSTrait {
 
 	/**
 	 * Normalize relative url to full url.
+	 *
+	 * @since 3.8.6
 	 *
 	 * @param string $url Url to be normalized.
 	 *

--- a/inc/Engine/Optimization/CSSTrait.php
+++ b/inc/Engine/Optimization/CSSTrait.php
@@ -353,14 +353,128 @@ trait CSSTrait {
 	 * @return array Array of two values ( full path, contents )
 	 */
 	private function get_internal_file_contents( $file, $base_path ) {
-		if ( ! rocket_direct_filesystem()->is_readable( $file ) ) {
+		if ( $this->is_external_path( $file ) && wp_http_validate_url( $file ) ) {
+			/**
+			 * Filter Import external urls.
+			 *
+			 * @since 3.6.8
+			 *
+			 * @param bool Allow status.
+			 * @param string $file File path/URL.
+			 */
+			if ( (bool) apply_filters( 'rocket_allow_import_externals', false, $file ) ) {
+				return [ $file, rocket_direct_filesystem()->get_contents( $file ) ];
+			}
+
+			return [ $file, false ];
+		}
+
+		if ( ! rocket_direct_filesystem()->is_readable( $this->get_local_path( $file ) ) ) {
 			$ds   = rocket_get_constant( 'DIRECTORY_SEPARATOR' );
 			$file = $base_path . $ds . str_replace( '/', $ds, $file );
 		}
 
-		$import_content = rocket_direct_filesystem()->get_contents( $file );
+		$import_content = rocket_direct_filesystem()->get_contents( $this->get_local_path( $file ) );
 
 		return [ $file, $import_content ];
+	}
+
+	/**
+	 * Determines if the file is external.
+	 *
+	 * @since 3.8
+	 *
+	 * @param string $url URL of the file.
+	 * @return bool True if external, false otherwise.
+	 */
+	 function is_external_path( $url ) {
+		 $file = get_rocket_parse_url( $url );
+
+		 if ( empty( $file['path'] ) ) {
+			 return true;
+		 }
+
+		 $parsed_site_url = wp_parse_url( site_url() );
+
+		 if ( empty( $parsed_site_url['host'] ) ) {
+			 return true;
+		 }
+
+		 // This filter is documented in inc/Engine/Admin/Settings/Settings.php.
+		 $hosts   = (array) apply_filters( 'rocket_cdn_hosts', [], [ 'all' ] );
+		 $hosts[] = $parsed_site_url['host'];
+		 $langs   = get_rocket_i18n_uri();
+
+		 // Get host for all langs.
+		 foreach ( $langs as $lang ) {
+			 $url_host = wp_parse_url( $lang, PHP_URL_HOST );
+
+			 if ( ! isset( $url_host ) ) {
+				 continue;
+			 }
+
+			 $hosts[] = $url_host;
+		 }
+
+		 $hosts = array_unique( $hosts );
+
+		 if ( empty( $hosts ) ) {
+			 return true;
+		 }
+
+		 // URL has domain and domain is part of the internal domains.
+		 if ( ! empty( $file['host'] ) ) {
+			 foreach ( $hosts as $host ) {
+				 if ( false !== strpos( $url, $host ) ) {
+					 return false;
+				 }
+			 }
+
+			 return true;
+		 }
+
+		 return false;
+	}
+
+	/**
+	 * Get local absolute path for image.
+	 *
+	 * @param string $url Image url.
+	 *
+	 * @return string Image absolute local path.
+	 */
+	private function get_local_path( $url ) {
+		$url = $this->normalize_url( $url );
+
+		$path = rocket_url_to_path( $url );
+		if ( $path ) {
+			return $path;
+		}
+
+		$relative_url = ltrim( wp_make_link_relative( $url ), '/' );
+		$ds           = rocket_get_constant( 'DIRECTORY_SEPARATOR' );
+		$base_path    = isset( $_SERVER['DOCUMENT_ROOT'] ) ? ( sanitize_text_field( wp_unslash( $_SERVER['DOCUMENT_ROOT'] ) ) . $ds ) : '';
+
+		return $base_path . str_replace( '/', $ds, $relative_url );
+	}
+
+	/**
+	 * Normalize relative url to full url.
+	 *
+	 * @param string $url Url to be normalized.
+	 *
+	 * @return string Normalized url.
+	 */
+	private function normalize_url( $url ) {
+		$url_host = wp_parse_url( $url, PHP_URL_HOST );
+
+		if ( empty( $url_host ) ) {
+			$relative_url        = ltrim( wp_make_link_relative( $url ), '/' );
+			$site_url_components = wp_parse_url( site_url( '/' ) );
+			return $site_url_components['scheme'] . '://' . $site_url_components['host'] . '/' . $relative_url;
+		}
+
+		return $url;
 	}
 
 }

--- a/inc/Engine/Optimization/CSSTrait.php
+++ b/inc/Engine/Optimization/CSSTrait.php
@@ -294,7 +294,7 @@ trait CSSTrait {
 
 		// loop the matches.
 		foreach ( $matches as $match ) {
-			if ( apply_filters( 'rocket_skip_import_replacement', false, $match['path'], $match ) ){
+			if ( apply_filters( 'rocket_skip_import_replacement', false, $match['path'], $match ) ) {
 				continue;
 			}
 

--- a/inc/Engine/Optimization/CSSTrait.php
+++ b/inc/Engine/Optimization/CSSTrait.php
@@ -294,6 +294,15 @@ trait CSSTrait {
 
 		// loop the matches.
 		foreach ( $matches as $match ) {
+			/**
+			 * Filter Skip import replacement for one file.
+			 *
+			 * @since 3.8.6
+			 *
+			 * @param bool Skipped or not (Default not skipped).
+			 * @param string $file_path Matched import path.
+			 * @param string $import_match Full import match.
+			 */
 			if ( apply_filters( 'rocket_skip_import_replacement', false, $match['path'], $match ) ) {
 				continue;
 			}

--- a/inc/Engine/Optimization/CSSTrait.php
+++ b/inc/Engine/Optimization/CSSTrait.php
@@ -4,6 +4,7 @@ namespace WP_Rocket\Engine\Optimization;
 
 use WP_Rocket\Dependencies\PathConverter\ConverterInterface;
 use WP_Rocket\Dependencies\PathConverter\Converter;
+use WP_Rocket\Logger\Logger;
 
 trait CSSTrait {
 	/**
@@ -383,6 +384,12 @@ trait CSSTrait {
 			$file = $base_path . $ds . str_replace( '/', $ds, $file );
 		}else {
 			$file = $this->get_local_path( $file );
+		}
+
+		$file_type = wp_check_filetype_and_ext( $file, basename( $file ), [ 'css' => 'text/css' ] );
+
+		if ( 'css' !== $file_type['ext'] ) {
+			return [ $file, null ];
 		}
 
 		$import_content = rocket_direct_filesystem()->get_contents( $file );

--- a/inc/Engine/Optimization/CSSTrait.php
+++ b/inc/Engine/Optimization/CSSTrait.php
@@ -300,7 +300,7 @@ trait CSSTrait {
 
 			if ( 'vfs' === $parsed_import_file['scheme'] ) {
 				$import_path = $match['path'];
-			}else{
+			}else {
 				$import_path = dirname( $target ) . DIRECTORY_SEPARATOR . $parsed_import_file['path'];
 			}
 

--- a/inc/Engine/Optimization/CSSTrait.php
+++ b/inc/Engine/Optimization/CSSTrait.php
@@ -292,16 +292,16 @@ trait CSSTrait {
 
 		// loop the matches.
 		foreach ( $matches as $match ) {
-			$parsed_import_file = get_rocket_parse_url( $match['path'] );
-
-			if ( ! empty( $parsed_import_file['host'] ) && 'vfs' !== $parsed_import_file['scheme'] ) {
+			$matched_path_is_url = wp_http_validate_url( $match['path'] );
+			if ( $matched_path_is_url ) {
 				continue;
 			}
 
-			if ( 'vfs' === $parsed_import_file['scheme'] ) {
+			if ( rocket_direct_filesystem()->is_readable( $match['path'] ) ) {
 				$import_path = $match['path'];
 			}else {
-				$import_path = dirname( $target ) . DIRECTORY_SEPARATOR . $parsed_import_file['path'];
+				$ds = rocket_get_constant( 'DIRECTORY_SEPARATOR' );
+				$import_path = dirname( $target ) . $ds . str_replace( '/', $ds, $match['path'] );
 			}
 
 			$import_content = rocket_direct_filesystem()->get_contents( $import_path );

--- a/inc/Engine/Optimization/CSSTrait.php
+++ b/inc/Engine/Optimization/CSSTrait.php
@@ -374,6 +374,9 @@ trait CSSTrait {
 			return [ $file, false ];
 		}
 
+		// Remove query strings.
+		$file = str_replace( '?' . wp_parse_url( $file, PHP_URL_QUERY ), '', $file );
+
 		// Check if this file is readable or it's relative path so we add base_path at it's start.
 		if ( ! rocket_direct_filesystem()->is_readable( $this->get_local_path( $file ) ) ) {
 			$ds   = rocket_get_constant( 'DIRECTORY_SEPARATOR' );
@@ -480,13 +483,14 @@ trait CSSTrait {
 	private function normalize_url( $url ) {
 		$url_host = wp_parse_url( $url, PHP_URL_HOST );
 
-		if ( empty( $url_host ) ) {
-			$relative_url        = ltrim( wp_make_link_relative( $url ), '/' );
-			$site_url_components = wp_parse_url( site_url( '/' ) );
-			return $site_url_components['scheme'] . '://' . $site_url_components['host'] . '/' . $relative_url;
+		if ( ! empty( $url_host ) ) {
+			return $url;
 		}
 
-		return $url;
+		$relative_url        = ltrim( wp_make_link_relative( $url ), '/' );
+		$site_url_components = wp_parse_url( site_url( '/' ) );
+
+		return $site_url_components['scheme'] . '://' . $site_url_components['host'] . '/' . $relative_url;
 	}
 
 }

--- a/inc/Engine/Optimization/CSSTrait.php
+++ b/inc/Engine/Optimization/CSSTrait.php
@@ -292,7 +292,19 @@ trait CSSTrait {
 
 		// loop the matches.
 		foreach ( $matches as $match ) {
-			$import_content = rocket_direct_filesystem()->get_contents( $match['path'] );
+			$parsed_import_file = get_rocket_parse_url( $match['path'] );
+
+			if ( ! empty( $parsed_import_file['host'] ) && 'vfs' !== $parsed_import_file['scheme'] ) {
+				continue;
+			}
+
+			if ( 'vfs' === $parsed_import_file['scheme'] ) {
+				$import_path = $match['path'];
+			}else{
+				$import_path = dirname( $target ) . DIRECTORY_SEPARATOR . $parsed_import_file['path'];
+			}
+
+			$import_content = rocket_direct_filesystem()->get_contents( $import_path );
 
 			if ( empty( $import_content ) ) {
 				continue;
@@ -304,7 +316,7 @@ trait CSSTrait {
 			}
 
 			// Use recursion to rewrite paths and combine imports again for imported content.
-			$import_content = $this->rewrite_paths( $match['path'], $target, $import_content );
+			$import_content = $this->rewrite_paths( $import_path, $target, $import_content );
 
 			// add to replacement array.
 			$search[]  = $match[0];

--- a/inc/Engine/Optimization/CSSTrait.php
+++ b/inc/Engine/Optimization/CSSTrait.php
@@ -390,9 +390,11 @@ trait CSSTrait {
 		if ( ! rocket_direct_filesystem()->is_readable( $this->get_local_path( $file ) ) ) {
 			$ds   = rocket_get_constant( 'DIRECTORY_SEPARATOR' );
 			$file = $base_path . $ds . str_replace( '/', $ds, $file );
+		}else{
+			$file = $this->get_local_path( $file );
 		}
 
-		$import_content = rocket_direct_filesystem()->get_contents( $this->get_local_path( $file ) );
+		$import_content = rocket_direct_filesystem()->get_contents( $file );
 
 		return [ $file, $import_content ];
 	}

--- a/inc/Engine/Optimization/CSSTrait.php
+++ b/inc/Engine/Optimization/CSSTrait.php
@@ -390,7 +390,7 @@ trait CSSTrait {
 		if ( ! rocket_direct_filesystem()->is_readable( $this->get_local_path( $file ) ) ) {
 			$ds   = rocket_get_constant( 'DIRECTORY_SEPARATOR' );
 			$file = $base_path . $ds . str_replace( '/', $ds, $file );
-		}else{
+		}else {
 			$file = $this->get_local_path( $file );
 		}
 

--- a/inc/Engine/Optimization/CSSTrait.php
+++ b/inc/Engine/Optimization/CSSTrait.php
@@ -292,19 +292,7 @@ trait CSSTrait {
 
 		// loop the matches.
 		foreach ( $matches as $match ) {
-			$matched_path_is_url = wp_http_validate_url( $match['path'] );
-			if ( $matched_path_is_url ) {
-				continue;
-			}
-
-			if ( rocket_direct_filesystem()->is_readable( $match['path'] ) ) {
-				$import_path = $match['path'];
-			}else {
-				$ds = rocket_get_constant( 'DIRECTORY_SEPARATOR' );
-				$import_path = dirname( $target ) . $ds . str_replace( '/', $ds, $match['path'] );
-			}
-
-			$import_content = rocket_direct_filesystem()->get_contents( $import_path );
+			list( $import_path, $import_content ) = $this->get_internal_file_contents( $match['path'], dirname( $target ) );
 
 			if ( empty( $import_content ) ) {
 				continue;
@@ -354,6 +342,25 @@ trait CSSTrait {
 			},
 			$css_file_content
 		);
+	}
+
+	/**
+	 * Get internal file full path and contents.
+	 *
+	 * @param string $file Internal file path (maybe external url or relative path).
+	 * @param string $base_path Base path as reference for relative paths.
+	 *
+	 * @return array Array of two values ( full path, contents )
+	 */
+	private function get_internal_file_contents( $file, $base_path ) {
+		if ( ! rocket_direct_filesystem()->is_readable( $file ) ) {
+			$ds   = rocket_get_constant( 'DIRECTORY_SEPARATOR' );
+			$file = $base_path . $ds . str_replace( '/', $ds, $file );
+		}
+
+		$import_content = rocket_direct_filesystem()->get_contents( $file );
+
+		return [ $file, $import_content ];
 	}
 
 }

--- a/inc/Engine/Optimization/CSSTrait.php
+++ b/inc/Engine/Optimization/CSSTrait.php
@@ -386,7 +386,7 @@ trait CSSTrait {
 			$file = $this->get_local_path( $file );
 		}
 
-		$file_type = wp_check_filetype_and_ext( $file, basename( $file ), [ 'css' => 'text/css' ] );
+		$file_type = wp_check_filetype( $file, [ 'css' => 'text/css' ] );
 
 		if ( 'css' !== $file_type['ext'] ) {
 			return [ $file, null ];

--- a/inc/Engine/Optimization/CSSTrait.php
+++ b/inc/Engine/Optimization/CSSTrait.php
@@ -294,6 +294,10 @@ trait CSSTrait {
 
 		// loop the matches.
 		foreach ( $matches as $match ) {
+			if ( apply_filters( 'rocket_skip_import_replacement', false, $match['path'], $match ) ){
+				continue;
+			}
+
 			list( $import_path, $import_content ) = $this->get_internal_file_contents( $match['path'], dirname( $target ) );
 
 			if ( empty( $import_content ) ) {

--- a/tests/Fixtures/inc/Engine/Optimization/Minify/CSS/Combine/combine.php
+++ b/tests/Fixtures/inc/Engine/Optimization/Minify/CSS/Combine/combine.php
@@ -64,7 +64,31 @@ return [
 					'wp-content/cache/min/1/b6dcf622d68835c7b1cd01e3cb339560.css',
 					'wp-content/cache/min/1/b6dcf622d68835c7b1cd01e3cb339560.css.gz',
 				],
-				'css' => '@import url(vfs://public/wp-content/themes/twentytwenty/style.css);body{font-family:Helvetica,Arial,sans-serif;text-align:center}body{font-family:Helvetica,Arial,sans-serif;text-align:center}',
+				'css' => 'body{font-family:Helvetica,Arial,sans-serif;text-align:center}body{font-family:Helvetica,Arial,sans-serif;text-align:center}body{font-family:Helvetica,Arial,sans-serif;text-align:center}',
+			],
+
+			'cdn_host' => [],
+			'cdn_url'  => 'http://example.org',
+			'site_url' => 'http://example.org',
+		],
+
+		'combineCssFilesWithNestedImport' => [
+			'original' =>
+				'<html><head><title>Sample Page</title>' .
+				'<link rel="stylesheet" href="http://example.org/wp-content/themes/twentytwenty/style-import2.css" type="text/css" media="all">' .
+				'<link rel="stylesheet" href="http://example.org/wp-content/plugins/hello-dolly/style.css">' .
+				'<link rel="stylesheet" href="http://example.org/wp-includes/css/dashicons.min.css">' .
+				'</head><body></body></html>',
+
+			'expected' => [
+				'html'  => '<html><head><title>Sample Page</title>' .
+				           '<link rel="stylesheet" href="http://example.org/wp-content/cache/min/1/a41edef8114680bb60b530fa32be3ca5.css" media="all" data-minify="1" />' .
+				           '</head><body></body></html>',
+				'files' => [
+					'wp-content/cache/min/1/a41edef8114680bb60b530fa32be3ca5.css',
+					'wp-content/cache/min/1/a41edef8114680bb60b530fa32be3ca5.css.gz',
+				],
+				'css' => '.style-another-import2{color:green}.style-another-import{color:red}body{font-family:Helvetica,Arial,sans-serif;text-align:center}body{font-family:Helvetica,Arial,sans-serif;text-align:center}',
 			],
 
 			'cdn_host' => [],
@@ -88,7 +112,7 @@ return [
 					'wp-content/cache/min/1/afeb29591023f7eb6314ad594ca01138.css',
 					'wp-content/cache/min/1/afeb29591023f7eb6314ad594ca01138.css.gz',
 				],
-				'css' => '@import url(vfs://public/wp-content/themes/twentytwenty/style.css);body{font-family:Helvetica,Arial,sans-serif;text-align:center}body{font-family:Helvetica,Arial,sans-serif;text-align:center}',
+				'css' => 'body{font-family:Helvetica,Arial,sans-serif;text-align:center}body{font-family:Helvetica,Arial,sans-serif;text-align:center}body{font-family:Helvetica,Arial,sans-serif;text-align:center}',
 			],
 
 			'cdn_host' => [],
@@ -247,7 +271,7 @@ return [
 					'wp-content/cache/min/1/074f89d1546ea3c6df831e874538e908.css',
 					'wp-content/cache/min/1/074f89d1546ea3c6df831e874538e908.css.gz',
 				],
-				'css' => "@import url(vfs://public/wp-content/themes/twentytwenty/style.css);@font-face{font-display:swap;font-family:'FontAwesome';src:url(https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/../fonts/fontawesome-webfont.eot?v=4.7.0);src:url('https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/../fonts/fontawesome-webfont.eot?#iefix&v=4.7.0') format('embedded-opentype'),url(https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/../fonts/fontawesome-webfont.woff2?v=4.7.0) format('woff2'),url(https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/../fonts/fontawesome-webfont.woff?v=4.7.0) format('woff'),url(https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/../fonts/fontawesome-webfont.ttf?v=4.7.0) format('truetype'),url('https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/../fonts/fontawesome-webfont.svg?v=4.7.0#fontawesomeregular') format('svg');font-weight:400;font-style:normal}body{font-family:Helvetica,Arial,sans-serif;text-align:center}body{font-family:Helvetica,Arial,sans-serif;text-align:center}body{font-family:Helvetica,Arial,sans-serif;text-align:center}@font-face{font-display:swap;font-family:Helvetica}footer{color:red}",
+				'css' => "@font-face{font-display:swap;font-family:'FontAwesome';src:url(https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/../fonts/fontawesome-webfont.eot?v=4.7.0);src:url('https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/../fonts/fontawesome-webfont.eot?#iefix&v=4.7.0') format('embedded-opentype'),url(https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/../fonts/fontawesome-webfont.woff2?v=4.7.0) format('woff2'),url(https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/../fonts/fontawesome-webfont.woff?v=4.7.0) format('woff'),url(https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/../fonts/fontawesome-webfont.ttf?v=4.7.0) format('truetype'),url('https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/../fonts/fontawesome-webfont.svg?v=4.7.0#fontawesomeregular') format('svg');font-weight:400;font-style:normal}body{font-family:Helvetica,Arial,sans-serif;text-align:center}body{font-family:Helvetica,Arial,sans-serif;text-align:center}body{font-family:Helvetica,Arial,sans-serif;text-align:center}@font-face{font-display:swap;font-family:Helvetica}body{font-family:Helvetica,Arial,sans-serif;text-align:center}footer{color:red}",
 			],
 
 			'cdn_host' => [],

--- a/tests/Fixtures/inc/Engine/Optimization/Minify/CSS/Combine/combine.php
+++ b/tests/Fixtures/inc/Engine/Optimization/Minify/CSS/Combine/combine.php
@@ -88,7 +88,7 @@ return [
 					'wp-content/cache/min/1/a41edef8114680bb60b530fa32be3ca5.css',
 					'wp-content/cache/min/1/a41edef8114680bb60b530fa32be3ca5.css.gz',
 				],
-				'css' => '.style-another-import2{color:green}.style-another-import{color:red}body{font-family:Helvetica,Arial,sans-serif;text-align:center}body{font-family:Helvetica,Arial,sans-serif;text-align:center}',
+				'css' => '@import "http://www.google.com/style.css";.style-import-external{color:green}.style-another-import2{color:green}.style-another-import{color:red}body{font-family:Helvetica,Arial,sans-serif;text-align:center}body{font-family:Helvetica,Arial,sans-serif;text-align:center}',
 			],
 
 			'cdn_host' => [],

--- a/tests/Fixtures/inc/Engine/Optimization/Minify/CSS/Combine/combine.php
+++ b/tests/Fixtures/inc/Engine/Optimization/Minify/CSS/Combine/combine.php
@@ -72,6 +72,28 @@ return [
 			'site_url' => 'http://example.org',
 		],
 
+		'combineCssFilesWithImportJSFile' => [
+			'original' =>
+				'<html><head><title>Sample Page</title>' .
+				'<link rel="stylesheet" href="http://example.org/wp-content/themes/twentytwenty/style-import-jsfile.css" type="text/css" media="all">' .
+				'</head><body></body></html>',
+
+			'expected' => [
+				'html'  => '<html><head><title>Sample Page</title>' .
+				           '<link rel="stylesheet" href="http://example.org/wp-content/cache/min/1/c78ec42dba4ed16fe23582b1e3d03895.css" media="all" data-minify="1" />' .
+				           '</head><body></body></html>',
+				'files' => [
+					'wp-content/cache/min/1/c78ec42dba4ed16fe23582b1e3d03895.css',
+					'wp-content/cache/min/1/c78ec42dba4ed16fe23582b1e3d03895.css.gz',
+				],
+				'css' => '@import url(vfs://public/wp-content/themes/twentytwenty/assets/script.js);',
+			],
+
+			'cdn_host' => [],
+			'cdn_url'  => 'http://example.org',
+			'site_url' => 'http://example.org',
+		],
+
 		'combineCssFilesWithNestedImport' => [
 			'original' =>
 				'<html><head><title>Sample Page</title>' .

--- a/tests/Fixtures/inc/Engine/Optimization/Minify/CSS/Subscriber/process.php
+++ b/tests/Fixtures/inc/Engine/Optimization/Minify/CSS/Subscriber/process.php
@@ -399,7 +399,7 @@ return [
 					'wp-content/cache/min/1/29cb84c177f1a73204fd92c3d4dae284.css',
 					'wp-content/cache/min/1/29cb84c177f1a73204fd92c3d4dae284.css.gz',
 				],
-				'css' => '.style-another-import2{color:green}.style-another-import{color:red}body{font-family:Helvetica,Arial,sans-serif;text-align:center}body{font-family:Helvetica,Arial,sans-serif;text-align:center}',
+				'css' => '@import "http://www.google.com/style.css";.style-import-external{color:green}.style-another-import2{color:green}.style-another-import{color:red}body{font-family:Helvetica,Arial,sans-serif;text-align:center}body{font-family:Helvetica,Arial,sans-serif;text-align:center}',
 			],
 
 			'settings' => [

--- a/tests/Fixtures/inc/Engine/Optimization/Minify/CSS/Subscriber/process.php
+++ b/tests/Fixtures/inc/Engine/Optimization/Minify/CSS/Subscriber/process.php
@@ -383,6 +383,40 @@ return [
 			],
 		],
 
+		'combineCssFilesWithImportJSFile' => [
+			'original' => '<html>' .
+			              '<head>' .
+			              '<title>Sample Page</title>' .
+			              '<link rel="stylesheet" href="http://example.org/wp-content/themes/twentytwenty/style-import-jsfile.css" type="text/css" media="all">' .
+			              '</head>' .
+			              '<body>' .
+			              '</body>' .
+			              '</html>',
+
+			'expected' => [
+				'html'  => '<html>' .
+				           '<head>' .
+				           '<title>Sample Page</title>' .
+				           '<link rel="stylesheet" href="http://example.org/wp-content/cache/min/1/005e912f43deb4a5c82ff794ba94b288.css" media="all" data-minify="1" />' .
+				           '</head>' .
+				           '<body>' .
+				           '</body>' .
+				           '</html>',
+				'files' => [
+					'wp-content/cache/min/1/005e912f43deb4a5c82ff794ba94b288.css',
+					'wp-content/cache/min/1/005e912f43deb4a5c82ff794ba94b288.css.gz',
+				],
+				'css' => '@import url(vfs://public/wp-content/themes/twentytwenty/assets/script.js);',
+			],
+
+			'settings' => [
+				'minify_concatenate_css' => 1,
+				'cdn'                    => 0,
+				'cdn_cnames'             => [],
+				'cdn_zone'               => [],
+			],
+		],
+
 		'combineCssFilesWithNestedImport' => [
 			'original' =>
 				'<html><head><title>Sample Page</title>' .

--- a/tests/Fixtures/inc/Engine/Optimization/Minify/CSS/Subscriber/process.php
+++ b/tests/Fixtures/inc/Engine/Optimization/Minify/CSS/Subscriber/process.php
@@ -372,7 +372,34 @@ return [
 					'wp-content/cache/min/1/5619350d0ac97fc96b40673a7e395900.css',
 					'wp-content/cache/min/1/5619350d0ac97fc96b40673a7e395900.css.gz',
 				],
-				'css' => '@import url(vfs://public/wp-content/themes/twentytwenty/style.css);body{font-family:Helvetica,Arial,sans-serif;text-align:center}body{font-family:Helvetica,Arial,sans-serif;text-align:center}',
+				'css' => 'body{font-family:Helvetica,Arial,sans-serif;text-align:center}body{font-family:Helvetica,Arial,sans-serif;text-align:center}body{font-family:Helvetica,Arial,sans-serif;text-align:center}',
+			],
+
+			'settings' => [
+				'minify_concatenate_css' => 1,
+				'cdn'                    => 0,
+				'cdn_cnames'             => [],
+				'cdn_zone'               => [],
+			],
+		],
+
+		'combineCssFilesWithNestedImport' => [
+			'original' =>
+				'<html><head><title>Sample Page</title>' .
+				'<link rel="stylesheet" href="http://example.org/wp-content/themes/twentytwenty/style-import2.css" type="text/css" media="all">' .
+				'<link rel="stylesheet" href="http://example.org/wp-content/plugins/hello-dolly/style.css">' .
+				'<link rel="stylesheet" href="http://example.org/wp-includes/css/dashicons.min.css">' .
+				'</head><body></body></html>',
+
+			'expected' => [
+				'html'  => '<html><head><title>Sample Page</title>' .
+				           '<link rel="stylesheet" href="http://example.org/wp-content/cache/min/1/29cb84c177f1a73204fd92c3d4dae284.css" media="all" data-minify="1" />' .
+				           '</head><body></body></html>',
+				'files' => [
+					'wp-content/cache/min/1/29cb84c177f1a73204fd92c3d4dae284.css',
+					'wp-content/cache/min/1/29cb84c177f1a73204fd92c3d4dae284.css.gz',
+				],
+				'css' => '.style-another-import2{color:green}.style-another-import{color:red}body{font-family:Helvetica,Arial,sans-serif;text-align:center}body{font-family:Helvetica,Arial,sans-serif;text-align:center}',
 			],
 
 			'settings' => [
@@ -408,7 +435,7 @@ return [
 					'wp-content/cache/min/1/77d8f7c4cbcc265ddf66e8e60dab3e7c.css',
 					'wp-content/cache/min/1/77d8f7c4cbcc265ddf66e8e60dab3e7c.css.gz',
 				],
-				'css' => '@import url(vfs://public/wp-content/themes/twentytwenty/style.css);body{font-family:Helvetica,Arial,sans-serif;text-align:center}body{font-family:Helvetica,Arial,sans-serif;text-align:center}',
+				'css' => 'body{font-family:Helvetica,Arial,sans-serif;text-align:center}body{font-family:Helvetica,Arial,sans-serif;text-align:center}body{font-family:Helvetica,Arial,sans-serif;text-align:center}',
 			],
 
 			'settings' => [

--- a/tests/Fixtures/vfs-structure/optimizeMinify.php
+++ b/tests/Fixtures/vfs-structure/optimizeMinify.php
@@ -26,6 +26,9 @@ return [
 					'script.js' => 'test',
 				],
 				'style-import.css' => '@import url(style.css)',
+				'style-import2.css' => '@import url(style-another-import.css)',
+				'style-another-import.css' => '@import url(style-another-import2.css);.style-another-import{color:red;}',
+				'style-another-import2.css' => '.style-another-import2{color:green;}',
 				'new-style.css' => 'footer{color:red;}',
 				'final-style.css' => 'header{color:red;}'
 			],

--- a/tests/Fixtures/vfs-structure/optimizeMinify.php
+++ b/tests/Fixtures/vfs-structure/optimizeMinify.php
@@ -30,6 +30,7 @@ return [
 				'style-another-import.css' => '@import url(style-another-import2.css);.style-another-import{color:red;}',
 				'style-another-import2.css' => '@import "style-import-external.css";.style-another-import2{color:green;}',
 				'style-import-external.css' => '@import "http://www.google.com/style.css";.style-import-external{color:green;}',
+				'style-import-jsfile.css' => '@import url(assets/script.js)',
 				'new-style.css' => 'footer{color:red;}',
 				'final-style.css' => 'header{color:red;}'
 			],

--- a/tests/Fixtures/vfs-structure/optimizeMinify.php
+++ b/tests/Fixtures/vfs-structure/optimizeMinify.php
@@ -28,7 +28,8 @@ return [
 				'style-import.css' => '@import url(style.css)',
 				'style-import2.css' => '@import url(style-another-import.css)',
 				'style-another-import.css' => '@import url(style-another-import2.css);.style-another-import{color:red;}',
-				'style-another-import2.css' => '.style-another-import2{color:green;}',
+				'style-another-import2.css' => '@import "style-import-external.css";.style-another-import2{color:green;}',
+				'style-import-external.css' => '@import "http://www.google.com/style.css";.style-import-external{color:green;}',
 				'new-style.css' => 'footer{color:red;}',
 				'final-style.css' => 'header{color:red;}'
 			],

--- a/tests/Integration/inc/Engine/Optimization/Minify/CSS/Subscriber/process.php
+++ b/tests/Integration/inc/Engine/Optimization/Minify/CSS/Subscriber/process.php
@@ -3,6 +3,7 @@
 namespace WP_Rocket\Tests\Integration\inc\Engine\Optimization\Minify\CSS\Subscriber;
 
 use WP_Rocket\Tests\Integration\inc\Engine\Optimization\TestCase;
+use Brain\Monkey\Functions;
 
 /**
  * @covers \WP_Rocket\Engine\Optimization\Minify\CSS\Subscriber::process

--- a/tests/Unit/inc/Engine/Optimization/Minify/CSS/Combine/optimize.php
+++ b/tests/Unit/inc/Engine/Optimization/Minify/CSS/Combine/optimize.php
@@ -62,6 +62,29 @@ class Test_Optimize extends TestCase {
 
 		Functions\when( 'esc_url' )->returnArg();
 
+		Functions\when( 'site_url' )->alias( function( $path = '') {
+			return 'http://example.org/' . ltrim( $path, '/' );
+		} );
+
+		Functions\when( 'wp_http_validate_url' )->alias( function( $path = '') {
+			if ( false !== strpos( 'vfs://', $path ) ) {
+				return $path;
+			}
+			return false;
+		} );
+
+		Functions\expect( 'wp_make_link_relative' )->andReturnUsing( function( $url ) {
+			return preg_replace( '|^(https?:)?//[^/]+(/?.*)|i', '$2', $url );
+		} );
+
+		Functions\when( 'sanitize_text_field' )->returnArg();
+
+		Functions\when( 'wp_unslash' )->alias(
+			function ( $value ) {
+				return stripslashes( $value );
+			}
+		);
+
 		$this->assertSame(
 			$this->format_the_html($expected['html']),
 			$this->format_the_html( $this->combine->optimize( $original ) )

--- a/tests/Unit/inc/Engine/Optimization/Minify/CSS/Combine/optimize.php
+++ b/tests/Unit/inc/Engine/Optimization/Minify/CSS/Combine/optimize.php
@@ -85,6 +85,25 @@ class Test_Optimize extends TestCase {
 			}
 		);
 
+		Functions\expect( 'wp_check_filetype_and_ext' )->andReturnUsing( function( $file, $filename, $mimes ) {
+			$filename_array = explode( '.', $filename );
+			$ext = false;
+			$type = false;
+			if ( $filename_array ) {
+				$ext = end( $filename_array );
+				if ( isset( $mimes[$ext] ) ) {
+					$type = $mimes[$ext];
+				}else{
+					$type = $ext = false;
+				}
+			}
+			return [
+				'ext' => $ext,
+				'type' => $type,
+				'proper_filename' => $filename
+			];
+		} );
+
 		$this->assertSame(
 			$this->format_the_html($expected['html']),
 			$this->format_the_html( $this->combine->optimize( $original ) )

--- a/tests/Unit/inc/Engine/Optimization/Minify/CSS/Combine/optimize.php
+++ b/tests/Unit/inc/Engine/Optimization/Minify/CSS/Combine/optimize.php
@@ -85,8 +85,8 @@ class Test_Optimize extends TestCase {
 			}
 		);
 
-		Functions\expect( 'wp_check_filetype_and_ext' )->andReturnUsing( function( $file, $filename, $mimes ) {
-			$filename_array = explode( '.', $filename );
+		Functions\expect( 'wp_check_filetype' )->andReturnUsing( function( $file, $mimes ) {
+			$filename_array = explode( '.', $file );
 			$ext = false;
 			$type = false;
 			if ( $filename_array ) {
@@ -100,7 +100,6 @@ class Test_Optimize extends TestCase {
 			return [
 				'ext' => $ext,
 				'type' => $type,
-				'proper_filename' => $filename
 			];
 		} );
 


### PR DESCRIPTION
## Description

We added a layer to combine imported CSS files into the main minified/combined recursively.

Fixes #3539 

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Is the solution different from the one proposed during the grooming?

I added only a small part to handle rewrite paths and combine imports resursively.

## How Has This Been Tested?

- [x] Added new fixtures to be passed to unit/integration tests.
- [x] Create page template with CSS file that has multiple imports and one of those imports has another import with some image paths and check if those are imported Also add another import for external file and it shouldn't be imported.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules