### PR TITLE
Ignore node_modules directories in phpcs

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -16,6 +16,7 @@
 	<exclude-pattern>/inc/vendors/*</exclude-pattern>
 	<exclude-pattern>/tests/*</exclude-pattern>
 	<exclude-pattern>/vendor/*</exclude-pattern>
+	<exclude-pattern>/node_modules/*</exclude-pattern>
 
 	<!-- ** HOW TO SCAN ** -->
 


### PR DESCRIPTION
## Description

After running npm install there are node modules that phpcs flags. We should ignore these.

## Type of change

- [X] Enhancement (non-breaking change which improves an existing functionality)

Testing:
With node_modules installed, phpcs passes.

# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes