### PR TITLE
Fixes #3821 Disable the combine JS option and field when delay JS is enabled

### DIFF
--- a/inc/Engine/Admin/Settings/Page.php
+++ b/inc/Engine/Admin/Settings/Page.php
@@ -715,7 +715,7 @@ class Page {
 					'label'             => __( 'Combine JavaScript files <em>(Enable Minify JavaScript files to select)</em>', 'rocket' ),
 					// translators: %1$s = opening <a> tag, %2$s = closing </a> tag.
 					'description'       => sprintf( __( 'Combine JavaScript files combines your site’s internal, 3rd party and inline JS reducing HTTP requests. Not recommended if your site uses HTTP/2. %1$sMore info%2$s', 'rocket' ), '<a href="' . esc_url( $combine_beacon['url'] ) . '" data-beacon-article="' . esc_attr( $combine_beacon['id'] ) . '" target="_blank">', '</a>' ),
-					'helper'            => get_rocket_option( 'delay_js' ) ? __( 'For compatibility and best results, this option is disabled when delay javascript execution is enabled.', 'wp-rocket' ) : '',
+					'helper'            => get_rocket_option( 'delay_js' ) ? __( 'For compatibility and best results, this option is disabled when delay javascript execution is enabled.', 'rocket' ) : '',
 					'container_class'   => [
 						$disable_combine_js ? 'wpr-isDisabled' : '',
 						'wpr-field--parent',

--- a/inc/Engine/Admin/Settings/Page.php
+++ b/inc/Engine/Admin/Settings/Page.php
@@ -558,6 +558,8 @@ class Page {
 		$delay_js_beacon   = $this->beacon->get_suggest( 'delay_js' );
 		$exclude_defer_js  = $this->beacon->get_suggest( 'exclude_defer_js' );
 
+		$disable_combine_js = $this->disable_combine_js();
+
 		$this->settings->add_page_section(
 			'file_optimization',
 			[
@@ -713,8 +715,9 @@ class Page {
 					'label'             => __( 'Combine JavaScript files <em>(Enable Minify JavaScript files to select)</em>', 'rocket' ),
 					// translators: %1$s = opening <a> tag, %2$s = closing </a> tag.
 					'description'       => sprintf( __( 'Combine JavaScript files combines your site’s internal, 3rd party and inline JS reducing HTTP requests. Not recommended if your site uses HTTP/2. %1$sMore info%2$s', 'rocket' ), '<a href="' . esc_url( $combine_beacon['url'] ) . '" data-beacon-article="' . esc_attr( $combine_beacon['id'] ) . '" target="_blank">', '</a>' ),
+					'helper'            => get_rocket_option( 'delay_js' ) ? __( 'For compatibility and best results, this option is disabled when delay javascript execution is enabled.', 'wp-rocket' ) : '',
 					'container_class'   => [
-						get_rocket_option( 'minify_js' ) ? '' : 'wpr-isDisabled',
+						$disable_combine_js ? 'wpr-isDisabled' : '',
 						'wpr-field--parent',
 					],
 					'section'           => 'js',
@@ -722,7 +725,7 @@ class Page {
 					'default'           => 0,
 					'sanitize_callback' => 'sanitize_checkbox',
 					'input_attr'        => [
-						'disabled' => get_rocket_option( 'minify_js' ) ? 0 : 1,
+						'disabled' => $disable_combine_js ? 1 : 0,
 					],
 					'warning'           => [
 						'title'        => __( 'This could break things!', 'rocket' ),
@@ -2066,5 +2069,20 @@ class Page {
 		$format = "<$tag_name>%s</$tag_name>";
 
 		return array_map( 'sprintf', array_fill( 0, count( $list ), $format ), $list );
+	}
+
+	/**
+	 * Checks if combine JS option should be disabled
+	 *
+	 * @since 3.9
+	 *
+	 * @return bool
+	 */
+	private function disable_combine_js(): bool {
+		if ( (bool) get_rocket_option( 'delay_js', 0 ) ) {
+			return true;
+		}
+
+		return ! (bool) get_rocket_option( 'minify_js', 0 );
 	}
 }

--- a/inc/Engine/Optimization/DelayJS/Admin/Settings.php
+++ b/inc/Engine/Optimization/DelayJS/Admin/Settings.php
@@ -49,7 +49,7 @@ class Settings {
 			&&
 			1 === (int) $options['delay_js']
 		) {
-			$options['delay_js_exclusions'] = [
+			$options['delay_js_exclusions']   = [
 				$this->get_excluded_internal_paths(),
 				'/jquery-?[0-9.]*(.min|.slim|.slim.min)?.js',
 				'js-(extra|after)',

--- a/inc/Engine/Optimization/DelayJS/Admin/Settings.php
+++ b/inc/Engine/Optimization/DelayJS/Admin/Settings.php
@@ -54,6 +54,7 @@ class Settings {
 				'/jquery-?[0-9.]*(.min|.slim|.slim.min)?.js',
 				'js-(extra|after)',
 			];
+			$options['minify_concatenate_js'] = 0;
 		}
 
 		update_option( 'wp_rocket_settings', $options );
@@ -74,6 +75,46 @@ class Settings {
 		$input['delay_js_exclusions'] = ! empty( $input['delay_js_exclusions'] ) ? rocket_sanitize_textarea_field( 'delay_js_exclusions', $input['delay_js_exclusions'] ) : [];
 
 		return $input;
+	}
+
+	/**
+	 * Disable combine JS option when delay JS is enabled
+	 *
+	 * @since 3.9
+	 *
+	 * @param array $value     The new, unserialized option value.
+	 * @param array $old_value The old option value.
+	 *
+	 * @return array
+	 */
+	public function maybe_disable_combine_js( $value, $old_value ): array {
+		if ( ! isset( $value['delay_js'], $value['minify_concatenate_js'] ) ) {
+			return $value;
+		}
+
+		if (
+			0 === $value['minify_concatenate_js']
+			||
+			0 === $value['delay_js']
+		) {
+			return $value;
+		}
+
+		if (
+			isset( $old_value['delay_js'], $old_value['minify_concatenate_js'] )
+			&&
+			$value['delay_js'] === $old_value['delay_js']
+			&&
+			1 === $value['delay_js']
+			&&
+			0 === $old_value['minify_concatenate_js']
+		) {
+			return $value;
+		}
+
+		$value['minify_concatenate_js'] = 0;
+
+		return $value;
 	}
 
 	/**

--- a/inc/Engine/Optimization/DelayJS/Admin/Subscriber.php
+++ b/inc/Engine/Optimization/DelayJS/Admin/Subscriber.php
@@ -30,9 +30,10 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events() {
 		return [
-			'rocket_first_install_options' => 'add_options',
-			'wp_rocket_upgrade'            => [ 'set_option_on_update', 13, 2 ],
-			'rocket_input_sanitize'        => [ 'sanitize_options', 13, 2 ],
+			'rocket_first_install_options'         => 'add_options',
+			'wp_rocket_upgrade'                    => [ 'set_option_on_update', 13, 2 ],
+			'rocket_input_sanitize'                => [ 'sanitize_options', 13, 2 ],
+			'pre_update_option_wp_rocket_settings' => [ 'maybe_disable_combine_js', 11, 2 ],
 		];
 	}
 
@@ -76,5 +77,19 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	public function sanitize_options( $input, AdminSettings $settings ) : array {
 		return $this->settings->sanitize_options( $input, $settings );
+	}
+
+	/**
+	 * Disable combine JS option when delay JS is enabled
+	 *
+	 * @since 3.9
+	 *
+	 * @param array $value     The new, unserialized option value.
+	 * @param array $old_value The old option value.
+	 *
+	 * @return array
+	 */
+	public function maybe_disable_combine_js( $value, $old_value ): array {
+		return $this->settings->maybe_disable_combine_js( $value, $old_value );
 	}
 }

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/Admin/Settings/maybeDisableCombineJs.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/Admin/Settings/maybeDisableCombineJs.php
@@ -1,0 +1,130 @@
+<?php
+
+return [
+	'testShouldReturnSameWhenOptionsNotSet' => [
+		'config' => [
+			'value'     => [
+				'minify_js' => 0,
+				'cdn'       => 0,
+			],
+			'old_value' => [
+				'minify_js' => 1,
+				'cdn'       => 0,
+			],
+		],
+		'expected' => [
+			'minify_js' => 0,
+			'cdn'       => 0,
+		],
+	],
+	'testShouldReturnSameWhenOptionsEqualZero' => [
+		'config' => [
+			'value'     => [
+				'minify_js'             => 0,
+				'minify_concatenate_js' => 0,
+				'delay_js'              => 0,
+				'cdn'                   => 0,
+			],
+			'old_value' => [
+				'minify_js'             => 1,
+				'minify_concatenate_js' => 0,
+				'delay_js'              => 1,
+				'cdn'                   => 0,
+			],
+		],
+		'expected' => [
+			'minify_js'             => 0,
+			'minify_concatenate_js' => 0,
+			'delay_js'              => 0,
+			'cdn'                   => 0,
+		],
+	],
+	'testShouldReturnSameWhenDelayJsEnabled' => [
+		'config' => [
+			'value'     => [
+				'minify_js'             => 0,
+				'minify_concatenate_js' => 0,
+				'delay_js'              => 1,
+				'cdn'                   => 0,
+			],
+			'old_value' => [
+				'minify_js'             => 1,
+				'minify_concatenate_js' => 0,
+				'delay_js'              => 1,
+				'cdn'                   => 0,
+			],
+		],
+		'expected' => [
+			'minify_js'             => 0,
+			'minify_concatenate_js' => 0,
+			'delay_js'              => 1,
+			'cdn'                   => 0,
+		],
+	],
+	'testShouldReturnSameWhenCombineJsEnabled' => [
+		'config' => [
+			'value'     => [
+				'minify_js'             => 1,
+				'minify_concatenate_js' => 1,
+				'delay_js'              => 0,
+				'cdn'                   => 0,
+			],
+			'old_value' => [
+				'minify_js'             => 1,
+				'minify_concatenate_js' => 0,
+				'delay_js'              => 0,
+				'cdn'                   => 0,
+			],
+		],
+		'expected' => [
+			'minify_js'             => 1,
+			'minify_concatenate_js' => 1,
+			'delay_js'              => 0,
+			'cdn'                   => 0,
+		],
+	],
+	'testShouldReturnUpdatedWhenCombineJsAndDelayJsEnabled' => [
+		'config' => [
+			'value'     => [
+				'minify_js'             => 1,
+				'minify_concatenate_js' => 1,
+				'delay_js'              => 1,
+				'cdn'                   => 0,
+			],
+			'old_value' => [
+				'minify_js'             => 1,
+				'minify_concatenate_js' => 0,
+				'delay_js'              => 0,
+				'cdn'                   => 0,
+			],
+		],
+		'expected' => [
+			'minify_js'             => 1,
+			'minify_concatenate_js' => 0,
+			'delay_js'              => 1,
+			'cdn'                   => 0,
+		],
+	],
+	'testShouldReturnUpdatedWhenCombineJsAndDelayJsEnabledBefore' => [
+		'config' => [
+			'value'     => [
+				'minify_js'             => 1,
+				'minify_concatenate_js' => 1,
+				'delay_js'              => 1,
+				'cdn'                   => 0,
+			],
+			'old_value' => [
+				'minify_js'             => 1,
+				'minify_concatenate_js' => 1,
+				'delay_js'              => 1,
+				'cdn'                   => 0,
+			],
+		],
+		'expected' => [
+			'minify_js'             => 1,
+			'minify_concatenate_js' => 0,
+			'delay_js'              => 1,
+			'cdn'                   => 0,
+		],
+	],
+];

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/Admin/Settings/setOptionOnUpdate.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/Admin/Settings/setOptionOnUpdate.php
@@ -24,15 +24,17 @@ return [
 			'delay_js_exclusions' => [],
 		],
 	],
-	'testShouldUpdateOptionWhenVersionBelow3.9AndDelayJSEquals1'    => [
+	'testShouldUpdateOptionWhenVersionBelow3.9AndDelayJSEquals1' => [
 		'options'       => [
-			'delay_js'            => 1,
+			'delay_js'              => 1,
+			'minify_concatenate_js' => 1,
 		],
 		'old_version'   => '3.8',
 		'valid_version' => true,
 		'expected'      => [
-			'delay_js'            => 1,
-			'delay_js_exclusions' => [
+			'delay_js'              => 1,
+			'minify_concatenate_js' => 0,
+			'delay_js_exclusions'   => [
 				'(?:/wp-content|/wp-includes/)(.*)',
 				'/jquery-?[0-9.]*(.min|.slim|.slim.min)?.js',
 				'js-(extra|after)',

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/Admin/Subscriber/maybeDisableCombineJs.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/Admin/Subscriber/maybeDisableCombineJs.php
@@ -1,0 +1,130 @@
+<?php
+
+return [
+	'testShouldReturnSameWhenOptionsNotSet' => [
+		'config' => [
+			'value'     => [
+				'minify_js' => 0,
+				'cdn'       => 0,
+			],
+			'old_value' => [
+				'minify_js' => 1,
+				'cdn'       => 0,
+			],
+		],
+		'expected' => [
+			'minify_js' => 0,
+			'cdn'       => 0,
+		],
+	],
+	'testShouldReturnSameWhenOptionsEqualZero' => [
+		'config' => [
+			'value'     => [
+				'minify_js'             => 0,
+				'minify_concatenate_js' => 0,
+				'delay_js'              => 0,
+				'cdn'                   => 0,
+			],
+			'old_value' => [
+				'minify_js'             => 1,
+				'minify_concatenate_js' => 0,
+				'delay_js'              => 1,
+				'cdn'                   => 0,
+			],
+		],
+		'expected' => [
+			'minify_js'             => 0,
+			'minify_concatenate_js' => 0,
+			'delay_js'              => 0,
+			'cdn'                   => 0,
+		],
+	],
+	'testShouldReturnSameWhenDelayJsEnabled' => [
+		'config' => [
+			'value'     => [
+				'minify_js'             => 0,
+				'minify_concatenate_js' => 0,
+				'delay_js'              => 1,
+				'cdn'                   => 0,
+			],
+			'old_value' => [
+				'minify_js'             => 1,
+				'minify_concatenate_js' => 0,
+				'delay_js'              => 1,
+				'cdn'                   => 0,
+			],
+		],
+		'expected' => [
+			'minify_js'             => 0,
+			'minify_concatenate_js' => 0,
+			'delay_js'              => 1,
+			'cdn'                   => 0,
+		],
+	],
+	'testShouldReturnSameWhenCombineJsEnabled' => [
+		'config' => [
+			'value'     => [
+				'minify_js'             => 1,
+				'minify_concatenate_js' => 1,
+				'delay_js'              => 0,
+				'cdn'                   => 0,
+			],
+			'old_value' => [
+				'minify_js'             => 1,
+				'minify_concatenate_js' => 0,
+				'delay_js'              => 0,
+				'cdn'                   => 0,
+			],
+		],
+		'expected' => [
+			'minify_js'             => 1,
+			'minify_concatenate_js' => 1,
+			'delay_js'              => 0,
+			'cdn'                   => 0,
+		],
+	],
+	'testShouldReturnUpdatedWhenCombineJsAndDelayJsEnabled' => [
+		'config' => [
+			'value'     => [
+				'minify_js'             => 1,
+				'minify_concatenate_js' => 1,
+				'delay_js'              => 1,
+				'cdn'                   => 0,
+			],
+			'old_value' => [
+				'minify_js'             => 1,
+				'minify_concatenate_js' => 0,
+				'delay_js'              => 0,
+				'cdn'                   => 0,
+			],
+		],
+		'expected' => [
+			'minify_js'             => 1,
+			'minify_concatenate_js' => 0,
+			'delay_js'              => 1,
+			'cdn'                   => 0,
+		],
+	],
+	'testShouldReturnUpdatedWhenCombineJsAndDelayJsEnabledBefore' => [
+		'config' => [
+			'value'     => [
+				'minify_js'             => 1,
+				'minify_concatenate_js' => 1,
+				'delay_js'              => 1,
+				'cdn'                   => 0,
+			],
+			'old_value' => [
+				'minify_js'             => 1,
+				'minify_concatenate_js' => 1,
+				'delay_js'              => 1,
+				'cdn'                   => 0,
+			],
+		],
+		'expected' => [
+			'minify_js'             => 1,
+			'minify_concatenate_js' => 0,
+			'delay_js'              => 1,
+			'cdn'                   => 0,
+		],
+	],
+];

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/Admin/Subscriber/setOptionOnUpdate.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/Admin/Subscriber/setOptionOnUpdate.php
@@ -22,14 +22,16 @@ return [
 			'delay_js_exclusions' => [],
 		],
 	],
-	'testShouldUpdateOptionWhenVersionBelow3.9AndDelayJSEquals1'    => [
+	'testShouldUpdateOptionWhenVersionBelow3.9AndDelayJSEquals1' => [
 		'options'       => [
-			'delay_js' => 1,
+			'delay_js'              => 1,
+			'minify_concatenate_js' => 1,
 		],
 		'old_version'   => '3.8',
 		'expected'      => [
-			'delay_js'            => 1,
-			'delay_js_exclusions' => [
+			'delay_js'              => 1,
+			'minify_concatenate_js' => 0,
+			'delay_js_exclusions'   => [
 				'(?:/wp-content|/wp-includes/)(.*)',
 				'/jquery-?[0-9.]*(.min|.slim|.slim.min)?.js',
 				'js-(extra|after)',

--- a/tests/Integration/inc/Engine/Optimization/DelayJS/Admin/Subscriber/maybeDisableCombineJs.php
+++ b/tests/Integration/inc/Engine/Optimization/DelayJS/Admin/Subscriber/maybeDisableCombineJs.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\Optimization\DelayJS\Admin\Subscriber;
+
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Optimization\DelayJS\Admin\Subscriber::maybe_disable_combine_js
+ *
+ * @group DelayJS
+ * @group AdminOnly
+ */
+class Test_MaybeDisableCombineJs extends TestCase {
+	public function setUp() : void {
+		parent::setUp();
+
+		$this->unregisterAllCallbacksExcept( 'pre_update_option_wp_rocket_settings', 'maybe_disable_combine_js', 11 );
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+
+		$this->restoreWpFilter( 'pre_update_option_wp_rocket_settings' );
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldDoExpectedForFirstInstallOptions( $config, $expected ) {
+		$this->assertSame(
+			$expected,
+			apply_filters( 'pre_update_option_wp_rocket_settings', $config['value'], $config['old_value'] )
+		);
+	}
+}

--- a/tests/Unit/inc/Engine/Optimization/DelayJS/Admin/Settings/maybeDisableCombineJs.php
+++ b/tests/Unit/inc/Engine/Optimization/DelayJS/Admin/Settings/maybeDisableCombineJs.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\DelayJS\Admin\Settings;
+
+use WP_Rocket\Engine\Optimization\DelayJS\Admin\Settings;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Optimization\DelayJS\Admin\Settings::maybe_disable_combine_js
+ *
+ * @group  DelayJS
+ */
+class Test_MaybeDisableCombineJs extends TestCase {
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldDoExpected( $config, $expected ) {
+		$settings = new Settings();
+
+		$this->assertSame(
+			$expected,
+			$settings->maybe_disable_combine_js( $config['value'], $config['old_value'] )
+		);
+	}
+}


### PR DESCRIPTION
## Description

Reflect on the settings page the disabling of the combine JS option when delay JS is enabled.

It is now:
- Disabled when updating to 3.9 and delay JS is already enabled
- Disabled whenever delay JS is enabled on the settings page and the changes saved

Fixes #3821 

## Type of change

- [x] Enhancement (non-breaking change which adds functionality)

## Is the solution different from the one proposed during the grooming?

No grooming done

## How Has This Been Tested?

- [x] Manual testing
- [x] Added new tests + updated existing tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes