### PR TITLE
Fixes #4257 Prevent fatal error when CSS file path is empty

### DIFF
--- a/inc/Engine/Optimization/UrlTrait.php
+++ b/inc/Engine/Optimization/UrlTrait.php
@@ -122,6 +122,9 @@ trait UrlTrait {
 	 * @return string
 	 */
 	protected function get_file_content( $file ) {
+		if ( empty( $file ) ) {
+			return false;
+		}
 		return rocket_direct_filesystem()->get_contents( $file );
 	}
 


### PR DESCRIPTION
## Description

file_get_contents will generate fatal error with an empty string



Fixes #4257 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Is the solution different from the one proposed during the grooming?
No

## How Has This Been Tested?

- [x] unit and integration

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
