### PR TITLE
Fixes #3743 Improve i18n of add-ons list separated with ' and '

### DIFF
--- a/inc/Engine/Admin/Settings/Page.php
+++ b/inc/Engine/Admin/Settings/Page.php
@@ -1572,16 +1572,16 @@ class Page {
 		}
 
 		if ( ! empty( $addons ) ) {
-			$maybe_display_cdn_helper = sprintf(
-				// translators: %1$s = opening em tag, %2$s = add-on name(s), %3$s = closing em tag.
+			$maybe_display_cdn_helper = wp_sprintf(
+				// translators: %1$s = opening em tag, %2$l = list of add-on name(s), %3$s = closing em tag.
 				_n(
-					'%1$s%2$s Add-on%3$s is currently enabled. Configuration of the CDN settings is not required for %2$s to work on your site.',
-					'%1$s%2$s Add-ons%3$s are currently enabled. Configuration of the CDN settings is not required for %2$s to work on your site.',
+					'%1$s%2$l Add-on%3$s is currently enabled. Configuration of the CDN settings is not required for %2$l to work on your site.',
+					'%1$s%2$l Add-ons%3$s are currently enabled. Configuration of the CDN settings is not required for %2$l to work on your site.',
 					count( $addons ),
 					'rocket'
 				),
 				'<em>',
-				implode( ' and ', $addons ),
+				$addons,
 				'</em>'
 			) . '<br>';
 		}


### PR DESCRIPTION
## Description
Fixes i18n of list of add-ons separated by non-i18n `' and '`, that is now translated by WP core itself.

WordPress itself can add a fully localized list separated with `','` and `' and '`.
Use `wp_sprintf()` with `$l` instead of regular `sprintf()` with custom non-i18n implode with ' and '.
Check out the function referrence:
https://developer.wordpress.org/reference/functions/wp_sprintf_l/

Fixes #3743

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation