### PR TITLE
Remove out of sync RUCSS resources

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -16,13 +16,14 @@ class UsedCSS {
 	use RegexTrait;
 
 	/**
-	 * UsedCss Query instance
+	 * UsedCss Query instance.
 	 *
 	 * @var UsedCSS_Query
 	 */
 	private $used_css_query;
 
 	/**
+	 * Resources Query instance.
 	 * @var ResourcesQuery
 	 */
 	private $resources_query;
@@ -188,7 +189,7 @@ class UsedCSS {
 			}
 
 			if ( 3 === $retries && ! empty( $treeshaked_result['unprocessed_css'] ) ) {
-				$this->remove_unprocessed_from_resources($treeshaked_result['unprocessed_css'] );
+				$this->remove_unprocessed_from_resources( $treeshaked_result['unprocessed_css'] );
 			}
 
 			$data = [
@@ -635,7 +636,7 @@ class UsedCSS {
 	 *
 	 * @since 3.9
 	 *
-	 * @param array $unprocessed_css Unprocessed CSS Items
+	 * @param array $unprocessed_css Unprocessed CSS Items.
 	 *
 	 * @return void
 	 */

--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -3,7 +3,6 @@ declare( strict_types=1 );
 
 namespace WP_Rocket\Engine\Optimization\RUCSS\Controller;
 
-use phpDocumentor\Reflection\DocBlock\Tags\Uses;
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\Cache\Purge;
 use WP_Rocket\Engine\Optimization\RegexTrait;
@@ -649,7 +648,7 @@ class UsedCSS {
 	 */
 	private function remove_unprocessed_from_resources( $unprocessed_css ) {
 		foreach ( $unprocessed_css as $resource ) {
-			$this->resources_query->remove( $resource['content'] );
+			$this->resources_query->remove_by_url( $resource['content'] );
 		}
 	}
 

--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -1,8 +1,9 @@
 <?php
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace WP_Rocket\Engine\Optimization\RUCSS\Controller;
 
+use phpDocumentor\Reflection\DocBlock\Tags\Uses;
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\Cache\Purge;
 use WP_Rocket\Engine\Optimization\RegexTrait;
@@ -145,7 +146,7 @@ class UsedCSS {
 	/**
 	 * Apply TreeShaked CSS to the current HTML page.
 	 *
-	 * @param string $html  HTML content.
+	 * @param string $html HTML content.
 	 *
 	 * @return string  HTML content.
 	 */
@@ -177,6 +178,7 @@ class UsedCSS {
 						'message' => $treeshaked_result['message'],
 					]
 				);
+
 				return $html;
 			}
 
@@ -187,10 +189,6 @@ class UsedCSS {
 
 			if ( ! empty( $treeshaked_result['unprocessed_css'] ) ) {
 				$this->schedule_rucss_retry();
-			}
-
-			if ( 3 === $retries && ! empty( $treeshaked_result['unprocessed_css'] ) ) {
-				$this->remove_unprocessed_from_resources( $treeshaked_result['unprocessed_css'] );
 			}
 
 			$data = [
@@ -209,6 +207,10 @@ class UsedCSS {
 			}
 		}
 
+		if ( 3 === $used_css->retries && ! empty( $used_css->unprocessedcss ) ) {
+			$this->remove_unprocessed_from_resources( $used_css->unprocessedcss );
+		}
+
 		$html = $this->remove_used_css_from_html( $html, $used_css->unprocessedcss );
 
 		$html = $this->add_used_css_to_html( $html, $used_css );
@@ -225,7 +227,7 @@ class UsedCSS {
 	 *
 	 * @return boolean
 	 */
-	public function delete_used_css( string $url ) : bool {
+	public function delete_used_css( string $url ): bool {
 		$used_css_arr = $this->used_css_query->query( [ 'url' => $url ] );
 
 		if ( empty( $used_css_arr ) ) {
@@ -280,11 +282,11 @@ class UsedCSS {
 	 */
 	private function get_used_css( string $url, bool $is_mobile = false ) {
 		$query = $this->used_css_query->query(
-					[
-						'url'       => $url,
-						'is_mobile' => $is_mobile,
-					]
-				);
+			[
+				'url'       => $url,
+				'is_mobile' => $is_mobile,
+			]
+		);
 
 		if ( empty( $query[0] ) ) {
 			return false;
@@ -313,14 +315,14 @@ class UsedCSS {
 	/**
 	 * Insert or update used css row based on URL.
 	 *
-	 * @param  array $data {
-	 *      Data to be saved / updated in database.
+	 * @param array $data           {
+	 *                              Data to be saved / updated in database.
 	 *
-	 *      @type string $url             The page URL.
-	 *      @type string $css             The page used css.
-	 *      @type string  $unprocessedcss A json_encoded array of the page unprocessed CSS list.
-	 *      @type int    $retries         No of automatically retries for generating the unused css.
-	 *      @type bool   $is_mobile       Is mobile page.
+	 * @type string $url            The page URL.
+	 * @type string $css            The page used css.
+	 * @type string $unprocessedcss A json_encoded array of the page unprocessed CSS list.
+	 * @type int    $retries        No of automatically retries for generating the unused css.
+	 * @type bool   $is_mobile      Is mobile page.
 	 * }
 	 *
 	 * @return UsedCSS_Row|false
@@ -415,7 +417,7 @@ class UsedCSS {
 				strstr( $style['url'], '//fonts.googleapis.com/css' )
 				||
 				in_array( htmlspecialchars_decode( $style['url'] ), $unprocessed_links, true )
-				) {
+			) {
 				continue;
 			}
 			$html = str_replace( $style[0], '', $html );
@@ -434,7 +436,7 @@ class UsedCSS {
 	/**
 	 * Alter HTML string and add the used CSS style in <head> tag,
 	 *
-	 * @param string      $html HTML content.
+	 * @param string      $html     HTML content.
 	 * @param UsedCSS_Row $used_css Used CSS DB row.
 	 *
 	 * @return string HTML content.
@@ -508,6 +510,7 @@ class UsedCSS {
 				$unprocessed_array[] = $this->strip_line_breaks( $css['content'] );
 			}
 		}
+
 		return $unprocessed_array;
 	}
 
@@ -520,6 +523,7 @@ class UsedCSS {
 	 */
 	private function strip_line_breaks( string $value ): string {
 		$value = str_replace( [ "\r", "\n", "\r\n", "\t" ], '', $value );
+
 		return trim( $value );
 	}
 
@@ -612,8 +616,8 @@ class UsedCSS {
 	 */
 	private function is_mobile(): bool {
 		return $this->options->get( 'cache_mobile', 0 ) &&
-			$this->options->get( 'do_caching_mobile_files', 0 ) &&
-			wp_is_mobile();
+		       $this->options->get( 'do_caching_mobile_files', 0 ) &&
+		       wp_is_mobile();
 	}
 
 	/**
@@ -643,7 +647,7 @@ class UsedCSS {
 	 */
 	private function remove_unprocessed_from_resources( $unprocessed_css ) {
 		foreach ( $unprocessed_css as $resource ) {
-			$this->resources_query->remove( $resource );
+			$this->resources_query->remove( $resource['content'] );
 		}
 	}
 

--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -24,6 +24,7 @@ class UsedCSS {
 
 	/**
 	 * Resources Query instance.
+	 *
 	 * @var ResourcesQuery
 	 */
 	private $resources_query;

--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -615,9 +615,11 @@ class UsedCSS {
 	 * @return boolean
 	 */
 	private function is_mobile(): bool {
-		return $this->options->get( 'cache_mobile', 0 ) &&
-		       $this->options->get( 'do_caching_mobile_files', 0 ) &&
-		       wp_is_mobile();
+		return $this->options->get( 'cache_mobile', 0 )
+			&&
+			$this->options->get( 'do_caching_mobile_files', 0 )
+			&&
+			wp_is_mobile();
 	}
 
 	/**

--- a/inc/Engine/Optimization/RUCSS/Database/Queries/ResourcesQuery.php
+++ b/inc/Engine/Optimization/RUCSS/Database/Queries/ResourcesQuery.php
@@ -1,5 +1,5 @@
 <?php
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace WP_Rocket\Engine\Optimization\RUCSS\Database\Queries;
 
@@ -130,19 +130,13 @@ class ResourcesQuery extends Query {
 	 *
 	 * @since 3.9
 	 *
-	 * @param string $url URL of the item to remove.
+	 * @param string $url URL of the item to remove_by_url.
 	 *
-	 * @return bool|int ID of the resource row removed, or false if was not in the table.
+	 * @return void
 	 */
-	public function remove( $url ) {
+	public function remove_by_url( $url ) {
 		$db_row = $this->get_item_by( 'url', $url );
 
-		if ( empty( $db_row ) ) {
-			return false;
-		}
-
 		$this->delete_item( $db_row->id );
-
-		return $db_row->id;
 	}
 }

--- a/inc/Engine/Optimization/RUCSS/Database/Queries/ResourcesQuery.php
+++ b/inc/Engine/Optimization/RUCSS/Database/Queries/ResourcesQuery.php
@@ -125,4 +125,24 @@ class ResourcesQuery extends Query {
 		return $db_row->id;
 	}
 
+	/**
+	 * Remove a resource from the table (if it is there).
+	 *
+	 * @since 3.9
+	 *
+	 * @param string $url URL of the item to remove.
+	 *
+	 * @return bool|int ID of the resource row removed, or false if was not in the table.
+	 */
+	public function remove( $url ) {
+		$db_row = $this->get_item_by( 'url', $url );
+
+		if ( empty( $db_row ) ) {
+			return false;
+		}
+
+		$this->delete_item( $db_row->id );
+
+		return $db_row->id;
+	}
 }

--- a/inc/Engine/Optimization/RUCSS/ServiceProvider.php
+++ b/inc/Engine/Optimization/RUCSS/ServiceProvider.php
@@ -56,6 +56,7 @@ class ServiceProvider extends AbstractServiceProvider {
 		$this->getContainer()->add( 'rucss_used_css_controller', 'WP_Rocket\Engine\Optimization\RUCSS\Controller\UsedCSS' )
 			->addArgument( $this->getContainer()->get( 'options' ) )
 			->addArgument( $this->getContainer()->get( 'rucss_used_css_query' ) )
+			->addArgument( $this->getContainer()->get( 'rucss_resources_query' ) )
 			->addArgument( $this->getContainer()->get( 'purge' ) )
 			->addArgument( $this->getContainer()->get( 'rucss_frontend_api_client' ) );
 
@@ -84,6 +85,5 @@ class ServiceProvider extends AbstractServiceProvider {
 		$this->getContainer()->share( 'rucss_warmup_subscriber', '\WP_Rocket\Engine\Optimization\RUCSS\Warmup\Subscriber' )
 			->addArgument( $this->getContainer()->get( 'options' ) )
 			->addArgument( $this->getContainer()->get( 'rucss_resource_fetcher' ) );
-
 	}
 }

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/treeshake.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/treeshake.php
@@ -333,7 +333,7 @@ return [
 					'is_mobile'      => false,
 				],
 				'has_cpcss'             => true,
-				'generated-file' => 'vfs://public/wp-content/cache/used-css/1/home/used.min.css',
+				'generated-file'        => 'vfs://public/wp-content/cache/used-css/1/home/used.min.css',
 			],
 			'api-response' => [
 				'body'     => json_encode(
@@ -374,6 +374,84 @@ return [
 </body>
 </html>'
 		],
-	],
 
+		'shouldRemovePreviouslySavedResourcesWhenInUnprocessedCssAndRetries3' => [
+			'config'       => [
+				'html'                  => '<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>My Awesome Page</title>
+	<link rel="stylesheet" type="text/css" href="http://example.org/wp-content/themes/theme-name/style.css">
+	<link rel="stylesheet" type="text/css" href="//example.org/wp-content/themes/theme-name/style.css">
+	<link rel="stylesheet" type="text/css" href="/wp-content/themes/theme-name/style.css">
+	<link rel="stylesheet" type="text/css" href="wp-content/themes/theme-name/style.css">
+	<link rel="stylesheet" type="text/css" href="/css/style.css">
+	<link rel="stylesheet" type="text/css" href="http://external.com/css/style.css">
+	<link rel="stylesheet" type="text/css" href="//external.com/css/style.css">
+	<style>h2{color:blue;}</style>
+</head>
+<body>
+ content here
+</body>
+</html>',
+				'used-css-row-contents' => [
+					'url'            => 'http://example.org/home',
+					'css'            => '',
+					'unprocessedcss' => wp_json_encode(
+						[
+							[
+								'type'    => 'link',
+								'content' => 'http://example.org/wp-content/themes/theme-name/style.css',
+							],
+						]
+					),
+					'retries'        => 3,
+					'is_mobile'      => false,
+				],
+				'has_cpcss'             => true,
+				'generated-file'        => 'vfs://public/wp-content/cache/used-css/1/home/used.min.css',
+				'saved-resources'       => [
+					'http://example.org/wp-content/themes/theme-name/style.css',
+				],
+			],
+			'api-response' => [
+				'body'     => json_encode(
+					[
+						'code'     => 200,
+						'message'  => 'OK',
+						'contents' => [
+							'shakedCSS'      => 'h1{color:red;}',
+							'unProcessedCss' => [
+								[
+									'type'    => 'link',
+									'content' => 'http://example.org/wp-content/themes/theme-name/style.css',
+								],
+								[
+									'type'    => 'inline',
+									'content' => 'h2{color:blue;}',
+								],
+							],
+						],
+					]
+				),
+				'response' => [
+					'code'    => 200,
+					'message' => 'OK',
+				],
+			],
+			'expected'     => '<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>My Awesome Page</title>
+	<link rel="stylesheet" data-no-minify="" id="wpr-usedcss-css" href="http://example.org/wp-content/cache/used-css/1/home/used.min.css?ver={{mtime}}">
+	<link rel="stylesheet" type="text/css" href="http://example.org/wp-content/themes/theme-name/style.css">
+</head>
+<body>
+ content here
+</body>
+</html>'
+		],
+	],
 ];

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Database/Queries/ResourcesQuery/remove.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Database/Queries/ResourcesQuery/remove.php
@@ -33,7 +33,7 @@ class Test_Remove extends TestCase {
 		$this->assertFalse( $rucss_resources_query->remove('https://www.example.org/style.css') );
 	}
 
-	public function testShouldRemoveItemIfExists() {
+	public function testShouldRemoveItemReturningIdOfRemovedWhenExists() {
 		$container             = apply_filters( 'rocket_container', null );
 		$rucss_resources_query = $container->get( 'rucss_resources_query' );
 

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Database/Queries/ResourcesQuery/remove.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Database/Queries/ResourcesQuery/remove.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\Optimization\RUCSS\Database\Queries\ResourcesQuery;
+
+use WP_Rocket\Tests\Integration\DBTrait;
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Optimization\RUCSS\Database\Queries\ResourcesQuery::create_or_update
+ *
+ * @group  RUCSS
+ */
+class Test_Remove extends TestCase {
+	use DBTrait;
+
+	public static function setUpBeforeClass(): void {
+		self::installFresh();
+
+		parent::setUpBeforeClass();
+	}
+
+	public static function tearDownAfterClass() {
+		parent::tearDownAfterClass();
+
+		self::uninstallAll();
+	}
+
+	public function testShouldReturnFalseWhenItemNotExists() {
+		$container             = apply_filters( 'rocket_container', null );
+		$rucss_resources_query = $container->get( 'rucss_resources_query' );
+
+		$this->assertFalse( $rucss_resources_query->remove('https://www.example.org/style.css') );
+	}
+
+	public function testShouldRemoveItemIfExists() {
+		$container             = apply_filters( 'rocket_container', null );
+		$rucss_resources_query = $container->get( 'rucss_resources_query' );
+
+		$item = [
+			'url'     => 'https://www.example.org/style.css',
+			'type'    => 'css',
+			'content' => '.example{color:red;}',
+			'media'   => 'all',
+		];
+
+		$id = $rucss_resources_query->add_item( $item );
+
+		$this->assertEquals( $id, $rucss_resources_query->remove($item['url'] ) );
+	}
+}

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Database/Queries/ResourcesQuery/removeByUrl.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Database/Queries/ResourcesQuery/removeByUrl.php
@@ -1,5 +1,5 @@
 <?php
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace WP_Rocket\Tests\Integration\inc\Engine\Optimization\RUCSS\Database\Queries\ResourcesQuery;
 
@@ -11,7 +11,7 @@ use WP_Rocket\Tests\Integration\TestCase;
  *
  * @group  RUCSS
  */
-class Test_Remove extends TestCase {
+class Test_RemoveByUrl extends TestCase {
 	use DBTrait;
 
 	public static function setUpBeforeClass(): void {
@@ -26,14 +26,7 @@ class Test_Remove extends TestCase {
 		self::uninstallAll();
 	}
 
-	public function testShouldReturnFalseWhenItemNotExists() {
-		$container             = apply_filters( 'rocket_container', null );
-		$rucss_resources_query = $container->get( 'rucss_resources_query' );
-
-		$this->assertFalse( $rucss_resources_query->remove('https://www.example.org/style.css') );
-	}
-
-	public function testShouldRemoveItemReturningIdOfRemovedWhenExists() {
+	public function testShouldRemoveResourceItem() {
 		$container             = apply_filters( 'rocket_container', null );
 		$rucss_resources_query = $container->get( 'rucss_resources_query' );
 
@@ -44,8 +37,14 @@ class Test_Remove extends TestCase {
 			'media'   => 'all',
 		];
 
-		$id = $rucss_resources_query->add_item( $item );
+		$added = $rucss_resources_query->add_item( $item );
 
-		$this->assertEquals( $id, $rucss_resources_query->remove($item['url'] ) );
+		// Check that it was added properly for the test.
+		$this->assertIsObject( $rucss_resources_query->get_item_by( 'url', $item['url'] ) );
+
+		$rucss_resources_query->remove_by_url( $item['url'] );
+
+		// Check that the method under test has removed it.
+		$this->assertFalse( $rucss_resources_query->get_item_by( 'url', $item['url'] ) );
 	}
 }


### PR DESCRIPTION
## Description

On certain occasions data in SaaS will be removed, leaving resources table for certain items out of sync with availablity to treeshake.
To get things back into sync, any time we have retries === 3, but we still have unprocessed CSS coming back from the treeshake we will check for those unprocessed resources in the resources table and remove them in order to trigger sending them again for warmup on the next warmup run.

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## Is the solution different from the one proposed during the grooming?
This is the solution as proposed in the dev team meeting

## How Has This Been Tested?

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules