### PR TITLE
Closes #3526 display notice if the global exclusion pattern is used in never cache URLs field

### DIFF
--- a/inc/Engine/Admin/Settings/Settings.php
+++ b/inc/Engine/Admin/Settings/Settings.php
@@ -697,6 +697,6 @@ class Settings {
 
 		add_settings_error( 'general', 'reject_uri_global_exclusion', __( 'Sorry! Adding /(.*) in Advanced Rules > Never Cache URL(s) was not saved because it disables caching and optimizations for every page on your site.', 'rocket' ) );
 
-		return array_diff_key( $field, array_keys( $field, '/(.*)', true ) );
+		return array_diff_key( $field, array_flip( array_keys( $field, '/(.*)', true ) ) );
 	}
 }

--- a/inc/Engine/Admin/Settings/Settings.php
+++ b/inc/Engine/Admin/Settings/Settings.php
@@ -263,6 +263,7 @@ class Settings {
 		// Option : Never cache the following pages.
 		if ( ! empty( $input['cache_reject_uri'] ) ) {
 			$input['cache_reject_uri'] = rocket_sanitize_textarea_field( 'cache_reject_uri', $input['cache_reject_uri'] );
+			$input['cache_reject_uri'] = $this->check_global_exclusion( $input['cache_reject_uri'] );
 		} else {
 			$input['cache_reject_uri'] = [];
 		}
@@ -678,5 +679,24 @@ class Settings {
 		}
 
 		return $sub_fields;
+	}
+
+	/**
+	 * Checks if the global exclusion pattern is used in the given field
+	 *
+	 * @since 3.10.3
+	 *
+	 * @param array $field A field array value.
+	 *
+	 * @return array
+	 */
+	private function check_global_exclusion( $field ) {
+		if ( ! in_array( '/(.*)', $field, true ) ) {
+			return $field;
+		}
+
+		add_settings_error( 'general', 'reject_uri_global_exclusion', __( 'Sorry! Adding /(.*) in Advanced Rules > Never Cache URL(s) was not saved because it disables caching and optimizations for every page on your site.', 'rocket' ) );
+
+		return array_diff_key( $field, array_keys( $field, '/(.*)', true ) );
 	}
 }


### PR DESCRIPTION
## Description

With this PR, a notice is displayed, and the value removed from the field, if the pattern `/(.*)` is used in the never cache URLs textarea.

Fixes #3526

![before](https://user-images.githubusercontent.com/3465180/139486971-439a84ba-28e6-4d6e-931b-a526b3961a17.jpg)

![after](https://user-images.githubusercontent.com/3465180/139486997-6780a59c-02c1-4650-8853-fa76c867fd68.jpg)


## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

No

## How Has This Been Tested?

- [x] Manual testing as shown in screenshots

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
