### PR TITLE
Handle resources without url schema

### DIFF
--- a/inc/Engine/Optimization/UrlTrait.php
+++ b/inc/Engine/Optimization/UrlTrait.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace WP_Rocket\Engine\Optimization;
 
+use WP_Rocket\Logger\Logger;
+
 trait UrlTrait {
 
 	/**
@@ -111,7 +113,7 @@ trait UrlTrait {
 			return $site_url_components['scheme'] . '://' . $site_url_components['host'] . '/' . $relative_url;
 		}
 
-		return $url;
+		return rocket_add_url_protocol( $url );
 	}
 
 	/**

--- a/inc/Engine/Optimization/UrlTrait.php
+++ b/inc/Engine/Optimization/UrlTrait.php
@@ -3,8 +3,6 @@ declare(strict_types=1);
 
 namespace WP_Rocket\Engine\Optimization;
 
-use WP_Rocket\Logger\Logger;
-
 trait UrlTrait {
 
 	/**

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Warmup/ResourceFetcher/Handle.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Warmup/ResourceFetcher/Handle.php
@@ -126,6 +126,32 @@ return [
 				],
 			],
 		],
+
+		'shouldQueueResourcesWithoutSchema' => [
+			'input' => [
+				'html' => '<!DOCTYPE html><html><head><title></title>'.
+				          '<link rel="stylesheet" type="text/css" href="//example.org/css/style1.css?ver=123">'.
+
+				          '<script type="text/javascript" src="//example.org/scripts/script1.js"></script>'.
+				          '</head><body>Content here</body></html>',
+			],
+			'expected' => [
+				'resources' => [
+					[
+						'url' => 'http://example.org/css/style1.css?ver=123',
+						'content' => '.first{color:red;}',
+						'type' => 'css',
+						'media' => 'all'
+					],
+					[
+						'url' => 'http://example.org/scripts/script1.js',
+						'content' => 'var first = "content 1";',
+						'type' => 'js'
+					]
+				],
+			],
+		],
+
 	]
 
 ];

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Warmup/ResourceFetcher/Handle.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Warmup/ResourceFetcher/Handle.php
@@ -88,6 +88,15 @@ class Test_Handle extends FilesystemTestCase {
 			'html' => $input['html'],
 		];
 
+		Functions\when( 'set_url_scheme')->alias( function ( $url ) {
+			$url = trim( $url );
+			if ( substr( $url, 0, 2 ) === '//' ) {
+				$url = 'http:' . $url;
+			}
+
+			return preg_replace( '#^\w+://#', 'http://', $url );
+		});
+
 		$resource_fetcher->handle();
 
 	}


### PR DESCRIPTION
## Description

Handle resources without URL schema, for example, this file

```
<link rel='stylesheet' id='woocommerce-general-css'  href='//new.rocketlabsqa.ovh/wp-content/plugins/woocommerce/assets/css/twenty-twenty.css?ver=5.2.2' media='all' />
```

needs to be saved into resources table with the URL
```
https//new.rocketlabsqa.ovh/wp-content/plugins/woocommerce/assets/css/twenty-twenty.css?ver=5.2.2
```
OR at least
```
http//new.rocketlabsqa.ovh/wp-content/plugins/woocommerce/assets/css/twenty-twenty.css?ver=5.2.2
```

based on the current site supports SSL or not.