### PR TITLE
Change resources DB table Index column size (url) to be 150

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Database/Tables/Resources.php
+++ b/inc/Engine/Optimization/RUCSS/Database/Tables/Resources.php
@@ -55,7 +55,7 @@ class Resources extends Table {
 			last_accessed    DATETIME            NOT NULL default '0000-00-00 00:00:00',
 			PRIMARY KEY (id),
 			KEY hash (hash),
-			KEY url (url),
+			KEY url (url(150)),
 			KEY type (type),
 			KEY last_accessed (last_accessed)";
 	}


### PR DESCRIPTION
## Description

Adjust the database's index size for the resource's URL to be 150.

## Steps to reset the database to make those changes applied:-

1. Delete the resources table from the database.
2. Go to Database's options table and delete the row for `option_name = wpr_rucss_resources_version`
3. Open the dashboard (wp-admin/) to make the database's table created again.