### PR TITLE
Fixes #3813 Be more accurate when replacing existing font-display property value

### DIFF
--- a/inc/Engine/Optimization/CSSTrait.php
+++ b/inc/Engine/Optimization/CSSTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace WP_Rocket\Engine\Optimization;
 
@@ -377,14 +378,16 @@ trait CSSTrait {
 			'/(?:@font-face)\s*{(?<value>[^}]+)}/i',
 			function ( $matches ) {
 				if ( preg_match( '/font-display:\s*(?<swap_value>\w*);?/i', $matches['value'], $attribute ) ) {
-					return 'swap' === strtolower( $attribute['swap_value'] )
-						? $matches[0]
-						: str_replace( $attribute['swap_value'], 'swap', $matches[0] );
-				} else {
-					$swap = "font-display:swap;{$matches['value']}";
+					if ( 'swap' === strtolower( $attribute['swap_value'] ) ) {
+						return $matches[0];
+					}
+
+					$swap = str_replace( $attribute['swap_value'], 'swap', $attribute[0] );
+
+					return preg_replace( '/font-display:\s*(?<swap_value>\w*);?/i', $swap, $matches[0] );
 				}
 
-				return str_replace( $matches['value'], $swap, $matches[0] );
+				return str_replace( $matches['value'], "font-display:swap;{$matches['value']}", $matches[0] );
 			},
 			$css_file_content
 		);

--- a/tests/Fixtures/inc/Engine/Optimization/CSSTraitApplyFontDisplaySwap.php
+++ b/tests/Fixtures/inc/Engine/Optimization/CSSTraitApplyFontDisplaySwap.php
@@ -1,9 +1,6 @@
 <?php
 
 return [
-	'vfs_dir' => 'wp-content/',
-
-	'test_data' => [
 		'shouldTargetOnlyFontFaceRuleSets' => [
 			'css'      => <<<CSS
 @font-face {
@@ -131,5 +128,15 @@ font-family:'MyWebFont';src:url('myfont.woff2')format('woff2'),url('myfont.woff'
 url("core/admin/fonts/modules.eot");src: url("core/admin/fonts/modules.eot#iefix")format("woff"), url("core/admin/fonts/modules.svg#ETModules")font-weight: normal;font-style: normal;
 CSS
 		],
-	],
+		'shouldReplaceOnlyDisplayPropertyValue' => [
+			'css'      => <<< CSS
+@font-face{font-display:auto;font-family:'Barlow';src:url('https://www.autophaus-glienicke.de/wp-content/uploads/avia_fonts/type_fonts/barlow/barlow-regular.ttf')format('ttf')}
+@font-face{font-family:'fa';src:url('/wp-content/plugins/recipe-card-blocks-by-wpzoom-pro/dist/assets/webfonts/fa-solid-900.woff2')format('woff2');font-display:block;}
+CSS
+			,
+			'expected' => <<<CSS
+@font-face{font-display:swap;font-family:'Barlow';src:url('https://www.autophaus-glienicke.de/wp-content/uploads/avia_fonts/type_fonts/barlow/barlow-regular.ttf')format('ttf')}
+@font-face{font-family:'fa';src:url('/wp-content/plugins/recipe-card-blocks-by-wpzoom-pro/dist/assets/webfonts/fa-solid-900.woff2')format('woff2');font-display:swap;}
+CSS
+		],
 ];

--- a/tests/Unit/inc/Engine/Optimization/CSSTraitApplyFontDisplaySwap.php
+++ b/tests/Unit/inc/Engine/Optimization/CSSTraitApplyFontDisplaySwap.php
@@ -3,21 +3,24 @@
 namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization;
 
 use WP_Rocket\Engine\Optimization\CSSTrait;
+use WP_Rocket\Tests\Unit\TestCase;
 
 /**
  * @covers \WP_Rocket\Engine\Optimization\CSSTrait::apply_font_display_swap
  *
  * @group  Optimize
+ * @group  CSSTrait
  */
 class CSSTraitTest extends TestCase {
 	use CSSTrait;
 
-	protected $path_to_test_data = '/inc/Engine/Optimization/CSSTraitApplyFontDisplaySwap.php';
-
 	/**
-	 * @dataProvider providerTestData
+	 * @dataProvider configTestData
 	 */
 	public function testApplyFontDisplaySwap( $css, $expected ) {
-		$this->assertEquals( $expected, $this->apply_font_display_swap( $css ) );
+		$this->assertSame(
+			$expected,
+			$this->apply_font_display_swap( $css )
+		);
 	}
 }


### PR DESCRIPTION
## Description

With this change, we will avoid to replace some text incorrectly when they match with a possible display value like `auto` or `block`.

Instead of performing the replacement over the whole font-face declaration, it's now a 2-steps process:
- first replace the value in the `font-display` property
- Then replace the whole `font-display` declaration in the `font-face` declaration

Fixes #3813
Fixes #4144 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

No

## How Has This Been Tested?

- [x] Added new fixture test to validate the change with examples provided from the support

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
