### PR TITLE
Fixes #4397 Guard against preg_replace() errors when moving meta charset to head

### DIFF
--- a/inc/Engine/Optimization/DelayJS/HTML.php
+++ b/inc/Engine/Optimization/DelayJS/HTML.php
@@ -216,16 +216,43 @@ class HTML {
 	 */
 	public function move_meta_charset_to_head( $html ): string {
 		$meta_pattern = "#<meta[^h]*(http-equiv[^=]*=[^\'\"]*[\'\" ]Content-Type[\'\"][ ]*[^>]*|)(charset[^=]*=[ ]*[\'\" ]*[^\'\"> ][^\'\">]+[^\'\"> ][\'\" ]*|charset[^=]*=*[^\'\"> ][^\'\">]+[^\'\"> ])([^>]*|)>(?=.*</head>)#Usmi";
-		if ( preg_match( $meta_pattern, $html, $matches ) ) {
-			$html = preg_replace( "$meta_pattern", '', $html );
-			if ( preg_match( '/<head\b/i', $html ) ) {
-				$html = preg_replace( '/(<head\b[^>]*?>)/i', "\${1}${matches[0]}", $html );
-			} elseif ( preg_match( '/<html\b/i', $html ) ) {
-				$html = preg_replace( '/(<html\b[^>]*?>)/i', "\${1}${matches[0]}", $html );
-			} else {
-				$html = preg_replace( '/(<\w+)/', "${matches[0]}\${1}", $html, 1 );
-			}
+
+		if ( ! preg_match( $meta_pattern, $html, $matches ) ) {
+			return $html;
 		}
-		return $html;
+
+		$replaced_html = preg_replace( "$meta_pattern", '', $html );
+
+		if ( empty( $replaced_html ) ) {
+			return $html;
+		}
+
+		if ( preg_match( '/<head\b/i', $replaced_html ) ) {
+			$replaced_html = preg_replace( '/(<head\b[^>]*?>)/i', "\${1}${matches[0]}", $replaced_html, 1 );
+
+			if ( empty( $replaced_html ) ) {
+				return $html;
+			}
+
+			return $replaced_html;
+		}
+
+		if ( preg_match( '/<html\b/i', $replaced_html ) ) {
+			$replaced_html = preg_replace( '/(<html\b[^>]*?>)/i', "\${1}${matches[0]}", $replaced_html, 1 );
+
+			if ( empty( $replaced_html ) ) {
+				return $html;
+			}
+
+			return $replaced_html;
+		}
+
+		$replaced_html = preg_replace( '/(<\w+)/', "${matches[0]}\${1}", $replaced_html, 1 );
+
+		if ( empty( $replaced_html ) ) {
+			return $html;
+		}
+
+		return $replaced_html;
 	}
 }


### PR DESCRIPTION
## Description

This PR adds guards to `move_meta_charset_to_head()`, to always return a string in case one of the `preg_replace()` encounters an error and returns `null` instead of the expected string value.

Fixes #4397

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Is the solution different from the one proposed during the grooming?

No grooming done

## How Has This Been Tested?

- [x] Automated tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
