### PR TITLE
Fix 4161 - Unnecessary database growth due to urls with same content

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Database/Queries/ResourcesQuery.php
+++ b/inc/Engine/Optimization/RUCSS/Database/Queries/ResourcesQuery.php
@@ -74,7 +74,7 @@ class ResourcesQuery extends Query {
 	 *
 	 * @param array $resource Resource array.
 	 *
-	 * @return bool
+	 * @return bool|int False if neither created or updated, or row-id of the new or modified resource.
 	 */
 	public function create_or_update( array $resource ) {
 		$hash = md5( $resource['content'] );
@@ -118,7 +118,7 @@ class ResourcesQuery extends Query {
 		);
 
 		// Check the content hash and bailout if the content is the same and we are not in prewarmup.
-		if ( $hash === $db_row->hash && ! $resource['prewarmup'] ) {
+		if ( $hash === $db_row->hash && 0 === ( $resource['prewarmup'] ?? 0 ) ) {
 			// Do nothing.
 			return false;
 		}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -16,6 +16,7 @@
 	<exclude-pattern>/inc/vendors/*</exclude-pattern>
 	<exclude-pattern>/tests/*</exclude-pattern>
 	<exclude-pattern>/vendor/*</exclude-pattern>
+	<exclude-pattern>/node_modules/*</exclude-pattern>
 
 	<!-- ** HOW TO SCAN ** -->
 

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Database/Queries/ResourcesQuery/createOrUpdate.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Database/Queries/ResourcesQuery/createOrUpdate.php
@@ -26,7 +26,7 @@ class Test_CreateOrUpdate extends TestCase{
 		self::uninstallAll();
 	}
 
-	public function testShouldCreateNewItemIfNotExists(){
+	public function testShouldCreateNewItemIfUrlAndHashUnmatched() {
 		$container             = apply_filters( 'rocket_container', null );
 		$rucss_resources_query = $container->get( 'rucss_resources_query' );
 
@@ -38,13 +38,44 @@ class Test_CreateOrUpdate extends TestCase{
 		];
 
 		$this->assertFalse( $rucss_resources_query->get_item_by( 'url', $item['url'] ) );
+		$this->assertFalse( $rucss_resources_query->get_item_by( 'hash', md5( $item['content'] ) ) );
 
 		$this->assertGreaterThan( 0, $rucss_resources_query->create_or_update( $item ) );
 
 		$this->assertIsObject( $rucss_resources_query->get_item_by( 'url', $item['url'] ) );
 	}
 
-	public function testShouldUpdateItemIfExists(){
+	public function testShouldNotCreateOrUpdateItemIfHashMatchesResource() {
+		$container             = apply_filters( 'rocket_container', null );
+		$rucss_resources_query = $container->get( 'rucss_resources_query' );
+
+		$item1 = [
+			'url'           => 'https://www.example.org/style.css',
+			'type'          => 'css',
+			'content'       => '.example{color:red;}',
+			'media'         => 'all',
+			'hash'          => md5('.example{color:red;}'), // original item is stored with a hash
+			'last_accessed' => $stored_last_access = current_time( 'mysql', true )
+		];
+
+		$item2 = [
+			'url'           => 'https://www.example.org/style.css?ver=12134534537abx',
+			'type'          => 'css',
+			'content'       => '.example{color:red;}',
+			'media'         => 'all',
+		];
+
+		$original_id = $rucss_resources_query->add_item( $item1 );
+
+		$this->assertFalse( $rucss_resources_query->get_item_by( 'url', $item2['url'] ) );
+		$this->assertIsObject( $rucss_resources_query->get_item_by( 'hash', md5( $item2['content'] ) ) );
+
+		// Assert that we have not changed the original item, except to update the last_accessed time.
+		$this->assertFalse( $rucss_resources_query->create_or_update( $item2 ) );
+		$this->assertGreaterThan( $stored_last_access, $rucss_resources_query->get_item_by( 'url', $item1['url'] ) );
+	}
+
+	public function testShouldUpdateItemIfExists() {
 		$container             = apply_filters( 'rocket_container', null );
 		$rucss_resources_query = $container->get( 'rucss_resources_query' );
 
@@ -70,6 +101,4 @@ class Test_CreateOrUpdate extends TestCase{
 		$this->assertIsObject( $new_row );
 		$this->assertSame( $new_row->content, $item['content'] );
 	}
-
-
 }


### PR DESCRIPTION
## Description

Fixes #4161 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement - Also adds exclude files pattern for `node_modules/*` to our phpcs

## Is the solution different from the one proposed during the grooming?

Per grooming, checking the URL first, and then the hash when url is not matched to make sure content is also different.
Also, because the 'prewarmup' item in the resource can now be unset when checking for change against hash we need to update how this check is made to avoid the php error in those conditions.

## How Has This Been Tested?


# Checklist:

Please delete the options that are not relevant.

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
