### PR TITLE
Preserve backslash in the used CSS

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -65,10 +65,10 @@ class UsedCSS {
 	public function save_or_update_used_css( array $data ) {
 		$used_css = $this->get_used_css( $data['url'], $data['is_mobile'] );
 
-		$data['css'] = preg_replace( '/content\s*:\s*"\\\\f/i', 'shaker-parser:"dashf', $data['css']);
-		$data['css'] = preg_replace( '/content\s*:\s*"\\\\e/i', 'shaker-parser:"dashe', $data['css']);
-		$data['css'] = preg_replace( '/content\s*:\s*\'\\\\f/i', 'shaker-parser:\'dashf', $data['css']);
-		$data['css'] = preg_replace( '/content\s*:\s*\'\\\\e/i', 'shaker-parser:\'dashe', $data['css']);
+		$data['css'] = preg_replace( '/content\s*:\s*"\\\\f/i', 'shaker-parser:"dashf', $data['css'] );
+		$data['css'] = preg_replace( '/content\s*:\s*"\\\\e/i', 'shaker-parser:"dashe', $data['css'] );
+		$data['css'] = preg_replace( '/content\s*:\s*\'\\\\f/i', 'shaker-parser:\'dashf', $data['css'] );
+		$data['css'] = preg_replace( '/content\s*:\s*\'\\\\e/i', 'shaker-parser:\'dashe', $data['css'] );
 
 		if ( empty( $used_css ) ) {
 			return $this->insert_used_css( $data );

--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -65,6 +65,11 @@ class UsedCSS {
 	public function save_or_update_used_css( array $data ) {
 		$used_css = $this->get_used_css( $data['url'], $data['is_mobile'] );
 
+		$data['css'] = preg_replace( '/content\s*:\s*"\\\\f/i', 'shaker-parser:"dashf', $data['css']);
+		$data['css'] = preg_replace( '/content\s*:\s*"\\\\e/i', 'shaker-parser:"dashe', $data['css']);
+		$data['css'] = preg_replace( '/content\s*:\s*\'\\\\f/i', 'shaker-parser:\'dashf', $data['css']);
+		$data['css'] = preg_replace( '/content\s*:\s*\'\\\\e/i', 'shaker-parser:\'dashe', $data['css']);
+
 		if ( empty( $used_css ) ) {
 			return $this->insert_used_css( $data );
 		}

--- a/inc/Engine/Optimization/RUCSS/Database/Row/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Database/Row/UsedCSS.php
@@ -20,6 +20,11 @@ class UsedCSS extends Row {
 		$this->id             = (int) $this->id;
 		$this->url            = (string) $this->url;
 		$this->css            = (string) $this->css;
+		$this->css            = str_replace( 'shaker-parser:"dashf', 'content:"\f', $this->css );
+		$this->css            = str_replace( 'shaker-parser:"dashe', 'content:"\e', $this->css );
+		$this->css            = str_replace( 'shaker-parser:\'dashf', 'content:\'\f', $this->css );
+		$this->css            = str_replace( 'shaker-parser:\'dashe', 'content:\'\e', $this->css );d
+
 		$this->unprocessedcss = json_decode( $this->unprocessedcss, true );
 		$this->retries        = (int) $this->retries;
 		$this->is_mobile      = (bool) $this->is_mobile;

--- a/inc/Engine/Optimization/RUCSS/Database/Row/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Database/Row/UsedCSS.php
@@ -23,8 +23,7 @@ class UsedCSS extends Row {
 		$this->css            = str_replace( 'shaker-parser:"dashf', 'content:"\f', $this->css );
 		$this->css            = str_replace( 'shaker-parser:"dashe', 'content:"\e', $this->css );
 		$this->css            = str_replace( 'shaker-parser:\'dashf', 'content:\'\f', $this->css );
-		$this->css            = str_replace( 'shaker-parser:\'dashe', 'content:\'\e', $this->css );d
-
+		$this->css            = str_replace( 'shaker-parser:\'dashe', 'content:\'\e', $this->css );
 		$this->unprocessedcss = json_decode( $this->unprocessedcss, true );
 		$this->retries        = (int) $this->retries;
 		$this->is_mobile      = (bool) $this->is_mobile;

--- a/inc/Engine/Optimization/RUCSS/Frontend/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Frontend/Subscriber.php
@@ -50,7 +50,7 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events() : array {
 		return [
-			'rocket_buffer' => [ 'treeshake', 1 ],
+			'rocket_buffer' => [ 'treeshake', 11 ],
 		];
 	}
 

--- a/inc/Engine/Optimization/RUCSS/Frontend/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Frontend/Subscriber.php
@@ -50,7 +50,7 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events() : array {
 		return [
-			'rocket_buffer' => [ 'treeshake', 11 ],
+			'rocket_buffer' => [ 'treeshake', 12 ],
 		];
 	}
 

--- a/inc/Engine/Optimization/RUCSS/Warmup/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Warmup/Subscriber.php
@@ -40,7 +40,7 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events() : array {
 		return [
-			'rocket_buffer' => [ 'collect_resources', 11 ],
+			'rocket_buffer' => [ 'collect_resources', 1 ],
 		];
 	}
 

--- a/inc/Engine/Optimization/RUCSS/Warmup/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Warmup/Subscriber.php
@@ -40,7 +40,7 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events() : array {
 		return [
-			'rocket_buffer' => 'collect_resources',
+			'rocket_buffer' => [ 'collect_resources', 11 ],
 		];
 	}
 


### PR DESCRIPTION
## Description

Related to : https://github.com/wp-media/tree-shaker/issues/73

Tested this and reproduced on 2 different sites. The backslash is removed from the CSS `content` attribute in the generated used CSS.

An example:

Original CSS rule:
```
.icon--calendar::before {
    content: "\e02b";
}
```

Used CSS rule:
```
.icon--calendar::before {
    content: "e02b";
}
```

This type of content value is often used by icons fonts. 

## Fixes  & Solution

The issue is related to `stripslashes` from Query on all strings. This is causing the error. In order to bypass this I replaced the `content: \e` with `shaker-parser:\'dashe` when storing it in the DB and when reading I am converting it back.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
