### PR TITLE
Add secret key to the folder name of the common cache for logged in u…

### DIFF
--- a/inc/classes/Buffer/class-cache.php
+++ b/inc/classes/Buffer/class-cache.php
@@ -528,7 +528,7 @@ class Cache extends Abstract_Buffer {
 		// Get cache folder of host name.
 		if ( $logged_in_cookie && isset( $cookies[ $logged_in_cookie ] ) && ! $this->tests->has_rejected_cookie( $logged_in_cookie_no_hash ) ) {
 			if ( $this->config->get_config( 'common_cache_logged_users' ) ) {
-				return $this->cache_dir_path . $host . '-loggedin' . rtrim( $request_uri, '/' );
+				return $this->cache_dir_path . $host . '-loggedin-' . $this->config->get_config( 'secret_cache_key' ) . rtrim( $request_uri, '/' );
 			}
 
 			$user_key = explode( '|', $cookies[ $logged_in_cookie ] );


### PR DESCRIPTION
## Description

This PR adds a secret cache key to the folder name where WP Rocket stores user cache, when the common cache for logged in users have been activated using our helper plugin:
https://github.com/wp-media/wp-rocket-helpers/tree/master/cache/wp-rocket-cache-common-cache-loggedin

Slack discussion:
https://wp-media.slack.com/archives/C43T1AYMQ/p1617708301135800

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which improves an existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Is the solution different from the one proposed during the grooming?

It's according to the Slack conversation and what I've discussed with @engahmeds3ed.

## How Has This Been Tested?

- [x] Local site.

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
