### PR TITLE
add a new filter to skip treeshaking for specific urls

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -175,7 +175,29 @@ class UsedCSS {
 		global $wp;
 		$url       = untrailingslashit( home_url( add_query_arg( [], $wp->request ) ) );
 		$is_mobile = $this->is_mobile();
-		$used_css  = $this->get_used_css( $url, $is_mobile );
+
+		/**
+		 * Filter skipping generating used CSS this page.
+		 *
+		 * @since 3.9.1
+		 *
+		 * @param bool   $skipped   true will skip treeshaking and false will continue generating Used CSS for this page.
+		 * @param string $url       Current page url.
+		 * @param bool   $is_mobile Is mobile request or not
+		 */
+		if ( apply_filters( 'rocket_skip_treeshaker', false, $url, $is_mobile ) ) {
+			Logger::error(
+				'Generating used CSS is skipped by filter.',
+				[
+					'url'       => $url,
+					'is_mobile' => $is_mobile,
+				]
+			);
+
+			return $html;
+		}
+
+		$used_css = $this->get_used_css( $url, $is_mobile );
 
 		if ( empty( $used_css ) || ( $used_css->retries < 3 ) ) {
 			$config = [


### PR DESCRIPTION
## Description

We need a filter to easily skip applying RUCSS on pages by url.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Use the filter directly on the theme functions.php.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules