### PR TITLE
Fix 4314 - Items in settings errors transient not displayed on settings update

### DIFF
--- a/inc/admin/admin.php
+++ b/inc/admin/admin.php
@@ -246,7 +246,7 @@ function rocket_rollback() {
 add_action( 'admin_post_rocket_rollback', 'rocket_rollback' );
 
 /**
- * After a rollback has been done, replace the "return to" link by a link pointing to WP Rocket's tools page.
+ * After a rollback has been done, replace the "return to" link by a link pointing to WP Rocket's tools page.
  * A link to the plugins page is kept in case the plugin is not reactivated correctly.
  *
  * @since  3.2.4

--- a/inc/admin/options.php
+++ b/inc/admin/options.php
@@ -155,13 +155,13 @@ function rocket_pre_main_option( $newvalue, $oldvalue ) {
 	}
 
 	if ( $errors ) {
-		$error_message  = _n( 'The following pattern is invalid and has been removed:', 'The following patterns are invalid and have been removed:', array_sum( array_map( 'count', $errors ) ), 'rocket' );
+		$error_message = _n( 'The following pattern is invalid and has been removed:', 'The following patterns are invalid and have been removed:', array_sum( array_map( 'count', $errors ) ), 'rocket' );
 
 		foreach ( $errors as $error ) {
 			$error_message .= '<ul><li>' . implode( '</li><li>', $error ) . '</li></ul>';
 		}
 
-		$errors         = [];
+		$errors = [];
 
 		$rocket_settings_errors[] = [
 			'setting' => 'general',

--- a/inc/admin/options.php
+++ b/inc/admin/options.php
@@ -120,13 +120,14 @@ function rocket_pre_main_option( $newvalue, $oldvalue ) {
 	$is_form_submit = WP_ROCKET_PLUGIN_SLUG === $is_form_submit;
 	$errors         = [];
 	$pattern_labels = [
-		'exclude_css'       => __( 'Excluded CSS Files', 'rocket' ),
-		'exclude_inline_js' => __( 'Excluded Inline JavaScript', 'rocket' ),
-		'exclude_js'        => __( 'Excluded JavaScript Files', 'rocket' ),
-		'cache_reject_uri'  => __( 'Never Cache URL(s)', 'rocket' ),
-		'cache_reject_ua'   => __( 'Never Cache User Agent(s)', 'rocket' ),
-		'cache_purge_pages' => __( 'Always Purge URL(s)', 'rocket' ),
-		'cdn_reject_files'  => __( 'Exclude files from CDN', 'rocket' ),
+		'exclude_css'         => __( 'Excluded CSS Files', 'rocket' ),
+		'exclude_inline_js'   => __( 'Excluded Inline JavaScript', 'rocket' ),
+		'exclude_js'          => __( 'Excluded JavaScript Files', 'rocket' ),
+		'delay_js_exclusions' => __( 'Excluded Delay JavaScript Files', 'rocket' ),
+		'cache_reject_uri'    => __( 'Never Cache URL(s)', 'rocket' ),
+		'cache_reject_ua'     => __( 'Never Cache User Agent(s)', 'rocket' ),
+		'cache_purge_pages'   => __( 'Always Purge URL(s)', 'rocket' ),
+		'cdn_reject_files'    => __( 'Exclude files from CDN', 'rocket' ),
 	];
 
 	foreach ( $pattern_labels as $pattern_field => $label ) {
@@ -144,7 +145,7 @@ function rocket_pre_main_option( $newvalue, $oldvalue ) {
 			function( $excluded ) use ( $pattern_field, $label, $is_form_submit, &$errors ) {
 				if ( false === @preg_match( '#' . str_replace( '#', '\#', $excluded ) . '#', 'dummy-sample' ) && $is_form_submit ) { // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 					/* translators: 1 and 2 can be anything. */
-					$errors[ $pattern_field ] = sprintf( __( '%1$s: <em>%2$s</em>.', 'rocket' ), $label, esc_html( $excluded ) );
+					$errors[ $pattern_field ][] = sprintf( __( '%1$s: <em>%2$s</em>.', 'rocket' ), $label, esc_html( $excluded ) );
 					return false;
 				}
 
@@ -154,8 +155,12 @@ function rocket_pre_main_option( $newvalue, $oldvalue ) {
 	}
 
 	if ( $errors ) {
-		$error_message  = _n( 'The following pattern is invalid and has been removed:', 'The following patterns are invalid and have been removed:', count( $errors ), 'rocket' );
-		$error_message .= '<ul><li>' . implode( '</li><li>', $errors ) . '</li></ul>';
+		$error_message  = _n( 'The following pattern is invalid and has been removed:', 'The following patterns are invalid and have been removed:', array_sum( array_map( 'count', $errors ) ), 'rocket' );
+
+		foreach ( $errors as $error ) {
+			$error_message .= '<ul><li>' . implode( '</li><li>', $error ) . '</li></ul>';
+		}
+
 		$errors         = [];
 
 		$rocket_settings_errors[] = [
@@ -201,18 +206,14 @@ function rocket_pre_main_option( $newvalue, $oldvalue ) {
 		return $newvalue;
 	}
 
-	/**
-	 * Display an error notice.
-	 * The notices are stored directly in the transient instead of using `add_settings_error()`, to make sure they are displayed even if we’re outside an admin screen.
-	 */
 	$transient_errors = get_transient( 'settings_errors' );
 	if ( ! $transient_errors || ! is_array( $transient_errors ) ) {
 		$transient_errors = [];
 	}
 
-	$transient_errors = array_merge( $transient_errors, $rocket_settings_errors );
+	$settings_errors = array_merge( $transient_errors, $rocket_settings_errors );
 
-	foreach ( $transient_errors as $error ) {
+	foreach ( $settings_errors as $error ) {
 		add_settings_error( $error['setting'], $error['code'], $error['message'], $error['type'] );
 	}
 

--- a/inc/admin/options.php
+++ b/inc/admin/options.php
@@ -206,14 +206,15 @@ function rocket_pre_main_option( $newvalue, $oldvalue ) {
 	 * The notices are stored directly in the transient instead of using `add_settings_error()`, to make sure they are displayed even if we’re outside an admin screen.
 	 */
 	$transient_errors = get_transient( 'settings_errors' );
-
 	if ( ! $transient_errors || ! is_array( $transient_errors ) ) {
 		$transient_errors = [];
 	}
 
 	$transient_errors = array_merge( $transient_errors, $rocket_settings_errors );
 
-	set_transient( 'settings_errors', $transient_errors, 30 );
+	foreach( $transient_errors as $error ) {
+		add_settings_error( $error['setting'], $error['code'], $error['message'], $error['type'] );
+	}
 
 	return $newvalue;
 }

--- a/inc/admin/options.php
+++ b/inc/admin/options.php
@@ -212,7 +212,7 @@ function rocket_pre_main_option( $newvalue, $oldvalue ) {
 
 	$transient_errors = array_merge( $transient_errors, $rocket_settings_errors );
 
-	foreach( $transient_errors as $error ) {
+	foreach ( $transient_errors as $error ) {
 		add_settings_error( $error['setting'], $error['code'], $error['message'], $error['type'] );
 	}
 


### PR DESCRIPTION
## Description

Changes our settings error process to use `add_settings_error` instead of the settings_errors transient.

Fixes #4314

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

Same as grooming.

## How Has This Been Tested?

Checked that errors are being displayed on local development environment.

# Checklist:

Please delete the options that are not relevant.

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes