### PR TITLE
Exclude Cloudflare Web Analytics and Tradingview widget from Delay JS

### DIFF
--- a/inc/Engine/Optimization/DelayJS/HTML.php
+++ b/inc/Engine/Optimization/DelayJS/HTML.php
@@ -59,6 +59,8 @@ class HTML {
 		'lazyLoadInstance',
 		'scripts.mediavine.com/tags/', // allows mediavine-video schema to be accessible by search engines.
 		'initCubePortfolio', // Cube Portfolio show images.
+		'//static.cloudflareinsights.com', // Cloudflare Web Analytics.
+		'//s3.tradingview.com', // Tradingview chart widget.
 	];
 
 	/**


### PR DESCRIPTION
Tradingview chart breaks the navigation on mobile when it's delayed.