### PR TITLE
Fixes #3449 rocket_need_api_key() - PHP error during license validation

### DIFF
--- a/inc/functions/admin.php
+++ b/inc/functions/admin.php
@@ -10,10 +10,8 @@ function rocket_need_api_key() {
 	$message = '';
 	$errors  = (array) get_transient( 'rocket_check_key_errors' );
 
-	if ( false !== $errors ) {
-		foreach ( $errors as $error ) {
-			$message .= '<p>' . $error . '</p>';
-		}
+	foreach ( $errors as $error ) {
+		$message .= '<p>' . $error . '</p>';
 	}
 
 	?>

--- a/inc/functions/admin.php
+++ b/inc/functions/admin.php
@@ -8,7 +8,7 @@ defined( 'ABSPATH' ) || exit;
  */
 function rocket_need_api_key() {
 	$message = '';
-	$errors  = get_transient( 'rocket_check_key_errors' );
+	$errors  = (array) get_transient( 'rocket_check_key_errors' );
 
 	if ( false !== $errors ) {
 		foreach ( $errors as $error ) {

--- a/inc/functions/options.php
+++ b/inc/functions/options.php
@@ -462,15 +462,20 @@ function rocket_valid_key() {
 	$valid_details = 8 === strlen( get_rocket_option( 'consumer_key' ) ) && hash_equals( $rocket_secret_key, hash( 'crc32', get_rocket_option( 'consumer_email' ) ) );
 
 	if ( ! $valid_details ) {
-
 		set_transient(
 			'rocket_check_key_errors',
-			// Translators: %1$s = opening link tag, %2$s = closing link tag.
-			[ __( 'Not valid License details.', 'rocket' ) . ' <br>' . sprintf( __( 'To resolve, please %1$scontact support%2$s.', 'rocket' ), '<a href="https://wp-rocket.me/support/" rel="noopener noreferrer" target=_"blank">', '</a>' ) ]
+			[
+				__( 'The provided license data are not valid.', 'rocket' ) .
+				' <br>' .
+				// Translators: %1$s = opening link tag, %2$s = closing link tag.
+				sprintf( __( 'To resolve, please %1$scontact support%2$s.', 'rocket' ), '<a href="https://wp-rocket.me/support/" rel="noopener noreferrer" target=_"blank">', '</a>' ),
+			]
 		);
-	}else {
-		delete_transient( 'rocket_check_key_errors' );
+
+		return $valid_details;
 	}
+
+	delete_transient( 'rocket_check_key_errors' );
 
 	return $valid_details;
 }

--- a/inc/functions/options.php
+++ b/inc/functions/options.php
@@ -462,8 +462,13 @@ function rocket_valid_key() {
 	$valid_details = 8 === strlen( get_rocket_option( 'consumer_key' ) ) && hash_equals( $rocket_secret_key, hash( 'crc32', get_rocket_option( 'consumer_email' ) ) );
 
 	if ( ! $valid_details ) {
-		set_transient( 'rocket_check_key_errors', [ __( 'Not valid License details.' . '<br>' . sprintf( __( 'To resolve, please %1$scontact support%2$s.', 'rocket' ), '<a href="https://wp-rocket.me/support/" rel="noopener noreferrer" target=_"blank">', '</a>' ), 'rocket' ) ] );
-	}else{
+
+		set_transient(
+			'rocket_check_key_errors',
+			// Translators: %1$s = opening link tag, %2$s = closing link tag.
+			[ __( 'Not valid License details.', 'rocket' ) . ' <br>' . sprintf( __( 'To resolve, please %1$scontact support%2$s.', 'rocket' ), '<a href="https://wp-rocket.me/support/" rel="noopener noreferrer" target=_"blank">', '</a>' ) ]
+		);
+	}else {
 		delete_transient( 'rocket_check_key_errors' );
 	}
 

--- a/inc/functions/options.php
+++ b/inc/functions/options.php
@@ -459,7 +459,15 @@ function rocket_valid_key() {
 		return false;
 	}
 
-	return 8 === strlen( get_rocket_option( 'consumer_key' ) ) && hash_equals( $rocket_secret_key, hash( 'crc32', get_rocket_option( 'consumer_email' ) ) );
+	$valid_details = 8 === strlen( get_rocket_option( 'consumer_key' ) ) && hash_equals( $rocket_secret_key, hash( 'crc32', get_rocket_option( 'consumer_email' ) ) );
+
+	if ( ! $valid_details ) {
+		set_transient( 'rocket_check_key_errors', [ __( 'Not valid License details.' . '<br>' . sprintf( __( 'To resolve, please %1$scontact support%2$s.', 'rocket' ), '<a href="https://wp-rocket.me/support/" rel="noopener noreferrer" target=_"blank">', '</a>' ), 'rocket' ) ] );
+	}else{
+		delete_transient( 'rocket_check_key_errors' );
+	}
+
+	return $valid_details;
 }
 
 /**


### PR DESCRIPTION
## Description

if the `consumer_key` exists but its length is less/more than 8 characters (and this key is the same on our server), we fail without showing any error message so the transient which has this error isn't exist and when trying to get it it gives boolean false value so when trying to use `count` method it fails with warnings on some environments and fatal errors on others.

Fixes #3449 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

Please describe in this section any change to the solution, and why.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I found the case on one of our customer's sites and this change solved the issue for them
- [x] I changed this number `8` on the following line to be `7`
https://github.com/wp-media/wp-rocket/blob/6ecc8b2df076136422dc5b0a89597eef4c978f38/inc/functions/options.php#L462

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules