### PR TITLE
Closes #2812 Add new filter to rewrite srcset to the CDN

### DIFF
--- a/inc/Engine/CDN/CDN.php
+++ b/inc/Engine/CDN/CDN.php
@@ -60,7 +60,7 @@ class CDN {
 	 * @return string
 	 */
 	public function rewrite_srcset( $html ) {
-		$pattern = '#\s+(?:data-lazy-|data-)?srcset\s*=\s*["\']\s*(?<sources>[^"\',\s]+\.[^"\',\s]+(?:\s+\d+[wx])?(?:\s*,\s*[^"\',\s]+\.[^"\',\s]+\s+\d+[wx])*)\s*["\']#i';
+		$pattern = '#\s+(?:' . $this->get_srcset_attributes() . ')?\s*=\s*["\']\s*(?<sources>[^"\',\s]+\.[^"\',\s]+(?:\s+\d+[wx])?(?:\s*,\s*[^"\',\s]+\.[^"\',\s]+\s+\d+[wx])*)\s*["\']#i';
 
 		if ( ! preg_match_all( $pattern, $html, $srcsets, PREG_SET_ORDER ) ) {
 			return $html;
@@ -367,5 +367,30 @@ class CDN {
 		);
 
 		return implode( '|', $files );
+	}
+	
+	/**
+	 * Get srcset attributes to rewrite to the CDN.
+	 *
+	 * @since 3.8.7
+	 *
+	 * @return string A pipe-separated list of srcset attributes.
+	 */
+	private function get_srcset_attributes() {
+		/**
+			* Filter the srcset attributes.
+			*
+			* @since 3.8.7
+			*
+			* @param array $srcset_attributes List of srcset attributes.
+		*/
+		$srcset_attributes = (array) apply_filters( 
+			'rocket_cdn_srcset_attributes',
+			[
+				'data-lazy-srcset',
+				'data-srcset',
+			]
+		);
+		return implode( '|', $srcset_attributes );
 	}
 }

--- a/inc/Engine/CDN/CDN.php
+++ b/inc/Engine/CDN/CDN.php
@@ -368,7 +368,7 @@ class CDN {
 
 		return implode( '|', $files );
 	}
-	
+
 	/**
 	 * Get srcset attributes to rewrite to the CDN.
 	 *
@@ -384,7 +384,7 @@ class CDN {
 			*
 			* @param array $srcset_attributes List of srcset attributes.
 		*/
-		$srcset_attributes = (array) apply_filters( 
+		$srcset_attributes = (array) apply_filters(
 			'rocket_cdn_srcset_attributes',
 			[
 				'data-lazy-srcset',

--- a/inc/Engine/CDN/CDN.php
+++ b/inc/Engine/CDN/CDN.php
@@ -378,12 +378,12 @@ class CDN {
 	 */
 	private function get_srcset_attributes() {
 		/**
-			* Filter the srcset attributes.
-			*
-			* @since 3.8.7
-			*
-			* @param array $srcset_attributes List of srcset attributes.
-		*/
+		 * Filter the srcset attributes.
+		 *
+		 * @since 3.8.7
+		 *
+		 * @param array $srcset_attributes List of srcset attributes.
+		 */
 		$srcset_attributes = (array) apply_filters(
 			'rocket_cdn_srcset_attributes',
 			[

--- a/inc/Engine/CDN/CDN.php
+++ b/inc/Engine/CDN/CDN.php
@@ -60,7 +60,7 @@ class CDN {
 	 * @return string
 	 */
 	public function rewrite_srcset( $html ) {
-		$pattern = '#\s+(?:' . $this->get_srcset_attributes() . ')?\s*=\s*["\']\s*(?<sources>[^"\',\s]+\.[^"\',\s]+(?:\s+\d+[wx])?(?:\s*,\s*[^"\',\s]+\.[^"\',\s]+\s+\d+[wx])*)\s*["\']#i';
+		$pattern = '#\s+(?:' . $this->get_srcset_attributes() . ')?srcset\s*=\s*["\']\s*(?<sources>[^"\',\s]+\.[^"\',\s]+(?:\s+\d+[wx])?(?:\s*,\s*[^"\',\s]+\.[^"\',\s]+\s+\d+[wx])*)\s*["\']#i';
 
 		if ( ! preg_match_all( $pattern, $html, $srcsets, PREG_SET_ORDER ) ) {
 			return $html;
@@ -387,8 +387,8 @@ class CDN {
 		$srcset_attributes = (array) apply_filters(
 			'rocket_cdn_srcset_attributes',
 			[
-				'data-lazy-srcset',
-				'data-srcset',
+				'data-lazy-',
+				'data-',
 			]
 		);
 		return implode( '|', $srcset_attributes );


### PR DESCRIPTION
## Description

A new filter `rocket_cdn_srcset_attributes` has been added to allow the addition of custom `srcset` attributes, in order for the URLs to be rewritten to the CDN.

Fixes #2812

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Is the solution different from the one proposed during the grooming?

No.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Testedlocally by adding a custom `srcset` attribute, and using the new filter, to check if that's rewritten to the CDN.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
