### PR TITLE
Fixes #3924 Add correct info on more info link in RUCSS prewarmup

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
@@ -5,6 +5,7 @@ namespace WP_Rocket\Engine\Optimization\RUCSS\Admin;
 
 use WP_Rocket\Admin\Options;
 use WP_Rocket\Engine\Admin\Settings\Settings as AdminSettings;
+use WP_Rocket\Engine\Admin\Beacon\Beacon;
 use WP_Rocket\Engine\Optimization\RUCSS\Controller\UsedCSS;
 use WP_Rocket\Engine\Optimization\RUCSS\Database\Row\UsedCSS as UsedCSS_Row;
 use WP_Rocket\Event_Management\Subscriber_Interface;
@@ -39,6 +40,13 @@ class Subscriber implements Subscriber_Interface {
 	private $options_api;
 
 	/**
+	 * Beacon instance
+	 *
+	 * @var Beacon
+	 */
+	private $beacon;
+
+	/**
 	 * Instantiate the class
 	 *
 	 * @param Settings $settings    Settings instance.
@@ -46,11 +54,18 @@ class Subscriber implements Subscriber_Interface {
 	 * @param UsedCSS  $used_css    UsedCSS instance.
 	 * @param Options  $options_api Options API instance.
 	 */
-	public function __construct( Settings $settings, Database $database, UsedCSS $used_css, Options $options_api ) {
+	public function __construct(
+		Settings $settings,
+		Database $database,
+		UsedCSS $used_css,
+		Options $options_api,
+		Beacon $beacon
+	) {
 		$this->settings    = $settings;
 		$this->database    = $database;
 		$this->used_css    = $used_css;
 		$this->options_api = $options_api;
+		$this->beacon      = $beacon;
 	}
 
 	/**
@@ -364,6 +379,8 @@ class Subscriber implements Subscriber_Interface {
 	 * @return array
 	 */
 	private function ui_translations(): array {
+		$rucss_beacon = $this->beacon->get_suggest( 'remove_unused_css' );
+
 		return [
 			'step1_txt'      => __( 'Collected resource files from {count} of {total} key pages.', 'rocket' ),
 			'step2_txt'      => __( 'Processed {count} of {total} resource files found on key pages.', 'rocket' ),
@@ -372,7 +389,7 @@ class Subscriber implements Subscriber_Interface {
 			'rucss_info_txt' => sprintf(
 				// translators: %1$s = opening link tag, %2$s = closing link tag.
 				__( 'We are processing the CSS on your site. This may take several minutes to complete. %1$sMore info.%2$s', 'rocket' ),
-				'<a href="#" target=_"blank" rel="noopener">',
+				'<a href="' . esc_url( $rucss_beacon['url'] ) . '" data-beacon-article="' . esc_attr( $rucss_beacon['id'] ) . '" target=_"blank" rel="noopener">',
 				'</a>'
 			),
 		];

--- a/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
@@ -53,6 +53,7 @@ class Subscriber implements Subscriber_Interface {
 	 * @param Database $database    Database instance.
 	 * @param UsedCSS  $used_css    UsedCSS instance.
 	 * @param Options  $options_api Options API instance.
+	 * @param Beacon   $beacon      Beacon instance.
 	 */
 	public function __construct(
 		Settings $settings,

--- a/inc/Engine/Optimization/RUCSS/ServiceProvider.php
+++ b/inc/Engine/Optimization/RUCSS/ServiceProvider.php
@@ -68,7 +68,8 @@ class ServiceProvider extends AbstractServiceProvider {
 			->addArgument( $this->getContainer()->get( 'rucss_settings' ) )
 			->addArgument( $this->getContainer()->get( 'rucss_database' ) )
 			->addArgument( $this->getContainer()->get( 'rucss_used_css_controller' ) )
-			->addArgument( $this->getContainer()->get( 'options_api' ) );
+			->addArgument( $this->getContainer()->get( 'options_api' ) )
+			->addArgument( $this->getContainer()->get( 'beacon' ) );
 		$this->getContainer()->share( 'rucss_frontend_subscriber', 'WP_Rocket\Engine\Optimization\RUCSS\Frontend\Subscriber' )
 			->addArgument( $this->getContainer()->get( 'rucss_used_css_controller' ) );
 

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cleanUsedCssAndCache.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cleanUsedCssAndCache.php
@@ -6,11 +6,12 @@ namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\RUCSS\Admin\Subscriber;
 use Mockery;
 use Brain\Monkey\Functions;
 use WP_Rocket\Admin\Options;
-use WP_Rocket\Tests\Unit\FilesystemTestCase;
+use WP_Rocket\Engine\Admin\Beacon\Beacon;
 use WP_Rocket\Engine\Optimization\RUCSS\Admin\Database;
 use WP_Rocket\Engine\Optimization\RUCSS\Admin\Settings;
 use WP_Rocket\Engine\Optimization\RUCSS\Admin\Subscriber;
 use WP_Rocket\Engine\Optimization\RUCSS\Controller\UsedCSS;
+use WP_Rocket\Tests\Unit\FilesystemTestCase;
 
 /**
  * @covers \WP_Rocket\Engine\Optimization\RUCSS\Admin\Subscriber::clean_used_css_and_cache
@@ -26,6 +27,7 @@ class Test_CleanUsedCssAndCache extends FilesystemTestCase {
 	private $usedCSS;
 	private $subscriber;
 	private $options_api;
+	private $beacon;
 
 	protected $path_to_test_data = '/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cleanUsedCssAndCache.php';
 
@@ -36,7 +38,8 @@ class Test_CleanUsedCssAndCache extends FilesystemTestCase {
 		$this->database    = Mockery::mock( Database::class );
 		$this->usedCSS     = Mockery::mock( UsedCSS::class );
 		$this->options_api = Mockery::mock( Options::class );
-		$this->subscriber  = new Subscriber( $this->settings, $this->database, $this->usedCSS, $this->options_api );
+		$this->beacon      = Mockery::mock( Beacon::class );
+		$this->subscriber  = new Subscriber( $this->settings, $this->database, $this->usedCSS, $this->options_api, $this->beacon );
 	}
 
 	/**

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/clearUsedcssResult.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/clearUsedcssResult.php
@@ -6,12 +6,12 @@ namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\RUCSS\Admin\Subscriber;
 use Mockery;
 use Brain\Monkey\Functions;
 use WP_Rocket\Admin\Options;
-use WP_Rocket\Tests\Unit\TestCase;
+use WP_Rocket\Engine\Admin\Beacon\Beacon;
 use WP_Rocket\Engine\Optimization\RUCSS\Admin\Database;
 use WP_Rocket\Engine\Optimization\RUCSS\Admin\Settings;
 use WP_Rocket\Engine\Optimization\RUCSS\Admin\Subscriber;
 use WP_Rocket\Engine\Optimization\RUCSS\Controller\UsedCSS;
-use WPDieException;
+use WP_Rocket\Tests\Unit\TestCase;
 
 /**
  * @covers \WP_Rocket\Engine\Optimization\RUCSS\Admin\Subscriber::clear_usedcss_result
@@ -25,6 +25,7 @@ class Test_ClearUsedcssResult extends TestCase {
 	private $usedCSS;
 	private $subscriber;
 	private $options_api;
+	private $beacon;
 
 	protected $path_to_test_data = '/inc/Engine/Optimization/RUCSS/Admin/Subscriber/clearUsedcssResult.php';
 
@@ -35,7 +36,8 @@ class Test_ClearUsedcssResult extends TestCase {
 		$this->database    = Mockery::mock( Database::class );
 		$this->usedCSS     = Mockery::mock( UsedCSS::class );
 		$this->options_api = Mockery::mock( Options::class );
-		$this->subscriber  = new Subscriber( $this->settings, $this->database, $this->usedCSS, $this->options_api );
+		$this->beacon      = Mockery::mock( Beacon::class );
+		$this->subscriber  = new Subscriber( $this->settings, $this->database, $this->usedCSS, $this->options_api, $this->beacon );
 	}
 
 	/**

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/truncateUsedCSSHandler.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/truncateUsedCSSHandler.php
@@ -6,11 +6,12 @@ namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\RUCSS\Admin\Subscriber;
 use Mockery;
 use Brain\Monkey\Functions;
 use WP_Rocket\Admin\Options;
-use WP_Rocket\Tests\Unit\TestCase;
+use WP_Rocket\Engine\Admin\Beacon\Beacon;
 use WP_Rocket\Engine\Optimization\RUCSS\Admin\Database;
 use WP_Rocket\Engine\Optimization\RUCSS\Admin\Settings;
 use WP_Rocket\Engine\Optimization\RUCSS\Admin\Subscriber;
 use WP_Rocket\Engine\Optimization\RUCSS\Controller\UsedCSS;
+use WP_Rocket\Tests\Unit\TestCase;
 use WPDieException;
 
 /**
@@ -25,6 +26,7 @@ class Test_TruncateUsedCSSHandler extends TestCase {
 	private $usedCSS;
 	private $subscriber;
 	private $options_api;
+	private $beacon;
 
 	protected $path_to_test_data = '/inc/Engine/Optimization/RUCSS/Admin/Subscriber/truncateUsedCSSHandler.php';
 
@@ -35,7 +37,8 @@ class Test_TruncateUsedCSSHandler extends TestCase {
 		$this->database    = Mockery::mock( Database::class );
 		$this->usedCSS     = Mockery::mock( UsedCSS::class );
 		$this->options_api = Mockery::mock( Options::class );
-		$this->subscriber  = new Subscriber( $this->settings, $this->database, $this->usedCSS, $this->options_api );
+		$this->beacon      = Mockery::mock( Beacon::class );
+		$this->subscriber  = new Subscriber( $this->settings, $this->database, $this->usedCSS, $this->options_api, $this->beacon );
 	}
 
 	public function tearDown() : void {


### PR DESCRIPTION
## Description

The URL and beacon attribute were missing on that "more info" link.

Fixes #3924

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

No

## How Has This Been Tested?

- [x] Manual test of the link on the settings page

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes