### PR TITLE
Add new inline JS exclusion to prevent the cache_dir_size issue

### DIFF
--- a/inc/Engine/Optimization/Minify/JS/Combine.php
+++ b/inc/Engine/Optimization/Minify/JS/Combine.php
@@ -707,6 +707,7 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 			'translation-revision-date',
 			'google_conversion_id',
 			'hbspt',
+			'var ht_ctc_chat_var',
 		];
 
 		$excluded_inline = array_merge( $defaults, $this->options->get( 'exclude_inline_js', [] ) );


### PR DESCRIPTION
## Description

Related ticket: https://secure.helpscout.net/conversation/1529127582/268033/

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] On the customer's website

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings