### PR TITLE
Exclude inline javascript for urls_polylangREPLACETOID

### DIFF
--- a/inc/Engine/Optimization/Minify/JS/Combine.php
+++ b/inc/Engine/Optimization/Minify/JS/Combine.php
@@ -714,6 +714,7 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 			'WoocommerceWidget/woocommerceWidget.js',
 			'var ht_ctc_chat_var',
 			'spuvar',
+			'urls_polylangREPLACETOID',
 		];
 
 		$excluded_inline = array_merge( $defaults, $this->options->get( 'exclude_inline_js', [] ) );


### PR DESCRIPTION
Polylang has an inline javascript that doesn't allow cache + is using huge disk space.


![image](https://user-images.githubusercontent.com/108828/132175152-c5c999d5-c8d7-4ffa-9b8f-9eac7c3e39a3.png)
