### PR TITLE
Fixes escaping of excluded patterns in delay JS

### DIFF
--- a/inc/Engine/Optimization/DelayJS/HTML.php
+++ b/inc/Engine/Optimization/DelayJS/HTML.php
@@ -52,7 +52,7 @@ class HTML {
 	 *
 	 * @return string
 	 */
-	public function delay_js( $html ) : string {
+	public function delay_js( $html ): string {
 		if ( ! $this->is_allowed() ) {
 			return $html;
 		}
@@ -67,6 +67,15 @@ class HTML {
 		 * @param array $excluded Array of excluded patterns.
 		 */
 		$this->excluded = apply_filters( 'rocket_delay_js_exclusions', $this->excluded );
+		$this->excluded = array_map( function( $value ) {
+				return str_replace(
+					[ '+', '?', '#', ],
+					[ '\+', '\?', '\#' ],
+					$value
+				);
+			},
+			$this->excluded
+		);
 
 		return $this->parse( $html );
 	}
@@ -78,7 +87,7 @@ class HTML {
 	 *
 	 * @return bool
 	 */
-	public function is_allowed() : bool {
+	public function is_allowed(): bool {
 		if ( rocket_bypass() ) {
 			return false;
 		}
@@ -101,7 +110,7 @@ class HTML {
 	 *
 	 * @return string
 	 */
-	public function get_ie_fallback() {
+	public function get_ie_fallback(): string {
 		return 'if(navigator.userAgent.match(/MSIE|Internet Explorer/i)||navigator.userAgent.match(/Trident\/7\..*?rv:11/i)){var href=document.location.href;if(!href.match(/[?&]nowprocket/)){if(href.indexOf("?")==-1){if(href.indexOf("#")==-1){document.location.href=href+"?nowprocket=1"}else{document.location.href=href.replace("#","?nowprocket=1#")}}else{if(href.indexOf("#")==-1){document.location.href=href+"&nowprocket=1"}else{document.location.href=href.replace("#","&nowprocket=1#")}}}}';
 	}
 
@@ -114,7 +123,7 @@ class HTML {
 	 *
 	 * @return string
 	 */
-	private function parse( $html ) : string {
+	private function parse( $html ): string {
 		$replaced_html = preg_replace_callback( '/<\s*script\s*(?<attr>[^>]*?)?>(?<content>.*?)?<\s*\/\s*script\s*>/ims', [ $this, 'replace_scripts' ], $html );
 
 		if ( empty( $replaced_html ) ) {
@@ -134,7 +143,7 @@ class HTML {
 	 *
 	 * @return string
 	 */
-	public function replace_scripts( $matches ) : string {
+	public function replace_scripts( $matches ): string {
 		foreach ( $this->excluded as $pattern ) {
 			if ( preg_match( "#{$pattern}#i", $matches[0] ) ) {
 				return $matches[0];

--- a/inc/Engine/Optimization/DelayJS/HTML.php
+++ b/inc/Engine/Optimization/DelayJS/HTML.php
@@ -67,9 +67,10 @@ class HTML {
 		 * @param array $excluded Array of excluded patterns.
 		 */
 		$this->excluded = apply_filters( 'rocket_delay_js_exclusions', $this->excluded );
-		$this->excluded = array_map( function( $value ) {
+		$this->excluded = array_map(
+			function( $value ) {
 				return str_replace(
-					[ '+', '?', '#', ],
+					[ '+', '?', '#' ],
 					[ '\+', '\?', '\#' ],
 					$value
 				);

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/HTML/delayJs.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/HTML/delayJs.php
@@ -87,7 +87,7 @@ return [
 				'post-excluded'        => false,
 				'delay_js'             => 1,
 				'delay_js_exclusions'  => [
-					'/wp-includes/js/comment-reply.min.js',
+					'/wp-includes/js/comment-reply.min.js?ver=5.7',
 					'js-(after|extra)',
 				],
 			],

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/Subscriber/delayJs.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/Subscriber/delayJs.php
@@ -92,7 +92,7 @@ return [
 				'post-excluded'        => false,
 				'delay_js'             => 1,
 				'delay_js_exclusions'  => [
-					'/wp-includes/js/comment-reply.min.js',
+					'/wp-includes/js/comment-reply.min.js?ver=5.7',
 					'js-(after|extra)',
 				],
 			],


### PR DESCRIPTION
## Description

The delay JS exclusion was not working correctly when some special characters were used, because they were evaluated as characters for the RegEx.

I'm using a custom callback instead of `preg_quote()`, because we don't want to escape characters that are actual patterns like `(.*)`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested? 

- [x] Manual testing
- [x] Unit/Integration test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes