### PR TITLE
Regression with minify JS strip single line comments

### DIFF
--- a/inc/Dependencies/Minify/JS.php
+++ b/inc/Dependencies/Minify/JS.php
@@ -219,7 +219,7 @@ class JS extends Minify
 		$this->registerPattern('/\n?\/\*(.*?)\*\/\n?/s', $callback);
 
 		// single-line comments
-		$this->registerPattern('/(\/\/)(?!i)(?!\.).*$/m', '');
+		$this->registerPattern('/\/\/.*$/m', '');
 	}
 
 	/**


### PR DESCRIPTION
## Description

Revert one of the changes introduced in #3907, specifically the change to the pattern for single comments stripping (issue #2974).

The initial change was introduced to prevent stripping RegEx inside JS. But it creates side-effects when single line comments contains a similar pattern (`//i` or `//.`).

An example:
```
function codeAddress(data) {
    "use strict";

    if (data === '')
    return;

    var contentString = '<div id="content">'+
        '<div id="siteNotice">'+
            '</div>'+
        '<div id="bodyContent">'+
            '<p>'+data+'</p>'+
            '</div>'+
        '</div>';
    var infowindow = new google.maps.InfoWindow({
    content: contentString
    });
    geocoder.geocode( { 'address': data}, function(results, status) {
        if (status === google.maps.GeocoderStatus.OK) {
            map.setCenter(results[0].geometry.location);
            var marker = new google.maps.Marker({
                map: map,
                position: results[0].geometry.location,
                icon:  'http://demo.qodeinteractive.com/bridge83/wp-content/themes/bridge/img/pin.png',
                title: data['store_title']
            });
            google.maps.event.addListener(marker, 'click', function() {
                infowindow.open(map,marker);
            });
            //infowindow.open(map,marker);
        }
    });
}
```

is minified to:
```
function codeAddress(data){"use strict";if(data==='')
return;var contentString='<div id="content">'+'<div id="siteNotice">'+'</div>'+'<div id="bodyContent">'+'<p>'+data+'</p>'+'</div>'+'</div>';var infowindow=new google.maps.InfoWindow({content:contentString});geocoder.geocode({'address':data},function(results,status){if(status===google.maps.GeocoderStatus.OK){map.setCenter(results[0].geometry.location);var marker=new google.maps.Marker({map:map,position:results[0].geometry.location,icon:'http://demo.qodeinteractive.com/bridge83/wp-content/themes/bridge/img/pin.png',title:data.store_title});google.maps.event.addListener(marker,'click',function(){infowindow.open(map,marker)});//infowindow.open(map,marker)}})}
```

Notice the preserved comment at the end, and since it's on the same line, the following closing parenthesis/brackets are considered inside the comments, thus breaking the code.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Reverting back to previous pattern which is working fine in most cases, except for RegEx pattern inside JS
- [x] Tested with user website JS files affected by the issue with 3.9.1

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
