### PR TITLE
Sanitize Remove unused CSS options

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Admin/Settings.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Settings.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 namespace WP_Rocket\Engine\Optimization\RUCSS\Admin;
 
 use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Engine\Admin\Settings\Settings as AdminSettings;
 
 class Settings {
-
 	/**
 	 * Instance of options handler.
 	 *
@@ -66,9 +66,28 @@ class Settings {
 	/**
 	 * Determines if Remove Unused CSS option is enabled.
 	 *
+	 * @since 3.9
+	 *
 	 * @return boolean
 	 */
 	public function is_enabled() : bool {
 		return (bool) $this->options->get( 'remove_unused_css', 0 );
+	}
+
+	/**
+	 * Sanitizes RUCSS options values when the settings form is submitted
+	 *
+	 * @since 3.9
+	 *
+	 * @param array         $input    Array of values submitted from the form.
+	 * @param AdminSettings $settings Settings class instance.
+	 *
+	 * @return array
+	 */
+	public function sanitize_options( array $input, AdminSettings $settings ) : array {
+		$input['remove_unused_css']          = $settings->sanitize_checkbox( $input, 'remove_unused_css' );
+		$input['remove_unused_css_safelist'] = ! empty( $input['remove_unused_css_safelist'] ) ? rocket_sanitize_textarea_field( 'remove_unused_css_safelist', $input['remove_unused_css_safelist'] ) : [];
+
+		return $input;
 	}
 }

--- a/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
@@ -3,8 +3,9 @@ declare(strict_types=1);
 
 namespace WP_Rocket\Engine\Optimization\RUCSS\Admin;
 
-use WP_Rocket\Event_Management\Subscriber_Interface;
+use WP_Rocket\Engine\Admin\Settings\Settings as AdminSettings;
 use WP_Rocket\Engine\Optimization\RUCSS\Controller\UsedCSS;
+use WP_Rocket\Event_Management\Subscriber_Interface;
 
 class Subscriber implements Subscriber_Interface {
 	/**
@@ -49,6 +50,7 @@ class Subscriber implements Subscriber_Interface {
 	public static function get_subscribed_events() : array {
 		return [
 			'rocket_first_install_options'     => 'add_options_first_time',
+			'rocket_input_sanitize'            => [ 'sanitize_options', 10, 2 ],
 			'wp_rocket_upgrade'                => [
 				[ 'set_option_on_update', 13, 2 ],
 			],
@@ -142,5 +144,19 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	public function set_option_on_update( $new_version, $old_version ) {
 		$this->settings->set_option_on_update( $old_version );
+	}
+
+	/**
+	 * Sanitizes RUCSS options values when the settings form is submitted
+	 *
+	 * @since 3.9
+	 *
+	 * @param array         $input    Array of values submitted from the form.
+	 * @param AdminSettings $settings Settings class instance.
+	 *
+	 * @return array
+	 */
+	public function sanitize_options( $input, AdminSettings $settings ) : array {
+		return $this->settings->sanitize_options( $input, $settings );
 	}
 }

--- a/inc/functions/formatting.php
+++ b/inc/functions/formatting.php
@@ -28,11 +28,11 @@ function rocket_clean_exclude_file( $file ) {
  * @author Soponar Cristina
  *
  * @param  string $path URL which needs to be cleaned.
- * @return bool\string  false if $path is empty or cleaned URL
+ * @return string Cleaned URL
  */
 function rocket_clean_wildcards( $path ) {
 	if ( ! $path ) {
-		return false;
+		return '';
 	}
 
 	$path_components = explode( '/', $path );
@@ -208,7 +208,7 @@ function rocket_sanitize_textarea_field( $field, $value ) {
 
 	// Sanitize.
 	foreach ( $sanitizations as $sanitization ) {
-		$value = array_map( $sanitization, $value );
+		$value = array_filter( array_map( $sanitization, $value ) );
 	}
 
 	return array_unique( $value );

--- a/inc/functions/formatting.php
+++ b/inc/functions/formatting.php
@@ -174,18 +174,19 @@ function rocket_is_internal_file( $file ) {
  */
 function rocket_sanitize_textarea_field( $field, $value ) {
 	$fields = [
-		'cache_purge_pages'    => [ 'esc_url', 'rocket_clean_exclude_file', 'rocket_clean_wildcards' ], // Pattern.
-		'cache_reject_cookies' => [ 'rocket_sanitize_key' ],
-		'cache_reject_ua'      => [ 'rocket_sanitize_ua', 'rocket_clean_wildcards' ], // Pattern.
-		'cache_reject_uri'     => [ 'esc_url', 'rocket_clean_exclude_file', 'rocket_clean_wildcards' ], // Pattern.
-		'cache_query_strings'  => [ 'rocket_sanitize_key' ],
-		'cdn_reject_files'     => [ 'rocket_clean_exclude_file', 'rocket_clean_wildcards' ], // Pattern.
-		'exclude_css'          => [ 'rocket_validate_css', 'rocket_clean_wildcards' ], // Pattern.
-		'exclude_inline_js'    => [ 'sanitize_text_field' ],
-		'exclude_defer_js'     => [ 'sanitize_text_field' ],
-		'exclude_js'           => [ 'rocket_validate_js', 'rocket_clean_wildcards' ], // Pattern.
-		'exclude_lazyload'     => [ 'sanitize_text_field' ],
-		'delay_js_scripts'     => [ 'sanitize_text_field' ],
+		'cache_purge_pages'          => [ 'esc_url', 'rocket_clean_exclude_file', 'rocket_clean_wildcards' ],   // Pattern.
+		'cache_reject_cookies'       => [ 'rocket_sanitize_key' ],
+		'cache_reject_ua'            => [ 'rocket_sanitize_ua', 'rocket_clean_wildcards' ],                     // Pattern.
+		'cache_reject_uri'           => [ 'esc_url', 'rocket_clean_exclude_file', 'rocket_clean_wildcards' ],   // Pattern.
+		'cache_query_strings'        => [ 'rocket_sanitize_key' ],
+		'cdn_reject_files'           => [ 'rocket_clean_exclude_file', 'rocket_clean_wildcards' ],              // Pattern.
+		'exclude_css'                => [ 'rocket_validate_css', 'rocket_clean_wildcards' ],                    // Pattern.
+		'exclude_inline_js'          => [ 'sanitize_text_field' ],
+		'exclude_defer_js'           => [ 'sanitize_text_field' ],
+		'exclude_js'                 => [ 'rocket_validate_js', 'rocket_clean_wildcards' ],                     // Pattern.
+		'exclude_lazyload'           => [ 'sanitize_text_field' ],
+		'delay_js_scripts'           => [ 'sanitize_text_field' ],
+		'remove_unused_css_safelist' => [ 'sanitize_text_field', 'rocket_clean_wildcards' ],
 	];
 
 	if ( ! isset( $fields[ $field ] ) ) {

--- a/tests/Fixtures/inc/Engine/Media/Lazyload/AdminSubscriber/sanitizeExcludeLazyload.php
+++ b/tests/Fixtures/inc/Engine/Media/Lazyload/AdminSubscriber/sanitizeExcludeLazyload.php
@@ -7,7 +7,6 @@ return [
         ],
 		'expected' => [
             'minify_css'        => 0,
-            'image_dimensions' => 0,
 			'exclude_lazyload'  => [],
 		]
 	],
@@ -24,7 +23,6 @@ return [
                 '/wp-content/plugins/test/test.jpg',
                 'data-image',
             ],
-            'image_dimensions' => 0,
 		]
 	],
 ];

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Settings/sanitizeOptions.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Settings/sanitizeOptions.php
@@ -1,0 +1,66 @@
+<?php
+
+return [
+	'testShouldSetDefaultValueIfNotSet' => [
+		'config'    => [
+			'input'           => [],
+			'sanitized_input' => null,
+		],
+		'expected' => [
+			'remove_unused_css'          => 0,
+			'remove_unused_css_safelist' => [],
+		],
+	],
+	'testShouldSetCorrectValueIfDifferentType' => [
+		'config'   => [
+			'input'           => [
+				'remove_unused_css'          => true,
+				'remove_unused_css_safelist' => "wp-content/themes/twentytwenty/style.css\n<script>\n.test\nbody\nwp-includes/.*.css",
+			],
+			'sanitized_input' => [
+				'wp-content/themes/twentytwenty/style.css',
+				'.test',
+				'body',
+				'wp-includes/(.*).css',
+			],
+		],
+		'expected' => [
+			'remove_unused_css'          => 1,
+			'remove_unused_css_safelist' => [
+				'wp-content/themes/twentytwenty/style.css',
+				'.test',
+				'body',
+				'wp-includes/(.*).css',
+			],
+		],
+	],
+	'testShouldPreserveValueIfCorrectType' => [
+		'config'   => [
+			'input'           => [
+				'remove_unused_css'          => 1,
+				'remove_unused_css_safelist' => [
+					'wp-content/themes/twentytwenty/style.css',
+					'.test',
+					'<script>',
+					'body',
+					'wp-includes/.*.css'
+				],
+			],
+			'sanitized_input' => [
+				'wp-content/themes/twentytwenty/style.css',
+				'.test',
+				'body',
+				'wp-includes/(.*).css',
+			],
+		],
+		'expected' => [
+			'remove_unused_css'          => 1,
+			'remove_unused_css_safelist' => [
+				'wp-content/themes/twentytwenty/style.css',
+				'.test',
+				'body',
+				'wp-includes/(.*).css',
+			],
+		],
+	],
+];

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/sanitizeOptions.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/sanitizeOptions.php
@@ -1,0 +1,53 @@
+<?php
+
+return [
+	'testShouldSetDefaultValueIfNotSet' => [
+		'config'    => [
+			'input'           => [],
+		],
+		'expected' => [
+			'remove_unused_css'          => 0,
+			'remove_unused_css_safelist' => [],
+		],
+	],
+	'testShouldSetCorrectValueIfDifferentType' => [
+		'config'   => [
+			'input'           => [
+				'remove_unused_css'          => true,
+				'remove_unused_css_safelist' => "wp-content/themes/twentytwenty/style.css\n<script>\n.test\nbody\nwp-includes/.*.css",
+			],
+		],
+		'expected' => [
+			'remove_unused_css'          => 1,
+			'remove_unused_css_safelist' => [
+				'wp-content/themes/twentytwenty/style.css',
+				'.test',
+				'body',
+				'wp-includes/(.*).css',
+			],
+		],
+	],
+	'testShouldPreserveValueIfCorrectType' => [
+		'config'   => [
+			'input'           => [
+				'remove_unused_css'          => 1,
+				'remove_unused_css_safelist' => [
+					'wp-content/themes/twentytwenty/style.css',
+					'.test',
+					'<script>',
+					'body',
+					'wp-includes/.*.css'
+				],
+			],
+		],
+		'expected' => [
+			'remove_unused_css'          => 1,
+			'remove_unused_css_safelist' => [
+				'wp-content/themes/twentytwenty/style.css',
+				'.test',
+				'body',
+				'wp-includes/(.*).css',
+			],
+		],
+	],
+];

--- a/tests/Integration/inc/Engine/Media/Lazyload/AdminSubscriber/sanitizeExcludeLazyload.php
+++ b/tests/Integration/inc/Engine/Media/Lazyload/AdminSubscriber/sanitizeExcludeLazyload.php
@@ -16,6 +16,18 @@ use Mockery;
  * @group Lazyload
  */
 class Test_SanitizeExcludeLazyload extends TestCase {
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->unregisterAllCallbacksExcept( 'rocket_input_sanitize', 'sanitize_exclude_lazyload' );
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+
+		$this->restoreWpFilter( 'rocket_input_sanitize' );
+	}
+
 	/**
 	 * @dataProvider configTestData
 	 */

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/sanitizeOptions.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/sanitizeOptions.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\Optimization\RUCSS\Admin\Subscriber;
+
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Optimization\RUCSS\Admin\Subscriber::sanitize_options
+ *
+ * @group  RUCSS
+ * @group  AdminOnly
+ */
+class Test_SanitizeOptions extends TestCase {
+    private static $admin_settings;
+
+    public static function setUpBeforeClass() : void {
+        $container = apply_filters( 'rocket_container', null );
+
+        self::$admin_settings = $container->get( 'settings' );
+    }
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->unregisterAllCallbacksExcept( 'rocket_input_sanitize', 'sanitize_options' );
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+
+		$this->restoreWpFilter( 'rocket_input_sanitize' );
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldDoExpected( $config, $expected ) {
+        $result = apply_filters( 'rocket_input_sanitize', $config['input'], self::$admin_settings );
+
+        $this->assertArrayHasKey( 'remove_unused_css', $result );
+        $this->assertArrayHasKey( 'remove_unused_css_safelist', $result );
+
+        $this->assertSame(
+			$expected['remove_unused_css'],
+			$result['remove_unused_css']
+		);
+
+        $this->assertArraySubset(
+			$expected['remove_unused_css_safelist'],
+			array_values( $result['remove_unused_css_safelist'] )
+		);
+	}
+}

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Settings/sanitizeOptions.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Settings/sanitizeOptions.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\RUCSS\Admin\Settings;
+
+use Brain\Monkey\Functions;
+use Mockery;
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Engine\Admin\Settings\Settings as AdminSettings;
+use WP_Rocket\Engine\Optimization\RUCSS\Admin\Settings;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Optimization\RUCSS\Admin\Settings::sanitize_options
+ *
+ * @group  RUCSS
+ */
+class Test_SanitizeOptions extends TestCase{
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldDoExpected( $config, $expected ) {
+		Functions\when( 'rocket_sanitize_textarea_field' )->justReturn( $config['sanitized_input'] );
+
+		$options_data   = Mockery::mock( Options_Data::class );
+		$settings       = new Settings( $options_data );
+		$admin_settings = new AdminSettings( $options_data );
+
+		$this->assertSame(
+			$expected,
+			$settings->sanitize_options( $config['input'], $admin_settings )
+		);
+	}
+}


### PR DESCRIPTION
## Description

Add sanitization for remove unused CSS options when the settings form is submitted

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

No

## How Has This Been Tested?

- [x] Manual testing by adding various values and submitting
- [x] Automated tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes