### PR TITLE
Add Delay JS auto-exclusion for some plugins

### DIFF
--- a/inc/Engine/Optimization/DelayJS/HTML.php
+++ b/inc/Engine/Optimization/DelayJS/HTML.php
@@ -42,7 +42,8 @@ class HTML {
 		'et_animation_data',
 		'wpforms_settings',
 		'var nfForms',
-		'ninja_column_' // Ninja Tables.
+		'ninja_column_', // Ninja Tables.
+		'var rbs_gallery_', // Robo Gallery.
 	];
 
 	/**

--- a/inc/Engine/Optimization/DelayJS/HTML.php
+++ b/inc/Engine/Optimization/DelayJS/HTML.php
@@ -44,6 +44,7 @@ class HTML {
 		'var nfForms',
 		'ninja_column_', // Ninja Tables.
 		'var rbs_gallery_', // Robo Gallery.
+		'var lepopup_', // Green Popup.
 	];
 
 	/**

--- a/inc/Engine/Optimization/DelayJS/HTML.php
+++ b/inc/Engine/Optimization/DelayJS/HTML.php
@@ -42,6 +42,7 @@ class HTML {
 		'et_animation_data',
 		'wpforms_settings',
 		'var nfForms',
+		'ninja_column_' // Ninja Tables.
 	];
 
 	/**

--- a/inc/Engine/Optimization/DelayJS/HTML.php
+++ b/inc/Engine/Optimization/DelayJS/HTML.php
@@ -45,6 +45,7 @@ class HTML {
 		'ninja_column_', // Ninja Tables.
 		'var rbs_gallery_', // Robo Gallery.
 		'var lepopup_', // Green Popup.
+		'var billing_additional_field', // Woo Autocomplete Nish.
 	];
 
 	/**

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/HTML/delayJs.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/HTML/delayJs.php
@@ -245,6 +245,7 @@ $delay_html_upgrade = '<html>
     };
     /* ]]> */
 </script>
+<script>window.ninja_table_instance_0={table_id:"1067",title:"MYGA Rates National - Sheet1.csv (Imported From Table Press)",caption:"",columns:[{name:"companyname",key:"companyname",title:"Company Name",breakpoints:"",type:"text",visible:!0,classes:["ninja_column_0","ninja_clmn_nm_companyname"],filterable:!0,sortable:!1,original:{key:"companyname",name:"Company Name",breakpoints:"",data_type:"text",dateFormat:"",enable_html_content:"false",header_html_content:"",contentAlign:"left",textAlign:"left",maxWidthUnit:"px",unsortable:"yes"}}]};</script>
 <script data-cfasync="false" data-pagespeed-no-defer type="text/javascript">//<![CDATA[
 	var gtm4wp_datalayer_name = "dataLayer";
 	var dataLayer = dataLayer || [];
@@ -270,7 +271,6 @@ $delay_html_upgrade = '<html>
 	var dataLayer_content = {"visitorDoNotTrack":1,"pagePostType":"product","pagePostType2":"single-product","pagePostAuthor":"remy","productRatingCounts":[],"productAverageRating":0,"productReviewCount":0,"productType":"simple","productIsVariable":0,"event":"gtm4wp.changeDetailViewEEC","ecommerce":{"currencyCode":"CAD","detail":{"products":[{"id":1762,"name":"Beanie","sku":1762,"category":"Accessories","price":18,"stocklevel":null}]}}};
 	dataLayer.push( dataLayer_content );//]]>
 </script>
-<script>window.ninja_table_instance_0={table_id:"1067",title:"MYGA Rates National - Sheet1.csv (Imported From Table Press)",caption:"",columns:[{name:"companyname",key:"companyname",title:"Company Name",breakpoints:"",type:"text",visible:!0,classes:["ninja_column_0","ninja_clmn_nm_companyname"],filterable:!0,sortable:!1,original:{key:"companyname",name:"Company Name",breakpoints:"",data_type:"text",dateFormat:"",enable_html_content:"false",header_html_content:"",contentAlign:"left",textAlign:"left",maxWidthUnit:"px",unsortable:"yes"}}]};</script>
 </body>
 </html>';
 

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/HTML/delayJs.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/HTML/delayJs.php
@@ -50,6 +50,17 @@ $html = '<html>
 	</script>
 </head>
 <body>
+<script>
+	// Billing
+	var billing_address =\' #billing_address_1\';
+	var billing_city =\'\';
+	var billing_state =\' #billing_city\';
+	var billing_zip_code =\'\';
+	var billing_country =\'\';
+	var billing_county =\'\';
+	var billing_additional_field =\'\';
+	var country_restriction =\'HK\';
+</script>
 <script>var rbs_gallery_60d183e796fbf = {"version":"3.0.7","id":27381,"class":"id27381","roboGalleryDelay":1000,"mainContainer":"#robo_gallery_main_block_rbs_gallery_60d183e796fbf","loadingContainer":"#rbs_gallery_60d183e796fbf-block-loader","loadingContainerObj":"rbs_gallery_60d183e796fbf-block-loader","columnWidth":"auto","columns":3,"resolutions":[{"columnWidth":"auto","columns":3,"maxWidth":960},{"columnWidth":"auto","columns":2,"maxWidth":650},{"columnWidth":300,"maxWidth":450}],"descBox":true,"descBoxClass":"rbs_desc_panel_light","lightboxOptions":{"gallery":{"enabled":true,"tCounter":"%curr% of %total%"}},"facebook":true,"twitter":true,"pinterest":true,"overlayEffect":"direction-aware-fade","boxesToLoadStart":6,"boxesToLoad":6,"lazyLoad":1,"waitUntilThumbLoads":1,"LoadingWord":"Loading Videos...","loadMoreWord":"Loading More Videos","noMoreEntriesWord":"No More Videos","horizontalSpaceBetweenBoxes":15,"verticalSpaceBetweenBoxes":15,"noHoverOnMobile":"false","wrapContainer":"#robo-gallery-wrap-rbs_gallery_60d183e796fbf"};</script>
 <script type="text/javascript">
 	var et_animation_data = [{"class":"et_pb_cta_0","style":"slideLeft","repeat":"once","duration":"1000ms","delay":"0ms","intensity":"50%","starting_opacity":"0%","speed_curve":"ease-in-out"}];
@@ -151,6 +162,17 @@ $delay_html_upgrade = '<html>
 	</script>
 </head>
 <body>
+<script>
+	// Billing
+	var billing_address =\' #billing_address_1\';
+	var billing_city =\'\';
+	var billing_state =\' #billing_city\';
+	var billing_zip_code =\'\';
+	var billing_country =\'\';
+	var billing_county =\'\';
+	var billing_additional_field =\'\';
+	var country_restriction =\'HK\';
+</script>
 <script>var rbs_gallery_60d183e796fbf = {"version":"3.0.7","id":27381,"class":"id27381","roboGalleryDelay":1000,"mainContainer":"#robo_gallery_main_block_rbs_gallery_60d183e796fbf","loadingContainer":"#rbs_gallery_60d183e796fbf-block-loader","loadingContainerObj":"rbs_gallery_60d183e796fbf-block-loader","columnWidth":"auto","columns":3,"resolutions":[{"columnWidth":"auto","columns":3,"maxWidth":960},{"columnWidth":"auto","columns":2,"maxWidth":650},{"columnWidth":300,"maxWidth":450}],"descBox":true,"descBoxClass":"rbs_desc_panel_light","lightboxOptions":{"gallery":{"enabled":true,"tCounter":"%curr% of %total%"}},"facebook":true,"twitter":true,"pinterest":true,"overlayEffect":"direction-aware-fade","boxesToLoadStart":6,"boxesToLoad":6,"lazyLoad":1,"waitUntilThumbLoads":1,"LoadingWord":"Loading Videos...","loadMoreWord":"Loading More Videos","noMoreEntriesWord":"No More Videos","horizontalSpaceBetweenBoxes":15,"verticalSpaceBetweenBoxes":15,"noHoverOnMobile":"false","wrapContainer":"#robo-gallery-wrap-rbs_gallery_60d183e796fbf"};</script>
 <script type="text/javascript">
 	var et_animation_data = [{"class":"et_pb_cta_0","style":"slideLeft","repeat":"once","duration":"1000ms","delay":"0ms","intensity":"50%","starting_opacity":"0%","speed_curve":"ease-in-out"}];
@@ -252,6 +274,17 @@ $delay_html = '<html>
 	</script>
 </head>
 <body>
+<script>
+	// Billing
+	var billing_address =\' #billing_address_1\';
+	var billing_city =\'\';
+	var billing_state =\' #billing_city\';
+	var billing_zip_code =\'\';
+	var billing_country =\'\';
+	var billing_county =\'\';
+	var billing_additional_field =\'\';
+	var country_restriction =\'HK\';
+</script>
 <script>var rbs_gallery_60d183e796fbf = {"version":"3.0.7","id":27381,"class":"id27381","roboGalleryDelay":1000,"mainContainer":"#robo_gallery_main_block_rbs_gallery_60d183e796fbf","loadingContainer":"#rbs_gallery_60d183e796fbf-block-loader","loadingContainerObj":"rbs_gallery_60d183e796fbf-block-loader","columnWidth":"auto","columns":3,"resolutions":[{"columnWidth":"auto","columns":3,"maxWidth":960},{"columnWidth":"auto","columns":2,"maxWidth":650},{"columnWidth":300,"maxWidth":450}],"descBox":true,"descBoxClass":"rbs_desc_panel_light","lightboxOptions":{"gallery":{"enabled":true,"tCounter":"%curr% of %total%"}},"facebook":true,"twitter":true,"pinterest":true,"overlayEffect":"direction-aware-fade","boxesToLoadStart":6,"boxesToLoad":6,"lazyLoad":1,"waitUntilThumbLoads":1,"LoadingWord":"Loading Videos...","loadMoreWord":"Loading More Videos","noMoreEntriesWord":"No More Videos","horizontalSpaceBetweenBoxes":15,"verticalSpaceBetweenBoxes":15,"noHoverOnMobile":"false","wrapContainer":"#robo-gallery-wrap-rbs_gallery_60d183e796fbf"};</script>
 <script type="text/javascript">
 	var et_animation_data = [{"class":"et_pb_cta_0","style":"slideLeft","repeat":"once","duration":"1000ms","delay":"0ms","intensity":"50%","starting_opacity":"0%","speed_curve":"ease-in-out"}];

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/HTML/delayJs.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/HTML/delayJs.php
@@ -11,6 +11,7 @@ $html = '<html>
 	<script type="application/ld+json" class="yoast-schema-graph">{"@context":"https://schema.org","@graph":[{"@type":"WebSite","@id":"http://example.org/#website","url":"http://example.org/"]}</script>
 	<script>var et_site_url=\'http://example.org\';var et_post_id=\'2\';function et_core_page_resource_fallback(a,b){"undefined"===typeof b&&(b=a.sheet.cssRules&&0===a.sheet.cssRules.length);b&&(a.onerror=null,a.onload=null,a.href?a.href=et_site_url+"/?et_core_page_resource="+a.id+et_post_id:a.src&&(a.src=et_site_url+"/?et_core_page_resource="+a.id+et_post_id))}
 	</script>
+	<script>var lepopup_customjs_handlers={};var lepopup_cookie_value="1624338829";var lepopup_events_data={};var lepopup_content_id="23638";</script>
 	<script>
 		// Store some global theme options used in JS
 		if ( window.$us === undefined ) {
@@ -111,6 +112,7 @@ $delay_html_upgrade = '<html>
 	<script type="application/ld+json" class="yoast-schema-graph">{"@context":"https://schema.org","@graph":[{"@type":"WebSite","@id":"http://example.org/#website","url":"http://example.org/"]}</script>
 	<script>var et_site_url=\'http://example.org\';var et_post_id=\'2\';function et_core_page_resource_fallback(a,b){"undefined"===typeof b&&(b=a.sheet.cssRules&&0===a.sheet.cssRules.length);b&&(a.onerror=null,a.onload=null,a.href?a.href=et_site_url+"/?et_core_page_resource="+a.id+et_post_id:a.src&&(a.src=et_site_url+"/?et_core_page_resource="+a.id+et_post_id))}
 	</script>
+	<script>var lepopup_customjs_handlers={};var lepopup_cookie_value="1624338829";var lepopup_events_data={};var lepopup_content_id="23638";</script>
 	<script>
 		// Store some global theme options used in JS
 		if ( window.$us === undefined ) {
@@ -211,6 +213,7 @@ $delay_html = '<html>
 	<script type="application/ld+json" class="yoast-schema-graph">{"@context":"https://schema.org","@graph":[{"@type":"WebSite","@id":"http://example.org/#website","url":"http://example.org/"]}</script>
 	<script>var et_site_url=\'http://example.org\';var et_post_id=\'2\';function et_core_page_resource_fallback(a,b){"undefined"===typeof b&&(b=a.sheet.cssRules&&0===a.sheet.cssRules.length);b&&(a.onerror=null,a.onload=null,a.href?a.href=et_site_url+"/?et_core_page_resource="+a.id+et_post_id:a.src&&(a.src=et_site_url+"/?et_core_page_resource="+a.id+et_post_id))}
 	</script>
+	<script>var lepopup_customjs_handlers={};var lepopup_cookie_value="1624338829";var lepopup_events_data={};var lepopup_content_id="23638";</script>
 	<script>
 		// Store some global theme options used in JS
 		if ( window.$us === undefined ) {

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/HTML/delayJs.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/HTML/delayJs.php
@@ -49,6 +49,7 @@ $html = '<html>
 	</script>
 </head>
 <body>
+<script>var rbs_gallery_60d183e796fbf = {"version":"3.0.7","id":27381,"class":"id27381","roboGalleryDelay":1000,"mainContainer":"#robo_gallery_main_block_rbs_gallery_60d183e796fbf","loadingContainer":"#rbs_gallery_60d183e796fbf-block-loader","loadingContainerObj":"rbs_gallery_60d183e796fbf-block-loader","columnWidth":"auto","columns":3,"resolutions":[{"columnWidth":"auto","columns":3,"maxWidth":960},{"columnWidth":"auto","columns":2,"maxWidth":650},{"columnWidth":300,"maxWidth":450}],"descBox":true,"descBoxClass":"rbs_desc_panel_light","lightboxOptions":{"gallery":{"enabled":true,"tCounter":"%curr% of %total%"}},"facebook":true,"twitter":true,"pinterest":true,"overlayEffect":"direction-aware-fade","boxesToLoadStart":6,"boxesToLoad":6,"lazyLoad":1,"waitUntilThumbLoads":1,"LoadingWord":"Loading Videos...","loadMoreWord":"Loading More Videos","noMoreEntriesWord":"No More Videos","horizontalSpaceBetweenBoxes":15,"verticalSpaceBetweenBoxes":15,"noHoverOnMobile":"false","wrapContainer":"#robo-gallery-wrap-rbs_gallery_60d183e796fbf"};</script>
 <script type="text/javascript">
 	var et_animation_data = [{"class":"et_pb_cta_0","style":"slideLeft","repeat":"once","duration":"1000ms","delay":"0ms","intensity":"50%","starting_opacity":"0%","speed_curve":"ease-in-out"}];
 </script>
@@ -148,6 +149,7 @@ $delay_html_upgrade = '<html>
 	</script>
 </head>
 <body>
+<script>var rbs_gallery_60d183e796fbf = {"version":"3.0.7","id":27381,"class":"id27381","roboGalleryDelay":1000,"mainContainer":"#robo_gallery_main_block_rbs_gallery_60d183e796fbf","loadingContainer":"#rbs_gallery_60d183e796fbf-block-loader","loadingContainerObj":"rbs_gallery_60d183e796fbf-block-loader","columnWidth":"auto","columns":3,"resolutions":[{"columnWidth":"auto","columns":3,"maxWidth":960},{"columnWidth":"auto","columns":2,"maxWidth":650},{"columnWidth":300,"maxWidth":450}],"descBox":true,"descBoxClass":"rbs_desc_panel_light","lightboxOptions":{"gallery":{"enabled":true,"tCounter":"%curr% of %total%"}},"facebook":true,"twitter":true,"pinterest":true,"overlayEffect":"direction-aware-fade","boxesToLoadStart":6,"boxesToLoad":6,"lazyLoad":1,"waitUntilThumbLoads":1,"LoadingWord":"Loading Videos...","loadMoreWord":"Loading More Videos","noMoreEntriesWord":"No More Videos","horizontalSpaceBetweenBoxes":15,"verticalSpaceBetweenBoxes":15,"noHoverOnMobile":"false","wrapContainer":"#robo-gallery-wrap-rbs_gallery_60d183e796fbf"};</script>
 <script type="text/javascript">
 	var et_animation_data = [{"class":"et_pb_cta_0","style":"slideLeft","repeat":"once","duration":"1000ms","delay":"0ms","intensity":"50%","starting_opacity":"0%","speed_curve":"ease-in-out"}];
 </script>
@@ -247,6 +249,7 @@ $delay_html = '<html>
 	</script>
 </head>
 <body>
+<script>var rbs_gallery_60d183e796fbf = {"version":"3.0.7","id":27381,"class":"id27381","roboGalleryDelay":1000,"mainContainer":"#robo_gallery_main_block_rbs_gallery_60d183e796fbf","loadingContainer":"#rbs_gallery_60d183e796fbf-block-loader","loadingContainerObj":"rbs_gallery_60d183e796fbf-block-loader","columnWidth":"auto","columns":3,"resolutions":[{"columnWidth":"auto","columns":3,"maxWidth":960},{"columnWidth":"auto","columns":2,"maxWidth":650},{"columnWidth":300,"maxWidth":450}],"descBox":true,"descBoxClass":"rbs_desc_panel_light","lightboxOptions":{"gallery":{"enabled":true,"tCounter":"%curr% of %total%"}},"facebook":true,"twitter":true,"pinterest":true,"overlayEffect":"direction-aware-fade","boxesToLoadStart":6,"boxesToLoad":6,"lazyLoad":1,"waitUntilThumbLoads":1,"LoadingWord":"Loading Videos...","loadMoreWord":"Loading More Videos","noMoreEntriesWord":"No More Videos","horizontalSpaceBetweenBoxes":15,"verticalSpaceBetweenBoxes":15,"noHoverOnMobile":"false","wrapContainer":"#robo-gallery-wrap-rbs_gallery_60d183e796fbf"};</script>
 <script type="text/javascript">
 	var et_animation_data = [{"class":"et_pb_cta_0","style":"slideLeft","repeat":"once","duration":"1000ms","delay":"0ms","intensity":"50%","starting_opacity":"0%","speed_curve":"ease-in-out"}];
 </script>

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/HTML/delayJs.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/HTML/delayJs.php
@@ -95,6 +95,7 @@ $html = '<html>
     };
     /* ]]> */
 </script>
+<script>window.ninja_table_instance_0={table_id:"1067",title:"MYGA Rates National - Sheet1.csv (Imported From Table Press)",caption:"",columns:[{name:"companyname",key:"companyname",title:"Company Name",breakpoints:"",type:"text",visible:!0,classes:["ninja_column_0","ninja_clmn_nm_companyname"],filterable:!0,sortable:!1,original:{key:"companyname",name:"Company Name",breakpoints:"",data_type:"text",dateFormat:"",enable_html_content:"false",header_html_content:"",contentAlign:"left",textAlign:"left",maxWidthUnit:"px",unsortable:"yes"}}]};</script>
 </body>
 </html>';
 
@@ -193,6 +194,7 @@ $delay_html_upgrade = '<html>
     };
     /* ]]> */
 </script>
+<script>window.ninja_table_instance_0={table_id:"1067",title:"MYGA Rates National - Sheet1.csv (Imported From Table Press)",caption:"",columns:[{name:"companyname",key:"companyname",title:"Company Name",breakpoints:"",type:"text",visible:!0,classes:["ninja_column_0","ninja_clmn_nm_companyname"],filterable:!0,sortable:!1,original:{key:"companyname",name:"Company Name",breakpoints:"",data_type:"text",dateFormat:"",enable_html_content:"false",header_html_content:"",contentAlign:"left",textAlign:"left",maxWidthUnit:"px",unsortable:"yes"}}]};</script>
 </body>
 </html>';
 
@@ -291,6 +293,7 @@ $delay_html = '<html>
     };
     /* ]]> */
 </script>
+<script>window.ninja_table_instance_0={table_id:"1067",title:"MYGA Rates National - Sheet1.csv (Imported From Table Press)",caption:"",columns:[{name:"companyname",key:"companyname",title:"Company Name",breakpoints:"",type:"text",visible:!0,classes:["ninja_column_0","ninja_clmn_nm_companyname"],filterable:!0,sortable:!1,original:{key:"companyname",name:"Company Name",breakpoints:"",data_type:"text",dateFormat:"",enable_html_content:"false",header_html_content:"",contentAlign:"left",textAlign:"left",maxWidthUnit:"px",unsortable:"yes"}}]};</script>
 </body>
 </html>';
 

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/Subscriber/delayJs.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/Subscriber/delayJs.php
@@ -26,6 +26,7 @@ $html = '<html>
 	</script>
 </head>
 <body>
+<script>var rbs_gallery_60d183e796fbf = {"version":"3.0.7","id":27381,"class":"id27381","roboGalleryDelay":1000,"mainContainer":"#robo_gallery_main_block_rbs_gallery_60d183e796fbf","loadingContainer":"#rbs_gallery_60d183e796fbf-block-loader","loadingContainerObj":"rbs_gallery_60d183e796fbf-block-loader","columnWidth":"auto","columns":3,"resolutions":[{"columnWidth":"auto","columns":3,"maxWidth":960},{"columnWidth":"auto","columns":2,"maxWidth":650},{"columnWidth":300,"maxWidth":450}],"descBox":true,"descBoxClass":"rbs_desc_panel_light","lightboxOptions":{"gallery":{"enabled":true,"tCounter":"%curr% of %total%"}},"facebook":true,"twitter":true,"pinterest":true,"overlayEffect":"direction-aware-fade","boxesToLoadStart":6,"boxesToLoad":6,"lazyLoad":1,"waitUntilThumbLoads":1,"LoadingWord":"Loading Videos...","loadMoreWord":"Loading More Videos","noMoreEntriesWord":"No More Videos","horizontalSpaceBetweenBoxes":15,"verticalSpaceBetweenBoxes":15,"noHoverOnMobile":"false","wrapContainer":"#robo-gallery-wrap-rbs_gallery_60d183e796fbf"};</script>
 <script type="text/javascript">
 	var et_animation_data = [{"class":"et_pb_cta_0","style":"slideLeft","repeat":"once","duration":"1000ms","delay":"0ms","intensity":"50%","starting_opacity":"0%","speed_curve":"ease-in-out"}];
 </script>
@@ -102,6 +103,7 @@ $delay_html_upgrade = '<html>
 	</script>
 </head>
 <body>
+<script>var rbs_gallery_60d183e796fbf = {"version":"3.0.7","id":27381,"class":"id27381","roboGalleryDelay":1000,"mainContainer":"#robo_gallery_main_block_rbs_gallery_60d183e796fbf","loadingContainer":"#rbs_gallery_60d183e796fbf-block-loader","loadingContainerObj":"rbs_gallery_60d183e796fbf-block-loader","columnWidth":"auto","columns":3,"resolutions":[{"columnWidth":"auto","columns":3,"maxWidth":960},{"columnWidth":"auto","columns":2,"maxWidth":650},{"columnWidth":300,"maxWidth":450}],"descBox":true,"descBoxClass":"rbs_desc_panel_light","lightboxOptions":{"gallery":{"enabled":true,"tCounter":"%curr% of %total%"}},"facebook":true,"twitter":true,"pinterest":true,"overlayEffect":"direction-aware-fade","boxesToLoadStart":6,"boxesToLoad":6,"lazyLoad":1,"waitUntilThumbLoads":1,"LoadingWord":"Loading Videos...","loadMoreWord":"Loading More Videos","noMoreEntriesWord":"No More Videos","horizontalSpaceBetweenBoxes":15,"verticalSpaceBetweenBoxes":15,"noHoverOnMobile":"false","wrapContainer":"#robo-gallery-wrap-rbs_gallery_60d183e796fbf"};</script>
 <script type="text/javascript">
 	var et_animation_data = [{"class":"et_pb_cta_0","style":"slideLeft","repeat":"once","duration":"1000ms","delay":"0ms","intensity":"50%","starting_opacity":"0%","speed_curve":"ease-in-out"}];
 </script>
@@ -178,6 +180,7 @@ $delay_html = '<html>
 	</script>
 </head>
 <body>
+<script>var rbs_gallery_60d183e796fbf = {"version":"3.0.7","id":27381,"class":"id27381","roboGalleryDelay":1000,"mainContainer":"#robo_gallery_main_block_rbs_gallery_60d183e796fbf","loadingContainer":"#rbs_gallery_60d183e796fbf-block-loader","loadingContainerObj":"rbs_gallery_60d183e796fbf-block-loader","columnWidth":"auto","columns":3,"resolutions":[{"columnWidth":"auto","columns":3,"maxWidth":960},{"columnWidth":"auto","columns":2,"maxWidth":650},{"columnWidth":300,"maxWidth":450}],"descBox":true,"descBoxClass":"rbs_desc_panel_light","lightboxOptions":{"gallery":{"enabled":true,"tCounter":"%curr% of %total%"}},"facebook":true,"twitter":true,"pinterest":true,"overlayEffect":"direction-aware-fade","boxesToLoadStart":6,"boxesToLoad":6,"lazyLoad":1,"waitUntilThumbLoads":1,"LoadingWord":"Loading Videos...","loadMoreWord":"Loading More Videos","noMoreEntriesWord":"No More Videos","horizontalSpaceBetweenBoxes":15,"verticalSpaceBetweenBoxes":15,"noHoverOnMobile":"false","wrapContainer":"#robo-gallery-wrap-rbs_gallery_60d183e796fbf"};</script>
 <script type="text/javascript">
 	var et_animation_data = [{"class":"et_pb_cta_0","style":"slideLeft","repeat":"once","duration":"1000ms","delay":"0ms","intensity":"50%","starting_opacity":"0%","speed_curve":"ease-in-out"}];
 </script>

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/Subscriber/delayJs.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/Subscriber/delayJs.php
@@ -11,6 +11,7 @@ $html = '<html>
 	<script type="application/ld+json" class="yoast-schema-graph">{"@context":"https://schema.org","@graph":[{"@type":"WebSite","@id":"http://example.org/#website","url":"http://example.org/"]}</script>
 	<script>var et_site_url=\'http://example.org\';var et_post_id=\'2\';function et_core_page_resource_fallback(a,b){"undefined"===typeof b&&(b=a.sheet.cssRules&&0===a.sheet.cssRules.length);b&&(a.onerror=null,a.onload=null,a.href?a.href=et_site_url+"/?et_core_page_resource="+a.id+et_post_id:a.src&&(a.src=et_site_url+"/?et_core_page_resource="+a.id+et_post_id))}
 	</script>
+	<script>var lepopup_customjs_handlers={};var lepopup_cookie_value="1624338829";var lepopup_events_data={};var lepopup_content_id="23638";</script>
 	<script>if ( window.$us === undefined ) window.$us = {};</script>
 	<script>fusionNavIsCollapsed</script>
 	<script>var eio_lazy_vars = {"exactdn_domain":"evp4mrv2nwt.exactdn.com","skip_autoscale":"0","threshold":"0"};</script>
@@ -88,6 +89,7 @@ $delay_html_upgrade = '<html>
 	<script type="application/ld+json" class="yoast-schema-graph">{"@context":"https://schema.org","@graph":[{"@type":"WebSite","@id":"http://example.org/#website","url":"http://example.org/"]}</script>
 	<script>var et_site_url=\'http://example.org\';var et_post_id=\'2\';function et_core_page_resource_fallback(a,b){"undefined"===typeof b&&(b=a.sheet.cssRules&&0===a.sheet.cssRules.length);b&&(a.onerror=null,a.onload=null,a.href?a.href=et_site_url+"/?et_core_page_resource="+a.id+et_post_id:a.src&&(a.src=et_site_url+"/?et_core_page_resource="+a.id+et_post_id))}
 	</script>
+	<script>var lepopup_customjs_handlers={};var lepopup_cookie_value="1624338829";var lepopup_events_data={};var lepopup_content_id="23638";</script>
 	<script>if ( window.$us === undefined ) window.$us = {};</script>
 	<script>fusionNavIsCollapsed</script>
 	<script>var eio_lazy_vars = {"exactdn_domain":"evp4mrv2nwt.exactdn.com","skip_autoscale":"0","threshold":"0"};</script>
@@ -165,6 +167,7 @@ $delay_html = '<html>
 	<script type="application/ld+json" class="yoast-schema-graph">{"@context":"https://schema.org","@graph":[{"@type":"WebSite","@id":"http://example.org/#website","url":"http://example.org/"]}</script>
 	<script>var et_site_url=\'http://example.org\';var et_post_id=\'2\';function et_core_page_resource_fallback(a,b){"undefined"===typeof b&&(b=a.sheet.cssRules&&0===a.sheet.cssRules.length);b&&(a.onerror=null,a.onload=null,a.href?a.href=et_site_url+"/?et_core_page_resource="+a.id+et_post_id:a.src&&(a.src=et_site_url+"/?et_core_page_resource="+a.id+et_post_id))}
 	</script>
+	<script>var lepopup_customjs_handlers={};var lepopup_cookie_value="1624338829";var lepopup_events_data={};var lepopup_content_id="23638";</script>
 	<script>if ( window.$us === undefined ) window.$us = {};</script>
 	<script>fusionNavIsCollapsed</script>
 	<script>var eio_lazy_vars = {"exactdn_domain":"evp4mrv2nwt.exactdn.com","skip_autoscale":"0","threshold":"0"};</script>

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/Subscriber/delayJs.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/Subscriber/delayJs.php
@@ -199,6 +199,7 @@ $delay_html_upgrade = '<html>
     };
     /* ]]> */
 </script>
+<script>window.ninja_table_instance_0={table_id:"1067",title:"MYGA Rates National - Sheet1.csv (Imported From Table Press)",caption:"",columns:[{name:"companyname",key:"companyname",title:"Company Name",breakpoints:"",type:"text",visible:!0,classes:["ninja_column_0","ninja_clmn_nm_companyname"],filterable:!0,sortable:!1,original:{key:"companyname",name:"Company Name",breakpoints:"",data_type:"text",dateFormat:"",enable_html_content:"false",header_html_content:"",contentAlign:"left",textAlign:"left",maxWidthUnit:"px",unsortable:"yes"}}]};</script>
 <script data-cfasync="false" data-pagespeed-no-defer type="text/javascript">//<![CDATA[
 	var gtm4wp_datalayer_name = "dataLayer";
 	var dataLayer = dataLayer || [];
@@ -224,7 +225,6 @@ $delay_html_upgrade = '<html>
 	var dataLayer_content = {"visitorDoNotTrack":1,"pagePostType":"product","pagePostType2":"single-product","pagePostAuthor":"remy","productRatingCounts":[],"productAverageRating":0,"productReviewCount":0,"productType":"simple","productIsVariable":0,"event":"gtm4wp.changeDetailViewEEC","ecommerce":{"currencyCode":"CAD","detail":{"products":[{"id":1762,"name":"Beanie","sku":1762,"category":"Accessories","price":18,"stocklevel":null}]}}};
 	dataLayer.push( dataLayer_content );//]]>
 </script>
-<script>window.ninja_table_instance_0={table_id:"1067",title:"MYGA Rates National - Sheet1.csv (Imported From Table Press)",caption:"",columns:[{name:"companyname",key:"companyname",title:"Company Name",breakpoints:"",type:"text",visible:!0,classes:["ninja_column_0","ninja_clmn_nm_companyname"],filterable:!0,sortable:!1,original:{key:"companyname",name:"Company Name",breakpoints:"",data_type:"text",dateFormat:"",enable_html_content:"false",header_html_content:"",contentAlign:"left",textAlign:"left",maxWidthUnit:"px",unsortable:"yes"}}]};</script>
 </body>
 </html>';
 

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/Subscriber/delayJs.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/Subscriber/delayJs.php
@@ -27,6 +27,17 @@ $html = '<html>
 	</script>
 </head>
 <body>
+<script>
+	// Billing
+	var billing_address =\' #billing_address_1\';
+	var billing_city =\'\';
+	var billing_state =\' #billing_city\';
+	var billing_zip_code =\'\';
+	var billing_country =\'\';
+	var billing_county =\'\';
+	var billing_additional_field =\'\';
+	var country_restriction =\'HK\';
+</script>
 <script>var rbs_gallery_60d183e796fbf = {"version":"3.0.7","id":27381,"class":"id27381","roboGalleryDelay":1000,"mainContainer":"#robo_gallery_main_block_rbs_gallery_60d183e796fbf","loadingContainer":"#rbs_gallery_60d183e796fbf-block-loader","loadingContainerObj":"rbs_gallery_60d183e796fbf-block-loader","columnWidth":"auto","columns":3,"resolutions":[{"columnWidth":"auto","columns":3,"maxWidth":960},{"columnWidth":"auto","columns":2,"maxWidth":650},{"columnWidth":300,"maxWidth":450}],"descBox":true,"descBoxClass":"rbs_desc_panel_light","lightboxOptions":{"gallery":{"enabled":true,"tCounter":"%curr% of %total%"}},"facebook":true,"twitter":true,"pinterest":true,"overlayEffect":"direction-aware-fade","boxesToLoadStart":6,"boxesToLoad":6,"lazyLoad":1,"waitUntilThumbLoads":1,"LoadingWord":"Loading Videos...","loadMoreWord":"Loading More Videos","noMoreEntriesWord":"No More Videos","horizontalSpaceBetweenBoxes":15,"verticalSpaceBetweenBoxes":15,"noHoverOnMobile":"false","wrapContainer":"#robo-gallery-wrap-rbs_gallery_60d183e796fbf"};</script>
 <script type="text/javascript">
 	var et_animation_data = [{"class":"et_pb_cta_0","style":"slideLeft","repeat":"once","duration":"1000ms","delay":"0ms","intensity":"50%","starting_opacity":"0%","speed_curve":"ease-in-out"}];
@@ -105,6 +116,17 @@ $delay_html_upgrade = '<html>
 	</script>
 </head>
 <body>
+<script>
+	// Billing
+	var billing_address =\' #billing_address_1\';
+	var billing_city =\'\';
+	var billing_state =\' #billing_city\';
+	var billing_zip_code =\'\';
+	var billing_country =\'\';
+	var billing_county =\'\';
+	var billing_additional_field =\'\';
+	var country_restriction =\'HK\';
+</script>
 <script>var rbs_gallery_60d183e796fbf = {"version":"3.0.7","id":27381,"class":"id27381","roboGalleryDelay":1000,"mainContainer":"#robo_gallery_main_block_rbs_gallery_60d183e796fbf","loadingContainer":"#rbs_gallery_60d183e796fbf-block-loader","loadingContainerObj":"rbs_gallery_60d183e796fbf-block-loader","columnWidth":"auto","columns":3,"resolutions":[{"columnWidth":"auto","columns":3,"maxWidth":960},{"columnWidth":"auto","columns":2,"maxWidth":650},{"columnWidth":300,"maxWidth":450}],"descBox":true,"descBoxClass":"rbs_desc_panel_light","lightboxOptions":{"gallery":{"enabled":true,"tCounter":"%curr% of %total%"}},"facebook":true,"twitter":true,"pinterest":true,"overlayEffect":"direction-aware-fade","boxesToLoadStart":6,"boxesToLoad":6,"lazyLoad":1,"waitUntilThumbLoads":1,"LoadingWord":"Loading Videos...","loadMoreWord":"Loading More Videos","noMoreEntriesWord":"No More Videos","horizontalSpaceBetweenBoxes":15,"verticalSpaceBetweenBoxes":15,"noHoverOnMobile":"false","wrapContainer":"#robo-gallery-wrap-rbs_gallery_60d183e796fbf"};</script>
 <script type="text/javascript">
 	var et_animation_data = [{"class":"et_pb_cta_0","style":"slideLeft","repeat":"once","duration":"1000ms","delay":"0ms","intensity":"50%","starting_opacity":"0%","speed_curve":"ease-in-out"}];
@@ -183,6 +205,17 @@ $delay_html = '<html>
 	</script>
 </head>
 <body>
+<script>
+	// Billing
+	var billing_address =\' #billing_address_1\';
+	var billing_city =\'\';
+	var billing_state =\' #billing_city\';
+	var billing_zip_code =\'\';
+	var billing_country =\'\';
+	var billing_county =\'\';
+	var billing_additional_field =\'\';
+	var country_restriction =\'HK\';
+</script>
 <script>var rbs_gallery_60d183e796fbf = {"version":"3.0.7","id":27381,"class":"id27381","roboGalleryDelay":1000,"mainContainer":"#robo_gallery_main_block_rbs_gallery_60d183e796fbf","loadingContainer":"#rbs_gallery_60d183e796fbf-block-loader","loadingContainerObj":"rbs_gallery_60d183e796fbf-block-loader","columnWidth":"auto","columns":3,"resolutions":[{"columnWidth":"auto","columns":3,"maxWidth":960},{"columnWidth":"auto","columns":2,"maxWidth":650},{"columnWidth":300,"maxWidth":450}],"descBox":true,"descBoxClass":"rbs_desc_panel_light","lightboxOptions":{"gallery":{"enabled":true,"tCounter":"%curr% of %total%"}},"facebook":true,"twitter":true,"pinterest":true,"overlayEffect":"direction-aware-fade","boxesToLoadStart":6,"boxesToLoad":6,"lazyLoad":1,"waitUntilThumbLoads":1,"LoadingWord":"Loading Videos...","loadMoreWord":"Loading More Videos","noMoreEntriesWord":"No More Videos","horizontalSpaceBetweenBoxes":15,"verticalSpaceBetweenBoxes":15,"noHoverOnMobile":"false","wrapContainer":"#robo-gallery-wrap-rbs_gallery_60d183e796fbf"};</script>
 <script type="text/javascript">
 	var et_animation_data = [{"class":"et_pb_cta_0","style":"slideLeft","repeat":"once","duration":"1000ms","delay":"0ms","intensity":"50%","starting_opacity":"0%","speed_curve":"ease-in-out"}];

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/Subscriber/delayJs.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/Subscriber/delayJs.php
@@ -72,6 +72,7 @@ $html = '<html>
     };
     /* ]]> */
 </script>
+<script>window.ninja_table_instance_0={table_id:"1067",title:"MYGA Rates National - Sheet1.csv (Imported From Table Press)",caption:"",columns:[{name:"companyname",key:"companyname",title:"Company Name",breakpoints:"",type:"text",visible:!0,classes:["ninja_column_0","ninja_clmn_nm_companyname"],filterable:!0,sortable:!1,original:{key:"companyname",name:"Company Name",breakpoints:"",data_type:"text",dateFormat:"",enable_html_content:"false",header_html_content:"",contentAlign:"left",textAlign:"left",maxWidthUnit:"px",unsortable:"yes"}}]};</script>
 </body>
 </html>';
 
@@ -147,6 +148,7 @@ $delay_html_upgrade = '<html>
     };
     /* ]]> */
 </script>
+<script>window.ninja_table_instance_0={table_id:"1067",title:"MYGA Rates National - Sheet1.csv (Imported From Table Press)",caption:"",columns:[{name:"companyname",key:"companyname",title:"Company Name",breakpoints:"",type:"text",visible:!0,classes:["ninja_column_0","ninja_clmn_nm_companyname"],filterable:!0,sortable:!1,original:{key:"companyname",name:"Company Name",breakpoints:"",data_type:"text",dateFormat:"",enable_html_content:"false",header_html_content:"",contentAlign:"left",textAlign:"left",maxWidthUnit:"px",unsortable:"yes"}}]};</script>
 </body>
 </html>';
 
@@ -222,6 +224,7 @@ $delay_html = '<html>
     };
     /* ]]> */
 </script>
+<script>window.ninja_table_instance_0={table_id:"1067",title:"MYGA Rates National - Sheet1.csv (Imported From Table Press)",caption:"",columns:[{name:"companyname",key:"companyname",title:"Company Name",breakpoints:"",type:"text",visible:!0,classes:["ninja_column_0","ninja_clmn_nm_companyname"],filterable:!0,sortable:!1,original:{key:"companyname",name:"Company Name",breakpoints:"",data_type:"text",dateFormat:"",enable_html_content:"false",header_html_content:"",contentAlign:"left",textAlign:"left",maxWidthUnit:"px",unsortable:"yes"}}]};</script>
 </body>
 </html>';
 


### PR DESCRIPTION
## Description

When our default exclusion list is added, we have errors with Ninja Tables, Robo Gallery, Green Popup and Woo Autocomplete Nish plugins. Some inline script need to be automatically excluded.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] On customer website by adding the exclusions using the field
- [x] On smashingcoding by updating the plugin code and checking the exclusion worked properly

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules