### PR TITLE
Fixes #3528 Add AMP query string to cached query strings when activating the plugin

### DIFF
--- a/inc/ThirdParty/Plugins/Optimization/AMP.php
+++ b/inc/ThirdParty/Plugins/Optimization/AMP.php
@@ -46,12 +46,13 @@ class AMP implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events() {
 		$events = [
-			'activate_amp/amp.php'   => 'generate_config_file',
-			'deactivate_amp/amp.php' => 'generate_config_file',
-			'wp'                     => 'disable_options_on_amp',
+			'activate_amp/amp.php'       => 'generate_config_file',
+			'deactivate_amp/amp.php'     => 'generate_config_file',
+			'wp'                         => 'disable_options_on_amp',
+			'rocket_cache_query_strings' => 'is_amp_compatible_callback',
 		];
+
 		if ( function_exists( 'is_amp_endpoint' ) ) {
-			$events['rocket_cache_query_strings'] = 'is_amp_compatible_callback';
 			$events['update_option_amp-options']  = 'generate_config_file';
 		}
 
@@ -76,6 +77,10 @@ class AMP implements Subscriber_Interface {
 	 * @return array
 	 */
 	public function is_amp_compatible_callback( $value ) {
+		if ( ! function_exists( 'is_amp_endpoint' ) ) {
+			return $value;
+		}
+	
 		$options       = get_option( self::AMP_OPTIONS, [] );
 		$query_strings = array_diff( $value, [ static::QUERY ] );
 

--- a/inc/ThirdParty/Plugins/Optimization/AMP.php
+++ b/inc/ThirdParty/Plugins/Optimization/AMP.php
@@ -53,7 +53,7 @@ class AMP implements Subscriber_Interface {
 		];
 
 		if ( function_exists( 'is_amp_endpoint' ) ) {
-			$events['update_option_amp-options']  = 'generate_config_file';
+			$events['update_option_amp-options'] = 'generate_config_file';
 		}
 
 		return $events;
@@ -80,7 +80,7 @@ class AMP implements Subscriber_Interface {
 		if ( ! function_exists( 'is_amp_endpoint' ) ) {
 			return $value;
 		}
-	
+
 		$options       = get_option( self::AMP_OPTIONS, [] );
 		$query_strings = array_diff( $value, [ static::QUERY ] );
 

--- a/tests/Fixtures/inc/ThirdParty/Plugins/Optimization/AMP/isAmpCompatibleCallback.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/Optimization/AMP/isAmpCompatibleCallback.php
@@ -2,32 +2,26 @@
 
 return [
 	'testShouldBailoutIfAmpNotEnabled'      => [
-		'enabled'  => false,
 		'setting'  => null,
 		'expected' => [],
 	],
 	'testShouldBailoutIfAmpThemeOptionsAreNull'      => [
-		'enabled'  => true,
 		'setting'  => null,
 		'expected' => [],
 	],
 	'testShouldBailoutIfAmpThemeSupportIsNull'       => [
-		'enabled'  => true,
 		'setting'  => [ 'theme_support' => null ],
 		'expected' => [],
 	],
 	'testShouldBailoutIfAmpIsNotTransitional'        => [
-		'enabled'  => true,
 		'setting'  => [ 'theme_support' => 'standard' ],
 		'expected' => [],
 	],
 	'testShouldAddAmpWhenThemeSupportIsTransitional' => [
-		'enabled'  => true,
 		'setting'  => [ 'theme_support' => 'transitional' ],
 		'expected' => [ 'amp' ],
 	],
 	'testShouldAddAmpWhenThemeSupportIsReader'       => [
-		'enabled'  => true,
 		'setting'  => [ 'theme_support' => 'reader' ],
 		'expected' => [ 'amp' ],
 	],

--- a/tests/Fixtures/inc/ThirdParty/Plugins/Optimization/AMP/isAmpCompatibleCallback.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/Optimization/AMP/isAmpCompatibleCallback.php
@@ -1,23 +1,33 @@
 <?php
 
 return [
+	'testShouldBailoutIfAmpNotEnabled'      => [
+		'enabled'  => false,
+		'setting'  => null,
+		'expected' => [],
+	],
 	'testShouldBailoutIfAmpThemeOptionsAreNull'      => [
+		'enabled'  => true,
 		'setting'  => null,
 		'expected' => [],
 	],
 	'testShouldBailoutIfAmpThemeSupportIsNull'       => [
+		'enabled'  => true,
 		'setting'  => [ 'theme_support' => null ],
 		'expected' => [],
 	],
 	'testShouldBailoutIfAmpIsNotTransitional'        => [
+		'enabled'  => true,
 		'setting'  => [ 'theme_support' => 'standard' ],
 		'expected' => [],
 	],
 	'testShouldAddAmpWhenThemeSupportIsTransitional' => [
+		'enabled'  => true,
 		'setting'  => [ 'theme_support' => 'transitional' ],
 		'expected' => [ 'amp' ],
 	],
 	'testShouldAddAmpWhenThemeSupportIsReader'       => [
+		'enabled'  => true,
 		'setting'  => [ 'theme_support' => 'reader' ],
 		'expected' => [ 'amp' ],
 	],

--- a/tests/Integration/inc/ThirdParty/Plugins/Optimization/AMP/isAmpCompatibleCallback.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Optimization/AMP/isAmpCompatibleCallback.php
@@ -23,7 +23,7 @@ class Test_IsAmpCompatibleCallback extends TestCase {
 	/**
 	 * @dataProvider ampDataProvider
 	 */
-	public function testShouldReturnExpected( $setting, $expected ) {
+	public function testShouldReturnExpected( $enabled, $setting, $expected ) {
 		// Set and then check the AMP theme support setting.
 		if ( ! is_null( $setting ) ) {
 			$this->setSettings( 'theme_support', $setting['theme_support'] );

--- a/tests/Integration/inc/ThirdParty/Plugins/Optimization/AMP/isAmpCompatibleCallback.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Optimization/AMP/isAmpCompatibleCallback.php
@@ -23,7 +23,7 @@ class Test_IsAmpCompatibleCallback extends TestCase {
 	/**
 	 * @dataProvider ampDataProvider
 	 */
-	public function testShouldReturnExpected( $enabled, $setting, $expected ) {
+	public function testShouldReturnExpected( $setting, $expected ) {
 		// Set and then check the AMP theme support setting.
 		if ( ! is_null( $setting ) ) {
 			$this->setSettings( 'theme_support', $setting['theme_support'] );

--- a/tests/Unit/inc/ThirdParty/Plugins/Optimization/AMP/isAmpCompatibleCallback.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/Optimization/AMP/isAmpCompatibleCallback.php
@@ -5,8 +5,8 @@ namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\Optimization\AMP;
 use Mockery;
 use Brain\Monkey\Functions;
 use WP_Rocket\Admin\Options_Data;
-use WPMedia\PHPUnit\Unit\TestCase;
 use WP_Rocket\Engine\CDN\Subscriber;
+use WP_Rocket\Tests\Unit\TestCase;
 use WP_Rocket\ThirdParty\Plugins\Optimization\AMP;
 
 /**
@@ -27,20 +27,22 @@ class Test_IsAmpCompatibleCallback extends TestCase {
 		$this->amp            = new AMP( $this->options, $this->cdn_subscriber );
 	}
 
-
 	/**
-	 * @dataProvider ampDataProvider
+	 * @dataProvider configTestData
 	 */
-	public function testShouldReturnExpected( $theme_support, $expected ) {
-		Functions\expect( 'get_option' )
-			->once()
-			->with( 'amp-options', [] )
-			->andReturn( $theme_support );
+	public function testShouldReturnExpected( $enabled, $theme_support, $expected ) {
+		if ( $enabled ) {
+			Functions\when( 'is_amp_endpoint' )->justReturn( $enabled );
+
+			Functions\expect( 'get_option' )
+				->once()
+				->with( 'amp-options', [] )
+				->andReturn( $theme_support );
+		} else {
+			Functions\expect( 'get_option' )
+				->never();
+		}
 
 		$this->assertSame( $expected, $this->amp->is_amp_compatible_callback( [] ) );
-	}
-
-	public function ampDataProvider() {
-		return require_once WP_ROCKET_TESTS_FIXTURES_DIR . '/inc/ThirdParty/Plugins/Optimization/AMP/isAmpCompatibleCallback.php';
 	}
 }

--- a/tests/Unit/inc/ThirdParty/Plugins/Optimization/AMP/isAmpCompatibleCallback.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/Optimization/AMP/isAmpCompatibleCallback.php
@@ -30,18 +30,11 @@ class Test_IsAmpCompatibleCallback extends TestCase {
 	/**
 	 * @dataProvider configTestData
 	 */
-	public function testShouldReturnExpected( $enabled, $theme_support, $expected ) {
-		if ( $enabled ) {
-			Functions\when( 'is_amp_endpoint' )->justReturn( $enabled );
-
-			Functions\expect( 'get_option' )
-				->once()
-				->with( 'amp-options', [] )
-				->andReturn( $theme_support );
-		} else {
-			Functions\expect( 'get_option' )
-				->never();
-		}
+	public function testShouldReturnExpected( $theme_support, $expected ) {
+		Functions\expect( 'get_option' )
+			->once()
+			->with( 'amp-options', [] )
+			->andReturn( $theme_support );
 
 		$this->assertSame( $expected, $this->amp->is_amp_compatible_callback( [] ) );
 	}


### PR DESCRIPTION
## Description

Move the function existance check to avoid the race condition.

Fixes #3528

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

No

## How Has This Been Tested?

- [x] Tested by activating/deactivating the AMP plugin, and checking the value in the config file

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes