### PR TITLE
Fixes #4466 PHP Notice when an external URL has no scheme during JS minification

### DIFF
--- a/inc/Engine/Optimization/Minify/JS/Minify.php
+++ b/inc/Engine/Optimization/Minify/JS/Minify.php
@@ -210,7 +210,7 @@ class Minify extends AbstractJSOptimization implements ProcessorInterface {
 		}
 
 		$is_external_url = $this->is_external_file( $url );
-		$file_path       = $is_external_url ? $this->local_cache->get_filepath( $url ) : $this->get_file_path( $url );
+		$file_path       = $is_external_url ? $this->local_cache->get_filepath( rocket_add_url_protocol( $url ) ) : $this->get_file_path( $url );
 
 		if ( ! $file_path ) {
 			Logger::error(


### PR DESCRIPTION
## Description

This PR prevents a PHP notice when an external URL has no scheme during JS minification.

Fixes #4466

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Manual test before/after the change, no notice in the log after

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
