### PR TITLE
Exclude nonce action for Discount Rules and Dynamic Pricing for WC

### DIFF
--- a/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber.php
+++ b/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber.php
@@ -480,6 +480,7 @@ class WooCommerceSubscriber implements Event_Manager_Aware_Subscriber_Interface 
 			'ybws123456', // Custom Bookly form.
 			'_wc_additional_variation_images_nonce', // WooCommerce Additional Variation Images.
 			'get_price_table', // Tiered Pricing Table for WooCommerce.
+			'wccs_single_product_nonce', // Discount Rules and Dynamic Pricing for WooCommerce.
 		];
 	}
 }


### PR DESCRIPTION

Related ticket: https://secure.helpscout.net/conversation/1453977081/247715/

## Description

Exclude `wccs_single_product_nonce` nonce action for [Discount Rules and Dynamic Pricing for WooCommerce](https://wordpress.org/plugins/easy-woocommerce-discounts/).

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Is the solution different from the one proposed during the grooming?

Not relevant.

## How Has This Been Tested?

- [x] Tested on the customer's website.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x]  I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x]  My changes generate no new warnings