### PR TITLE
Ignore Pinterest ads "pp" query string

### DIFF
--- a/inc/functions/options.php
+++ b/inc/functions/options.php
@@ -216,6 +216,7 @@ function rocket_get_ignored_parameters() {
 		'msclkid'               => 1,
 		'dm_i'                  => 1,
 		'epik'                  => 1,
+		'pp'                    => 1,
 	];
 
 	/**


### PR DESCRIPTION
Added `pp` in the ignored `$params` array.

**Ticket:** https://secure.helpscout.net/conversation/1453980382/247717/

## Description

Pinterest is using `pp` in their ads for the following reason:

> Pinterest will append either a PP=0 or PP=1, which will indicate if they (the visitors) came to your page from an ad or from a re-pin. 

**Reference:** https://www.thestartersclub.com/blog/132-pinterest-ads-with-jess-bahr-and-why-they-might-just-be-the-gold-mine-you-re-looking-for

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Is the solution different from the one proposed during the grooming?

Non-relevant.

## How Has This Been Tested?

- [x] On the customer's website.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation