### PR TITLE
Update wp-background-process.php

### DIFF
--- a/inc/classes/dependencies/wp-media/background-processing/wp-background-process.php
+++ b/inc/classes/dependencies/wp-media/background-processing/wp-background-process.php
@@ -310,19 +310,20 @@ abstract class WP_Rocket_WP_Background_Process extends WP_Rocket_WP_Async_Reques
 
 		do {
 			$batch = $this->get_batch();
+			if ( is_array( $batch->data ) {
+				foreach ( $batch->data as $key => $value ) {
+					$task = $this->task( $value );
 
-			foreach ( $batch->data as $key => $value ) {
-				$task = $this->task( $value );
+					if ( false !== $task ) {
+						$batch->data[ $key ] = $task;
+					} else {
+						unset( $batch->data[ $key ] );
+					}
 
-				if ( false !== $task ) {
-					$batch->data[ $key ] = $task;
-				} else {
-					unset( $batch->data[ $key ] );
-				}
-
-				if ( $this->time_exceeded() || $this->memory_exceeded() || $this->is_process_cancelled() ) {
-					// Batch limits reached.
-					break;
+					if ( $this->time_exceeded() || $this->memory_exceeded() || $this->is_process_cancelled() ) {
+						// Batch limits reached.
+						break;
+					}
 				}
 			}
 


### PR DESCRIPTION
Validate $batch->data is an array, before treating it as one.

## Description

Make sure $batch->data is a array before running foreach.
Alternative could have been 
```
foreach ( (array) $batch->data as $key => $value ) {
```

Fixes #4230 

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

It has'nt
