### PR TITLE
Fixes #4331 Prevent removing style tags inserted with inline JS when RUCSS is enabled

### DIFF
--- a/inc/Engine/Optimization/RUCSS/AbstractAPIClient.php
+++ b/inc/Engine/Optimization/RUCSS/AbstractAPIClient.php
@@ -83,7 +83,7 @@ abstract class AbstractAPIClient {
 	}
 
 	/**
-	 * Handle Saas request error.
+	 * Handle SaaS request error.
 	 *
 	 * @param array|WP_Error $response WP Remote request.
 	 *

--- a/inc/Engine/Optimization/RUCSS/Admin/Settings.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Settings.php
@@ -5,7 +5,6 @@ namespace WP_Rocket\Engine\Optimization\RUCSS\Admin;
 
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\Admin\Settings\Settings as AdminSettings;
-use WP_Rocket\Engine\Admin\Settings\Render;
 
 class Settings {
 	/**

--- a/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 namespace WP_Rocket\Engine\Optimization\RUCSS\Admin;
 
 use WP_Rocket\Admin\Options;
-use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\Admin\Settings\Settings as AdminSettings;
 use WP_Rocket\Engine\Optimization\RUCSS\Controller\UsedCSS;
-use WP_Rocket\Engine\Optimization\RUCSS\Database\Row\UsedCSS as UsedCSS_Row;
 use WP_Rocket\Engine\Preload\Homepage;
 use WP_Rocket\Event_Management\Subscriber_Interface;
 
@@ -142,7 +140,6 @@ class Subscriber implements Subscriber_Interface {
 
 	/**
 	 * Cron callback for deleting old rows in both table databases.
-	 * Deletes used css files and also cache file for old used css.
 	 *
 	 * @since 3.9
 	 *
@@ -151,13 +148,6 @@ class Subscriber implements Subscriber_Interface {
 	public function cron_clean_rows() {
 		if ( ! $this->settings->is_enabled() ) {
 			return;
-		}
-
-		$old_used_css_ids = $this->database->get_old_used_css();
-		foreach ( $old_used_css_ids as $old_used_css ) {
-			$used_css_item = new UsedCSS_Row( $old_used_css );
-			// Delete file from filesystem.
-			$this->used_css->delete_used_css_file( $used_css_item );
 		}
 
 		$this->database->delete_old_used_css();

--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -537,7 +537,7 @@ class UsedCSS {
 	 *
 	 * @since 3.10.2
 	 *
-	 * @param string $html HTML content
+	 * @param string $html HTML content.
 	 *
 	 * @return string
 	 */

--- a/inc/Engine/Optimization/RUCSS/Frontend/APIClient.php
+++ b/inc/Engine/Optimization/RUCSS/Frontend/APIClient.php
@@ -8,14 +8,14 @@ use WP_Rocket\Engine\Optimization\RUCSS\AbstractAPIClient;
 class APIClient extends AbstractAPIClient {
 
 	/**
-	 * SAAS main API path.
+	 * SaaS main API path.
 	 *
 	 * @var string
 	 */
 	protected $request_path = 'api';
 
 	/**
-	 * Calls Central Saas API.
+	 * Calls Central SaaS API.
 	 *
 	 * @param string $html    HTML content.
 	 * @param string $url     HTML url.
@@ -58,7 +58,7 @@ class APIClient extends AbstractAPIClient {
 			'code'            => $result['code'],
 			'message'         => $result['message'],
 			'css'             => $result['contents']['shakedCSS'],
-			'unprocessed_css' => ( is_array( $result['contents']['unProcessedCss'] ) ? $result['contents']['unProcessedCss'] : [] ),
+			'unprocessed_css' => is_array( $result['contents']['unProcessedCss'] ) ? $result['contents']['unProcessedCss'] : [],
 		];
 	}
 }

--- a/inc/Engine/Optimization/RUCSS/Frontend/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Frontend/Subscriber.php
@@ -29,7 +29,7 @@ class Subscriber implements Subscriber_Interface {
 	 *
 	 * @return array
 	 */
-	public static function get_subscribed_events() : array {
+	public static function get_subscribed_events(): array {
 		return [
 			'rocket_buffer'                => [ 'treeshake', 12 ],
 			'rocket_rucss_retries_cron'    => 'rucss_retries',
@@ -44,7 +44,7 @@ class Subscriber implements Subscriber_Interface {
 	 *
 	 * @return string  HTML content.
 	 */
-	public function treeshake( string $html ) : string {
+	public function treeshake( string $html ): string {
 		return $this->used_css->treeshake( $html );
 	}
 
@@ -58,7 +58,7 @@ class Subscriber implements Subscriber_Interface {
 	}
 
 	/**
-	 * Disables the preload fonts if RUCSS is enabled + CPCSS disabled
+	 * Disables the preload fonts if RUCSS is enabled
 	 *
 	 * @since 3.9
 	 *

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cronCleanRows.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cronCleanRows.php
@@ -44,53 +44,12 @@ $resources = [
 ];
 
 return [
-	'vfs_dir' => 'wp-content/',
-
-	// Virtual filesystem structure.
-	'structure' => [
-		'wp-content' => [
-			'cache' => [
-				'wp-rocket' => [
-					'example.org'                                => [
-						'index.html'      => '',
-						'index.html_gzip' => '',
-					],
-					'example.org-wpmedia-594d03f6ae698691165999' => [
-						'index.html'      => '',
-						'index.html_gzip' => '',
-					],
-					'example.org-Foo-594d03f6ae698691165999'     => [
-						'index.html'      => '',
-						'index.html_gzip' => '',
-					],
-				],
-
-				'used-css' => [
-					'1' => [
-						'home' => [
-							'used.css' => '',
-							'used-mobile.css' => '',
-						],
-						'category' => [
-							'level1' => [
-								'used.css' => '',
-								'used-mobile.css' => '',
-							]
-						]
-					],
-				],
-			],
-		],
-	],
-
-	// Test data.
 	'test_data' => [
 		'shouldNotDeleteOnUpdateDueToMissingSettings' => [
 			'input' => [
 				'remove_unused_css'      => false,
 				'used_css'               => $used_css,
 				'resources'              => $resources,
-				'deleted_used_css_files' => [],
 			]
 		],
 		'shouldDeleteOnUpdate' => [
@@ -98,12 +57,6 @@ return [
 				'remove_unused_css' => true,
 				'used_css'          => $used_css,
 				'resources'         => $resources,
-				'deleted_used_css_files' => [
-					'vfs://public/wp-content/cache/used-css/1/home/used.css' => null,
-					'vfs://public/wp-content/cache/used-css/1/home/used-mobile.css' => null,
-					'vfs://public/wp-content/cache/used-css/1/category/level1/used.css' => null,
-					'vfs://public/wp-content/cache/used-css/1/category/level1/used-mobile.css' => null,
-				],
 			]
 		],
 	],

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/maybeDisablePreloadFonts.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/maybeDisablePreloadFonts.php
@@ -7,11 +7,9 @@ return [
                 'type'                           => 'front_page',
                 'DONOTROCKETOPTIMIZE'            => true,
                 'options'                        => [
-                    'async_css'         => true,
                     'remove_unused_css' => true,
                 ],
                 'is_rocket_post_excluded_option' => [
-					'async_css'         => false,
                     'remove_unused_css' => false,
 				],
             ],
@@ -22,11 +20,9 @@ return [
                 'type'                           => 'front_page',
                 'DONOTROCKETOPTIMIZE'            => false,
                 'options'                        => [
-                    'async_css'         => true,
                     'remove_unused_css' => false,
                 ],
                 'is_rocket_post_excluded_option' => [
-					'async_css'         => false,
                     'remove_unused_css' => false,
 				],
             ],
@@ -37,41 +33,22 @@ return [
                 'type'                           => 'is_post',
                 'DONOTROCKETOPTIMIZE'            => false,
                 'options'                        => [
-                    'async_css'         => true,
                     'remove_unused_css' => true,
                 ],
                 'is_rocket_post_excluded_option' => [
-					'async_css'         => false,
                     'remove_unused_css' => true,
 				],
             ],
             'expected' => false,
         ],
-        'testShouldReturnTrueWhenAsyncDisabled' => [
+        'testShouldReturnTrueWhenRUCSSEnabled' => [
             'config'   => [
                 'type'                           => 'front_page',
                 'DONOTROCKETOPTIMIZE'            => false,
                 'options'                        => [
-                    'async_css'         => false,
                     'remove_unused_css' => true,
                 ],
                 'is_rocket_post_excluded_option' => [
-					'async_css'         => false,
-                    'remove_unused_css' => false,
-				],
-            ],
-            'expected' => true,
-        ],
-        'testShouldReturnTrueWhenAsyncDisabledPost' => [
-            'config'   => [
-                'type'                           => 'is_post',
-                'DONOTROCKETOPTIMIZE'            => false,
-                'options'                        => [
-                    'async_css'         => true,
-                    'remove_unused_css' => true,
-                ],
-                'is_rocket_post_excluded_option' => [
-					'async_css'         => true,
                     'remove_unused_css' => false,
 				],
             ],

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/treeshake.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/treeshake.php
@@ -251,6 +251,9 @@ return [
 	<style id="test3">h5{color:white;}</style >
 	<noscript id="noscript2"><style id="test2">h2{color:green;}</style></noscript>
 	<noscript><style id="test">div{display:none !important;}</style></noscript >
+	<script type="text/javascript">
+		(function($) {$("head").append("<style>.my-style{color:red;}</style>")})(jQuery);
+	</script>
 </head>
 <body>
  content here
@@ -292,6 +295,9 @@ return [
 	</noscript>
 	<noscript id="noscript2"><style id="test2">h2{color:green;}</style></noscript>
 	<noscript><style id="test">div{display:none !important;}</style></noscript >
+	<script type="text/javascript">
+		(function($) {$("head").append("<style>.my-style{color:red;}</style>")})(jQuery);
+	</script>
 </head>
 <body>
  content here

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cronCleanRows.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cronCleanRows.php
@@ -4,19 +4,17 @@ declare(strict_types=1);
 namespace WP_Rocket\Tests\Integration\inc\Engine\Optimization\RUCSS\Admin\Subscriber;
 
 use WP_Rocket\Tests\Integration\DBTrait;
-use WP_Rocket\Tests\Integration\FilesystemTestCase;
+use WP_Rocket\Tests\Integration\TestCase;
 
 /**
  * @covers \WP_Rocket\Engine\Optimization\RUCSS\Admin\Subscriber::cron_clean_rows
  *
  * @group  RUCSS
  */
-class Test_CronCleanRows extends FilesystemTestCase {
+class Test_CronCleanRows extends TestCase {
 	use DBTrait;
 
 	private $input;
-
-	protected $path_to_test_data = '/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cronCleanRows.php';
 
 	public static function setUpBeforeClass(): void {
 		self::installFresh();
@@ -37,7 +35,7 @@ class Test_CronCleanRows extends FilesystemTestCase {
 	}
 
 	/**
-	 * @dataProvider providerTestData
+	 * @dataProvider configTestData
 	 */
 	public function testShouldDoExpected( $input ){
 		$container              = apply_filters( 'rocket_container', null );
@@ -49,10 +47,6 @@ class Test_CronCleanRows extends FilesystemTestCase {
 		$this->input = $input;
 		add_filter( 'pre_get_rocket_option_remove_unused_css', [ $this, 'set_rucss_option' ] );
 		$this->set_permalink_structure( "/%postname%/" );
-
-		foreach ( $input['deleted_used_css_files'] as $file => $content ) {
-			$this->assertTrue( $this->filesystem->exists( $file ) );
-		}
 
 		$count_remain_used_css = 0;
 		foreach ( $input['used_css'] as $used_css ) {
@@ -91,10 +85,6 @@ class Test_CronCleanRows extends FilesystemTestCase {
 		} else {
 			$this->assertCount( count( $input['used_css'] ), $resultUsedCssAfterClean );
 			$this->assertCount( count( $input['resources'] ), $resultResourcesAfterClean );
-		}
-
-		foreach ( $input['deleted_used_css_files'] as $file => $content ) {
-			$this->assertFalse( $this->filesystem->exists( $file ) );
 		}
 	}
 

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/maybeDisablePreloadFonts.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/maybeDisablePreloadFonts.php
@@ -8,23 +8,19 @@ use WP_Rocket\Tests\Integration\TestCase;
 /**
  * @covers   \WP_Rocket\Engine\Optimization\RUCSS\Frontend\Subscriber::maybe_disable_preload_fonts
  * @covers   \WP_Rocket\Engine\Optimization\RUCSS\Controller\UsedCSS::is_allowed()
- * @covers   \WP_Rocket\Engine\Optimization\RUCSS\Controller\UsedCSS::cpcss_enabled()
  *
  * @group    RUCSS
  */
 class Test_MaybeDisablePreloadFonts extends TestCase {
 	use ContentTrait;
 
-	private $async_css;
 	private $rucss;
 	private $post;
 
 	public function tearDown(): void {
-		remove_filter( 'pre_get_rocket_option_async_css', [ $this, 'async_css' ] );
 		remove_filter( 'pre_get_rocket_option_remove_unused_css', [ $this, 'rucss' ] );
 
 		if ( isset( $this->post->ID ) ) {
-			delete_post_meta( $this->post->ID, '_rocket_exclude_async_css', 1, true );
 			delete_post_meta( $this->post->ID, '_rocket_exclude_remove_unused_css', 1, true );
 		}
 
@@ -41,15 +37,9 @@ class Test_MaybeDisablePreloadFonts extends TestCase {
 
 		$this->donotrocketoptimize = $config['DONOTROCKETOPTIMIZE'];
 
-		$this->async_css = $config['options']['async_css'];
 		$this->rucss     = $config['options']['remove_unused_css'];
 
-		add_filter( 'pre_get_rocket_option_async_css', [ $this, 'async_css' ] );
 		add_filter( 'pre_get_rocket_option_remove_unused_css', [ $this, 'rucss' ] );
-
-		if ( $config['is_rocket_post_excluded_option']['async_css'] ) {
-			add_post_meta( $this->post->ID, '_rocket_exclude_async_css', 1, true );
-		}
 
 		if ( $config['is_rocket_post_excluded_option']['remove_unused_css'] ) {
 			add_post_meta( $this->post->ID, '_rocket_exclude_remove_unused_css', 1, true );
@@ -64,10 +54,6 @@ class Test_MaybeDisablePreloadFonts extends TestCase {
 		} else {
 			$this->assertFalse( $value );
 		}
-	}
-
-	public function async_css() {
-		return $this->async_css;
 	}
 
 	public function rucss() {

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/treeshake.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/treeshake.php
@@ -51,7 +51,6 @@ class Test_Treeshake extends FilesystemTestCase {
 		unset( $GLOBALS['wp'] );
 
 		remove_filter( 'pre_get_rocket_option_remove_unused_css', [ $this, 'set_rucss_option' ] );
-		remove_filter( 'pre_get_rocket_option_async_css', [ $this, 'set_cpcss_option' ] );
 		remove_filter( 'pre_get_rocket_option_cache_logged_user', [ $this, 'set_cached_user' ] );
 		remove_filter( 'pre_http_request', [ $this, 'set_api_response' ] );
 		remove_filter( 'pre_option_wp_rocket_prewarmup_stats', [ $this, 'return_prewarmup_stats' ] );
@@ -80,11 +79,6 @@ class Test_Treeshake extends FilesystemTestCase {
 		}
 
 		add_filter( 'pre_get_rocket_option_remove_unused_css', [ $this, 'set_rucss_option' ] );
-
-		if ( isset( $config['has_cpcss'] ) ) {
-			$this->config_data['cpcss_option'] = $config['has_cpcss'];
-			add_filter( 'pre_get_rocket_option_async_css', [ $this, 'set_cpcss_option' ] );
-		}
 
 		if ( $config['logged-in'] ?? false ) {
 			$user = $this->factory->user->create();
@@ -146,10 +140,6 @@ class Test_Treeshake extends FilesystemTestCase {
 
 	public function set_api_response() {
 		return $this->config_data['api-response'];
-	}
-
-	public function set_cpcss_option() {
-		return $this->config_data['cpcss_option'] ?? false;
 	}
 
 	public function return_prewarmup_stats( $option_value ) {


### PR DESCRIPTION
## Description

This PR prevents the removal of style tags inserted with inline JS when RUCSS is enabled. It also cleans up the code where needed, notably in tests after the changes in 3.10

Fixes #4331

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

No

## How Has This Been Tested?

- [x] Updated fixture to add an inline script inserting a style

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
