### PR TITLE
Change enqueue position of the delay JS script depending on exclusions field value

### DIFF
--- a/inc/Engine/Optimization/DelayJS/ServiceProvider.php
+++ b/inc/Engine/Optimization/DelayJS/ServiceProvider.php
@@ -41,6 +41,7 @@ class ServiceProvider extends AbstractServiceProvider {
 		$this->getContainer()->share( 'delay_js_subscriber', 'WP_Rocket\Engine\Optimization\DelayJS\Subscriber' )
 			->addArgument( $this->getContainer()->get( 'delay_js_html' ) )
 			->addArgument( rocket_direct_filesystem() )
+			->addArgument( $this->getContainer()->get( 'options' ) )
 			->addTag( 'front_subscriber' );
 	}
 }

--- a/inc/Engine/Optimization/DelayJS/Subscriber.php
+++ b/inc/Engine/Optimization/DelayJS/Subscriber.php
@@ -47,7 +47,7 @@ class Subscriber implements Subscriber_Interface {
 	 *
 	 * @param HTML                  $html HTML Instance.
 	 * @param \WP_Filesystem_Direct $filesystem The Filesystem object.
-	 * @param Options_data          $options Options data instance.
+	 * @param Options_Data          $options Options data instance.
 	 */
 	public function __construct( HTML $html, $filesystem, Options_Data $options ) {
 		$this->html       = $html;
@@ -105,7 +105,7 @@ class Subscriber implements Subscriber_Interface {
 			'',
 			[],
 			'',
-			empty( $this->options->get('delay_js_exclusions', [] ) )
+			empty( $this->options->get( 'delay_js_exclusions', [] ) )
 		);
 		wp_enqueue_script( 'rocket-delay-js' );
 

--- a/inc/Engine/Optimization/DelayJS/Subscriber.php
+++ b/inc/Engine/Optimization/DelayJS/Subscriber.php
@@ -65,7 +65,7 @@ class Subscriber implements Subscriber_Interface {
 	public static function get_subscribed_events() {
 		return [
 			'rocket_buffer'                               => [ 'delay_js', 26 ],
-			'wp_enqueue_scripts'                          => 'add_delay_js_script',
+			'wp_enqueue_scripts'                          => [ 'add_delay_js_script', 1 ],
 			'pre_get_rocket_option_minify_concatenate_js' => 'maybe_disable_option',
 		];
 	}

--- a/inc/Engine/Optimization/DelayJS/Subscriber.php
+++ b/inc/Engine/Optimization/DelayJS/Subscriber.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace WP_Rocket\Engine\Optimization\DelayJS;
 
+use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Event_Management\Subscriber_Interface;
 
 class Subscriber implements Subscriber_Interface {
@@ -26,6 +27,13 @@ class Subscriber implements Subscriber_Interface {
 	private $filesystem;
 
 	/**
+	 * Options Data instance
+	 *
+	 * @var Options_Data
+	 */
+	private $options;
+
+	/**
 	 * Script enqueued status.
 	 *
 	 * @since 3.7
@@ -39,10 +47,12 @@ class Subscriber implements Subscriber_Interface {
 	 *
 	 * @param HTML                  $html HTML Instance.
 	 * @param \WP_Filesystem_Direct $filesystem The Filesystem object.
+	 * @param Options_data          $options Options data instance.
 	 */
-	public function __construct( HTML $html, $filesystem ) {
+	public function __construct( HTML $html, $filesystem, Options_Data $options ) {
 		$this->html       = $html;
 		$this->filesystem = $filesystem;
+		$this->options    = $options;
 	}
 
 	/**
@@ -95,7 +105,7 @@ class Subscriber implements Subscriber_Interface {
 			'',
 			[],
 			'',
-			true
+			empty( $this->options->get('delay_js_exclusions', [] ) )
 		);
 		wp_enqueue_script( 'rocket-delay-js' );
 


### PR DESCRIPTION
## Description

As discussed during stand-up, the position of the delay JS script should change depending on if we have exclusions or not.

This PR updates the code to change the enqueue position depending on the option value:
- In footer if the field is empty
- In header if it's not

## Type of change

- [x] Enhancement (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Manual testing with and without values in the exclusions field

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes