### PR TITLE
Fixes #4224 Add exclusions from delay JS execution for Avada compatibility

### DIFF
--- a/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber.php
+++ b/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber.php
@@ -550,7 +550,7 @@ class WooCommerceSubscriber implements Event_Manager_Aware_Subscriber_Interface 
 	 *
 	 * @return array
 	 */
-	public function show_notempty_product_gallery_with_delayJS( array $exclusions = [] ) {
+	public function show_notempty_product_gallery_with_delayJS( $exclusions = [] ): array {
 		global $wp_version;
 
 		if ( ! $this->delayjs_html->is_allowed() ) {
@@ -565,20 +565,31 @@ class WooCommerceSubscriber implements Event_Manager_Aware_Subscriber_Interface 
 			return $exclusions;
 		}
 
-		$exclusions[] = '/jquery-?[0-9.]*(.min|.slim|.slim.min)?.js';
-		$exclusions[] = '/woocommerce/assets/js/zoom/jquery.zoom(.min)?.js';
-		$exclusions[] = '/woocommerce/assets/js/photoswipe/';
-		$exclusions[] = '/woocommerce/assets/js/flexslider/jquery.flexslider(.min)?.js';
-		$exclusions[] = '/woocommerce/assets/js/frontend/single-product(.min)?.js';
+		$exclusions_gallery = [
+			'/jquery-?[0-9.]*(.min|.slim|.slim.min)?.js',
+			'/woocommerce/assets/js/zoom/jquery.zoom(.min)?.js',
+			'/woocommerce/assets/js/photoswipe/',
+			'/woocommerce/assets/js/flexslider/jquery.flexslider(.min)?.js',
+			'/woocommerce/assets/js/frontend/single-product(.min)?.js'
+		];
 
 		if (
 			isset( $wp_version )
 			&&
 			version_compare( $wp_version, '5.7', '<' )
 		) {
-			$exclusions[] = '/jquery-migrate(.min)?.js';
+			$exclusions_gallery[] = '/jquery-migrate(.min)?.js';
 		}
 
-		return $exclusions;
+		/**
+		 * Filters the JS files excluded from delay JS when WC product gallery has images.
+		 *
+		 * @since 3.10.2
+		 *
+		 * @param array $exclusions_gallery Array of excluded filepaths.
+		 */
+		$exclusions_gallery = apply_filters( 'rocket_wc_product_gallery_delay_js_exclusions', $exclusions_gallery );
+
+		return array_merge( $exclusions, $exclusions_gallery );
 	}
 }

--- a/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber.php
+++ b/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber.php
@@ -570,7 +570,7 @@ class WooCommerceSubscriber implements Event_Manager_Aware_Subscriber_Interface 
 			'/woocommerce/assets/js/zoom/jquery.zoom(.min)?.js',
 			'/woocommerce/assets/js/photoswipe/',
 			'/woocommerce/assets/js/flexslider/jquery.flexslider(.min)?.js',
-			'/woocommerce/assets/js/frontend/single-product(.min)?.js'
+			'/woocommerce/assets/js/frontend/single-product(.min)?.js',
 		];
 
 		if (

--- a/inc/ThirdParty/Themes/Avada.php
+++ b/inc/ThirdParty/Themes/Avada.php
@@ -28,12 +28,12 @@ class Avada implements Subscriber_Interface {
 		}
 
 		return [
-			'avada_clear_dynamic_css_cache'        => 'clean_domain',
-			'rocket_exclude_defer_js'              => 'exclude_defer_js',
-			'rocket_maybe_disable_lazyload_helper' => 'maybe_disable_lazyload',
-			'fusion_cache_reset_after'             => 'clean_domain',
-			'update_option_fusion_options'         => [ 'maybe_deactivate_lazyload', 10, 2 ],
-			'rocket_delay_js_exclusions'           => 'exclude_delay_js',
+			'avada_clear_dynamic_css_cache'                 => 'clean_domain',
+			'rocket_exclude_defer_js'                       => 'exclude_defer_js',
+			'rocket_maybe_disable_lazyload_helper'          => 'maybe_disable_lazyload',
+			'fusion_cache_reset_after'                      => 'clean_domain',
+			'update_option_fusion_options'                  => [ 'maybe_deactivate_lazyload', 10, 2 ],
+			'rocket_wc_product_gallery_delay_js_exclusions' => 'exclude_delay_js',
 		];
 	}
 
@@ -121,7 +121,7 @@ class Avada implements Subscriber_Interface {
 	}
 
 	/**
-	 * Excludes some Avada JS from delay JS execution
+	 * Excludes some Avada JS from delay JS execution  when WC product gallery has images
 	 *
 	 * @since 3.10.2
 	 *

--- a/inc/ThirdParty/Themes/Avada.php
+++ b/inc/ThirdParty/Themes/Avada.php
@@ -33,6 +33,7 @@ class Avada implements Subscriber_Interface {
 			'rocket_maybe_disable_lazyload_helper' => 'maybe_disable_lazyload',
 			'fusion_cache_reset_after'             => 'clean_domain',
 			'update_option_fusion_options'         => [ 'maybe_deactivate_lazyload', 10, 2 ],
+			'rocket_delay_js_exclusions'           => 'exclude_delay_js',
 		];
 	}
 
@@ -117,5 +118,27 @@ class Avada implements Subscriber_Interface {
 
 		$disable_images_lazyload[] = __( 'Avada', 'rocket' );
 		return $disable_images_lazyload;
+	}
+
+	/**
+	 * Excludes some Avada JS from delay JS execution
+	 *
+	 * @since 3.10.2
+	 *
+	 * @param array $exclusions Array of exclusion patterns.
+	 *
+	 * @return array
+	 */
+	public function exclude_delay_js( $exclusions ): array {
+		$base_path = wp_parse_url( get_stylesheet_directory_uri(), PHP_URL_PATH );
+
+		if ( empty( $base_path ) ) {
+			return $exclusions;
+		}
+
+		$exclusions[] = $base_path . '/includes/lib/assets/min/js/library/jquery.flexslider.js';
+		$exclusions[] = $base_path . '/assets/min/js/general/avada-woo-product-images.js';
+
+		return $exclusions;
 	}
 }

--- a/inc/ThirdParty/Themes/Avada.php
+++ b/inc/ThirdParty/Themes/Avada.php
@@ -28,11 +28,11 @@ class Avada implements Subscriber_Interface {
 		}
 
 		return [
-			'avada_clear_dynamic_css_cache'                 => 'clean_domain',
-			'rocket_exclude_defer_js'                       => 'exclude_defer_js',
-			'rocket_maybe_disable_lazyload_helper'          => 'maybe_disable_lazyload',
-			'fusion_cache_reset_after'                      => 'clean_domain',
-			'update_option_fusion_options'                  => [ 'maybe_deactivate_lazyload', 10, 2 ],
+			'avada_clear_dynamic_css_cache'        => 'clean_domain',
+			'rocket_exclude_defer_js'              => 'exclude_defer_js',
+			'rocket_maybe_disable_lazyload_helper' => 'maybe_disable_lazyload',
+			'fusion_cache_reset_after'             => 'clean_domain',
+			'update_option_fusion_options'         => [ 'maybe_deactivate_lazyload', 10, 2 ],
 			'rocket_wc_product_gallery_delay_js_exclusions' => 'exclude_delay_js',
 		];
 	}

--- a/tests/Fixtures/inc/ThirdParty/Themes/Avada/excludeDelayJs.php
+++ b/tests/Fixtures/inc/ThirdParty/Themes/Avada/excludeDelayJs.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+	'shouldReturnUpdatedExclusions' => [
+		'exclusions' => [],
+		'expected'   => [
+			'/wp-content/themes/Avada/includes/lib/assets/min/js/library/jquery.flexslider.js',
+			'/wp-content/themes/Avada/assets/min/js/general/avada-woo-product-images.js',
+		],
+	],
+];

--- a/tests/Integration/inc/ThirdParty/Themes/Avada/excludeDelayJs.php
+++ b/tests/Integration/inc/ThirdParty/Themes/Avada/excludeDelayJs.php
@@ -61,7 +61,7 @@ class Test_ExcludeDelayJs extends TestCase {
 	public function testShouldReturnExpected( $exclusions, $expected ) {
 		$this->assertSame(
 			$expected,
-			apply_filters( 'rocket_delay_js_exclusions', $exclusions )
+			apply_filters( 'rocket_wc_product_gallery_delay_js_exclusions', $exclusions )
 		);
 	}
 }

--- a/tests/Integration/inc/ThirdParty/Themes/Avada/excludeDelayJs.php
+++ b/tests/Integration/inc/ThirdParty/Themes/Avada/excludeDelayJs.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\ThirdParty\Themes\Avada;
+
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * @covers \WP_Rocket\ThirdParty\Avada::exclude_delay_js
+ *
+ * @group  AvadaTheme
+ * @group  ThirdParty
+ */
+class Test_ExcludeDelayJs extends TestCase {
+	private static $container;
+
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
+		self::$container = apply_filters( 'rocket_container', '' );
+	}
+
+	public static function tearDownAfterClass() {
+		parent::tearDownAfterClass();
+
+		self::$container->get( 'event_manager' )->remove_subscriber( self::$container->get( 'avada_subscriber' ) );
+	}
+
+	public function setUp(): void {
+		parent::setUp();
+
+		add_filter( 'pre_option_stylesheet', [ $this, 'set_stylesheet' ] );
+		add_filter( 'pre_option_stylesheet_root', [ $this, 'set_stylesheet_root' ] );
+
+		self::$container->get( 'event_manager' )->add_subscriber( self::$container->get( 'avada_subscriber' ) );
+	}
+
+	public function tearDown() {
+		global $wp_theme_directories;
+		unset( $wp_theme_directories['virtual'] );
+
+		remove_filter( 'pre_option_stylesheet', [ $this, 'set_stylesheet' ] );
+		remove_filter( 'pre_option_stylesheet_root', [ $this, 'set_stylesheet_root' ] );
+		parent::tearDown();
+	}
+
+	public function set_stylesheet() {
+		return 'Avada';
+	}
+
+	public function set_stylesheet_root() {
+		global $wp_theme_directories;
+
+		$wp_theme_directories['virtual'] = 'http://example.org/wp-content/themes';
+
+		return 'http://example.org/wp-content/themes';
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnExpected( $exclusions, $expected ) {
+		$this->assertSame(
+			$expected,
+			apply_filters( 'rocket_delay_js_exclusions', $exclusions )
+		);
+	}
+}


### PR DESCRIPTION
## Description

Exclude 2 Avada scripts from delay JS execution to prevent display issue on the WooCommerce product gallery.

Fixes #4224 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

No

## How Has This Been Tested?

- [x] Added integration test for the new method adding the exclusions

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
