### PR TITLE
Fixes #4374 prevent PHP fatal error by adding guard clauses if preg_replace() fails in delay JS add script

### DIFF
--- a/inc/Engine/Optimization/DelayJS/Subscriber.php
+++ b/inc/Engine/Optimization/DelayJS/Subscriber.php
@@ -105,13 +105,23 @@ class Subscriber implements Subscriber_Interface {
 
 		$lazyload_script = $this->filesystem->get_contents( rocket_get_constant( 'WP_ROCKET_PATH' ) . 'assets/js/lazyload-scripts.min.js' );
 
+		$replaced_html = $html;
+
 		if ( false !== $lazyload_script ) {
-			$html = preg_replace( $pattern, "$0<script>{$lazyload_script}</script>", $html, 1 );
+			$replaced_html = preg_replace( $pattern, "$0<script>{$lazyload_script}</script>", $replaced_html, 1 );
+
+			if ( empty( $replaced_html ) ) {
+				return $html;
+			}
 		}
 
-		$html = preg_replace( $pattern, '$0<script>' . $this->html->get_ie_fallback() . '</script>', $html, 1 );
+		$replaced_html = preg_replace( $pattern, '$0<script>' . $this->html->get_ie_fallback() . '</script>', $replaced_html, 1 );
 
-		return $this->html->move_meta_charset_to_head( $html );
+		if ( empty( $replaced_html ) ) {
+			return $html;
+		}
+
+		return $this->html->move_meta_charset_to_head( $replaced_html );
 	}
 
 	/**


### PR DESCRIPTION
## Description

Add guard clauses if `preg_replace()` fails in `add_delay_js_script()`, to avoid passing a `null` value to `move_meta_charset_to_head()` instead of a string.

Fixes #4374 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

No grooming done

## How Has This Been Tested?

- [x] Automated tests

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
