### PR TITLE
Change Purge to Ban for clear_home

### DIFF
--- a/inc/ThirdParty/Hostings/Godaddy.php
+++ b/inc/ThirdParty/Hostings/Godaddy.php
@@ -121,8 +121,8 @@ class Godaddy implements Subscriber_Interface {
 		$home_url            = trailingslashit( get_rocket_i18n_home_url( $lang ) );
 		$home_pagination_url = $home_url . trailingslashit( $GLOBALS['wp_rewrite']->pagination_base );
 
-		$this->purge_request( 'PURGE', $home_url );
-		$this->purge_request( 'PURGE', $home_pagination_url );
+		$this->purge_request( 'BAN', $home_url );
+		$this->purge_request( 'BAN', $home_pagination_url );
 	}
 
 

--- a/tests/Unit/inc/ThirdParty/Hostings/Godaddy/cleanHome.php
+++ b/tests/Unit/inc/ThirdParty/Hostings/Godaddy/cleanHome.php
@@ -55,7 +55,7 @@ class Test_cleanHome extends TestCase {
 			->with(
 				$full_url,
 				[
-					'method'      => 'PURGE',
+					'method'      => 'BAN',
 					'blocking'    => false,
 					'headers'     => [
 						'Host' => $host,
@@ -68,7 +68,7 @@ class Test_cleanHome extends TestCase {
 			->with(
 				$full_url .'/page',
 				[
-					'method'      => 'PURGE',
+					'method'      => 'BAN',
 					'blocking'    => false,
 					'headers'     => [
 						'Host' => $host,


### PR DESCRIPTION
## Description

Very small adjustment to update #4094 per QA of 3.9.2
Changes GoDaddy clear_home from PURGE to BAN.

Fixes #(issue number)
#3690 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

Please describe in this section if there is any change to the solution, and why.

QA Observed that BAN is needed to purge the varnish cache -- PURGE was not working.

# Checklist:

Please delete the options that are not relevant.

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes