### PR TITLE
Stop preload while prewarmup is running

### DIFF
--- a/inc/API/preload.php
+++ b/inc/API/preload.php
@@ -91,6 +91,12 @@ function do_admin_post_rocket_preload_cache() { // phpcs:ignore WordPress.Naming
 		die();
 	}
 
+	$prewarmup_stats = get_option( 'wp_rocket_prewarmup_stats' );
+	if ( empty( $prewarmup_stats['allow_optimization'] ) ) {
+		wp_safe_redirect( wp_get_referer() );
+		die();
+	}
+
 	$preload_process = new FullProcess();
 
 	if ( $preload_process->is_process_running() ) {

--- a/inc/API/preload.php
+++ b/inc/API/preload.php
@@ -92,7 +92,7 @@ function do_admin_post_rocket_preload_cache() { // phpcs:ignore WordPress.Naming
 	}
 
 	$prewarmup_stats = get_option( 'wp_rocket_prewarmup_stats' );
-	if ( empty( $prewarmup_stats['allow_optimization'] ) ) {
+	if ( get_rocket_option( 'remove_unused_css' ) && empty( $prewarmup_stats['allow_optimization'] ) ) {
 		wp_safe_redirect( wp_get_referer() );
 		die();
 	}

--- a/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
@@ -7,6 +7,7 @@ use WP_Rocket\Admin\Options;
 use WP_Rocket\Engine\Admin\Settings\Settings as AdminSettings;
 use WP_Rocket\Engine\Optimization\RUCSS\Controller\UsedCSS;
 use WP_Rocket\Engine\Optimization\RUCSS\Database\Row\UsedCSS as UsedCSS_Row;
+use WP_Rocket\Engine\Preload\Homepage;
 use WP_Rocket\Event_Management\Subscriber_Interface;
 
 class Subscriber implements Subscriber_Interface {
@@ -39,18 +40,27 @@ class Subscriber implements Subscriber_Interface {
 	private $options_api;
 
 	/**
+	 * Homepage Preload instance
+	 *
+	 * @var Homepage
+	 */
+	private $homepage_preloader;
+
+	/**
 	 * Instantiate the class
 	 *
 	 * @param Settings $settings    Settings instance.
 	 * @param Database $database    Database instance.
 	 * @param UsedCSS  $used_css    UsedCSS instance.
 	 * @param Options  $options_api Options API instance.
+	 * @param Homepage $homepage_preloader Homepage Preload instance.
 	 */
-	public function __construct( Settings $settings, Database $database, UsedCSS $used_css, Options $options_api ) {
-		$this->settings    = $settings;
-		$this->database    = $database;
-		$this->used_css    = $used_css;
-		$this->options_api = $options_api;
+	public function __construct( Settings $settings, Database $database, UsedCSS $used_css, Options $options_api, Homepage $homepage_preloader ) {
+		$this->settings           = $settings;
+		$this->database           = $database;
+		$this->used_css           = $used_css;
+		$this->options_api        = $options_api;
+		$this->homepage_preloader = $homepage_preloader;
 	}
 
 	/**
@@ -64,7 +74,10 @@ class Subscriber implements Subscriber_Interface {
 		return [
 			'rocket_first_install_options'       => 'add_options_first_time',
 			'rocket_input_sanitize'              => [ 'sanitize_options', 14, 2 ],
-			'update_option_' . $slug             => [ 'clean_used_css_and_cache', 10, 2 ],
+			'update_option_' . $slug             => [
+				[ 'clean_used_css_and_cache', 10, 2 ],
+				[ 'maybe_cancel_preload', 10, 2 ],
+			],
 			'switch_theme'                       => 'truncate_used_css',
 			'rocket_rucss_file_changed'          => 'truncate_used_css',
 			'wp_trash_post'                      => 'delete_used_css_on_update_or_delete',
@@ -257,6 +270,27 @@ class Subscriber implements Subscriber_Interface {
 			$this->database->truncate_used_css_table();
 			// Clear all caching files.
 			rocket_clean_domain();
+		}
+	}
+
+	/**
+	 * Cancels any preload currently running if the RUCSS option is enabled and preload is enabled.
+	 *
+	 * @since 3.9.1
+	 *
+	 * @param array $old_value Previous option values.
+	 * @param array $value     New option values.
+	 */
+	public function maybe_cancel_preload( $old_value, $value ) {
+		if (
+			! empty( $value['remove_unused_css'] )
+			&&
+			empty( $old_value['remove_unused_css'] )
+			&&
+			! empty( $value['manual_preload'] )
+		) {
+			delete_transient( 'rocket_preload_errors' );
+			$this->homepage_preloader->cancel_preload();
 		}
 	}
 

--- a/inc/Engine/Optimization/RUCSS/ServiceProvider.php
+++ b/inc/Engine/Optimization/RUCSS/ServiceProvider.php
@@ -68,7 +68,8 @@ class ServiceProvider extends AbstractServiceProvider {
 			->addArgument( $this->getContainer()->get( 'rucss_settings' ) )
 			->addArgument( $this->getContainer()->get( 'rucss_database' ) )
 			->addArgument( $this->getContainer()->get( 'rucss_used_css_controller' ) )
-			->addArgument( $this->getContainer()->get( 'options_api' ) );
+			->addArgument( $this->getContainer()->get( 'options_api' ) )
+			->addArgument( $this->getContainer()->get( 'homepage_preload' ) );
 		$this->getContainer()->share( 'rucss_frontend_subscriber', 'WP_Rocket\Engine\Optimization\RUCSS\Frontend\Subscriber' )
 			->addArgument( $this->getContainer()->get( 'rucss_used_css_controller' ) );
 

--- a/inc/Engine/Optimization/RUCSS/Warmup/Status/Checker.php
+++ b/inc/Engine/Optimization/RUCSS/Warmup/Status/Checker.php
@@ -54,6 +54,13 @@ class Checker extends AbstractAPIClient {
 	private function set_warmup_status_completed() {
 		$this->set_warmup_status_finish_time();
 		$this->set_warmup_force_optimization();
+
+		/**
+		 * Fires when the Pre-warmup process is completed.
+		 *
+		 * @since 3.9.0.1
+		 */
+		do_action( 'rocket_prewarmup_finished' );
 	}
 
 	/**

--- a/inc/Engine/Preload/PreloadSubscriber.php
+++ b/inc/Engine/Preload/PreloadSubscriber.php
@@ -130,7 +130,23 @@ class PreloadSubscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function maybe_cancel_preload( $old_value, $value ) {
-		if ( isset( $old_value['manual_preload'], $value['manual_preload'] ) && $old_value['manual_preload'] !== $value['manual_preload'] && 0 === (int) $value['manual_preload'] ) {
+		if (
+			(
+				! empty( $value['remove_unused_css'] )
+				&&
+				empty( $old_value['remove_unused_css'] )
+				&&
+				! empty( $value['manual_preload'] )
+			)
+			||
+			(
+				isset( $old_value['manual_preload'], $value['manual_preload'] )
+				&&
+				$old_value['manual_preload'] !== $value['manual_preload']
+				&&
+				0 === (int) $value['manual_preload']
+			)
+		) {
 			delete_transient( 'rocket_preload_errors' );
 			$this->homepage_preloader->cancel_preload();
 		}

--- a/inc/Engine/Preload/PreloadSubscriber.php
+++ b/inc/Engine/Preload/PreloadSubscriber.php
@@ -130,23 +130,7 @@ class PreloadSubscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function maybe_cancel_preload( $old_value, $value ) {
-		if (
-			(
-				! empty( $value['remove_unused_css'] )
-				&&
-				empty( $old_value['remove_unused_css'] )
-				&&
-				! empty( $value['manual_preload'] )
-			)
-			||
-			(
-				isset( $old_value['manual_preload'], $value['manual_preload'] )
-				&&
-				$old_value['manual_preload'] !== $value['manual_preload']
-				&&
-				0 === (int) $value['manual_preload']
-			)
-		) {
+		if ( isset( $old_value['manual_preload'], $value['manual_preload'] ) && $old_value['manual_preload'] !== $value['manual_preload'] && 0 === (int) $value['manual_preload'] ) {
 			delete_transient( 'rocket_preload_errors' );
 			$this->homepage_preloader->cancel_preload();
 		}

--- a/inc/Engine/Preload/ServiceProvider.php
+++ b/inc/Engine/Preload/ServiceProvider.php
@@ -53,6 +53,7 @@ class ServiceProvider extends AbstractServiceProvider {
 		$this->getContainer()->share( 'preload_subscriber', 'WP_Rocket\Engine\Preload\PreloadSubscriber' )
 			->addArgument( $this->getContainer()->get( 'homepage_preload' ) )
 			->addArgument( $options )
+			->addArgument( $this->getContainer()->get( 'rucss_status_checker' ) )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()->share( 'sitemap_preload_subscriber', 'WP_Rocket\Engine\Preload\SitemapPreloadSubscriber' )
 			->addArgument( $this->getContainer()->get( 'sitemap_preload' ) )

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cleanUsedCssAndCache.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cleanUsedCssAndCache.php
@@ -6,6 +6,7 @@ namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\RUCSS\Admin\Subscriber;
 use Mockery;
 use Brain\Monkey\Functions;
 use WP_Rocket\Admin\Options;
+use WP_Rocket\Engine\Preload\Homepage;
 use WP_Rocket\Tests\Unit\FilesystemTestCase;
 use WP_Rocket\Engine\Optimization\RUCSS\Admin\Database;
 use WP_Rocket\Engine\Optimization\RUCSS\Admin\Settings;
@@ -26,17 +27,19 @@ class Test_CleanUsedCssAndCache extends FilesystemTestCase {
 	private $usedCSS;
 	private $subscriber;
 	private $options_api;
+	private $homepage_preloader;
 
 	protected $path_to_test_data = '/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cleanUsedCssAndCache.php';
 
 	public function setUp() : void {
 		parent::setUp();
 
-		$this->settings    = Mockery::mock( Settings::class );
-		$this->database    = Mockery::mock( Database::class );
-		$this->usedCSS     = Mockery::mock( UsedCSS::class );
-		$this->options_api = Mockery::mock( Options::class );
-		$this->subscriber  = new Subscriber( $this->settings, $this->database, $this->usedCSS, $this->options_api );
+		$this->settings           = Mockery::mock( Settings::class );
+		$this->database           = Mockery::mock( Database::class );
+		$this->usedCSS            = Mockery::mock( UsedCSS::class );
+		$this->options_api        = Mockery::mock( Options::class );
+		$this->homepage_preloader = Mockery::mock( Homepage::class );
+		$this->subscriber  = new Subscriber( $this->settings, $this->database, $this->usedCSS, $this->options_api, $this->homepage_preloader );
 	}
 
 	/**

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/clearUsedcssResult.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/clearUsedcssResult.php
@@ -6,6 +6,7 @@ namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\RUCSS\Admin\Subscriber;
 use Mockery;
 use Brain\Monkey\Functions;
 use WP_Rocket\Admin\Options;
+use WP_Rocket\Engine\Preload\Homepage;
 use WP_Rocket\Tests\Unit\TestCase;
 use WP_Rocket\Engine\Optimization\RUCSS\Admin\Database;
 use WP_Rocket\Engine\Optimization\RUCSS\Admin\Settings;
@@ -25,17 +26,19 @@ class Test_ClearUsedcssResult extends TestCase {
 	private $usedCSS;
 	private $subscriber;
 	private $options_api;
+	private $homepage_preloader;
 
 	protected $path_to_test_data = '/inc/Engine/Optimization/RUCSS/Admin/Subscriber/clearUsedcssResult.php';
 
 	public function setUp() : void {
 		parent::setUp();
 
-		$this->settings    = Mockery::mock( Settings::class );
-		$this->database    = Mockery::mock( Database::class );
-		$this->usedCSS     = Mockery::mock( UsedCSS::class );
-		$this->options_api = Mockery::mock( Options::class );
-		$this->subscriber  = new Subscriber( $this->settings, $this->database, $this->usedCSS, $this->options_api );
+		$this->settings           = Mockery::mock( Settings::class );
+		$this->database           = Mockery::mock( Database::class );
+		$this->usedCSS            = Mockery::mock( UsedCSS::class );
+		$this->options_api        = Mockery::mock( Options::class );
+		$this->homepage_preloader = Mockery::mock( Homepage::class );
+		$this->subscriber         = new Subscriber( $this->settings, $this->database, $this->usedCSS, $this->options_api, $this->homepage_preloader );
 	}
 
 	/**

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/truncateUsedCSSHandler.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/truncateUsedCSSHandler.php
@@ -6,6 +6,7 @@ namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\RUCSS\Admin\Subscriber;
 use Mockery;
 use Brain\Monkey\Functions;
 use WP_Rocket\Admin\Options;
+use WP_Rocket\Engine\Preload\Homepage;
 use WP_Rocket\Tests\Unit\TestCase;
 use WP_Rocket\Engine\Optimization\RUCSS\Admin\Database;
 use WP_Rocket\Engine\Optimization\RUCSS\Admin\Settings;
@@ -25,6 +26,7 @@ class Test_TruncateUsedCSSHandler extends TestCase {
 	private $usedCSS;
 	private $subscriber;
 	private $options_api;
+	private $homepage_preloader;
 
 	protected $path_to_test_data = '/inc/Engine/Optimization/RUCSS/Admin/Subscriber/truncateUsedCSSHandler.php';
 
@@ -35,7 +37,8 @@ class Test_TruncateUsedCSSHandler extends TestCase {
 		$this->database    = Mockery::mock( Database::class );
 		$this->usedCSS     = Mockery::mock( UsedCSS::class );
 		$this->options_api = Mockery::mock( Options::class );
-		$this->subscriber  = new Subscriber( $this->settings, $this->database, $this->usedCSS, $this->options_api );
+		$this->homepage_preloader = Mockery::mock( Homepage::class );
+		$this->subscriber  = new Subscriber( $this->settings, $this->database, $this->usedCSS, $this->options_api, $this->homepage_preloader );
 	}
 
 	public function tearDown() : void {

--- a/tests/Unit/inc/Engine/Preload/PreloadSubscriber/maybePreloadMobileHomepage.php
+++ b/tests/Unit/inc/Engine/Preload/PreloadSubscriber/maybePreloadMobileHomepage.php
@@ -4,6 +4,7 @@ namespace WP_Rocket\Tests\Unit\inc\Engine\Preload\PreloadSubscriber;
 
 use Mockery;
 use Brain\Monkey\Functions;
+use WP_Rocket\Engine\Optimization\RUCSS\Warmup\Status\Checker;
 use WPMedia\PHPUnit\Unit\TestCase;
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\Preload\FullProcess;
@@ -22,6 +23,7 @@ class Test_MaybePreloadMobileHomepage extends TestCase {
 	public function testShouldUseMobilePrefixWhenMobilePreloadIsEnabled() {
 		$options            = Mockery::mock( Options_Data::class );
 		$homepage_preloader = Mockery::mock( Homepage::class );
+		$checker            = Mockery::mock( Checker::class );
 		$homepage_preloader
 			->shouldReceive( 'is_mobile_preload_enabled' )
 			->once()
@@ -40,7 +42,7 @@ class Test_MaybePreloadMobileHomepage extends TestCase {
 				]
 			);
 
-		$subscriber = new PreloadSubscriber( $homepage_preloader, $options );
+		$subscriber = new PreloadSubscriber( $homepage_preloader, $options, $checker );
 
 		$subscriber->maybe_preload_mobile_homepage( $this->home_url, 'whatever', [] );
 	}
@@ -48,6 +50,7 @@ class Test_MaybePreloadMobileHomepage extends TestCase {
 	public function testShouldNotUseMobilePrefixWhenMobilePreloadIsNotEnabled() {
 		$options            = Mockery::mock( Options_Data::class );
 		$homepage_preloader = Mockery::mock( Homepage::class );
+		$checker            = Mockery::mock( Checker::class );
 		$homepage_preloader
 			->shouldReceive( 'is_mobile_preload_enabled' )
 			->once()
@@ -59,7 +62,7 @@ class Test_MaybePreloadMobileHomepage extends TestCase {
 		Functions\expect( 'wp_safe_remote_get' )
 			->never();
 
-		$subscriber = new PreloadSubscriber( $homepage_preloader, $options );
+		$subscriber = new PreloadSubscriber( $homepage_preloader, $options, $checker );
 
 		$subscriber->maybe_preload_mobile_homepage( $this->home_url, 'whatever', [] );
 	}


### PR DESCRIPTION
## Description

We found when preload is enabled and the RUCSS option is enabled, that it's a big headache on the client's server so we need to delay preload till prewarmup finishes its work.

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Manually enable RUCSS when preload is working => should stop preload and start prewarmup
- [ ] Manually enable RUCSS when preload is enabled but not working => should start prewarmup and when finished the preload will start.
- [ ] Manually enable RUCSS while preload is disabled => should start prewarmup only
- [ ] When preload is enabled and manually clicked the button for forcing preload from the top menu or settings dashboard while prewarmup is working => prewarmup will continue and nothing will happen with preload.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules