### PR TITLE
Tests for Database::truncate_used_css_table()

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Database/Tables/Resources.php
+++ b/inc/Engine/Optimization/RUCSS/Database/Tables/Resources.php
@@ -7,7 +7,7 @@ use WP_Rocket\Dependencies\Database\Table;
 /**
  * RUCSS Resources Table.
  */
-final class Resources extends Table {
+class Resources extends Table {
 
 	/**
 	 * Table name

--- a/inc/Engine/Optimization/RUCSS/Database/Tables/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Database/Tables/UsedCSS.php
@@ -7,7 +7,7 @@ use WP_Rocket\Dependencies\Database\Table;
 /**
  * RUCSS UsedCSS Table.
  */
-final class UsedCSS extends Table {
+class UsedCSS extends Table {
 
 	/**
 	 * Table name

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Database/truncateUsedCssTable.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Database/truncateUsedCssTable.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+	'test_data' => [
+		'shouldBailoutWhenTablesDoNotExist' => [
+			'input' => [
+				'usedCSS' => [
+					'exists' => false,
+				],
+			],
+		],
+		'shouldTruncate' => [
+			'input' => [
+				'usedCSS' => [
+					'exists'   => true,
+					'truncate' => true,
+				],
+			],
+		],
+	],
+];

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Database/truncateUsedCssTable.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Database/truncateUsedCssTable.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\Optimization\RUCSS\Admin\Database;
+
+use WP_Rocket\Tests\Integration\DBTrait;
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Optimization\RUCSS\Admin\Database::truncate_used_css_table
+ *
+ * @group  RUCSS
+ */
+class Test_TruncateUsedCssTable extends TestCase{
+	use DBTrait;
+
+	public static function setUpBeforeClass(): void {
+		self::installFresh();
+
+		parent::setUpBeforeClass();
+	}
+
+	public static function tearDownAfterClass() {
+		parent::tearDownAfterClass();
+
+		self::uninstallAll();
+	}
+
+	public function tearDown() : void {
+		remove_filter( 'pre_get_rocket_option_remove_unused_css', [ $this, 'set_rucss_option' ] );
+
+		parent::tearDown();
+	}
+
+	public function testShouldTruncateTableWhenOptionIsEnabled(){
+		$container           = apply_filters( 'rocket_container', null );
+		$rucss_usedcss_table = $container->get( 'rucss_usedcss_table' );
+		$rucss_usedcss_query = $container->get( 'rucss_used_css_query' );
+
+		add_filter( 'pre_get_rocket_option_remove_unused_css', [ $this, 'set_rucss_option' ] );
+
+		$rucss_usedcss_query->add_item(
+			[
+				'url'            => 'http://example.org/home',
+				'css'            => 'h1{color:red;}',
+				'unprocessedcss' => wp_json_encode( [] ),
+				'retries'        => 3,
+				'is_mobile'      => false,
+			]
+		);
+		$rucss_usedcss_query->add_item(
+			[
+				'url'            => 'http://example.org/home',
+				'css'            => 'h1{color:red;}',
+				'unprocessedcss' => wp_json_encode( [] ),
+				'retries'        => 3,
+				'is_mobile'      => true,
+			]
+		);
+
+		$result = $rucss_usedcss_query->query();
+
+		$this->assertTrue( $rucss_usedcss_table->exists() );
+		$this->assertCount( 2, $result );
+
+		do_action( 'rocket_rucss_file_changed' );
+
+		$rucss_usedcss_query = $container->get( 'rucss_used_css_query' );
+		$resultAfterTruncate = $rucss_usedcss_query->query();
+
+		$this->assertCount( 0, $resultAfterTruncate );
+	}
+
+	public function set_rucss_option() {
+		return true;
+	}
+}

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Database/truncateUsedCssTable.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Database/truncateUsedCssTable.php
@@ -11,7 +11,7 @@ use WP_Rocket\Engine\Optimization\RUCSS\Database\Tables\UsedCSS;
 /**
  * @covers \WP_Rocket\Engine\Optimization\RUCSS\Admin\Database::truncate_used_css_table
  *
- * @group  RUCSSX
+ * @group  RUCSS
  */
 class Test_TruncateUsedCssTable extends TestCase{
 	private $resources;

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Database/truncateUsedCssTable.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Database/truncateUsedCssTable.php
@@ -1,0 +1,74 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\RUCSS\Admin\Database;
+
+use WP_Rocket\Tests\Unit\TestCase;
+use WP_Rocket\Engine\Optimization\RUCSS\Admin\Database;
+use WP_Rocket\Engine\Optimization\RUCSS\Database\Tables\Resources;
+use WP_Rocket\Engine\Optimization\RUCSS\Database\Tables\UsedCSS;
+
+/**
+ * @covers \WP_Rocket\Engine\Optimization\RUCSS\Admin\Database::truncate_used_css_table
+ *
+ * @group  RUCSSX
+ */
+class Test_TruncateUsedCssTable extends TestCase{
+	private $resources;
+	private $usedCSS;
+	private $database;
+
+	public function setUp() : void {
+		parent::setUp();
+
+		if ( $this->isPHP8() ) {
+			return;
+		}
+
+		$this->resources = $this->getMockBuilder('WP_Rocket\Engine\Optimization\RUCSS\Database\Tables\Resources')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->usedCSS = $this->getMockBuilder('WP_Rocket\Engine\Optimization\RUCSS\Database\Tables\UsedCSS')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->database  = new Database( $this->resources, $this->usedCSS );
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldDoExpected( $input ){
+		if ( $this->isPHP8() ) {
+			$this->assertTrue(true);
+			return;
+		}
+
+		$this->usedCSS->expects( $this->once() )
+			->method( 'exists' )
+			->will( $this->returnValue( $input['usedCSS']['exists'] ) );
+
+		if ( true === $input['usedCSS']['exists'] ) {
+			$this->usedCSS->expects( $this->once() )
+				->method('truncate')
+				->will( $this->returnValue( $input['usedCSS']['truncate'] ) );
+		}
+
+		$this->database->truncate_used_css_table();
+	}
+
+	/**
+	 * Check if is PHP8.
+	 *
+	 * @return bool
+	 */
+	public function isPHP8() {
+		$version = explode('.', PHP_VERSION);
+		if ( $version[0] >= 8 ) {
+			$this->assertTrue(true);
+			return true;
+		}
+
+		return false;
+	}
+}


### PR DESCRIPTION
## Description

Subtask of #3635

Tests for  **Admin\Database**
-  truncate_used_css_table() - Cristina

## How Has This Been Tested?

Unit and Integration tests pass.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules