### PR TITLE
Closes #4299 Delete term used CSS after editing

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
@@ -84,6 +84,7 @@ class Subscriber implements Subscriber_Interface {
 			'delete_post'                         => 'delete_used_css_on_update_or_delete',
 			'clean_post_cache'                    => 'delete_used_css_on_update_or_delete',
 			'wp_update_comment_count'             => 'delete_used_css_on_update_or_delete',
+			'edit_term'                           => 'delete_term_used_css',
 			'init'                                => 'schedule_clean_not_commonly_used_rows',
 			'rocket_rucss_clean_rows_time_event'  => 'cron_clean_rows',
 			'admin_post_rocket_clear_usedcss'     => 'truncate_used_css_handler',
@@ -200,6 +201,29 @@ class Subscriber implements Subscriber_Interface {
 		$url = get_permalink( $post_id );
 
 		if ( false === $url ) {
+			return;
+		}
+
+		$this->used_css->delete_used_css( untrailingslashit( $url ) );
+	}
+
+	/**
+	 * Deletes the used CSS when updating a term
+	 *
+	 * @since 3.10.2
+	 *
+	 * @param int $term_id the term ID.
+	 *
+	 * @return void
+	 */
+	public function delete_term_used_css( $term_id ) {
+		if ( ! $this->settings->is_enabled() ) {
+			return;
+		}
+
+		$url = get_term_link( (int) $term_id );
+
+		if ( is_wp_error( $url ) ) {
 			return;
 		}
 

--- a/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
@@ -85,6 +85,7 @@ class Subscriber implements Subscriber_Interface {
 			'clean_post_cache'                    => 'delete_used_css_on_update_or_delete',
 			'wp_update_comment_count'             => 'delete_used_css_on_update_or_delete',
 			'edit_term'                           => 'delete_term_used_css',
+			'pre_delete_term'                     => 'delete_term_used_css',
 			'init'                                => 'schedule_clean_not_commonly_used_rows',
 			'rocket_rucss_clean_rows_time_event'  => 'cron_clean_rows',
 			'admin_post_rocket_clear_usedcss'     => 'truncate_used_css_handler',

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/deleteTermUsedCss.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/deleteTermUsedCss.php
@@ -7,6 +7,7 @@ return [
 			'url' => 'http://example.org/category/test/',
 			'wp_error' => false,
 			'term_id' => 1,
+			'removed' => false,
 		],
 	],
 	'shouldDoNothingWhenWPError' => [
@@ -15,6 +16,7 @@ return [
 			'url' => 'http://example.org/category/test/',
 			'wp_error' => true,
 			'term_id' => 1,
+			'removed' => false,
 		],
 	],
 	'shouldDelete' => [
@@ -23,6 +25,7 @@ return [
 			'url' => 'http://example.org/category/test/',
 			'wp_error' => false,
 			'term_id' => 1,
+			'removed' => true,
 		],
 	],
 ];

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/deleteTermUsedCss.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/deleteTermUsedCss.php
@@ -1,0 +1,28 @@
+<?php
+
+return [
+	'shouldDoNothingWhenRucssDisabled' => [
+		'config' => [
+			'remove_unused_css' => false,
+			'url' => 'http://example.org/category/test/',
+			'wp_error' => false,
+			'term_id' => 1,
+		],
+	],
+	'shouldDoNothingWhenWPError' => [
+		'config' => [
+			'remove_unused_css' => true,
+			'url' => 'http://example.org/category/test/',
+			'wp_error' => true,
+			'term_id' => 1,
+		],
+	],
+	'shouldDelete' => [
+		'config' => [
+			'remove_unused_css' => true,
+			'url' => 'http://example.org/category/test/',
+			'wp_error' => false,
+			'term_id' => 1,
+		],
+	],
+];

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/deleteTermUsedCss.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/deleteTermUsedCss.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\Optimization\RUCSS\Admin\Subscriber;
+
+use WP_Rocket\Tests\Integration\DBTrait;
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Optimization\RUCSS\Admin\Subscriber::delete_term_used_css
+ *
+ * @group  RUCSS
+ */
+class Test_DeleteTermUsedCss extends TestCase {
+	use DBTrait;
+
+	private $rucss_option;
+
+	public static function setUpBeforeClass(): void {
+		self::installFresh();
+
+		parent::setUpBeforeClass();
+	}
+
+	public static function tearDownAfterClass() {
+		parent::tearDownAfterClass();
+
+		self::uninstallAll();
+	}
+
+	public function tearDown(): void {
+		remove_filter( 'pre_get_rocket_option_remove_unused_css', [ $this, 'set_rucss_option' ] );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldDoExpected( $config ) {
+		$container           = apply_filters( 'rocket_container', null );
+		$rucss_usedcss_query = $container->get( 'rucss_used_css_query' );
+
+		$this->rucss_option = $config['remove_unused_css'];
+		$this->set_permalink_structure( "/%postname%/" );
+
+		$term = $this->factory->term->create_and_get([
+			'name' => 'test_taxonomy'
+		]);
+
+		$item = [
+			'url' => untrailingslashit( get_term_link( $term->term_id ) ),
+		];
+
+		$rucss_usedcss_query->add_item( $item );
+
+		$result = $rucss_usedcss_query->query();
+		$this->assertCount( 1, $result );
+
+		add_filter( 'pre_get_rocket_option_remove_unused_css', [ $this, 'set_rucss_option' ] );
+
+		if ( $config['wp_error'] ) {
+			do_action( 'edit_term', 0, 0, 'category' );
+
+		} else {
+			do_action( 'edit_term', $term->term_id, $term->term_taxonomy_id, $term->taxonomy );
+		}
+
+
+		$rucss_usedcss_query = $container->get( 'rucss_used_css_query' );
+		$resultAfterDelete = $rucss_usedcss_query->query();
+
+		if ( $config['removed'] ) {
+			$this->assertCount( 0, $resultAfterDelete );
+		} else {
+			$this->assertCount( 1, $resultAfterDelete );
+		}
+	}
+
+	public function set_rucss_option() {
+		return $this->rucss_option;
+	}
+}

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/deleteTermUsedCss.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/deleteTermUsedCss.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\RUCSS\Admin\Subscriber;
+
+use Mockery;
+use Brain\Monkey\Functions;
+use WP_Rocket\Admin\Options;
+use WP_Rocket\Engine\Preload\Homepage;
+use WP_Rocket\Tests\Unit\TestCase;
+use WP_Rocket\Engine\Optimization\RUCSS\Admin\Database;
+use WP_Rocket\Engine\Optimization\RUCSS\Admin\Settings;
+use WP_Rocket\Engine\Optimization\RUCSS\Admin\Subscriber;
+use WP_Rocket\Engine\Optimization\RUCSS\Controller\UsedCSS;
+
+/**
+ * @covers \WP_Rocket\Engine\Optimization\RUCSS\Admin\Subscriber::delete_term_used_css
+ *
+ * @group  RUCSS
+ */
+class Test_DeleteTermUsedCss extends TestCase {
+	private $settings;
+	private $database;
+	private $usedCSS;
+	private $subscriber;
+	private $options_api;
+	private $homepage_preloader;
+
+	public function setUp() : void {
+		parent::setUp();
+
+		$this->settings           = Mockery::mock( Settings::class );
+		$this->database           = Mockery::mock( Database::class );
+		$this->usedCSS            = Mockery::mock( UsedCSS::class );
+		$this->options_api        = Mockery::mock( Options::class );
+		$this->homepage_preloader = Mockery::mock( Homepage::class );
+		$this->subscriber  = new Subscriber( $this->settings, $this->database, $this->usedCSS, $this->options_api, $this->homepage_preloader );
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldDoExpected( $config ) {
+		$this->settings
+				->shouldReceive( 'is_enabled' )
+				->once()
+				->andReturn( $config['remove_unused_css'] );
+
+		Functions\when( 'get_term_link' )
+			->justReturn( $config['url'] );
+
+		Functions\expect( 'is_wp_error' )
+			->andReturn( $config['wp_error'] );
+
+
+		$this->usedCSS->shouldReceive( 'delete_used_css' )
+			->atMost()
+			->once()
+			->with( rtrim( $config['url'], '/' ) );
+
+		$this->subscriber->delete_term_used_css( $config['term_id'] );
+	}
+}


### PR DESCRIPTION
## Description

With this PR, we will delete the used CSS for a specific term after it has been edited.

Fixes #4299

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

No

## How Has This Been Tested?

- [x] Unit/Integration tests

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
