### PR TITLE
Exclude nonce actions for Improvise theme by noomia

### DIFF
--- a/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber.php
+++ b/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber.php
@@ -481,6 +481,7 @@ class WooCommerceSubscriber implements Event_Manager_Aware_Subscriber_Interface 
 			'_wc_additional_variation_images_nonce', // WooCommerce Additional Variation Images.
 			'get_price_table', // Tiered Pricing Table for WooCommerce.
 			'wccs_single_product_nonce', // Discount Rules and Dynamic Pricing for WooCommerce.
+			'sign_signin', // Custom Login for Improvise Theme by Noomia.
 		];
 	}
 }


### PR DESCRIPTION
## Description
Exclude `sign_signin` nonce action for Custom Login for Improvise theme by Noomia.

Related ticket: https://secure.helpscout.net/conversation/1467733961/251535/

403 errors on admin-ajax.php when trying to login at the site frontend

## Type of change

- [x] Enhancement (non-breaking change which adds functionality)

## Is the solution different from the one proposed during the grooming?
non-relevant 

Please describe in this section any change to the solution, and why.

## How Has This Been Tested?

- [x] tested at the customer's website

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
