### PR TITLE
Closes #2883 UI improvement for Never Cache URL placeholder

### DIFF
--- a/inc/Engine/Admin/Settings/Page.php
+++ b/inc/Engine/Admin/Settings/Page.php
@@ -1303,7 +1303,7 @@ class Page {
 					'type'              => 'textarea',
 					'description'       => __( 'Specify URLs of pages or posts that should never be cached (one per line)', 'rocket' ),
 					'helper'            => __( 'The domain part of the URL will be stripped automatically.<br>Use (.*) wildcards to address multiple URLs under a given path.', 'rocket' ),
-					'placeholder'       => '/members/(.*)',
+					'placeholder'       => '/example/(.*)',
 					'section'           => 'cache_reject_uri_section',
 					'page'              => 'advanced_cache',
 					'default'           => [],


### PR DESCRIPTION
## Description

Replaces "/members/(.*)" placeholder with "/example/(.*)" in the Never Cache URL(s) text area.
Closes #2883

## Type of change

Enhancement

## Is the solution different from the one proposed during the grooming?

No. I realized at this point that there is already a pull request done, although it wasn't assigned to anyone. 
This is exactly the same edit with a different branch naming.

## How Has This Been Tested?

Tested on the current version WP Rocket 3.8.5 by directly editing the code.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules