### PR TITLE
remove cache clear notice after clear used css

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
@@ -325,6 +325,7 @@ class Subscriber implements Subscriber_Interface {
 
 		$this->database->truncate_used_css_table();
 		rocket_clean_domain();
+		rocket_dismiss_box( 'rocket_warning_plugin_modification' );
 
 		set_transient(
 			'rocket_clear_usedcss_response',

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/truncateUsedCSSHandler.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/truncateUsedCSSHandler.php
@@ -118,6 +118,7 @@ class Test_TruncateUsedCSSHandler extends TestCase {
 		if ( $expected['truncated'] ) {
 			$this->database->shouldReceive( 'truncate_used_css_table' )->once();
 			Functions\expect( 'rocket_clean_domain' )->once();
+			Functions\expect( 'rocket_dismiss_box' )->with('rocket_warning_plugin_modification')->once();
 		}
 
 		$this->expectException( WPDieException::class );


### PR DESCRIPTION
## Description

call to rocket_dismiss_box( 'rocket_warning_plugin_modification' ) to remove  cache clear notice after clear used css

Fixes #4212 

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)


## Is the solution different from the one proposed during the grooming?

No

## How Has This Been Tested?

- [x] Test localy
- [x] Test unit and integration

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

