### PR TITLE
Fix failing WP Smush integration tests

### DIFF
--- a/inc/ThirdParty/Plugins/Smush.php
+++ b/inc/ThirdParty/Plugins/Smush.php
@@ -42,13 +42,11 @@ class Smush implements Subscriber_Interface {
 			];
 		}
 
-		$prefix = rocket_get_constant( 'WP_SMUSH_PREFIX', 'wp-smush-' );
-
 		return [
-			"update_option_{$prefix}settings"              => [ 'maybe_deactivate_rocket_lazyload', 11 ],
-			"update_site_option_{$prefix}settings"         => [ 'maybe_deactivate_rocket_lazyload', 11 ],
-			"update_option_{$prefix}lazy_load"             => [ 'maybe_deactivate_rocket_lazyload', 11 ],
-			"update_site_option_{$prefix}lazy_load"        => [ 'maybe_deactivate_rocket_lazyload', 11 ],
+			"update_option_wp-smush-settings"              => [ 'maybe_deactivate_rocket_lazyload', 11 ],
+			"update_site_option_wp-smush-settings"         => [ 'maybe_deactivate_rocket_lazyload', 11 ],
+			"update_option_wp-smush-lazy_load"             => [ 'maybe_deactivate_rocket_lazyload', 11 ],
+			"update_site_option_wp-smush-lazy_load"        => [ 'maybe_deactivate_rocket_lazyload', 11 ],
 			'rocket_maybe_disable_lazyload_helper'         => 'is_smush_lazyload_active',
 			'rocket_maybe_disable_iframes_lazyload_helper' => 'is_smush_iframes_lazyload_active',
 		];
@@ -165,8 +163,7 @@ class Smush implements Subscriber_Interface {
 			return $enabled;
 		}
 
-		$prefix  = rocket_get_constant( 'WP_SMUSH_PREFIX', 'wp-smush-' );
-		$formats = $smush_settings->get_setting( $prefix . 'lazy_load' );
+		$formats = $smush_settings->get_setting( 'wp-smush-lazy_load' );
 		$formats = ! empty( $formats['format'] ) && is_array( $formats['format'] ) ? array_filter( $formats['format'] ) : [];
 
 		$image_formats = array_intersect_key(

--- a/inc/ThirdParty/Plugins/Smush.php
+++ b/inc/ThirdParty/Plugins/Smush.php
@@ -43,10 +43,10 @@ class Smush implements Subscriber_Interface {
 		}
 
 		return [
-			"update_option_wp-smush-settings"              => [ 'maybe_deactivate_rocket_lazyload', 11 ],
-			"update_site_option_wp-smush-settings"         => [ 'maybe_deactivate_rocket_lazyload', 11 ],
-			"update_option_wp-smush-lazy_load"             => [ 'maybe_deactivate_rocket_lazyload', 11 ],
-			"update_site_option_wp-smush-lazy_load"        => [ 'maybe_deactivate_rocket_lazyload', 11 ],
+			'update_option_wp-smush-settings'              => [ 'maybe_deactivate_rocket_lazyload', 11 ],
+			'update_site_option_wp-smush-settings'         => [ 'maybe_deactivate_rocket_lazyload', 11 ],
+			'update_option_wp-smush-lazy_load'             => [ 'maybe_deactivate_rocket_lazyload', 11 ],
+			'update_site_option_wp-smush-lazy_load'        => [ 'maybe_deactivate_rocket_lazyload', 11 ],
 			'rocket_maybe_disable_lazyload_helper'         => 'is_smush_lazyload_active',
 			'rocket_maybe_disable_iframes_lazyload_helper' => 'is_smush_iframes_lazyload_active',
 		];

--- a/tests/Integration/inc/ThirdParty/Plugins/Smush/SmushSubscriberTestCase.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Smush/SmushSubscriberTestCase.php
@@ -28,9 +28,9 @@ abstract class SmushSubscriberTestCase extends TestCase {
 		$this->options_api  = $container->get( 'options_api' );
 
 		$this->smush                      = Settings::get_instance();
-		$this->smush_settings_option_name = WP_SMUSH_PREFIX . 'settings';
+		$this->smush_settings_option_name = 'wp-smush-settings';
 		$this->smush_settings             = $this->smush->get_setting( $this->smush_settings_option_name );
-		$this->smush_lazy_option_name     = WP_SMUSH_PREFIX . 'lazy_load';
+		$this->smush_lazy_option_name     = 'wp-smush-lazy_load';
 		$this->smush_lazy                 = $this->smush->get_setting( $this->smush_lazy_option_name );
 	}
 

--- a/tests/Unit/inc/ThirdParty/Plugins/Smush/SmushSubscriberTestCase.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/Smush/SmushSubscriberTestCase.php
@@ -11,10 +11,6 @@ abstract class SmushSubscriberTestCase extends TestCase {
 	public static function setUpBeforeClass() : void {
 		parent::setUpBeforeClass();
 
-		Functions\expect( 'rocket_get_constant' )
-			->with( 'WP_SMUSH_PREFIX' )
-			->andReturn( 'wp-smush-' );
-
 		require_once WP_ROCKET_TESTS_FIXTURES_DIR . '/inc/ThirdParty/Plugins/Smush/SmushCoreSettings.php';
 	}
 


### PR DESCRIPTION
## Description

In version 3.9.1 of WP Smush, the constant `WP_SMUSH_PREFIX` was removed. This caused our integration tests to start failing.

This PR fixes this issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Automated tests pass again

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
