### PR TITLE
Add before to the inline JS exclusion pattern for delay JS

### DIFF
--- a/inc/Engine/Optimization/DelayJS/Admin/Settings.php
+++ b/inc/Engine/Optimization/DelayJS/Admin/Settings.php
@@ -52,7 +52,7 @@ class Settings {
 			$options['delay_js_exclusions']   = [
 				$this->get_excluded_internal_paths(),
 				'/jquery-?[0-9.]*(.min|.slim|.slim.min)?.js',
-				'js-(extra|after)',
+				'js-(extra|before|after)',
 			];
 			$options['minify_concatenate_js'] = 0;
 		}

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/Admin/Settings/setOptionOnUpdate.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/Admin/Settings/setOptionOnUpdate.php
@@ -37,7 +37,7 @@ return [
 			'delay_js_exclusions'   => [
 				'(?:/wp-content|/wp-includes/)(.*)',
 				'/jquery-?[0-9.]*(.min|.slim|.slim.min)?.js',
-				'js-(extra|after)',
+				'js-(extra|before|after)',
 			],
 		],
 	],

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/Admin/Subscriber/setOptionOnUpdate.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/Admin/Subscriber/setOptionOnUpdate.php
@@ -34,7 +34,7 @@ return [
 			'delay_js_exclusions'   => [
 				'(?:/wp-content|/wp-includes/)(.*)',
 				'/jquery-?[0-9.]*(.min|.slim|.slim.min)?.js',
-				'js-(extra|after)',
+				'js-(extra|before|after)',
 			],
 		],
 	],

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/HTML/delayJs.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/HTML/delayJs.php
@@ -107,7 +107,7 @@ return [
 				'delay_js_exclusions'  => [
 					'(?:/wp-content|/wp-includes/)(.*)',
 					'/jquery-?[0-9.]*(.min|.slim|.slim.min)?.js',
-					'js-(extra|after)',
+					'js-(extra|before|after)',
 				],
 			],
 			'html'     => $html,

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/Subscriber/delayJs.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/Subscriber/delayJs.php
@@ -128,7 +128,7 @@ return [
 				'delay_js_exclusions'  => [
 					'(?:/wp-content|/wp-includes/)(.*)',
 					'/jquery-?[0-9.]*(.min|.slim|.slim.min)?.js',
-					'js-(extra|after)',
+					'js-(extra|before|after)',
 				],
 			],
 			'html'     => $html,


### PR DESCRIPTION
## Description

Add `js-before` to the inline JS exclusion pattern when upgrading to 3.9 with delay JS. It's in addition to `js-extra` and `js-after`, to be sure we catch them all.

## Type of change

- [x] Enhancement (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Updated automated tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes