### PR TITLE
Fixes #2776 Process buffer only if there is a closing </html> tag during cache

### DIFF
--- a/inc/classes/Buffer/class-tests.php
+++ b/inc/classes/Buffer/class-tests.php
@@ -804,7 +804,7 @@ class Tests {
 	 * @return bool
 	 */
 	public function is_html( $buffer ) {
-		return (bool) preg_match( '/<\/html>/i', $buffer );
+		return (bool) preg_match( '/<\s*\/\s*html\s*>/i', $buffer );
 	}
 
 	/** ----------------------------------------------------------------------------------------- */

--- a/inc/classes/Buffer/class-tests.php
+++ b/inc/classes/Buffer/class-tests.php
@@ -66,6 +66,7 @@ class Tests {
 		'donotcachepage'   => 1,
 		'wp_404'           => 1,
 		'search'           => 1,
+		'is_html'          => 1,
 	];
 
 	/**
@@ -348,6 +349,12 @@ class Tests {
 		if ( $this->has_test( 'search' ) && $this->is_search() ) {
 			// Don't process search results.
 			$this->set_error( 'Search page is excluded.' );
+			return false;
+		}
+
+		if ( $this->has_test( 'is_html' ) && ! $this->is_html( $buffer ) ) {
+			// Don't process if there isn't a closing </html>.
+			$this->set_error( 'No closing </html> was found.' );
 			return false;
 		}
 
@@ -780,6 +787,19 @@ class Tests {
 		 * @param bool $cache_search True will force caching search results.
 		 */
 		return ! apply_filters( 'rocket_cache_search', false );
+	}
+
+	/**
+	 * Tell if the page content has a closing </html>.
+	 *
+	 * @since  3.8.8
+	 * @access public
+	 *
+	 * @param  string $buffer The buffer content.
+	 * @return bool
+	 */
+	public function is_html( $buffer ) {
+		return preg_match( '/<\/html>/i', $buffer );
 	}
 
 	/** ----------------------------------------------------------------------------------------- */

--- a/inc/classes/Buffer/class-tests.php
+++ b/inc/classes/Buffer/class-tests.php
@@ -352,7 +352,7 @@ class Tests {
 			return false;
 		}
 
-		if ( $this->has_test( 'is_html' ) && ! $this->is_html( $buffer ) ) {
+		if ( $this->has_test( 'is_html' ) && ! $this->is_html( $buffer ) && ! defined( 'REST_REQUEST' ) ) {
 			// Don't process if there isn't a closing </html>.
 			$this->set_error( 'No closing </html> was found.' );
 			return false;

--- a/inc/classes/Buffer/class-tests.php
+++ b/inc/classes/Buffer/class-tests.php
@@ -352,7 +352,13 @@ class Tests {
 			return false;
 		}
 
-		if ( $this->has_test( 'is_html' ) && ! $this->is_html( $buffer ) && ! defined( 'REST_REQUEST' ) ) {
+		if (
+			$this->has_test( 'is_html' )
+			&&
+			! $this->is_html( $buffer )
+			&&
+			! defined( 'REST_REQUEST' )
+		) {
 			// Don't process if there isn't a closing </html>.
 			$this->set_error( 'No closing </html> was found.' );
 			return false;
@@ -792,14 +798,13 @@ class Tests {
 	/**
 	 * Tell if the page content has a closing </html>.
 	 *
-	 * @since  3.8.8
-	 * @access public
+	 * @since 3.9
 	 *
 	 * @param  string $buffer The buffer content.
 	 * @return bool
 	 */
 	public function is_html( $buffer ) {
-		return preg_match( '/<\/html>/i', $buffer );
+		return (bool) preg_match( '/<\/html>/i', $buffer );
 	}
 
 	/** ----------------------------------------------------------------------------------------- */


### PR DESCRIPTION
## Description

There are [reports](https://github.com/wp-media/wp-rocket/issues/2776) where pages are cached partially.

These happen randomly, and the issue is resolved by clearing the cache.

This PR will prevent a page that doesn't have a `</html>` to be saved on the disk. A check is in place for request from the REST API, in case the REST API cache is enabled.

Fixes #2776

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

Grooming wasn't done on this issue

## How Has This Been Tested?

- [x] Locally.
- [x] On a customer's website.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings