### PR TITLE
Exclude reload_attached_coupons from inline merge

### DIFF
--- a/inc/Engine/Optimization/Minify/JS/Combine.php
+++ b/inc/Engine/Optimization/Minify/JS/Combine.php
@@ -692,6 +692,7 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 			'ct_ultimate_gdpr_cookie',
 			'wcpv_registration_local',
 			'www.idxhome.com',
+			'reload_attached_coupons',
 		];
 
 		$excluded_inline = array_merge( $defaults, $this->options->get( 'exclude_inline_js', [] ) );


### PR DESCRIPTION
WooCommerce Smart Coupons adds the following inline JS and it changes its URI Component every product. For larger stores where this is the only difference it can cause the cache size to balloon out of control.

Diff checker: https://www.diffchecker.com/m7oUR6P0

I noticed this on a store that had 4k products which for smaller stores this wouldn't be an issue but it ended up consuming a very large amount of storage. Excluding the inline JS appears to have fixed the issue.