### PR TITLE
Closes #4378 Reduce requests to Wistia

### DIFF
--- a/views/settings/page-sections/dashboard.php
+++ b/views/settings/page-sections/dashboard.php
@@ -236,7 +236,6 @@ defined( 'ABSPATH' ) || exit;
 	</div>
 	<div class="wpr-Page-row">
 		<div class="wpr-Page-col">
-			<?php $this->render_part( 'getting-started' ); ?>
 			<div class="wpr-optionHeader">
 				<h3 class="wpr-title2"><?php esc_html_e( 'Frequently Asked Questions', 'rocket' ); ?></h3>
 			</div>


### PR DESCRIPTION
## Description

To reduce the number of requests/bandwith to Wistia, we are testing to remove the getting started block from the WP Rocket settings dashboard.

This changes reduces the number of requests to Wistia on page load from 50+ to 13.

Fixes #4378

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

It's different as the tutorials tab is likely not the culprit of the increased bandwith usage.

## How Has This Been Tested?

- [x] Compare the number of requests to Wistia with and without the getting started block

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
