### PR TITLE
Exclude Google Ads inline tracking code

### DIFF
--- a/inc/Engine/Optimization/Minify/JS/Combine.php
+++ b/inc/Engine/Optimization/Minify/JS/Combine.php
@@ -696,6 +696,7 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 			'reload_attached_coupons',
 			'var ftpp',
 			'forminatorFront',
+			'google_conversion_id',
 		];
 
 		$excluded_inline = array_merge( $defaults, $this->options->get( 'exclude_inline_js', [] ) );


### PR DESCRIPTION
## Description

Google Ads conversion tracking depends on info added in `CDATA` like this:
```
/* <![CDATA[ */
var google_conversion_id = 996648267;
var google_conversion_language = "en";
var google_conversion_format = "3";
var google_conversion_color = "ffffff";
var google_conversion_label = "H9yxCPqni2QQy8qe2wM";
var google_remarketing_only = false;
/* ]]> */
```
When that's combined using the **Combine JavaScript files** feature, conversion tracking is not working.

Related ticket: https://secure.helpscout.net/conversation/1477985180/254386/

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Customer's website.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
