### PR TITLE
Fixes #3073 - Remove content from attribute list in get_attribute_names function

### DIFF
--- a/inc/classes/subscriber/Media/class-webp-subscriber.php
+++ b/inc/classes/subscriber/Media/class-webp-subscriber.php
@@ -495,7 +495,7 @@ class Webp_Subscriber implements Subscriber_Interface {
 	 * @return array
 	 */
 	private function get_attribute_names() {
-		$attributes = [ 'href', 'src', 'srcset', 'content', 'data-large_image', 'data-thumb' ];
+		$attributes = [ 'href', 'src', 'srcset', 'data-large_image', 'data-thumb' ];
 
 		/**
 		 * Filter the names of the HTML attributes where WP Rocket must search for image files.

--- a/tests/Fixtures/inc/classes/subscriber/Media/WebpSubscriber/convert-to-webp-match.php
+++ b/tests/Fixtures/inc/classes/subscriber/Media/WebpSubscriber/convert-to-webp-match.php
@@ -22,7 +22,7 @@ return [
 		'<!DOCTYPE html>
 		<html lang="en-US" dir="ltr">
 		<head>
-			<meta property="og:image" content="https://example.com/wp-content/uploads/2019/09/one-image.webp"/>
+			<meta property="og:image" content="https://example.com/wp-content/uploads/2019/09/one-image.png"/>
 			<link rel="image_src" href="https://example.com/wp-content/uploads/2019/09/one-image.webp" />
 			<link rel="apple-touch-icon" href="https://cdn-example.net/wp-content/uploads/2017/02/apple-touch-icon.png.webp" />
 			<link rel="icon" type="image/png" href="https://example.com/wp-content/uploads/2017/02/favicon-32x32.webp" sizes="32x32" />


### PR DESCRIPTION
## Description

Removes `'content'` from $attributes list in `get_attribute_names()`

Fixes #3073

## Type of change

- [x] Enhancement

## Is the solution different from the one proposed during the grooming?

No

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code