### PR TITLE
Guard smilies content from filter return

### DIFF
--- a/inc/Dependencies/RocketLazyload/Image.php
+++ b/inc/Dependencies/RocketLazyload/Image.php
@@ -513,6 +513,10 @@ class Image {
 	public function convertSmilies( $text ) {
 		global $wp_smiliessearch;
 
+		if ( empty( $text ) || ! is_string( $text ) ) {
+			return $text;
+		}
+
 		if ( ! get_option( 'use_smilies' ) || empty( $wp_smiliessearch ) ) {
 			return $text;
 		}


### PR DESCRIPTION
## Description

Guard our smilies content from being changed by WP filters (mainly the_content one).

Fixes #4509

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Is the solution different from the one proposed during the grooming?

Not groomed, it's hotfix.

## How Has This Been Tested?

To test that you need to add the following code to your current active theme's `functions.php` file

```
add_filter( 'pre_option_use_smilies', function($status){
    return true;
} );

add_filter( 'the_content', function($content){
    return null;
} );
```

Also you need to enable lazyload for images.

You shouldn't see any error/warning at `debug.log` after this PR.

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
