### PR TITLE
Clear used_css directory contents

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
@@ -60,7 +60,10 @@ class Subscriber implements Subscriber_Interface {
 			'wp_rocket_upgrade'                  => [
 				[ 'set_option_on_update', 14, 2 ],
 			],
-			'switch_theme'                       => 'truncate_used_css',
+			'switch_theme'                       => [
+				[ 'truncate_used_css' ],
+				[ 'clear_used_css_directory' ],
+			],
 			'rocket_rucss_file_changed'          => 'truncate_used_css',
 			'wp_trash_post'                      => 'delete_used_css_on_update_or_delete',
 			'delete_post'                        => 'delete_used_css_on_update_or_delete',
@@ -139,6 +142,12 @@ class Subscriber implements Subscriber_Interface {
 		}
 
 		$this->database->truncate_used_css_table();
+	}
+
+	/**
+	 * Clear used_css directory completely.
+	 */
+	public function clear_used_css_directory() {
 		$this->used_css->delete_all_used_css_files();
 	}
 
@@ -209,7 +218,7 @@ class Subscriber implements Subscriber_Interface {
 			$this->database->truncate_used_css_table();
 			// Clear all caching files.
 			rocket_clean_domain();
-			$this->used_css->delete_all_used_css_files();
+			$this->clear_used_css_directory();
 		}
 	}
 
@@ -236,7 +245,7 @@ class Subscriber implements Subscriber_Interface {
 			&&
 			! (bool) $value['async_css']
 		) {
-			$this->used_css->delete_all_used_css_files();
+			$this->clear_used_css_directory();
 		}
 	}
 
@@ -269,7 +278,7 @@ class Subscriber implements Subscriber_Interface {
 
 		$this->database->truncate_used_css_table();
 		rocket_clean_domain();
-		$this->used_css->delete_all_used_css_files();
+		$this->clear_used_css_directory();
 
 		set_transient(
 			'rocket_clear_usedcss_response',

--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -220,6 +220,9 @@ class UsedCSS {
 			if ( empty( $used_css->id ) ) {
 				continue;
 			}
+			// Delete file from filesystem.
+			$this->delete_used_css_file( $used_css );
+
 			$deleted = $deleted && $this->used_css_query->delete_item( $used_css->id );
 		}
 
@@ -600,5 +603,35 @@ class UsedCSS {
 		}
 
 		wp_schedule_single_event( time() + ( 0.5 * HOUR_IN_SECONDS ), 'rocket_rucss_retries_cron' );
+	}
+
+	/**
+	 * Remove used_css for one page.
+	 *
+	 * @since 3.9
+	 *
+	 * @param UsedCSS_Row $used_css Used CSS DB row.
+	 */
+	private function delete_used_css_file( UsedCSS_Row $used_css ) {
+		// Delete the file itself and its directory.
+		$file_path = $this->base_path . $this->get_used_css_filepath( $used_css );
+		$dir       = dirname( $file_path );
+
+		if ( ! $this->filesystem->exists( $dir ) ) {
+			return;
+		}
+
+		rocket_rrmdir( $dir );
+	}
+
+	/**
+	 * Remove all used_css directory contents.
+	 */
+	public function delete_all_used_css_files() {
+		if ( ! $this->filesystem->exists( $this->base_path ) ) {
+			return;
+		}
+
+		rocket_rrmdir( $this->base_path );
 	}
 }

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cleanUsedCssAndCache.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cleanUsedCssAndCache.php
@@ -17,6 +17,17 @@ $items = [
 	],
 ];
 
+$used_css_files = [
+	'vfs://public/wp-content/cache/used-css/1/' => null,
+	'vfs://public/wp-content/cache/used-css/1/'.md5( 'https://example.org/' ).'/' => null,
+	'vfs://public/wp-content/cache/used-css/1/'.md5( 'https://example.org/' ).'/used.css' => null,
+	'vfs://public/wp-content/cache/used-css/1/'.md5( 'https://example.org/' ).'/used-mobile.css' => null,
+	'vfs://public/wp-content/cache/used-css/1/category/' => null,
+	'vfs://public/wp-content/cache/used-css/1/category/level1/' => null,
+	'vfs://public/wp-content/cache/used-css/1/category/level1/used.css' => null,
+	'vfs://public/wp-content/cache/used-css/1/category/level1/used-mobile.css' => null,
+];
+
 $cache_files = [
 	'vfs://public/wp-content/cache/wp-rocket/example.org/index.html'                                     => null,
 	'vfs://public/wp-content/cache/wp-rocket/example.org/index.html_gzip'                                => null,
@@ -47,6 +58,21 @@ return [
 						'index.html_gzip' => '',
 					],
 				],
+
+				'used-css' => [
+					'1' => [
+						md5( 'https://example.org/' ) => [
+							'used.css' => '',
+							'used-mobile.css' => '',
+						],
+						'category' => [
+							'level1' => [
+								'used.css' => '',
+								'used-mobile.css' => '',
+							]
+						]
+					],
+				],
 			],
 		],
 	],
@@ -60,6 +86,7 @@ return [
 				'settings'          => [],
 				'old_settings'      => [],
 				'cache_files'       => $cache_files,
+				'used_css_files' => $used_css_files,
 			],
 		],
 		'shouldNotTruncateUnusedCSSDueToSettings' => [
@@ -73,6 +100,7 @@ return [
 					'remove_unused_css_safelist' => [],
 				],
 				'cache_files'       => $cache_files,
+				'used_css_files' => $used_css_files,
 			],
 		],
 		'shouldTruncateUnusedCSS' => [
@@ -86,6 +114,7 @@ return [
 					'remove_unused_css_safelist' => [ 'class1' ],
 				],
 				'cache_files'       => $cache_files,
+				'used_css_files' => $used_css_files,
 			],
 		],
 	],

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cleanUsedCssDirectoryCpcssDisabled.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cleanUsedCssDirectoryCpcssDisabled.php
@@ -1,0 +1,104 @@
+<?php
+
+return [
+
+	'test_data' => [
+		'BailoutWhenCurrentUserCant' => [
+			'input' => [
+				'cap' => false,
+				'old_value' => [
+					'async_css' => true,
+				],
+				'new_value' => [
+					'async_css' => true,
+				],
+			],
+			'expected' => [
+				'cleaned' => false,
+				'reason' => 'cap'
+			],
+		],
+
+		'BailoutWhenRUCSSDisabled' => [
+			'input' => [
+				'cap' => true,
+				'remove_unused_css' => false,
+				'old_value' => [
+					'async_css' => true,
+				],
+				'new_value' => [
+					'async_css' => true,
+				],
+			],
+			'expected' => [
+				'cleaned' => false,
+				'reason' => 'option'
+			],
+		],
+
+		'BailoutWhenCPCSSNotInsideOldValue' => [
+			'input' => [
+				'cap' => true,
+				'remove_unused_css' => true,
+				'old_value' => [],
+				'new_value' => [
+					'async_css' => true,
+				],
+			],
+			'expected' => [
+				'cleaned' => false,
+				'reason' => 'cpcss'
+			],
+		],
+
+		'BailoutWhenCPCSSNotInsideNewValue' => [
+			'input' => [
+				'cap' => true,
+				'remove_unused_css' => true,
+				'old_value' => [
+					'async_css' => true,
+				],
+				'new_value' => [],
+			],
+			'expected' => [
+				'cleaned' => false,
+				'reason' => 'cpcss'
+			],
+		],
+
+		'BailoutWhenCPCSSChangedFromDisabledToEnabled' => [
+			'input' => [
+				'cap' => true,
+				'remove_unused_css' => true,
+				'old_value' => [
+					'async_css' => false,
+				],
+				'new_value' => [
+					'async_css' => true,
+				],
+			],
+			'expected' => [
+				'cleaned' => false,
+				'reason' => 'cpcss'
+			],
+		],
+
+		'CleanWhenCPCSSChangedFromEnabledToDisabled' => [
+			'input' => [
+				'cap' => true,
+				'remove_unused_css' => true,
+				'old_value' => [
+					'async_css' => true,
+				],
+				'new_value' => [
+					'async_css' => false,
+				],
+			],
+			'expected' => [
+				'cleaned' => true,
+			],
+		],
+
+	],
+
+];

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cleanUsedCssDirectoryCpcssDisabled.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cleanUsedCssDirectoryCpcssDisabled.php
@@ -1,14 +1,14 @@
 <?php
 
 $files = [
-	'vfs://public/wp-content/cache/used_css/1/',
-	'vfs://public/wp-content/cache/used_css/1/'.md5( 'https://example.org/' ).'/',
-	'vfs://public/wp-content/cache/used_css/1/'.md5( 'https://example.org/' ).'/used.css',
-	'vfs://public/wp-content/cache/used_css/1/'.md5( 'https://example.org/' ).'/used-mobile.css',
-	'vfs://public/wp-content/cache/used_css/1/category/',
-	'vfs://public/wp-content/cache/used_css/1/category/level1/',
-	'vfs://public/wp-content/cache/used_css/1/category/level1/used.css',
-	'vfs://public/wp-content/cache/used_css/1/category/level1/used-mobile.css',
+	'vfs://public/wp-content/cache/used-css/1/',
+	'vfs://public/wp-content/cache/used-css/1/'.md5( 'https://example.org/' ).'/',
+	'vfs://public/wp-content/cache/used-css/1/'.md5( 'https://example.org/' ).'/used.css',
+	'vfs://public/wp-content/cache/used-css/1/'.md5( 'https://example.org/' ).'/used-mobile.css',
+	'vfs://public/wp-content/cache/used-css/1/category/',
+	'vfs://public/wp-content/cache/used-css/1/category/level1/',
+	'vfs://public/wp-content/cache/used-css/1/category/level1/used.css',
+	'vfs://public/wp-content/cache/used-css/1/category/level1/used-mobile.css',
 ];
 
 return [
@@ -19,16 +19,16 @@ return [
 	'structure' => [
 		'wp-content' => [
 			'cache' => [
-				'used_css' => [
+				'used-css' => [
 					1 => [
 						md5( 'https://example.org/' ) => [
 							'used.css' => '',
-							'used-mobile.css',
+							'used-mobile.css' => '',
 						],
 						'category' => [
 							'level1' => [
-								'used.css',
-								'used-mobile.css',
+								'used.css' => '',
+								'used-mobile.css' => '',
 							]
 						]
 					],

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cleanUsedCssDirectoryCpcssDisabled.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cleanUsedCssDirectoryCpcssDisabled.php
@@ -1,6 +1,41 @@
 <?php
 
+$files = [
+	'vfs://public/wp-content/cache/used_css/1/',
+	'vfs://public/wp-content/cache/used_css/1/'.md5( 'https://example.org/' ).'/',
+	'vfs://public/wp-content/cache/used_css/1/'.md5( 'https://example.org/' ).'/used.css',
+	'vfs://public/wp-content/cache/used_css/1/'.md5( 'https://example.org/' ).'/used-mobile.css',
+	'vfs://public/wp-content/cache/used_css/1/category/',
+	'vfs://public/wp-content/cache/used_css/1/category/level1/',
+	'vfs://public/wp-content/cache/used_css/1/category/level1/used.css',
+	'vfs://public/wp-content/cache/used_css/1/category/level1/used-mobile.css',
+];
+
 return [
+
+	'vfs_dir' => 'wp-content/',
+
+	// Virtual filesystem structure.
+	'structure' => [
+		'wp-content' => [
+			'cache' => [
+				'used_css' => [
+					1 => [
+						md5( 'https://example.org/' ) => [
+							'used.css' => '',
+							'used-mobile.css',
+						],
+						'category' => [
+							'level1' => [
+								'used.css',
+								'used-mobile.css',
+							]
+						]
+					],
+				],
+			],
+		],
+	],
 
 	'test_data' => [
 		'BailoutWhenCurrentUserCant' => [
@@ -12,10 +47,11 @@ return [
 				'new_value' => [
 					'async_css' => true,
 				],
+				'files' => $files,
 			],
 			'expected' => [
 				'cleaned' => false,
-				'reason' => 'cap'
+				'reason' => 'cap',
 			],
 		],
 
@@ -29,10 +65,11 @@ return [
 				'new_value' => [
 					'async_css' => true,
 				],
+				'files' => $files,
 			],
 			'expected' => [
 				'cleaned' => false,
-				'reason' => 'option'
+				'reason' => 'option',
 			],
 		],
 
@@ -44,10 +81,11 @@ return [
 				'new_value' => [
 					'async_css' => true,
 				],
+				'files' => $files,
 			],
 			'expected' => [
 				'cleaned' => false,
-				'reason' => 'cpcss'
+				'reason' => 'cpcss',
 			],
 		],
 
@@ -59,6 +97,7 @@ return [
 					'async_css' => true,
 				],
 				'new_value' => [],
+				'files' => $files,
 			],
 			'expected' => [
 				'cleaned' => false,
@@ -76,6 +115,7 @@ return [
 				'new_value' => [
 					'async_css' => true,
 				],
+				'files' => $files
 			],
 			'expected' => [
 				'cleaned' => false,
@@ -93,6 +133,7 @@ return [
 				'new_value' => [
 					'async_css' => false,
 				],
+				'files' => $files
 			],
 			'expected' => [
 				'cleaned' => true,

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/deleteUsedCssOnUpdateOrDelete.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/deleteUsedCssOnUpdateOrDelete.php
@@ -17,18 +17,66 @@ $items = [
 	],
 ];
 
+$files = [
+	'vfs://public/wp-content/cache/used-css/1/slug_0/',
+	'vfs://public/wp-content/cache/used-css/1/slug_0/used.css',
+	'vfs://public/wp-content/cache/used-css/1/slug_0/used-mobile.css',
+	'vfs://public/wp-content/cache/used-css/1/slug_1/',
+	'vfs://public/wp-content/cache/used-css/1/slug_1/used.css',
+	'vfs://public/wp-content/cache/used-css/1/slug_1/used-mobile.css',
+];
+
+$preserved = [
+	'vfs://public/wp-content/cache/used-css/1/slug_preserved/',
+	'vfs://public/wp-content/cache/used-css/1/slug_preserved/used.css',
+	'vfs://public/wp-content/cache/used-css/1/slug_preserved/used-mobile.css',
+];
 
 return [
-	'shouldNotDeleteOnUpdateDueToMissingSettings' => [
-		'input' => [
-			'remove_unused_css' => false,
-			'items'             => $items,
-		]
+
+	'vfs_dir' => 'wp-content/',
+
+	// Virtual filesystem structure.
+	'structure' => [
+		'wp-content' => [
+			'cache' => [
+				'used-css' => [
+					1 => [
+						'slug_0' => [
+							'used.css' => '',
+							'used-mobile.css' => '',
+						],
+						'slug_1' => [
+							'used.css' => '',
+							'used-mobile.css' => '',
+						],
+						'slug_preserved' => [
+							'used.css' => '',
+							'used-mobile.css' => '',
+						],
+					],
+				],
+			],
+		],
 	],
-	'shouldDeleteOnUpdate' => [
-		'input' => [
-			'remove_unused_css' => true,
-			'items'             => $items,
-		]
-	],
+
+	'test_data' => [
+		'shouldNotDeleteOnUpdateDueToMissingSettings' => [
+			'input' => [
+				'remove_unused_css' => false,
+				'items'             => $items,
+				'files_deleted'     => [],
+				'files_preserved'   => array_merge( $files, $preserved ),
+			]
+		],
+		'shouldDeleteOnUpdate' => [
+			'input' => [
+				'remove_unused_css' => true,
+				'items'             => $items,
+				'files_deleted'     => $files,
+				'files_preserved'   => $preserved,
+			]
+		],
+	]
+
 ];

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cleanUsedCssAndCache.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cleanUsedCssAndCache.php
@@ -85,11 +85,16 @@ class Test_CleanUsedCssAndCache extends FilesystemTestCase {
 
 			// Test that cache Files are deleted.
 			$this->checkEntriesDeleted( $input['cache_files'] );
+			$this->checkEntriesDeleted( $input['used_css_files'] );
 		} else {
 			$this->assertCount( count( $input['items'] ), $result );
 
 			// Test that cache Files are still available.
 			foreach ( $input['cache_files'] as $file => $content ) {
+				$this->assertTrue( $this->filesystem->exists( $file ) );
+			}
+
+			foreach ( $input['used_css_files'] as $file => $content ) {
 				$this->assertTrue( $this->filesystem->exists( $file ) );
 			}
 		}

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cleanUsedCssDirectoryCpcssDisabled.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cleanUsedCssDirectoryCpcssDisabled.php
@@ -33,6 +33,7 @@ class Test_CleanUsedCssDirectoryCpcssDisabled extends FilesystemTestCase {
 	}
 
 	public function tearDown() : void {
+		remove_filter( 'pre_get_rocket_option_remove_unused_css', [ $this, 'set_rucss_option' ] );
 
 		parent::tearDown();
 	}

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cleanUsedCssDirectoryCpcssDisabled.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cleanUsedCssDirectoryCpcssDisabled.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\Optimization\RUCSS\Admin\Subscriber;
+
+use WP_Rocket\Tests\Integration\DBTrait;
+use WP_Rocket\Tests\Integration\CapTrait;
+use WP_Rocket\Tests\Integration\FilesystemTestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Optimization\RUCSS\Admin\Subscriber::clean_used_css_directory_cpcss_disabled
+ *
+ * @group  RUCSS
+ * @group  AdminOnly
+ */
+class Test_CleanUsedCssDirectoryCpcssDisabled extends FilesystemTestCase {
+	use CapTrait;
+
+	private        $rucss_option;
+	private static $admin_user_id;
+	private static $contributer_user_id;
+
+	protected $path_to_test_data = '/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cleanUsedCssdirectoryCpcssDisabled.php';
+
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
+		CapTrait::hasAdminCapBeforeClass();
+		CapTrait::setAdminCap();
+
+		self::$admin_user_id = static::factory()->user->create( [ 'role' => 'administrator' ] );
+		self::$contributer_user_id = static::factory()->user->create( [ 'role' => 'contributor' ] );
+	}
+
+	public function tearDown() : void {
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @dataProvider providerTestData
+	 */
+	public function testShouldDoExpected( $input, $expected ){
+		if ( isset( $input['cap'] ) ) {
+			if ( $input['cap'] ) {
+				$user_id = self::$admin_user_id;
+			}else{
+				$user_id = self::$contributer_user_id;
+			}
+			wp_set_current_user( $user_id );
+		}
+
+		$this->rucss_option = $input['remove_unused_css'] ?? false;
+		add_filter( 'pre_get_rocket_option_remove_unused_css', [ $this, 'set_rucss_option' ] );
+
+		// Test that used_css Files are available.
+		foreach ( $input['files'] as $file => $content ) {
+			$this->assertTrue( $this->filesystem->exists( $file ) );
+		}
+
+		do_action( 'update_option_wp_rocket_settings', $input['old_value'], $input['new_value'] );
+
+		// Test that used_css Files are available.
+		foreach ( $expected['files'] as $file => $content ) {
+			if ( $expected['cleaned'] ) {
+				$this->assertFalse( $this->filesystem->exists( $file ) );
+			}else{
+				$this->assertTrue( $this->filesystem->exists( $file ) );
+			}
+		}
+
+
+	}
+
+	public function set_rucss_option() {
+		return $this->rucss_option;
+	}
+}

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cleanUsedCssDirectoryCpcssDisabled.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cleanUsedCssDirectoryCpcssDisabled.php
@@ -20,7 +20,7 @@ class Test_CleanUsedCssDirectoryCpcssDisabled extends FilesystemTestCase {
 	private static $admin_user_id;
 	private static $contributer_user_id;
 
-	protected $path_to_test_data = '/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cleanUsedCssdirectoryCpcssDisabled.php';
+	protected $path_to_test_data = '/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cleanUsedCssDirectoryCpcssDisabled.php';
 
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
@@ -54,14 +54,14 @@ class Test_CleanUsedCssDirectoryCpcssDisabled extends FilesystemTestCase {
 		add_filter( 'pre_get_rocket_option_remove_unused_css', [ $this, 'set_rucss_option' ] );
 
 		// Test that used_css Files are available.
-		foreach ( $input['files'] as $file => $content ) {
+		foreach ( $input['files'] as $file ) {
 			$this->assertTrue( $this->filesystem->exists( $file ) );
 		}
 
 		do_action( 'update_option_wp_rocket_settings', $input['old_value'], $input['new_value'] );
 
 		// Test that used_css Files are available.
-		foreach ( $expected['files'] as $file => $content ) {
+		foreach ( $input['files'] as $file ) {
 			if ( $expected['cleaned'] ) {
 				$this->assertFalse( $this->filesystem->exists( $file ) );
 			}else{

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cleanUsedCssAndCache.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cleanUsedCssAndCache.php
@@ -62,6 +62,7 @@ class Test_CleanUsedCssAndCache extends FilesystemTestCase {
 
 			Functions\expect( 'rocket_clean_domain' )
 				->once();
+			$this->usedCSS->shouldReceive( 'delete_all_used_css_files' )->once();
 		} else {
 			$this->database
 				->shouldReceive( 'truncate_used_css_table' )
@@ -69,6 +70,8 @@ class Test_CleanUsedCssAndCache extends FilesystemTestCase {
 
 			Functions\expect( 'rocket_clean_domain' )
 				->never();
+
+			$this->usedCSS->shouldReceive( 'delete_all_used_css_files' )->never();
 		}
 
 		$this->subscriber->clean_used_css_and_cache( $input['settings'], $input['old_settings'] );

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cleanUsedCssDirectoryCpcssDisabled.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cleanUsedCssDirectoryCpcssDisabled.php
@@ -35,10 +35,6 @@ class Test_CleanUsedCssDirectoryCpcssDisabled extends TestCase {
 		$this->subscriber = new Subscriber( $this->settings, $this->database, $this->usedCSS );
 	}
 
-	public function tearDown() : void {
-		parent::tearDown();
-	}
-
 	/**
 	 * @dataProvider configTestData
 	 */

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cleanUsedCssDirectoryCpcssDisabled.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cleanUsedCssDirectoryCpcssDisabled.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\RUCSS\Admin\Subscriber;
+
+use Mockery;
+use Brain\Monkey\Functions;
+use WP_Rocket\Tests\Unit\TestCase;
+use WP_Rocket\Engine\Optimization\RUCSS\Admin\Database;
+use WP_Rocket\Engine\Optimization\RUCSS\Admin\Settings;
+use WP_Rocket\Engine\Optimization\RUCSS\Admin\Subscriber;
+use WP_Rocket\Engine\Optimization\RUCSS\Controller\UsedCSS;
+
+
+/**
+ * @covers \WP_Rocket\Engine\Optimization\RUCSS\Admin\Subscriber::clean_used_css_directory_cpcss_disabled
+ *
+ * @group  RUCSS
+ */
+class Test_CleanUsedCssDirectoryCpcssDisabled extends TestCase {
+
+	private $settings;
+	private $database;
+	private $usedCSS;
+	private $subscriber;
+
+	protected $path_to_test_data = '/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cleanUsedCssDirectoryCpcssDisabled.php';
+
+	public function setUp() : void {
+		parent::setUp();
+
+		$this->settings   = Mockery::mock( Settings::class );
+		$this->database   = Mockery::mock( Database::class );
+		$this->usedCSS    = Mockery::mock( UsedCSS::class );
+		$this->subscriber = new Subscriber( $this->settings, $this->database, $this->usedCSS );
+	}
+
+	public function tearDown() : void {
+		parent::tearDown();
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldDoExpected( $input, $expected ) {
+		if ( isset( $input['cap'] ) ) {
+			Functions\expect( 'current_user_can' )
+				->once()
+				->with( 'rocket_manage_options' )
+				->andReturn( $input['cap'] );
+		}
+
+		if ( isset( $input['remove_unused_css'] ) ) {
+			$this->settings->shouldReceive( 'is_enabled' )->once()->andReturn( $input['remove_unused_css'] );
+		}
+
+		if ( $expected['cleaned'] ) {
+			$this->usedCSS->shouldReceive( 'delete_all_used_css_files' )->once();
+		}else{
+			$this->usedCSS->shouldReceive( 'delete_all_used_css_files' )->never();
+		}
+
+		$this->subscriber->clean_used_css_directory_cpcss_disabled( $input['old_value'], $input['new_value'] );
+	}
+}

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/truncateUsedCSSHandler.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/truncateUsedCSSHandler.php
@@ -24,7 +24,7 @@ class Test_TruncateUsedCSSHandler extends TestCase {
 	private $usedCSS;
 	private $subscriber;
 
-	protected $path_to_test_data = '/inc/Engine/Optimization/RUCSS/Admin/Subscriber/TruncateUsedCSSHandler.php';
+	protected $path_to_test_data = '/inc/Engine/Optimization/RUCSS/Admin/Subscriber/truncateUsedCSSHandler.php';
 
 	public function setUp() : void {
 		parent::setUp();

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/truncateUsedCSSHandler.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/truncateUsedCSSHandler.php
@@ -112,10 +112,10 @@ class Test_TruncateUsedCSSHandler extends TestCase {
 		if ( $expected['truncated'] ) {
 			$this->database->shouldReceive( 'truncate_used_css_table' )->once();
 			Functions\expect( 'rocket_clean_domain' )->once();
-			$this->expectException( WPDieException::class );
-		}else{
-			$this->expectException( WPDieException::class );
+			$this->usedCSS->shouldReceive( 'delete_all_used_css_files' )->once();
 		}
+
+		$this->expectException( WPDieException::class );
 
 		$this->subscriber->truncate_used_css_handler();
 	}


### PR DESCRIPTION
## Description

- [x] Clear the full used_css directory with truncate table cases.
- [x] Clear used_css one by one with their cases like 'wp_trash_post' and all hooks that uses the callback `delete_used_css_on_update_or_delete`
- [x] Unit tests
- [x] Integration tests

**Completely remove used_css directory contents:**
- Save options (with cpcss changed disabled)
- Click the clear used CSS button
- switch theme

**In the following cases we remove only one by one (I think those also are purging cache)**
- wp_trash_post
- delete_post
- clean_post_cache
- wp_update_comment_count