### PR TITLE
Add Jetpack Stats Delay JS Auto-Exclusion

### DIFF
--- a/inc/Engine/Optimization/DelayJS/HTML.php
+++ b/inc/Engine/Optimization/DelayJS/HTML.php
@@ -42,6 +42,8 @@ class HTML {
 		'et_animation_data',
 		'wpforms_settings',
 		'var nfForms',
+		'//stats.wp.com', // Jetpack Stats
+		'_stq.push', 	  // Jetpack Stats
 	];
 
 	/**

--- a/inc/Engine/Optimization/DelayJS/HTML.php
+++ b/inc/Engine/Optimization/DelayJS/HTML.php
@@ -42,8 +42,8 @@ class HTML {
 		'et_animation_data',
 		'wpforms_settings',
 		'var nfForms',
-		'//stats.wp.com', // Jetpack Stats
-		'_stq.push', 	  // Jetpack Stats
+		'//stats.wp.com', // Jetpack Stats.
+		'_stq.push', // Jetpack Stats.
 	];
 
 	/**

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/HTML/delayJs.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/HTML/delayJs.php
@@ -95,6 +95,12 @@ $html = '<html>
     };
     /* ]]> */
 </script>
+<script src=\'https://stats.wp.com/e-202124.js\' defer></script>
+<script>
+	_stq = window._stq || [];
+	_stq.push([ \'view\', {v:\'ext\',j:\'1:9.8.1\',blog:\'11111111\',post:\'39721\',tz:\'-5\',srv:\'example.com\'} ]);
+	_stq.push([ \'clickTrackerInit\', \'11111111\', \'39721\' ]);
+</script>
 </body>
 </html>';
 
@@ -193,6 +199,12 @@ $delay_html_upgrade = '<html>
     };
     /* ]]> */
 </script>
+<script src=\'https://stats.wp.com/e-202124.js\' defer></script>
+<script>
+	_stq = window._stq || [];
+	_stq.push([ \'view\', {v:\'ext\',j:\'1:9.8.1\',blog:\'11111111\',post:\'39721\',tz:\'-5\',srv:\'example.com\'} ]);
+	_stq.push([ \'clickTrackerInit\', \'11111111\', \'39721\' ]);
+</script>
 </body>
 </html>';
 
@@ -290,6 +302,12 @@ $delay_html = '<html>
         is_ssl: "1",
     };
     /* ]]> */
+</script>
+<script src=\'https://stats.wp.com/e-202124.js\' defer></script>
+<script>
+	_stq = window._stq || [];
+	_stq.push([ \'view\', {v:\'ext\',j:\'1:9.8.1\',blog:\'11111111\',post:\'39721\',tz:\'-5\',srv:\'example.com\'} ]);
+	_stq.push([ \'clickTrackerInit\', \'11111111\', \'39721\' ]);
 </script>
 </body>
 </html>';

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/Subscriber/delayJs.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/Subscriber/delayJs.php
@@ -178,6 +178,12 @@ $delay_html_upgrade = '<html>
     };
     /* ]]> */
 </script>
+<script src=\'https://stats.wp.com/e-202124.js\' defer></script>
+<script>
+	_stq = window._stq || [];
+	_stq.push([ \'view\', {v:\'ext\',j:\'1:9.8.1\',blog:\'11111111\',post:\'39721\',tz:\'-5\',srv:\'example.com\'} ]);
+	_stq.push([ \'clickTrackerInit\', \'11111111\', \'39721\' ]);
+</script>
 <script data-cfasync="false" data-pagespeed-no-defer type="text/javascript">//<![CDATA[
 	var gtm4wp_datalayer_name = "dataLayer";
 	var dataLayer = dataLayer || [];
@@ -202,12 +208,6 @@ $delay_html_upgrade = '<html>
 <script data-cfasync="false" data-pagespeed-no-defer type="text/javascript">//<![CDATA[
 	var dataLayer_content = {"visitorDoNotTrack":1,"pagePostType":"product","pagePostType2":"single-product","pagePostAuthor":"remy","productRatingCounts":[],"productAverageRating":0,"productReviewCount":0,"productType":"simple","productIsVariable":0,"event":"gtm4wp.changeDetailViewEEC","ecommerce":{"currencyCode":"CAD","detail":{"products":[{"id":1762,"name":"Beanie","sku":1762,"category":"Accessories","price":18,"stocklevel":null}]}}};
 	dataLayer.push( dataLayer_content );//]]>
-</script>
-<script src=\'https://stats.wp.com/e-202124.js\' defer></script>
-<script>
-	_stq = window._stq || [];
-	_stq.push([ \'view\', {v:\'ext\',j:\'1:9.8.1\',blog:\'11111111\',post:\'39721\',tz:\'-5\',srv:\'example.com\'} ]);
-	_stq.push([ \'clickTrackerInit\', \'11111111\', \'39721\' ]);
 </script>
 </body>
 </html>';

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/Subscriber/delayJs.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/Subscriber/delayJs.php
@@ -72,6 +72,12 @@ $html = '<html>
     };
     /* ]]> */
 </script>
+<script src=\'https://stats.wp.com/e-202124.js\' defer></script>
+<script>
+	_stq = window._stq || [];
+	_stq.push([ \'view\', {v:\'ext\',j:\'1:9.8.1\',blog:\'11111111\',post:\'39721\',tz:\'-5\',srv:\'example.com\'} ]);
+	_stq.push([ \'clickTrackerInit\', \'11111111\', \'39721\' ]);
+</script>
 </body>
 </html>';
 
@@ -147,6 +153,12 @@ $delay_html_upgrade = '<html>
     };
     /* ]]> */
 </script>
+<script src=\'https://stats.wp.com/e-202124.js\' defer></script>
+<script>
+	_stq = window._stq || [];
+	_stq.push([ \'view\', {v:\'ext\',j:\'1:9.8.1\',blog:\'11111111\',post:\'39721\',tz:\'-5\',srv:\'example.com\'} ]);
+	_stq.push([ \'clickTrackerInit\', \'11111111\', \'39721\' ]);
+</script>
 </body>
 </html>';
 
@@ -221,6 +233,12 @@ $delay_html = '<html>
         is_ssl: "1",
     };
     /* ]]> */
+</script>
+<script src=\'https://stats.wp.com/e-202124.js\' defer></script>
+<script>
+	_stq = window._stq || [];
+	_stq.push([ \'view\', {v:\'ext\',j:\'1:9.8.1\',blog:\'11111111\',post:\'39721\',tz:\'-5\',srv:\'example.com\'} ]);
+	_stq.push([ \'clickTrackerInit\', \'11111111\', \'39721\' ]);
 </script>
 </body>
 </html>';


### PR DESCRIPTION
## Description

Adds auto-exclusion for Jetpack Stats. Some users reported wrong reports since files of Jetpack Stats are delayed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] On customer website by adding the exclusions using the field
- [x] On smashingcoding by updating the plugin code and checking the exclusion worked properly

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules