### PR TITLE
Fixes #3394 PHP notice in Update_Subscriber::disable_auto_updates()

### DIFF
--- a/inc/classes/subscriber/Plugin/class-updater-subscriber.php
+++ b/inc/classes/subscriber/Plugin/class-updater-subscriber.php
@@ -268,7 +268,7 @@ class Updater_Subscriber implements Subscriber_Interface {
 	 * @return bool|null
 	 */
 	public function disable_auto_updates( $update, $item ) {
-		if ( 'wp-rocket/wp-rocket.php' === $item->plugin ) {
+		if ( isset( $item->plugin ) && ( 'wp-rocket/wp-rocket.php' === $item->plugin ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
## Description

Adds guard close isset() to prevent the PHP notice, by checking if the property is set before using it.
Fixes #3394 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

No

## How Has This Been Tested?

The issue was reproduced by adding
`unset($item->plugin);`
under this line: https://github.com/wp-media/wp-rocket/blob/f403aa56b4a08e527762a1637cfb8d60695c1e35/inc/classes/subscriber/Plugin/class-updater-subscriber.php#L270

This caused error in debug.log:
_PHP Notice:  Undefined property: stdClass::$plugin in /home4/nataliad/testsite.nataliadrause.com/wp-content/plugins/wp-rocket/inc/classes/subscriber/Plugin/class-updater-subscriber.php on line 272_

After the submitted code modification there are no errors in debug.log

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules