### PR TITLE
RUCSS Onboarding: Prevent RUCSS on frontend while pre-warmup runs

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -126,6 +126,10 @@ class UsedCSS {
 			return false;
 		}
 
+		if ( get_option( 'wp_rocket_scanner_start_time', false ) ) {
+			return false;
+		}
+
 		return true;
 	}
 


### PR DESCRIPTION
## Description

To avoid partial used CSS on the frontend during pre-warmup, check if the option corresponding to the pre-warmup process exists, and bail-out if it does.

Sub-task of #3836 

## Type of change

- [x] Enhancement (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes