### PR TITLE
Fire action when any resource content changed

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Warmup/ResourceFetcherProcess.php
+++ b/inc/Engine/Optimization/RUCSS/Warmup/ResourceFetcherProcess.php
@@ -63,7 +63,7 @@ class ResourceFetcherProcess extends WP_Rocket_WP_Background_Process {
 	 *
 	 * @param array $resource Resource array consists of url, content, type and media (for css only).
 	 *
-	 * @return false
+	 * @return bool False for success, remove item from queue and True for failure so requeue this item.
 	 */
 	protected function task( $resource ) {
 		if ( ! is_array( $resource ) ) {


### PR DESCRIPTION
Fire a new action `rocket_rucss_file_changed` when any resource on the page changed its content so we can hook this action to empty used_css table as we don't know which resource is attached to which page.

**Note:** The sequence of emptying used_css table would be as follows:-

1. Page is loaded.
2. Resources are being collected via Async process.
3. In another background process we are making the DB checks for the content and detect changed resources then we call saas warmup and also fire this new action.
4. On the same page loading we call saas treeshaker lately and used_css row is created for this page and added to the cache file.
5. In most cases if content changed, used_css row will be deleted right after the cache file being created and used_css row is created also, SO this change will affect the next round of cache.