### PR TITLE
Prevent error if $wp_version is not defined in Delay JS code

### DIFF
--- a/inc/Engine/Optimization/DelayJS/Admin/Settings.php
+++ b/inc/Engine/Optimization/DelayJS/Admin/Settings.php
@@ -163,7 +163,11 @@ class Settings {
 			'js-(before|after)',
 		];
 
-		if ( version_compare( $wp_version, '5.7', '<' ) ) {
+		if (
+			isset( $wp_version )
+			&&
+			version_compare( $wp_version, '5.7', '<' )
+		) {
 			$exclusions[] = '/jquery-migrate(.min)?.js';
 		}
 

--- a/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber.php
+++ b/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber.php
@@ -568,7 +568,11 @@ class WooCommerceSubscriber implements Event_Manager_Aware_Subscriber_Interface 
 		$exclusions[] = '/woocommerce/assets/js/flexslider/jquery.flexslider(.min)?.js';
 		$exclusions[] = '/woocommerce/assets/js/frontend/single-product(.min)?.js';
 
-		if ( version_compare( $wp_version, '5.7', '<' ) ) {
+		if (
+			isset( $wp_version )
+			&&
+			version_compare( $wp_version, '5.7', '<' )
+		) {
 			$exclusions[] = '/jquery-migrate(.min)?.js';
 		}
 


### PR DESCRIPTION
## Description

One user reported the following error when updating to 3.9.1:

```
Error details
=======================
An E_ERROR type error was caused in line 166 of the /wp-content/plugins/wp-rocket/inc/Engine/Optimization/DelayJS/Admin/Settings.php file.
Error message: Uncaught TypeError: version_compare () expects parameter 1 to be string, null given in
/wp-content/plugins/wp-rocket/inc/Engine/Optimization/DelayJS/Admin/Settings.php:166
Stack trace:
/wp-content/plugins/wp-rocket/inc/Engine/Optimization/DelayJS/Admin/Settings.php(166):
version_compare (NULL, '5.7', ' 
``` 

`$wp_version` should always be set in the normal WP loading behaviour, but to be safe, I'm adding an `isset()` check for it before using it in the `version_compare()` call.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

No test was performed for this change, as we're not able to reproduce the error. But the change is safe, as it's adding a layer of validation.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
