### PR TITLE
Fixes #1590 Remove translations on custom radio button in the dashboard

### DIFF
--- a/views/settings/fields/one-click-addon.php
+++ b/views/settings/fields/one-click-addon.php
@@ -37,8 +37,8 @@ defined( 'ABSPATH' ) || exit;
 			<div class="wpr-radio wpr-radio--reverse">
 				<input type="checkbox" id="<?php echo esc_attr( $data['id'] ); ?>" class="" name="wp_rocket_settings[<?php echo esc_attr( $data['id'] ); ?>]" value="1" <?php checked( $data['value'], 1 ); ?>>
 				<label for="<?php echo esc_attr( $data['id'] ); ?>" class="">
-					<span data-l10n-active="<?php echo esc_attr_x( 'On', 'Active state of checkbox', 'rocket' ); ?>"
-						data-l10n-inactive="<?php echo esc_attr_x( 'Off', 'Inactive state of checkbox', 'rocket' ); ?>" class="wpr-radio-ui"></span>
+					<span data-l10n-active="On"
+						data-l10n-inactive="Off" class="wpr-radio-ui"></span>
 					<?php esc_html_e( 'Add-on status', 'rocket' ); ?>
 				</label>
 			</div>

--- a/views/settings/fields/rocket-addon.php
+++ b/views/settings/fields/rocket-addon.php
@@ -28,8 +28,8 @@ $rocket_settings_page = ! empty( $data['settings_page'] ) ? $data['settings_page
 			<div class="wpr-radio wpr-radio--reverse">
 				<input type="checkbox" id="<?php echo esc_attr( $data['id'] ); ?>" class="" name="wp_rocket_settings[<?php echo esc_attr( $data['id'] ); ?>]" value="1" <?php checked( $data['value'], 1 ); ?>>
 				<label for="<?php echo esc_attr( $data['id'] ); ?>" class="">
-					<span data-l10n-active="<?php echo esc_attr_x( 'On', 'Active state of checkbox', 'rocket' ); ?>"
-						data-l10n-inactive="<?php echo esc_attr_x( 'Off', 'Inactive state of checkbox', 'rocket' ); ?>" class="wpr-radio-ui"></span>
+					<span data-l10n-active="On"
+						data-l10n-inactive="Off" class="wpr-radio-ui"></span>
 					<?php esc_html_e( 'Add-on status', 'rocket' ); ?>
 				</label>
 			</div>

--- a/views/settings/fields/sliding-checkbox.php
+++ b/views/settings/fields/sliding-checkbox.php
@@ -22,8 +22,8 @@ defined( 'ABSPATH' ) || exit;
 	<div class="wpr-radio">
 		<input type="checkbox" id="<?php echo esc_attr( $data['id'] ); ?>" class="" name="wp_rocket_settings[<?php echo esc_attr( $data['id'] ); ?>]" value="1" <?php checked( $data['value'], 1 ); ?>>
 		<label for="<?php echo esc_attr( $data['id'] ); ?>" class="">
-			<span data-l10n-active="<?php echo esc_attr_x( 'On', 'Active state of checkbox', 'rocket' ); ?>"
-				data-l10n-inactive="<?php echo esc_attr_x( 'Off', 'Inactive state of checkbox', 'rocket' ); ?>" class="wpr-radio-ui"></span>
+			<span data-l10n-active="On"
+				data-l10n-inactive="Off" class="wpr-radio-ui"></span>
 			<?php echo esc_html( $data['label'] ); ?>
 		</label>
 	</div>

--- a/views/settings/page.php
+++ b/views/settings/page.php
@@ -52,8 +52,8 @@ settings_errors( $data['slug'] ); ?>
 				<div class="wpr-radio wpr-radio--reverse wpr-radio--tips">
 					<input type="checkbox" class="wpr-js-tips" id="wpr-js-tips" value="1" checked>
 					<label for="wpr-js-tips">
-						<span data-l10n-active="<?php echo esc_attr_x( 'On', 'Active state of checkbox', 'rocket' ); ?>"
-							data-l10n-inactive="<?php echo esc_attr_x( 'Off', 'Inactive state of checkbox', 'rocket' ); ?>" class="wpr-radio-ui"></span>
+						<span data-l10n-active="On"
+							data-l10n-inactive="Off" class="wpr-radio-ui"></span>
 						<?php esc_html_e( 'Show Sidebar', 'rocket' ); ?></label>
 				</div>
 			</div>


### PR DESCRIPTION
## Description

Remove the translations on the custom radio button labels in the dashboard.

The translations were causing display issues when using words that are not short like the original On/Off in english.

Fixes #1590

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

No

## How Has This Been Tested?

- [x] Manual test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings