### PR TITLE
Add anr_captcha_field_div to Defer JS inline exclusions

### DIFF
--- a/inc/Engine/Optimization/DeferJS/DeferJS.php
+++ b/inc/Engine/Optimization/DeferJS/DeferJS.php
@@ -27,6 +27,7 @@ class DeferJS {
 		'rev_slider_wrapper',
 		'FB3D_CLIENT_LOCALE',
 		'ewww_webp_supported',
+		'anr_captcha_field_div',
 	];
 
 	/**


### PR DESCRIPTION
## Description
Adding `anr_captcha_field_div` to Defer JS inline exclusions. This will affect only recaptcha v2, as their v3 implementation is using a different code: https://jmp.sh/fm2JQ9l

Fixes #4515

## Type of change

Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?
This one is not groomed, a compatibility exclusion based on the ticket
 
## How Has This Been Tested?
Tested on my test site and customer's site

# Checklist:

Please delete the options that are not relevant.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
