### PR TITLE
RUCSS cron for auto-retries after 30minutes

### DIFF
--- a/inc/Engine/Cache/Purge.php
+++ b/inc/Engine/Cache/Purge.php
@@ -46,7 +46,7 @@ class Purge {
 	 * @param boolean $pagination Purge also pagination.
 	 * @return void
 	 */
-	private function purge_url( $url, $pagination = false ) {
+	public function purge_url( $url, $pagination = false ) {
 		global $wp_rewrite;
 
 		$parsed_url = $this->parse_url( $url );

--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -77,7 +77,7 @@ class UsedCSS {
 	/**
 	 * Get UsedCSS from DB table which has unprocessed CSS files.
 	 *
-	 * @return void
+	 * @return array
 	 */
 	public function get_used_css_with_unprocessed_css() {
 		$query = $this->used_css_query->query(

--- a/inc/Engine/Optimization/RUCSS/Frontend/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Frontend/Subscriber.php
@@ -31,11 +31,18 @@ class Subscriber implements Subscriber_Interface {
 	private $used_css;
 
 	/**
+	 * Name of the cron.
+	 *
+	 * @var string
+	 */
+	const CRON_NAME = 'rocket_rucss_retries';
+
+	/**
 	 * Instantiate the class
 	 *
-	 * @param Options_Data $options      Plugin options instance.
-	 * @param UsedCSS      $used_css Settings instance.
-	 * @param APIClient    $api      Database instance.
+	 * @param Options_Data $options  Plugin options instance.
+	 * @param UsedCSS      $used_css UsedCSS instance.
+	 * @param APIClient    $api      APIClient instance.
 	 */
 	public function __construct( Options_Data $options, UsedCSS $used_css, APIClient $api ) {
 		$this->options  = $options;
@@ -51,6 +58,7 @@ class Subscriber implements Subscriber_Interface {
 	public static function get_subscribed_events() : array {
 		return [
 			'rocket_buffer' => [ 'treeshake', 12 ],
+			self::CRON_NAME => 'rucss_retries',
 		];
 	}
 
@@ -99,6 +107,10 @@ class Subscriber implements Subscriber_Interface {
 				$retries = $used_css->retries;
 			}
 
+			if ( ! empty( $treeshaked_result['unprocessed_css'] ) ) {
+				$this->schedule_rucss_retry();
+			}
+
 			$data = [
 				'url'            => $url,
 				'css'            => $treeshaked_result['css'],
@@ -121,6 +133,35 @@ class Subscriber implements Subscriber_Interface {
 		$this->used_css->update_last_accessed( (int) $used_css->id );
 
 		return $html;
+	}
+
+	/**
+	 * Schedules RUCSS to retry pages with missing CSS files.
+	 * Retries happen after 30 minutes.
+	 *
+	 * @return void
+	 */
+	public function schedule_rucss_retry() {
+		$scheduled = wp_next_scheduled( self::CRON_NAME );
+
+		if ( $scheduled ) {
+			return;
+		}
+
+		wp_schedule_single_event( time() + ( 60 * 30 ), self::CRON_NAME );
+	}
+
+	/**
+	 * Retries to regenerate the used css.
+	 *
+	 * @return void
+	 */
+	public function rucss_retries() {
+		if ( ! $this->is_allowed() ) {
+			return;
+		}
+
+		$this->used_css->retries_pages_with_unprocessed_css();
 	}
 
 	/**

--- a/inc/Engine/Optimization/RUCSS/Frontend/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Frontend/Subscriber.php
@@ -148,7 +148,7 @@ class Subscriber implements Subscriber_Interface {
 			return;
 		}
 
-		wp_schedule_single_event( time() + ( 60 * 30 ), self::CRON_NAME );
+		wp_schedule_single_event( time() + ( 0.5 * HOUR_IN_SECONDS ), self::CRON_NAME );
 	}
 
 	/**

--- a/inc/Engine/Optimization/RUCSS/Frontend/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Frontend/Subscriber.php
@@ -35,7 +35,7 @@ class Subscriber implements Subscriber_Interface {
 	 *
 	 * @var string
 	 */
-	const CRON_NAME = 'rocket_rucss_retries';
+	const CRON_NAME = 'rocket_rucss_retries_cron';
 
 	/**
 	 * Instantiate the class
@@ -157,7 +157,7 @@ class Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function rucss_retries() {
-		if ( ! $this->is_allowed() ) {
+		if ( ! (bool) $this->options->get( 'remove_unused_css', 0 ) ) {
 			return;
 		}
 

--- a/inc/Engine/Optimization/RUCSS/ServiceProvider.php
+++ b/inc/Engine/Optimization/RUCSS/ServiceProvider.php
@@ -53,7 +53,8 @@ class ServiceProvider extends AbstractServiceProvider {
 		$this->getContainer()->add( 'rucss_used_css_query', 'WP_Rocket\Engine\Optimization\RUCSS\Database\Query\UsedCSS' );
 		$this->getContainer()->add( 'rucss_frontend_api_client', 'WP_Rocket\Engine\Optimization\RUCSS\Frontend\APIClient' );
 		$this->getContainer()->add( 'rucss_used_css_controller', 'WP_Rocket\Engine\Optimization\RUCSS\Controller\UsedCSS' )
-			->addArgument( $this->getContainer()->get( 'rucss_used_css_query' ) );
+			->addArgument( $this->getContainer()->get( 'rucss_used_css_query' ) )
+			->addArgument( $this->getContainer()->get( 'purge' ) );
 
 		$this->getContainer()->share( 'rucss_admin_subscriber', 'WP_Rocket\Engine\Optimization\RUCSS\Admin\Subscriber' )
 			->addArgument( $this->getContainer()->get( 'rucss_settings' ) )


### PR DESCRIPTION
## Description

Cron for retry regenerating Used CSS from Saas in case there are any missed CSS files (from unprocesscss list).

In case a page returns a not empty `unprocessed_css` it will trigger a cron (`wp_schedule_single_event`) which will:
1. Grab all URLs which have not empty `unprocessed_css` from the DB
2. Will reset the `retries = 1`
3. Will clean the page cache.

In this way we force the page cache to be regenerated with RUCSS after 30 minutes we identify any missing CSS files from Saas cache.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules