### PR TITLE
Update to composer 2 in Github actions

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -42,7 +42,7 @@ jobs:
       with:
         php-version: ${{ matrix.php-versions }}
         coverage: xdebug
-        tools: composer:v1, phpunit
+        tools: composer:v2, phpunit
 
     - name: Setup problem matchers for PHP
       run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"

--- a/.github/workflows/deploy_plugin.yml
+++ b/.github/workflows/deploy_plugin.yml
@@ -1,6 +1,6 @@
 on:
   release:
-    types: 
+    types:
       - published
 
 name: Deploy Rocket Plugin
@@ -15,7 +15,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'
-          tools: composer:v1
+          tools: composer:v2
 
       - name: Get composer cache directory
         id: composercache
@@ -37,7 +37,7 @@ jobs:
       - name: Run composer
         run: composer install --no-scripts --no-dev
         working-directory: /tmp/wp-rocket
-  
+
       - name: Zip Folder
         run: zip -r __wp-rocket_${GITHUB_REF##*v}.zip wp-rocket
         working-directory: /tmp
@@ -61,8 +61,8 @@ jobs:
         run: |
           /usr/bin/swift upload rocket-plugin __wp-rocket_${GITHUB_REF##*v}.zip
           /usr/bin/swift post --header "X-Delete-After: 600" rocket-plugin __wp-rocket_${GITHUB_REF##*v}.zip
-        
-            
+
+
       # Call the webhook on AWX to fetch and deploy the zip
       - name: Invoke deployment hook
         uses: distributhor/workflow-webhook@v1

--- a/.github/workflows/lint_phpstan.yml
+++ b/.github/workflows/lint_phpstan.yml
@@ -11,13 +11,13 @@ on:
 jobs:
   run:
     runs-on: ${{ matrix.operating-system }}
-    
+
     strategy:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-latest]
         php-versions: ['7.4']
-    
+
     name: WPRocket lint with PHPStan. PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }}.
     steps:
     - name: Checkout
@@ -28,7 +28,7 @@ jobs:
       with:
         php-version: ${{ matrix.php-versions }}
         coverage: none  # XDebug can be enabled here 'coverage: xdebug'
-        tools: composer:v1
+        tools: composer:v2
 
     # Linting
     - name: Lint with phpstan


### PR DESCRIPTION
## Description

Use composer 2 instead of composer 1 in some of our Github actions that were not updated yet.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
