### PR TITLE
Fixes #4474 Preserve svg in used CSS

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -603,7 +603,7 @@ class UsedCSS {
 		$used_css_contents = $this->handle_charsets( $used_css->css, false );
 		return sprintf(
 			'<style id="wpr-usedcss">%s</style>',
-			wp_strip_all_tags( $used_css_contents )
+			$used_css_contents
 		);
 	}
 

--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -53,27 +53,6 @@ class UsedCSS {
 	private $api;
 
 	/**
-	 * Filesystem instance
-	 *
-	 * @var \WP_Filesystem_Direct
-	 */
-	private $filesystem;
-
-	/**
-	 * Base path for Used CSS storage
-	 *
-	 * @var string
-	 */
-	private $base_path;
-
-	/**
-	 * Base URL for Used CSS files
-	 *
-	 * @var string
-	 */
-	private $base_url;
-
-	/**
 	 * Inline exclusions regexes not to removed from the page after treeshaking.
 	 *
 	 * @var string[]
@@ -103,9 +82,6 @@ class UsedCSS {
 		$this->resources_query = $resources_query;
 		$this->purge           = $purge;
 		$this->api             = $api;
-		$this->filesystem      = rocket_direct_filesystem();
-		$this->base_path       = rocket_get_constant( 'WP_ROCKET_USED_CSS_PATH' ) . get_current_blog_id();
-		$this->base_url        = rocket_get_constant( 'WP_ROCKET_USED_CSS_URL' ) . get_current_blog_id();
 	}
 
 	/**
@@ -341,7 +317,7 @@ class UsedCSS {
 		$minifier    = new MinifyCSS( $data['css'] );
 
 		/**
-		 * Filters Used CSS content before saving into DB and filesystem.
+		 * Filters Used CSS content before saving into DB.
 		 *
 		 * @since 3.9.0.2
 		 *

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/treeshake.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/treeshake.php
@@ -472,5 +472,55 @@ return [
 </body>
 </html>'
 		],
+		'shouldRunRucssAndKeepSVG' => [
+			'config'       => [
+				'html'                  => '<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>My Awesome Page</title>
+	<style>#ub_styled_list li::before{top:3px;font-size:1em;height:1.1em;width:1.1em;background-image:url("data:image/svg+xml;utf8,<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 512 512\"><path fill=\"%238ed1fc\" d=\"M507.73 109.1c-2.24-9.03-13.54-12.09-20.12-5.51l-74.36 74.36-67.88-11.31-11.31-67.88 74.36-74.36c6.62-6.62 3.43-17.9-5.66-20.16-47.38-11.74-99.55.91-136.58 37.93-39.64 39.64-50.55 97.1-34.05 147.2L18.74 402.76c-24.99 24.99-24.99 65.51 0 90.5 24.99 24.99 65.51 24.99 90.5 0l213.21-213.21c50.12 16.71 107.47 5.68 147.37-34.22 37.07-37.07 49.7-89.32 37.91-136.73zM64 472c-13.25 0-24-10.75-24-24 0-13.26 10.75-24 24-24s24 10.74 24 24c0 13.25-10.75 24-24 24z\"></path></svg>")}
+	</style>
+</head>
+<body>
+ content here
+</body>
+</html>',
+				'used-css-row-contents' => [
+					'url'            => 'http://example.org/home',
+					'css'            => '',
+					'unprocessedcss' => '',
+					'retries'        => 1,
+					'is_mobile'      => false,
+				],
+
+			],
+			'api-response' => [
+				'body'     => json_encode(
+					[
+						'code'     => 200,
+						'message'  => 'OK',
+						'contents' => [
+							'shakedCSS'      => '#ub_styled_list li::before{top:3px;font-size:1em;height:1.1em;width:1.1em;background-image:url("data:image/svg+xml;utf8,<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 512 512\"><path fill=\"%238ed1fc\" d=\"M507.73 109.1c-2.24-9.03-13.54-12.09-20.12-5.51l-74.36 74.36-67.88-11.31-11.31-67.88 74.36-74.36c6.62-6.62 3.43-17.9-5.66-20.16-47.38-11.74-99.55.91-136.58 37.93-39.64 39.64-50.55 97.1-34.05 147.2L18.74 402.76c-24.99 24.99-24.99 65.51 0 90.5 24.99 24.99 65.51 24.99 90.5 0l213.21-213.21c50.12 16.71 107.47 5.68 147.37-34.22 37.07-37.07 49.7-89.32 37.91-136.73zM64 472c-13.25 0-24-10.75-24-24 0-13.26 10.75-24 24-24s24 10.74 24 24c0 13.25-10.75 24-24 24z\"></path></svg>")}',
+							'unProcessedCss' => [],
+						],
+					]
+				),
+				'response' => [
+					'code'    => 200,
+					'message' => 'OK',
+				],
+			],
+			'expected'     => '<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>My Awesome Page</title><style id="wpr-usedcss">#ub_styled_list li::before{top:3px;font-size:1em;height:1.1em;width:1.1em;background-image:url("data:image/svg+xml;utf8,<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 512 512\"><path fill=\"%238ed1fc\" d=\"M507.73 109.1c-2.24-9.03-13.54-12.09-20.12-5.51l-74.36 74.36-67.88-11.31-11.31-67.88 74.36-74.36c6.62-6.62 3.43-17.9-5.66-20.16-47.38-11.74-99.55.91-136.58 37.93-39.64 39.64-50.55 97.1-34.05 147.2L18.74 402.76c-24.99 24.99-24.99 65.51 0 90.5 24.99 24.99 65.51 24.99 90.5 0l213.21-213.21c50.12 16.71 107.47 5.68 147.37-34.22 37.07-37.07 49.7-89.32 37.91-136.73zM64 472c-13.25 0-24-10.75-24-24 0-13.26 10.75-24 24-24s24 10.74 24 24c0 13.25-10.75 24-24 24z\"></path></svg>")}</style>
+</head>
+<body>
+ content here
+</body>
+</html>'
+		],
 	],
 ];


### PR DESCRIPTION
## Description

This PR removes the stripping of tags on the used CSS output, to preserve svg markup that can be used inside `background-image` for example.

Fixes #4474

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] New integration test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
