### PR TITLE
Update WebP compatibility addon description

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
 		"coenjacobs/mozart": "^0.7",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
 		"league/container": "^3.3",
-		"mikey179/vfsstream": "^1.6",
+		"mikey179/vfsstream": "1.6.9",
 		"mnsami/composer-custom-directory-installer": "^2.0",
 		"mobiledetect/mobiledetectlib": "^2.8",
 		"phpcompatibility/phpcompatibility-wp": "^2.0",

--- a/inc/classes/subscriber/Media/class-webp-subscriber.php
+++ b/inc/classes/subscriber/Media/class-webp-subscriber.php
@@ -266,7 +266,7 @@ class Webp_Subscriber implements Subscriber_Interface {
 			// 5, 8.
 			$cache_webp_field['description'] = sprintf(
 			// Translators: %1$s = plugin name(s), %2$s = opening <a> tag, %3$s = closing </a> tag.
-				esc_html( _n( 'You are using %1$s to serve WebP images so you do not need to enable this option. %2$sMore info%3$s %4$s If you prefer to have WP Rocket serve WebP for you instead, please disable them from serving in %1$s.', 'You are using %1$s to serve WebP images so you do not need to enable this option. %2$sMore info%3$s %4$s If you prefer to have WP Rocket serve WebP for you instead, please disable them from serving in %1$s.', count( $serving ), 'rocket' ) ),
+				esc_html( _n( 'You are using %1$s to serve WebP images so you do not need to enable this option. %2$sMore info%3$s %4$s If you prefer to have WP Rocket serve WebP for you instead, please disable WebP display in %1$s.', 'You are using %1$s to serve WebP images so you do not need to enable this option. %2$sMore info%3$s %4$s If you prefer to have WP Rocket serve WebP for you instead, please disable WebP display in %1$s.', count( $serving ), 'rocket' ) ),
 				esc_html( wp_sprintf_l( '%l', $serving ) ),
 				'<a href="' . esc_url( $webp_beacon['url'] ) . '" data-beacon-article="' . esc_attr( $webp_beacon['id'] ) . '" target="_blank" rel="noopener noreferrer">',
 				'</a>',

--- a/inc/classes/subscriber/Media/class-webp-subscriber.php
+++ b/inc/classes/subscriber/Media/class-webp-subscriber.php
@@ -266,7 +266,7 @@ class Webp_Subscriber implements Subscriber_Interface {
 			// 5, 8.
 			$cache_webp_field['description'] = sprintf(
 			// Translators: %1$s = plugin name(s), %2$s = opening <a> tag, %3$s = closing </a> tag.
-				esc_html( _n( 'You are using %1$s to serve WebP images so you do not need to enable this option. If you prefer to have WP Rocket serve WebP for you instead, please disable them from serving in %1$s. %2$sMore info%3$s', 'You are using %1$s to serve WebP images so you do not need to enable this option. If you prefer to have WP Rocket serve WebP for you instead, please disable them from serving in %1$s. %2$sMore info%3$s', count( $serving ), 'rocket' ) ),
+				esc_html( _n( 'You are using %1$s to serve WebP images so you do not need to enable this option. %2$sMore info%3$s If you prefer to have WP Rocket serve WebP for you instead, please disable them from serving in %1$s.', 'You are using %1$s to serve WebP images so you do not need to enable this option. %2$sMore info%3$s If you prefer to have WP Rocket serve WebP for you instead, please disable them from serving in %1$s.', count( $serving ), 'rocket' ) ),
 				esc_html( wp_sprintf_l( '%l', $serving ) ),
 				'<a href="' . esc_url( $webp_beacon['url'] ) . '" data-beacon-article="' . esc_attr( $webp_beacon['id'] ) . '" target="_blank" rel="noopener noreferrer">',
 				'</a>'

--- a/inc/classes/subscriber/Media/class-webp-subscriber.php
+++ b/inc/classes/subscriber/Media/class-webp-subscriber.php
@@ -266,10 +266,11 @@ class Webp_Subscriber implements Subscriber_Interface {
 			// 5, 8.
 			$cache_webp_field['description'] = sprintf(
 			// Translators: %1$s = plugin name(s), %2$s = opening <a> tag, %3$s = closing </a> tag.
-				esc_html( _n( 'You are using %1$s to serve WebP images so you do not need to enable this option. %2$sMore info%3$s If you prefer to have WP Rocket serve WebP for you instead, please disable them from serving in %1$s.', 'You are using %1$s to serve WebP images so you do not need to enable this option. %2$sMore info%3$s If you prefer to have WP Rocket serve WebP for you instead, please disable them from serving in %1$s.', count( $serving ), 'rocket' ) ),
+				esc_html( _n( 'You are using %1$s to serve WebP images so you do not need to enable this option. %2$sMore info%3$s %4$s If you prefer to have WP Rocket serve WebP for you instead, please disable them from serving in %1$s.', 'You are using %1$s to serve WebP images so you do not need to enable this option. %2$sMore info%3$s %4$s If you prefer to have WP Rocket serve WebP for you instead, please disable them from serving in %1$s.', count( $serving ), 'rocket' ) ),
 				esc_html( wp_sprintf_l( '%l', $serving ) ),
 				'<a href="' . esc_url( $webp_beacon['url'] ) . '" data-beacon-article="' . esc_attr( $webp_beacon['id'] ) . '" target="_blank" rel="noopener noreferrer">',
-				'</a>'
+				'</a>',
+				'<br>'
 			);
 
 			return $cache_webp_field;

--- a/inc/classes/subscriber/Media/class-webp-subscriber.php
+++ b/inc/classes/subscriber/Media/class-webp-subscriber.php
@@ -264,7 +264,7 @@ class Webp_Subscriber implements Subscriber_Interface {
 
 		if ( $serving ) {
 			// 5, 8.
-			$cache_webp_field['helper'] = sprintf(
+			$cache_webp_field['description'] = sprintf(
 			// Translators: %1$s = plugin name(s), %2$s = opening <a> tag, %3$s = closing </a> tag.
 				esc_html( _n( 'You are using %1$s to serve WebP images so you do not need to enable this option. If you prefer to have WP Rocket serve WebP for you instead, please disable them from serving in %1$s. %2$sMore info%3$s', 'You are using %1$s to serve WebP images so you do not need to enable this option. If you prefer to have WP Rocket serve WebP for you instead, please disable them from serving in %1$s. %2$sMore info%3$s', count( $serving ), 'rocket' ) ),
 				esc_html( wp_sprintf_l( '%l', $serving ) ),
@@ -277,7 +277,7 @@ class Webp_Subscriber implements Subscriber_Interface {
 
 		/** This filter is documented in inc/classes/buffer/class-cache.php */
 		if ( apply_filters( 'rocket_disable_webp_cache', false ) ) {
-			$cache_webp_field['helper'] = esc_html__( 'WebP cache is disabled by filter.', 'rocket' );
+			$cache_webp_field['description'] = esc_html__( 'WebP cache is disabled by filter.', 'rocket' );
 
 			return $cache_webp_field;
 		}
@@ -285,7 +285,7 @@ class Webp_Subscriber implements Subscriber_Interface {
 		if ( $serving_not_compatible ) {
 			if ( ! $this->options_data->get( 'cache_webp' ) ) {
 				// 6.
-				$cache_webp_field['helper'] = sprintf(
+				$cache_webp_field['description'] = sprintf(
 				// Translators: %1$s = plugin name(s), %2$s = opening <a> tag, %3$s = closing </a> tag.
 					esc_html( _n( 'You are using %1$s to convert images to WebP. If you want WP Rocket to serve them for you, activate this option. %2$sMore info%3$s', 'You are using %1$s to convert images to WebP. If you want WP Rocket to serve them for you, activate this option. %2$sMore info%3$s', count( $serving_not_compatible ), 'rocket' ) ),
 					esc_html( wp_sprintf_l( '%l', $serving_not_compatible ) ),
@@ -297,7 +297,7 @@ class Webp_Subscriber implements Subscriber_Interface {
 			}
 
 			// 7.
-			$cache_webp_field['helper'] = sprintf(
+			$cache_webp_field['description'] = sprintf(
 			// Translators: %1$s = plugin name(s), %2$s = opening <a> tag, %3$s = closing </a> tag.
 				esc_html( _n( 'You are using %1$s to convert images to WebP. WP Rocket will create separate cache files to serve your WebP images. %2$sMore info%3$s', 'You are using %1$s to convert images to WebP. WP Rocket will create separate cache files to serve your WebP images. %2$sMore info%3$s', count( $serving_not_compatible ), 'rocket' ) ),
 				esc_html( wp_sprintf_l( '%l', $serving_not_compatible ) ),
@@ -311,7 +311,7 @@ class Webp_Subscriber implements Subscriber_Interface {
 		if ( $creating ) {
 			if ( ! $this->options_data->get( 'cache_webp' ) ) {
 				// 3.
-				$cache_webp_field['helper'] = sprintf(
+				$cache_webp_field['description'] = sprintf(
 				// Translators: %1$s = plugin name(s), %2$s = opening <a> tag, %3$s = closing </a> tag.
 					esc_html( _n( 'You are using %1$s to convert images to WebP. If you want WP Rocket to serve them for you, activate this option. %2$sMore info%3$s', 'You are using %1$s to convert images to WebP. If you want WP Rocket to serve them for you, activate this option. %2$sMore info%3$s', count( $creating ), 'rocket' ) ),
 					esc_html( wp_sprintf_l( '%l', $creating ) ),
@@ -323,7 +323,7 @@ class Webp_Subscriber implements Subscriber_Interface {
 			}
 
 			// 4.
-			$cache_webp_field['helper'] = sprintf(
+			$cache_webp_field['description'] = sprintf(
 			// Translators: %1$s = plugin name(s), %2$s = opening <a> tag, %3$s = closing </a> tag.
 				esc_html( _n( 'You are using %1$s to convert images to WebP. WP Rocket will create separate cache files to serve your WebP images. %2$sMore info%3$s', 'You are using %1$s to convert images to WebP. WP Rocket will create separate cache files to serve your WebP images. %2$sMore info%3$s', count( $creating ), 'rocket' ) ),
 				esc_html( wp_sprintf_l( '%l', $creating ) ),
@@ -343,7 +343,7 @@ class Webp_Subscriber implements Subscriber_Interface {
 				$imagify_link = '<a href="https://wordpress.org/plugins/imagify/" target="_blank" rel="noopener noreferrer">';
 			}
 
-			$cache_webp_field['helper'] = sprintf(
+			$cache_webp_field['description'] = sprintf(
 			// Translators: %1$s = opening <a> tag, %2$s = closing </a> tag.
 				esc_html__( '%5$sWe have not detected any compatible WebP plugin!%6$s%4$s If you don’t already have WebP images on your site consider using %3$sImagify%2$s or another supported plugin. %1$sMore info%2$s %4$s If you are not using WebP do not enable this option.', 'rocket' ),
 				'<a href="' . esc_url( $webp_beacon['url'] ) . '" data-beacon-article="' . esc_attr( $webp_beacon['id'] ) . '" target="_blank" rel="noopener noreferrer">',
@@ -357,7 +357,7 @@ class Webp_Subscriber implements Subscriber_Interface {
 		}
 
 		// 2.
-		$cache_webp_field['helper'] = esc_html__( 'WP Rocket will create separate cache files to serve your WebP images.', 'rocket' );
+		$cache_webp_field['description'] = esc_html__( 'WP Rocket will create separate cache files to serve your WebP images.', 'rocket' );
 
 		return $cache_webp_field;
 	}

--- a/tests/Unit/inc/classes/subscriber/Media/WebpSubscriber/webpSectionDescription.php
+++ b/tests/Unit/inc/classes/subscriber/Media/WebpSubscriber/webpSectionDescription.php
@@ -30,8 +30,8 @@ class Test_WebpSectionDescription extends TestCase {
 		// Text under field.
 		$expectedText = '<strong>We have not detected any compatible WebP plugin!</strong><br>';
 
-		$this->assertArrayHasKey( 'helper', $field );
-		$this->assertStringStartsWith( $expectedText, $field['helper'] );
+		$this->assertArrayHasKey( 'description', $field );
+		$this->assertStringStartsWith( $expectedText, $field['description'] );
 
 	}
 
@@ -44,8 +44,8 @@ class Test_WebpSectionDescription extends TestCase {
 		$webpSubscriber = new Webp_Subscriber( $mocks['optionsData'], $mocks['optionsApi'], $mocks['cdn'], $mocks['beacon'] );
 		$field          = $webpSubscriber->webp_section_description( [] );
 
-		$this->assertArrayHasKey( 'helper', $field );
-		$this->assertSame( $expectedText, $field['helper'] );
+		$this->assertArrayHasKey( 'description', $field );
+		$this->assertSame( $expectedText, $field['description'] );
 	}
 
 	public function testShouldReturnTextWhenPluginCreatingWebpAvailableAndCacheOptionDisabled() {
@@ -91,8 +91,8 @@ class Test_WebpSectionDescription extends TestCase {
 		$webpSubscriber = new Webp_Subscriber( $mocks['optionsData'], $mocks['optionsApi'], $mocks['cdn'], $mocks['beacon'] );
 		$field          = $webpSubscriber->webp_section_description( [] );
 
-		$this->assertArrayHasKey( 'helper', $field );
-		$this->assertStringStartsWith( $expectedText, $field['helper'] );
+		$this->assertArrayHasKey( 'description', $field );
+		$this->assertStringStartsWith( $expectedText, $field['description'] );
 	}
 
 	public function testShouldReturnTextWhenPluginCreatingWebpAvailableAndCacheOptionEnabled() {
@@ -138,8 +138,8 @@ class Test_WebpSectionDescription extends TestCase {
 		$webpSubscriber = new Webp_Subscriber( $mocks['optionsData'], $mocks['optionsApi'], $mocks['cdn'], $mocks['beacon'] );
 		$field          = $webpSubscriber->webp_section_description( [] );
 
-		$this->assertArrayHasKey( 'helper', $field );
-		$this->assertStringStartsWith( $expectedText, $field['helper'] );
+		$this->assertArrayHasKey( 'description', $field );
+		$this->assertStringStartsWith( $expectedText, $field['description'] );
 	}
 
 	public function testShouldReturnTextWhenPluginServingWebpNotCompatibleAndCacheOptionDisabled() {
@@ -185,8 +185,8 @@ class Test_WebpSectionDescription extends TestCase {
 		$webpSubscriber = new Webp_Subscriber( $mocks['optionsData'], $mocks['optionsApi'], $mocks['cdn'], $mocks['beacon'] );
 		$field          = $webpSubscriber->webp_section_description( [] );
 
-		$this->assertArrayHasKey( 'helper', $field );
-		$this->assertStringStartsWith( $expectedText, $field['helper'] );
+		$this->assertArrayHasKey( 'description', $field );
+		$this->assertStringStartsWith( $expectedText, $field['description'] );
 	}
 
 	public function testShouldReturnTextWhenPluginServingWebpNotCompatibleAndCacheOptionEnabled() {
@@ -232,8 +232,8 @@ class Test_WebpSectionDescription extends TestCase {
 		$webpSubscriber = new Webp_Subscriber( $mocks['optionsData'], $mocks['optionsApi'], $mocks['cdn'], $mocks['beacon'] );
 		$field          = $webpSubscriber->webp_section_description( [] );
 
-		$this->assertArrayHasKey( 'helper', $field );
-		$this->assertStringStartsWith( $expectedText, $field['helper'] );
+		$this->assertArrayHasKey( 'description', $field );
+		$this->assertStringStartsWith( $expectedText, $field['description'] );
 	}
 
 	public function testShouldReturnTextWhenPluginServingWebpAvailable() {
@@ -279,8 +279,8 @@ class Test_WebpSectionDescription extends TestCase {
 		$webpSubscriber = new Webp_Subscriber( $mocks['optionsData'], $mocks['optionsApi'], $mocks['cdn'], $mocks['beacon'] );
 		$field          = $webpSubscriber->webp_section_description( [] );
 
-		$this->assertArrayHasKey( 'helper', $field );
-		$this->assertStringStartsWith( $expectedText, $field['helper'] );
+		$this->assertArrayHasKey( 'description', $field );
+		$this->assertStringStartsWith( $expectedText, $field['description'] );
 
 		// Webp cache option enabled.
 		$mocks = $this->getConstructorMocks();
@@ -288,8 +288,8 @@ class Test_WebpSectionDescription extends TestCase {
 		$webpSubscriber = new Webp_Subscriber( $mocks['optionsData'], $mocks['optionsApi'], $mocks['cdn'], $mocks['beacon'] );
 		$field          = $webpSubscriber->webp_section_description( [] );
 
-		$this->assertArrayHasKey( 'helper', $field );
-		$this->assertStringStartsWith( $expectedText, $field['helper'] );
+		$this->assertArrayHasKey( 'description', $field );
+		$this->assertStringStartsWith( $expectedText, $field['description'] );
 	}
 
 	public function testShouldReturnTextWhenCacheOptionDisabledByFilter() {
@@ -340,8 +340,8 @@ class Test_WebpSectionDescription extends TestCase {
 		$webpSubscriberNoCache = new Webp_Subscriber( $mocks['optionsData'], $mocks['optionsApi'], $mocks['cdn'], $mocks['beacon'] );
 		$field                 = $webpSubscriberNoCache->webp_section_description( [] );
 
-		$this->assertArrayHasKey( 'helper', $field );
-		$this->assertSame( $expectedText, $field['helper'] );
+		$this->assertArrayHasKey( 'description', $field );
+		$this->assertSame( $expectedText, $field['description'] );
 
 		// Webp cache option enabled.
 		$mocks = $this->getConstructorMocks( 1 );
@@ -349,8 +349,8 @@ class Test_WebpSectionDescription extends TestCase {
 		$webpSubscriberWithCache = new Webp_Subscriber( $mocks['optionsData'], $mocks['optionsApi'], $mocks['cdn'], $mocks['beacon'] );
 		$field                   = $webpSubscriberWithCache->webp_section_description( [] );
 
-		$this->assertArrayHasKey( 'helper', $field );
-		$this->assertSame( $expectedText, $field['helper'] );
+		$this->assertArrayHasKey( 'description', $field );
+		$this->assertSame( $expectedText, $field['description'] );
 
 		// Generating but not serving webp.
 		$webpPluginMock
@@ -364,13 +364,13 @@ class Test_WebpSectionDescription extends TestCase {
 		// Webp cache option disabled.
 		$field = $webpSubscriberNoCache->webp_section_description( [] );
 
-		$this->assertArrayHasKey( 'helper', $field );
-		$this->assertSame( $expectedText, $field['helper'] );
+		$this->assertArrayHasKey( 'description', $field );
+		$this->assertSame( $expectedText, $field['description'] );
 
 		// Webp cache option enabled.
 		$field = $webpSubscriberWithCache->webp_section_description( [] );
 
-		$this->assertArrayHasKey( 'helper', $field );
-		$this->assertSame( $expectedText, $field['helper'] );
+		$this->assertArrayHasKey( 'description', $field );
+		$this->assertSame( $expectedText, $field['description'] );
 	}
 }

--- a/views/settings/fields/one-click-addon.php
+++ b/views/settings/fields/one-click-addon.php
@@ -61,12 +61,6 @@ defined( 'ABSPATH' ) || exit;
 					<?php if ( ! empty( $data['description'] ) ) : ?>
 						<div class="wpr-field-description">
 							<?php echo $data['description']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Dynamic content is properly escaped in the view. ?>
-
-							<?php if ( ! empty( $data['helper'] ) ) : ?>
-								<div class="wpr-fieldsContainer-helper wpr-add-on-helper wpr-icon-important">
-									<?php echo $data['helper']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Dynamic content is properly escaped in the view. ?>
-								</div>
-							<?php endif; ?>
 						</div>
 					<?php endif; ?>
 				</div>


### PR DESCRIPTION
## Description

Replace the addon description depending on the context, instead of keeping a fixed description with an additional helper.

![webp-no-plugin](https://user-images.githubusercontent.com/3465180/134728976-eeb50a8a-4d7f-476d-ace0-5a7c80dbda59.jpg)
s
![webp-enabled](https://user-images.githubusercontent.com/3465180/134728972-e18b886e-745d-4a35-aac4-6f59d60c0fbc.jpg)
![webp-disabled-plugin](https://user-images.githubusercontent.com/3465180/134728969-95b4d097-fc72-4863-aa91-27d2efcfb5a3.jpg)
![webp-enabled-plugin](https://user-images.githubusercontent.com/3465180/134728975-e9dc1421-74ab-458d-80f1-d1af00aa78fc.jpg)
![webp-disabled-serving-plugin](https://user-images.githubusercontent.com/3465180/134728971-41ebef7c-1b93-4ff3-a71b-bd7621c8b630.jpg)

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## How Has This Been Tested?

- [x] Tested using the different possible contexts for WebP compatibility

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warning