### PR TITLE
Fixes #3966 Delete used-css folder on uninstall

### DIFF
--- a/inc/Engine/WPRocketUninstall.php
+++ b/inc/Engine/WPRocketUninstall.php
@@ -84,6 +84,7 @@ class WPRocketUninstall {
 		'min',
 		'busting',
 		'critical-css',
+		'used-css',
 	];
 
 	/**


### PR DESCRIPTION
## Description
delete used-css folder on plugin uninstall (delete)


Fixes #3966 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Is the solution different from the one proposed during the grooming?

No

## How Has This Been Tested?

- [x] Uninstall the plugin locally and check if the used-css folder exists

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
