### PR TITLE
Add unit tests code coverage

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -1,0 +1,74 @@
+name: PHPUnit Code Coverage
+
+on:
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  run:
+    runs-on: ${{ matrix.operating-system }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ubuntu-latest]
+        php-versions: ['7.4']
+        wp-versions: ['latest']
+
+    name: Code Coverage.
+
+    env:
+      WP_TESTS_DIR: "/tmp/tests/phpunit"
+      WP_CORE_DIR: "/tmp/wordpress-develop"
+      ROCKETCDN_EMAIL: ${{ secrets.ROCKETCDN_EMAIL }}
+      ROCKETCDN_PWD: ${{ secrets.ROCKETCDN_PWD }}
+      ROCKETCDN_TOKEN: ${{ secrets.ROCKETCDN_TOKEN }}
+      ROCKETCDN_URL: ${{ secrets.ROCKETCDN_URL }}
+      ROCKETCDN_WEBSITE_ID: ${{ secrets.ROCKETCDN_WEBSITE_ID }}
+      ROCKET_EMAIL: ${{ secrets.ROCKET_EMAIL }}
+      ROCKET_KEY: ${{ secrets.ROCKET_KEY }}
+      ROCKET_CLOUDFLARE_API_KEY: ${{ secrets.ROCKET_CLOUDFLARE_API_KEY }}
+      ROCKET_CLOUDFLARE_EMAIL: ${{ secrets.ROCKET_CLOUDFLARE_EMAIL }}
+      ROCKET_CLOUDFLARE_SITE_URL: ${{ secrets.ROCKET_CLOUDFLARE_SITE_URL }}
+      ROCKET_CLOUDFLARE_ZONE_ID: ${{ secrets.ROCKET_CLOUDFLARE_ZONE_ID }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-versions }}
+        coverage: none  # XDebug can be enabled here 'coverage: xdebug'
+        tools: composer:v1, phpunit
+
+    - name: Setup problem matchers for PHP
+      run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+
+    - name: Setup problem matchers for PHPUnit
+      run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+    - name: Get composer cache directory
+      id: composercache
+      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+    - name: Cache dependencies
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.composercache.outputs.dir }}
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+        restore-keys: ${{ runner.os }}-composer-
+
+    - name: Install dependencies
+      run: composer install --no-interaction --no-scripts
+
+    - name: Code Coverage
+      run: composer code-coverage
+
+    - name: Run codacy-coverage-reporter
+      uses: codacy/codacy-coverage-reporter-action@v1
+      with:
+        project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+        coverage-reports: tests/report/coverage.clover

--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -41,7 +41,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-versions }}
-        coverage: none  # XDebug can be enabled here 'coverage: xdebug'
+        coverage: xdebug
         tools: composer:v1, phpunit
 
     - name: Setup problem matchers for PHP

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
 		"sort-packages": true,
 		"preferred-install": {
 			"wp-media/phpunit": "source"
-		}
+		},
+		"process-timeout": 0
 	},
 	"support": {
 		"issues": "https://github.com/wp-media/wp-rocket/issues",
@@ -169,6 +170,7 @@
 		"post-update-cmd": [
 			"\"vendor/bin/mozart\" compose",
 			"composer dump-autoload"
-		]
+		],
+		"code-coverage": "\"vendor/bin/phpunit\" --testsuite unit --colors=always --configuration tests/Unit/phpunit.xml.dist --coverage-clover=tests/report/coverage.clover"
 	}
 }

--- a/tests/Unit/inc/Engine/Cache/Purge/purgeDatesArchives.php
+++ b/tests/Unit/inc/Engine/Cache/Purge/purgeDatesArchives.php
@@ -9,7 +9,7 @@ use WP_Rocket\Tests\Unit\FilesystemTestCase;
 use WP_Rocket\Engine\Cache\Purge;
 
 /**
- * @covers \WP_Rocket\Engine\Cache\Purge:purge_dates_archives
+ * @covers \WP_Rocket\Engine\Cache\Purge::purge_dates_archives
  * @group  purge_actions
  */
 class Test_PurgeDatesArchives extends FilesystemTestCase {

--- a/tests/Unit/inc/Engine/Cache/Purge/purgePostTermsUrls.php
+++ b/tests/Unit/inc/Engine/Cache/Purge/purgePostTermsUrls.php
@@ -11,7 +11,7 @@ use WP_Rocket\Tests\Unit\FilesystemTestCase;
 use WP_Rocket\Engine\Cache\Purge;
 
 /**
- * @covers ::get_rocket_post_terms_urls
+ * @covers \WP_Rocket\Engine\Cache\Purge::purge_post_terms_urls
  * @group  Purge
  * @group  purge_actions
  */

--- a/tests/Unit/inc/Engine/Cache/PurgeActionsSubscriber/maybePurgeCacheOnTermChange.php
+++ b/tests/Unit/inc/Engine/Cache/PurgeActionsSubscriber/maybePurgeCacheOnTermChange.php
@@ -10,7 +10,7 @@ use WP_Rocket\Engine\Cache\Purge;
 use WP_Rocket\Engine\Cache\PurgeActionsSubscriber;
 
 /**
- * @covers \WP_Rocket\Engine\Cache\PurgeActionsSubscriber:maybe_purge_cache_on_term_change
+ * @covers \WP_Rocket\Engine\Cache\PurgeActionsSubscriber::maybe_purge_cache_on_term_change
  *
  * @group  purge_actions
  */

--- a/tests/Unit/inc/Engine/Cache/PurgeActionsSubscriber/purgeUserCache.php
+++ b/tests/Unit/inc/Engine/Cache/PurgeActionsSubscriber/purgeUserCache.php
@@ -11,7 +11,7 @@ use WP_Rocket\Engine\Cache\Purge;
 use WP_Rocket\Engine\Cache\PurgeActionsSubscriber;
 
 /**
- * @covers \WP_Rocket\Engine\Cache\PurgeActionsSubscriber:purge_user_cache
+ * @covers \WP_Rocket\Engine\Cache\PurgeActionsSubscriber::purge_user_cache
  * @group  purge_actions
  */
 class Test_PurgeUserCache extends TestCase {
@@ -56,7 +56,7 @@ class Test_PurgeUserCache extends TestCase {
 		$this->options->shouldReceive( 'get' )
 			->with( 'cache_logged_user', 0 )
 			->andReturn( 1 );
-	
+
 		$this->subscriber->purge_user_cache( 1 );
 	}
 }

--- a/tests/Unit/inc/Engine/Cache/PurgeExpired/PurgeExpiredCache/purgeExpiredFiles.php
+++ b/tests/Unit/inc/Engine/Cache/PurgeExpired/PurgeExpiredCache/purgeExpiredFiles.php
@@ -8,7 +8,7 @@ use WP_Rocket\Engine\Cache\PurgeExpired\PurgeExpiredCache;
 use WP_Rocket\Tests\Unit\FilesystemTestCase;
 
 /**
- * @covers PurgeExpiredCache::purge_expired_files
+ * @covers \WP_Rocket\Engine\Cache\PurgeExpired\PurgeExpiredCache::purge_expired_files
  * @uses   \WP_Rocket\Buffer\Cache::can_generate_caching_files
  * @group  Cache
  * @group  vfs

--- a/tests/Unit/inc/Engine/Cache/PurgeExpired/PurgeExpiredCache/updateLifespanValue.php
+++ b/tests/Unit/inc/Engine/Cache/PurgeExpired/PurgeExpiredCache/updateLifespanValue.php
@@ -7,7 +7,7 @@ use WP_Rocket\Engine\Cache\PurgeExpired\PurgeExpiredCache;
 use WP_Rocket\Tests\Unit\TestCase;
 
 /**
- * @covers PurgeExpiredCache::update_lifespan_value
+ * @covers \WP_Rocket\Engine\Cache\PurgeExpired\PurgeExpiredCache::update_lifespan_value
  * @group  Cache
  */
 class Test_UpdateLifespanValue extends TestCase {

--- a/tests/Unit/inc/Engine/Cache/WPCache/findWpConfigPath.php
+++ b/tests/Unit/inc/Engine/Cache/WPCache/findWpConfigPath.php
@@ -3,14 +3,11 @@
 namespace WP_Rocket\Tests\Unit\inc\Engine\Cache\WPCache;
 
 use Brain\Monkey\Filters;
-use Brain\Monkey\Functions;
-use Mockery;
 use ReflectionMethod;
 use WP_Rocket\Engine\Cache\WPCache;
 use WP_Rocket\Tests\Unit\FilesystemTestCase;
 
 /**
- * @covers \WP_Rocket\Engine\Cache\WPCache::find_wp_config_path
  * @uses   ::rocket_get_constant
  *
  * @group  WPCache

--- a/tests/Unit/inc/Engine/Cache/WPCache/maybePreventDeactivation.php
+++ b/tests/Unit/inc/Engine/Cache/WPCache/maybePreventDeactivation.php
@@ -7,7 +7,7 @@ use Brain\Monkey\Filters;
 
 /**
  * @covers \WP_Rocket\Engine\Cache\WPCache::maybe_prevent_deactivation
- * @uses   ::find_wp_config_path
+ * @uses   \WP_Rocket\Engine\Cache\WPCache::find_wp_config_path
  *
  * @group  WPCache
  */

--- a/tests/Unit/inc/Engine/Cache/WPCache/updateWPCache.php
+++ b/tests/Unit/inc/Engine/Cache/WPCache/updateWPCache.php
@@ -7,8 +7,8 @@ use WP_Rocket\Tests\Unit\TestCase;
 
 /**
  * @covers \WP_Rocket\Engine\Cache\WPCache::update_wp_cache
- * @uses   rocket_valid_key()
- * @uses   ::set_wp_cache_constant
+ * @uses   \rocket_valid_key()
+ * @uses   \WP_Rocket\Engine\Cache\WPCache::set_wp_cache_constant
  *
  * @group  WPCache
  */

--- a/tests/Unit/inc/Engine/CriticalPath/Admin/Settings/displayCpcssMobileSection.php
+++ b/tests/Unit/inc/Engine/CriticalPath/Admin/Settings/displayCpcssMobileSection.php
@@ -9,7 +9,7 @@ use WP_Rocket\Engine\CriticalPath\Admin\Settings;
 use WP_Rocket\Tests\Unit\inc\Engine\CriticalPath\Admin\AdminTrait;
 
 /**
- * @covers \WP_Rocket\Engine\CriticalPath\AdminSubscriber::cpcss_section
+ * @covers \WP_Rocket\Engine\CriticalPath\Admin\Subscriber::cpcss_section
  *
  * @group  CriticalPath
  */

--- a/tests/Unit/inc/Engine/Media/EmbedsSubscriber/removeEmbedEndpoint.php
+++ b/tests/Unit/inc/Engine/Media/EmbedsSubscriber/removeEmbedEndpoint.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WP_Rocket\Tests\Unit\inc\Engine\Media\EmbedsSubscriber;
+namespace WP_Rocket\Tests\Unit\inc\Engine\Media\Embeds\EmbedsSubscriber;
 
 use Brain\Monkey\Functions;
 use Mockery;
@@ -9,7 +9,7 @@ use WP_Rocket\Engine\Media\Embeds\EmbedsSubscriber;
 use WP_Rocket\Tests\Unit\TestCase;
 
 /**
- * @covers \WP_Rocket\Engine\Media\EmbedsSubscriber::remove_embed_endpoint
+ * @covers \WP_Rocket\Engine\Media\Embeds\EmbedsSubscriber::remove_embed_endpoint
  *
  * @group Media
  * @group Embeds

--- a/tests/Unit/inc/Engine/Media/EmbedsSubscriber/removeEmbedsRewriteRules.php
+++ b/tests/Unit/inc/Engine/Media/EmbedsSubscriber/removeEmbedsRewriteRules.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WP_Rocket\Tests\Unit\inc\Engine\Media\EmbedsSubscriber;
+namespace WP_Rocket\Tests\Unit\inc\Engine\Media\Embeds\EmbedsSubscriber;
 
 use Brain\Monkey\Functions;
 use Mockery;
@@ -9,7 +9,7 @@ use WP_Rocket\Engine\Media\Embeds\EmbedsSubscriber;
 use WP_Rocket\Tests\Unit\TestCase;
 
 /**
- * @covers \WP_Rocket\Engine\Media\EmbedsSubscriber::remove_embeds_rewrite_rules
+ * @covers \WP_Rocket\Engine\Media\Embeds\EmbedsSubscriber::remove_embeds_rewrite_rules
  *
  * @group Media
  * @group Embeds

--- a/tests/Unit/inc/Engine/Optimization/DelayJS/HTML/delayJs.php
+++ b/tests/Unit/inc/Engine/Optimization/DelayJS/HTML/delayJs.php
@@ -13,7 +13,7 @@ use WP_Rocket\Tests\Unit\TestCase;
  * @group  Optimize
  * @group  DelayJS
  *
- * @uses   rocket_get_constant()
+ * @uses   ::rocket_get_constant()
  */
 class Test_DelayJs extends TestCase {
 	private $options;

--- a/tests/Unit/inc/Engine/Optimization/GoogleFonts/Admin/Settings/displayGoogleFontsEnabler.php
+++ b/tests/Unit/inc/Engine/Optimization/GoogleFonts/Admin/Settings/displayGoogleFontsEnabler.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\GoogleFonts;
+namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\GoogleFonts\Admin\Settings;
 
 use Mockery;
 use WP_Rocket\Admin\Options_Data;
@@ -11,7 +11,7 @@ use Brain\Monkey\Functions;
 use WP_Rocket\Tests\Unit\FilesystemTestCase;
 
 /**
- * @covers \WP_Rocket\Engine\Optimization\GoogleFonts\Admin::enable_google_fonts()
+ * @covers \WP_Rocket\Engine\Optimization\GoogleFonts\Admin\Settings::enable_google_fonts()
  *
  * @group  GoogleFontsAdmin
  */

--- a/tests/Unit/inc/Engine/Optimization/GoogleFonts/Admin/Settings/enableGoogleFonts.php
+++ b/tests/Unit/inc/Engine/Optimization/GoogleFonts/Admin/Settings/enableGoogleFonts.php
@@ -1,5 +1,5 @@
 <?php
-namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\GoogleFonts;
+namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\GoogleFonts\Admin\Settings;
 
 use Mockery;
 use WP_Rocket\Admin\Options_Data;
@@ -9,7 +9,7 @@ use WPMedia\PHPUnit\Unit\TestCase;
 use Brain\Monkey\Functions;
 
 /**
- * @covers \WP_Rocket\Engine\Optimization\GoogleFonts\Admin::enable_google_fonts()
+ * @covers \WP_Rocket\Engine\Optimization\GoogleFonts\Admin\Settings::enable_google_fonts()
  *
  * @group  GoogleFontsAdmin
  */

--- a/tests/Unit/inc/Engine/Optimization/GoogleFonts/Combine/optimize.php
+++ b/tests/Unit/inc/Engine/Optimization/GoogleFonts/Combine/optimize.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\GoogleFonts;
+namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\GoogleFonts\Combine;
 
 use Brain\Monkey\Functions;
 use WPMedia\PHPUnit\Unit\TestCase;
 use WP_Rocket\Engine\Optimization\GoogleFonts\Combine;
 
 /**
- * @covers \ WP_Rocket\Engine\Optimization\GoogleFonts\Combine::optimize
+ * @covers \WP_Rocket\Engine\Optimization\GoogleFonts\Combine::optimize
  * @group  Optimize
  * @group  GoogleFonts
  */

--- a/tests/Unit/inc/Engine/Optimization/GoogleFonts/CombineV2/optimize.php
+++ b/tests/Unit/inc/Engine/Optimization/GoogleFonts/CombineV2/optimize.php
@@ -1,10 +1,9 @@
 <?php
 
-namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\GoogleFonts;
+namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\GoogleFonts\CombineV2;
 
 use Brain\Monkey\Functions;
 use WP_Rocket\Engine\Optimization\GoogleFonts\CombineV2;
-use WP_Rocket\Logger\Logger;
 use WP_Rocket\Tests\Unit\TestCase;
 
 /**
@@ -13,8 +12,8 @@ use WP_Rocket\Tests\Unit\TestCase;
  * @group  Optimize
  * @group  GoogleFonts
  *
- * @uses   Logger::info
- * @uses   Logger::debug
+ * @uses   \WP_Rocket\Logger\Logger::info
+ * @uses   \WP_Rocket\Logger\Logger::debug
  */
 class Test_OptimizeV2 extends TestCase {
 

--- a/tests/Unit/inc/ThirdParty/Themes/Divi/addDiviToDescription.php
+++ b/tests/Unit/inc/ThirdParty/Themes/Divi/addDiviToDescription.php
@@ -9,7 +9,7 @@ use WP_Theme;
 
 /**
  * @covers \WP_Rocket\ThirdParty\Themes\Divi::add_divi_to_description
- * @uses   ::is_divi
+ * @uses   \WP_Rocket\ThirdParty\Themes\Divi::is_divi
  *
  * @group  ThirdParty
  */

--- a/tests/Unit/inc/ThirdParty/Themes/Divi/disableImageDimensionsHeightPercentage.php
+++ b/tests/Unit/inc/ThirdParty/Themes/Divi/disableImageDimensionsHeightPercentage.php
@@ -12,7 +12,7 @@ use WP_Theme;
 
 /**
  * @covers \WP_Rocket\ThirdParty\Themes\Divi::disable_image_dimensions_height_percentage
- * @uses   ::is_divi
+ * @uses   \WP_Rocket\ThirdParty\Themes\Divi::is_divi
  *
  * @group  ThirdParty
  */

--- a/tests/Unit/inc/ThirdParty/Themes/Divi/excludeJS.php
+++ b/tests/Unit/inc/ThirdParty/Themes/Divi/excludeJS.php
@@ -8,7 +8,7 @@ use Brain\Monkey\Functions;
 
 /**
  * @covers \WP_Rocket\ThirdParty\Themes\Divi::exclude_js
- * @uses   rocket_get_constant()
+ * @uses   ::rocket_get_constant()
  *
  * @group  ThirdParty
  */

--- a/tests/Unit/inc/ThirdParty/Themes/Divi/maybeDisableYoutubePreview.php
+++ b/tests/Unit/inc/ThirdParty/Themes/Divi/maybeDisableYoutubePreview.php
@@ -9,7 +9,7 @@ use Brain\Monkey\Functions;
 
 /**
  * @covers \WP_Rocket\ThirdParty\Themes\Divi::maybe_disable_youtube_preview
- * @uses   ::is_divi
+ * @uses   \WP_Rocket\ThirdParty\Themes\Divi::is_divi
  *
  * @group  ThirdParty
  */

--- a/tests/Unit/inc/classes/third-party/plugins/Images/Webp/EWWW_Subscriber/isServingWebp.php
+++ b/tests/Unit/inc/classes/third-party/plugins/Images/Webp/EWWW_Subscriber/isServingWebp.php
@@ -10,7 +10,7 @@ use WP_Rocket\Subscriber\Third_Party\Plugins\Images\Webp\EWWW_Subscriber;
 use WPMedia\PHPUnit\Unit\TestCase;
 
 /**
- * @covers \WP_Rocket\Subscriber\Third_Party\Plugins\Images\Webp\EWWW_Subscriber::::is_serving_webp
+ * @covers \WP_Rocket\Subscriber\Third_Party\Plugins\Images\Webp\EWWW_Subscriber::is_serving_webp
  * @group  ThirdParty
  * @group  Webp
  */

--- a/tests/Unit/inc/classes/third-party/plugins/Images/Webp/EWWW_Subscriber/loadHooks.php
+++ b/tests/Unit/inc/classes/third-party/plugins/Images/Webp/EWWW_Subscriber/loadHooks.php
@@ -11,7 +11,7 @@ use WP_Rocket\Subscriber\Third_Party\Plugins\Images\Webp\EWWW_Subscriber;
 use WPMedia\PHPUnit\Unit\TestCase;
 
 /**
- * @covers \WP_Rocket\Subscriber\Third_Party\Plugins\Images\Webp\EWWW_Subscriber::::load_hooks
+ * @covers \WP_Rocket\Subscriber\Third_Party\Plugins\Images\Webp\EWWW_Subscriber::load_hooks
  * @group  ThirdParty
  * @group  Webp
  */

--- a/tests/Unit/inc/classes/third-party/plugins/Images/Webp/EWWW_Subscriber/maybeRemoveImagesCnames.php
+++ b/tests/Unit/inc/classes/third-party/plugins/Images/Webp/EWWW_Subscriber/maybeRemoveImagesCnames.php
@@ -10,7 +10,7 @@ use WP_Rocket\Subscriber\Third_Party\Plugins\Images\Webp\EWWW_Subscriber;
 use WPMedia\PHPUnit\Unit\TestCase;
 
 /**
- * @covers \WP_Rocket\Subscriber\Third_Party\Plugins\Images\Webp\EWWW_Subscriber::::maybe_remove_images_cnames
+ * @covers \WP_Rocket\Subscriber\Third_Party\Plugins\Images\Webp\EWWW_Subscriber::maybe_remove_images_cnames
  * @group  ThirdParty
  * @group  Webp
  */
@@ -112,7 +112,7 @@ class Test_MaybeRemoveImagesCnames extends TestCase {
 			->shouldReceive( 'get' )
 			->with( 'cdn_cnames', [] )
 			->andReturn( [ 'dns.example.com, all.example.com', 'evil.example.com' ] );
-		
+
 		$optionsData
 			->shouldReceive( 'get' )
 			->with( 'cdn_zone', [] )

--- a/tests/Unit/inc/classes/third-party/plugins/Images/Webp/EWWW_Subscriber/maybeRemoveImagesFromCdnDropdown.php
+++ b/tests/Unit/inc/classes/third-party/plugins/Images/Webp/EWWW_Subscriber/maybeRemoveImagesFromCdnDropdown.php
@@ -9,7 +9,7 @@ use WPMedia\PHPUnit\Unit\TestCase;
 use WP_Rocket\Subscriber\Third_Party\Plugins\Images\Webp\EWWW_Subscriber;
 
 /**
- * @covers \WP_Rocket\Subscriber\Third_Party\Plugins\Images\Webp\EWWW_Subscriber::::maybe_remove_images_from_cdn_dropdown
+ * @covers \WP_Rocket\Subscriber\Third_Party\Plugins\Images\Webp\EWWW_Subscriber::maybe_remove_images_from_cdn_dropdown
  * @group  ThirdParty
  * @group  Webp
  */


### PR DESCRIPTION
## Description

This PR adds unit tests code coverage reporting. It's using PHPUnit code coverage reporting, which is then sent to Codacy to generate the full report.

All of this is handled  through a new Github action and a new composer command.

A number of our tests files had to be updated to use correct formatting of the `@covers` annotation.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Generate the report locally
- [x] Sent the report manually to Codacy

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings