### PR TITLE
Make sure we return `is_success()` results when migrating

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Database/Tables/Resources.php
+++ b/inc/Engine/Optimization/RUCSS/Database/Tables/Resources.php
@@ -78,8 +78,7 @@ final class Resources extends Table {
 		$removed = $this->get_db()->query( "ALTER TABLE {$this->table_name} DROP INDEX hash" );
 		$added   = $this->get_db()->query( "ALTER TABLE {$this->table_name} ADD INDEX hash (hash)" );
 
-		$this->is_success( $removed && $added );
-
+		return $this->is_success( $removed && $added );
 	}
 
 	/**
@@ -96,8 +95,7 @@ final class Resources extends Table {
 
 		$created = $this->get_db()->query( "ALTER TABLE {$this->table_name} ADD COLUMN media VARCHAR(255) NULL default 'all' AFTER type " );
 
-		$this->is_success( $created );
-
+		return $this->is_success( $created );
 	}
 
 }

--- a/inc/Engine/Optimization/RUCSS/Database/Tables/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Database/Tables/UsedCSS.php
@@ -97,6 +97,6 @@ final class UsedCSS extends Table {
 		$removed = $this->get_db()->query( "ALTER TABLE {$this->table_name} DROP INDEX url" );
 		$added   = $this->get_db()->query( "ALTER TABLE {$this->table_name} ADD INDEX url (url(150), is_mobile)" );
 
-		$this->is_success( $removed && $added );
+		return $this->is_success( $removed && $added );
 	}
 }


### PR DESCRIPTION
## Fixes the missing return statements on the DB migration methods.

Just a quick patch to the last line of the methods here.