### PR TITLE
Fixes #3852 Correctly show updated options values after plugin update

### DIFF
--- a/inc/admin/upgrader.php
+++ b/inc/admin/upgrader.php
@@ -40,6 +40,15 @@ function rocket_upgrader() {
 
 	$page = filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING );
 
+	if (
+		did_action( 'wp_rocket_upgrade' )
+		&&
+		'wprocket' === $page
+	) {
+		wp_safe_redirect( esc_url_raw( admin_url( 'options-general.php?page=wprocket' ) ) );
+		exit;
+	}
+
 	if ( ! rocket_valid_key() && current_user_can( 'rocket_manage_options' ) && 'wprocket' === $page ) {
 		add_action( 'admin_notices', 'rocket_need_api_key' );
 	}

--- a/inc/admin/upgrader.php
+++ b/inc/admin/upgrader.php
@@ -41,9 +41,9 @@ function rocket_upgrader() {
 	$page = filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING );
 
 	if (
-		did_action( 'wp_rocket_upgrade' )
-		&&
 		'wprocket' === $page
+		&&
+		did_action( 'wp_rocket_upgrade' )
 	) {
 		wp_safe_redirect( esc_url_raw( admin_url( 'options-general.php?page=wprocket' ) ) );
 		exit;


### PR DESCRIPTION
## Description

As described in the issue, we are in a race condition when loading the settings page as the first page after updating the plugin, which results in incorrect display of the options values sometimes.

Forcing a reload of the page once `wp_rocket_upgrade` is finished will prevent this.

Fixes #3852 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

No

## How Has This Been Tested?

- [x] Tested manually by switching between versions of the plugin, and verifying the redirect was correctly triggered

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes