### PR TITLE
Closes #3675 Update assets configuration for native lazyload

### DIFF
--- a/inc/Dependencies/RocketLazyload/Assets.php
+++ b/inc/Dependencies/RocketLazyload/Assets.php
@@ -31,7 +31,6 @@ class Assets {
 	public function getInlineLazyloadScript( $args = [] ) {
 		$defaults = [
 			'elements'  => [
-				'img',
 				'iframe',
 			],
 			'threshold' => 300,
@@ -42,13 +41,24 @@ class Assets {
 			'container'           => 1,
 			'thresholds'          => 1,
 			'data_bg'             => 1,
+			'data_bg_hidpi'       => 1,
+			'data_bg_multi'       => 1,
+			'data_bg_multi_hidpi' => 1,
+			'data_poster'         => 1,
+			'class_applied'       => 1,
 			'class_error'         => 1,
+			'class_entered'       => 1,
+			'class_exited'        => 1,
 			'cancel_on_exit'      => 1,
+			'unobserve_entered'   => 1,
 			'unobserve_completed' => 1,
 			'callback_enter'      => 1,
 			'callback_exit'       => 1,
 			'callback_loading'    => 1,
+			'callback_cancel'     => 1,
+			'callback_loaded'     => 1,
 			'callback_error'      => 1,
+			'callback_applied'    => 1,
 			'callback_finish'     => 1,
 			'use_native'          => 1,
 		];
@@ -101,7 +111,7 @@ class Assets {
                     var rocketlazy_count = 0;
 
                     mutations.forEach(function(mutation) {
-                        for (i = 0; i < mutation.addedNodes.length; i++) {
+                        for (var i = 0; i < mutation.addedNodes.length; i++) {
                             if (typeof mutation.addedNodes[i].getElementsByTagName !== \'function\') {
                                 continue;
                             }
@@ -155,16 +165,10 @@ class Assets {
 		$defaults = [
 			'base_url' => '',
 			'version'  => '',
-			'polyfill' => false,
 		];
 
-		$args   = wp_parse_args( $args, $defaults );
-		$min    = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
-		$script = '';
-
-		if ( isset( $args['polyfill'] ) && $args['polyfill'] ) {
-			$script .= '<script crossorigin="anonymous" src="https://polyfill.io/v3/polyfill.min.js?flags=gated&features=default%2CIntersectionObserver%2CIntersectionObserverEntry"></script>';
-		}
+		$args = wp_parse_args( $args, $defaults );
+		$min  = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 
 		/**
 		 * Filters the script tag for the lazyload script
@@ -173,9 +177,7 @@ class Assets {
 		 *
 		 * @param $script_tag HTML tag for the lazyload script.
 		 */
-		$script .= apply_filters( 'rocket_lazyload_script_tag', '<script data-no-minify="1" async src="' . $args['base_url'] . $args['version'] . '/lazyload' . $min . '.js"></script>' );
-
-		return $script;
+		return apply_filters( 'rocket_lazyload_script_tag', '<script data-no-minify="1" async src="' . $args['base_url'] . $args['version'] . '/lazyload' . $min . '.js"></script>' );
 	}
 
 	/**

--- a/inc/Engine/Media/Lazyload/Subscriber.php
+++ b/inc/Engine/Media/Lazyload/Subscriber.php
@@ -153,7 +153,6 @@ class Subscriber implements Subscriber_Interface {
 		 * Filters the threshold at which lazyload is triggered
 		 *
 		 * @since 1.2
-		 * @author Remy Perona
 		 *
 		 * @param int $threshold Threshold value.
 		 */
@@ -167,11 +166,12 @@ class Subscriber implements Subscriber_Interface {
 		 * Filters the use of native lazyload
 		 *
 		 * @since 3.4
-		 * @author Remy Perona
 		 *
 		 * @param bool $use_native True to use native lazyload, false otherwise.
 		 */
-		if ( (bool) apply_filters( 'rocket_use_native_lazyload', false ) ) {
+		$use_native =  (bool) apply_filters( 'rocket_use_native_lazyload', true );
+
+		if ( $use_native ) {
 			$inline_args['options']             = [
 				'use_native' => 'true',
 			];
@@ -179,7 +179,10 @@ class Subscriber implements Subscriber_Interface {
 		}
 
 		if ( $this->options->get( 'lazyload', 0 ) ) {
-			$inline_args['elements']['image']            = 'img[data-lazy-src]';
+			if ( ! $use_native ) {
+				$inline_args['elements']['image'] = 'img[data-lazy-src]';
+			}
+
 			$inline_args['elements']['background_image'] = '.rocket-lazyload';
 		}
 
@@ -191,7 +194,6 @@ class Subscriber implements Subscriber_Interface {
 		 * Filters the arguments array for the lazyload script options
 		 *
 		 * @since 3.3
-		 * @author Remy Perona
 		 *
 		 * @param array $inline_args Arguments used for the lazyload script options.
 		 */

--- a/inc/Engine/Media/Lazyload/Subscriber.php
+++ b/inc/Engine/Media/Lazyload/Subscriber.php
@@ -104,20 +104,9 @@ class Subscriber implements Subscriber_Interface {
 			return;
 		}
 
-		/**
-		 * Filters the use of the polyfill for intersectionObserver
-		 *
-		 * @since 3.3
-		 * @author Remy Perona
-		 *
-		 * @param bool $polyfill True to use the polyfill, false otherwise.
-		 */
-		$polyfill = (bool) apply_filters( 'rocket_lazyload_polyfill', false );
-
 		$script_args = [
 			'base_url' => rocket_get_constant( 'WP_ROCKET_ASSETS_JS_URL' ) . 'lazyload/',
 			'version'  => self::SCRIPT_VERSION,
-			'polyfill' => $polyfill,
 		];
 
 		$this->add_inline_script();
@@ -172,10 +161,8 @@ class Subscriber implements Subscriber_Interface {
 		$use_native =  (bool) apply_filters( 'rocket_use_native_lazyload', true );
 
 		if ( $use_native ) {
-			$inline_args['options']             = [
-				'use_native' => 'true',
-			];
-			$inline_args['elements']['loading'] = '[loading=lazy]';
+			$inline_args['options']['use_native'] = true;
+			$inline_args['elements']['loading']   = '[loading=lazy]';
 		}
 
 		if ( $this->options->get( 'lazyload', 0 ) ) {

--- a/tests/Fixtures/inc/Engine/Media/Lazyload/Subscriber/content/getInlineLazyloadScript.php
+++ b/tests/Fixtures/inc/Engine/Media/Lazyload/Subscriber/content/getInlineLazyloadScript.php
@@ -52,90 +52,7 @@ $observer = 'window.addEventListener(\'LazyLoad::Initialized\', function (e) {
 }, false);';
 
 $script_image = 'window.lazyLoadOptions = {
-	elements_selector: "img[data-lazy-src],.rocket-lazyload",
-	data_src: "lazy-src",
-	data_srcset: "lazy-srcset",
-	data_sizes: "lazy-sizes",
-	class_loading: "lazyloading",
-	class_loaded: "lazyloaded",
-	threshold: 300,
-	callback_loaded: function(element) {
-		if ( element.tagName === "IFRAME" && element.dataset.rocketLazyload == "fitvidscompatible" ) {
-			if (element.classList.contains("lazyloaded") ) {
-				if (typeof window.jQuery != "undefined") {
-					if (jQuery.fn.fitVids) {
-						jQuery(element).parent().fitVids();
-					}
-				}
-			}
-		}
-	}
-};';
-
-$script_iframe = 'window.lazyLoadOptions = {
-	elements_selector: "iframe[data-lazy-src]",
-	data_src: "lazy-src",
-	data_srcset: "lazy-srcset",
-	data_sizes: "lazy-sizes",
-	class_loading: "lazyloading",
-	class_loaded: "lazyloaded",
-	threshold: 300,
-	callback_loaded: function(element) {
-		if ( element.tagName === "IFRAME" && element.dataset.rocketLazyload == "fitvidscompatible" ) {
-			if (element.classList.contains("lazyloaded") ) {
-				if (typeof window.jQuery != "undefined") {
-					if (jQuery.fn.fitVids) {
-						jQuery(element).parent().fitVids();
-					}
-				}
-			}
-		}
-	}
-};';
-
-$script_both = 'window.lazyLoadOptions = {
-	elements_selector: "img[data-lazy-src],.rocket-lazyload,iframe[data-lazy-src]",
-	data_src: "lazy-src",
-	data_srcset: "lazy-srcset",
-	data_sizes: "lazy-sizes",
-	class_loading: "lazyloading",
-	class_loaded: "lazyloaded",
-	threshold: 300,
-	callback_loaded: function(element) {
-		if ( element.tagName === "IFRAME" && element.dataset.rocketLazyload == "fitvidscompatible" ) {
-			if (element.classList.contains("lazyloaded") ) {
-				if (typeof window.jQuery != "undefined") {
-					if (jQuery.fn.fitVids) {
-						jQuery(element).parent().fitVids();
-					}
-				}
-			}
-		}
-	}
-};';
-
-$script_custom_threshold = 'window.lazyLoadOptions = {
-	elements_selector: "img[data-lazy-src],.rocket-lazyload,iframe[data-lazy-src]",
-	data_src: "lazy-src",
-	data_srcset: "lazy-srcset",
-	data_sizes: "lazy-sizes",
-	class_loading: "lazyloading",
-	class_loaded: "lazyloaded",
-	threshold: 500,
-	callback_loaded: function(element) {
-		if ( element.tagName === "IFRAME" && element.dataset.rocketLazyload == "fitvidscompatible" ) {
-			if (element.classList.contains("lazyloaded") ) {
-				if (typeof window.jQuery != "undefined") {
-					if (jQuery.fn.fitVids) {
-						jQuery(element).parent().fitVids();
-					}
-				}
-			}
-		}
-	};';
-
-$script_native_lazyload = 'window.lazyLoadOptions = {
-	elements_selector: "[loading=lazy],img[data-lazy-src],.rocket-lazyload,iframe[data-lazy-src]",
+	elements_selector: "[loading=lazy],.rocket-lazyload",
 	data_src: "lazy-src",
 	data_srcset: "lazy-srcset",
 	data_sizes: "lazy-sizes",
@@ -156,10 +73,96 @@ $script_native_lazyload = 'window.lazyLoadOptions = {
 	use_native: true
 };';
 
+$script_iframe = 'window.lazyLoadOptions = {
+	elements_selector: "[loading=lazy],iframe[data-lazy-src]",
+	data_src: "lazy-src",
+	data_srcset: "lazy-srcset",
+	data_sizes: "lazy-sizes",
+	class_loading: "lazyloading",
+	class_loaded: "lazyloaded",
+	threshold: 300,
+	callback_loaded: function(element) {
+		if ( element.tagName === "IFRAME" && element.dataset.rocketLazyload == "fitvidscompatible" ) {
+			if (element.classList.contains("lazyloaded") ) {
+				if (typeof window.jQuery != "undefined") {
+					if (jQuery.fn.fitVids) {
+						jQuery(element).parent().fitVids();
+					}
+				}
+			}
+		}
+	},
+	use_native: true
+};';
+
+$script_both = 'window.lazyLoadOptions = {
+	elements_selector: "[loading=lazy],.rocket-lazyload,iframe[data-lazy-src]",
+	data_src: "lazy-src",
+	data_srcset: "lazy-srcset",
+	data_sizes: "lazy-sizes",
+	class_loading: "lazyloading",
+	class_loaded: "lazyloaded",
+	threshold: 300,
+	callback_loaded: function(element) {
+		if ( element.tagName === "IFRAME" && element.dataset.rocketLazyload == "fitvidscompatible" ) {
+			if (element.classList.contains("lazyloaded") ) {
+				if (typeof window.jQuery != "undefined") {
+					if (jQuery.fn.fitVids) {
+						jQuery(element).parent().fitVids();
+					}
+				}
+			}
+		}
+	},
+	use_native: true
+};';
+
+$script_custom_threshold = 'window.lazyLoadOptions = {
+	elements_selector: "[loading=lazy],.rocket-lazyload,iframe[data-lazy-src]",
+	data_src: "lazy-src",
+	data_srcset: "lazy-srcset",
+	data_sizes: "lazy-sizes",
+	class_loading: "lazyloading",
+	class_loaded: "lazyloaded",
+	threshold: 500,
+	callback_loaded: function(element) {
+		if ( element.tagName === "IFRAME" && element.dataset.rocketLazyload == "fitvidscompatible" ) {
+			if (element.classList.contains("lazyloaded") ) {
+				if (typeof window.jQuery != "undefined") {
+					if (jQuery.fn.fitVids) {
+						jQuery(element).parent().fitVids();
+					}
+				}
+			}
+		}
+	},
+	use_native: true
+};';
+
+$script_no_native_lazyload = 'window.lazyLoadOptions = {
+	elements_selector: "img[data-lazy-src],.rocket-lazyload,iframe[data-lazy-src]",
+	data_src: "lazy-src",
+	data_srcset: "lazy-srcset",
+	data_sizes: "lazy-sizes",
+	class_loading: "lazyloading",
+	class_loaded: "lazyloaded",
+	threshold: 300,
+	callback_loaded: function(element) {
+		if ( element.tagName === "IFRAME" && element.dataset.rocketLazyload == "fitvidscompatible" ) {
+			if (element.classList.contains("lazyloaded") ) {
+				if (typeof window.jQuery != "undefined") {
+					if (jQuery.fn.fitVids) {
+						jQuery(element).parent().fitVids();
+					}
+				}
+			}
+		}
+	};';
+
 return [
-	'script_image'            => "{$script_image}{$observer}",
-	'script_iframe'           => "{$script_iframe}{$observer}",
-	'script_both'             => "{$script_both}{$observer}",
-	'script_custom_threshold' => "{$script_custom_threshold}{$observer}",
-	'script_native_lazyload'  => "{$script_native_lazyload}{$observer}",
+	'script_image'              => "{$script_image}{$observer}",
+	'script_iframe'             => "{$script_iframe}{$observer}",
+	'script_both'               => "{$script_both}{$observer}",
+	'script_custom_threshold'   => "{$script_custom_threshold}{$observer}",
+	'script_no_native_lazyload' => "{$script_no_native_lazyload}{$observer}",
 ];

--- a/tests/Fixtures/inc/Engine/Media/Lazyload/Subscriber/content/insertLazyloadScript.php
+++ b/tests/Fixtures/inc/Engine/Media/Lazyload/Subscriber/content/insertLazyloadScript.php
@@ -1,12 +1,9 @@
 <?php
 
-$polyfill   = '<script crossorigin="anonymous" src="https://polyfill.io/v3/polyfill.min.js?flags=gated&features=default%2CIntersectionObserver%2CIntersectionObserverEntry"></script>';
 $script     = '<script data-no-minify="1" async src="http://example.org/wp-content/plugins/wp-rocket/assets/js/lazyload/16.1/lazyload.js"></script>';
 $min_script = '<script data-no-minify="1" async src="http://example.org/wp-content/plugins/wp-rocket/assets/js/lazyload/16.1/lazyload.min.js"></script>';
 
 return [
 	'min_script'          => $min_script,
 	'script'              => $script,
-	'min_script_polyfill' => "{$polyfill}{$min_script}",
-	'script_polyfill'     => "{$polyfill}{$script}",
 ];

--- a/tests/Fixtures/inc/Engine/Media/Lazyload/Subscriber/insertLazyloadScript.php
+++ b/tests/Fixtures/inc/Engine/Media/Lazyload/Subscriber/insertLazyloadScript.php
@@ -127,6 +127,7 @@ return [
 			'options'  => [
 				'lazyload'         => 1,
 				'lazyload_iframes' => 0,
+				'use_native'       => true,
 			],
 		],
 		'expected' => [
@@ -136,7 +137,7 @@ return [
 				'result'        => "<script>{$inline_script['script_image']}</script>{$lazyload_script['min_script']}",
 			],
 			'integration' => '<script>
-		window.lazyLoadOptions={elements_selector:"img[data-lazy-src],.rocket-lazyload",data_src:"lazy-src",data_srcset:"lazy-srcset",data_sizes:"lazy-sizes",class_loading:"lazyloading",class_loaded:"lazyloaded",threshold:300,callback_loaded:function(element){if(element.tagName==="IFRAME"&&element.dataset.rocketLazyload=="fitvidscompatible"){if(element.classList.contains("lazyloaded")){if(typeof window.jQuery!="undefined"){if(jQuery.fn.fitVids){jQuery(element).parent().fitVids()}}}}}};window.addEventListener(\'LazyLoad::Initialized\',function(e){var lazyLoadInstance=e.detail.instance;if(window.MutationObserver){var observer=new MutationObserver(function(mutations){var image_count=0;var iframe_count=0;var rocketlazy_count=0;mutations.forEach(function(mutation){for(i=0;i<mutation.addedNodes.length;i++){if(typeof mutation.addedNodes[i].getElementsByTagName!==\'function\'){continue}
+		window.lazyLoadOptions={elements_selector:"[loading=lazy],.rocket-lazyload",data_src:"lazy-src",data_srcset:"lazy-srcset",data_sizes:"lazy-sizes",class_loading:"lazyloading",class_loaded:"lazyloaded",threshold:300,callback_loaded:function(element){if(element.tagName==="IFRAME"&&element.dataset.rocketLazyload=="fitvidscompatible"){if(element.classList.contains("lazyloaded")){if(typeof window.jQuery!="undefined"){if(jQuery.fn.fitVids){jQuery(element).parent().fitVids()}}}}},use_native:1};window.addEventListener(\'LazyLoad::Initialized\',function(e){var lazyLoadInstance=e.detail.instance;if(window.MutationObserver){var observer=new MutationObserver(function(mutations){var image_count=0;var iframe_count=0;var rocketlazy_count=0;mutations.forEach(function(mutation){for(var i=0;i<mutation.addedNodes.length;i++){if(typeof mutation.addedNodes[i].getElementsByTagName!==\'function\'){continue}
 if(typeof mutation.addedNodes[i].getElementsByClassName!==\'function\'){continue}
 images=mutation.addedNodes[i].getElementsByTagName(\'img\');is_image=mutation.addedNodes[i].tagName=="IMG";iframes=mutation.addedNodes[i].getElementsByTagName(\'iframe\');is_iframe=mutation.addedNodes[i].tagName=="IFRAME";rocket_lazy=mutation.addedNodes[i].getElementsByClassName(\'rocket-lazyload\');image_count+=images.length;iframe_count+=iframes.length;rocketlazy_count+=rocket_lazy.length;if(is_image){image_count+=1}
 if(is_iframe){iframe_count+=1}}});if(image_count>0||iframe_count>0||rocketlazy_count>0){lazyLoadInstance.update()}});var b=document.getElementsByTagName("body")[0];var config={childList:!0,subtree:!0};observer.observe(b,config)}},!1)</script><script data-no-minify="1" async src="http://example.org/wp-content/plugins/wp-rocket/assets/js/lazyload/16.1/lazyload.min.js"></script>',
@@ -148,6 +149,7 @@ if(is_iframe){iframe_count+=1}}});if(image_count>0||iframe_count>0||rocketlazy_c
 			'options'  => [
 				'lazyload'         => 0,
 				'lazyload_iframes' => 1,
+				'use_native'       => true,
 			],
 		],
 		'expected' => [
@@ -157,7 +159,7 @@ if(is_iframe){iframe_count+=1}}});if(image_count>0||iframe_count>0||rocketlazy_c
 				'result'        => "<script>{$inline_script['script_iframe']}</script>{$lazyload_script['min_script']}",
 			],
 			'integration' => '<script>
-		window.lazyLoadOptions={elements_selector:"iframe[data-lazy-src]",data_src:"lazy-src",data_srcset:"lazy-srcset",data_sizes:"lazy-sizes",class_loading:"lazyloading",class_loaded:"lazyloaded",threshold:300,callback_loaded:function(element){if(element.tagName==="IFRAME"&&element.dataset.rocketLazyload=="fitvidscompatible"){if(element.classList.contains("lazyloaded")){if(typeof window.jQuery!="undefined"){if(jQuery.fn.fitVids){jQuery(element).parent().fitVids()}}}}}};window.addEventListener(\'LazyLoad::Initialized\',function(e){var lazyLoadInstance=e.detail.instance;if(window.MutationObserver){var observer=new MutationObserver(function(mutations){var image_count=0;var iframe_count=0;var rocketlazy_count=0;mutations.forEach(function(mutation){for(i=0;i<mutation.addedNodes.length;i++){if(typeof mutation.addedNodes[i].getElementsByTagName!==\'function\'){continue}
+		window.lazyLoadOptions={elements_selector:"[loading=lazy],iframe[data-lazy-src]",data_src:"lazy-src",data_srcset:"lazy-srcset",data_sizes:"lazy-sizes",class_loading:"lazyloading",class_loaded:"lazyloaded",threshold:300,callback_loaded:function(element){if(element.tagName==="IFRAME"&&element.dataset.rocketLazyload=="fitvidscompatible"){if(element.classList.contains("lazyloaded")){if(typeof window.jQuery!="undefined"){if(jQuery.fn.fitVids){jQuery(element).parent().fitVids()}}}}},use_native:1};window.addEventListener(\'LazyLoad::Initialized\',function(e){var lazyLoadInstance=e.detail.instance;if(window.MutationObserver){var observer=new MutationObserver(function(mutations){var image_count=0;var iframe_count=0;var rocketlazy_count=0;mutations.forEach(function(mutation){for(var i=0;i<mutation.addedNodes.length;i++){if(typeof mutation.addedNodes[i].getElementsByTagName!==\'function\'){continue}
 if(typeof mutation.addedNodes[i].getElementsByClassName!==\'function\'){continue}
 images=mutation.addedNodes[i].getElementsByTagName(\'img\');is_image=mutation.addedNodes[i].tagName=="IMG";iframes=mutation.addedNodes[i].getElementsByTagName(\'iframe\');is_iframe=mutation.addedNodes[i].tagName=="IFRAME";rocket_lazy=mutation.addedNodes[i].getElementsByClassName(\'rocket-lazyload\');image_count+=images.length;iframe_count+=iframes.length;rocketlazy_count+=rocket_lazy.length;if(is_image){image_count+=1}
 if(is_iframe){iframe_count+=1}}});if(image_count>0||iframe_count>0||rocketlazy_count>0){lazyLoadInstance.update()}});var b=document.getElementsByTagName("body")[0];var config={childList:!0,subtree:!0};observer.observe(b,config)}},!1)</script><script data-no-minify="1" async src="http://example.org/wp-content/plugins/wp-rocket/assets/js/lazyload/16.1/lazyload.min.js"></script>',
@@ -168,6 +170,7 @@ if(is_iframe){iframe_count+=1}}});if(image_count>0||iframe_count>0||rocketlazy_c
 			'options'  => [
 				'lazyload'         => 1,
 				'lazyload_iframes' => 1,
+				'use_native'       => true,
 			],
 		],
 		'expected' => [
@@ -177,7 +180,7 @@ if(is_iframe){iframe_count+=1}}});if(image_count>0||iframe_count>0||rocketlazy_c
 				'result'        => "<script>{$inline_script['script_both']}</script>{$lazyload_script['min_script']}",
 			],
 			'integration' => '<script>
-		window.lazyLoadOptions={elements_selector:"img[data-lazy-src],.rocket-lazyload,iframe[data-lazy-src]",data_src:"lazy-src",data_srcset:"lazy-srcset",data_sizes:"lazy-sizes",class_loading:"lazyloading",class_loaded:"lazyloaded",threshold:300,callback_loaded:function(element){if(element.tagName==="IFRAME"&&element.dataset.rocketLazyload=="fitvidscompatible"){if(element.classList.contains("lazyloaded")){if(typeof window.jQuery!="undefined"){if(jQuery.fn.fitVids){jQuery(element).parent().fitVids()}}}}}};window.addEventListener(\'LazyLoad::Initialized\',function(e){var lazyLoadInstance=e.detail.instance;if(window.MutationObserver){var observer=new MutationObserver(function(mutations){var image_count=0;var iframe_count=0;var rocketlazy_count=0;mutations.forEach(function(mutation){for(i=0;i<mutation.addedNodes.length;i++){if(typeof mutation.addedNodes[i].getElementsByTagName!==\'function\'){continue}
+		window.lazyLoadOptions={elements_selector:"[loading=lazy],.rocket-lazyload,iframe[data-lazy-src]",data_src:"lazy-src",data_srcset:"lazy-srcset",data_sizes:"lazy-sizes",class_loading:"lazyloading",class_loaded:"lazyloaded",threshold:300,callback_loaded:function(element){if(element.tagName==="IFRAME"&&element.dataset.rocketLazyload=="fitvidscompatible"){if(element.classList.contains("lazyloaded")){if(typeof window.jQuery!="undefined"){if(jQuery.fn.fitVids){jQuery(element).parent().fitVids()}}}}},use_native:1};window.addEventListener(\'LazyLoad::Initialized\',function(e){var lazyLoadInstance=e.detail.instance;if(window.MutationObserver){var observer=new MutationObserver(function(mutations){var image_count=0;var iframe_count=0;var rocketlazy_count=0;mutations.forEach(function(mutation){for(var i=0;i<mutation.addedNodes.length;i++){if(typeof mutation.addedNodes[i].getElementsByTagName!==\'function\'){continue}
 if(typeof mutation.addedNodes[i].getElementsByClassName!==\'function\'){continue}
 images=mutation.addedNodes[i].getElementsByTagName(\'img\');is_image=mutation.addedNodes[i].tagName=="IMG";iframes=mutation.addedNodes[i].getElementsByTagName(\'iframe\');is_iframe=mutation.addedNodes[i].tagName=="IFRAME";rocket_lazy=mutation.addedNodes[i].getElementsByClassName(\'rocket-lazyload\');image_count+=images.length;iframe_count+=iframes.length;rocketlazy_count+=rocket_lazy.length;if(is_image){image_count+=1}
 if(is_iframe){iframe_count+=1}}});if(image_count>0||iframe_count>0||rocketlazy_count>0){lazyLoadInstance.update()}});var b=document.getElementsByTagName("body")[0];var config={childList:!0,subtree:!0};observer.observe(b,config)}},!1)</script><script data-no-minify="1" async src="http://example.org/wp-content/plugins/wp-rocket/assets/js/lazyload/16.1/lazyload.min.js"></script>',
@@ -189,6 +192,7 @@ if(is_iframe){iframe_count+=1}}});if(image_count>0||iframe_count>0||rocketlazy_c
 				'lazyload'         => 1,
 				'lazyload_iframes' => 1,
 				'threshold'        => 500,
+				'use_native'       => true,
 			],
 		],
 		'expected' => [
@@ -198,49 +202,28 @@ if(is_iframe){iframe_count+=1}}});if(image_count>0||iframe_count>0||rocketlazy_c
 				'result'        => "<script>{$inline_script['script_custom_threshold']}</script>{$lazyload_script['min_script']}",
 			],
 			'integration' => '<script>
-		window.lazyLoadOptions={elements_selector:"img[data-lazy-src],.rocket-lazyload,iframe[data-lazy-src]",data_src:"lazy-src",data_srcset:"lazy-srcset",data_sizes:"lazy-sizes",class_loading:"lazyloading",class_loaded:"lazyloaded",threshold:500,callback_loaded:function(element){if(element.tagName==="IFRAME"&&element.dataset.rocketLazyload=="fitvidscompatible"){if(element.classList.contains("lazyloaded")){if(typeof window.jQuery!="undefined"){if(jQuery.fn.fitVids){jQuery(element).parent().fitVids()}}}}}};window.addEventListener(\'LazyLoad::Initialized\',function(e){var lazyLoadInstance=e.detail.instance;if(window.MutationObserver){var observer=new MutationObserver(function(mutations){var image_count=0;var iframe_count=0;var rocketlazy_count=0;mutations.forEach(function(mutation){for(i=0;i<mutation.addedNodes.length;i++){if(typeof mutation.addedNodes[i].getElementsByTagName!==\'function\'){continue}
+		window.lazyLoadOptions={elements_selector:"[loading=lazy],.rocket-lazyload,iframe[data-lazy-src]",data_src:"lazy-src",data_srcset:"lazy-srcset",data_sizes:"lazy-sizes",class_loading:"lazyloading",class_loaded:"lazyloaded",threshold:500,callback_loaded:function(element){if(element.tagName==="IFRAME"&&element.dataset.rocketLazyload=="fitvidscompatible"){if(element.classList.contains("lazyloaded")){if(typeof window.jQuery!="undefined"){if(jQuery.fn.fitVids){jQuery(element).parent().fitVids()}}}}},use_native:1};window.addEventListener(\'LazyLoad::Initialized\',function(e){var lazyLoadInstance=e.detail.instance;if(window.MutationObserver){var observer=new MutationObserver(function(mutations){var image_count=0;var iframe_count=0;var rocketlazy_count=0;mutations.forEach(function(mutation){for(var i=0;i<mutation.addedNodes.length;i++){if(typeof mutation.addedNodes[i].getElementsByTagName!==\'function\'){continue}
 if(typeof mutation.addedNodes[i].getElementsByClassName!==\'function\'){continue}
 images=mutation.addedNodes[i].getElementsByTagName(\'img\');is_image=mutation.addedNodes[i].tagName=="IMG";iframes=mutation.addedNodes[i].getElementsByTagName(\'iframe\');is_iframe=mutation.addedNodes[i].tagName=="IFRAME";rocket_lazy=mutation.addedNodes[i].getElementsByClassName(\'rocket-lazyload\');image_count+=images.length;iframe_count+=iframes.length;rocketlazy_count+=rocket_lazy.length;if(is_image){image_count+=1}
 if(is_iframe){iframe_count+=1}}});if(image_count>0||iframe_count>0||rocketlazy_count>0){lazyLoadInstance.update()}});var b=document.getElementsByTagName("body")[0];var config={childList:!0,subtree:!0};observer.observe(b,config)}},!1)</script><script data-no-minify="1" async src="http://example.org/wp-content/plugins/wp-rocket/assets/js/lazyload/16.1/lazyload.min.js"></script>',
 		],
 	],
-	'testShouldReturnLazyloadForImagesAndIframesWithPolyfill' => [
+	'testShouldReturnLazyloadForImagesAndIframesWithoutNativeLazyload' => [
 		'config' => [
 			'options'  => [
 				'lazyload'         => 1,
 				'lazyload_iframes' => 1,
-				'polyfill'         => true,
+				'use_native'       => false,
 			],
 		],
 		'expected' => [
 			'unit' => [
-				'inline_script' => $inline_script['script_both'],
-				'script'        => $lazyload_script['min_script_polyfill'],
-				'result'        => "<script>{$inline_script['script_both']}</script>{$lazyload_script['min_script_polyfill']}",
-			],
-			'integration' => '<script>
-		window.lazyLoadOptions={elements_selector:"img[data-lazy-src],.rocket-lazyload,iframe[data-lazy-src]",data_src:"lazy-src",data_srcset:"lazy-srcset",data_sizes:"lazy-sizes",class_loading:"lazyloading",class_loaded:"lazyloaded",threshold:300,callback_loaded:function(element){if(element.tagName==="IFRAME"&&element.dataset.rocketLazyload=="fitvidscompatible"){if(element.classList.contains("lazyloaded")){if(typeof window.jQuery!="undefined"){if(jQuery.fn.fitVids){jQuery(element).parent().fitVids()}}}}}};window.addEventListener(\'LazyLoad::Initialized\',function(e){var lazyLoadInstance=e.detail.instance;if(window.MutationObserver){var observer=new MutationObserver(function(mutations){var image_count=0;var iframe_count=0;var rocketlazy_count=0;mutations.forEach(function(mutation){for(i=0;i<mutation.addedNodes.length;i++){if(typeof mutation.addedNodes[i].getElementsByTagName!==\'function\'){continue}
-if(typeof mutation.addedNodes[i].getElementsByClassName!==\'function\'){continue}
-images=mutation.addedNodes[i].getElementsByTagName(\'img\');is_image=mutation.addedNodes[i].tagName=="IMG";iframes=mutation.addedNodes[i].getElementsByTagName(\'iframe\');is_iframe=mutation.addedNodes[i].tagName=="IFRAME";rocket_lazy=mutation.addedNodes[i].getElementsByClassName(\'rocket-lazyload\');image_count+=images.length;iframe_count+=iframes.length;rocketlazy_count+=rocket_lazy.length;if(is_image){image_count+=1}
-if(is_iframe){iframe_count+=1}}});if(image_count>0||iframe_count>0||rocketlazy_count>0){lazyLoadInstance.update()}});var b=document.getElementsByTagName("body")[0];var config={childList:!0,subtree:!0};observer.observe(b,config)}},!1)</script><script crossorigin="anonymous" src="https://polyfill.io/v3/polyfill.min.js?flags=gated&features=default%2CIntersectionObserver%2CIntersectionObserverEntry"></script><script data-no-minify="1" async src="http://example.org/wp-content/plugins/wp-rocket/assets/js/lazyload/16.1/lazyload.min.js"></script>',
-		],
-	],
-	'testShouldReturnLazyloadForImagesAndIframesWithNativeLazyload' => [
-		'config' => [
-			'options'  => [
-				'lazyload'         => 1,
-				'lazyload_iframes' => 1,
-				'use_native'       => true,
-			],
-		],
-		'expected' => [
-			'unit' => [
-				'inline_script' => $inline_script['script_native_lazyload'],
+				'inline_script' => $inline_script['script_no_native_lazyload'],
 				'script'        => $lazyload_script['min_script'],
-				'result'        => "<script>{$inline_script['script_native_lazyload']}</script>{$lazyload_script['min_script']}",
+				'result'        => "<script>{$inline_script['script_no_native_lazyload']}</script>{$lazyload_script['min_script']}",
 			],
 			'integration' => '<script>
-		window.lazyLoadOptions={elements_selector:"[loading=lazy],img[data-lazy-src],.rocket-lazyload,iframe[data-lazy-src]",data_src:"lazy-src",data_srcset:"lazy-srcset",data_sizes:"lazy-sizes",class_loading:"lazyloading",class_loaded:"lazyloaded",threshold:300,callback_loaded:function(element){if(element.tagName==="IFRAME"&&element.dataset.rocketLazyload=="fitvidscompatible"){if(element.classList.contains("lazyloaded")){if(typeof window.jQuery!="undefined"){if(jQuery.fn.fitVids){jQuery(element).parent().fitVids()}}}}},use_native:!0};window.addEventListener(\'LazyLoad::Initialized\',function(e){var lazyLoadInstance=e.detail.instance;if(window.MutationObserver){var observer=new MutationObserver(function(mutations){var image_count=0;var iframe_count=0;var rocketlazy_count=0;mutations.forEach(function(mutation){for(i=0;i<mutation.addedNodes.length;i++){if(typeof mutation.addedNodes[i].getElementsByTagName!==\'function\'){continue}
+		window.lazyLoadOptions={elements_selector:"img[data-lazy-src],.rocket-lazyload,iframe[data-lazy-src]",data_src:"lazy-src",data_srcset:"lazy-srcset",data_sizes:"lazy-sizes",class_loading:"lazyloading",class_loaded:"lazyloaded",threshold:300,callback_loaded:function(element){if(element.tagName==="IFRAME"&&element.dataset.rocketLazyload=="fitvidscompatible"){if(element.classList.contains("lazyloaded")){if(typeof window.jQuery!="undefined"){if(jQuery.fn.fitVids){jQuery(element).parent().fitVids()}}}}}};window.addEventListener(\'LazyLoad::Initialized\',function(e){var lazyLoadInstance=e.detail.instance;if(window.MutationObserver){var observer=new MutationObserver(function(mutations){var image_count=0;var iframe_count=0;var rocketlazy_count=0;mutations.forEach(function(mutation){for(var i=0;i<mutation.addedNodes.length;i++){if(typeof mutation.addedNodes[i].getElementsByTagName!==\'function\'){continue}
 if(typeof mutation.addedNodes[i].getElementsByClassName!==\'function\'){continue}
 images=mutation.addedNodes[i].getElementsByTagName(\'img\');is_image=mutation.addedNodes[i].tagName=="IMG";iframes=mutation.addedNodes[i].getElementsByTagName(\'iframe\');is_iframe=mutation.addedNodes[i].tagName=="IFRAME";rocket_lazy=mutation.addedNodes[i].getElementsByClassName(\'rocket-lazyload\');image_count+=images.length;iframe_count+=iframes.length;rocketlazy_count+=rocket_lazy.length;if(is_image){image_count+=1}
 if(is_iframe){iframe_count+=1}}});if(image_count>0||iframe_count>0||rocketlazy_count>0){lazyLoadInstance.update()}});var b=document.getElementsByTagName("body")[0];var config={childList:!0,subtree:!0};observer.observe(b,config)}},!1)</script><script data-no-minify="1" async src="http://example.org/wp-content/plugins/wp-rocket/assets/js/lazyload/16.1/lazyload.min.js"></script>',

--- a/tests/Integration/inc/Engine/Media/Lazyload/Subscriber/insertLazyloadScript.php
+++ b/tests/Integration/inc/Engine/Media/Lazyload/Subscriber/insertLazyloadScript.php
@@ -3,7 +3,6 @@
 namespace WP_Rocket\Tests\Integration\inc\Engine\Media\Lazyload\Subscriber;
 
 use WP_Rocket\Tests\Integration\TestCase;
-use Brain\Monkey\Functions;
 
 /**
  * @covers \WP_Rocket\Engine\Media\Lazyload\Subscriber::insert_lazyload_script
@@ -18,8 +17,6 @@ class Test_InsertLazyloadScript extends TestCase {
 	private $threshold;
 
 	public function setUp() : void {
-		$this->script_debug = false;
-
 		parent::setUp();
 
 		$this->lazyload  = null;
@@ -32,7 +29,7 @@ class Test_InsertLazyloadScript extends TestCase {
 		remove_filter( 'pre_get_rocket_option_lazyload', [ $this, 'setLazyload' ] );
 		remove_filter( 'pre_get_rocket_option_lazyload_iframes', [ $this, 'setIframes' ] );
 		remove_filter( 'rocket_lazyload_threshold', [ $this, 'setThreshold' ] );
-		remove_filter( 'rocket_lazyload_threshold', [ $this, 'return_true' ] );
+		remove_filter( 'rocket_use_native_lazyload', [ $this, 'return_false' ] );
 		remove_filter( 'rocket_use_native_lazyload', [ $this, 'return_true' ] );
 
 		global $wp_query;
@@ -62,7 +59,7 @@ class Test_InsertLazyloadScript extends TestCase {
             'request'    => 'http://example.org',
 		];
 
-		$options = $config['options'];
+		$options        = $config['options'];
 		$this->lazyload = $options['lazyload'];
 		$this->iframes  = $options['lazyload_iframes'];
 
@@ -77,14 +74,14 @@ class Test_InsertLazyloadScript extends TestCase {
 		set_current_screen( $is_admin ? 'settings_page_wprocket' : 'front' );
 
 		global $wp_query;
-		$wp_query->is_feed = $is_feed;
+		$wp_query->is_feed    = $is_feed;
 		$wp_query->is_preview = $is_preview;
-		$wp_query->is_search = $is_search;
+		$wp_query->is_search  = $is_search;
 
 		//Constants.
-		$this->constants['REST_REQUEST'] = $is_rest_request;
-		$this->constants['DONOTLAZYLOAD'] = !$is_lazy_load;
-		$this->donotrocketoptimize = !$is_rocket_optimize;
+		$this->constants['REST_REQUEST']  = $is_rest_request;
+		$this->constants['DONOTLAZYLOAD'] = ! $is_lazy_load;
+		$this->donotrocketoptimize        = ! $is_rocket_optimize;
 		$this->constants['WP_ROCKET_ASSETS_JS_URL'] = 'http://example.org/wp-content/plugins/wp-rocket/assets/';
 
 		// wp-media/rocket-lazyload-common uses the constant for determining whether to set as .min.js.
@@ -101,12 +98,12 @@ class Test_InsertLazyloadScript extends TestCase {
 			add_filter( 'rocket_lazyload_threshold', [ $this, 'setThreshold' ] );
 		}
 
-		if ( isset( $options['polyfill'] ) ) {
-			add_filter( 'rocket_lazyload_polyfill', [ $this, 'return_true' ] );
-		}
-
 		if ( isset( $options['use_native'] ) ) {
-			add_filter( 'rocket_use_native_lazyload', [ $this, 'return_true' ] );
+			if ( $options['use_native'] ) {
+				add_filter( 'rocket_use_native_lazyload', [ $this, 'return_true' ] );
+			} else {
+				add_filter( 'rocket_use_native_lazyload', [ $this, 'return_false' ] );
+			}
 		}
 
 		if ( empty( $expected['integration'] ) ) {

--- a/tests/Unit/inc/Engine/Media/Lazyload/Subscriber/insertLazyloadScript.php
+++ b/tests/Unit/inc/Engine/Media/Lazyload/Subscriber/insertLazyloadScript.php
@@ -92,12 +92,6 @@ class Test_InsertLazyloadScript extends TestCase {
 				->andReturn( $options['use_native'] );
 		}
 
-		if ( isset( $options['polyfill'] ) ) {
-			Filters\expectApplied( 'rocket_lazyload_polyfill' )
-				->once()
-				->andReturn( $options['polyfill'] );
-		}
-
 		$this->assertSame(
 			$this->format_the_html( $expected['unit']['result'] ),
 			$this->getActualHtml()


### PR DESCRIPTION
## Description

**In this PR**
Update the Assets class to:
- remove `img` as a default selector
- add new script options added by the lazyload script
- fix a var declaration in the mutation observer JS
- remove the polyfill option

Update the Subscriber class to:
- remove polyfill addition
- use native lazyload by default
- preserve the data-lazy-src selector for images if the use_native filter is false

Update all the related tests

Fixes #3675
Fixes #3976 

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

It was necessary to do changes in the common library, and also in the subscriber

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
