### PR TITLE
Apply CDN rewrite on used CSS before saving it to a file

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -521,7 +521,8 @@ class UsedCSS {
 			}
 		}
 
-		return rocket_put_content( $used_css_filepath, $used_css->css );
+		// This filter is documented in inc/Engine/Optimization/CSSTrait.php#52.
+		return rocket_put_content( $used_css_filepath, apply_filters( 'rocket_css_content', $used_css->css ) );
 	}
 
 	/**


### PR DESCRIPTION
## Description

When we save the used CSS to a file, we need to rewrite any internal URL to the CDN URL.

This is not necessary when outputting the CSS directly on the page, as the CDN callback will parse the whole HTML.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes