### PR TITLE
Fixes #4337 Only try to clear RUCSS scheduled event if it is scheduled

### DIFF
--- a/inc/Engine/Deactivation/Deactivation.php
+++ b/inc/Engine/Deactivation/Deactivation.php
@@ -89,8 +89,7 @@ class Deactivation {
 		delete_site_transient( 'update_wprocket_response' );
 
 		// Unschedule WP Cron events.
-		wp_clear_scheduled_hook( 'rocket_facebook_tracking_cache_update' );
-		wp_clear_scheduled_hook( 'rocket_google_tracking_cache_update' );
+		wp_clear_scheduled_hook( 'rocket_rucss_clean_rows_time_event' );
 		wp_clear_scheduled_hook( 'rocket_cache_dir_size_check' );
 
 		/**

--- a/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
@@ -172,6 +172,10 @@ class Subscriber implements Subscriber_Interface {
 			return;
 		}
 
+		if ( ! $this->settings->is_enabled() ) {
+			return;
+		}
+
 		if ( wp_next_scheduled( 'rocket_rucss_clean_rows_time_event' ) ) {
 			return;
 		}

--- a/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
@@ -162,7 +162,11 @@ class Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function schedule_clean_not_commonly_used_rows() {
-		if ( ! $this->settings->is_enabled() ) {
+		if (
+			! $this->settings->is_enabled()
+			&&
+			wp_next_scheduled( 'rocket_rucss_clean_rows_time_event' )
+		) {
 			wp_clear_scheduled_hook( 'rocket_rucss_clean_rows_time_event' );
 
 			return;


### PR DESCRIPTION
## Description

Previously we were only checking if the RUCSS option is enabled before calling the unschedule function. So that call would happen every time a page is loaded and the RUCSS is disabled, doing unnecessary processing.

With that change, it will be called only if RUCSS is disabled AND there is an event scheduled.

Fixes #4337

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

A bit, as it checks for the scheduled event in addition to the setting being disabled in the same condition.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
