### PR TITLE
Add new inline JS exclusion to prevent the cache_dir_size issue

### DIFF
--- a/inc/Engine/Optimization/Minify/JS/Combine.php
+++ b/inc/Engine/Optimization/Minify/JS/Combine.php
@@ -713,6 +713,7 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 			'referrer_for_pageload',
 			'WoocommerceWidget/woocommerceWidget.js',
 			'var ht_ctc_chat_var',
+			'spuvar',
 		];
 
 		$excluded_inline = array_merge( $defaults, $this->options->get( 'exclude_inline_js', [] ) );


### PR DESCRIPTION
## Description

ticket: https://secure.helpscout.net/conversation/1605911790/288549?folderId=2683093

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

on the customer's website

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
