### PR TITLE
Add check for updated classname in PDFEmbedder compatibility

### DIFF
--- a/inc/ThirdParty/Plugins/PDFEmbedder.php
+++ b/inc/ThirdParty/Plugins/PDFEmbedder.php
@@ -34,8 +34,13 @@ class PDFEmbedder implements Subscriber_Interface {
 	 * @return array
 	 */
 	public function exclude_pdfembedder_scripts( $excluded_js ) {
-		if ( class_exists( 'pdfemb_basic_pdf_embedder' ) ) {
+		if (
+			class_exists( 'PDF_Embedder_Basic' )
+			||
+			class_exists( 'pdfemb_basic_pdf_embedder' )
+		) {
 			// Exclude Free version.
+			//var_dump($this->exclude_pdfembedder_scripts());die();
 			return array_merge(
 				$excluded_js,
 				$this->pdfembedder_free_scripts()

--- a/inc/ThirdParty/Plugins/PDFEmbedder.php
+++ b/inc/ThirdParty/Plugins/PDFEmbedder.php
@@ -40,7 +40,6 @@ class PDFEmbedder implements Subscriber_Interface {
 			class_exists( 'pdfemb_basic_pdf_embedder' )
 		) {
 			// Exclude Free version.
-			//var_dump($this->exclude_pdfembedder_scripts());die();
 			return array_merge(
 				$excluded_js,
 				$this->pdfembedder_free_scripts()


### PR DESCRIPTION
This PR patches the recent PDFEmbedder update (v4.6.3) that changes the classname of the main plugin class.

We still check for the old classname to preserve backwards compatibility for Embedder users who have not yet updated.

The error was found as a result of failing integration test on the `PDFEmbedder` group; this PR restores test to passing.