### PR TITLE
Bailout if used_css not inserted/updated properly

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -315,6 +315,10 @@ class UsedCSS {
 		if ( empty( $used_css ) ) {
 			$inserted = $this->insert_used_css( $data );
 
+			if ( ! $inserted ) {
+				return false;
+			}
+
 			// Save used_css into filesystem.
 			$this->save_used_css_in_filesystem( $inserted );
 
@@ -322,6 +326,10 @@ class UsedCSS {
 		}
 
 		$updated = $this->update_used_css( (int) $used_css->id, $data );
+
+		if ( ! $updated ) {
+			return false;
+		}
 
 		// Save used_css into filesystem.
 		$this->save_used_css_in_filesystem( $updated );


### PR DESCRIPTION
## Description

Solving the following error:-
```
PHP Fatal error:  Uncaught TypeError: Argument 1 passed to WP_Rocket\Engine\Optimization\RUCSS\Controller\UsedCSS::save_used_css_in_filesystem() must be an instance of WP_Rocket\Engine\Optimization\RUCSS\Database\Row\UsedCSS, bool given
```