### PR TITLE
Clear delay JS exclusion list when updating from version older than 3.9

### DIFF
--- a/inc/Engine/Optimization/DelayJS/Admin/Settings.php
+++ b/inc/Engine/Optimization/DelayJS/Admin/Settings.php
@@ -85,11 +85,6 @@ class Settings {
 			&&
 			1 === (int) $options['delay_js']
 		) {
-			$options['delay_js_exclusions']   = [
-				$this->get_excluded_internal_paths(),
-				'/jquery-?[0-9.]*(.min|.slim|.slim.min)?.js',
-				'js-(before|after)',
-			];
 			$options['minify_concatenate_js'] = 0;
 		}
 
@@ -153,35 +148,4 @@ class Settings {
 		return $value;
 	}
 
-	/**
-	 * Gets a regex pattern of excluded paths for wp-content and wp-includes
-	 *
-	 * @since 3.9
-	 *
-	 * @return string
-	 */
-	private function get_excluded_internal_paths() : string {
-		$wp_content  = wp_parse_url( content_url( '/' ), PHP_URL_PATH );
-		$wp_includes = wp_parse_url( includes_url( '/' ), PHP_URL_PATH );
-		$pattern     = '(?:placeholder)(.*)';
-		$paths       = [];
-
-		if (
-			! $wp_content
-			&&
-			! $wp_includes
-		) {
-			return '';
-		}
-
-		if ( $wp_content ) {
-			$paths[] = $wp_content;
-		}
-
-		if ( $wp_includes ) {
-			$paths[] = $wp_includes;
-		}
-
-		return str_replace( 'placeholder', implode( '|', $paths ), $pattern );
-	}
 }

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/Admin/Subscriber/setOptionOnUpdate.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/Admin/Subscriber/setOptionOnUpdate.php
@@ -31,11 +31,7 @@ return [
 		'expected'      => [
 			'delay_js'              => 1,
 			'minify_concatenate_js' => 0,
-			'delay_js_exclusions'   => [
-				'(?:/wp-content/|/wp-includes/)(.*)',
-				'/jquery-?[0-9.]*(.min|.slim|.slim.min)?.js',
-				'js-(before|after)',
-			],
+			'delay_js_exclusions'   => [],
 		],
 	],
 ];


### PR DESCRIPTION
## Description

Stop adding the default exclusion list to delay JS and make it empty for users updating from versions older than 3.9

Fixes #4111

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Is the solution different from the one proposed during the grooming?

Please describe in this section any change to the solution, and why.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] We have Integration tests covering this update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules