### PR TITLE
Pre-warmup database changes

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Database/Row/ResourceRow.php
+++ b/inc/Engine/Optimization/RUCSS/Database/Row/ResourceRow.php
@@ -20,6 +20,8 @@ class ResourceRow extends Row {
 		$this->type          = (string) $this->type;
 		$this->content       = (string) $this->content;
 		$this->hash          = (string) $this->hash;
+		$this->prewarmup     = (int) $this->prewarmup;
+		$this->warmup_status = (int) $this->warmup_status;
 		$this->media         = (string) $this->media;
 		$this->modified      = false === $this->modified ? 0 : strtotime( $this->modified );
 		$this->last_accessed = false === $this->last_accessed ? 0 : strtotime( $this->last_accessed );

--- a/inc/Engine/Optimization/RUCSS/Database/Schemas/Resources.php
+++ b/inc/Engine/Optimization/RUCSS/Database/Schemas/Resources.php
@@ -70,6 +70,28 @@ class Resources extends Schema {
 			'sortable'   => true,
 		],
 
+		// prewarmup column.
+		[
+			'name'       => 'prewarmup',
+			'type'       => 'tinyint',
+			'length'     => '1',
+			'default'    => 0,
+			'cache_key'  => true,
+			'searchable' => true,
+			'sortable'   => true,
+		],
+
+		// warmup_status column.
+		[
+			'name'       => 'warmup_status',
+			'type'       => 'tinyint',
+			'length'     => '1',
+			'default'    => '0',
+			'cache_key'  => true,
+			'searchable' => true,
+			'sortable'   => true,
+		],
+
 		// MEDIA column.
 		[
 			'name'       => 'media',

--- a/inc/Engine/Optimization/RUCSS/Database/Tables/Resources.php
+++ b/inc/Engine/Optimization/RUCSS/Database/Tables/Resources.php
@@ -28,7 +28,7 @@ class Resources extends Table {
 	 *
 	 * @var int
 	 */
-	protected $version = 20210401;
+	protected $version = 20210429;
 
 
 	/**

--- a/inc/Engine/Optimization/RUCSS/Database/Tables/Resources.php
+++ b/inc/Engine/Optimization/RUCSS/Database/Tables/Resources.php
@@ -51,6 +51,8 @@ class Resources extends Table {
 			media            varchar(255)            NULL default 'all',
 			content          longtext                     default NULL,
 			hash             varchar(100)        NOT NULL default '',
+			prewarmup        tinyint(1) unsigned     NULL default 0,
+			warmup_status    tinyint(1) unsigned     NULL default 0,
 			modified         DATETIME                NULL default '0000-00-00 00:00:00',
 			last_accessed    DATETIME            NOT NULL default '0000-00-00 00:00:00',
 			PRIMARY KEY (id),


### PR DESCRIPTION
## Description

I made this PR to be merged quickly as all other parts need it.

Create two new columns for resources table

## Steps to reset the database to make those changes applied:-

1. Delete the resources table from the database.
2. Go to Database's options table and delete the row for `option_name = wpr_rucss_resources_version`
3. Open the dashboard (wp-admin/) to make the database's table created again.