### PR TITLE
Start prewarmup only after collecting resources

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -126,7 +126,7 @@ class UsedCSS {
 			return false;
 		}
 
-		if ( get_option( 'wp_rocket_scanner_start_time', false ) ) {
+		if ( get_option( 'wp_rocket_prewarmup_stats', false ) ) {
 			return false;
 		}
 

--- a/inc/Engine/Optimization/RUCSS/ServiceProvider.php
+++ b/inc/Engine/Optimization/RUCSS/ServiceProvider.php
@@ -79,7 +79,8 @@ class ServiceProvider extends AbstractServiceProvider {
 
 		$this->getContainer()->add( 'rucss_resource_fetcher_process', '\WP_Rocket\Engine\Optimization\RUCSS\Warmup\ResourceFetcherProcess' )
 			->addArgument( $this->getContainer()->get( 'rucss_resources_query' ) )
-			->addArgument( $this->getContainer()->get( 'rucss_warmup_api_client' ) );
+			->addArgument( $this->getContainer()->get( 'rucss_warmup_api_client' ) )
+			->addArgument( $this->getContainer()->get( 'options_api' ) );
 
 		$this->getContainer()->share( 'rucss_resource_fetcher', '\WP_Rocket\Engine\Optimization\RUCSS\Warmup\ResourceFetcher' )
 			->addArgument( $this->getContainer()->get( 'local_cache' ) )

--- a/inc/Engine/Optimization/RUCSS/Warmup/ResourceFetcher.php
+++ b/inc/Engine/Optimization/RUCSS/Warmup/ResourceFetcher.php
@@ -107,6 +107,8 @@ class ResourceFetcher extends WP_Rocket_WP_Async_Request {
 		// Send resources to the background process to be saved into DB.
 		foreach ( $this->resources as $resource ) {
 			$resource['prewarmup'] = (int) ! empty( $_POST['prewarmup'] );// phpcs:ignore WordPress.Security.NonceVerification.Missing
+			$resource['page_url']  = ! empty( $_POST['page_url'] ) ? esc_url_raw( wp_unslash( $_POST['page_url'] ) ) : '';// phpcs:ignore WordPress.Security.NonceVerification.Missing
+
 			$this->process->push_to_queue( $resource );
 		}
 

--- a/inc/Engine/Optimization/RUCSS/Warmup/ResourceFetcherProcess.php
+++ b/inc/Engine/Optimization/RUCSS/Warmup/ResourceFetcherProcess.php
@@ -115,7 +115,6 @@ class ResourceFetcherProcess extends WP_Rocket_WP_Background_Process {
 	 * @return void
 	 */
 	protected function complete() {
-
 		parent::complete();
 
 		if ( ! $this->content_changed ) {

--- a/inc/Engine/Optimization/RUCSS/Warmup/ResourceFetcherProcess.php
+++ b/inc/Engine/Optimization/RUCSS/Warmup/ResourceFetcherProcess.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace WP_Rocket\Engine\Optimization\RUCSS\Warmup;
 
+use WP_Rocket\Admin\Options;
 use WP_Rocket\Engine\Optimization\RUCSS\Database\Queries\ResourcesQuery;
 use \WP_Rocket_WP_Background_Process;
 
@@ -45,16 +46,32 @@ class ResourceFetcherProcess extends WP_Rocket_WP_Background_Process {
 	private $content_changed = false;
 
 	/**
+	 * Current page url that has the current resource.
+	 *
+	 * @var string
+	 */
+	public $page_url = '';
+
+	/**
+	 * Options API instance.
+	 *
+	 * @var Options
+	 */
+	private $options_api;
+
+	/**
 	 * ResourceFetcherProcess constructor.
 	 *
 	 * @param ResourcesQuery $resources_query ResourcesQuery instance.
 	 * @param APIClient      $api_client APIClient instance.
+	 * @param Options        $options_api Options API instance.
 	 */
-	public function __construct( ResourcesQuery $resources_query, APIClient $api_client ) {
+	public function __construct( ResourcesQuery $resources_query, APIClient $api_client, Options $options_api ) {
 		parent::__construct();
 
 		$this->resources_query = $resources_query;
 		$this->api_client      = $api_client;
+		$this->options_api     = $options_api;
 	}
 
 
@@ -69,6 +86,8 @@ class ResourceFetcherProcess extends WP_Rocket_WP_Background_Process {
 		if ( ! is_array( $resource ) ) {
 			return false;
 		}
+
+		$this->page_url = $resource['page_url'] ?? '';
 
 		if ( $this->resources_query->create_or_update( $resource ) ) {
 			$this->content_changed = true;
@@ -96,6 +115,7 @@ class ResourceFetcherProcess extends WP_Rocket_WP_Background_Process {
 	 * @return void
 	 */
 	protected function complete() {
+
 		parent::complete();
 
 		if ( ! $this->content_changed ) {
@@ -103,5 +123,26 @@ class ResourceFetcherProcess extends WP_Rocket_WP_Background_Process {
 		}
 
 		do_action( 'rocket_rucss_file_changed' );
+	}
+
+	/**
+	 * Batch completed callback.
+	 */
+	protected function complete_batch() {
+		if ( empty( $this->page_url ) ) {
+			return;
+		}
+
+		$option = $this->options_api->get( 'resources_scanner', [] );
+		foreach ( $option as $key => $item ) {
+			if ( $this->page_url !== $item['url'] ) {
+				continue;
+			}
+
+			$item['is_fetched'] = true;
+			$option[ $key ]     = $item;
+		}
+
+		$this->options_api->set( 'resources_scanner', $option );
 	}
 }

--- a/inc/Engine/Optimization/RUCSS/Warmup/ResourceFetcherProcess.php
+++ b/inc/Engine/Optimization/RUCSS/Warmup/ResourceFetcherProcess.php
@@ -133,15 +133,27 @@ class ResourceFetcherProcess extends WP_Rocket_WP_Background_Process {
 			return;
 		}
 
-		$option = $this->options_api->get( 'resources_scanner', [] );
+		$option          = $this->options_api->get( 'resources_scanner', [] );
+		$fetched_counter = 0;
 		foreach ( $option as $key => $item ) {
+			if ( isset( $item['is_fetched'] ) && $item['is_fetched'] ) {
+				$fetched_counter++;
+			}
 			if ( $this->page_url !== $item['url'] ) {
 				continue;
 			}
 
 			$option[ $key ]['is_fetched'] = true;
+			$fetched_counter++;
 		}
 
 		$this->options_api->set( 'resources_scanner', $option );
+
+		if ( count( $option ) === $fetched_counter ) {
+			// Fetching resources is finished.
+			$prewarmup_stats                      = $this->options_api->get( 'prewarmup_stats', [] );
+			$prewarmup_stats['fetch_finish_time'] = time();
+			$this->options_api->set( 'prewarmup_stats', $prewarmup_stats );
+		}
 	}
 }

--- a/inc/Engine/Optimization/RUCSS/Warmup/ResourceFetcherProcess.php
+++ b/inc/Engine/Optimization/RUCSS/Warmup/ResourceFetcherProcess.php
@@ -50,7 +50,7 @@ class ResourceFetcherProcess extends WP_Rocket_WP_Background_Process {
 	 *
 	 * @var string
 	 */
-	public $page_url = '';
+	private $page_url = '';
 
 	/**
 	 * Options API instance.
@@ -139,8 +139,7 @@ class ResourceFetcherProcess extends WP_Rocket_WP_Background_Process {
 				continue;
 			}
 
-			$item['is_fetched'] = true;
-			$option[ $key ]     = $item;
+			$option[ $key ]['is_fetched'] = true;
 		}
 
 		$this->options_api->set( 'resources_scanner', $option );

--- a/inc/Engine/Optimization/RUCSS/Warmup/Scanner.php
+++ b/inc/Engine/Optimization/RUCSS/Warmup/Scanner.php
@@ -93,7 +93,11 @@ class Scanner {
 
 		array_map( [ $this->process, 'push_to_queue' ], $this->items );
 
-		$this->options_api->set( 'scanner_start_time', time() );
+		$prewarmup_stats = [
+			'scan_start_time'   => time(),
+			'fetch_finish_time' => null,
+		];
+		$this->options_api->set( 'prewarmup_stats', $prewarmup_stats );
 
 		$this->process->save()->dispatch();
 	}

--- a/inc/Engine/Optimization/RUCSS/Warmup/Scanner.php
+++ b/inc/Engine/Optimization/RUCSS/Warmup/Scanner.php
@@ -5,6 +5,7 @@ namespace WP_Rocket\Engine\Optimization\RUCSS\Warmup;
 
 use WP_Rocket\Admin\Options;
 use WP_Rocket\Engine\Optimization\ContentTrait;
+use WP_Rocket\Logger\Logger;
 
 class Scanner {
 	use ContentTrait;
@@ -87,6 +88,8 @@ class Scanner {
 	 */
 	private function dispatcher() {
 		$this->set_items();
+
+		$this->options_api->delete( 'resources_scanner' );
 
 		array_map( [ $this->process, 'push_to_queue' ], $this->items );
 

--- a/inc/Engine/Optimization/RUCSS/Warmup/Scanner.php
+++ b/inc/Engine/Optimization/RUCSS/Warmup/Scanner.php
@@ -5,7 +5,6 @@ namespace WP_Rocket\Engine\Optimization\RUCSS\Warmup;
 
 use WP_Rocket\Admin\Options;
 use WP_Rocket\Engine\Optimization\ContentTrait;
-use WP_Rocket\Logger\Logger;
 
 class Scanner {
 	use ContentTrait;

--- a/inc/Engine/Optimization/RUCSS/Warmup/ScannerProcess.php
+++ b/inc/Engine/Optimization/RUCSS/Warmup/ScannerProcess.php
@@ -69,6 +69,7 @@ class ScannerProcess extends WP_Rocket_WP_Background_Process {
 			[
 				'html'      => $html,
 				'prewarmup' => 1,
+				'page_url'  => $item['url'],
 			]
 		)->dispatch();
 

--- a/inc/Engine/Optimization/RUCSS/Warmup/Status/Checker.php
+++ b/inc/Engine/Optimization/RUCSS/Warmup/Status/Checker.php
@@ -51,13 +51,13 @@ class Checker extends AbstractAPIClient {
 	 * @return void
 	 */
 	public function check_warmup_status() {
-		$start_time = $this->options_api->get( 'scanner_start_time', false );
+		$prewarmup_stats = $this->options_api->get( 'prewarmup_stats', [] );
 
-		if ( false === $start_time ) {
+		if ( empty( $prewarmup_stats['scan_start_time'] ) ) {
 			return;
 		}
 
-		if ( time() > strtotime( '+1 hour', (int) $start_time ) ) {
+		if ( time() > strtotime( '+1 hour', (int) $prewarmup_stats['scan_start_time'] ) ) {
 			/**
 			 * Fires this action when the prewarmup lifespan is expired
 			 *
@@ -65,7 +65,6 @@ class Checker extends AbstractAPIClient {
 			 */
 			do_action( 'rocket_rucss_prewarmup_error' );
 
-			$this->options_api->delete( 'scanner_start_time' );
 			rocket_clean_domain();
 
 			return;
@@ -81,7 +80,6 @@ class Checker extends AbstractAPIClient {
 			 */
 			do_action( 'rocket_rucss_prewarmup_success' );
 
-			$this->options_api->delete( 'scanner_start_time' );
 			rocket_clean_domain();
 
 			return;

--- a/inc/Engine/Optimization/RUCSS/Warmup/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Warmup/Subscriber.php
@@ -114,6 +114,11 @@ class Subscriber implements Subscriber_Interface {
 			return;
 		}
 
+		$prewarmup_stats = get_option( 'wp_rocket_prewarmup_stats', [] );
+		if ( empty( $prewarmup_stats ) || empty( $prewarmup_stats['fetch_finish_time'] ) ) {
+			return;
+		}
+
 		$this->status_checker->check_warmup_status();
 	}
 

--- a/inc/classes/dependencies/wp-media/background-processing/wp-background-process.php
+++ b/inc/classes/dependencies/wp-media/background-processing/wp-background-process.php
@@ -330,6 +330,7 @@ abstract class WP_Rocket_WP_Background_Process extends WP_Rocket_WP_Async_Reques
 			if ( ! empty( $batch->data ) && ! $this->is_process_cancelled() ) {
 				$this->update( $batch->key, $batch->data );
 			} else {
+				$this->complete_batch();
 				$this->delete( $batch->key );
 			}
 		} while ( ! $this->time_exceeded() && ! $this->memory_exceeded() && ! $this->is_queue_empty() && ! $this->is_process_cancelled() );
@@ -404,6 +405,13 @@ abstract class WP_Rocket_WP_Background_Process extends WP_Rocket_WP_Async_Reques
 		}
 
 		return apply_filters( $this->identifier . '_time_exceeded', $return );
+	}
+
+	/**
+	 * Current batch is completed.
+	 */
+	protected function complete_batch(){
+		// Override this code on the instantiated process class WP_Rocket_just if needed.
 	}
 
 	/**

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Warmup/ResourceFetcher/Handle.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Warmup/ResourceFetcher/Handle.php
@@ -7,13 +7,13 @@ return [
 	'structure' => [
 
 		'css'     => [
-			'style1.css'      => '.first{color:red;}',
-			'style2.css'      => '.second{color:green;}',
-			'style3.css'      => '.third{color:#000000;}',
-			'style-empty.css' => '',
-			'stylewithimport.css' => '@import "style1.css";.another-class-in-stylewithimport{color: white;}',
-			'stylewithimportedmqs.css' => '@import "style3.css" screen;.another-imported-class{color: blue;}',
-			'stylewithimport-recursion.css' => '@import "stylewithimport-recursion.css";.another-class-in-stylewithimport-recursion{color: white;}',
+			'style1.css'                      => '.first{color:red;}',
+			'style2.css'                      => '.second{color:green;}',
+			'style3.css'                      => '.third{color:#000000;}',
+			'style-empty.css'                 => '',
+			'stylewithimport.css'             => '@import "style1.css";.another-class-in-stylewithimport{color: white;}',
+			'stylewithimportedmqs.css'        => '@import "style3.css" screen;.another-imported-class{color: blue;}',
+			'stylewithimport-recursion.css'   => '@import "stylewithimport-recursion.css";.another-class-in-stylewithimport-recursion{color: white;}',
 			'stylewithrelativepathimport.css' => '@import "./../relativelypathedstyles.css";.some-imported-class{color:pink;}',
 		],
 		'scripts' => [
@@ -53,18 +53,20 @@ return [
 			'expected' => [
 				'resources' => [
 					[
-						'url'     => 'http://example.org/css/style-empty.css',
-						'content' => '*',
-						'type'    => 'css',
-						'media'   => 'all',
+						'url'       => 'http://example.org/css/style-empty.css',
+						'content'   => '*',
+						'type'      => 'css',
+						'media'     => 'all',
 						'prewarmup' => 0,
+						'page_url'  => '',
 					],
 					[
-						'url'     => 'http://example.org/css/style-notfound.css',
-						'content' => '*',
-						'type'    => 'css',
-						'media'   => 'all',
+						'url'       => 'http://example.org/css/style-notfound.css',
+						'content'   => '*',
+						'type'      => 'css',
+						'media'     => 'all',
 						'prewarmup' => 0,
+						'page_url'  => '',
 					]
 				],
 			],
@@ -88,24 +90,27 @@ return [
 			'expected' => [
 				'resources' => [
 					[
-						'url'     => 'http://example.org/css/style1.css?ver=123',
-						'content' => '.first{color:red}',
-						'type'    => 'css',
-						'media'   => 'all',
+						'url'       => 'http://example.org/css/style1.css?ver=123',
+						'content'   => '.first{color:red}',
+						'type'      => 'css',
+						'media'     => 'all',
 						'prewarmup' => 0,
+						'page_url'  => '',
 					],
 					[
-						'url'     => 'http://example.org/css/style2.css',
-						'content' => '.second{color:green}',
-						'type'    => 'css',
-						'media'   => 'all',
+						'url'       => 'http://example.org/css/style2.css',
+						'content'   => '.second{color:green}',
+						'type'      => 'css',
+						'media'     => 'all',
 						'prewarmup' => 0,
+						'page_url'  => '',
 					],
 					[
-						'url'     => 'http://example.org/scripts/script2.js',
-						'content' => 'var second = "content 2";',
-						'type'    => 'js',
+						'url'       => 'http://example.org/scripts/script2.js',
+						'content'   => 'var second = "content 2";',
+						'type'      => 'js',
 						'prewarmup' => 0,
+						'page_url'  => '',
 					]
 				],
 			],
@@ -121,18 +126,20 @@ return [
 			'expected' => [
 				'resources' => [
 					[
-						'url'     => 'http://example.org/css/style1.css?ver=123',
-						'content' => '.first{color:red}',
-						'type'    => 'css',
-						'media'   => 'all',
+						'url'       => 'http://example.org/css/style1.css?ver=123',
+						'content'   => '.first{color:red}',
+						'type'      => 'css',
+						'media'     => 'all',
 						'prewarmup' => 0,
+						'page_url'  => '',
 					],
 					[
-						'url'     => 'http://example.org/css/style2.css',
-						'content' => '.second{color:green}',
-						'type'    => 'css',
-						'media'   => 'print',
+						'url'       => 'http://example.org/css/style2.css',
+						'content'   => '.second{color:green}',
+						'type'      => 'css',
+						'media'     => 'print',
 						'prewarmup' => 0,
+						'page_url'  => '',
 					]
 
 				],
@@ -149,17 +156,19 @@ return [
 			'expected' => [
 				'resources' => [
 					[
-						'url'     => 'http://example.org/css/style1.css?ver=123',
-						'content' => '.first{color:red}',
-						'type'    => 'css',
-						'media'   => 'all',
+						'url'       => 'http://example.org/css/style1.css?ver=123',
+						'content'   => '.first{color:red}',
+						'type'      => 'css',
+						'media'     => 'all',
 						'prewarmup' => 0,
+						'page_url'  => '',
 					],
 					[
-						'url'     => 'http://example.org/scripts/script1.js',
-						'content' => 'var first = "content 1";',
-						'type'    => 'js',
+						'url'       => 'http://example.org/scripts/script1.js',
+						'content'   => 'var first = "content 1";',
+						'type'      => 'js',
 						'prewarmup' => 0,
+						'page_url'  => '',
 					]
 				],
 			],
@@ -175,17 +184,19 @@ return [
 			'expected' => [
 				'resources' => [
 					[
-						'url'     => 'http://example.org/css/stylewithimport.css?ver=123',
-						'content' => '.first{color:red}.another-class-in-stylewithimport{color:#fff}',
-						'type'    => 'css',
-						'media'   => 'all',
+						'url'       => 'http://example.org/css/stylewithimport.css?ver=123',
+						'content'   => '.first{color:red}.another-class-in-stylewithimport{color:#fff}',
+						'type'      => 'css',
+						'media'     => 'all',
 						'prewarmup' => 0,
+						'page_url'  => '',
 					],
 					[
-						'url'     => 'http://example.org/scripts/script1.js',
-						'content' => 'var first = "content 1";',
-						'type'    => 'js',
+						'url'       => 'http://example.org/scripts/script1.js',
+						'content'   => 'var first = "content 1";',
+						'type'      => 'js',
 						'prewarmup' => 0,
+						'page_url'  => '',
 					],
 				],
 			],
@@ -201,17 +212,19 @@ return [
 			'expected' => [
 				'resources' => [
 					[
-						'url'     => 'http://example.org/css/stylewithimportedmqs.css?ver=123',
-						'content' => '@media screen{.third{color:#000}}.another-imported-class{color:blue}',
-						'type'    => 'css',
-						'media'   => 'all',
+						'url'       => 'http://example.org/css/stylewithimportedmqs.css?ver=123',
+						'content'   => '@media screen{.third{color:#000}}.another-imported-class{color:blue}',
+						'type'      => 'css',
+						'media'     => 'all',
 						'prewarmup' => 0,
+						'page_url'  => '',
 					],
 					[
-						'url'     => 'http://example.org/scripts/script1.js',
-						'content' => 'var first = "content 1";',
-						'type'    => 'js',
+						'url'       => 'http://example.org/scripts/script1.js',
+						'content'   => 'var first = "content 1";',
+						'type'      => 'js',
 						'prewarmup' => 0,
+						'page_url'  => '',
 					],
 				],
 			],
@@ -227,17 +240,19 @@ return [
 			'expected' => [
 				'resources' => [
 					[
-						'url'     => 'http://example.org/css/stylewithrelativepathimport.css?ver=123',
-						'content' => '.relatively-pathed-imported-class{color:#000}.some-imported-class{color:pink}',
-						'type'    => 'css',
-						'media'   => 'all',
+						'url'       => 'http://example.org/css/stylewithrelativepathimport.css?ver=123',
+						'content'   => '.relatively-pathed-imported-class{color:#000}.some-imported-class{color:pink}',
+						'type'      => 'css',
+						'media'     => 'all',
 						'prewarmup' => 0,
+						'page_url'  => '',
 					],
 					[
-						'url'     => 'http://example.org/scripts/script1.js',
-						'content' => 'var first = "content 1";',
-						'type'    => 'js',
+						'url'       => 'http://example.org/scripts/script1.js',
+						'content'   => 'var first = "content 1";',
+						'type'      => 'js',
 						'prewarmup' => 0,
+						'page_url'  => '',
 					],
 				],
 			],
@@ -253,17 +268,19 @@ return [
 			'expected' => [
 				'resources' => [
 					[
-						'url'     => 'http://example.org/css/stylewithimport-recursion.css?ver=123',
-						'content' => ".another-class-in-stylewithimport-recursion{color:#fff}",
-						'type'    => 'css',
-						'media'   => 'all',
+						'url'       => 'http://example.org/css/stylewithimport-recursion.css?ver=123',
+						'content'   => ".another-class-in-stylewithimport-recursion{color:#fff}",
+						'type'      => 'css',
+						'media'     => 'all',
 						'prewarmup' => 0,
+						'page_url'  => '',
 					],
 					[
-						'url'     => 'http://example.org/scripts/script1.js',
-						'content' => 'var first = "content 1";',
-						'type'    => 'js',
+						'url'       => 'http://example.org/scripts/script1.js',
+						'content'   => 'var first = "content 1";',
+						'type'      => 'js',
 						'prewarmup' => 0,
+						'page_url'  => '',
 					],
 				],
 			],
@@ -278,11 +295,12 @@ return [
 			'expected' => [
 				'resources' => [
 					[
-						'url'     => 'http://example.org/css/style1.css?ver=123&q=5',
-						'content' => '.first{color:red}',
-						'type'    => 'css',
-						'media'   => 'all',
+						'url'       => 'http://example.org/css/style1.css?ver=123&q=5',
+						'content'   => '.first{color:red}',
+						'type'      => 'css',
+						'media'     => 'all',
 						'prewarmup' => 0,
+						'page_url'  => '',
 					],
 				],
 			],


### PR DESCRIPTION
## Description

We need a way to start prewarmup process (RESTAPI and the finish admin notice) only after collecting all resources and add them into the DB.

As in some cases when enabling the `RUCSS` option, it shows a message directly that `prewarmup` finished and this is because the `resourcefetcher` is Async and maybe the `init` is called before filling the resources table with the collected resources which leads to this finish message.

Also, the progress bar will send a request to REST API and it returned total => 3 resources and on the second tick total => 10 because again the Async behavior of `resourcefetcher`