### PR TITLE
Add Integration Tests for Frontend/Subscriber and Controller/UsedCss

### DIFF
--- a/.github/workflows/licence_data.yml
+++ b/.github/workflows/licence_data.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Add a file
         if: ${{ steps.find.outcome == 'failure' }}
-        run: git checkout origin/master licence-data.php
+        run: git checkout trunk/master licence-data.php
         id: add
 
       - name: Commit the missing file

--- a/.github/workflows/licence_data.yml
+++ b/.github/workflows/licence_data.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Add a file
         if: ${{ steps.find.outcome == 'failure' }}
-        run: git checkout trunk/master licence-data.php
+        run: git checkout origin/trunk licence-data.php
         id: add
 
       - name: Commit the missing file

--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -89,6 +89,21 @@ class UsedCSS {
 	}
 
 	/**
+	 * Checks if CPCSS is enabled on the current page
+	 *
+	 * @since 3.9
+	 *
+	 * @return bool
+	 */
+	public function cpcss_enabled() {
+		if ( ! $this->options->get( 'async_css', 0 ) ) {
+			return false;
+		}
+
+		return ! is_rocket_post_excluded_option( 'async_css' );
+	}
+
+	/**
 	 * Apply TreeShaked CSS to the current HTML page.
 	 *
 	 * @param string $html  HTML content.
@@ -163,26 +178,29 @@ class UsedCSS {
 	}
 
 	/**
-	 * Get UsedCSS from DB table based on page url.
+	 * Delete used css based on URL.
 	 *
-	 * @param string $url       The page URL.
-	 * @param bool   $is_mobile Page is_mobile.
+	 * @param string $url The page URL.
 	 *
-	 * @return UsedCSS_Row|false
+	 * @return boolean
 	 */
-	public function get_used_css( string $url, bool $is_mobile = false ) {
-		$query = $this->used_css_query->query(
-					[
-						'url'       => $url,
-						'is_mobile' => $is_mobile,
-					]
-				);
+	public function delete_used_css( string $url ) : bool {
+		$used_css_arr = $this->used_css_query->query( [ 'url' => $url ] );
 
-		if ( empty( $query[0] ) ) {
+		if ( empty( $used_css_arr ) ) {
 			return false;
 		}
 
-		return $query[0];
+		$deleted = true;
+
+		foreach ( $used_css_arr as $used_css ) {
+			if ( empty( $used_css->id ) ) {
+				continue;
+			}
+			$deleted = $deleted && $this->used_css_query->delete_item( $used_css->id );
+		}
+
+		return $deleted;
 	}
 
 	/**
@@ -200,19 +218,43 @@ class UsedCSS {
 		foreach ( $used_css_list as $used_css_item ) {
 			// Resets retries to 1.
 			$updated = $this->used_css_query->update_item(
-							$used_css_item->id,
-							[ 'retries' => 1 ]
-						);
+				$used_css_item->id,
+				[ 'retries' => 1 ]
+			);
 			// Cleans page cache.
 			$this->purge->purge_url( $used_css_item->url );
 		}
 	}
+
+	/**
+	 * Get UsedCSS from DB table based on page url.
+	 *
+	 * @param string $url       The page URL.
+	 * @param bool   $is_mobile Page is_mobile.
+	 *
+	 * @return UsedCSS_Row|false
+	 */
+	private function get_used_css( string $url, bool $is_mobile = false ) {
+		$query = $this->used_css_query->query(
+					[
+						'url'       => $url,
+						'is_mobile' => $is_mobile,
+					]
+				);
+
+		if ( empty( $query[0] ) ) {
+			return false;
+		}
+
+		return $query[0];
+	}
+
 	/**
 	 * Get UsedCSS from DB table which has unprocessed CSS files.
 	 *
 	 * @return array
 	 */
-	public function get_used_css_with_unprocessed_css() {
+	private function get_used_css_with_unprocessed_css() {
 		$query = $this->used_css_query->query(
 			[
 				'unprocessedcss__not_in' => [
@@ -239,7 +281,7 @@ class UsedCSS {
 	 *
 	 * @return UsedCSS_Row|false
 	 */
-	public function save_or_update_used_css( array $data ) {
+	private function save_or_update_used_css( array $data ) {
 		$used_css = $this->get_used_css( $data['url'], $data['is_mobile'] );
 
 		$data['css'] = preg_replace( '/content\s*:\s*"\\\\f/i', 'shaker-parser:"dashf', $data['css'] );
@@ -271,7 +313,7 @@ class UsedCSS {
 	 *
 	 * @return object|false
 	 */
-	public function insert_used_css( array $data ) {
+	private function insert_used_css( array $data ) {
 		$id = $this->used_css_query->add_item( $data );
 		if ( empty( $id ) ) {
 			return false;
@@ -288,7 +330,7 @@ class UsedCSS {
 	 *
 	 * @return object|false
 	 */
-	public function update_used_css( int $id, array $data ) {
+	private function update_used_css( int $id, array $data ) {
 		$updated = $this->used_css_query->update_item( $id, $data );
 
 		if ( ! $updated ) {
@@ -299,32 +341,6 @@ class UsedCSS {
 	}
 
 	/**
-	 * Delete used css based on URL.
-	 *
-	 * @param string $url The page URL.
-	 *
-	 * @return boolean
-	 */
-	public function delete_used_css( string $url ) : bool {
-		$used_css_arr = $this->used_css_query->query( [ 'url' => $url ] );
-
-		if ( empty( $used_css_arr ) ) {
-			return false;
-		}
-
-		$deleted = true;
-
-		foreach ( $used_css_arr as $used_css ) {
-			if ( empty( $used_css->id ) ) {
-				continue;
-			}
-			$deleted = $deleted && $this->used_css_query->delete_item( $used_css->id );
-		}
-
-		return $deleted;
-	}
-
-	/**
 	 * Alter HTML and remove all CSS which was processed from HTML page.
 	 *
 	 * @param string $html            HTML content.
@@ -332,7 +348,7 @@ class UsedCSS {
 	 *
 	 * @return string HTML content.
 	 */
-	public function remove_used_css_from_html( string $html, array $unprocessed_css ) : string {
+	private function remove_used_css_from_html( string $html, array $unprocessed_css ) : string {
 		$html_nocomments    = $this->hide_comments( $html );
 		$link_styles        = $this->find( '<link\s+([^>]+[\s"\'])?href\s*=\s*[\'"]\s*?(?<url>[^\'"]+\.css(?:\?[^\'"]*)?)\s*?[\'"]([^>]+)?\/?>', $html_nocomments );
 		$inline_styles      = $this->find( '<style.*>(?<content>.*)<\/style>', $html_nocomments );
@@ -370,7 +386,7 @@ class UsedCSS {
 	 *
 	 * @return string HTML content.
 	 */
-	public function add_used_css_to_html( string $html, UsedCSS_Row $used_css ) : string {
+	private function add_used_css_to_html( string $html, UsedCSS_Row $used_css ) : string {
 		$replace = preg_replace(
 			'#</title>#iU',
 			'</title>' . $this->get_used_css_markup( $used_css ),
@@ -392,7 +408,7 @@ class UsedCSS {
 	 *
 	 * @return bool
 	 */
-	public function update_last_accessed( int $id ) : bool {
+	private function update_last_accessed( int $id ) : bool {
 		return (bool) $this->used_css_query->update_item(
 			$id,
 			[
@@ -408,7 +424,7 @@ class UsedCSS {
 	 *
 	 * @return string
 	 */
-	protected function hide_comments( string $html ) : string {
+	private function hide_comments( string $html ) : string {
 		$replace = preg_replace( '#<!--\s*noptimize\s*-->.*?<!--\s*/\s*noptimize\s*-->#is', '', $html );
 
 		if ( null === $replace ) {
@@ -432,7 +448,7 @@ class UsedCSS {
 	 *
 	 * @return array Array with type of unprocessed CSS.
 	 */
-	protected function unprocessed_flat_array( string $type, array $unprocessed_css ) : array {
+	private function unprocessed_flat_array( string $type, array $unprocessed_css ) : array {
 		$unprocessed_array = [];
 		foreach ( $unprocessed_css as $css ) {
 			if ( $type === $css['type'] ) {
@@ -449,7 +465,7 @@ class UsedCSS {
 	 *
 	 * @return string
 	 */
-	protected function strip_line_breaks( string $value ) : string {
+	private function strip_line_breaks( string $value ) : string {
 		$value = str_replace( [ "\r", "\n", "\r\n", "\t" ], '', $value );
 		return trim( $value );
 	}
@@ -540,7 +556,7 @@ class UsedCSS {
 	 *
 	 * @return void
 	 */
-	public function schedule_rucss_retry() {
+	private function schedule_rucss_retry() {
 		$scheduled = wp_next_scheduled( 'rocket_rucss_retries_cron' );
 
 		if ( $scheduled ) {
@@ -548,20 +564,5 @@ class UsedCSS {
 		}
 
 		wp_schedule_single_event( time() + ( 0.5 * HOUR_IN_SECONDS ), 'rocket_rucss_retries_cron' );
-	}
-
-	/**
-	 * Checks if CPCSS is enabled on the current page
-	 *
-	 * @since 3.9
-	 *
-	 * @return bool
-	 */
-	public function cpcss_enabled() {
-		if ( ! $this->options->get( 'async_css', 0 ) ) {
-			return false;
-		}
-
-		return ! is_rocket_post_excluded_option( 'async_css' );
 	}
 }

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/rucssRetries.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/rucssRetries.php
@@ -1,21 +1,30 @@
 <?php
 
 return [
-	'vfs_dir' => 'public/',
+	'vfs_dir' => 'wp-content/',
 
 	'structure' => [
 		'wp-content' => [
-			'themes' => [
-				'theme-name' => [
-					'style.css' => '.theme-name{color:red;}'
-				]
-			],
 			'cache' => [
-				'unused-css' => [
-					'leaveMeHere.css' => 'random css file contents',
-					'page1.css' => '.first{color:red;}',
-					'page2.css' => '.second{color:green;}',
-					'page3.css' => '.third{color:blue;}',
+				'wp-rocket' => [
+					'example.org'                                => [
+						'index.html'      => '',
+						'index.html_gzip' => '',
+						'page1.html'      => '',
+						'page1.html_gzip' => '',
+						'page2.html'      => '',
+						'page2.html_gzip' => '',
+						'page3.html'      => '',
+						'page3.html_gzip' => '',
+					],
+					'example.org-wpmedia-594d03f6ae698691165999' => [
+						'index.html'      => '',
+						'index.html_gzip' => '',
+					],
+					'example.org-Foo-594d03f6ae698691165999'     => [
+						'index.html'      => '',
+						'index.html_gzip' => '',
+					],
 				],
 			],
 		],
@@ -28,14 +37,14 @@ return [
 				'items'         => [
 					[
 						'id'             => '1',
-						'url'            => 'example.com/wp-content/cache/unused-css/page1.css',
+						'url'            => 'http://example.org/page1.html',
 						'css'            => '.example{color:red;}',
 						'unprocessedcss' => json_encode( [] ),
 						'retries'        => '1',
 					],
 					[
 						'id'             => '2',
-						'url'            => 'vfs://public/wp-content/cache/unused-css/page2.css',
+						'url'            => 'http://example.org/page2.html',
 						'css'            => '.example{color:green;}',
 						'unprocessedcss' => json_encode( [
 							'styles/mystyle.css'
@@ -44,7 +53,7 @@ return [
 					],
 					[
 						'id'             => '3',
-						'url'            => 'vfs://public/wp-content/cache/unused-css/page3.css',
+						'url'            => 'http://example.org/page3.html',
 						'css'            => '.example{color:blue;}',
 						'unprocessedcss' => json_encode( [
 							'styles/yourstyle.css',
@@ -69,12 +78,7 @@ return [
 						'retries' => '3',
 					],
 				],
-				'files-after' => [
-					'leaveMeHere.css',
-					'page1.css',
-					'page2.css',
-					'page3.css',
-				],
+				'purged-files' => [],
 			],
 		],
 
@@ -84,7 +88,7 @@ return [
 				'items'         => [
 					[
 						'id'             => '1',
-						'url'            => 'vfs://public/wp-content/cache/unused-css/page1.css',
+						'url'            => 'http://example.org/page1.css',
 						'css'            => '.example{color:red;}',
 						'unprocessedcss' => json_encode( [] ),
 						'retries'        => '3',
@@ -98,12 +102,7 @@ return [
 						'retries' => '3',
 					],
 				],
-				'files-after' => [
-					'leaveMeHere.css',
-					'page1.css',
-					'page2.css',
-					'page3.css',
-				],
+				'purged-files' => [],
 			],
 		],
 
@@ -113,7 +112,7 @@ return [
 				'items'         => [
 					[
 						'id'             => '2',
-						'url'            => 'https://example.com/wp-content/cache/unused-css/page2.css',
+						'url'            => 'http://example.org/page2.html',
 						'css'            => '.example{color:green;}',
 						'unprocessedcss' => json_encode( [
 							'styles/mystyle.css'
@@ -122,7 +121,7 @@ return [
 					],
 					[
 						'id'             => '3',
-						'url'            => 'https://example.com/wp-content/cache/unused-css/page3.css',
+						'url'            => 'http://example.org/page3.html',
 						'css'            => '.example{color:blue;}',
 						'unprocessedcss' => json_encode( [
 							'styles/yourstyle.css',
@@ -133,19 +132,21 @@ return [
 				],
 			],
 			'expected' => [
-				'items-after' => [
+				'items-after'  => [
 					[
 						'id'      => '2',
 						'retries' => '1',
 					],
 					[
-						'id' => '3',
+						'id'      => '3',
 						'retries' => '1',
 					],
 				],
-				'files-after' => [
-					'leaveMeHere.css',
-					'page1.css',
+				'purged-files' => [
+					'vfs://public/wp-content/cache/wp-rocket/example.org/page1.html',
+					'vfs://public/wp-content/cache/wp-rocket/example.org/page1.html_gzip',
+					'vfs://public/wp-content/cache/wp-rocket/example.org/page2.html',
+					'vfs://public/wp-content/cache/wp-rocket/example.org/page2.html_gzip',
 				]
 			],
 		],

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/rucssRetries.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/rucssRetries.php
@@ -10,12 +10,18 @@ return [
 					'example.org'                                => [
 						'index.html'      => '',
 						'index.html_gzip' => '',
-						'page1.html'      => '',
-						'page1.html_gzip' => '',
-						'page2.html'      => '',
-						'page2.html_gzip' => '',
-						'page3.html'      => '',
-						'page3.html_gzip' => '',
+						'page1' => [
+							'index.html'      => '',
+							'index.html_gzip' => '',
+						],
+						'page2'      => [
+							'index.html'      => '',
+							'index.html_gzip' => '',
+						],
+						'page3'      => [
+							'index.html'      => '',
+							'index.html_gzip' => '',
+						],
 					],
 					'example.org-wpmedia-594d03f6ae698691165999' => [
 						'index.html'      => '',
@@ -112,7 +118,7 @@ return [
 				'items'         => [
 					[
 						'id'             => '2',
-						'url'            => 'http://example.org/page2.html',
+						'url'            => 'http://example.org/page2/',
 						'css'            => '.example{color:green;}',
 						'unprocessedcss' => json_encode( [
 							'styles/mystyle.css'
@@ -121,7 +127,7 @@ return [
 					],
 					[
 						'id'             => '3',
-						'url'            => 'http://example.org/page3.html',
+						'url'            => 'http://example.org/page3/',
 						'css'            => '.example{color:blue;}',
 						'unprocessedcss' => json_encode( [
 							'styles/yourstyle.css',
@@ -143,10 +149,10 @@ return [
 					],
 				],
 				'purged-files' => [
-					'vfs://public/wp-content/cache/wp-rocket/example.org/page1.html',
-					'vfs://public/wp-content/cache/wp-rocket/example.org/page1.html_gzip',
-					'vfs://public/wp-content/cache/wp-rocket/example.org/page2.html',
-					'vfs://public/wp-content/cache/wp-rocket/example.org/page2.html_gzip',
+					'vfs://public/wp-content/cache/wp-rocket/example.org/page2/index.html',
+					'vfs://public/wp-content/cache/wp-rocket/example.org/page2/index.html_gzip',
+					'vfs://public/wp-content/cache/wp-rocket/example.org/page3/index.html',
+					'vfs://public/wp-content/cache/wp-rocket/example.org/page3/index.html_gzip',
 				]
 			],
 		],

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/rucssRetries.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/rucssRetries.php
@@ -1,0 +1,153 @@
+<?php
+
+return [
+	'vfs_dir' => 'public/',
+
+	'structure' => [
+		'wp-content' => [
+			'themes' => [
+				'theme-name' => [
+					'style.css' => '.theme-name{color:red;}'
+				]
+			],
+			'cache' => [
+				'unused-css' => [
+					'leaveMeHere.css' => 'random css file contents',
+					'page1.css' => '.first{color:red;}',
+					'page2.css' => '.second{color:green;}',
+					'page3.css' => '.third{color:blue;}',
+				],
+			],
+		],
+	],
+
+	'test_data' => [
+		'shouldBailOutWhenRucssDisabled' => [
+			'config'   => [
+				'rucss-enabled' => false,
+				'items'         => [
+					[
+						'id'             => '1',
+						'url'            => 'example.com/wp-content/cache/unused-css/page1.css',
+						'css'            => '.example{color:red;}',
+						'unprocessedcss' => json_encode( [] ),
+						'retries'        => '1',
+					],
+					[
+						'id'             => '2',
+						'url'            => 'vfs://public/wp-content/cache/unused-css/page2.css',
+						'css'            => '.example{color:green;}',
+						'unprocessedcss' => json_encode( [
+							'styles/mystyle.css'
+						] ),
+						'retries'        => '3',
+					],
+					[
+						'id'             => '3',
+						'url'            => 'vfs://public/wp-content/cache/unused-css/page3.css',
+						'css'            => '.example{color:blue;}',
+						'unprocessedcss' => json_encode( [
+							'styles/yourstyle.css',
+							'js/myslides.js',
+						] ),
+						'retries'        => '3',
+					],
+				],
+			],
+			'expected' => [
+				'items-after' => [
+					[
+						'id'      => '1',
+						'retries' => '1',
+					],
+					[
+						'id'      => '2',
+						'retries' => '3',
+					],
+					[
+						'id'      => '3',
+						'retries' => '3',
+					],
+				],
+				'files-after' => [
+					'leaveMeHere.css',
+					'page1.css',
+					'page2.css',
+					'page3.css',
+				],
+			],
+		],
+
+		'shouldIgnoreEntriesWithNoUnusedCSS' => [
+			'config'   => [
+				'rucss-enabled' => true,
+				'items'         => [
+					[
+						'id'             => '1',
+						'url'            => 'vfs://public/wp-content/cache/unused-css/page1.css',
+						'css'            => '.example{color:red;}',
+						'unprocessedcss' => json_encode( [] ),
+						'retries'        => '3',
+					],
+				],
+			],
+			'expected' => [
+				'items-after' => [
+					[
+						'id'      => '1',
+						'retries' => '3',
+					],
+				],
+				'files-after' => [
+					'leaveMeHere.css',
+					'page1.css',
+					'page2.css',
+					'page3.css',
+				],
+			],
+		],
+
+		'shouldPurgeAndResetRetriesOfItemsWithUnusedCssTo1' => [
+			'config'   => [
+				'rucss-enabled' => true,
+				'items'         => [
+					[
+						'id'             => '2',
+						'url'            => 'https://example.com/wp-content/cache/unused-css/page2.css',
+						'css'            => '.example{color:green;}',
+						'unprocessedcss' => json_encode( [
+							'styles/mystyle.css'
+						] ),
+						'retries'        => '3',
+					],
+					[
+						'id'             => '3',
+						'url'            => 'https://example.com/wp-content/cache/unused-css/page3.css',
+						'css'            => '.example{color:blue;}',
+						'unprocessedcss' => json_encode( [
+							'styles/yourstyle.css',
+							'js/myslides.js',
+						] ),
+						'retries'        => '3',
+					],
+				],
+			],
+			'expected' => [
+				'items-after' => [
+					[
+						'id'      => '2',
+						'retries' => '1',
+					],
+					[
+						'id' => '3',
+						'retries' => '1',
+					],
+				],
+				'files-after' => [
+					'leaveMeHere.css',
+					'page1.css',
+				]
+			],
+		],
+	],
+];

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/treeshake.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/treeshake.php
@@ -188,7 +188,7 @@ return [
 					'css'            => '',
 					'unprocessedcss' => wp_json_encode(
 						[
-							'http://example.org/wp-content/themes/theme-name/style.css',
+							'vfs://public/wp-content/themes/theme-name/style.css',
 						]
 					),
 					'retries'        => 1,
@@ -209,7 +209,7 @@ return [
 									'content' => 'http://example.org/wp-content/themes/theme-name/style.css',
 								],
 								[
-									'type' => 'inline',
+									'type'    => 'inline',
 									'content' => 'h2{color:blue;}',
 								],
 							],
@@ -234,5 +234,80 @@ return [
 </body>
 </html>'
 		],
+
+		'shouldNotInterfereWithCPCSS' => [
+			'config'       => [
+				'html'                  => '<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>My Awesome Page</title>
+	<link rel="stylesheet" type="text/css" href="http://example.org/wp-content/themes/theme-name/style.css">
+	<link rel="stylesheet" type="text/css" href="//example.org/wp-content/themes/theme-name/style.css">
+	<link rel="stylesheet" type="text/css" href="/wp-content/themes/theme-name/style.css">
+	<link rel="stylesheet" type="text/css" href="wp-content/themes/theme-name/style.css">
+	<link rel="stylesheet" type="text/css" href="/css/style.css">
+	<link rel="stylesheet" type="text/css" href="http://external.com/css/style.css">
+	<link rel="stylesheet" type="text/css" href="//external.com/css/style.css">
+	<style>h2{color:blue;}</style>
+</head>
+<body>
+ content here
+</body>
+</html>',
+				'used-css-row-contents' => [
+					'url'            => 'http://example.org/home',
+					'css'            => '',
+					'unprocessedcss' => wp_json_encode(
+						[
+							'http://example.org/wp-content/themes/theme-name/style.css',
+						]
+					),
+					'retries'        => 1,
+					'is_mobile'      => false,
+				],
+				'has_cpcss'             => true,
+				'generated-file' => 'vfs://public/wp-content/cache/used-css/2664e301f9920094b0c21e1378f8702a.css',
+			],
+			'api-response' => [
+				'body'     => json_encode(
+					[
+						'code'     => 200,
+						'message'  => 'OK',
+						'contents' => [
+							'shakedCSS'      => 'h1{color:red;}',
+							'unProcessedCss' => [
+								[
+									'type'    => 'link',
+									'content' => 'http://example.org/wp-content/themes/theme-name/style.css',
+								],
+								[
+									'type'    => 'inline',
+									'content' => 'h2{color:blue;}',
+								],
+							],
+						],
+					]
+				),
+				'response' => [
+					'code'    => 200,
+					'message' => 'OK',
+				],
+			],
+			'expected'     => '<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>My Awesome Page</title>
+	<link rel="stylesheet" id="wpr-usedcss-css" href="http://example.org/wp-content/cache/used-css/2664e301f9920094b0c21e1378f8702a.css?ver={{mtime}}">
+	<link rel="stylesheet" type="text/css" href="http://example.org/wp-content/themes/theme-name/style.css">
+	<style>h2{color:blue;}</style>
+</head>
+<body>
+ content here
+</body>
+</html>'
+		],
 	],
+
 ];

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/deleteUsedCssOnUpdateOrDelete.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/deleteUsedCssOnUpdateOrDelete.php
@@ -8,6 +8,7 @@ use WP_Rocket\Tests\Integration\TestCase;
 
 /**
  * @covers \WP_Rocket\Engine\Optimization\RUCSS\Admin\Subscriber::delete_used_css_on_update_or_delete
+ * @covers \WP_Rocket\Engine\Optimization\RUCSS\Controller\UsedCSS::delete_used_css
  *
  * @group  RUCSS
  */

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/maybeDisablePreloadFonts.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/maybeDisablePreloadFonts.php
@@ -6,65 +6,67 @@ use WP_Rocket\Tests\Integration\ContentTrait;
 use WP_Rocket\Tests\Integration\TestCase;
 
 /**
- * @covers \WP_Rocket\Engine\Optimization\RUCSS\Frontend\Subscriber::maybe_disable_preload_fonts
+ * @covers   \WP_Rocket\Engine\Optimization\RUCSS\Frontend\Subscriber::maybe_disable_preload_fonts
+ * @covers   \WP_Rocket\Engine\Optimization\RUCSS\Controller\UsedCSS::is_allowed()
+ * @covers   \WP_Rocket\Engine\Optimization\RUCSS\Controller\UsedCSS::cpcss_enabled()
  *
- * @group RUCSS
+ * @group    RUCSS
  */
 class Test_MaybeDisablePreloadFonts extends TestCase {
-    use ContentTrait;
+	use ContentTrait;
 
-    private $async_css;
-    private $rucss;
-    private $post;
+	private $async_css;
+	private $rucss;
+	private $post;
 
-    public function tearDown() : void {
-        remove_filter( 'pre_get_rocket_option_async_css', [ $this, 'async_css' ] );
-        remove_filter( 'pre_get_rocket_option_remove_unused_css', [ $this, 'rucss' ] );
+	public function tearDown(): void {
+		remove_filter( 'pre_get_rocket_option_async_css', [ $this, 'async_css' ] );
+		remove_filter( 'pre_get_rocket_option_remove_unused_css', [ $this, 'rucss' ] );
 
-        if ( isset( $this->post->ID) ) {
+		if ( isset( $this->post->ID ) ) {
 			delete_post_meta( $this->post->ID, '_rocket_exclude_async_css', 1, true );
-            delete_post_meta( $this->post->ID, '_rocket_exclude_remove_unused_css', 1, true );
-        }
+			delete_post_meta( $this->post->ID, '_rocket_exclude_remove_unused_css', 1, true );
+		}
 
-        parent::tearDown();
-    }
+		parent::tearDown();
+	}
 
-    /**
+	/**
 	 * @dataProvider configTestData
 	 */
-    public function testShouldReturnExpected( $config, $expected ) {
-        $this->post = $this->goToContentType( $config );
+	public function testShouldReturnExpected( $config, $expected ) {
+		$this->post = $this->goToContentType( $config );
 
-        $this->donotrocketoptimize = $config['DONOTROCKETOPTIMIZE'];
+		$this->donotrocketoptimize = $config['DONOTROCKETOPTIMIZE'];
 
-        $this->async_css = $config['options']['async_css'];
-        $this->rucss     = $config['options']['remove_unused_css'];
+		$this->async_css = $config['options']['async_css'];
+		$this->rucss     = $config['options']['remove_unused_css'];
 
-        add_filter( 'pre_get_rocket_option_async_css', [ $this, 'async_css' ] );
-        add_filter( 'pre_get_rocket_option_remove_unused_css', [ $this, 'rucss' ] );
+		add_filter( 'pre_get_rocket_option_async_css', [ $this, 'async_css' ] );
+		add_filter( 'pre_get_rocket_option_remove_unused_css', [ $this, 'rucss' ] );
 
-        if ( $config['is_rocket_post_excluded_option']['async_css'] ) {
-            add_post_meta( $this->post->ID, '_rocket_exclude_async_css', 1, true );
-        }
+		if ( $config['is_rocket_post_excluded_option']['async_css'] ) {
+			add_post_meta( $this->post->ID, '_rocket_exclude_async_css', 1, true );
+		}
 
 		if ( $config['is_rocket_post_excluded_option']['remove_unused_css'] ) {
-            add_post_meta( $this->post->ID, '_rocket_exclude_remove_unused_css', 1, true );
-        }
+			add_post_meta( $this->post->ID, '_rocket_exclude_remove_unused_css', 1, true );
+		}
 
-        $value = apply_filters( 'rocket_disable_preload_fonts', false );
+		$value = apply_filters( 'rocket_disable_preload_fonts', false );
 
-        if ( $expected ) {
-            $this->assertTrue( $value );
-        } else {
-            $this->assertFalse( $value );
-        }
-    }
+		if ( $expected ) {
+			$this->assertTrue( $value );
+		} else {
+			$this->assertFalse( $value );
+		}
+	}
 
-    public function async_css() {
-        return $this->async_css;
-    }
+	public function async_css() {
+		return $this->async_css;
+	}
 
-    public function rucss() {
-        return $this->rucss;
-    }
+	public function rucss() {
+		return $this->rucss;
+	}
 }

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/rucssRetries.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/rucssRetries.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\Optimization\RUCSS\Frontend\Subscriber;
+
+use WP_Rocket\Tests\Integration\DBTrait;
+use WP_Rocket\Tests\Integration\FilesystemTestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Optimization\RUCSS\Frontend\Subscriber::rucss_retries
+ * @uses   \WP_Rocket\Engine\Optimization\RUCSS\Controller\UsedCSS::retries_pages_with_unprocessed_css()
+ *
+ * @group  RUCSS
+ */
+class Test_RucssRetries extends FilesystemTestCase {
+	use DBTrait;
+
+	protected $path_to_test_data = '/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/rucssRetries.php';
+
+	public static function setUpBeforeClass(): void {
+		self::installFresh();
+
+		parent::setUpBeforeClass();
+	}
+
+	public static function tearDownAfterClass() {
+		parent::tearDownAfterClass();
+
+		self::uninstallAll();
+	}
+
+	public function tearDown() {
+		remove_filter( 'pre_get_rocket_option_remove_unused_css', [ $this, 'set_rucss_option' ] );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @dataProvider providerTestData
+	 */
+	public function testShouldDoExpected( $config, $expected ): void {
+		$this->unregisterAllCallbacksExcept( 'rocket_rucss_retries_cron', 'rucss_retries' );
+
+		if ( $config['rucss-enabled'] ) {
+			add_filter( 'pre_get_rocket_option_remove_unused_css', [ $this, 'set_rucss_option' ] );
+		}
+
+		$container    = apply_filters( 'rocket_container', null );
+		$usedCssQuery = $container->get( 'rucss_used_css_query' );
+
+		foreach ( $config['items'] as $item ) {
+			$usedCssQuery->add_item( $item );
+		}
+
+		do_action( 'rocket_rucss_retries_cron' );
+
+		$itemsAfter = $usedCssQuery->get_results(
+			[ 'id', 'retries' ],
+			[],
+			25,
+			null,
+			ARRAY_A
+		);
+
+		$this->assertSame( $expected['items-after'], $itemsAfter );
+	}
+
+	public function set_rucss_option(): bool {
+		return true;
+	}
+}

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/rucssRetries.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/rucssRetries.php
@@ -62,6 +62,11 @@ class Test_RucssRetries extends FilesystemTestCase {
 		);
 
 		$this->assertSame( $expected['items-after'], $itemsAfter );
+
+		foreach ( $expected['purged-files'] as $file ) {
+			$this->assertFalse( $this->filesystem->exists( $file )
+			);
+		}
 	}
 
 	public function set_rucss_option(): bool {

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/rucssRetries.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/rucssRetries.php
@@ -6,10 +6,10 @@ use WP_Rocket\Tests\Integration\DBTrait;
 use WP_Rocket\Tests\Integration\FilesystemTestCase;
 
 /**
- * @covers \WP_Rocket\Engine\Optimization\RUCSS\Frontend\Subscriber::rucss_retries
- * @uses   \WP_Rocket\Engine\Optimization\RUCSS\Controller\UsedCSS::retries_pages_with_unprocessed_css()
+ * @covers   \WP_Rocket\Engine\Optimization\RUCSS\Frontend\Subscriber::rucss_retries
+ * @covers   \WP_Rocket\Engine\Optimization\RUCSS\Controller\UsedCSS::retries_pages_with_unprocessed_css()
  *
- * @group  RUCSS
+ * @group    RUCSS
  */
 class Test_RucssRetries extends FilesystemTestCase {
 	use DBTrait;

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/treeshake.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/treeshake.php
@@ -7,7 +7,7 @@ use WP_Rocket\Tests\Integration\FilesystemTestCase;
 
 /**
  * @covers \WP_Rocket\Engine\Optimization\RUCSS\Frontend\Subscriber::treeshake
- * @uses \WP_Rocket\Engine\Optimization\RUCSS\Controller\UsedCSS::treeshake()
+ * @covers \WP_Rocket\Engine\Optimization\RUCSS\Controller\UsedCSS::treeshake()
  *
  * @group  RUCSS
  */

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/treeshake.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/treeshake.php
@@ -1,12 +1,13 @@
 <?php
 
-namespace WP_Rocket\Tests\Integration\inc\Engine\Optimization\RUCSS\Frontend\APIClient;
+namespace WP_Rocket\Tests\Integration\inc\Engine\Optimization\RUCSS\Frontend\Subscriber;
 
 use WP_Rocket\Tests\Integration\DBTrait;
 use WP_Rocket\Tests\Integration\FilesystemTestCase;
 
 /**
  * @covers \WP_Rocket\Engine\Optimization\RUCSS\Frontend\Subscriber::treeshake
+ * @uses \WP_Rocket\Engine\Optimization\RUCSS\Controller\UsedCSS::treeshake()
  *
  * @group  RUCSS
  */

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Warmup/Subscriber/collectResources.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Warmup/Subscriber/collectResources.php
@@ -8,6 +8,7 @@ use WP_Rocket\Tests\Integration\FilesystemTestCase;
 
 /**
  * @covers \WP_Rocket\Engine\Optimization\RUCSS\Warmup\Subscriber::collect_resources
+ * @covers \WP_Rocket\Engine\Optimization\RUCSS\Controller\UsedCSS::delete_used_css
  *
  * @group RUCSS
  */


### PR DESCRIPTION
## Description

Subtask of #3635

Adds test coverage for updates to the RUCSS Frontend Subscriber and Controller/UsedCSS
All Controller/UsedCSS methods are invoked via other subsrcibers in Frontend and Admin packages -- Integration tests for those Subscribers provide full covarage of UsedCSS.

Also, we change all methods not used by Subscribers in UsedCSS to private to properly encapsulate everything.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## Is the solution different from the one proposed during the grooming?

No.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes