### PR TITLE
Fixes #3853 Exclude inline scripts added by wp_localize_script() from delay JS

### DIFF
--- a/inc/Engine/Optimization/DelayJS/Admin/Settings.php
+++ b/inc/Engine/Optimization/DelayJS/Admin/Settings.php
@@ -52,7 +52,7 @@ class Settings {
 			$options['delay_js_exclusions']   = [
 				$this->get_excluded_internal_paths(),
 				'/jquery-?[0-9.]*(.min|.slim|.slim.min)?.js',
-				'js-(extra|before|after)',
+				'js-(before|after)',
 			];
 			$options['minify_concatenate_js'] = 0;
 		}

--- a/inc/Engine/Optimization/DelayJS/HTML.php
+++ b/inc/Engine/Optimization/DelayJS/HTML.php
@@ -29,6 +29,7 @@ class HTML {
 		'lazyLoadOptions',
 		'lazyLoadThumb',
 		'wp-rocket/assets/js/lazyload/(.*)',
+		'js-extra',
 	];
 
 	/**

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/Admin/Settings/setOptionOnUpdate.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/Admin/Settings/setOptionOnUpdate.php
@@ -37,7 +37,7 @@ return [
 			'delay_js_exclusions'   => [
 				'(?:/wp-content|/wp-includes/)(.*)',
 				'/jquery-?[0-9.]*(.min|.slim|.slim.min)?.js',
-				'js-(extra|before|after)',
+				'js-(before|after)',
 			],
 		],
 	],

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/Admin/Subscriber/setOptionOnUpdate.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/Admin/Subscriber/setOptionOnUpdate.php
@@ -34,7 +34,7 @@ return [
 			'delay_js_exclusions'   => [
 				'(?:/wp-content|/wp-includes/)(.*)',
 				'/jquery-?[0-9.]*(.min|.slim|.slim.min)?.js',
-				'js-(extra|before|after)',
+				'js-(before|after)',
 			],
 		],
 	],

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/HTML/delayJs.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/HTML/delayJs.php
@@ -107,7 +107,7 @@ return [
 				'delay_js_exclusions'  => [
 					'(?:/wp-content|/wp-includes/)(.*)',
 					'/jquery-?[0-9.]*(.min|.slim|.slim.min)?.js',
-					'js-(extra|before|after)',
+					'js-(before|after)',
 				],
 			],
 			'html'     => $html,

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/Subscriber/delayJs.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/Subscriber/delayJs.php
@@ -128,7 +128,7 @@ return [
 				'delay_js_exclusions'  => [
 					'(?:/wp-content|/wp-includes/)(.*)',
 					'/jquery-?[0-9.]*(.min|.slim|.slim.min)?.js',
-					'js-(extra|before|after)',
+					'js-(before|after)',
 				],
 			],
 			'html'     => $html,


### PR DESCRIPTION
## Description

Exclude inline scripts added by the `wp_localize_script()` function from delay JS. It is not required to delay them, as there is no code execution in it. And it can also avoid unexpected issues.

Fixes #3853 

## Type of change

- [x] Enhancement (non-breaking change which adds functionality)

## Is the solution different from the one proposed during the grooming?

No

## How Has This Been Tested?

- [x] Automated tests in place
- [x] Manual tests on pages with this type of inline script

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
