### PR TITLE
Fixes #4226 bail-out if WP_IMPORTING is defined

### DIFF
--- a/inc/main.php
+++ b/inc/main.php
@@ -34,6 +34,10 @@ function rocket_init() {
 		return;
 	}
 
+	if ( defined( 'WP_IMPORTING' ) ) {
+		return;
+	}
+
 	// Call defines and functions.
 	require WP_ROCKET_FUNCTIONS_PATH . 'options.php';
 


### PR DESCRIPTION
## Description

Stop the plugin initialization if `WP_IMPORTING` is defined, to prevent issue with too much cache clearing with each post/page imported, especially when there is a lot to import.

Fixes #4226

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

No

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
