### PR TITLE
Add jquery migrate to delay JS exclusions for woocommerce gallery and default list

### DIFF
--- a/inc/Engine/Optimization/DelayJS/Admin/Settings.php
+++ b/inc/Engine/Optimization/DelayJS/Admin/Settings.php
@@ -156,10 +156,17 @@ class Settings {
 	 * @return string[]
 	 */
 	public static function get_delay_js_default_exclusions(): array {
-		$exclusions  = [
+		global $wp_version;
+
+		$exclusions = [
 			'/jquery-?[0-9.](.*)(.min|.slim|.slim.min)?.js',
 			'js-(before|after)',
 		];
+
+		if ( version_compare( $wp_version, '5.7', '<=' ) ) {
+			$exclusions[] = '/jquery-migrate(.min)?.js';
+		}
+
 		$wp_content  = wp_parse_url( content_url( '/' ), PHP_URL_PATH );
 		$wp_includes = wp_parse_url( includes_url( '/' ), PHP_URL_PATH );
 		$pattern     = '(?:placeholder)(.*)';

--- a/inc/Engine/Optimization/DelayJS/Admin/Settings.php
+++ b/inc/Engine/Optimization/DelayJS/Admin/Settings.php
@@ -163,7 +163,7 @@ class Settings {
 			'js-(before|after)',
 		];
 
-		if ( version_compare( $wp_version, '5.7', '<=' ) ) {
+		if ( version_compare( $wp_version, '5.7', '<' ) ) {
 			$exclusions[] = '/jquery-migrate(.min)?.js';
 		}
 

--- a/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber.php
+++ b/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber.php
@@ -568,7 +568,7 @@ class WooCommerceSubscriber implements Event_Manager_Aware_Subscriber_Interface 
 		$exclusions[] = '/woocommerce/assets/js/flexslider/jquery.flexslider(.min)?.js';
 		$exclusions[] = '/woocommerce/assets/js/frontend/single-product(.min)?.js';
 
-		if ( version_compare( $wp_version, '5.7', '<=' ) ) {
+		if ( version_compare( $wp_version, '5.7', '<' ) ) {
 			$exclusions[] = '/jquery-migrate(.min)?.js';
 		}
 

--- a/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber.php
+++ b/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber.php
@@ -548,6 +548,8 @@ class WooCommerceSubscriber implements Event_Manager_Aware_Subscriber_Interface 
 	 * @return array
 	 */
 	public function show_notempty_product_gallery_with_delayJS( array $exclusions = [] ) {
+		global $wp_version;
+
 		if ( ! $this->delayjs_html->is_allowed() ) {
 			return $exclusions;
 		}
@@ -565,6 +567,10 @@ class WooCommerceSubscriber implements Event_Manager_Aware_Subscriber_Interface 
 		$exclusions[] = '/woocommerce/assets/js/photoswipe/';
 		$exclusions[] = '/woocommerce/assets/js/flexslider/jquery.flexslider(.min)?.js';
 		$exclusions[] = '/woocommerce/assets/js/frontend/single-product(.min)?.js';
+
+		if ( version_compare( $wp_version, '5.7', '<=' ) ) {
+			$exclusions[] = '/jquery-migrate(.min)?.js';
+		}
 
 		return $exclusions;
 	}

--- a/tests/Fixtures/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/showNotemptyProductGalleryWithDelayJS.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/showNotemptyProductGalleryWithDelayJS.php
@@ -32,11 +32,31 @@ return [
 			],
 		],
 
-		'shouldExcludeScriptsIfGalleryHasSomeImages' => [
+		'shouldExcludeScriptsIfGalleryHasSomeImagesWithWP5.6' => [
 			'input' => [
 				'is_allowed' => true,
 				'in_product_page' => true,
 				'has_images' => true,
+				'wp_version' => '5.6',
+			],
+			'expected' => [
+				'excluded' => [
+					'/jquery-?[0-9.]*(.min|.slim|.slim.min)?.js',
+					'/woocommerce/assets/js/zoom/jquery.zoom(.min)?.js',
+					'/woocommerce/assets/js/photoswipe/',
+					'/woocommerce/assets/js/flexslider/jquery.flexslider(.min)?.js',
+					'/woocommerce/assets/js/frontend/single-product(.min)?.js',
+					'/jquery-migrate(.min)?.js',
+				],
+			],
+		],
+
+		'shouldExcludeScriptsIfGalleryHasSomeImagesWithWP5.7' => [
+			'input' => [
+				'is_allowed' => true,
+				'in_product_page' => true,
+				'has_images' => true,
+				'wp_version' => '5.7',
 			],
 			'expected' => [
 				'excluded' => [

--- a/tests/Integration/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/showNotemptyProductGalleryWithDelayJS.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/showNotemptyProductGalleryWithDelayJS.php
@@ -15,16 +15,25 @@ class Test_ShowNotEmptyProductGalleryWithDelayJS extends TestCase {
 	private $delay_js_option;
 	private $product_with_gallery;
 	private $product_without_gallery;
+	private $wp_version;
 
 	public function setUp() : void {
+		global $wp_version;
+
 		parent::setUp();
 
 		$this->product_without_gallery = $this->create_product();
 		$this->product_with_gallery = $this->create_product( [1, 2, 3] );
+
+		$this->wp_version = $wp_version;
 	}
 
 	public function tearDown() : void {
+		global $wp_version;
+
 		parent::tearDown();
+
+		$wp_version = $this->wp_version;
 
 		remove_filter( 'pre_get_rocket_option_delay_js', [ $this, 'set_delay_js' ] );
 	}
@@ -33,9 +42,15 @@ class Test_ShowNotEmptyProductGalleryWithDelayJS extends TestCase {
 	 * @dataProvider configTestData
 	 */
 	public function testShouldReturnExpected( $config, $expected ) {
-		$this->delay_js_option      = $config['is_allowed'] ?? false;
-		$in_product_page = $config['in_product_page'] ?? null;
-		$has_images      = $config['has_images'] ?? null;
+		$this->delay_js_option = $config['is_allowed'] ?? false;
+		$in_product_page       = $config['in_product_page'] ?? null;
+		$has_images            = $config['has_images'] ?? null;
+		$current_wp_version            = $config['wp_version'] ?? null;
+
+		if ( ! is_null( $current_wp_version ) ) {
+			global $wp_version;
+			$wp_version = $current_wp_version;
+		}
 
 		add_filter( 'pre_get_rocket_option_delay_js', [ $this, 'set_delay_js' ] );
 

--- a/tests/Unit/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/showNotemptyProductGalleryWithDelayJS.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/showNotemptyProductGalleryWithDelayJS.php
@@ -25,6 +25,8 @@ class Test_ShowNotemptyProductGalleryWithDelayJS extends TestCase {
 	}
 
 	public function tearDown() : void {
+		unset( $GLOBALS['wp_version']);
+
 		parent::tearDown();
 	}
 
@@ -32,9 +34,15 @@ class Test_ShowNotemptyProductGalleryWithDelayJS extends TestCase {
 	 * @dataProvider configTestData
 	 */
 	public function testShouldReturnExpected( $config, $expected ) {
-		$is_allowed      = $config['is_allowed'] ?? null;
-		$in_product_page = $config['in_product_page'] ?? null;
-		$has_images      = $config['has_images'] ?? null;
+		$is_allowed         = $config['is_allowed'] ?? null;
+		$in_product_page    = $config['in_product_page'] ?? null;
+		$has_images         = $config['has_images'] ?? null;
+		$current_wp_version = $config['wp_version'] ?? null;
+
+		if ( ! is_null( $current_wp_version ) ) {
+			global $wp_version;
+			$wp_version = $current_wp_version;
+		}
 
 		if ( ! is_null( $is_allowed ) ) {
 			$this->delayjs_html->shouldReceive( 'is_allowed' )->once()->andReturn( $is_allowed );


### PR DESCRIPTION
## Description

Add jquery migrate to delay JS exclusions for woocommerce gallery and the default list.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)


## Is the solution different from the one proposed during the grooming?

Not groomed.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Updated automated tests

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
