### PR TITLE
Removing the ^ from the regex to apply the optimization in cases where the family value is not at the beginning of the font URL

### DIFF
--- a/inc/Engine/Optimization/GoogleFonts/CombineV2.php
+++ b/inc/Engine/Optimization/GoogleFonts/CombineV2.php
@@ -98,7 +98,7 @@ class CombineV2 extends AbstractGFOptimization {
 			return [];
 		}
 
-		$url_pattern     = '#^(family=[A-Za-z0-9;:,=%&\+\@\.]+)$#';
+		$url_pattern     = '#(family=[A-Za-z0-9;:,=%&\+\@\.]+)$#';
 		$display_pattern = '#&display=(?:swap|auto|block|fallback|optional)#';
 		$decoded_url     = html_entity_decode( $tag['url'] );
 		$query           = wp_parse_url( $decoded_url, PHP_URL_QUERY );


### PR DESCRIPTION

## Description
Applied the fix as recommended during grooming:
> Updating the pattern to remove the `^` token to allow matching the family value wherever it is in the URL's query.
https://github.com/wp-media/wp-rocket/issues/4188#issuecomment-905860440

Fixes #4188

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?
No

## How Has This Been Tested?
Tested on my local environment

# Checklist:

Please delete the options that are not relevant.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
