### PR TITLE
Add the site's name to the exported options file's filename

### DIFF
--- a/inc/admin/admin.php
+++ b/inc/admin/admin.php
@@ -182,7 +182,9 @@ function rocket_do_options_export() {
 		wp_nonce_ays( '' );
 	}
 
-	$filename = sprintf( 'wp-rocket-settings-%s-%s.json', date( 'Y-m-d' ), uniqid() ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
+	$site_name = get_rocket_parse_url( get_home_url() );
+	$site_name = $site_name['host']. $site_name['path'];
+	$filename = sprintf( 'wp-rocket-settings-%s-%s-%s.json', $site_name , date( 'Y-m-d' ), uniqid() );  phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
 	$gz       = 'gz' . strrev( 'etalfed' );
 	$options  = wp_json_encode( get_option( WP_ROCKET_SLUG ) ); // do not use get_rocket_option() here.
 	nocache_headers();
@@ -508,7 +510,7 @@ function rocket_handle_settings_import() {
 		rocket_settings_import_redirect( __( 'Settings import failed: no file uploaded.', 'rocket' ), 'error' );
 	}
 
-	if ( isset( $_FILES['import']['name'] ) && ! preg_match( '/wp-rocket-settings-20\d{2}-\d{2}-\d{2}-[a-f0-9]{13}\.(?:txt|json)/', sanitize_file_name( $_FILES['import']['name'] ) ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+	if ( isset( $_FILES['import']['name'] ) && ! preg_match( '/wp-rocket-settings(?:-.*)?-20\d{2}-\d{2}-\d{2}-[a-f0-9]{13}\.(?:txt|json)/', sanitize_file_name( $_FILES['import']['name'] ) ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 		rocket_settings_import_redirect( __( 'Settings import failed: incorrect filename.', 'rocket' ), 'error' );
 	}
 

--- a/inc/admin/admin.php
+++ b/inc/admin/admin.php
@@ -183,10 +183,10 @@ function rocket_do_options_export() {
 	}
 
 	$site_name = get_rocket_parse_url( get_home_url() );
-	$site_name = $site_name['host']. $site_name['path'];
-	$filename = sprintf( 'wp-rocket-settings-%s-%s-%s.json', $site_name , date( 'Y-m-d' ), uniqid() );  phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
-	$gz       = 'gz' . strrev( 'etalfed' );
-	$options  = wp_json_encode( get_option( WP_ROCKET_SLUG ) ); // do not use get_rocket_option() here.
+	$site_name = $site_name['host'] . $site_name['path'];
+	$filename  = sprintf( 'wp-rocket-settings-%s-%s-%s.json', $site_name, date( 'Y-m-d' ), uniqid() ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
+	$gz        = 'gz' . strrev( 'etalfed' );
+	$options   = wp_json_encode( get_option( WP_ROCKET_SLUG ) ); // do not use get_rocket_option() here.
 	nocache_headers();
 	@header( 'Content-Type: application/json' );
 	@header( 'Content-Disposition: attachment; filename="' . $filename . '"' );


### PR DESCRIPTION
## Description

This PR adds a site's name to the filename of the exported options ( Tools tab > Export Settings).

**Slack convo:** https://wp-media.slack.com/archives/C43T1AYMQ/p1636117397077200

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

Non-relevant.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Local test site
- [x] Our Mega/multisite

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

