### PR TITLE
Fix Filename Cases in uninstall.php to work on case-sensitive filesystems

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -13,15 +13,15 @@ if ( ! defined( 'WP_ROCKET_CONFIG_PATH' ) ) {
 require_once dirname( __FILE__ ) . '/inc/Engine/WPRocketUninstall.php';
 
 // RUCSS Database Engine.
-require_once dirname( __FILE__ ) . '/inc/Dependencies/Database/base.php';
-require_once dirname( __FILE__ ) . '/inc/Dependencies/Database/column.php';
-require_once dirname( __FILE__ ) . '/inc/Dependencies/Database/schema.php';
-require_once dirname( __FILE__ ) . '/inc/Dependencies/Database/query.php';
-require_once dirname( __FILE__ ) . '/inc/Dependencies/Database/row.php';
-require_once dirname( __FILE__ ) . '/inc/Dependencies/Database/table.php';
-require_once dirname( __FILE__ ) . '/inc/Dependencies/Database/Queries/meta.php';
-require_once dirname( __FILE__ ) . '/inc/Dependencies/Database/Queries/date.php';
-require_once dirname( __FILE__ ) . '/inc/Dependencies/Database/Queries/compare.php';
+require_once dirname( __FILE__ ) . '/inc/Dependencies/Database/Base.php';
+require_once dirname( __FILE__ ) . '/inc/Dependencies/Database/Column.php';
+require_once dirname( __FILE__ ) . '/inc/Dependencies/Database/Schema.php';
+require_once dirname( __FILE__ ) . '/inc/Dependencies/Database/Query.php';
+require_once dirname( __FILE__ ) . '/inc/Dependencies/Database/Row.php';
+require_once dirname( __FILE__ ) . '/inc/Dependencies/Database/Table.php';
+require_once dirname( __FILE__ ) . '/inc/Dependencies/Database/Queries/Meta.php';
+require_once dirname( __FILE__ ) . '/inc/Dependencies/Database/Queries/Date.php';
+require_once dirname( __FILE__ ) . '/inc/Dependencies/Database/Queries/Compare.php';
 require_once dirname( __FILE__ ) . '/inc/Engine/Optimization/RUCSS/Database/Tables/Resources.php';
 require_once dirname( __FILE__ ) . '/inc/Engine/Optimization/RUCSS/Database/Tables/UsedCSS.php';
 


### PR DESCRIPTION
## Description

Resolves an issue where filename case mismatches in requires causes fatal error on uninstall when on case sensitive filesystems.

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?
Not groomed.... issue and solution were discussed in team channel.
This does comform to the agreed solution.

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes