### PR TITLE
Exclude CallRail's script from JS Minification

### DIFF
--- a/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
+++ b/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
@@ -245,6 +245,7 @@ abstract class AbstractJSOptimization extends AbstractOptimization {
 			'cdna.hubpeople.com/js/widget_standalone_two_modes.js',
 			's3.tradingview.com',
 			'www.vbt.io/ext/vbtforms.js',
+			'cdn.callrail.com',
 		];
 
 		$excluded_external = array_merge( $defaults, $this->options->get( 'exclude_js', [] ) );


### PR DESCRIPTION
## Description

Storing the file locally during JavaScript minification breaks the script.
Ticket: https://secure.helpscout.net/conversation/1644626876/297711/

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?
Not applicable.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] On my local test site.

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
