### PR TITLE
Fix the conflict with Cloudinary plugin

### DIFF
--- a/inc/Engine/Media/Lazyload/Subscriber.php
+++ b/inc/Engine/Media/Lazyload/Subscriber.php
@@ -464,7 +464,7 @@ class Subscriber implements Subscriber_Interface {
 	 *
 	 * @return bool
 	 */
-	public function maybe_disable_core_lazyload( $value, $tag_name ) {
+	public function maybe_disable_core_lazyload( $value, $tag_name = 'img' ) {
 		if ( false === $value ) {
 			return $value;
 		}


### PR DESCRIPTION
## Description

Everything is mentioned on the issue's description.

Fixes #4518 

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which improves an existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Is the solution different from the one proposed during the grooming?

No

## How Has This Been Tested?

## Using cloudinary plugin

1. Install cloudinary along with WPR 3.10.3
2. Once both are installed you will not find a fatal error inside debug.log

## Using custom code (Simple way to test the issue)
1. Add the following code into your current active theme's `functions.php` file
```
apply_filters( 'wp_lazy_loading_enabled', true);
```
2. Activate WPR
3. Check debug.log file, you shouldn't see an error there.

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
