### PR TITLE
Closes #3677 Update lazyload subscriber class

### DIFF
--- a/inc/Engine/Media/Lazyload/Subscriber.php
+++ b/inc/Engine/Media/Lazyload/Subscriber.php
@@ -81,7 +81,6 @@ class Subscriber implements Subscriber_Interface {
 			'rocket_lazyload_html'                     => 'lazyload_responsive',
 			'init'                                     => 'lazyload_smilies',
 			'wp'                                       => 'deactivate_lazyload_on_specific_posts',
-			'wp_lazy_loading_enabled'                  => 'maybe_disable_core_lazyload',
 			'rocket_lazyload_excluded_attributes'      => 'add_exclusions',
 			'rocket_lazyload_excluded_src'             => 'add_exclusions',
 			'rocket_lazyload_iframe_excluded_patterns' => 'add_exclusions',
@@ -459,22 +458,6 @@ class Subscriber implements Subscriber_Interface {
 		if ( is_rocket_post_excluded_option( 'lazyload_iframes' ) ) {
 			add_filter( 'do_rocket_lazyload_iframes', '__return_false' );
 		}
-	}
-
-	/**
-	 * Disable WP core lazyload if our images lazyload is active
-	 *
-	 * @since 3.5
-	 *
-	 * @param bool $value Current value for the enabling variable.
-	 * @return bool
-	 */
-	public function maybe_disable_core_lazyload( $value ) {
-		if ( false === $value ) {
-			return $value;
-		}
-
-		return ! (bool) $this->can_lazyload_images();
 	}
 
 	/**


### PR DESCRIPTION
## Description

This PRs remove the hook and callback related to the native lazyload in WP core

Fixes #3677

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

Part of the changes originally listed were done in the previous PRs. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
