### PR TITLE
RUCSS Onboarding step 1: Pages scanner

### DIFF
--- a/inc/Engine/CriticalPath/CriticalCSS.php
+++ b/inc/Engine/CriticalPath/CriticalCSS.php
@@ -6,6 +6,7 @@ use FilesystemIterator;
 use UnexpectedValueException;
 use WP_Filesystem_Direct;
 use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Engine\Optimization\ContentTrait;
 
 /**
  * Handles the critical CSS generation process.
@@ -13,6 +14,8 @@ use WP_Rocket\Admin\Options_Data;
  * @since 2.11
  */
 class CriticalCSS {
+	use ContentTrait;
+
 	/**
 	 * Background Process instance.
 	 *
@@ -193,123 +196,6 @@ class CriticalCSS {
 			// No logging yet.
 			return [];
 		}
-	}
-
-	/**
-	 * Gets all public post types.
-	 *
-	 * @since 2.11
-	 */
-	private function get_public_post_types() {
-		global $wpdb;
-
-		$post_types = get_post_types(
-			[
-				'public'             => true,
-				'publicly_queryable' => true,
-			]
-		);
-
-		$post_types[] = 'page';
-
-		/**
-		 * Filters the post types excluded from critical CSS generation.
-		 *
-		 * @since 2.11
-		 *
-		 * @param array $excluded_post_types An array of post types names.
-		 *
-		 * @return array
-		 */
-		$excluded_post_types = (array) apply_filters(
-			'rocket_cpcss_excluded_post_types',
-			[
-				'elementor_library',
-				'oceanwp_library',
-				'tbuilder_layout',
-				'tbuilder_layout_part',
-				'slider',
-				'karma-slider',
-				'tt-gallery',
-				'xlwcty_thankyou',
-				'fusion_template',
-				'blocks',
-				'jet-woo-builder',
-				'fl-builder-template',
-				'cms_block',
-				'web-story',
-			]
-		);
-
-		$post_types = array_diff( $post_types, $excluded_post_types );
-		$post_types = esc_sql( $post_types );
-		$post_types = "'" . implode( "','", $post_types ) . "'";
-
-		return $wpdb->get_results(
-			"SELECT MAX(ID) as ID, post_type
-		    FROM (
-		        SELECT ID, post_type
-		        FROM $wpdb->posts
-				WHERE post_type IN ( $post_types )
-		        AND post_status = 'publish'
-		        ORDER BY post_date DESC
-		    ) AS posts
-		    GROUP BY post_type"
-		);
-	}
-
-	/**
-	 * Gets all public taxonomies.
-	 *
-	 * @since  2.11
-	 */
-	private function get_public_taxonomies() {
-		global $wpdb;
-
-		$taxonomies = get_taxonomies(
-			[
-				'public'             => true,
-				'publicly_queryable' => true,
-			]
-		);
-
-		/**
-		 * Filters the taxonomies excluded from critical CSS generation.
-		 *
-		 * @since  2.11
-		 *
-		 * @param array $excluded_taxonomies An array of taxonomies names.
-		 *
-		 * @return array
-		 */
-		$excluded_taxonomies = (array) apply_filters(
-			'rocket_cpcss_excluded_taxonomies',
-			[
-				'post_format',
-				'product_shipping_class',
-				'karma-slider-category',
-				'truethemes-gallery-category',
-				'coupon_campaign',
-				'element_category',
-				'mediamatic_wpfolder',
-				'attachment_category',
-			]
-		);
-
-		$taxonomies = array_diff( $taxonomies, $excluded_taxonomies );
-		$taxonomies = esc_sql( $taxonomies );
-		$taxonomies = "'" . implode( "','", $taxonomies ) . "'";
-
-		return $wpdb->get_results(
-			"SELECT MAX( term_id ) AS ID, taxonomy
-			FROM (
-				SELECT term_id, taxonomy
-				FROM $wpdb->term_taxonomy
-				WHERE taxonomy IN ( $taxonomies )
-				AND count > 0
-			) AS taxonomies
-			GROUP BY taxonomy"
-		);
 	}
 
 	/**

--- a/inc/Engine/Optimization/ContentTrait.php
+++ b/inc/Engine/Optimization/ContentTrait.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace WP_Rocket\Engine\Optimization;
+
+trait ContentTrait {
+	/**
+	 * Gets all public post types.
+	 *
+	 * @since 3.9 moved into trait
+	 * @since 2.11
+	 */
+	private function get_public_post_types() {
+		global $wpdb;
+
+		$post_types = get_post_types(
+			[
+				'public'             => true,
+				'publicly_queryable' => true,
+			]
+		);
+
+		$post_types[] = 'page';
+
+		/**
+		 * Filters the post types excluded from critical CSS generation.
+		 *
+		 * @since 2.11
+		 *
+		 * @param array $excluded_post_types An array of post types names.
+		 *
+		 * @return array
+		 */
+		$excluded_post_types = (array) apply_filters(
+			'rocket_cpcss_excluded_post_types',
+			[
+				'elementor_library',
+				'oceanwp_library',
+				'tbuilder_layout',
+				'tbuilder_layout_part',
+				'slider',
+				'karma-slider',
+				'tt-gallery',
+				'xlwcty_thankyou',
+				'fusion_template',
+				'blocks',
+				'jet-woo-builder',
+				'fl-builder-template',
+				'cms_block',
+				'web-story',
+			]
+		);
+
+		$post_types = array_diff( $post_types, $excluded_post_types );
+		$post_types = esc_sql( $post_types );
+		$post_types = "'" . implode( "','", $post_types ) . "'";
+
+		return $wpdb->get_results(
+			"SELECT MAX(ID) as ID, post_type
+		    FROM (
+		        SELECT ID, post_type
+		        FROM $wpdb->posts
+				WHERE post_type IN ( $post_types )
+		        AND post_status = 'publish'
+		        ORDER BY post_date DESC
+		    ) AS posts
+		    GROUP BY post_type"
+		);
+	}
+
+	/**
+	 * Gets all public taxonomies.
+	 *
+	 * @since 3.9 moved into trait
+	 * @since 2.11
+	 */
+	private function get_public_taxonomies() {
+		global $wpdb;
+
+		$taxonomies = get_taxonomies(
+			[
+				'public'             => true,
+				'publicly_queryable' => true,
+			]
+		);
+
+		/**
+		 * Filters the taxonomies excluded from critical CSS generation.
+		 *
+		 * @since  2.11
+		 *
+		 * @param array $excluded_taxonomies An array of taxonomies names.
+		 *
+		 * @return array
+		 */
+		$excluded_taxonomies = (array) apply_filters(
+			'rocket_cpcss_excluded_taxonomies',
+			[
+				'post_format',
+				'product_shipping_class',
+				'karma-slider-category',
+				'truethemes-gallery-category',
+				'coupon_campaign',
+				'element_category',
+				'mediamatic_wpfolder',
+				'attachment_category',
+			]
+		);
+
+		$taxonomies = array_diff( $taxonomies, $excluded_taxonomies );
+		$taxonomies = esc_sql( $taxonomies );
+		$taxonomies = "'" . implode( "','", $taxonomies ) . "'";
+
+		return $wpdb->get_results(
+			"SELECT MAX( term_id ) AS ID, taxonomy
+			FROM (
+				SELECT term_id, taxonomy
+				FROM $wpdb->term_taxonomy
+				WHERE taxonomy IN ( $taxonomies )
+				AND count > 0
+			) AS taxonomies
+			GROUP BY taxonomy"
+		);
+	}
+}

--- a/inc/Engine/Optimization/RUCSS/ServiceProvider.php
+++ b/inc/Engine/Optimization/RUCSS/ServiceProvider.php
@@ -85,9 +85,11 @@ class ServiceProvider extends AbstractServiceProvider {
 			->addArgument( $this->getContainer()->get( 'rucss_resource_fetcher_process' ) );
 
 		$this->getContainer()->add( 'rucss_scanner_process', '\WP_Rocket\Engine\Optimization\RUCSS\Warmup\ScannerProcess' )
-			->addArgument( $this->getContainer()->get( 'rucss_resource_fetcher' ) );
+			->addArgument( $this->getContainer()->get( 'rucss_resource_fetcher' ) )
+			->addArgument( $this->getContainer()->get( 'options_api' ) );
 		$this->getContainer()->add( 'rucss_scanner', '\WP_Rocket\Engine\Optimization\RUCSS\Warmup\Scanner' )
-			->addArgument( $this->getContainer()->get( 'rucss_scanner_process' ) );
+			->addArgument( $this->getContainer()->get( 'rucss_scanner_process' ) )
+			->addArgument( $this->getContainer()->get( 'options_api' ) );
 
 		$this->getContainer()->share( 'rucss_warmup_subscriber', '\WP_Rocket\Engine\Optimization\RUCSS\Warmup\Subscriber' )
 			->addArgument( $this->getContainer()->get( 'options' ) )

--- a/inc/Engine/Optimization/RUCSS/ServiceProvider.php
+++ b/inc/Engine/Optimization/RUCSS/ServiceProvider.php
@@ -32,6 +32,8 @@ class ServiceProvider extends AbstractServiceProvider {
 		'rucss_resource_fetcher',
 		'rucss_resources_query',
 		'rucss_warmup_api_client',
+		'rucss_scanner',
+		'rucss_scanner_process',
 	];
 
 	/**
@@ -82,8 +84,14 @@ class ServiceProvider extends AbstractServiceProvider {
 			->addArgument( $this->getContainer()->get( 'local_cache' ) )
 			->addArgument( $this->getContainer()->get( 'rucss_resource_fetcher_process' ) );
 
+		$this->getContainer()->add( 'rucss_scanner_process', '\WP_Rocket\Engine\Optimization\RUCSS\Warmup\ScannerProcess' )
+			->addArgument( $this->getContainer()->get( 'rucss_resource_fetcher' ) );
+		$this->getContainer()->add( 'rucss_scanner', '\WP_Rocket\Engine\Optimization\RUCSS\Warmup\Scanner' )
+			->addArgument( $this->getContainer()->get( 'rucss_scanner_process' ) );
+
 		$this->getContainer()->share( 'rucss_warmup_subscriber', '\WP_Rocket\Engine\Optimization\RUCSS\Warmup\Subscriber' )
 			->addArgument( $this->getContainer()->get( 'options' ) )
-			->addArgument( $this->getContainer()->get( 'rucss_resource_fetcher' ) );
+			->addArgument( $this->getContainer()->get( 'rucss_resource_fetcher' ) )
+			->addArgument( $this->getContainer()->get( 'rucss_scanner' ) );
 	}
 }

--- a/inc/Engine/Optimization/RUCSS/Warmup/Scanner.php
+++ b/inc/Engine/Optimization/RUCSS/Warmup/Scanner.php
@@ -52,8 +52,21 @@ class Scanner {
 	 * @return void
 	 */
 	public function start_scanner( $old_value, $value ) {
+		if ( ! isset( $value['remove_unused_css'] ) ) {
+			return;
+		}
+
 		if (
-			! isset( $value['remove_unused_css'] )
+			! isset( $old_value['remove_unused_css'] )
+			&&
+			1 === (int) $value['remove_unused_css']
+		) {
+			$this->dispatcher();
+			return;
+		}
+
+		if (
+			! isset( $old_value['remove_unused_css'] )
 			||
 			( $old_value['remove_unused_css'] === $value['remove_unused_css'] )
 			||

--- a/inc/Engine/Optimization/RUCSS/Warmup/Scanner.php
+++ b/inc/Engine/Optimization/RUCSS/Warmup/Scanner.php
@@ -2,6 +2,7 @@
 
 namespace WP_Rocket\Engine\Optimization\RUCSS\Warmup;
 
+use WP_Rocket\Admin\Options;
 use WP_Rocket\Engine\Optimization\ContentTrait;
 
 class Scanner {
@@ -15,6 +16,13 @@ class Scanner {
 	public $process;
 
 	/**
+	 * Options API instance.
+	 *
+	 * @var Options
+	 */
+	private $options_api;
+
+	/**
 	 * Items for which we get the resources to warmup.
 	 *
 	 * @var array
@@ -25,9 +33,11 @@ class Scanner {
 	 * Instantiate the class
 	 *
 	 * @param ScannerProcess $process Background process instance.
+	 * @param Options        $options_api Options API instance.
 	 */
-	public function __construct( ScannerProcess $process ) {
-		$this->process = $process;
+	public function __construct( ScannerProcess $process, Options $options_api ) {
+		$this->process     = $process;
+		$this->options_api = $options_api;
 	}
 
 	/**
@@ -64,6 +74,8 @@ class Scanner {
 		$this->set_items();
 
 		array_map( [ $this->process, 'push_to_queue' ], $this->items );
+
+		$this->options_api->set( 'scanner_start_time', current_time() );
 
 		$this->process->save()->dispatch();
 	}

--- a/inc/Engine/Optimization/RUCSS/Warmup/Scanner.php
+++ b/inc/Engine/Optimization/RUCSS/Warmup/Scanner.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace WP_Rocket\Engine\Optimization\RUCSS\Warmup;
 
@@ -52,10 +53,11 @@ class Scanner {
 	 */
 	public function start_scanner( $old_value, $value ) {
 		if (
-			! isset( $old_value['remove_unused_css'], $value['remove_unused_css'] )
+			! isset( $value['remove_unused_css'] )
 			||
 			( $old_value['remove_unused_css'] === $value['remove_unused_css'] )
-			|| 1 !== (int) $value['remove_unused_css']
+			||
+			1 !== (int) $value['remove_unused_css']
 		) {
 			return;
 		}
@@ -75,7 +77,7 @@ class Scanner {
 
 		array_map( [ $this->process, 'push_to_queue' ], $this->items );
 
-		$this->options_api->set( 'scanner_start_time', current_time() );
+		$this->options_api->set( 'scanner_start_time', current_time( 'timestamp' ) );
 
 		$this->process->save()->dispatch();
 	}

--- a/inc/Engine/Optimization/RUCSS/Warmup/Scanner.php
+++ b/inc/Engine/Optimization/RUCSS/Warmup/Scanner.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace WP_Rocket\Engine\Optimization\RUCSS\Warmup;
+
+use WP_Rocket\Engine\Optimization\ContentTrait;
+
+class Scanner {
+	use ContentTrait;
+
+	/**
+	 * Background Process instance.
+	 *
+	 * @var ScannerProcess
+	 */
+	public $process;
+
+	/**
+	 * Items for which we get the resources to warmup.
+	 *
+	 * @var array
+	 */
+	public $items = [];
+
+	/**
+	 * Instantiate the class
+	 *
+	 * @param ScannerProcess $process Background process instance.
+	 */
+	public function __construct( ScannerProcess $process ) {
+		$this->process = $process;
+	}
+
+	/**
+	 * Launches the scanner when activating the RUCSS option
+	 *
+	 * @since 3.9
+	 *
+	 * @param array $old_value Previous values for WP Rocket settings.
+	 * @param array $value     New values for WP Rocket settings.
+	 *
+	 * @return void
+	 */
+	public function start_scanner( $old_value, $value ) {
+		if (
+			! isset( $old_value['remove_unused_css'], $value['remove_unused_css'] )
+			||
+			( $old_value['remove_unused_css'] === $value['remove_unused_css'] )
+			|| 1 !== (int) $value['remove_unused_css']
+		) {
+			return;
+		}
+
+		$this->dispatcher();
+	}
+
+	/**
+	 * Gets the items to scan and dispatch them to the scanner
+	 *
+	 * @since 3.9
+	 *
+	 * @return void
+	 */
+	private function dispatcher() {
+		$this->set_items();
+
+		array_map( [ $this->process, 'push_to_queue' ], $this->items );
+
+		$this->process->save()->dispatch();
+	}
+
+	/**
+	 * Sets the items for which we get the resources to warmup.
+	 *
+	 * @since 3.9
+	 *
+	 * @return void
+	 */
+	private function set_items() {
+		$this->items['front_page'] = [
+			'type'       => 'front_page',
+			'url'        => home_url( '/' ),
+			'is_scanned' => false,
+		];
+
+		$page_for_posts = get_option( 'page_for_posts' );
+
+		if (
+			'page' === get_option( 'show_on_front' )
+			&&
+			! empty( $page_for_posts )
+		) {
+			$this->items['home'] = [
+				'type'       => 'home',
+				'url'        => get_permalink( $page_for_posts ),
+				'is_scanned' => false,
+			];
+		}
+
+		$post_types = $this->get_public_post_types();
+
+		foreach ( $post_types as $post_type ) {
+			$this->items[ $post_type->post_type ] = [
+				'type'       => $post_type->post_type,
+				'url'        => get_permalink( $post_type->ID ),
+				'is_scanned' => false,
+			];
+		}
+
+		$taxonomies = $this->get_public_taxonomies();
+
+		foreach ( $taxonomies as $taxonomy ) {
+			$this->items[ $taxonomy->taxonomy ] = [
+				'type'       => $taxonomy->taxonomy,
+				'url'        => get_term_link( (int) $taxonomy->ID, $taxonomy->taxonomy ),
+				'is_scanned' => false,
+			];
+		}
+	}
+}

--- a/inc/Engine/Optimization/RUCSS/Warmup/Scanner.php
+++ b/inc/Engine/Optimization/RUCSS/Warmup/Scanner.php
@@ -77,7 +77,7 @@ class Scanner {
 
 		array_map( [ $this->process, 'push_to_queue' ], $this->items );
 
-		$this->options_api->set( 'scanner_start_time', current_time( 'timestamp' ) );
+		$this->options_api->set( 'scanner_start_time', time() );
 
 		$this->process->save()->dispatch();
 	}

--- a/inc/Engine/Optimization/RUCSS/Warmup/ScannerProcess.php
+++ b/inc/Engine/Optimization/RUCSS/Warmup/ScannerProcess.php
@@ -66,7 +66,8 @@ class ScannerProcess extends WP_Rocket_WP_Background_Process {
 
 		$this->resource_fetcher->data(
 			[
-				'html' => $html,
+				'html'      => $html,
+				'prewarmup' => 1,
 			]
 		)->dispatch();
 

--- a/inc/Engine/Optimization/RUCSS/Warmup/ScannerProcess.php
+++ b/inc/Engine/Optimization/RUCSS/Warmup/ScannerProcess.php
@@ -3,6 +3,7 @@
 namespace WP_Rocket\Engine\Optimization\RUCSS\Warmup;
 
 use WP_Rocket_WP_Background_Process;
+use WP_Rocket\Admin\Options;
 
 class ScannerProcess extends WP_Rocket_WP_Background_Process {
 	/**
@@ -13,14 +14,23 @@ class ScannerProcess extends WP_Rocket_WP_Background_Process {
 	private $resource_fetcher;
 
 	/**
+	 * Options API instance.
+	 *
+	 * @var Options
+	 */
+	private $options_api;
+
+	/**
 	 * Instantiate the class
 	 *
 	 * @param ResourceFetcher $resource_fetcher Resource fetcher instance.
+	 * @param Options         $options_api Options API instance.
 	 */
-	public function __construct( ResourceFetcher $resource_fetcher ) {
+	public function __construct( ResourceFetcher $resource_fetcher, Options $options_api ) {
 		parent::__construct();
 
 		$this->resource_fetcher = $resource_fetcher;
+		$this->options_api      = $options_api;
 	}
 
 	/**
@@ -61,10 +71,10 @@ class ScannerProcess extends WP_Rocket_WP_Background_Process {
 		)->dispatch();
 
 		$item['is_scanned'] = true;
-		$option             = get_option( 'wp_rocket_resources_scanner', [] );
+		$option             = $this->options_api->get( 'resources_scanner', [] );
 		$option[]           = $item;
 
-		update_option( 'wp_rocket_resources_scanner', $option );
+		$this->options_api->set( 'resources_scanner', $option );
 
 		return false;
 	}

--- a/inc/Engine/Optimization/RUCSS/Warmup/ScannerProcess.php
+++ b/inc/Engine/Optimization/RUCSS/Warmup/ScannerProcess.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace WP_Rocket\Engine\Optimization\RUCSS\Warmup;
+
+use WP_Rocket_WP_Background_Process;
+
+class ScannerProcess extends WP_Rocket_WP_Background_Process {
+	/**
+	 * Resource fetcher instance
+	 *
+	 * @var Resource Fetcher
+	 */
+	private $resource_fetcher;
+
+	/**
+	 * Instantiate the class
+	 *
+	 * @param ResourceFetcher $resource_fetcher
+	 */
+	public function __construct( ResourceFetcher $resource_fetcher ) {
+		parent::__construct();
+
+		$this->resource_fetcher = $resource_fetcher;
+	}
+
+	/**
+	 * Gets the HTML of the page, and send it to the resource fetcher
+	 *
+	 * @since 3.9
+	 *
+	 * @param array $item Item to process.
+	 *
+	 * @return mixed
+	 */
+	public function task( $item ) {
+		if ( ! isset( $item['url'] ) ) {
+			return false;
+		}
+
+		$response = wp_remote_get(
+			add_query_arg( 'nowprocket', '1', $item['url'] ),
+			[
+				'sslverify'  => apply_filters( 'https_local_ssl_verify', false ), // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+			]
+		);
+
+		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return false;
+		}
+
+		$html = wp_remote_retrieve_body( $response );
+
+		if ( empty( $html ) ) {
+			return false;
+		}
+
+		$this->resource_fetcher->data(
+			[
+				'html' => $html,
+			]
+		)->dispatch();
+
+		$item['is_scanned'] = true;
+		$option             = get_option( 'wp_rocket_resources_scanner', [] );
+		$option[]           = $item;
+
+		update_option( 'wp_rocket_resources_scanner', $option );
+
+		return false;
+	}
+}

--- a/inc/Engine/Optimization/RUCSS/Warmup/ScannerProcess.php
+++ b/inc/Engine/Optimization/RUCSS/Warmup/ScannerProcess.php
@@ -15,7 +15,7 @@ class ScannerProcess extends WP_Rocket_WP_Background_Process {
 	/**
 	 * Instantiate the class
 	 *
-	 * @param ResourceFetcher $resource_fetcher
+	 * @param ResourceFetcher $resource_fetcher Resource fetcher instance.
 	 */
 	public function __construct( ResourceFetcher $resource_fetcher ) {
 		parent::__construct();
@@ -40,7 +40,7 @@ class ScannerProcess extends WP_Rocket_WP_Background_Process {
 		$response = wp_remote_get(
 			add_query_arg( 'nowprocket', '1', $item['url'] ),
 			[
-				'sslverify'  => apply_filters( 'https_local_ssl_verify', false ), // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+				'sslverify' => apply_filters( 'https_local_ssl_verify', false ), // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 			]
 		);
 

--- a/inc/Engine/Optimization/RUCSS/Warmup/ScannerProcess.php
+++ b/inc/Engine/Optimization/RUCSS/Warmup/ScannerProcess.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace WP_Rocket\Engine\Optimization\RUCSS\Warmup;
 

--- a/inc/Engine/Optimization/RUCSS/Warmup/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Warmup/Subscriber.php
@@ -23,14 +23,22 @@ class Subscriber implements Subscriber_Interface {
 	private $resource_fetcher;
 
 	/**
+	 * Scanner instance
+	 *
+	 * @var Scanner
+	 */
+	private $scanner;
+
+	/**
 	 * Subscriber constructor.
 	 *
 	 * @param Options_Data    $options Options instance.
 	 * @param ResourceFetcher $resource_fetcher Resource object.
 	 */
-	public function __construct( Options_Data $options, ResourceFetcher $resource_fetcher ) {
+	public function __construct( Options_Data $options, ResourceFetcher $resource_fetcher, Scanner $scanner ) {
 		$this->resource_fetcher = $resource_fetcher;
 		$this->options          = $options;
+		$this->scanner          = $scanner;
 	}
 
 	/**
@@ -40,7 +48,8 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events() : array {
 		return [
-			'rocket_buffer' => [ 'collect_resources', 1 ],
+			'rocket_buffer'                                            => [ 'collect_resources', 11 ],
+			'update_option_' . rocket_get_constant( 'WP_ROCKET_SLUG' ) => [ 'start_scanner', 15, 2 ],
 		];
 	}
 
@@ -61,6 +70,20 @@ class Subscriber implements Subscriber_Interface {
 		}
 
 		return $html;
+	}
+
+	/**
+	 * Launches the scanner when activating the RUCSS option
+	 *
+	 * @since 3.9
+	 *
+	 * @param array $old_value Previous values for WP Rocket settings.
+	 * @param array $value     New values for WP Rocket settings.
+	 *
+	 * @return void
+	 */
+	public function start_scanner( $value, $old_value ) {
+		$this->scanner->start_scanner( $value, $old_value );
 	}
 
 	/**

--- a/inc/Engine/Optimization/RUCSS/Warmup/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Warmup/Subscriber.php
@@ -34,6 +34,7 @@ class Subscriber implements Subscriber_Interface {
 	 *
 	 * @param Options_Data    $options Options instance.
 	 * @param ResourceFetcher $resource_fetcher Resource object.
+	 * @param Scanner         $scanner Scanner instance.
 	 */
 	public function __construct( Options_Data $options, ResourceFetcher $resource_fetcher, Scanner $scanner ) {
 		$this->resource_fetcher = $resource_fetcher;
@@ -48,7 +49,7 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events() : array {
 		return [
-			'rocket_buffer'                                            => [ 'collect_resources', 11 ],
+			'rocket_buffer' => [ 'collect_resources', 11 ],
 			'update_option_' . rocket_get_constant( 'WP_ROCKET_SLUG' ) => [ 'start_scanner', 15, 2 ],
 		];
 	}
@@ -82,8 +83,8 @@ class Subscriber implements Subscriber_Interface {
 	 *
 	 * @return void
 	 */
-	public function start_scanner( $value, $old_value ) {
-		$this->scanner->start_scanner( $value, $old_value );
+	public function start_scanner( $old_value, $value ) {
+		$this->scanner->start_scanner( $old_value, $value );
 	}
 
 	/**

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -81,14 +81,14 @@
 	<rule ref="WordPress.DB.DirectDatabaseQuery.DirectQuery">
 		<exclude-pattern>inc/classes/admin/Database/class-optimization-process.php</exclude-pattern>
 		<exclude-pattern>inc/classes/admin/Database/class-optimization.php</exclude-pattern>
-		<exclude-pattern>inc/Engine/CriticalPath/CriticalCSS.php</exclude-pattern>
+		<exclude-pattern>inc/Engine/Optimization/ContentTrait.php</exclude-pattern>
 		<exclude-pattern>inc/Engine/Optimization/RUCSS/Database/Query/UsedCSS.php</exclude-pattern>
 	</rule>
 
 	<rule ref="WordPress.DB.DirectDatabaseQuery.NoCaching">
 		<exclude-pattern>inc/classes/admin/Database/class-optimization-process.php</exclude-pattern>
 		<exclude-pattern>inc/classes/admin/Database/class-optimization.php</exclude-pattern>
-		<exclude-pattern>inc/Engine/CriticalPath/CriticalCSS.php</exclude-pattern>
+		<exclude-pattern>inc/Engine/Optimization/ContentTrait.php</exclude-pattern>
 		<exclude-pattern>inc/Engine/Optimization/RUCSS/Database/Query/UsedCSS.php</exclude-pattern>
 	</rule>
 
@@ -100,7 +100,7 @@
 
 	<rule ref="WordPress.DB.PreparedSQL.InterpolatedNotPrepared">
 		<exclude-pattern>inc/classes/admin/Database/class-optimization-process.php</exclude-pattern>
-		<exclude-pattern>inc/Engine/CriticalPath/CriticalCSS.php</exclude-pattern>
+		<exclude-pattern>inc/Engine/Optimization/ContentTrait.php</exclude-pattern>
 	</rule>
 
 	<rule ref="WordPress-Docs">

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Warmup/Subscriber/collectResources.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Warmup/Subscriber/collectResources.php
@@ -42,7 +42,7 @@ class Test_CollectResources extends FilesystemTestCase {
 
 		parent::setUp();
 
-		$this->unregisterAllCallbacksExcept( 'rocket_buffer', 'collect_resources', 1 );
+		$this->unregisterAllCallbacksExcept( 'rocket_buffer', 'collect_resources', 11 );
 	}
 
 	public function tearDown() : void {

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Warmup/Subscriber/collectResources.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Warmup/Subscriber/collectResources.php
@@ -7,6 +7,7 @@ use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\Optimization\AssetsLocalCache;
 use WP_Rocket\Engine\Optimization\RUCSS\Warmup\ResourceFetcher;
 use WP_Rocket\Engine\Optimization\RUCSS\Warmup\ResourceFetcherProcess;
+use WP_Rocket\Engine\Optimization\RUCSS\Warmup\Scanner;
 use WP_Rocket\Engine\Optimization\RUCSS\Warmup\Subscriber;
 use WP_Rocket\Tests\Unit\TestCase;
 use Brain\Monkey\Functions;
@@ -26,6 +27,7 @@ class Test_CollectResources extends TestCase {
 
 		$options_data = Mockery::mock( Options_Data::class );
 		$fetcher = Mockery::mock( ResourceFetcher::class );
+		$scanner = Mockery::mock( Scanner::class );
 
 		$this->donotrocketoptimize = isset( $input['DONOTROCKETOPTIMIZE'] ) ? $input['DONOTROCKETOPTIMIZE'] : false;
 
@@ -60,7 +62,7 @@ class Test_CollectResources extends TestCase {
 				->andReturn( null );
 		}
 
-		$subscriber = new Subscriber( $options_data, $fetcher );
+		$subscriber = new Subscriber( $options_data, $fetcher, $scanner );
 		$this->assertSame( $input['html'], $subscriber->collect_resources( $input['html'] ) );
 
 	}


### PR DESCRIPTION
## Description

Add new `Scanner` and `ScannerProcess` classes. Those classes are used on RUCSS activation, to:
- Get URLs to scan and send them to the scanner process
- Scanner process gets the HTML of those URLs, and sends the found resources to the `ResourceFetcher`
- It also stores each processed URL in an option, to be used in the UI to keep track of the status

Sub-task for #3836 

## Type of change

- [x] Enhancement (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Manual testing, checking that each step is correctly triggered, and that the resources table is correctly populated

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes