### PR TITLE
Fix 3219 - Add preconnect link to google fonts only when google fonts are found

### DIFF
--- a/inc/Engine/Optimization/GoogleFonts/AbstractGFOptimization.php
+++ b/inc/Engine/Optimization/GoogleFonts/AbstractGFOptimization.php
@@ -35,7 +35,7 @@ abstract class AbstractGFOptimization extends AbstractOptimization {
 	 *
 	 * @var bool
 	 */
-	protected $has_google_fonts;
+	protected $has_google_fonts = true;
 
 
 	/**
@@ -46,7 +46,7 @@ abstract class AbstractGFOptimization extends AbstractOptimization {
 	 * @return bool Will default to true when extending classes have not set via the optimize() method.
 	 */
 	public function has_google_fonts() {
-		return isset( $this->has_google_fonts ) ? $this->has_google_fonts : true;
+		return $this->has_google_fonts;
 	}
 
 	/**

--- a/inc/Engine/Optimization/GoogleFonts/AbstractGFOptimization.php
+++ b/inc/Engine/Optimization/GoogleFonts/AbstractGFOptimization.php
@@ -31,9 +31,25 @@ abstract class AbstractGFOptimization extends AbstractOptimization {
 	/**
 	 * Flag for whether google fonts have been detected (Default: true)
 	 *
+	 * @since 3.8.8
+	 *
 	 * @var bool
 	 */
 	protected $has_google_fonts = true;
+
+
+	/**
+	 * Check whether the optimizer has found google fonts on the page.
+	 *
+	 * Note: Will always return true if the optimize() method has yet been called.
+	 *
+	 * @since 3.8.8
+	 *
+	 * @return bool
+	 */
+	public function has_google_fonts() {
+		return $this->has_google_fonts;
+	}
 
 	/**
 	 * Returns font with display value.

--- a/inc/Engine/Optimization/GoogleFonts/AbstractGFOptimization.php
+++ b/inc/Engine/Optimization/GoogleFonts/AbstractGFOptimization.php
@@ -29,6 +29,13 @@ abstract class AbstractGFOptimization extends AbstractOptimization {
 	];
 
 	/**
+	 * Flag for whether google fonts have been detected (Default: true)
+	 *
+	 * @var bool
+	 */
+	protected $has_google_fonts = true;
+
+	/**
 	 * Returns font with display value.
 	 *
 	 * @since  3.8 Moved here from GoogleFonts\Combine::class

--- a/inc/Engine/Optimization/GoogleFonts/AbstractGFOptimization.php
+++ b/inc/Engine/Optimization/GoogleFonts/AbstractGFOptimization.php
@@ -35,20 +35,18 @@ abstract class AbstractGFOptimization extends AbstractOptimization {
 	 *
 	 * @var bool
 	 */
-	protected $has_google_fonts = true;
+	protected $has_google_fonts;
 
 
 	/**
 	 * Check whether the optimizer has found google fonts on the page.
 	 *
-	 * Note: Will always return true if the optimize() method has yet been called.
-	 *
 	 * @since 3.8.8
 	 *
-	 * @return bool
+	 * @return bool Will default to true when extending classes have not set via the optimize() method.
 	 */
 	public function has_google_fonts() {
-		return $this->has_google_fonts;
+		return isset( $this->has_google_fonts ) ? $this->has_google_fonts : true;
 	}
 
 	/**

--- a/inc/Engine/Optimization/GoogleFonts/Combine.php
+++ b/inc/Engine/Optimization/GoogleFonts/Combine.php
@@ -34,7 +34,6 @@ class Combine extends AbstractGFOptimization {
 	 * Combines multiple Google Fonts links into one
 	 *
 	 * @since  3.1
-	 * @author Remy Perona
 	 *
 	 * @param string $html HTML content.
 	 *
@@ -53,6 +52,8 @@ class Combine extends AbstractGFOptimization {
 
 			return $html;
 		}
+
+		$this->has_google_fonts = true;
 
 		$num_fonts = count( $fonts );
 
@@ -97,7 +98,6 @@ class Combine extends AbstractGFOptimization {
 	 * Parses found matches to extract fonts and subsets.
 	 *
 	 * @since  3.1
-	 * @author Remy Perona
 	 *
 	 * @param array $matches Found matches for the pattern.
 	 *
@@ -138,7 +138,6 @@ class Combine extends AbstractGFOptimization {
 	 *
 	 * @since  3.3.5 Add support for the display parameter
 	 * @since  3.1
-	 * @author Remy Perona
 	 *
 	 * @return string
 	 */

--- a/inc/Engine/Optimization/GoogleFonts/Combine.php
+++ b/inc/Engine/Optimization/GoogleFonts/Combine.php
@@ -49,6 +49,8 @@ class Combine extends AbstractGFOptimization {
 		if ( ! $fonts ) {
 			Logger::debug( 'No Google Fonts found.', [ 'GF combine process' ] );
 
+			$this->has_google_fonts = false;
+
 			return $html;
 		}
 

--- a/inc/Engine/Optimization/GoogleFonts/CombineV2.php
+++ b/inc/Engine/Optimization/GoogleFonts/CombineV2.php
@@ -46,6 +46,9 @@ class CombineV2 extends AbstractGFOptimization {
 
 		if ( ! $font_tags ) {
 			Logger::debug( 'No v2 Google Fonts found.', [ 'GF combine process' ] );
+
+			$this->has_google_fonts = false;
+			
 			return $html;
 		}
 

--- a/inc/Engine/Optimization/GoogleFonts/CombineV2.php
+++ b/inc/Engine/Optimization/GoogleFonts/CombineV2.php
@@ -48,7 +48,7 @@ class CombineV2 extends AbstractGFOptimization {
 			Logger::debug( 'No v2 Google Fonts found.', [ 'GF combine process' ] );
 
 			$this->has_google_fonts = false;
-			
+
 			return $html;
 		}
 

--- a/inc/Engine/Optimization/GoogleFonts/CombineV2.php
+++ b/inc/Engine/Optimization/GoogleFonts/CombineV2.php
@@ -52,6 +52,8 @@ class CombineV2 extends AbstractGFOptimization {
 			return $html;
 		}
 
+		$this->has_google_fonts = true;
+
 		$num_tags = count( $font_tags );
 
 		Logger::debug(

--- a/inc/Engine/Optimization/GoogleFonts/Subscriber.php
+++ b/inc/Engine/Optimization/GoogleFonts/Subscriber.php
@@ -101,7 +101,13 @@ class Subscriber implements Subscriber_Interface {
 		// Combine Google Font API V2.
 		$html = $this->combine_v2->optimize( $html );
 		// Combine Google Font API V1.
-		return $this->combine->optimize( $html );
+		$html = $this->combine->optimize( $html );
+
+		if ( ! $this->combine->has_google_fonts() && ! $this->combine_v2->has_google_fonts() ) {
+			$html = str_replace( "<link href='https://fonts.gstatic.com' crossorigin rel='preconnect' />", '', $html );
+		}
+
+		return $html;
 	}
 
 	/**

--- a/inc/Engine/Optimization/GoogleFonts/Subscriber.php
+++ b/inc/Engine/Optimization/GoogleFonts/Subscriber.php
@@ -104,7 +104,7 @@ class Subscriber implements Subscriber_Interface {
 		$html = $this->combine->optimize( $html );
 
 		if ( ! $this->combine->has_google_fonts() && ! $this->combine_v2->has_google_fonts() ) {
-			$html = str_replace( "<link href='https://fonts.gstatic.com' crossorigin rel='preconnect' />", '', $html );
+			$html = preg_replace( '/<link\s+(?:[^>]+[\s"\'])?href\s*=\s*[\'"]https:\/\/fonts\.gstatic\.com[\'"](?:[^>]+[\s"\'])?\s?\/?>/', '', $html );
 		}
 
 		return $html;

--- a/tests/Fixtures/inc/Engine/Optimization/GoogleFonts/CombineV1V2/optimize.php
+++ b/tests/Fixtures/inc/Engine/Optimization/GoogleFonts/CombineV1V2/optimize.php
@@ -117,4 +117,31 @@ return [
 				'</body>' .
 			'</html>'
 	],
+	'shouldRemovePreconnectWhenNoGoogleFontsPresentOnPage' => [
+		'given' =>
+			'<!doctype html>' .
+			'<html>' .
+				'<head>' .
+					'<meta charset="UTF-8" />' .
+					'<title>Sample Page</title>' .
+					"<link href='https://fonts.gstatic.com' crossorigin rel='preconnect' />" .
+					'<link rel="prefetch" href="https://my-cdn.com" crossorigin>' .
+					'<style>h1 { color: red; }</style>' .
+					'</head>' .
+				'<body></body>' .
+			'</html>'
+		,
+		'expected' =>
+			'<!doctype html>' .
+			'<html>' .
+				'<head>' .
+					'<meta charset="UTF-8" />' .
+					'<title>Sample Page</title>' .
+					'<link rel="prefetch" href="https://my-cdn.com" crossorigin>' .
+					'<style>h1 { color: red; }</style>' .
+					'</head>' .
+				'<body></body>' .
+			'</html>'
+		,
+	]
 ];


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #3219

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?
It is mostly as groomed. I've also included setting the flag in the concrete optimizers `optimize()` methods for cases where google fonts _are_ present as well as when they are not, rather than assuming a default flag status in the Combine classes. (The `AbstractGFOptimization::has_google_fonts()` method will return true if for any reason the flag fails to be set, so that preconnect link will not be inadvertently removed in any edge cases.)

## How Has This Been Tested?

- [X] Integration testcase has been added in the V2V1 fixture.
- [X] Steps to check: With Combine Google Fonts setting active ---
      1. Activate a theme -- or set a page where -- google fonts are present on the page.
      2. Clear rocket cache and load page. Observe that preconnect link is added to inside the page `<head>` html.
      3. Activate a theme -- or set a page where -- google fonts are NOT present on the page.
      4. Clear rocket cache and load page. Observe that there is NOT a preconnect link added inside the page `<head>` html.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules