### PR TITLE
ARForms - Exclude arf_footer_cl_logic_call from combine js

### DIFF
--- a/inc/Engine/Optimization/Minify/JS/Combine.php
+++ b/inc/Engine/Optimization/Minify/JS/Combine.php
@@ -692,6 +692,7 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 			'ct_ultimate_gdpr_cookie',
 			'wcpv_registration_local',
 			'www.idxhome.com',
+			'arf_footer_cl_logic_call',
 		];
 
 		$excluded_inline = array_merge( $defaults, $this->options->get( 'exclude_inline_js', [] ) );


### PR DESCRIPTION
ARForms has an inline JS pattern that changes on every single load (when being merged it causes the cache size to get out of control. This function stops both of the different inline scripts from being added. 

Script 1 (just a snippet is shown)
function arf_footer_cl_logic_call(){eval('arf_cl_apply_v3(39710, (the 39710 number changes everytime on load. 

Script 2 just a snippet is shown

The second script has quite a few different locations but it uses the same arf_footer_cl_logic_call to start the JS off 
field_rxsxll_83235

but the field numbers change on every load. Excluding both of these allowed the form to still work while also stopping the cache size from growing out of control.
