### PR TITLE
Exclude documentcloud.adobe.com/view-sdk/main.js from JS minify and combine

### DIFF
--- a/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
+++ b/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
@@ -246,6 +246,7 @@ abstract class AbstractJSOptimization extends AbstractOptimization {
 			's3.tradingview.com',
 			'www.vbt.io/ext/vbtforms.js',
 			'cdn.callrail.com',
+			'documentcloud.adobe.com/view-sdk/main.js',
 		];
 
 		$excluded_external = array_merge( $defaults, $this->options->get( 'exclude_js', [] ) );


### PR DESCRIPTION
## Description

Exclude documentcloud.adobe.com/view-sdk/main.js from JS minify and combine. 

Fixes #4420

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
On my test environment

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
