### PR TITLE
Fixes #3993 Add font-display:swap in the generated used CSS

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -347,7 +347,7 @@ class UsedCSS {
 
 		$minifier = new MinifyCSS( $data['css'] );
 
-		$data['css'] = $minifier->minify();
+		$data['css'] = $this->apply_font_display_swap( $minifier->minify() );
 
 		if ( empty( $used_css ) ) {
 			$inserted = $this->insert_used_css( $data );

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/treeshake.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/treeshake.php
@@ -503,5 +503,57 @@ return [
 </body>
 </html>'
 		],
+		'shouldRunRucssAndAddFontDisplaySwap' => [
+			'config'       => [
+				'html'                  => '<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>My Awesome Page</title>
+	<style>@font-face {
+			font-family: "TestFont";
+		}
+	</style>
+</head>
+<body>
+ content here
+</body>
+</html>',
+				'used-css-row-contents' => [
+					'url'            => 'http://example.org/home',
+					'css'            => '',
+					'unprocessedcss' => '',
+					'retries'        => 1,
+					'is_mobile'      => false,
+				],
+
+			],
+			'api-response' => [
+				'body'     => json_encode(
+					[
+						'code'     => 200,
+						'message'  => 'OK',
+						'contents' => [
+							'shakedCSS'      => '@font-face{font-family:"TestFont"}',
+							'unProcessedCss' => [],
+						],
+					]
+				),
+				'response' => [
+					'code'    => 200,
+					'message' => 'OK',
+				],
+			],
+			'expected'     => '<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>My Awesome Page</title><style id="wpr-usedcss">@font-face{font-display:swap;font-family:"TestFont"}</style>
+</head>
+<body>
+ content here
+</body>
+</html>'
+		],
 	],
 ];


### PR DESCRIPTION
## Description

add font display swap to font face after RUCSS is finished

Fixes #3993

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Is the solution different from the one proposed during the grooming?

No

## How Has This Been Tested?

- [x] I tested locally
- [x]  add new Fixtures in "Fixtures/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/treeshake.php"
- [x] Run unit and integration test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
