### PR TITLE
Fix purge expired cache issue on some environments (Bitnami)

### DIFF
--- a/inc/Engine/Cache/PurgeExpired/PurgeExpiredCache.php
+++ b/inc/Engine/Cache/PurgeExpired/PurgeExpiredCache.php
@@ -318,12 +318,12 @@ class PurgeExpiredCache {
 				$dir_deleted = $this->purge_dir( $item->getPathname(), $file_age_limit );
 				$deleted     = array_merge( $deleted, $dir_deleted );
 
-			} elseif ( $item->isFile() && $item->getCTime() < $file_age_limit ) {
+			} elseif ( $item->isFile() && $item->getMTime() < $file_age_limit ) {
 				$file_path = $item->getPathname();
 
 				/**
 				 * The file is older than our limit.
-				 * This will also delete the file if `$item->getCTime()` fails.
+				 * This will also delete the file if `$item->getMTime()` fails.
 				 */
 				if ( ! $this->filesystem->delete( $file_path ) ) {
 					continue;

--- a/tests/Integration/inc/Engine/Cache/PurgeExpired/PurgeExpiredCache/purgeExpiredFiles.php
+++ b/tests/Integration/inc/Engine/Cache/PurgeExpired/PurgeExpiredCache/purgeExpiredFiles.php
@@ -83,7 +83,7 @@ class Test_PurgeExpiredFiles extends FilesystemTestCase {
 	private function setFilesToExpire( $files, $expirationTime = '11 hours ago' ) {
 		foreach ( $files as $filepath ) {
 			$file = $this->filesystem->getFile( $filepath );
-			$file->lastAttributeModified( strtotime( $expirationTime ) );
+			$file->lastModified( strtotime( $expirationTime ) );
 		}
 	}
 }

--- a/tests/Unit/inc/Engine/Cache/PurgeExpired/PurgeExpiredCache/purgeExpiredFiles.php
+++ b/tests/Unit/inc/Engine/Cache/PurgeExpired/PurgeExpiredCache/purgeExpiredFiles.php
@@ -96,7 +96,7 @@ class Test_PurgeExpiredFiles extends FilesystemTestCase {
 	private function setFilesToExpire( $files, $expirationTime = '11 hours ago' ) {
 		foreach ( $files as $filepath ) {
 			$file = $this->filesystem->getFile( $filepath );
-			$file->lastAttributeModified( strtotime( $expirationTime ) );
+			$file->lastModified( strtotime( $expirationTime ) );
 		}
 	}
 }


### PR DESCRIPTION
## Description

On some server environments, in this case on a Bitnami Apache server, the old cache files are not being purged/removed automatically.

Fixes #3668 

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Is the solution different from the one proposed during the grooming?

Not groomed as it's [XS] effort.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] We tested it directly on customer's site and made sure that cache purge is working automatically.
- [x] I'm not able to reproduce this issue locally but I checked the main functionality of purge cache and it's working properly.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules