### PR TITLE
Disable preload fonts when RUCSS is enabled and CPCSS is disabled

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -72,6 +72,10 @@ class UsedCSS {
 			return false;
 		}
 
+		if ( is_rocket_post_excluded_option( 'remove_unused_css' ) ) {
+			return false;
+		}
+
 		if ( ! (bool) $this->options->get( 'remove_unused_css', 0 ) ) {
 			return false;
 		}
@@ -530,11 +534,17 @@ class UsedCSS {
 	}
 
 	/**
-	 * Is CPCSS option active or not?
+	 * Checks if CPCSS is enabled on the current page
+	 *
+	 * @since 3.9
 	 *
 	 * @return bool
 	 */
-	private function cpcss_enabled() {
-		return (bool) $this->options->get( 'async_css', 0 );
+	public function cpcss_enabled() {
+		if ( ! $this->options->get( 'async_css', 0 ) ) {
+			return false;
+		}
+
+		return ! is_rocket_post_excluded_option( 'async_css' );
 	}
 }

--- a/inc/Engine/Optimization/RUCSS/Frontend/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Frontend/Subscriber.php
@@ -31,8 +31,9 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events() : array {
 		return [
-			'rocket_buffer'             => [ 'treeshake', 12 ],
-			'rocket_rucss_retries_cron' => 'rucss_retries',
+			'rocket_buffer'                => [ 'treeshake', 12 ],
+			'rocket_rucss_retries_cron'    => 'rucss_retries',
+			'rocket_disable_preload_fonts' => 'maybe_disable_preload_fonts',
 		];
 	}
 
@@ -54,5 +55,26 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	public function rucss_retries() {
 		$this->used_css->retries_pages_with_unprocessed_css();
+	}
+
+	/**
+	 * Disables the preload fonts if RUCSS is enabled + CPCSS disabled
+	 *
+	 * @since 3.9
+	 *
+	 * @param bool $value Value for the disable preload fonts filter.
+	 *
+	 * @return bool
+	 */
+	public function maybe_disable_preload_fonts( $value ): bool {
+		if (
+			$this->used_css->is_allowed()
+			&&
+			! $this->used_css->cpcss_enabled()
+		) {
+			return true;
+		}
+
+		return $value;
 	}
 }

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/maybeDisablePreloadFonts.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/maybeDisablePreloadFonts.php
@@ -1,0 +1,81 @@
+<?php
+
+return [
+    'test_data' => [
+        'testShouldReturnFalseWhenDONOTROCKETOPTIMIZE' => [
+            'config'   => [
+                'type'                           => 'front_page',
+                'DONOTROCKETOPTIMIZE'            => true,
+                'options'                        => [
+                    'async_css'         => true,
+                    'remove_unused_css' => true,
+                ],
+                'is_rocket_post_excluded_option' => [
+					'async_css'         => false,
+                    'remove_unused_css' => false,
+				],
+            ],
+            'expected' => false,
+        ],
+		'testShouldReturnFalseWhenRUCSSDisabled' => [
+            'config'   => [
+                'type'                           => 'front_page',
+                'DONOTROCKETOPTIMIZE'            => false,
+                'options'                        => [
+                    'async_css'         => true,
+                    'remove_unused_css' => false,
+                ],
+                'is_rocket_post_excluded_option' => [
+					'async_css'         => false,
+                    'remove_unused_css' => false,
+				],
+            ],
+            'expected' => false,
+        ],
+		'testShouldReturnFalseWhenRUCSSDisabledPost' => [
+            'config'   => [
+                'type'                           => 'is_post',
+                'DONOTROCKETOPTIMIZE'            => false,
+                'options'                        => [
+                    'async_css'         => true,
+                    'remove_unused_css' => true,
+                ],
+                'is_rocket_post_excluded_option' => [
+					'async_css'         => false,
+                    'remove_unused_css' => true,
+				],
+            ],
+            'expected' => false,
+        ],
+        'testShouldReturnTrueWhenAsyncDisabled' => [
+            'config'   => [
+                'type'                           => 'front_page',
+                'DONOTROCKETOPTIMIZE'            => false,
+                'options'                        => [
+                    'async_css'         => false,
+                    'remove_unused_css' => true,
+                ],
+                'is_rocket_post_excluded_option' => [
+					'async_css'         => false,
+                    'remove_unused_css' => false,
+				],
+            ],
+            'expected' => true,
+        ],
+        'testShouldReturnTrueWhenAsyncDisabledPost' => [
+            'config'   => [
+                'type'                           => 'is_post',
+                'DONOTROCKETOPTIMIZE'            => false,
+                'options'                        => [
+                    'async_css'         => true,
+                    'remove_unused_css' => true,
+                ],
+                'is_rocket_post_excluded_option' => [
+					'async_css'         => true,
+                    'remove_unused_css' => false,
+				],
+            ],
+            'expected' => true,
+        ],
+    ],
+];

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/maybeDisablePreloadFonts.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/maybeDisablePreloadFonts.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\Optimization\RUCSS\Frontend\Subscriber;
+
+use WP_Rocket\Tests\Integration\ContentTrait;
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Optimization\RUCSS\Frontend\Subscriber::maybe_disable_preload_fonts
+ *
+ * @group RUCSS
+ */
+class Test_MaybeDisablePreloadFonts extends TestCase {
+    use ContentTrait;
+
+    private $async_css;
+    private $rucss;
+    private $post;
+
+    public function tearDown() : void {
+        remove_filter( 'pre_get_rocket_option_async_css', [ $this, 'async_css' ] );
+        remove_filter( 'pre_get_rocket_option_remove_unused_css', [ $this, 'rucss' ] );
+
+        if ( isset( $this->post->ID) ) {
+			delete_post_meta( $this->post->ID, '_rocket_exclude_async_css', 1, true );
+            delete_post_meta( $this->post->ID, '_rocket_exclude_remove_unused_css', 1, true );
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+	 * @dataProvider configTestData
+	 */
+    public function testShouldReturnExpected( $config, $expected ) {
+        $this->post = $this->goToContentType( $config );
+
+        $this->donotrocketoptimize = $config['DONOTROCKETOPTIMIZE'];
+
+        $this->async_css = $config['options']['async_css'];
+        $this->rucss     = $config['options']['remove_unused_css'];
+
+        add_filter( 'pre_get_rocket_option_async_css', [ $this, 'async_css' ] );
+        add_filter( 'pre_get_rocket_option_remove_unused_css', [ $this, 'rucss' ] );
+
+        if ( $config['is_rocket_post_excluded_option']['async_css'] ) {
+            add_post_meta( $this->post->ID, '_rocket_exclude_async_css', 1, true );
+        }
+
+		if ( $config['is_rocket_post_excluded_option']['remove_unused_css'] ) {
+            add_post_meta( $this->post->ID, '_rocket_exclude_remove_unused_css', 1, true );
+        }
+
+        $value = apply_filters( 'rocket_disable_preload_fonts', false );
+
+        if ( $expected ) {
+            $this->assertTrue( $value );
+        } else {
+            $this->assertFalse( $value );
+        }
+    }
+
+    public function async_css() {
+        return $this->async_css;
+    }
+
+    public function rucss() {
+        return $this->rucss;
+    }
+}


### PR DESCRIPTION
## Description

This PR disabled the preload fonts when RUCSS is enabled, and CPCSS is disabled.

The preloading is not necessary when the fonts links are contained inline in the HTML. But it is when they are inside a CSS file, which will be the case when we have CPCSS + RUCSS enabled.

It also adds checks for the exclusion of the options on a post from the metabox, which was missing.

## Type of change

- [x] Enhancement (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Added integration tests to validate the new method

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes