### PR TITLE
Fixes #3704 Prevent server error if charset value is empty in htaccess rules

### DIFF
--- a/inc/functions/htaccess.php
+++ b/inc/functions/htaccess.php
@@ -506,6 +506,10 @@ function get_rocket_htaccess_charset() { // phpcs:ignore WordPress.NamingConvent
 	// Get charset of the blog.
 	$charset = preg_replace( '/[^a-zA-Z0-9_\-\.:]+/', '', get_bloginfo( 'charset', 'display' ) );
 
+	if ( empty( $charset ) ) {
+		return '';
+	}
+
 	$rules = "# Use $charset encoding for anything served text/plain or text/html" . PHP_EOL;
 	$rules .= "AddDefaultCharset $charset" . PHP_EOL;
 	$rules .= "# Force $charset for a number of file formats" . PHP_EOL;


### PR DESCRIPTION
## Description

It seems in some cases the charset value can be empty, which will result in invalid htaccess rules and creating a server error.

To avoid the issue, we check if the value is empty, and if it is, we bail-out early.

Fixes #3704

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

No

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
