### PR TITLE
Warmup javascript files firstly

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Warmup/ResourceFetcher.php
+++ b/inc/Engine/Optimization/RUCSS/Warmup/ResourceFetcher.php
@@ -93,8 +93,8 @@ class ResourceFetcher extends WP_Rocket_WP_Async_Request {
 			return;
 		}
 
-		$this->find_resources( $html, 'css' );
 		$this->find_resources( $html, 'js' );
+		$this->find_resources( $html, 'css' );
 
 		if ( empty( $this->resources ) ) {
 			return;


### PR DESCRIPTION
## Description

Just send javascript files firstly to be warmed-up so it may eliminate the issue of calling saas treeshaker before warming up the JS files