### PR TITLE
Auto-exclusion for WooCommerce Product Gallery when Delay JS is enabled

### DIFF
--- a/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber.php
+++ b/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber.php
@@ -1,19 +1,18 @@
 <?php
 namespace WP_Rocket\ThirdParty\Plugins\Ecommerce;
 
+use WP_Rocket\Engine\Optimization\DelayJS\HTML;
 use WP_Rocket\Event_Management\Event_Manager;
 use WP_Rocket\Event_Management\Event_Manager_Aware_Subscriber_Interface;
-use WooCommerce;
-use WC_API;
+use WP_Rocket\Traits\Config_Updater;
 
 /**
  * WooCommerce compatibility
  *
  * @since 3.1
- * @author Remy Perona
  */
 class WooCommerceSubscriber implements Event_Manager_Aware_Subscriber_Interface {
-	use \WP_Rocket\Traits\Config_Updater;
+	use Config_Updater;
 
 	/**
 	 * The WordPress Event Manager
@@ -21,6 +20,22 @@ class WooCommerceSubscriber implements Event_Manager_Aware_Subscriber_Interface 
 	 * @var Event_Manager;
 	 */
 	protected $event_manager;
+
+	/**
+	 * Delay JS HTML class.
+	 *
+	 * @var HTML
+	 */
+	private $delayjs_html;
+
+	/**
+	 * WooCommerceSubscriber constructor.
+	 *
+	 * @param HTML $delayjs_html DelayJS HTML class.
+	 */
+	public function __construct( HTML $delayjs_html ) {
+		$this->delayjs_html = $delayjs_html;
+	}
 
 	/**
 	 * {@inheritdoc}
@@ -68,6 +83,9 @@ class WooCommerceSubscriber implements Event_Manager_Aware_Subscriber_Interface 
 				$events['template_redirect'] = [ 'cache_empty_cart', -1 ];
 				$events['switch_theme']      = 'delete_cache_empty_cart';
 			}
+
+			$events['wp_enqueue_scripts']         = 'show_empty_product_gallery_with_delayJS';
+			$events['rocket_delay_js_exclusions'] = 'show_notempty_product_gallery_with_delayJS';
 		}
 
 		if ( class_exists( 'WC_API' ) ) {
@@ -484,5 +502,64 @@ class WooCommerceSubscriber implements Event_Manager_Aware_Subscriber_Interface 
 			'bookyourtravel_nonce', // Book Your Travel theme.
 			'sign_signin', // Custom Login for Improvise Theme by Noomia.
 		];
+	}
+
+	/**
+	 * Check if current product page has images in gallery.
+	 *
+	 * @return bool
+	 */
+	private function product_has_gallery_images() {
+		$product = wc_get_product( get_the_ID() );
+		return ! empty( $product->get_gallery_image_ids() );
+	}
+
+	/**
+	 * Show product gallery main image directly when delay JS is enabled.
+	 */
+	public function show_empty_product_gallery_with_delayJS() {
+		if ( ! $this->delayjs_html->is_allowed() ) {
+			return;
+		}
+
+		if ( ! is_product() ) {
+			return;
+		}
+
+		if ( $this->product_has_gallery_images() ) {
+			return;
+		}
+
+		$custom_css = '.woocommerce-product-gallery{ opacity: 1 !important; }';
+		wp_add_inline_style( 'woocommerce-layout', $custom_css );
+	}
+
+	/**
+	 * Exclude some JS files from delay JS when product gallery has images.
+	 *
+	 * @param array $exclusions Exclusions array.
+	 *
+	 * @return array
+	 */
+	public function show_notempty_product_gallery_with_delayJS( array $exclusions = [] ) {
+		if ( ! $this->delayjs_html->is_allowed() ) {
+			return $exclusions;
+		}
+
+		if ( ! is_product() ) {
+			return $exclusions;
+		}
+
+		if ( ! $this->product_has_gallery_images() ) {
+			return $exclusions;
+		}
+
+		$exclusions[] = '/jquery-?[0-9.]*(.min|.slim|.slim.min)?.js';
+		$exclusions[] = '/woocommerce/assets/js/zoom/jquery.zoom(.min)?.js';
+		$exclusions[] = '/woocommerce/assets/js/photoswipe/';
+		$exclusions[] = '/woocommerce/assets/js/flexslider/jquery.flexslider(.min)?.js';
+		$exclusions[] = '/woocommerce/assets/js/frontend/single-product(.min)?.js';
+
+		return $exclusions;
 	}
 }

--- a/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber.php
+++ b/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber.php
@@ -507,6 +507,8 @@ class WooCommerceSubscriber implements Event_Manager_Aware_Subscriber_Interface 
 	/**
 	 * Check if current product page has images in gallery.
 	 *
+	 * @since 3.9.1
+	 *
 	 * @return bool
 	 */
 	private function product_has_gallery_images() {
@@ -516,6 +518,9 @@ class WooCommerceSubscriber implements Event_Manager_Aware_Subscriber_Interface 
 
 	/**
 	 * Show product gallery main image directly when delay JS is enabled.
+	 *
+	 * @since 3.9.1
+	 *
 	 */
 	public function show_empty_product_gallery_with_delayJS() {
 		if ( ! $this->delayjs_html->is_allowed() ) {
@@ -536,6 +541,8 @@ class WooCommerceSubscriber implements Event_Manager_Aware_Subscriber_Interface 
 
 	/**
 	 * Exclude some JS files from delay JS when product gallery has images.
+	 *
+	 * @since 3.9.1
 	 *
 	 * @param array $exclusions Exclusions array.
 	 *

--- a/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber.php
+++ b/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber.php
@@ -520,7 +520,6 @@ class WooCommerceSubscriber implements Event_Manager_Aware_Subscriber_Interface 
 	 * Show product gallery main image directly when delay JS is enabled.
 	 *
 	 * @since 3.9.1
-	 *
 	 */
 	public function show_empty_product_gallery_with_delayJS() {
 		if ( ! $this->delayjs_html->is_allowed() ) {

--- a/inc/ThirdParty/ServiceProvider.php
+++ b/inc/ThirdParty/ServiceProvider.php
@@ -61,6 +61,7 @@ class ServiceProvider extends AbstractServiceProvider {
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
 			->share( 'woocommerce_subscriber', 'WP_Rocket\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber' )
+			->addArgument( $this->getContainer()->get( 'delay_js_html' ) )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
 			->share( 'syntaxhighlighter_subscriber', 'WP_Rocket\Subscriber\Third_Party\Plugins\SyntaxHighlighter_Subscriber' )

--- a/tests/Fixtures/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/showEmptyProductGalleryWithDelayJS.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/showEmptyProductGalleryWithDelayJS.php
@@ -1,0 +1,47 @@
+<?php
+return [
+	'test_data' => [
+
+		'shouldBailoutIfNotAllowed' => [
+			'input' => [
+				'is_allowed' => false,
+			],
+			'expected' => [
+				'style' => ''
+			],
+		],
+
+		'shouldBailoutIfNotInProductPage' => [
+			'input' => [
+				'is_allowed' => true,
+				'in_product_page' => false,
+			],
+			'expected' => [
+				'style' => ''
+			],
+		],
+
+		'shouldBailoutIfGalleryHasMultipleImages' => [
+			'input' => [
+				'is_allowed' => true,
+				'in_product_page' => true,
+				'has_images' => true,
+			],
+			'expected' => [
+				'style' => ''
+			],
+		],
+
+		'shouldAddStyleIfGalleryHasNoImages' => [
+			'input' => [
+				'is_allowed' => true,
+				'in_product_page' => true,
+				'has_images' => false,
+			],
+			'expected' => [
+				'style' => '.woocommerce-product-gallery{ opacity: 1 !important; }'
+			],
+		],
+
+	],
+];

--- a/tests/Fixtures/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/showNotemptyProductGalleryWithDelayJS.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/showNotemptyProductGalleryWithDelayJS.php
@@ -7,7 +7,7 @@ return [
 				'is_allowed' => false,
 			],
 			'expected' => [
-				'style' => '',
+				'excluded' => [],
 			],
 		],
 
@@ -17,29 +17,35 @@ return [
 				'in_product_page' => false,
 			],
 			'expected' => [
-				'style' => '',
+				'excluded' => [],
 			],
 		],
 
-		'shouldBailoutIfGalleryHasMultipleImages' => [
-			'input' => [
-				'is_allowed' => true,
-				'in_product_page' => true,
-				'has_images' => true,
-			],
-			'expected' => [
-				'style' => '',
-			],
-		],
-
-		'shouldAddStyleIfGalleryHasNoImages' => [
+		'shouldBailoutIfGalleryHasNoImages' => [
 			'input' => [
 				'is_allowed' => true,
 				'in_product_page' => true,
 				'has_images' => false,
 			],
 			'expected' => [
-				'style' => '.woocommerce-product-gallery{ opacity: 1 !important; }',
+				'excluded' => []
+			],
+		],
+
+		'shouldExcludeScriptsIfGalleryHasSomeImages' => [
+			'input' => [
+				'is_allowed' => true,
+				'in_product_page' => true,
+				'has_images' => true,
+			],
+			'expected' => [
+				'excluded' => [
+					'/jquery-?[0-9.]*(.min|.slim|.slim.min)?.js',
+					'/woocommerce/assets/js/zoom/jquery.zoom(.min)?.js',
+					'/woocommerce/assets/js/photoswipe/',
+					'/woocommerce/assets/js/flexslider/jquery.flexslider(.min)?.js',
+					'/woocommerce/assets/js/frontend/single-product(.min)?.js',
+				],
 			],
 		],
 

--- a/tests/Integration/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/WooTrait.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/WooTrait.php
@@ -1,0 +1,31 @@
+<?php
+namespace WP_Rocket\Tests\Integration\inc\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber;
+
+use WC_Product_Simple;
+
+trait WooTrait {
+
+	private function create_product( $gallery_image_ids = [] ) {
+		$product       = new WC_Product_Simple();
+		$product_data =
+			array(
+				'name'          => 'Dummy Product',
+				'regular_price' => 10,
+				'price'         => 10,
+				'sku'           => 'DUMMY SKU',
+				'manage_stock'  => false,
+				'tax_status'    => 'taxable',
+				'downloadable'  => false,
+				'virtual'       => false,
+				'stock_status'  => 'instock',
+				'weight'        => '1.1',
+				'gallery_image_ids' => $gallery_image_ids,
+			);
+
+		$product->set_props( $product_data );
+
+		$product->save();
+		return wc_get_product( $product->get_id() );
+	}
+
+}

--- a/tests/Integration/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/showEmptyProductGalleryWithDelayJS.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/showEmptyProductGalleryWithDelayJS.php
@@ -1,0 +1,95 @@
+<?php
+namespace WP_Rocket\Tests\Integration\inc\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber;
+
+use WP_Rocket\Engine\Optimization\DelayJS\HTML;
+use WP_Rocket\Tests\Integration\TestCase;
+use WP_Rocket\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber;
+use Mockery;
+use Brain\Monkey\Functions;
+
+/**
+ * @covers \WP_Rocket\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber::show_empty_product_gallery_with_delayJS
+ * @group WooCommerce
+ * @group ThirdParty
+ * @group WithWoo
+ */
+class Test_ShowEmptyProductGalleryWithDelayJS extends TestCase {
+
+	private $delay_js_option;
+	private $product_with_gallery;
+	private $product_without_gallery;
+
+	private function create_product( $gallery_image_ids = [] ) {
+		$product       = new \WC_Product_Simple();
+		$product_data =
+			array(
+				'name'          => 'Dummy Product',
+				'regular_price' => 10,
+				'price'         => 10,
+				'sku'           => 'DUMMY SKU',
+				'manage_stock'  => false,
+				'tax_status'    => 'taxable',
+				'downloadable'  => false,
+				'virtual'       => false,
+				'stock_status'  => 'instock',
+				'weight'        => '1.1',
+				'gallery_image_ids' => $gallery_image_ids,
+			);
+
+		$product->set_props( $product_data );
+
+		$product->save();
+		return wc_get_product( $product->get_id() );
+	}
+
+	public function setUp() : void {
+		parent::setUp();
+
+		$this->product_without_gallery = $this->create_product();
+		$this->product_with_gallery = $this->create_product( [1, 2, 3] );
+	}
+
+	public function tearDown() : void {
+		parent::tearDown();
+
+		remove_filter( 'pre_get_rocket_option_delay_js', [ $this, 'set_delay_js' ] );
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnExpected( $config, $expected ) {
+		$this->delay_js_option      = $config['is_allowed'] ?? false;
+		$in_product_page = $config['in_product_page'] ?? null;
+		$has_images      = $config['has_images'] ?? null;
+
+		add_filter( 'pre_get_rocket_option_delay_js', [ $this, 'set_delay_js' ] );
+
+		if ( $in_product_page ) {
+			$this->go_to( $has_images ? $this->product_with_gallery->get_permalink() : $this->product_without_gallery->get_permalink() );
+		}else{
+			$this->go_to( home_url() );
+		}
+
+		foreach ( wp_styles()->registered as $style ) {
+			if ( 'woocommerce-layout' === $style->handle ) {
+				$this->assertArrayNotHasKey( 'after', $style->extra );
+			}
+		}
+
+		do_action( 'wp_enqueue_scripts' );
+
+		foreach ( wp_styles()->registered as $style ) {
+			if ( 'woocommerce-layout' === $style->handle ) {
+				$this->assertArrayHasKey( 'after', $style->extra );
+				$this->assertNotEmpty( ($style->extra)['after'] );
+				$this->assertContains( '.woocommerce-product-gallery{ opacity: 1 !important; }', ($style->extra)['after'] );
+			}
+		}
+	}
+
+	public function set_delay_js($options) {
+		return $this->delay_js_option;
+	}
+
+}

--- a/tests/Integration/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/showEmptyProductGalleryWithDelayJS.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/showEmptyProductGalleryWithDelayJS.php
@@ -79,13 +79,21 @@ class Test_ShowEmptyProductGalleryWithDelayJS extends TestCase {
 
 		do_action( 'wp_enqueue_scripts' );
 
+		$extra_after = [];
 		foreach ( wp_styles()->registered as $style ) {
 			if ( 'woocommerce-layout' === $style->handle ) {
-				$this->assertArrayHasKey( 'after', $style->extra );
-				$this->assertNotEmpty( ($style->extra)['after'] );
-				$this->assertContains( '.woocommerce-product-gallery{ opacity: 1 !important; }', ($style->extra)['after'] );
+				$extra_after = $style->extra;
 			}
 		}
+
+		if ( empty( $expected['style'] ) ) {
+			$this->assertArrayNotHasKey( 'after', $extra_after );
+		}else{
+			$this->assertArrayHasKey( 'after', $extra_after );
+			$this->assertNotEmpty( $extra_after['after'] );
+			$this->assertContains( '.woocommerce-product-gallery{ opacity: 1 !important; }', $extra_after['after'] );
+		}
+
 	}
 
 	public function set_delay_js($options) {

--- a/tests/Integration/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/showEmptyProductGalleryWithDelayJS.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/showEmptyProductGalleryWithDelayJS.php
@@ -1,12 +1,7 @@
 <?php
 namespace WP_Rocket\Tests\Integration\inc\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber;
 
-use WP_Rocket\Engine\Optimization\DelayJS\HTML;
 use WP_Rocket\Tests\Integration\TestCase;
-use WP_Rocket\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber;
-use Mockery;
-use Brain\Monkey\Functions;
-
 /**
  * @covers \WP_Rocket\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber::show_empty_product_gallery_with_delayJS
  * @group WooCommerce

--- a/tests/Integration/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/showNotemptyProductGalleryWithDelayJS.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/showNotemptyProductGalleryWithDelayJS.php
@@ -1,11 +1,7 @@
 <?php
 namespace WP_Rocket\Tests\Integration\inc\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber;
 
-use WP_Rocket\Engine\Optimization\DelayJS\HTML;
 use WP_Rocket\Tests\Integration\TestCase;
-use WP_Rocket\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber;
-use Mockery;
-use Brain\Monkey\Functions;
 
 /**
  * @covers \WP_Rocket\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber::show_notempty_product_gallery_with_delayJS
@@ -50,7 +46,7 @@ class Test_ShowNotEmptyProductGalleryWithDelayJS extends TestCase {
 		}
 
 		$actual = apply_filters( 'rocket_delay_js_exclusions', [] );
-		$this->assertEquals( $expected['excluded'], $actual );
+		$this->assertSame( $expected['excluded'], $actual );
 
 	}
 

--- a/tests/Integration/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/showNotemptyProductGalleryWithDelayJS.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/showNotemptyProductGalleryWithDelayJS.php
@@ -8,12 +8,12 @@ use Mockery;
 use Brain\Monkey\Functions;
 
 /**
- * @covers \WP_Rocket\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber::show_empty_product_gallery_with_delayJS
+ * @covers \WP_Rocket\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber::show_notempty_product_gallery_with_delayJS
  * @group WooCommerce
  * @group ThirdParty
  * @group WithWoo
  */
-class Test_ShowEmptyProductGalleryWithDelayJS extends TestCase {
+class Test_ShowNotEmptyProductGalleryWithDelayJS extends TestCase {
 	use WooTrait;
 
 	private $delay_js_option;
@@ -49,28 +49,8 @@ class Test_ShowEmptyProductGalleryWithDelayJS extends TestCase {
 			$this->go_to( home_url() );
 		}
 
-		foreach ( wp_styles()->registered as $style ) {
-			if ( 'woocommerce-layout' === $style->handle ) {
-				$this->assertArrayNotHasKey( 'after', $style->extra );
-			}
-		}
-
-		do_action( 'wp_enqueue_scripts' );
-
-		$extra_after = [];
-		foreach ( wp_styles()->registered as $style ) {
-			if ( 'woocommerce-layout' === $style->handle ) {
-				$extra_after = $style->extra;
-			}
-		}
-
-		if ( empty( $expected['style'] ) ) {
-			$this->assertArrayNotHasKey( 'after', $extra_after );
-		}else{
-			$this->assertArrayHasKey( 'after', $extra_after );
-			$this->assertNotEmpty( $extra_after['after'] );
-			$this->assertContains( '.woocommerce-product-gallery{ opacity: 1 !important; }', $extra_after['after'] );
-		}
+		$actual = apply_filters( 'rocket_delay_js_exclusions', [] );
+		$this->assertEquals( $expected['excluded'], $actual );
 
 	}
 

--- a/tests/Unit/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/cacheEmptyCart.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/cacheEmptyCart.php
@@ -2,8 +2,10 @@
 namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber;
 
 use Brain\Monkey\Functions;
+use WP_Rocket\Engine\Optimization\DelayJS\HTML;
 use WP_Rocket\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber;
 use WP_Rocket\Tests\Unit\TestCase;
+use Mockery;
 
 /**
  * @covers \WP_Rocket\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber::cache_empty_cart
@@ -16,10 +18,10 @@ class Test_CacheEmptyCart extends TestCase {
 	public function setUp() : void {
 		parent::setUp();
 
-		$this->subscriber = new WooCommerceSubscriber();
+		$this->subscriber = new WooCommerceSubscriber( Mockery::mock( HTML::class ) );
 	}
 
-	public function tearDown() {
+	public function tearDown() : void {
 		parent::tearDown();
 
 		unset( $_GET['wc-ajax'] );

--- a/tests/Unit/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/maybeRevertUidForNonceActions.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/maybeRevertUidForNonceActions.php
@@ -1,8 +1,10 @@
 <?php
 namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber;
 
+use WP_Rocket\Engine\Optimization\DelayJS\HTML;
 use WP_Rocket\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber;
 use WPMedia\PHPUnit\Unit\TestCase;
+use Mockery;
 
 /**
  * @covers \WP_Rocket\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber::maybe_revert_uid_for_nonce_actions
@@ -15,7 +17,7 @@ class Test_MaybeRevertUidForNonceActions extends TestCase {
 	public function setUp() : void {
 		parent::setUp();
 
-		$this->subscriber = new WooCommerceSubscriber();
+		$this->subscriber = new WooCommerceSubscriber( Mockery::mock( HTML::class ) );
 	}
 
 	/**

--- a/tests/Unit/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/serveCacheEmptyCart.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/serveCacheEmptyCart.php
@@ -2,8 +2,10 @@
 namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber;
 
 use Brain\Monkey\Functions;
+use WP_Rocket\Engine\Optimization\DelayJS\HTML;
 use WP_Rocket\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber;
 use WP_Rocket\Tests\Unit\TestCase;
+use Mockery;
 
 /**
  * @covers \WP_Rocket\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber::serve_cache_empty_cart
@@ -16,10 +18,10 @@ class Test_ServeCacheEmptyCart extends TestCase {
 	public function setUp() : void {
 		parent::setUp();
 
-		$this->subscriber = new WooCommerceSubscriber();
+		$this->subscriber = new WooCommerceSubscriber( Mockery::mock( HTML::class ) );
 	}
 
-	public function tearDown() {
+	public function tearDown() : void {
 		parent::tearDown();
 
 		unset( $_GET['wc-ajax'] );

--- a/tests/Unit/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/showEmptyProductGalleryWithDelayJS.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/showEmptyProductGalleryWithDelayJS.php
@@ -1,0 +1,85 @@
+<?php
+namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber;
+
+use WP_Rocket\Engine\Optimization\DelayJS\HTML;
+use WP_Rocket\Tests\Unit\TestCase;
+use WP_Rocket\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber;
+use Mockery;
+use Brain\Monkey\Functions;
+
+/**
+ * @covers \WP_Rocket\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber::show_empty_product_gallery_with_delayJS
+ * @group WooCommerce
+ * @group ThirdParty
+ */
+class Test_ShowEmptyProductGalleryWithDelayJS extends TestCase {
+
+	private $subscriber;
+	private $delayjs_html;
+
+	public function setUp() : void {
+		parent::setUp();
+
+		$this->delayjs_html = Mockery::mock( HTML::class );
+		$this->subscriber   = new WooCommerceSubscriber( $this->delayjs_html );
+	}
+
+	public function tearDown() : void {
+		parent::tearDown();
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnExpected( $config, $expected ) {
+		$is_allowed      = $config['is_allowed'] ?? null;
+		$in_product_page = $config['in_product_page'] ?? null;
+		$has_images      = $config['has_images'] ?? null;
+
+		if ( ! is_null( $is_allowed ) ) {
+			$this->delayjs_html->shouldReceive( 'is_allowed' )->once()->andReturn( $is_allowed );
+		}
+
+		if ( ! is_null( $in_product_page ) ) {
+			Functions\expect( 'is_product' )
+				->once()
+				->withNoArgs()
+				->andReturn( $in_product_page );
+		}
+
+		if ( ! is_null( $has_images ) ) {
+			Functions\expect( 'get_the_ID' )
+				->once()
+				->withNoArgs()
+				->andReturn( 'product_id' );
+
+			$product = new class( $has_images ) {
+				private $has_images;
+				public function __construct( $has_images ) {
+					$this->has_images = $has_images;
+				}
+
+				public function get_gallery_image_ids() {
+					return (int) $this->has_images;
+				}
+			};
+
+			Functions\expect( 'wc_get_product' )
+				->once()
+				->with( 'product_id' )
+				->andReturn( $product );
+		}
+
+		if ( ! empty( $expected['style'] ) ) {
+			Functions\expect( 'wp_add_inline_style' )
+				->once()
+				->with( 'woocommerce-layout', $expected['style'] );
+		}else{
+			Functions\expect( 'wp_add_inline_style' )
+				->never();
+		}
+
+		$this->subscriber->show_empty_product_gallery_with_delayJS();
+	}
+
+}

--- a/tests/Unit/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/showNotemptyProductGalleryWithDelayJS.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/showNotemptyProductGalleryWithDelayJS.php
@@ -1,0 +1,78 @@
+<?php
+namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber;
+
+use WP_Rocket\Engine\Optimization\DelayJS\HTML;
+use WP_Rocket\Tests\Unit\TestCase;
+use WP_Rocket\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber;
+use Mockery;
+use Brain\Monkey\Functions;
+
+/**
+ * @covers \WP_Rocket\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber::show_notempty_product_gallery_with_delayJS
+ * @group WooCommerce
+ * @group ThirdParty
+ */
+class Test_ShowNotemptyProductGalleryWithDelayJS extends TestCase {
+
+	private $subscriber;
+	private $delayjs_html;
+
+	public function setUp() : void {
+		parent::setUp();
+
+		$this->delayjs_html = Mockery::mock( HTML::class );
+		$this->subscriber   = new WooCommerceSubscriber( $this->delayjs_html );
+	}
+
+	public function tearDown() : void {
+		parent::tearDown();
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnExpected( $config, $expected ) {
+		$is_allowed      = $config['is_allowed'] ?? null;
+		$in_product_page = $config['in_product_page'] ?? null;
+		$has_images      = $config['has_images'] ?? null;
+
+		if ( ! is_null( $is_allowed ) ) {
+			$this->delayjs_html->shouldReceive( 'is_allowed' )->once()->andReturn( $is_allowed );
+		}
+
+		if ( ! is_null( $in_product_page ) ) {
+			Functions\expect( 'is_product' )
+				->once()
+				->withNoArgs()
+				->andReturn( $in_product_page );
+		}
+
+		if ( ! is_null( $has_images ) ) {
+			Functions\expect( 'get_the_ID' )
+				->once()
+				->withNoArgs()
+				->andReturn( 'product_id' );
+
+			$product = new class( $has_images ) {
+				private $has_images;
+				public function __construct( $has_images ) {
+					$this->has_images = $has_images;
+				}
+
+				public function get_gallery_image_ids() {
+					return (int) $this->has_images;
+				}
+			};
+
+			Functions\expect( 'wc_get_product' )
+				->once()
+				->with( 'product_id' )
+				->andReturn( $product );
+		}
+
+		$actual = $this->subscriber->show_notempty_product_gallery_with_delayJS( [] );
+
+		$this->assertSame( $expected['excluded'], $actual );
+	}
+
+}


### PR DESCRIPTION
## Description

As mentioned on the issue itself we need to show the gallery directly into the page once loaded.

Fixes #4077

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Is the solution different from the one proposed during the grooming?

I did some research on the issue itself but didn't groom.

## How Has This Been Tested?

- [ ] Test A
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules