### PR TITLE
Add Hubspot iframe inline JS exclusion from combine JS

### DIFF
--- a/inc/Engine/Optimization/Minify/JS/Combine.php
+++ b/inc/Engine/Optimization/Minify/JS/Combine.php
@@ -706,6 +706,7 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 			'defaultCategoryId',
 			'translation-revision-date',
 			'google_conversion_id',
+			'hbspt',
 		];
 
 		$excluded_inline = array_merge( $defaults, $this->options->get( 'exclude_inline_js', [] ) );


### PR DESCRIPTION
## Description

Fixes a broken Hubspot iframe.
Related ticket: https://secure.helpscout.net/conversation/1517369011/265005?folderId=3864740

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Customer tested on their site.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules