### PR TITLE
Closes #4457 Add back the getting started section on the dashboard

### DIFF
--- a/views/settings/page-sections/dashboard.php
+++ b/views/settings/page-sections/dashboard.php
@@ -236,6 +236,7 @@ defined( 'ABSPATH' ) || exit;
 	</div>
 	<div class="wpr-Page-row">
 		<div class="wpr-Page-col">
+			<?php $this->render_part( 'getting-started' ); ?>
 			<div class="wpr-optionHeader">
 				<h3 class="wpr-title2"><?php esc_html_e( 'Frequently Asked Questions', 'rocket' ); ?></h3>
 			</div>


### PR DESCRIPTION
## Description

Add back the getting started section on the dashboard that was removed to reduce Wistia bandwith usage. Turns out the issue was coming from their side.

Fixes #4457

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## How Has This Been Tested?

- [x] Manual test checking the section is displayed again

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
