### PR TITLE
Update process.php and add a new filter for the HTML buffer

### DIFF
--- a/inc/front/process.php
+++ b/inc/front/process.php
@@ -354,6 +354,9 @@ function do_rocket_callback( $buffer ) { // phpcs:ignore WordPress.NamingConvent
 			if ( $is_html ) {
 				$footprint = get_rocket_footprint();
 			}
+			
+			// allow buffer override before saving cache file
+			$buffer = apply_filters( 'rocket_override_html_buffer', $buffer);
 
 			// Save the cache file.
 			rocket_put_content( $rocket_cache_filepath, $buffer . $footprint );


### PR DESCRIPTION
Add a new filter called `rocket_override_html_buffer` to allow modification of the HTML buffer before cache saving.

Fixes #4272

## Type of change
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
It's just 1 line of code with a new filter.

# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
