### PR TITLE
Add auto-exclusion for Fluent Form & ConverPro

### DIFF
--- a/inc/Engine/Optimization/DelayJS/HTML.php
+++ b/inc/Engine/Optimization/DelayJS/HTML.php
@@ -42,6 +42,8 @@ class HTML {
 		'et_animation_data',
 		'wpforms_settings',
 		'var nfForms',
+		'fluent_form_ff_form_instance_', // Fluent Forms.
+		'cpLoadCSS', // Convert Pro.
 	];
 
 	/**

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/HTML/delayJs.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/HTML/delayJs.php
@@ -47,8 +47,13 @@ $html = '<html>
 				var analytics_code = "<!-- Global site tag (gtag.js) - Google Analytics -->\n<script async src=\"https:\/\/www.googletagmanager.com\/gtag\/js?id=XXX\"><\/script>\n<script>\n  window.dataLayer = window.dataLayer || [];\n  function gtag(){dataLayer.push(arguments);}\n  gtag(\'js\', new Date());\n\n  gtag(\'config\', \'XXX\');\n<\/script>".replace(/\"/g, \'"\' );
 		})( jQuery );
 	</script>
+	<script>function cpLoadCSS(e,t,n){"use strict";var i=window.document.createElement("link"),o=t||window.document.getElementsByTagName("script")[0];return i.rel="stylesheet",i.href=e,i.media="only x",o.parentNode.insertBefore(i,o),setTimeout(function(){i.media=n||"all"}),i}</script>
+	<script>document.addEventListener(\'DOMContentLoaded\', function(event) {  if( typeof cpLoadCSS !== \'undefined\' ) { cpLoadCSS(\'https://example.org/wp-content/plugins/convertpro/assets/modules/css/cp-popup.min.css?ver=1.7.0\', 0, \'all\'); } }); </script>
 </head>
 <body>
+<script type="text/javascript">
+window.fluent_form_ff_form_instance_1_1 = {"id":"1","settings":{"layout":{"labelPlacement":"top","helpMessagePlacement":"with_label","errorMessagePlacement":"inline","asteriskPlacement":"asterisk-right"},"id":"39","restrictions":{"denyEmptySubmission":{"enabled":false}}},"form_instance":"ff_form_instance_1_1","form_id_selector":"fluentform_1","rules":{"first_name[first_name]":{"required":{"value":false,"message":"This field is required"}},"first_name[middle_name]":{"required":{"value":false,"message":"This field is required"}},"first_name[last_name]":{"required":{"value":false,"message":"This field is required"}},"email":{"required":{"value":true,"message":"This field is required"},"email":{"value":true,"message":"This field must contain a valid email"}},"biggest_challenge":{"required":{"value":false,"message":"This field is required"}}}};
+</script>
 <script type="text/javascript">
 	var et_animation_data = [{"class":"et_pb_cta_0","style":"slideLeft","repeat":"once","duration":"1000ms","delay":"0ms","intensity":"50%","starting_opacity":"0%","speed_curve":"ease-in-out"}];
 </script>
@@ -145,8 +150,13 @@ $delay_html_upgrade = '<html>
 				var analytics_code = "<!-- Global site tag (gtag.js) - Google Analytics -->\n<script async src=\"https:\/\/www.googletagmanager.com\/gtag\/js?id=XXX\"><\/script>\n<script>\n  window.dataLayer = window.dataLayer || [];\n  function gtag(){dataLayer.push(arguments);}\n  gtag(\'js\', new Date());\n\n  gtag(\'config\', \'XXX\');\n<\/script>".replace(/\"/g, \'"\' );
 		})( jQuery );
 	</script>
+	<script>function cpLoadCSS(e,t,n){"use strict";var i=window.document.createElement("link"),o=t||window.document.getElementsByTagName("script")[0];return i.rel="stylesheet",i.href=e,i.media="only x",o.parentNode.insertBefore(i,o),setTimeout(function(){i.media=n||"all"}),i}</script>
+	<script>document.addEventListener(\'DOMContentLoaded\', function(event) {  if( typeof cpLoadCSS !== \'undefined\' ) { cpLoadCSS(\'https://example.org/wp-content/plugins/convertpro/assets/modules/css/cp-popup.min.css?ver=1.7.0\', 0, \'all\'); } }); </script>
 </head>
 <body>
+<script type="text/javascript">
+window.fluent_form_ff_form_instance_1_1 = {"id":"1","settings":{"layout":{"labelPlacement":"top","helpMessagePlacement":"with_label","errorMessagePlacement":"inline","asteriskPlacement":"asterisk-right"},"id":"39","restrictions":{"denyEmptySubmission":{"enabled":false}}},"form_instance":"ff_form_instance_1_1","form_id_selector":"fluentform_1","rules":{"first_name[first_name]":{"required":{"value":false,"message":"This field is required"}},"first_name[middle_name]":{"required":{"value":false,"message":"This field is required"}},"first_name[last_name]":{"required":{"value":false,"message":"This field is required"}},"email":{"required":{"value":true,"message":"This field is required"},"email":{"value":true,"message":"This field must contain a valid email"}},"biggest_challenge":{"required":{"value":false,"message":"This field is required"}}}};
+</script>
 <script type="text/javascript">
 	var et_animation_data = [{"class":"et_pb_cta_0","style":"slideLeft","repeat":"once","duration":"1000ms","delay":"0ms","intensity":"50%","starting_opacity":"0%","speed_curve":"ease-in-out"}];
 </script>
@@ -243,8 +253,13 @@ $delay_html = '<html>
 				var analytics_code = "<!-- Global site tag (gtag.js) - Google Analytics -->\n<script async src=\"https:\/\/www.googletagmanager.com\/gtag\/js?id=XXX\"><\/script>\n<script>\n  window.dataLayer = window.dataLayer || [];\n  function gtag(){dataLayer.push(arguments);}\n  gtag(\'js\', new Date());\n\n  gtag(\'config\', \'XXX\');\n<\/script>".replace(/\"/g, \'"\' );
 		})( jQuery );
 	</script>
+	<script>function cpLoadCSS(e,t,n){"use strict";var i=window.document.createElement("link"),o=t||window.document.getElementsByTagName("script")[0];return i.rel="stylesheet",i.href=e,i.media="only x",o.parentNode.insertBefore(i,o),setTimeout(function(){i.media=n||"all"}),i}</script>
+	<script>document.addEventListener(\'DOMContentLoaded\', function(event) {  if( typeof cpLoadCSS !== \'undefined\' ) { cpLoadCSS(\'https://example.org/wp-content/plugins/convertpro/assets/modules/css/cp-popup.min.css?ver=1.7.0\', 0, \'all\'); } }); </script>
 </head>
 <body>
+<script type="text/javascript">
+window.fluent_form_ff_form_instance_1_1 = {"id":"1","settings":{"layout":{"labelPlacement":"top","helpMessagePlacement":"with_label","errorMessagePlacement":"inline","asteriskPlacement":"asterisk-right"},"id":"39","restrictions":{"denyEmptySubmission":{"enabled":false}}},"form_instance":"ff_form_instance_1_1","form_id_selector":"fluentform_1","rules":{"first_name[first_name]":{"required":{"value":false,"message":"This field is required"}},"first_name[middle_name]":{"required":{"value":false,"message":"This field is required"}},"first_name[last_name]":{"required":{"value":false,"message":"This field is required"}},"email":{"required":{"value":true,"message":"This field is required"},"email":{"value":true,"message":"This field must contain a valid email"}},"biggest_challenge":{"required":{"value":false,"message":"This field is required"}}}};
+</script>
 <script type="text/javascript">
 	var et_animation_data = [{"class":"et_pb_cta_0","style":"slideLeft","repeat":"once","duration":"1000ms","delay":"0ms","intensity":"50%","starting_opacity":"0%","speed_curve":"ease-in-out"}];
 </script>

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/Subscriber/delayJs.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/Subscriber/delayJs.php
@@ -24,8 +24,13 @@ $html = '<html>
 				var analytics_code = "<!-- Global site tag (gtag.js) - Google Analytics -->\n<script async src=\"https:\/\/www.googletagmanager.com\/gtag\/js?id=XXX\"><\/script>\n<script>\n  window.dataLayer = window.dataLayer || [];\n  function gtag(){dataLayer.push(arguments);}\n  gtag(\'js\', new Date());\n\n  gtag(\'config\', \'XXX\');\n<\/script>".replace(/\"/g, \'"\' );
 		})( jQuery );
 	</script>
+	<script>function cpLoadCSS(e,t,n){"use strict";var i=window.document.createElement("link"),o=t||window.document.getElementsByTagName("script")[0];return i.rel="stylesheet",i.href=e,i.media="only x",o.parentNode.insertBefore(i,o),setTimeout(function(){i.media=n||"all"}),i}</script>
+	<script>document.addEventListener(\'DOMContentLoaded\', function(event) {  if( typeof cpLoadCSS !== \'undefined\' ) { cpLoadCSS(\'https://example.org/wp-content/plugins/convertpro/assets/modules/css/cp-popup.min.css?ver=1.7.0\', 0, \'all\'); } }); </script>
 </head>
 <body>
+<script type="text/javascript">
+window.fluent_form_ff_form_instance_1_1 = {"id":"1","settings":{"layout":{"labelPlacement":"top","helpMessagePlacement":"with_label","errorMessagePlacement":"inline","asteriskPlacement":"asterisk-right"},"id":"39","restrictions":{"denyEmptySubmission":{"enabled":false}}},"form_instance":"ff_form_instance_1_1","form_id_selector":"fluentform_1","rules":{"first_name[first_name]":{"required":{"value":false,"message":"This field is required"}},"first_name[middle_name]":{"required":{"value":false,"message":"This field is required"}},"first_name[last_name]":{"required":{"value":false,"message":"This field is required"}},"email":{"required":{"value":true,"message":"This field is required"},"email":{"value":true,"message":"This field must contain a valid email"}},"biggest_challenge":{"required":{"value":false,"message":"This field is required"}}}};
+</script>
 <script type="text/javascript">
 	var et_animation_data = [{"class":"et_pb_cta_0","style":"slideLeft","repeat":"once","duration":"1000ms","delay":"0ms","intensity":"50%","starting_opacity":"0%","speed_curve":"ease-in-out"}];
 </script>
@@ -99,8 +104,13 @@ $delay_html_upgrade = '<html>
 				var analytics_code = "<!-- Global site tag (gtag.js) - Google Analytics -->\n<script async src=\"https:\/\/www.googletagmanager.com\/gtag\/js?id=XXX\"><\/script>\n<script>\n  window.dataLayer = window.dataLayer || [];\n  function gtag(){dataLayer.push(arguments);}\n  gtag(\'js\', new Date());\n\n  gtag(\'config\', \'XXX\');\n<\/script>".replace(/\"/g, \'"\' );
 		})( jQuery );
 	</script>
+	<script>function cpLoadCSS(e,t,n){"use strict";var i=window.document.createElement("link"),o=t||window.document.getElementsByTagName("script")[0];return i.rel="stylesheet",i.href=e,i.media="only x",o.parentNode.insertBefore(i,o),setTimeout(function(){i.media=n||"all"}),i}</script>
+	<script>document.addEventListener(\'DOMContentLoaded\', function(event) {  if( typeof cpLoadCSS !== \'undefined\' ) { cpLoadCSS(\'https://example.org/wp-content/plugins/convertpro/assets/modules/css/cp-popup.min.css?ver=1.7.0\', 0, \'all\'); } }); </script>
 </head>
 <body>
+<script type="text/javascript">
+window.fluent_form_ff_form_instance_1_1 = {"id":"1","settings":{"layout":{"labelPlacement":"top","helpMessagePlacement":"with_label","errorMessagePlacement":"inline","asteriskPlacement":"asterisk-right"},"id":"39","restrictions":{"denyEmptySubmission":{"enabled":false}}},"form_instance":"ff_form_instance_1_1","form_id_selector":"fluentform_1","rules":{"first_name[first_name]":{"required":{"value":false,"message":"This field is required"}},"first_name[middle_name]":{"required":{"value":false,"message":"This field is required"}},"first_name[last_name]":{"required":{"value":false,"message":"This field is required"}},"email":{"required":{"value":true,"message":"This field is required"},"email":{"value":true,"message":"This field must contain a valid email"}},"biggest_challenge":{"required":{"value":false,"message":"This field is required"}}}};
+</script>
 <script type="text/javascript">
 	var et_animation_data = [{"class":"et_pb_cta_0","style":"slideLeft","repeat":"once","duration":"1000ms","delay":"0ms","intensity":"50%","starting_opacity":"0%","speed_curve":"ease-in-out"}];
 </script>
@@ -174,8 +184,13 @@ $delay_html = '<html>
 				var analytics_code = "<!-- Global site tag (gtag.js) - Google Analytics -->\n<script async src=\"https:\/\/www.googletagmanager.com\/gtag\/js?id=XXX\"><\/script>\n<script>\n  window.dataLayer = window.dataLayer || [];\n  function gtag(){dataLayer.push(arguments);}\n  gtag(\'js\', new Date());\n\n  gtag(\'config\', \'XXX\');\n<\/script>".replace(/\"/g, \'"\' );
 		})( jQuery );
 	</script>
+	<script>function cpLoadCSS(e,t,n){"use strict";var i=window.document.createElement("link"),o=t||window.document.getElementsByTagName("script")[0];return i.rel="stylesheet",i.href=e,i.media="only x",o.parentNode.insertBefore(i,o),setTimeout(function(){i.media=n||"all"}),i}</script>
+	<script>document.addEventListener(\'DOMContentLoaded\', function(event) {  if( typeof cpLoadCSS !== \'undefined\' ) { cpLoadCSS(\'https://example.org/wp-content/plugins/convertpro/assets/modules/css/cp-popup.min.css?ver=1.7.0\', 0, \'all\'); } }); </script>
 </head>
 <body>
+<script type="text/javascript">
+window.fluent_form_ff_form_instance_1_1 = {"id":"1","settings":{"layout":{"labelPlacement":"top","helpMessagePlacement":"with_label","errorMessagePlacement":"inline","asteriskPlacement":"asterisk-right"},"id":"39","restrictions":{"denyEmptySubmission":{"enabled":false}}},"form_instance":"ff_form_instance_1_1","form_id_selector":"fluentform_1","rules":{"first_name[first_name]":{"required":{"value":false,"message":"This field is required"}},"first_name[middle_name]":{"required":{"value":false,"message":"This field is required"}},"first_name[last_name]":{"required":{"value":false,"message":"This field is required"}},"email":{"required":{"value":true,"message":"This field is required"},"email":{"value":true,"message":"This field must contain a valid email"}},"biggest_challenge":{"required":{"value":false,"message":"This field is required"}}}};
+</script>
 <script type="text/javascript">
 	var et_animation_data = [{"class":"et_pb_cta_0","style":"slideLeft","repeat":"once","duration":"1000ms","delay":"0ms","intensity":"50%","starting_opacity":"0%","speed_curve":"ease-in-out"}];
 </script>


### PR DESCRIPTION
## Description

When our default exclusion list is added, we have errors with Fluent Forms and ConvertPro plugins. Some inline script need to be automatically excluded.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] On customer website by adding the exclusions using the field
- [x] On smashingcoding by updating the plugin code and checking the exclusion worked properly

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules