### PR TITLE
Remove incorrect URLs when running rocket_clean_post()

### DIFF
--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -62,16 +62,8 @@ function rocket_get_purge_urls( $post_id, $post ) {
 	if ( 'post' !== $post_type ) {
 		$post_type_archive = get_post_type_archive_link( $post_type );
 		if ( $post_type_archive ) {
-			// Rename the caching filename for SSL URLs.
-			$filename = 'index';
-			if ( is_ssl() ) {
-				$filename .= '-https';
-			}
-
 			$post_type_archive = trailingslashit( $post_type_archive );
-			$purge_urls[]      = $post_type_archive . $filename . '.html';
-			$purge_urls[]      = $post_type_archive . $filename . '.html_gzip';
-			$purge_urls[]      = $post_type_archive . $filename . $GLOBALS['wp_rewrite']->pagination_base;
+			$purge_urls[]      = $post_type_archive . $GLOBALS['wp_rewrite']->pagination_base;
 		}
 	}
 


### PR DESCRIPTION
## Description

This change is meant to remove the incorrect URLs that are added for clearing of non-post post types:
https://github.com/wp-media/wp-rocket/blob/364467d0a240dbb7e4a07a015b236c630ed058df/inc/common/purge.php#L72-L73

Fixes #2068 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

Non-relevant.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] On a customer's website.
- [x] Locally.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules