### PR TITLE
Fixes Delay JS escaping for ? character

### DIFF
--- a/inc/Engine/Optimization/DelayJS/HTML.php
+++ b/inc/Engine/Optimization/DelayJS/HTML.php
@@ -70,8 +70,8 @@ class HTML {
 		$this->excluded = array_map(
 			function( $value ) {
 				return str_replace(
-					[ '+', '?', '#' ],
-					[ '\+', '\?', '\#' ],
+					[ '+', '?ver', '#' ],
+					[ '\+', '\?ver', '\#' ],
 					$value
 				);
 			},

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/HTML/delayJs.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/HTML/delayJs.php
@@ -15,6 +15,21 @@ $html = '<html>
 </body>
 </html>';
 
+$delay_html_upgrade = '<html>
+<head>
+	<script src="http://example.org/wp-includes/js/jquery/jquery.min.js?ver=3.5.1"></script>
+	<script type="rocketlazyloadscript" data-rocket-type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js">< / script>
+	<script src="https://tests.local/wp-includes/js/wp-embed.min.js?ver=5.7" id="wp-embed-js"></script>
+</head>
+<body>
+<script>if(navigator.userAgent.match(/MSIE|Internet Explorer/i)||navigator.userAgent.match(/Trident\/7\..*?rv:11/i)){var href=document.location.href;if(!href.match(/[?&]nowprocket/)){if(href.indexOf("?")==-1){if(href.indexOf("#")==-1){document.location.href=href+"?nowprocket=1"}else{document.location.href=href.replace("#","?nowprocket=1#")}}else{if(href.indexOf("#")==-1){document.location.href=href+"&nowprocket=1"}else{document.location.href=href.replace("#","&nowprocket=1#")}}}}</script>
+<script type="rocketlazyloadscript">var screenReaderText = {"expand":"expand child menu","collapse":"collapse child menu"};</script>
+<script src="http://example.org/wp-includes/js/comment-reply.min.js?ver=5.7" id="comment-reply-js"></script>
+<script type="module" src="http://example.org/wp-content/plugins/module/test.js"></script>
+<script id="astra-theme-js-js-extra">var astra = {"break_point:"921","isRtl:""};</script>
+</body>
+</html>';
+
 $delay_html = '<html>
 <head>
 	<script type="rocketlazyloadscript" src="http://example.org/wp-includes/js/jquery/jquery.min.js?ver=3.5.1"></script>
@@ -78,6 +93,22 @@ return [
 			],
 			'html'     => $html,
 			'expected' => $html,
+		],
+
+		'testShouldDelayJSWithUpgradeExclusions' => [
+			'config'   => [
+				'bypass'               => false,
+				'donotoptimize'        => false,
+				'post-excluded'        => false,
+				'delay_js'             => 1,
+				'delay_js_exclusions'  => [
+					'(?:/wp-content|/wp-includes/)(.*)',
+					'/jquery-?[0-9.]*(.min|.slim|.slim.min)?.js',
+					'js-(extra|after)',
+				],
+			],
+			'html'     => $html,
+			'expected' => $delay_html_upgrade,
 		],
 
 		'testShouldDelayJS' => [

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/Subscriber/delayJs.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/Subscriber/delayJs.php
@@ -15,6 +15,21 @@ $html = '<html>
 </body>
 </html>';
 
+$delay_html_upgrade = '<html>
+<head>
+	<script src="http://example.org/wp-includes/js/jquery/jquery.min.js?ver=3.5.1"></script>
+	<script type="rocketlazyloadscript" data-rocket-type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.0/js/bootstrap.js">< / script>
+	<script src="https://tests.local/wp-includes/js/wp-embed.min.js?ver=5.7" id="wp-embed-js"></script>
+</head>
+<body>
+<script>if(navigator.userAgent.match(/MSIE|Internet Explorer/i)||navigator.userAgent.match(/Trident\/7\..*?rv:11/i)){var href=document.location.href;if(!href.match(/[?&]nowprocket/)){if(href.indexOf("?")==-1){if(href.indexOf("#")==-1){document.location.href=href+"?nowprocket=1"}else{document.location.href=href.replace("#","?nowprocket=1#")}}else{if(href.indexOf("#")==-1){document.location.href=href+"&nowprocket=1"}else{document.location.href=href.replace("#","&nowprocket=1#")}}}}</script>
+<script type="rocketlazyloadscript">var screenReaderText = {"expand":"expand child menu","collapse":"collapse child menu"};</script>
+<script src="http://example.org/wp-includes/js/comment-reply.min.js?ver=5.7" id="comment-reply-js"></script>
+<script type="module" src="http://example.org/wp-content/plugins/module/test.js"></script>
+<script id="astra-theme-js-js-extra">var astra = {"break_point:"921","isRtl:""};</script>
+</body>
+</html>';
+
 $delay_html = '<html>
 <head>
 	<script type="rocketlazyloadscript" src="http://example.org/wp-includes/js/jquery/jquery.min.js?ver=3.5.1"></script>
@@ -98,6 +113,23 @@ return [
 			],
 			'html'     => $html,
 			'expected' => $delay_html,
+		],
+
+		'testShouldDelayJSWithUpgradeExclusions' => [
+			'config'   => [
+				'type'                 => 'front_page',
+				'bypass'               => false,
+				'donotoptimize'        => false,
+				'post-excluded'        => false,
+				'delay_js'             => 1,
+				'delay_js_exclusions'  => [
+					'(?:/wp-content|/wp-includes/)(.*)',
+					'/jquery-?[0-9.]*(.min|.slim|.slim.min)?.js',
+					'js-(extra|after)',
+				],
+			],
+			'html'     => $html,
+			'expected' => $delay_html_upgrade,
 		],
 	]
 ];


### PR DESCRIPTION
## Description

We can't escape the `?` character specifically, because it's used in the patterns added during the upgrade.

Instead, let's do the escaping on a more specific pattern `?ver`.

Also added a test case for the upgrade exclusion patterns to make sure there is no regression.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Manual test
- [x] New test cases

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes