### PR TITLE
Fix #3877 Delete RUCSS tables on multisite sub-sites when uninstalling WP Rocket

### DIFF
--- a/inc/Engine/WPRocketUninstall.php
+++ b/inc/Engine/WPRocketUninstall.php
@@ -94,6 +94,13 @@ class WPRocketUninstall {
 	private $rucss_resources_table;
 
 	/**
+	 * Instance of RUCSS used_css table.
+	 *
+	 * @var WP_Rocket\Engine\Optimization\RUCSS\Database\Tables\UsedCSS
+	 */
+	private $rucss_usedcss_table;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param string    $cache_path            Path to the cache folder.
@@ -136,6 +143,24 @@ class WPRocketUninstall {
 		if ( $this->rucss_usedcss_table->exists() ) {
 			$this->rucss_usedcss_table->uninstall();
 		}
+
+		if ( ! is_multisite() ) {
+			return;
+		}
+
+		foreach ( get_sites( [ 'fields' => 'ids' ] ) as $site_id ) {
+			switch_to_blog( $site_id );
+
+			if ( $this->rucss_resources_table->exists() ) {
+				$this->rucss_resources_table->uninstall();
+			}
+			if ( $this->rucss_usedcss_table->exists() ) {
+				$this->rucss_usedcss_table->uninstall();
+			}
+
+			restore_current_blog();
+		}
+
 	}
 
 	/**

--- a/inc/Engine/WPRocketUninstall.php
+++ b/inc/Engine/WPRocketUninstall.php
@@ -137,12 +137,7 @@ class WPRocketUninstall {
 	 */
 	private function drop_rucss_database_tables() {
 		// If the table exist, then drop the table.
-		if ( $this->rucss_resources_table->exists() ) {
-			$this->rucss_resources_table->uninstall();
-		}
-		if ( $this->rucss_usedcss_table->exists() ) {
-			$this->rucss_usedcss_table->uninstall();
-		}
+		$this->drop_rucss_current_site_tables();
 
 		if ( ! is_multisite() ) {
 			return;
@@ -151,16 +146,23 @@ class WPRocketUninstall {
 		foreach ( get_sites( [ 'fields' => 'ids' ] ) as $site_id ) {
 			switch_to_blog( $site_id );
 
-			if ( $this->rucss_resources_table->exists() ) {
-				$this->rucss_resources_table->uninstall();
-			}
-			if ( $this->rucss_usedcss_table->exists() ) {
-				$this->rucss_usedcss_table->uninstall();
-			}
+			$this->drop_rucss_current_site_tables();
 
 			restore_current_blog();
 		}
 
+	}
+
+	/**
+	 * Drop RUCSS tables for current active site.
+	 */
+	private function drop_rucss_current_site_tables() {
+		if ( $this->rucss_resources_table->exists() ) {
+			$this->rucss_resources_table->uninstall();
+		}
+		if ( $this->rucss_usedcss_table->exists() ) {
+			$this->rucss_usedcss_table->uninstall();
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Description

In multisite, Remove all subsites' DB tables created by us

Fixes #3877

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Manually on our multisite staging site

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules