### PR TITLE
fix delete if row not found

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Database/Queries/ResourcesQuery.php
+++ b/inc/Engine/Optimization/RUCSS/Database/Queries/ResourcesQuery.php
@@ -140,7 +140,9 @@ class ResourcesQuery extends Query {
 	 */
 	public function remove_by_url( $url ) {
 		$db_row = $this->get_item_by( 'url', $url );
-
+		if ( ! is_object( $db_row ) ) {
+			return;
+		}
 		$this->delete_item( $db_row->id );
 	}
 


### PR DESCRIPTION
## Description
check if $db_row is an object, and bail-out if it isn't

Fixes #4243 

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)


## Is the solution different from the one proposed during the grooming?

No
## How Has This Been Tested?

- [x] unit and integration tests

# Checklist:


- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

