### PR TITLE
Fixes #4291 Revert to old pattern to match inline comments in JS files during minification

### DIFF
--- a/inc/Dependencies/Minify/JS.php
+++ b/inc/Dependencies/Minify/JS.php
@@ -219,7 +219,7 @@ class JS extends Minify
 		$this->registerPattern('/\n?\/\*(.*?)\*\/\n?/s', $callback);
 
 		// single-line comments
-		$this->registerPattern('/(\/\/)(?!i)(?!\.).*$/m', '');
+		$this->registerPattern('/\/\/.*$/m', '');
 	}
 
 	/**


### PR DESCRIPTION
## Description

We already revert this change in 3.9.1.1, but it seems to have been lost when we did the final merge for 3.9.2.

Fixes #4291

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

No grooming needed

## How Has This Been Tested?

- [x] Already tested for 3.9.1.1

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
