### PR TITLE
Add tests for RUCSS/Admin/Subscriber

### DIFF
--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cronCleanRows.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cronCleanRows.php
@@ -1,0 +1,61 @@
+<?php
+
+$current_date = current_time( 'mysql', true );
+$old_date     = date('Y-m-d H:i:s', strtotime( $current_date. ' - 1 month' ) );
+
+$used_css = [
+	[
+		'url'            => 'http://example.org/path1',
+		'css'            => 'h1{color:red;}',
+		'unprocessedcss' => wp_json_encode( [] ),
+		'retries'        => 3,
+		'is_mobile'      => false,
+		'modified'       => $old_date,
+		'last_accessed'  => $old_date,
+	],
+	[
+		'url'            => 'http://example.org/path2',
+		'css'            => 'h1{color:red;}',
+		'unprocessedcss' => wp_json_encode( [] ),
+		'retries'        => 3,
+		'is_mobile'      => false,
+		'modified'       => $old_date,
+		'last_accessed'  => $old_date,
+	],
+];
+
+$resources = [
+	[
+		'url'           => 'http://example.org/wp-content/themes/theme-name/style.css',
+		'content'       => '.theme-name{color:red;}',
+		'type'          => 'css',
+		'media'         => 'all',
+		'modified'      => $old_date,
+		'last_accessed' => $old_date,
+	],
+	[
+		'url'           => 'http://example.org/css/style.css',
+		'content'       => '.first{color:green;}',
+		'type'          => 'css',
+		'media'         => 'all',
+		'modified'      => $current_date,
+		'last_accessed' => $current_date,
+	]
+];
+
+return [
+	'shouldNotDeleteOnUpdateDueToMissingSettings' => [
+		'input' => [
+			'remove_unused_css' => false,
+			'used_css'          => $used_css,
+			'resources'         => $resources,
+		]
+	],
+	'shouldDeleteOnUpdate' => [
+		'input' => [
+			'remove_unused_css' => true,
+			'used_css'          => $used_css,
+			'resources'         => $resources,
+		]
+	],
+];

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/deleteUsedCssOnUpdateOrDelete.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/deleteUsedCssOnUpdateOrDelete.php
@@ -1,0 +1,34 @@
+<?php
+
+$items = [
+	[
+		'url'            => 'http://example.org/path1',
+		'css'            => 'h1{color:red;}',
+		'unprocessedcss' => wp_json_encode( [] ),
+		'retries'        => 3,
+		'is_mobile'      => false,
+	],
+	[
+		'url'            => 'http://example.org/path2',
+		'css'            => 'h1{color:red;}',
+		'unprocessedcss' => wp_json_encode( [] ),
+		'retries'        => 3,
+		'is_mobile'      => false,
+	],
+];
+
+
+return [
+	'shouldNotDeleteOnUpdateDueToMissingSettings' => [
+		'input' => [
+			'remove_unused_css' => false,
+			'items'             => $items,
+		]
+	],
+	'shouldDeleteOnUpdate' => [
+		'input' => [
+			'remove_unused_css' => true,
+			'items'             => $items,
+		]
+	],
+];

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/scheduleCleanNotCommonlyUsedRows.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/scheduleCleanNotCommonlyUsedRows.php
@@ -1,0 +1,14 @@
+<?php
+
+return [
+	'shouldNotScheduleCronDueToMissingSettings' => [
+		'input' => [
+			'remove_unused_css' => false,
+		]
+	],
+	'shouldScheduleCron' => [
+		'input' => [
+			'remove_unused_css' => true,
+		]
+	],
+];

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/truncateUsedCss.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/truncateUsedCss.php
@@ -1,0 +1,34 @@
+<?php
+
+$items = [
+	[
+		'url'            => 'http://example.org/home',
+		'css'            => 'h1{color:red;}',
+		'unprocessedcss' => wp_json_encode( [] ),
+		'retries'        => 3,
+		'is_mobile'      => false,
+	],
+	[
+		'url'            => 'http://example.org/home',
+		'css'            => 'h1{color:red;}',
+		'unprocessedcss' => wp_json_encode( [] ),
+		'retries'        => 3,
+		'is_mobile'      => true,
+	],
+];
+
+
+return [
+	'shouldNotTruncateUnusedCSSDueToMissingSettings' => [
+		'input' => [
+			'remove_unused_css' => false,
+			'items'             => $items,
+		]
+	],
+	'shouldTruncateUnusedCSS' => [
+		'input' => [
+			'remove_unused_css' => true,
+			'items'             => $items,
+		]
+	],
+];

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cronCleanRows.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cronCleanRows.php
@@ -14,7 +14,7 @@ use WP_Rocket\Tests\Integration\TestCase;
 class Test_CronCleanRows extends TestCase{
 	use DBTrait;
 
-	private $posts;
+	private $input;
 
 	public static function setUpBeforeClass(): void {
 		self::installFresh();

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cronCleanRows.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cronCleanRows.php
@@ -1,0 +1,93 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\Optimization\RUCSS\Admin\Subscriber;
+
+use WP_Rocket\Tests\Integration\DBTrait;
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Optimization\RUCSS\Admin\Subscriber::cron_clean_rows
+ *
+ * @group  RUCSS
+ */
+class Test_CronCleanRows extends TestCase{
+	use DBTrait;
+
+	private $posts;
+
+	public static function setUpBeforeClass(): void {
+		self::installFresh();
+
+		parent::setUpBeforeClass();
+	}
+
+	public static function tearDownAfterClass() {
+		parent::tearDownAfterClass();
+
+		self::uninstallAll();
+	}
+
+	public function tearDown() : void {
+		remove_filter( 'pre_get_rocket_option_remove_unused_css', [ $this, 'set_rucss_option' ] );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldDoExpected( $input ){
+		$container              = apply_filters( 'rocket_container', null );
+		$rucss_usedcss_query   = $container->get( 'rucss_used_css_query' );
+		$rucss_resources_query = $container->get( 'rucss_resources_query' );
+		$current_date          = current_time( 'mysql', true );
+		$old_date              = strtotime( $current_date. ' - 1 month' );
+
+		$this->input = $input;
+		add_filter( 'pre_get_rocket_option_remove_unused_css', [ $this, 'set_rucss_option' ] );
+
+		$count_remain_used_css = 0;
+		foreach ( $input['used_css'] as $used_css ) {
+			if ( $old_date <  strtotime( $used_css['last_accessed']) ) {
+				$count_remain_used_css ++;
+			}
+			$rucss_usedcss_query->add_item( $used_css );
+		}
+
+		$result_used_css = $rucss_usedcss_query->query();
+		$this->assertCount( count( $input['used_css'] ), $result_used_css );
+
+
+		$count_remain_resources = 0;
+		foreach ( $input['resources'] as $resource ) {
+			if ( $old_date <  strtotime( $resource['last_accessed']) ) {
+				$count_remain_resources ++;
+			}
+			$rucss_resources_query->add_item( $resource );
+		}
+
+		$result_resources = $rucss_resources_query->query();
+		$this->assertCount( count( $input['resources'] ), $result_resources );
+
+		do_action( 'rocket_rucss_clean_rows_time_event' );
+
+		$rucss_usedcss_query       = $container->get( 'rucss_used_css_query' );
+		$rucss_resources_query     = $container->get( 'rucss_resources_query' );
+		$resultUsedCssAfterClean   = $rucss_usedcss_query->query();
+		$resultResourcesAfterClean = $rucss_resources_query->query();
+
+
+		if ( $this->input['remove_unused_css'] ) {
+			$this->assertCount( $count_remain_used_css,$resultUsedCssAfterClean );
+			$this->assertCount( $count_remain_resources, $resultResourcesAfterClean );
+		} else {
+			$this->assertCount( count( $input['used_css'] ), $resultUsedCssAfterClean );
+			$this->assertCount( count( $input['resources'] ), $resultResourcesAfterClean );
+		}
+	}
+
+	public function set_rucss_option() {
+		return $this->input['remove_unused_css'] ?? false;
+	}
+}

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/deleteUsedCssOnUpdateOrDelete.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/deleteUsedCssOnUpdateOrDelete.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\Optimization\RUCSS\Admin\Subscriber;
+
+use WP_Rocket\Tests\Integration\DBTrait;
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Optimization\RUCSS\Admin\Subscriber::delete_used_css_on_update_or_delete
+ *
+ * @group  RUCSS
+ */
+class Test_DeleteUsedCssOnUpdateOrDelete extends TestCase{
+	use DBTrait;
+
+	private $posts;
+
+	public static function setUpBeforeClass(): void {
+		self::installFresh();
+
+		parent::setUpBeforeClass();
+	}
+
+	public static function tearDownAfterClass() {
+		parent::tearDownAfterClass();
+
+		self::uninstallAll();
+	}
+
+	public function tearDown() : void {
+		remove_filter( 'pre_get_rocket_option_remove_unused_css', [ $this, 'set_rucss_option' ] );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldTruncateTableWhenOptionIsEnabled( $input ){
+		$container           = apply_filters( 'rocket_container', null );
+		$rucss_usedcss_query = $container->get( 'rucss_used_css_query' );
+
+		$this->input = $input;
+		add_filter( 'pre_get_rocket_option_remove_unused_css', [ $this, 'set_rucss_option' ] );
+
+		foreach ( $input['items'] as $item ) {
+			$post          = $this->factory->post->create_and_get();
+			$url           = untrailingslashit( get_permalink( $post->ID ) );
+			$item['url']   = $url;
+			$this->posts[] = $post;
+
+			$rucss_usedcss_query->add_item( $item );
+		}
+
+		$result = $rucss_usedcss_query->query();
+		$this->assertCount( count( $input['items'] ), $result );
+
+		foreach ( $this->posts as $post ) {
+			do_action( 'delete_post', $post->ID );
+		}
+
+		$rucss_usedcss_query = $container->get( 'rucss_used_css_query' );
+		$resultAfterTruncate = $rucss_usedcss_query->query();
+
+		if ( $this->input['remove_unused_css'] ) {
+			$this->assertCount( 0, $resultAfterTruncate );
+		} else {
+			$this->assertCount( count( $input['items'] ), $result );
+		}
+	}
+
+	public function set_rucss_option() {
+		return $this->input['remove_unused_css'] ?? false;
+	}
+}

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/deleteUsedCssOnUpdateOrDelete.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/deleteUsedCssOnUpdateOrDelete.php
@@ -15,6 +15,7 @@ class Test_DeleteUsedCssOnUpdateOrDelete extends TestCase{
 	use DBTrait;
 
 	private $posts;
+	private $input;
 
 	public static function setUpBeforeClass(): void {
 		self::installFresh();

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/scheduleCleanNotCommonlyUsedRows.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/scheduleCleanNotCommonlyUsedRows.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\Optimization\RUCSS\Admin\Subscriber;
+
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Optimization\RUCSS\Admin\Subscriber::schedule_clean_not_commonly_used_rows
+ *
+ * @group  RUCSS
+ */
+class Test_ScheduleCleanNotCommonlyUsedRows extends TestCase{
+
+	public function tearDown() : void {
+		remove_filter( 'pre_get_rocket_option_remove_unused_css', [ $this, 'set_rucss_option' ] );
+		wp_clear_scheduled_hook( 'rocket_rucss_clean_rows_time_event' );
+		parent::tearDown();
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldDoExpected( $input ){
+		$this->input = $input;
+		add_filter( 'pre_get_rocket_option_remove_unused_css', [ $this, 'set_rucss_option' ] );
+
+		do_action( 'init' );
+
+		if ( $this->input['remove_unused_css'] ) {
+			$this->assertNotFalse( wp_next_scheduled( 'rocket_rucss_clean_rows_time_event' ) );
+		} else {
+			$this->assertFalse( wp_next_scheduled( 'rocket_rucss_clean_rows_time_event' ) );
+		}
+	}
+
+	public function set_rucss_option() {
+		return $this->input['remove_unused_css'] ?? false;
+	}
+}

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/truncateUsedCss.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/truncateUsedCss.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\Optimization\RUCSS\Admin\Subscriber;
+
+use WP_Rocket\Tests\Integration\DBTrait;
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Optimization\RUCSS\Admin\Subscriber::truncate_used_css
+ *
+ * @group  RUCSS
+ */
+class Test_TruncateUsedCss extends TestCase{
+	use DBTrait;
+
+	public static function setUpBeforeClass(): void {
+		self::installFresh();
+
+		parent::setUpBeforeClass();
+	}
+
+	public static function tearDownAfterClass() {
+		parent::tearDownAfterClass();
+
+		self::uninstallAll();
+	}
+
+	public function tearDown() : void {
+		remove_filter( 'pre_get_rocket_option_remove_unused_css', [ $this, 'set_rucss_option' ] );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldTruncateTableWhenOptionIsEnabled( $input ){
+		$container           = apply_filters( 'rocket_container', null );
+		$rucss_usedcss_query = $container->get( 'rucss_used_css_query' );
+
+		$this->input = $input;
+		add_filter( 'pre_get_rocket_option_remove_unused_css', [ $this, 'set_rucss_option' ] );
+
+		foreach ( $input['items'] as $item ) {
+			$rucss_usedcss_query->add_item( $item );
+		}
+
+		$result = $rucss_usedcss_query->query();
+
+		$this->assertCount( count( $input['items'] ), $result );
+
+		do_action( 'rocket_rucss_file_changed' );
+
+		$rucss_usedcss_query = $container->get( 'rucss_used_css_query' );
+		$resultAfterTruncate = $rucss_usedcss_query->query();
+
+		if ( $this->input['remove_unused_css'] ) {
+			$this->assertCount( 0, $resultAfterTruncate );
+		} else {
+			$this->assertCount( count( $input['items'] ), $result );
+		}
+	}
+
+	public function set_rucss_option() {
+		return $this->input['remove_unused_css'] ?? false;
+	}
+}

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/truncateUsedCss.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/truncateUsedCss.php
@@ -14,6 +14,8 @@ use WP_Rocket\Tests\Integration\TestCase;
 class Test_TruncateUsedCss extends TestCase{
 	use DBTrait;
 
+	private $input;
+
 	public static function setUpBeforeClass(): void {
 		self::installFresh();
 


### PR DESCRIPTION
## Description

Subtask of #3635

#### `Admin\Subscriber`
- [x] `cron_clean_rows()` - Cristina
- [x] `schedule_clean_not_commonly_used_rows()` - Cristina
- [x] `delete_used_css_on_update_or_delete()` - Cristina
- [x] `truncate_used_css()` - Cristina

## How Has This Been Tested?

Integration tests pass.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules