### PR TITLE
Load DelayJS script right after the opening <head>

### DIFF
--- a/inc/Engine/Optimization/DelayJS/Subscriber.php
+++ b/inc/Engine/Optimization/DelayJS/Subscriber.php
@@ -91,6 +91,8 @@ class Subscriber implements Subscriber_Interface {
 	 * @since 3.9 Hooked on rocket_buffer, display the script right after <head>
 	 * @since 3.7
 	 *
+	 * @param string $html HTML content.
+	 *
 	 * @return string
 	 */
 	public function add_delay_js_script( $html ): string {
@@ -106,7 +108,7 @@ class Subscriber implements Subscriber_Interface {
 			$html = preg_replace( $pattern, "$0<script>{$lazyload_script}</script>", $html, 1 );
 		}
 
-		return preg_replace( $pattern, "$0<script>" . $this->html->get_ie_fallback() . "</script>", $html, 1 );
+		return preg_replace( $pattern, '$0<script>' . $this->html->get_ie_fallback() . '</script>', $html, 1 );
 	}
 
 	/**

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/Subscriber/addDelayJsScript.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/Subscriber/addDelayJsScript.php
@@ -1,5 +1,16 @@
 <?php
 
+$html = '<html>
+<head><title>Sample Page</title></head>
+<body></body>
+</html>';
+
+$expected = '<html>
+<head><script>if(navigator.userAgent.match(/MSIE|Internet Explorer/i)||navigator.userAgent.match(/Trident\/7\..*?rv:11/i)){var href=document.location.href;if(!href.match(/[?&]nowprocket/)){if(href.indexOf("?")==-1){if(href.indexOf("#")==-1){document.location.href=href+"?nowprocket=1"}else{document.location.href=href.replace("#","?nowprocket=1#")}}else{if(href.indexOf("#")==-1){document.location.href=href+"&nowprocket=1"}else{document.location.href=href.replace("#","&nowprocket=1#")}}}}</script><script>class RocketLazyLoadScripts{constructor(e){this.triggerEvents=e,this.eventOptions={passive:!0},this.userEventListener=this.triggerListener.bind(this),this.delayedScripts={normal:[],async:[],defer:[]},this.allJQueries=[]}_addUserInteractionListener(e){this.triggerEvents.forEach((t=>window.addEventListener(t,e.userEventListener,e.eventOptions)))}_removeUserInteractionListener(e){this.triggerEvents.forEach((t=>window.removeEventListener(t,e.userEventListener,e.eventOptions)))}triggerListener(){this._removeUserInteractionListener(this),this._loadEverythingNow()}async _loadEverythingNow(){this._handleDocumentWrite(),this._registerAllDelayedScripts(),this._preloadAllScripts(),await this._loadScriptsFromList(this.delayedScripts.normal),await this._loadScriptsFromList(this.delayedScripts.defer),await this._loadScriptsFromList(this.delayedScripts.async),await this._triggerDOMContentLoaded(),await this._triggerWindowLoad(),window.dispatchEvent(new Event("rocket-allScriptsLoaded"))}_registerAllDelayedScripts(){document.querySelectorAll("script[type=rocketlazyloadscript]").forEach((e=>{e.hasAttribute("src")?e.hasAttribute("async")&&!1!==e.async?this.delayedScripts.async.push(e):e.hasAttribute("defer")&&!1!==e.defer||"module"===e.getAttribute("data-rocket-type")?this.delayedScripts.defer.push(e):this.delayedScripts.normal.push(e):this.delayedScripts.normal.push(e)}))}async _transformScript(e){return await this._requestAnimFrame(),new Promise((t=>{var n=document.createElement("script");[...e.attributes].forEach((e=>{let t=e.nodeName;"type"!==t&&("data-rocket-type"===t&&(t="type"),n.setAttribute(t,e.nodeValue))})),e.hasAttribute("src")?(n.addEventListener("load",t),n.addEventListener("error",t)):(n.text=e.text,t()),e.parentNode.replaceChild(n,e)}))}async _loadScriptsFromList(e){const t=e.shift();return t?(await this._transformScript(t),this._loadScriptsFromList(e)):Promise.resolve()}_preloadAllScripts(){var e=document.createDocumentFragment();[...this.delayedScripts.normal,...this.delayedScripts.defer,...this.delayedScripts.async].forEach((t=>{const n=t.getAttribute("src");if(n){const t=document.createElement("link");t.href=n,t.rel="preload",t.as="script",e.appendChild(t)}})),document.head.appendChild(e)}_delayEventListeners(){let e={};function t(t,n){!function(t){function n(n){return e[t].eventsToRewrite.indexOf(n)>=0?"rocket-"+n:n}e[t]||(e[t]={originalFunctions:{add:t.addEventListener,remove:t.removeEventListener},eventsToRewrite:[]},t.addEventListener=function(){arguments[0]=n(arguments[0]),e[t].originalFunctions.add.apply(t,arguments)},t.removeEventListener=function(){arguments[0]=n(arguments[0]),e[t].originalFunctions.remove.apply(t,arguments)})}(t),e[t].eventsToRewrite.push(n)}function n(e,t){const n=e[t];Object.defineProperty(e,t,{get:n||function(){},set:n=>{e["rocket"+t]=n}})}t(document,"DOMContentLoaded"),t(window,"DOMContentLoaded"),t(window,"load"),t(window,"pageshow"),t(document,"readystatechange"),n(document,"onreadystatechange"),n(window,"onload"),n(window,"onpageshow")}_delayJQueryReady(e){let t;Object.defineProperty(window,"jQuery",{get:()=>t,set(n){if(n&&n.fn&&!e.allJQueries.includes(n)){n.fn.ready=n.fn.init.prototype.ready=function(t){e.domReadyFired?t.bind(document)(n):document.addEventListener("rocket-DOMContentLoaded",(()=>t.bind(document)(n)))};const t=n.fn.on;n.fn.on=n.fn.init.prototype.on=function(){if(this[0]===window){function e(e){return e.split(" ").map((e=>"load"===e?"rocket-load":e)).join(" ")}"string"==typeof arguments[0]||arguments[0]instanceof String?arguments[0]=e(arguments[0]):"object"==typeof arguments[0]&&Object.keys(arguments[0]).forEach((t=>{delete Object.assign(arguments[0],{[e(t)]:arguments[0][t]})[t]}))}return t.apply(this,arguments),this},e.allJQueries.push(n)}t=n}})}async _triggerDOMContentLoaded(){this.domReadyFired=!0,await this._requestAnimFrame(),document.dispatchEvent(new Event("rocket-DOMContentLoaded")),await this._requestAnimFrame(),window.dispatchEvent(new Event("rocket-DOMContentLoaded")),await this._requestAnimFrame(),document.dispatchEvent(new Event("rocket-readystatechange")),await this._requestAnimFrame(),document.rocketonreadystatechange&&document.rocketonreadystatechange()}async _triggerWindowLoad(){await this._requestAnimFrame(),window.dispatchEvent(new Event("rocket-load")),await this._requestAnimFrame(),window.rocketonload&&window.rocketonload(),await this._requestAnimFrame(),this.allJQueries.forEach((e=>e(window).trigger("rocket-load"))),window.dispatchEvent(new Event("rocket-pageshow")),await this._requestAnimFrame(),window.rocketonpageshow&&window.rocketonpageshow()}_handleDocumentWrite(){const e=new Map;document.write=document.writeln=function(t){const n=document.currentScript,r=document.createRange(),i=n.parentElement;let o=e.get(n);void 0===o&&(o=n.nextSibling,e.set(n,o));const a=document.createDocumentFragment();r.setStart(a,0),a.appendChild(r.createContextualFragment(t)),i.insertBefore(a,o)}}async _requestAnimFrame(){return new Promise((e=>requestAnimationFrame(e)))}static run(){const e=new RocketLazyLoadScripts(["keydown","mouseover","touchmove","touchstart","wheel"]);e._delayEventListeners(),e._delayJQueryReady(e),e._addUserInteractionListener(e)}}RocketLazyLoadScripts.run();
+</script><title>Sample Page</title></head>
+<body></body>
+</html>';
+
 return [
 	'testShouldNotAddScriptsWhenBypass' => [
 		'config'   => [
@@ -7,7 +18,8 @@ return [
 			'donotoptimize' => false,
 			'bypass'        => true,
 		],
-		'expected' => false,
+		'html'     => $html,
+		'expected' => $html,
 	],
 
 	'testShouldNotAddScriptsWhenDONOTOPTIMIZE' => [
@@ -16,7 +28,8 @@ return [
 			'donotoptimize' => true,
 			'bypass'        => false,
 		],
-		'expected' => false,
+		'html'     => $html,
+		'expected' => $html,
 	],
 
 	'testShouldNotAddScriptsWhenDelaySettingDisabled' => [
@@ -25,7 +38,8 @@ return [
 			'donotoptimize' => false,
 			'bypass'        => false,
 		],
-		'expected' => false,
+		'html'     => $html,
+		'expected' => $html,
 	],
 
 	'testShouldAddScripts' => [
@@ -34,6 +48,7 @@ return [
 			'donotoptimize' => false,
 			'bypass'        => false,
 		],
-		'expected' => true,
+		'html'     => $html,
+		'expected' => $expected,
 	],
 ];

--- a/tests/Integration/inc/Engine/Optimization/DelayJS/Subscriber/addDelayJsScript.php
+++ b/tests/Integration/inc/Engine/Optimization/DelayJS/Subscriber/addDelayJsScript.php
@@ -14,13 +14,16 @@ use WP_Rocket\Tests\Integration\TestCase;
 class Test_AddDelayJsScript extends TestCase {
 	private $delay_js = false;
 
+	public function setUp(): void {
+		$this->unregisterAllCallbacksExcept( 'rocket_buffer', 'add_delay_js_script', 26 );
+	}
+
 	public function tearDown() {
 		unset( $GLOBALS['wp'] );
 		remove_filter( 'pre_get_rocket_option_delay_js', [ $this, 'set_delay_js_option' ] );
 
 		$this->delay_js = false;
-
-		wp_dequeue_script('rocket-delay-js');
+		$this->restoreWpFilter( 'rocket_buffer' );
 
 		parent::tearDown();
 	}
@@ -28,7 +31,7 @@ class Test_AddDelayJsScript extends TestCase {
 	/**
 	 * @dataProvider configTestData
 	 */
-	public function testShouldDoExpected( $config, $expected ) {
+	public function testShouldDoExpected( $config, $html, $expected ) {
 		$this->donotrocketoptimize = $config['donotoptimize'];
 		$this->delay_js            = $config['delay_js'];
 
@@ -46,14 +49,10 @@ class Test_AddDelayJsScript extends TestCase {
 			$GLOBALS['wp']->query_vars['nowprocket'] = 1;
 		}
 
-		do_action( 'wp_enqueue_scripts' );
-
-		if ( false === $expected ) {
-			$this->assertFalse( wp_script_is( 'rocket-delay-js' ) );
-		} else {
-			$this->assertTrue( wp_script_is( 'rocket-delay-js' ) );
-		}
-
+		$this->assertSame(
+			$expected,
+			apply_filters( 'rocket_buffer', $html )
+		);
 	}
 
 	public function set_delay_js_option() {


### PR DESCRIPTION
## Description

After discussions, it was determined that the best place to load the script is right at the start of the document, after the `<head>` opening tag.

This PR reflects that change, using `rocket_buffer` to insert the script in the HTML.

## Type of change

- [x] Enhancement (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual test
- [x] Updated automated test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes