### PR TITLE
Exclude Jetpack Boost's lazyload script from Delay JS

### DIFF
--- a/inc/Engine/Optimization/DelayJS/HTML.php
+++ b/inc/Engine/Optimization/DelayJS/HTML.php
@@ -59,8 +59,8 @@ class HTML {
 		'lazyLoadInstance',
 		'scripts.mediavine.com/tags/', // allows mediavine-video schema to be accessible by search engines.
 		'initCubePortfolio', // Cube Portfolio show images.
-		'/jetpack-boost/vendor/automattic/jetpack-lazy-images/(.*)', // Jetpack Boost plugin lazyload
-		'jetpack-lazy-images-js-enabled',  // Jetpack Boost plugin lazyload
+		'/jetpack-boost/vendor/automattic/jetpack-lazy-images/(.*)', // Jetpack Boost plugin lazyload.
+		'jetpack-lazy-images-js-enabled',  // Jetpack Boost plugin lazyload.
 	];
 
 	/**

--- a/inc/Engine/Optimization/DelayJS/HTML.php
+++ b/inc/Engine/Optimization/DelayJS/HTML.php
@@ -59,6 +59,8 @@ class HTML {
 		'lazyLoadInstance',
 		'scripts.mediavine.com/tags/', // allows mediavine-video schema to be accessible by search engines.
 		'initCubePortfolio', // Cube Portfolio show images.
+		'/jetpack-boost/vendor/automattic/jetpack-lazy-images/(.*)', // Jetpack Boost plugin lazyload
+		'jetpack-lazy-images-js-enabled',  // Jetpack Boost plugin lazyload
 	];
 
 	/**

--- a/inc/Engine/Optimization/DelayJS/HTML.php
+++ b/inc/Engine/Optimization/DelayJS/HTML.php
@@ -61,6 +61,7 @@ class HTML {
 		'initCubePortfolio', // Cube Portfolio show images.
 		'/jetpack-boost/vendor/automattic/jetpack-lazy-images/(.*)', // Jetpack Boost plugin lazyload.
 		'jetpack-lazy-images-js-enabled',  // Jetpack Boost plugin lazyload.
+		'jetpack-boost-critical-css', // Jetpack Boost plugin critical CSS.
 	];
 
 	/**


### PR DESCRIPTION
fixes https://github.com/wp-media/wp-rocket/issues/4473

## Description

when the lazyload feature of the Jetpack Boost plugin and WP Rocket's Delay JavaScript Execution is enabled,
the images will not be displayed until there is user interaction.

Adding the following automatic exclusions from Delay JS to fix the issue:

```
/jetpack-boost/vendor/automattic/jetpack-lazy-images/(.*)
jetpack-lazy-images-js-enabled
```

Fixes #4473
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)

# Checklist:

Please delete the options that are not relevant.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
