### PR TITLE
Fixes #3725 Use pre_http_request filter in integration tests for API requests

### DIFF
--- a/tests/Fixtures/inc/Engine/License/API/PricingClient/getPricingData.php
+++ b/tests/Fixtures/inc/Engine/License/API/PricingClient/getPricingData.php
@@ -46,9 +46,14 @@ return [
 			'pricing-transient' => false,
 			'timeout-active'    => false,
 			'timeout-duration'  => false,
-			'response'          => [
-				'code' => 404,
-				'body' => false,
+			'response'  => [
+				'headers' => [],
+				'body' => 'error 404',
+				'response' => [
+					'code' => 404,
+				],
+				'cookies' => [],
+				'filename' => '',
 			],
 		],
 		'expected' => [
@@ -61,8 +66,14 @@ return [
 			'pricing-transient' => false,
 			'timeout-active'    => false,
 			'timeout-duration'  => false,
-			'response'          => [
-				'code' => 200,
+			'response'  => [
+				'headers' => [],
+				'body' => '',
+				'response' => [
+					'code' => 200,
+				],
+				'cookies' => [],
+				'filename' => '',
 			],
 		],
 		'expected' => [
@@ -75,9 +86,14 @@ return [
 			'pricing-transient' => false,
 			'timeout-active'    => false,
 			'timeout-duration'  => false,
-			'response'          => [
-				'code' => 200,
+			'response'  => [
+				'headers' => [],
 				'body' => $json,
+				'response' => [
+					'code' => 200,
+				],
+				'cookies' => [],
+				'filename' => '',
 			],
 		],
 		'expected' => [
@@ -90,7 +106,15 @@ return [
 			'pricing-transient' => false,
 			'timeout-active'    => false,
 			'timeout-duration'  => 300,
-			'response'          => [ 'code' => 404 ],
+			'response'  => [
+				'headers' => [],
+				'body' => 'error 404',
+				'response' => [
+					'code' => 404,
+				],
+				'cookies' => [],
+				'filename' => '',
+			],
 		],
 		'expected' => [
 			'result'           => false,
@@ -104,7 +128,15 @@ return [
 			'timeout-active'    => false,
 			'timeout-duration'  => rocket_get_constant( 'DAY_IN_SECONDS' )
 								   - rocket_get_constant( 'HOUR_IN_SECONDS' ),
-			'response'          => [ 'code' => 404 ],
+			'response'  => [
+				'headers' => [],
+				'body' => 'error 404',
+				'response' => [
+					'code' => 404,
+				],
+				'cookies' => [],
+				'filename' => '',
+			],
 		],
 		'expected' => [
 			'result'           => false,

--- a/tests/Fixtures/inc/Engine/License/API/UserClient/getUserData.php
+++ b/tests/Fixtures/inc/Engine/License/API/UserClient/getUserData.php
@@ -15,8 +15,13 @@ return [
 		'config'   => [
 			'transient' => false,
 			'response'  => [
-				'code' => 404,
-				'body' => false,
+				'headers' => [],
+				'body' => 'error 404',
+				'response' => [
+					'code' => 404,
+				],
+				'cookies' => [],
+				'filename' => '',
 			],
 		],
 		'expected' => false,
@@ -25,7 +30,13 @@ return [
 		'config'   => [
 			'transient' => false,
 			'response'  => [
-				'code' => 200,
+				'headers' => [],
+				'body' => '',
+				'response' => [
+					'code' => 200,
+				],
+				'cookies' => [],
+				'filename' => '',
 			],
 		],
 		'expected' => false,
@@ -33,7 +44,15 @@ return [
 	'testShouldReturnDataWhenCached'   => [
 		'config'   => [
 			'transient' => true,
-			'response'  => false,
+			'response'  => [
+				'headers' => [],
+				'body' => $json,
+				'response' => [
+					'code' => 200,
+				],
+				'cookies' => [],
+				'filename' => '',
+			],
 		],
 		'expected' => $data,
 	],
@@ -41,8 +60,13 @@ return [
 		'config'   => [
 			'transient' => false,
 			'response'  => [
-				'code' => 200,
+				'headers' => [],
 				'body' => $json,
+				'response' => [
+					'code' => 200,
+				],
+				'cookies' => [],
+				'filename' => '',
 			],
 		],
 		'expected' => $data,

--- a/tests/Integration/inc/Engine/License/API/PricingClient/getPricingData.php
+++ b/tests/Integration/inc/Engine/License/API/PricingClient/getPricingData.php
@@ -18,6 +18,8 @@ class GetPricingData extends TestCase {
 		'wp_rocket_pricing_timeout_active'
 	];
 
+	private $response;
+
 	public function setUp() : void {
 		parent::setUp();
 
@@ -31,6 +33,8 @@ class GetPricingData extends TestCase {
 		delete_transient( 'wp_rocket_pricing_timeout' );
 		delete_transient( 'wp_rocket_pricing_timeout_active' );
 
+		remove_filter( 'pre_http_request', [ $this, 'set_response' ] );
+
 		parent::tearDown();
 	}
 
@@ -39,6 +43,10 @@ class GetPricingData extends TestCase {
 	 */
 	public function testShouldReturnExpected( $config, $expected ) {
 		$client = new PricingClient();
+
+		$this->response = $config['response'];
+
+		add_filter( 'pre_http_request', [ $this, 'set_response' ] );
 
 		if ( true === $config['pricing-transient'] ) {
 			set_transient( 'wp_rocket_pricing', $expected['result'] );
@@ -52,26 +60,10 @@ class GetPricingData extends TestCase {
 			set_transient( 'wp_rocket_pricing_timeout_active', true, WEEK_IN_SECONDS );
 		}
 
-		if ( false === $config['timeout-active'] && false === $expected['result'] ) {
-			Functions\expect( 'wp_safe_remote_get' )
-				->once()
-				->with( PricingClient::PRICING_ENDPOINT )
-				->andReturn( $config['response'] );
-
-			$this->assertFalse( $client->get_pricing_data() );
-		} else {
-			$this->assertEquals(
-				array_keys( (array) $expected['result'] ),
-				array_keys( (array) $client->get_pricing_data() )
-			);
-
-			if ( false === $config['pricing-transient'] ) {
-				$this->assertEquals(
-					array_keys( (array) $expected['result'] ),
-					array_keys( (array) get_transient( 'wp_rocket_pricing' ) )
-				);
-			}
-		}
+		$this->assertEquals(
+			$expected['result'],
+			$client->get_pricing_data()
+		);
 
 		if ( false !== $config['timeout-duration'] ) {
 			$this->assertEquals(
@@ -79,5 +71,9 @@ class GetPricingData extends TestCase {
 				get_transient( 'wp_rocket_pricing_timeout' )
 			);
 		}
+	}
+
+	public function set_response() {
+		return $this->response;
 	}
 }

--- a/tests/Integration/inc/Engine/License/API/PricingClient/getPricingData.php
+++ b/tests/Integration/inc/Engine/License/API/PricingClient/getPricingData.php
@@ -2,7 +2,6 @@
 
 namespace WP_Rocket\Tests\Integration\inc\Engine\License\API\PricingClient;
 
-use Brain\Monkey\Functions;
 use WP_Rocket\Engine\License\API\PricingClient;
 use WP_Rocket\Tests\Integration\TestCase;
 
@@ -20,7 +19,7 @@ class GetPricingData extends TestCase {
 
 	private $response;
 
-	public function setUp() : void {
+	public function setUp(): void {
 		parent::setUp();
 
 		delete_transient( 'wp_rocket_pricing' );

--- a/tests/Integration/inc/Engine/License/API/UserClient/getUserData.php
+++ b/tests/Integration/inc/Engine/License/API/UserClient/getUserData.php
@@ -2,9 +2,7 @@
 
 namespace WP_Rocket\Tests\Integration\inc\Engine\License\API\UserClient;
 
-use Brain\Monkey\Functions;
 use WPMedia\PHPUnit\Integration\ApiTrait;
-use WP_Rocket\Engine\License\API\UserClient;
 use WP_Rocket\Tests\Integration\TestCase;
 
 /**
@@ -13,13 +11,14 @@ use WP_Rocket\Tests\Integration\TestCase;
  * @group License
  * @group AdminOnly
  */
-class GetUserData extends TestCase {
+class Test_GetUserData extends TestCase {
 	use ApiTrait;
 
 	protected static $api_credentials_config_file = 'license.php';
 	private static $client;
+	private $response;
 
-	public static function setUpBeforeClass() : void {
+	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
 
 		self::pathToApiCredentialsConfigFile( WP_ROCKET_TESTS_DIR . '/../env/local/' );
@@ -29,7 +28,7 @@ class GetUserData extends TestCase {
 		self::$client = $container->get( 'user_client' );
 	}
 
-	public function setUp() : void {
+	public function setUp(): void {
 		parent::setUp();
 
 		add_filter( 'pre_get_rocket_option_consumer_email', [ $this, 'set_consumer_email' ] );
@@ -40,6 +39,7 @@ class GetUserData extends TestCase {
 		delete_transient( 'wp_rocket_customer_data' );
 		remove_filter( 'pre_get_rocket_option_consumer_email', [ $this, 'set_consumer_email' ] );
 		remove_filter( 'pre_get_rocket_option_consumer_key', [ $this, 'set_consumer_key' ] );
+		remove_filter( 'pre_http_request', [ $this, 'set_response' ] );
 
 		parent::tearDown();
 	}
@@ -52,31 +52,14 @@ class GetUserData extends TestCase {
 			set_transient( 'wp_rocket_customer_data', $expected );
 		}
 
-		if ( false === $expected ) {
-			Functions\expect( 'wp_safe_remote_post' )
-			->once()
-			->with(
-				UserClient::USER_ENDPOINT,
-				[
-					'body' => 'user_id=' . rawurlencode( self::getApiCredential( 'ROCKET_EMAIL' ) ) . '&consumer_key=' . self::getApiCredential( 'ROCKET_KEY' ),
-				]
-			)
-			->andReturn( $config['response'] );
+		$this->response = $config['response'];
 
-			$this->assertFalse( self::$client->get_user_data() );
-		} else {
-			$this->assertEquals(
-				array_keys( (array) $expected ),
-				array_keys( (array) self::$client->get_user_data() )
-			);
+		add_filter( 'pre_http_request', [ $this, 'set_response' ] );
 
-			if ( false === $config['transient'] ) {
-				$this->assertEquals(
-					array_keys( (array) $expected ),
-					array_keys( (array) get_transient( 'wp_rocket_customer_data' ) )
-				);
-			}
-		}
+		$this->assertEquals(
+			$expected,
+			self::$client->get_user_data()
+		);
 	}
 
 	public function set_consumer_email() {
@@ -85,5 +68,9 @@ class GetUserData extends TestCase {
 
 	public function set_consumer_key() {
 		return self::getApiCredential( 'ROCKET_KEY' );
+	}
+
+	public function set_response() {
+		return $this->response;
 	}
 }

--- a/tests/Unit/inc/Engine/License/API/PricingClient/getPricingData.php
+++ b/tests/Unit/inc/Engine/License/API/PricingClient/getPricingData.php
@@ -26,14 +26,14 @@ class GetPricingData extends TestCase {
 
 		Functions\when( 'wp_remote_retrieve_response_code' )
 			->justReturn(
-				is_array( $config['response'] ) && isset( $config['response']['code'] )
-					? $config['response']['code']
+				is_array( $config['response'] )
+					? $config['response']['response']['code']
 					: ''
 			);
 
 		Functions\when( 'wp_remote_retrieve_body' )
 			->justReturn(
-				is_array( $config['response'] ) && isset( $config['response']['body'] )
+				is_array( $config['response'] )
 					? $config['response']['body']
 					: ''
 			);
@@ -53,8 +53,8 @@ class GetPricingData extends TestCase {
 
 			if (
 				! is_array( $config['response'] ) ||
-				200 !== $config['response']['code'] ||
-				! isset( $config['response']['body'] )
+				200 !== $config['response']['response']['code'] ||
+				empty( $config['response']['body'] )
 			) {
 				Functions\expect( 'get_transient' )
 					->once()

--- a/tests/Unit/inc/Engine/License/API/UserClient/getUserData.php
+++ b/tests/Unit/inc/Engine/License/API/UserClient/getUserData.php
@@ -28,7 +28,7 @@ class GetPricingData extends TestCase {
 		self::pathToApiCredentialsConfigFile( WP_ROCKET_TESTS_DIR . '/../env/local/' );
 	}
 
-	public function setUp() : void {
+	public function setUp(): void {
 		$this->options = Mockery::mock( Options_Data::class );
 		$this->client  = new UserClient( $this->options );
 	}
@@ -42,7 +42,7 @@ class GetPricingData extends TestCase {
 			->with( 'wp_rocket_customer_data' )
 			->andReturn( true === $config['transient'] ? $expected : false );
 
-		if ( false !== $config['response'] ) {
+		if ( false === $config['transient'] ) {
 			$this->options->shouldReceive( 'get' )
 			->twice()
 			->with( 'consumer_key', '' )
@@ -67,14 +67,14 @@ class GetPricingData extends TestCase {
 
 			Functions\when( 'wp_remote_retrieve_response_code' )
 			->justReturn(
-				is_array( $config['response'] ) && isset( $config['response']['code'] )
-				? $config['response']['code']
+				is_array( $config['response'] )
+				? $config['response']['response']['code']
 				: ''
 			);
 
 			Functions\when( 'wp_remote_retrieve_body' )
 			->justReturn(
-				is_array( $config['response'] ) && isset( $config['response']['body'] )
+				is_array( $config['response'] )
 				? $config['response']['body']
 				: ''
 			);


### PR DESCRIPTION
## Description

Update the License User and Pricing integration tests to use the `pre_http_request` filter to bypass API request and mock return values instead.

Fixes #3725

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

No grooming done

## How Has This Been Tested?

- [x] Automated tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing integration tests pass locally with my changes
