### PR TITLE
Fixes #3658 Force the PSR Container dependency to v1.0.0

### DIFF
--- a/.github/workflows/test_wprocket.yml
+++ b/.github/workflows/test_wprocket.yml
@@ -46,9 +46,7 @@ jobs:
         tools: composer:v1, phpunit
     
     - name: Start mysql service
-      run: |
-        sudo bash -c "echo "default_authentication_plugin=mysql_native_password" >> /etc/mysql/conf.d/mysql.cnf"
-        sudo /etc/init.d/mysql start
+      run: sudo /etc/init.d/mysql start
     
     - name: Setup problem matchers for PHP
       run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
@@ -72,6 +70,9 @@ jobs:
 
     - name: Install tests
       run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1:3306 ${{ matrix.wp-versions }}
+    
+    - name: Mysql8 auth plugin workaround
+      run: sudo mysql -u root -proot -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';"
 
     - name: Test
       run: composer run-tests

--- a/.github/workflows/test_wprocket.yml
+++ b/.github/workflows/test_wprocket.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         operating-system: [ubuntu-latest]
         php-versions: ['7.3', '7.4']
-        wp-versions: ['latest']
+        wp-versions: ['5.6.2']
   
     name: WP ${{ matrix.wp-versions }} with PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }}.
     

--- a/.github/workflows/test_wprocket.yml
+++ b/.github/workflows/test_wprocket.yml
@@ -46,7 +46,9 @@ jobs:
         tools: composer:v1, phpunit
     
     - name: Start mysql service
-      run: sudo /etc/init.d/mysql start
+      run: |
+        sudo bash -c "echo "default_authentication_plugin=mysql_native_password" >> /etc/mysql/conf.d/mysql.cnf"
+        sudo /etc/init.d/mysql start
     
     - name: Setup problem matchers for PHP
       run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"

--- a/.github/workflows/test_wprocket_legacy.yml
+++ b/.github/workflows/test_wprocket_legacy.yml
@@ -74,6 +74,9 @@ jobs:
 
     - name: Install tests
       run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1:3306 ${{ matrix.wp-versions }}
+    
+    - name: Mysql8 auth plugin workaround
+      run: sudo mysql -u root -proot -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';"
 
     - name: Test
       run: composer run-tests

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
 		"wp-media/module-rocketcdn": "^1.0",
 		"wp-media/module-varnish": "^1.0",
 		"wp-media/rocket-lazyload-common": "^2",
-		"wp-media/phpunit": "^1.0",
+		"wp-media/phpunit": "1.1.6",
 		"wp-media/wp-imagify-partner": "^1.0",
 		"wpackagist-plugin/amp": "^1.1.4",
 		"wpackagist-plugin/hummingbird-performance": "2.0.1",

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
 		"php": ">=7.0",
 		"composer/installers": "~1.0",
 		"monolog/monolog": "^1.0",
-		"psr/container": "^1.0"
+		"psr/container": "1.0.0"
 	},
 	"require-dev": {
 		"php": "^7",

--- a/wp-rocket.php
+++ b/wp-rocket.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Rocket
  * Plugin URI: https://wp-rocket.me
  * Description: The best WordPress performance plugin.
- * Version: 3.8.6
+ * Version: 3.8.6.1
  * Requires at least: 5.2
  * Requires PHP: 7.0
  * Code Name: Naboo
@@ -20,7 +20,7 @@
 defined( 'ABSPATH' ) || exit;
 
 // Rocket defines.
-define( 'WP_ROCKET_VERSION',               '3.8.6' );
+define( 'WP_ROCKET_VERSION',               '3.8.6.1' );
 define( 'WP_ROCKET_WP_VERSION',            '5.2' );
 define( 'WP_ROCKET_WP_VERSION_TESTED',     '5.5.1' );
 define( 'WP_ROCKET_PHP_VERSION',           '7.0' );

--- a/wp-rocket.php
+++ b/wp-rocket.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Rocket
  * Plugin URI: https://wp-rocket.me
  * Description: The best WordPress performance plugin.
- * Version: 3.8.6.1
+ * Version: 3.8.6
  * Requires at least: 5.2
  * Requires PHP: 7.0
  * Code Name: Naboo
@@ -20,7 +20,7 @@
 defined( 'ABSPATH' ) || exit;
 
 // Rocket defines.
-define( 'WP_ROCKET_VERSION',               '3.8.6.1' );
+define( 'WP_ROCKET_VERSION',               '3.8.6' );
 define( 'WP_ROCKET_WP_VERSION',            '5.2' );
 define( 'WP_ROCKET_WP_VERSION_TESTED',     '5.5.1' );
 define( 'WP_ROCKET_PHP_VERSION',           '7.0' );


### PR DESCRIPTION
## Description

There are a few reports where while updating to `3.8.6` the following fatal error occurred:
```
Fatal error: Declaration of WP_Rocket\Engine\Container\Container::get($alias, array $args = Array) must be compatible with Psr\Container\ContainerInterface::get(string $id) in /www/htdocs/example.com/wp-content/plugins/wp-rocket/inc/Engine/Container/Container.php on line 16
```

This issue appears after the release of PSR v1.1.1 6 days ago.
This commit introduced a breaking change in PSR:
https://github.com/php-fig/container/commit/6c2bc7fc1619d0f3f3442be69f177e6103d27dc7

Fixes #3658 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

There was no grooming on this one.
The solution was to always keep in composer.json PSR package v1.0.0.

## How Has This Been Tested?

On customer website, reverting the problematic file in PSR package fixed the issue. 
Manually applied the change on 2 customer websites with different WP Rocket and Wordpress versions.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules