### PR TITLE
Save full url into warmup DB

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Warmup/ResourceFetcher.php
+++ b/inc/Engine/Optimization/RUCSS/Warmup/ResourceFetcher.php
@@ -146,7 +146,7 @@ class ResourceFetcher extends WP_Rocket_WP_Async_Request {
 			}
 
 			$this->resources[ $path ] = [
-				'url'     => rocket_add_url_protocol( $resource['url'] ),
+				'url'     => $this->normalize_url( $resource['url'] ),
 				'content' => $contents,
 				'type'    => $type,
 			];

--- a/inc/Engine/Optimization/RUCSS/Warmup/ResourceFetcher.php
+++ b/inc/Engine/Optimization/RUCSS/Warmup/ResourceFetcher.php
@@ -146,7 +146,7 @@ class ResourceFetcher extends WP_Rocket_WP_Async_Request {
 			}
 
 			$this->resources[ $path ] = [
-				'url'     => $this->normalize_url( $resource['url'] ),
+				'url'     => $this->normalize_url( $resource['url'], false ),
 				'content' => $contents,
 				'type'    => $type,
 			];

--- a/inc/Engine/Optimization/UrlTrait.php
+++ b/inc/Engine/Optimization/UrlTrait.php
@@ -94,7 +94,7 @@ trait UrlTrait {
 	 * Normalize relative url to full url.
 	 *
 	 * @param string $url Url to be normalized.
-	 * @param string $remove_query Remove Query string or not.
+	 * @param bool   $remove_query Remove Query string or not.
 	 *
 	 * @return string Normalized url.
 	 */

--- a/inc/Engine/Optimization/UrlTrait.php
+++ b/inc/Engine/Optimization/UrlTrait.php
@@ -97,7 +97,7 @@ trait UrlTrait {
 	 *
 	 * @return string Normalized url.
 	 */
-	private function normalize_url( $url ) {
+	public function normalize_url( $url ) {
 		$parsed_url = wp_parse_url( $url );
 
 		if ( ! empty( $parsed_url['query'] ) ) {

--- a/inc/Engine/Optimization/UrlTrait.php
+++ b/inc/Engine/Optimization/UrlTrait.php
@@ -94,13 +94,14 @@ trait UrlTrait {
 	 * Normalize relative url to full url.
 	 *
 	 * @param string $url Url to be normalized.
+	 * @param string $remove_query Remove Query string or not.
 	 *
 	 * @return string Normalized url.
 	 */
-	public function normalize_url( $url ) {
+	public function normalize_url( string $url, bool $remove_query = true ) {
 		$parsed_url = wp_parse_url( $url );
 
-		if ( ! empty( $parsed_url['query'] ) ) {
+		if ( $remove_query && ! empty( $parsed_url['query'] ) ) {
 			$url = str_replace( '?' . $parsed_url['query'], '', $url );
 		}
 

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Warmup/ResourceFetcher/Handle.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Warmup/ResourceFetcher/Handle.php
@@ -67,6 +67,7 @@ class Test_Handle extends FilesystemTestCase {
 		}else{
 
 			foreach ( $expected['resources'] as $resource ) {
+
 				$process
 					->shouldReceive( 'push_to_queue' )
 					->with( $resource )

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Warmup/ResourceFetcher/Handle.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Warmup/ResourceFetcher/Handle.php
@@ -67,7 +67,6 @@ class Test_Handle extends FilesystemTestCase {
 		}else{
 
 			foreach ( $expected['resources'] as $resource ) {
-
 				$process
 					->shouldReceive( 'push_to_queue' )
 					->with( $resource )


### PR DESCRIPTION
## Description

When we have relative CSS/JS files, we get their contents properly but saving them with the relative URL into the DB and we need to save the full absolute URL instead of that.