### PR TITLE
Fix #3621 move @charset rule should be added before the @import in the minified/combined file

### DIFF
--- a/inc/Engine/Optimization/CSSTrait.php
+++ b/inc/Engine/Optimization/CSSTrait.php
@@ -40,6 +40,8 @@ trait CSSTrait {
 
 		$content = $this->combine_imports( $content, $target );
 
+		$content = $this->move_charset( $content );
+
 		/**
 		 * Filters the content of a CSS file
 		 *
@@ -329,6 +331,21 @@ trait CSSTrait {
 
 		// replace the import statements.
 		return str_replace( $search, $replace, $content );
+	}
+
+	/**
+	 * Move Charset to the top of the page.
+	 *
+	 * @param string $content CSS content to be parsed.
+	 *
+	 * @return string Content after moving charset to the top of it.
+	 */
+	private function move_charset( $content ) {
+		if ( ! preg_match_all( '#@charset.*;#iU', $content, $charset_matches ) ) {
+			return $content;
+		}
+
+		return implode( '', $charset_matches[0] ) . str_replace( $charset_matches[0], '', $content );
 	}
 
 	/**


### PR DESCRIPTION
## Description

Move `@charset` CSS rule to the top of the combined/minified file.

Fixes #3621 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## Is the solution different from the one proposed during the grooming?

Not groomed as it's `XS` effort

## How Has This Been Tested?

- [ ] Create CSS file and import more than one file and in the second file add `@charset "utf-8";` then enable minify/combine CSS at WP Rocket settings page and check the minified/combined file you will find this charset at the top of the page

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules