### PR TITLE
Closes #3676 Use native lazyload in Image class

### DIFF
--- a/inc/Dependencies/RocketLazyload/Image.php
+++ b/inc/Dependencies/RocketLazyload/Image.php
@@ -17,12 +17,11 @@ class Image {
 	 *
 	 * @param string $html   Original HTML.
 	 * @param string $buffer Content to parse.
+	 * @param bool   $use_native Use native lazyload.
 	 * @return string
 	 */
-	public function lazyloadImages( $html, $buffer ) {
-		$clean_buffer = preg_replace( '/<script\b(?:[^>]*)>(?:.+)?<\/script>/Umsi', '', $html );
-		$clean_buffer = preg_replace( '#<noscript>(?:.+)</noscript>#Umsi', '', $clean_buffer );
-		if (! preg_match_all('#<img(?<atts>\s.+)\s?/?>#iUs', $clean_buffer, $images, PREG_SET_ORDER)) {
+	public function lazyloadImages( $html, $buffer, $use_native = true ) {
+		if (! preg_match_all('#<img(?<atts>\s.+)\s?/?>#iUs', $buffer, $images, PREG_SET_ORDER)) {
 			return $html;
 		}
 
@@ -35,9 +34,13 @@ class Image {
 				continue;
 			}
 
-			$image_lazyload  = $this->replaceImage( $image );
-			$image_lazyload .= $this->noscript( $image[0] );
-			$html            = str_replace( $image[0], $image_lazyload, $html );
+			$image_lazyload  = $this->replaceImage( $image, $use_native );
+
+			if ( ! $use_native ) {
+				$image_lazyload .= $this->noscript( $image[0] );
+			}
+
+			$html = str_replace( $image[0], $image_lazyload, $html );
 
 			unset( $image_lazyload );
 		}
@@ -256,9 +259,9 @@ class Image {
 				if ( ! preg_match( '#<img(?<atts>\s.+)\s?/?>#iUs', $picture[0], $img ) ) {
 					continue;
 				}
-	
+
 				$img = $this->canLazyload( $img );
-	
+
 				if ( ! $img ) {
 					continue;
 				}
@@ -336,13 +339,6 @@ class Image {
 			return false;
 		}
 
-		// Don't apply LazyLoad on images from WP Retina x2.
-		if ( function_exists( 'wr2x_picture_rewrite' ) ) {
-			if ( wr2x_get_retina( trailingslashit( ABSPATH ) . wr2x_get_pathinfo_from_image_src( trim( $image['src'], '"' ) ) ) ) {
-				return false;
-			}
-		}
-
 		return $image;
 	}
 
@@ -381,7 +377,6 @@ class Image {
 		 * Filters the attributes used to prevent lazylad from being applied
 		 *
 		 * @since 1.0
-		 * @author Remy Perona
 		 *
 		 * @param array $excluded_attributes An array of excluded attributes.
 		 */
@@ -407,8 +402,6 @@ class Image {
 				'data-height-percentage',
 				'data-large_image',
 				'avia-bg-style-fixed',
-				'data-skip-lazy',
-				'skip-lazy',
 				'image-compare__',
 			]
 		);
@@ -424,7 +417,6 @@ class Image {
 		 * Filters the src used to prevent lazylad from being applied
 		 *
 		 * @since 1.0
-		 * @author Remy Perona
 		 *
 		 * @param array $excluded_src An array of excluded src.
 		 */
@@ -442,26 +434,32 @@ class Image {
 	 * Replaces the original image by the lazyload one
 	 *
 	 * @param array $image Array of matches elements.
+	 * @param bool  $use_native Use native lazyload
+	 *
 	 * @return string
 	 */
-	private function replaceImage( $image ) {
-		$width  = 0;
-		$height = 0;
+	private function replaceImage( $image, $use_native = true ) {
+		if ( $use_native ) {
+			if ( preg_match( '@\sloading\s*=\s*(\'|")(?:lazy|auto)\1@i', $image[0] ) ) {
+				return $image[0];
+			}
 
-		if ( preg_match( '@[\s"\']width\s*=\s*(\'|")(?<width>.*)\1@iUs', $image['atts'], $atts ) ) {
-			$width = absint( $atts['width'] );
-		}
+			$image_lazyload = str_replace( '<img', '<img loading="lazy"', $image[0] );
+		} else {
+			$width  = 0;
+			$height = 0;
 
-		if ( preg_match( '@[\s"\']height\s*=\s*(\'|")(?<height>.*)\1@iUs', $image['atts'], $atts ) ) {
-			$height = absint( $atts['height'] );
-		}
+			if ( preg_match( '@[\s"\']width\s*=\s*(\'|")(?<width>.*)\1@iUs', $image['atts'], $atts ) ) {
+				$width = absint( $atts['width'] );
+			}
 
-		$placeholder_atts = preg_replace( '@\ssrc\s*=\s*(\'|")(?<src>.*)\1@iUs', ' src="' . $this->getPlaceholder( $width, $height ) . '"', $image['atts'] );
+			if ( preg_match( '@[\s"\']height\s*=\s*(\'|")(?<height>.*)\1@iUs', $image['atts'], $atts ) ) {
+				$height = absint( $atts['height'] );
+			}
 
-		$image_lazyload = str_replace( $image['atts'], $placeholder_atts . ' data-lazy-src="' . $image['src'] . '"', $image[0] );
+			$placeholder_atts = preg_replace( '@\ssrc\s*=\s*(\'|")(?<src>.*)\1@iUs', ' src="' . $this->getPlaceholder( $width, $height ) . '"', $image['atts'] );
 
-		if ( ! preg_match( '@\sloading\s*=\s*(\'|")(?:lazy|auto)\1@i', $image_lazyload ) && apply_filters( 'rocket_use_native_lazyload', false ) ) {
-			$image_lazyload = str_replace( '<img', '<img loading="lazy"', $image_lazyload );
+			$image_lazyload = str_replace( $image['atts'], $placeholder_atts . ' data-lazy-src="' . $image['src'] . '"', $image[0] );
 		}
 
 		/**
@@ -593,7 +591,6 @@ class Image {
 	 * Returns the placeholder for the src attribute
 	 *
 	 * @since 1.2
-	 * @author Remy Perona
 	 *
 	 * @param int $width  Width of the placeholder image. Default 0.
 	 * @param int $height Height of the placeholder image. Default 0.

--- a/inc/Engine/Media/Lazyload/Subscriber.php
+++ b/inc/Engine/Media/Lazyload/Subscriber.php
@@ -82,7 +82,10 @@ class Subscriber implements Subscriber_Interface {
 			'init'                                     => 'lazyload_smilies',
 			'wp'                                       => 'deactivate_lazyload_on_specific_posts',
 			'wp_lazy_loading_enabled'                  => 'maybe_disable_core_lazyload',
-			'rocket_lazyload_excluded_attributes'      => 'add_exclusions',
+			'rocket_lazyload_excluded_attributes'      => [
+				[ 'add_exclusions' ],
+				[ 'maybe_add_skip_attributes' ],
+			],
 			'rocket_lazyload_excluded_src'             => 'add_exclusions',
 			'rocket_lazyload_iframe_excluded_patterns' => 'add_exclusions',
 		];
@@ -382,8 +385,11 @@ class Subscriber implements Subscriber_Interface {
 		}
 
 		if ( $this->can_lazyload_images() ) {
-			$html = $this->image->lazyloadPictures( $html, $buffer );
-			$html = $this->image->lazyloadImages( $html, $buffer );
+			if ( ! $this->is_native() ) {
+				$html = $this->image->lazyloadPictures( $html, $buffer );
+			}
+
+			$html = $this->image->lazyloadImages( $html, $buffer, $this->is_native() );
 
 			/**
 			 * Filters the application of lazyload on background images
@@ -409,6 +415,10 @@ class Subscriber implements Subscriber_Interface {
 	 * @return string
 	 */
 	public function lazyload_responsive( $html ) {
+		if ( $this->is_native() ) {
+			return $html;
+		}
+
 		return $this->image->lazyloadResponsiveAttributes( $html );
 	}
 
@@ -563,5 +573,43 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	private function ignore_noscripts( $html ) {
 		return preg_replace( '#<noscript>(?:.+)</noscript>#Umsi', '', $html );
+	}
+
+	/**
+	 * Checks if native lazyload is enabled
+	 *
+	 * @since 3.10
+	 *
+	 * @return bool
+	 */
+	private function is_native(): bool {
+		/**
+		 * Filters the use of native lazyload
+		 *
+		 * @since 3.4
+		 *
+		 * @param bool $use_native True to use native lazyload, false otherwise.
+		 */
+		return (bool) apply_filters( 'rocket_use_native_lazyload', true );
+	}
+
+	/**
+	 * Adds the skip attributes exclusions if not using native lazyload
+	 *
+	 * @since 3.10
+	 *
+	 * @param array $exclusions Exclusions array
+	 *
+	 * @return array
+	 */
+	public function maybe_add_skip_attributes( $exclusions ): array {
+		if ( $this->is_native() ) {
+			return $exclusions;
+		}
+
+		$exclusions[] = 'data-skip-lazy';
+		$exclusions[] = 'skip-lazy';
+
+		return $exclusions;
 	}
 }


### PR DESCRIPTION
## Description

**In this PR**
Update the Image class to:
- Perform a different image replacement if using native lazyload
- Remove exception for WP Retina

Update the Subscriber class to:
- Add a method to check if using native lazyload
- Use this method where necessary to avoid unnecessary replacements
- Add a method to add back the skip-lazy attributes if native lazyload is disabled

Fixes #3676
Fixes #2492

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

I split the modifications between the Image class and the subscriber

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
