### PR TITLE
Fixes #4417 Always display WooCommerce product gallery when delay JS execution is enabled

### DIFF
--- a/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber.php
+++ b/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber.php
@@ -84,7 +84,7 @@ class WooCommerceSubscriber implements Event_Manager_Aware_Subscriber_Interface 
 				$events['switch_theme']      = 'delete_cache_empty_cart';
 			}
 
-			$events['wp_enqueue_scripts']         = 'show_empty_product_gallery_with_delayJS';
+			$events['wp_head']                    = 'show_empty_product_gallery_with_delayJS';
 			$events['rocket_delay_js_exclusions'] = 'show_notempty_product_gallery_with_delayJS';
 		}
 
@@ -537,8 +537,7 @@ class WooCommerceSubscriber implements Event_Manager_Aware_Subscriber_Interface 
 			return;
 		}
 
-		$custom_css = '.woocommerce-product-gallery{ opacity: 1 !important; }';
-		wp_add_inline_style( 'woocommerce-layout', $custom_css );
+		echo '<style>.woocommerce-product-gallery{ opacity: 1 !important; }</style>';
 	}
 
 	/**

--- a/tests/Fixtures/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/showEmptyProductGalleryWithDelayJS.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/showEmptyProductGalleryWithDelayJS.php
@@ -6,9 +6,7 @@ return [
 			'input' => [
 				'is_allowed' => false,
 			],
-			'expected' => [
-				'style' => '',
-			],
+			'expected' => '',
 		],
 
 		'shouldBailoutIfNotInProductPage' => [
@@ -16,9 +14,8 @@ return [
 				'is_allowed' => true,
 				'in_product_page' => false,
 			],
-			'expected' => [
-				'style' => '',
-			],
+			'expected' => '',
+
 		],
 
 		'shouldBailoutIfGalleryHasMultipleImages' => [
@@ -27,9 +24,7 @@ return [
 				'in_product_page' => true,
 				'has_images' => true,
 			],
-			'expected' => [
-				'style' => '',
-			],
+			'expected' => '',
 		],
 
 		'shouldAddStyleIfGalleryHasNoImages' => [
@@ -38,9 +33,7 @@ return [
 				'in_product_page' => true,
 				'has_images' => false,
 			],
-			'expected' => [
-				'style' => '.woocommerce-product-gallery{ opacity: 1 !important; }',
-			],
+			'expected' => '<style>.woocommerce-product-gallery{ opacity: 1 !important; }</style>',
 		],
 
 	],

--- a/tests/Integration/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/showEmptyProductGalleryWithDelayJS.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/showEmptyProductGalleryWithDelayJS.php
@@ -2,6 +2,7 @@
 namespace WP_Rocket\Tests\Integration\inc\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber;
 
 use WP_Rocket\Tests\Integration\TestCase;
+
 /**
  * @covers \WP_Rocket\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber::show_empty_product_gallery_with_delayJS
  * @group WooCommerce
@@ -26,6 +27,8 @@ class Test_ShowEmptyProductGalleryWithDelayJS extends TestCase {
 		parent::tearDown();
 
 		remove_filter( 'pre_get_rocket_option_delay_js', [ $this, 'set_delay_js' ] );
+
+		$this->restoreWpFilter( 'wp_head' );
 	}
 
 	/**
@@ -40,36 +43,18 @@ class Test_ShowEmptyProductGalleryWithDelayJS extends TestCase {
 
 		if ( $in_product_page ) {
 			$this->go_to( $has_images ? $this->product_with_gallery->get_permalink() : $this->product_without_gallery->get_permalink() );
-		}else{
+		} else {
 			$this->go_to( home_url() );
 		}
 
-		foreach ( wp_styles()->registered as $style ) {
-			if ( 'woocommerce-layout' === $style->handle ) {
-				$this->assertArrayNotHasKey( 'after', $style->extra );
-			}
-		}
+		$this->unregisterAllCallbacksExcept( 'wp_head', 'show_empty_product_gallery_with_delayJS' );
 
-		do_action( 'wp_enqueue_scripts' );
+		do_action( 'wp_head' );
 
-		$extra_after = [];
-		foreach ( wp_styles()->registered as $style ) {
-			if ( 'woocommerce-layout' === $style->handle ) {
-				$extra_after = $style->extra;
-			}
-		}
-
-		if ( empty( $expected['style'] ) ) {
-			$this->assertArrayNotHasKey( 'after', $extra_after );
-		}else{
-			$this->assertArrayHasKey( 'after', $extra_after );
-			$this->assertNotEmpty( $extra_after['after'] );
-			$this->assertContains( '.woocommerce-product-gallery{ opacity: 1 !important; }', $extra_after['after'] );
-		}
-
+		$this->expectOutputString( $expected );
 	}
 
-	public function set_delay_js($options) {
+	public function set_delay_js() {
 		return $this->delay_js_option;
 	}
 

--- a/tests/Unit/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/showEmptyProductGalleryWithDelayJS.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/showEmptyProductGalleryWithDelayJS.php
@@ -70,14 +70,7 @@ class Test_ShowEmptyProductGalleryWithDelayJS extends TestCase {
 				->andReturn( $product );
 		}
 
-		if ( ! empty( $expected['style'] ) ) {
-			Functions\expect( 'wp_add_inline_style' )
-				->once()
-				->with( 'woocommerce-layout', $expected['style'] );
-		}else{
-			Functions\expect( 'wp_add_inline_style' )
-				->never();
-		}
+		$this->expectOutputString( $expected );
 
 		$this->subscriber->show_empty_product_gallery_with_delayJS();
 	}


### PR DESCRIPTION
## Description

This changes makes sure the WC product gallery is always displayed when delay JS execution is enabled, by removing the dependency on the `woocommerce-layout` style enqueue, and instead outputting the necessary CSS directly by using `wp_head` action.

Fixes #4417 

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

No

## How Has This Been Tested?

- [x] Updated unit & integration tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
