### PR TITLE
Delete prewarmup_stats option at the end of the process

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Warmup/Status/Checker.php
+++ b/inc/Engine/Optimization/RUCSS/Warmup/Status/Checker.php
@@ -66,6 +66,7 @@ class Checker extends AbstractAPIClient {
 			do_action( 'rocket_rucss_prewarmup_error' );
 
 			rocket_clean_domain();
+			$this->options_api->delete( 'prewarmup_stats' );
 
 			return;
 		}
@@ -81,6 +82,7 @@ class Checker extends AbstractAPIClient {
 			do_action( 'rocket_rucss_prewarmup_success' );
 
 			rocket_clean_domain();
+			$this->options_api->delete( 'prewarmup_stats' );
 
 			return;
 		}


### PR DESCRIPTION
## Description

We need to delete the `prewarmup_stats` option at the end of the process to release the frontend treeshaking.