### PR TITLE
Fixes #3945 Display warning when WP Meteor is enabled with WP Rocket delay JS

### DIFF
--- a/inc/Engine/Optimization/DelayJS/Admin/Settings.php
+++ b/inc/Engine/Optimization/DelayJS/Admin/Settings.php
@@ -3,9 +3,45 @@ declare(strict_types=1);
 
 namespace WP_Rocket\Engine\Optimization\DelayJS\Admin;
 
+use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\Admin\Settings\Settings as AdminSettings;
 
 class Settings {
+	/**
+	 * Options data instance
+	 *
+	 * @var Options_Data
+	 */
+	private $options;
+
+	/**
+	 * Instantiate the class
+	 *
+	 * @param Options_Data $options Options Data instance.
+	 */
+	public function __construct( Options_Data $options ) {
+		$this->options = $options;
+	}
+
+	/**
+	 * Adds plugins incompatible with delay JS to the list
+	 *
+	 * @since 3.9.0.1
+	 *
+	 * @param string[] $plugins Array of recommended plugins to deactivate.
+	 *
+	 * @return array
+	 */
+	public function add_plugins_incompatibility( $plugins ): array {
+		if ( ! $this->options->get( 'delay_js', 0 ) ) {
+			return $plugins;
+		}
+
+		$plugins['wp-meteor'] = 'wp-meteor/wp-meteor.php';
+
+		return $plugins;
+	}
+
 	/**
 	 * Add the delay JS options to the WP Rocket options array
 	 *

--- a/inc/Engine/Optimization/DelayJS/Admin/Subscriber.php
+++ b/inc/Engine/Optimization/DelayJS/Admin/Subscriber.php
@@ -34,6 +34,7 @@ class Subscriber implements Subscriber_Interface {
 			'wp_rocket_upgrade'                    => [ 'set_option_on_update', 13, 2 ],
 			'rocket_input_sanitize'                => [ 'sanitize_options', 13, 2 ],
 			'pre_update_option_wp_rocket_settings' => [ 'maybe_disable_combine_js', 11, 2 ],
+			'rocket_plugins_to_deactivate'         => 'add_plugins_incompatibility',
 		];
 	}
 
@@ -91,5 +92,18 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	public function maybe_disable_combine_js( $value, $old_value ): array {
 		return $this->settings->maybe_disable_combine_js( $value, $old_value );
+	}
+
+	/**
+	 * Adds plugins incompatible with delay JS to the list
+	 *
+	 * @since 3.9.0.1
+	 *
+	 * @param string[] $plugins Array of recommended plugins to deactivate.
+	 *
+	 * @return array
+	 */
+	public function add_plugins_incompatibility( $plugins ): array {
+		return $this->settings->add_plugins_incompatibility( $plugins );
 	}
 }

--- a/inc/Engine/Optimization/DelayJS/ServiceProvider.php
+++ b/inc/Engine/Optimization/DelayJS/ServiceProvider.php
@@ -32,7 +32,8 @@ class ServiceProvider extends AbstractServiceProvider {
 	 * @return void
 	 */
 	public function register() {
-		$this->getContainer()->add( 'delay_js_settings', 'WP_Rocket\Engine\Optimization\DelayJS\Admin\Settings' );
+		$this->getContainer()->add( 'delay_js_settings', 'WP_Rocket\Engine\Optimization\DelayJS\Admin\Settings' )
+			->addArgument( $this->getContainer()->get( 'options' ) );
 		$this->getContainer()->share( 'delay_js_admin_subscriber', 'WP_Rocket\Engine\Optimization\DelayJS\Admin\Subscriber' )
 			->addArgument( $this->getContainer()->get( 'delay_js_settings' ) )
 			->addTag( 'admin_subscriber' );

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/Admin/Settings/addPluginsIncompatibility.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/Admin/Settings/addPluginsIncompatibility.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+	'testShouldReturnDefaultWhenOptionDisabled' => [
+		'options'  => [
+			'delay_js' => 0,
+		],
+		'plugins'  => [],
+		'expected' => [],
+	],
+	'testShouldReturnUpdatedArrayWhenOptionEnabled' => [
+		'options'  => [
+			'delay_js' => 1,
+		],
+		'plugins'  => [],
+		'expected' => [
+			'wp-meteor' => 'wp-meteor/wp-meteor.php',
+		],
+	],
+];

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/Admin/Subscriber/addPluginsIncompatibility.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/Admin/Subscriber/addPluginsIncompatibility.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+	'testShouldReturnDefaultWhenOptionDisabled' => [
+		'options'  => [
+			'delay_js' => 0,
+		],
+		'plugins'  => [],
+		'expected' => [],
+	],
+	'testShouldReturnUpdatedArrayWhenOptionEnabled' => [
+		'options'  => [
+			'delay_js' => 1,
+		],
+		'plugins'  => [],
+		'expected' => [
+			'wp-meteor' => 'wp-meteor/wp-meteor.php',
+		],
+	],
+];

--- a/tests/Integration/inc/Engine/Optimization/DelayJS/Admin/Subscriber/addPluginsIncompatibility.php
+++ b/tests/Integration/inc/Engine/Optimization/DelayJS/Admin/Subscriber/addPluginsIncompatibility.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\Optimization\DelayJS\Admin\Subscriber;
+
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Optimization\DelayJS\Admin\Subscriber::add_plugins_incompatibility
+ *
+ * @group DelayJS
+ * @group AdminOnly
+ */
+class Test_AddPluginsIncompatibility extends TestCase {
+	private $delay_js;
+
+	public function setUp() : void {
+		parent::setUp();
+
+		$this->unregisterAllCallbacksExcept( 'rocket_plugins_to_deactivate', 'add_plugins_incompatibility' );
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+
+		remove_filter( 'pre_get_rocket_option_delay_js', [ $this, 'set_delay_js' ] );
+		$this->restoreWpFilter( 'rocket_plugins_to_deactivate' );
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnExpected( $options, $plugins, $expected ) {
+		$this->delay_js = $options['delay_js'];
+
+		add_filter( 'pre_get_rocket_option_delay_js', [ $this, 'set_delay_js' ] );
+
+		$this->assertSame(
+			$expected,
+			apply_filters( 'rocket_plugins_to_deactivate', $plugins )
+		);
+	}
+
+	public function set_delay_js() {
+		return $this->delay_js;
+	}
+}

--- a/tests/Unit/inc/Engine/Optimization/DelayJS/Admin/Settings/addOptions.php
+++ b/tests/Unit/inc/Engine/Optimization/DelayJS/Admin/Settings/addOptions.php
@@ -2,6 +2,8 @@
 
 namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\DelayJS\Admin\Settings;
 
+use Mockery;
+use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\Optimization\DelayJS\Admin\Settings;
 use WP_Rocket\Tests\Unit\TestCase;
 
@@ -16,7 +18,7 @@ class Test_AddOptions extends TestCase {
 	 */
 	public function testShouldDoExpected( $input, $expected ) {
 		$options  = isset( $input['options'] )  ? $input['options']  : [];
-		$settings = new Settings();
+		$settings = new Settings( Mockery::mock( Options_Data::class) );
 
 		$this->assertSame(
 			$expected,

--- a/tests/Unit/inc/Engine/Optimization/DelayJS/Admin/Settings/addPluginsIncompatibility.php
+++ b/tests/Unit/inc/Engine/Optimization/DelayJS/Admin/Settings/addPluginsIncompatibility.php
@@ -16,9 +16,14 @@ class Test_AddPluginsIncompatibility extends TestCase {
 	/**
 	 * @dataProvider configTestData
 	 */
-	public function testShouldDoExpected( $plugins, $expected ) {
-		$options  = Mockery::mock( Options_Data::class);
+	public function testShouldDoExpected( $options_data, $plugins, $expected ) {
+		$options  = Mockery::mock( Options_Data::class );
 		$settings = new Settings( $options );
+
+		$options->shouldReceive( 'get' )
+			->once()
+			->with( 'delay_js', 0 )
+			->andReturn( $options_data['delay_js'] );
 
 		$this->assertSame(
 			$expected,

--- a/tests/Unit/inc/Engine/Optimization/DelayJS/Admin/Settings/addPluginsIncompatibility.php
+++ b/tests/Unit/inc/Engine/Optimization/DelayJS/Admin/Settings/addPluginsIncompatibility.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\DelayJS\Admin\Settings;
+
+use Mockery;
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Engine\Optimization\DelayJS\Admin\Settings;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Optimization\DelayJS\Admin\Settings::add_plugins_incompatibility
+ *
+ * @group  DelayJS
+ */
+class Test_AddPluginsIncompatibility extends TestCase {
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldDoExpected( $plugins, $expected ) {
+		$options  = Mockery::mock( Options_Data::class);
+		$settings = new Settings( $options );
+
+		$this->assertSame(
+			$expected,
+			$settings->add_plugins_incompatibility( $plugins )
+		);
+	}
+}

--- a/tests/Unit/inc/Engine/Optimization/DelayJS/Admin/Settings/maybeDisableCombineJs.php
+++ b/tests/Unit/inc/Engine/Optimization/DelayJS/Admin/Settings/maybeDisableCombineJs.php
@@ -2,6 +2,8 @@
 
 namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\DelayJS\Admin\Settings;
 
+use Mockery;
+use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\Optimization\DelayJS\Admin\Settings;
 use WP_Rocket\Tests\Unit\TestCase;
 
@@ -15,7 +17,7 @@ class Test_MaybeDisableCombineJs extends TestCase {
 	 * @dataProvider configTestData
 	 */
 	public function testShouldDoExpected( $config, $expected ) {
-		$settings = new Settings();
+		$settings = new Settings( Mockery::mock( Options_Data::class) );
 
 		$this->assertSame(
 			$expected,

--- a/tests/Unit/inc/Engine/Optimization/DelayJS/Admin/Settings/sanitizeOptions.php
+++ b/tests/Unit/inc/Engine/Optimization/DelayJS/Admin/Settings/sanitizeOptions.php
@@ -4,6 +4,7 @@ namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\DelayJS\Admin\Settings;
 
 use Brain\Monkey\Functions;
 use Mockery;
+use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\Admin\Settings\Settings as AdminSettings;
 use WP_Rocket\Engine\Optimization\DelayJS\Admin\Settings;
 use WP_Rocket\Tests\Unit\TestCase;
@@ -21,7 +22,7 @@ class Test_SanitizeOptions extends TestCase {
 		Functions\when( 'rocket_sanitize_textarea_field' )->justReturn( $config['sanitized_input']['delay_js_exclusions'] );
 
 		$admin_settings = Mockery::mock( AdminSettings::class );
-		$settings       = new Settings();
+		$settings = new Settings( Mockery::mock( Options_Data::class) );
 
 		$admin_settings->shouldReceive( 'sanitize_checkbox' )
 			->atMost()

--- a/tests/Unit/inc/Engine/Optimization/DelayJS/Admin/Settings/setOptionOnUpdate.php
+++ b/tests/Unit/inc/Engine/Optimization/DelayJS/Admin/Settings/setOptionOnUpdate.php
@@ -3,6 +3,8 @@
 namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\DelayJS\Admin\Settings;
 
 use Brain\Monkey\Functions;
+use Mockery;
+use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\Optimization\DelayJS\Admin\Settings;
 use WP_Rocket\Tests\Unit\TestCase;
 
@@ -16,7 +18,7 @@ class Test_SetOptionOnUpdate extends TestCase {
 	 * @dataProvider configTestData
 	 */
 	public function testShouldDoExpected( $options, $old_version, $valid_version, $expected ) {
-		$settings = new Settings();
+		$settings = new Settings( Mockery::mock( Options_Data::class) );
 
 		if ( $valid_version ) {
 			$this->stubWpParseUrl();


### PR DESCRIPTION
## Description

Add WP Meteor to the list of incompatible plugins when WP Rocket delay JS is enabled

Fixes #3945 

## Type of change

- [x] Enhancement(non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Tested manually with WP Meteor and delay JS enabled
- [x] Added automated tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes