### PR TITLE
lock vfsstream to 1.6.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
 		"coenjacobs/mozart": "^0.7",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
 		"league/container": "^3.3",
-		"mikey179/vfsstream": "^1.6",
+		"mikey179/vfsstream": "1.6.9",
 		"mnsami/composer-custom-directory-installer": "^2.0",
 		"mobiledetect/mobiledetectlib": "^2.8",
 		"phpcompatibility/phpcompatibility-wp": "^2.0",


### PR DESCRIPTION
## Description

After mikey179/vfsstream package -- released v1.6.10 it caused problems with PHP 8 and tests
revert back to 1.6.9 fixed the problem for now.

@Tabrisrp We need to check this.

