### PR TITLE
Fixes #3478 Enable installation through composer v2

### DIFF
--- a/.github/workflows/lint_phpcs.yml
+++ b/.github/workflows/lint_phpcs.yml
@@ -11,13 +11,13 @@ on:
 jobs:
   run:
     runs-on: ${{ matrix.operating-system }}
-    
+
     strategy:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-latest]
         php-versions: ['7.4']
-    
+
     name: WPRocket lint with PHPCS. PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }}.
     steps:
     - name: Checkout
@@ -28,7 +28,7 @@ jobs:
       with:
         php-version: ${{ matrix.php-versions }}
         coverage: none  # XDebug can be enabled here 'coverage: xdebug'
-        tools: composer:v1
+        tools: composer:v2
 
     - name: Install dependencies
       run: composer install --prefer-dist --no-interaction --no-scripts
@@ -37,4 +37,4 @@ jobs:
       run: |
         vendor/bin/phpcs --config-set installed_paths ../../phpcompatibility/phpcompatibility-paragonie,../../phpcompatibility/phpcompatibility-wp,../../wp-coding-standards/wpcs,../../phpcompatibility/php-compatibility
         composer phpcs
- 
+

--- a/.github/workflows/test_php8.yml
+++ b/.github/workflows/test_php8.yml
@@ -45,7 +45,7 @@ jobs:
       with:
         php-version: ${{ matrix.php-versions }}
         coverage: none  # XDebug can be enabled here 'coverage: xdebug'
-        tools: composer:v1, phpunit
+        tools: composer:v2, phpunit
 
     - name: Start mysql service
       run: sudo /etc/init.d/mysql start

--- a/.github/workflows/test_wprocket.yml
+++ b/.github/workflows/test_wprocket.yml
@@ -45,7 +45,7 @@ jobs:
       with:
         php-version: ${{ matrix.php-versions }}
         coverage: none  # XDebug can be enabled here 'coverage: xdebug'
-        tools: composer:v1, phpunit
+        tools: composer:v2, phpunit
 
     - name: Start mysql service
       run: sudo /etc/init.d/mysql start

--- a/.github/workflows/test_wprocket_legacy.yml
+++ b/.github/workflows/test_wprocket_legacy.yml
@@ -11,16 +11,16 @@ on:
 jobs:
   run:
     runs-on: ${{ matrix.operating-system }}
-    
+
     strategy:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-latest]
         php-versions: ['7.1', '7.2']
         wp-versions: ['5.3.6']
-  
+
     name: WP ${{ matrix.wp-versions }} with PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }}.
-    
+
     env:
       WP_TESTS_DIR: "/tmp/tests/phpunit"
       WP_CORE_DIR: "/tmp/wordpress-develop"
@@ -46,11 +46,11 @@ jobs:
         php-version: ${{ matrix.php-versions }}
         extensions: mysqli
         coverage: none  # XDebug can be enabled here 'coverage: xdebug'
-        tools: composer:v1, phpunit
-        
+        tools: composer:v2, phpunit
+
     - name: Start mysql service
       run: sudo /etc/init.d/mysql start
-    
+
     - name: Setup problem matchers for PHP
       run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
 
@@ -60,7 +60,7 @@ jobs:
     - name: Get composer cache directory
       id: composercache
       run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-    
+
     - name: Cache dependencies
       uses: actions/cache@v2
       with:
@@ -70,13 +70,13 @@ jobs:
 
     - name: Remove unmet dependencies by legacy versions
       run: composer remove --dev --no-scripts phpstan/phpstan szepeviktor/phpstan-wordpress coenjacobs/mozart
-    
+
     - name: Install dependencies
       run: composer install --prefer-dist --no-interaction --no-scripts
 
     - name: Install tests
       run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1:3306 ${{ matrix.wp-versions }}
-    
+
     - name: Mysql8 auth plugin workaround
       run: sudo mysql -u root -proot -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';"
 

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,6 @@
 		"phpunit/phpunit": "^7.5",
 		"roave/security-advisories": "dev-master",
 		"szepeviktor/phpstan-wordpress": "^0.7.0",
-		"woocommerce/woocommerce": "^3.9",
 		"wp-coding-standards/wpcs": "^2",
 		"wp-media/background-processing": "^1.3",
 		"wp-media/cloudflare": "^1.0",
@@ -67,6 +66,7 @@
 		"wpackagist-plugin/pdf-embedder": "^4.6",
 		"wpackagist-plugin/simple-custom-css": "^4.0.3",
 		"wpackagist-plugin/spinupwp": "^1.1",
+		"wpackagist-plugin/woocommerce": "^4.9.2",
 		"wpackagist-plugin/wp-smushit": "^3.0"
 	},
 	"autoload": {

--- a/tests/Integration/bootstrap.php
+++ b/tests/Integration/bootstrap.php
@@ -56,7 +56,7 @@ tests_add_filter(
 			// Load WooCommerce.
 			define( 'WC_TAX_ROUNDING_MODE', 'auto' );
 			define( 'WC_USE_TRANSACTIONS', false );
-			require WP_ROCKET_PLUGIN_ROOT . '/vendor/woocommerce/woocommerce/woocommerce.php';
+			require WP_ROCKET_PLUGIN_ROOT . 'vendor/wpackagist-plugin/woocommerce/woocommerce.php';
 		}
 
 		if ( BootstrapManager::isGroup( 'BeaverBuilder' ) ) {
@@ -138,7 +138,7 @@ tests_add_filter(
 		// Clean existing install first.
 		define( 'WP_UNINSTALL_PLUGIN', true );
 		define( 'WC_REMOVE_ALL_DATA', true );
-		include WP_ROCKET_PLUGIN_ROOT . '/vendor/woocommerce/woocommerce/uninstall.php';
+		include WP_ROCKET_PLUGIN_ROOT . 'vendor/wpackagist-plugin/woocommerce/uninstall.php';
 
 		WC_Install::install();
 


### PR DESCRIPTION
## Description

This PR updates the WooCommerce dev dependency to 4.9.2, and pulls it from wpackagist instead of the origin repository.

It removes the conflict that was preventing the usage of composer v2 to install/update the plugin.

Fixes #3478

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

Used `wpackagist-plugin` instead of `woocommerce/woocommerce` to work against the built version of the plugin.

## How Has This Been Tested?

- [x] Automated tests are running correctly after updating `integration/bootstrap.php`
- [x] Installation works with composer v2

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes