### PR TITLE
Fix failing tests related to adding prewarmup functionality

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Database/Tables/Resources.php
+++ b/inc/Engine/Optimization/RUCSS/Database/Tables/Resources.php
@@ -88,6 +88,10 @@ class Resources extends Table {
 	 * @return bool|int
 	 */
 	public function reset_prewarmup_fields() {
+		if ( ! $this->exists() ) {
+			return false;
+		}
+
 		// Get the database interface.
 		$db = $this->get_db();
 

--- a/inc/Engine/Optimization/RUCSS/ServiceProvider.php
+++ b/inc/Engine/Optimization/RUCSS/ServiceProvider.php
@@ -101,7 +101,8 @@ class ServiceProvider extends AbstractServiceProvider {
 		$this->getContainer()->add( 'rucss_scanner', '\WP_Rocket\Engine\Optimization\RUCSS\Warmup\Scanner' )
 			->addArgument( $this->getContainer()->get( 'rucss_scanner_process' ) )
 			->addArgument( $this->getContainer()->get( 'options_api' ) )
-			->addArgument( $this->getContainer()->get( 'rucss_resources_table' ) );
+			->addArgument( $this->getContainer()->get( 'rucss_resources_table' ) )
+			->addArgument( $this->getContainer()->get( 'options' ) );
 
 		$this->getContainer()->add( 'rucss_status_checker', '\WP_Rocket\Engine\Optimization\RUCSS\Warmup\Status\Checker' )
 			->addArgument( $this->getContainer()->get( 'options_api' ) )

--- a/inc/Engine/Optimization/RUCSS/Warmup/Scanner.php
+++ b/inc/Engine/Optimization/RUCSS/Warmup/Scanner.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace WP_Rocket\Engine\Optimization\RUCSS\Warmup;
 
 use WP_Rocket\Admin\Options;
+use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\Optimization\ContentTrait;
 use WP_Rocket\Engine\Optimization\RUCSS\Database\Tables\Resources;
 
@@ -39,16 +40,25 @@ class Scanner {
 	private $resources_table;
 
 	/**
+	 * Plugin options instance.
+	 *
+	 * @var Options_Data
+	 */
+	private $options;
+
+	/**
 	 * Instantiate the class
 	 *
 	 * @param ScannerProcess $process Background process instance.
 	 * @param Options        $options_api Options API instance.
 	 * @param Resources      $resources_table Resources table instance.
+	 * @param Options_Data   $options Options instance.
 	 */
-	public function __construct( ScannerProcess $process, Options $options_api, Resources $resources_table ) {
+	public function __construct( ScannerProcess $process, Options $options_api, Resources $resources_table, Options_Data $options ) {
 		$this->process         = $process;
 		$this->options_api     = $options_api;
 		$this->resources_table = $resources_table;
+		$this->options         = $options;
 	}
 
 	/**
@@ -96,6 +106,10 @@ class Scanner {
 	 * @return void
 	 */
 	public function auto_start_scanner() {
+		if ( ! $this->options->get( 'remove_unused_css' ) ) {
+			return;
+		}
+
 		$this->dispatcher();
 	}
 


### PR DESCRIPTION
## Description

Sometimes we see errors at integration tests specifically for tests that use `switch_theme` function like what we do at Divi third-party tests.

After some investigations, I got that the issue is in two places:-
1. When we reset prewarmup fields at the start of the scanning process, we need to check if the table exists or not.
2. With switch_theme we restart prearmup process without checking the status of RUCSS option, we need to bailout if disabled.

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- [x] All tests are passing now properly.
- [x] I tested to switch theme without enabling RUCSS and the scanner process didn't start

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules