### PR TITLE
Closes #2200 Add Ezoic to conflict notice with custom explanation

### DIFF
--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -287,6 +287,7 @@ class Plugin {
 			'wp-meteor',
 			'revolution_slider_subscriber',
 			'wordfence_subscriber',
+			'ezoic',
 		];
 
 		$host_type = HostResolver::get_host_service();

--- a/inc/ThirdParty/Plugins/Optimization/Ezoic.php
+++ b/inc/ThirdParty/Plugins/Optimization/Ezoic.php
@@ -40,8 +40,8 @@ class Ezoic implements Subscriber_Interface {
 	 * @return array
 	 */
 	public function add_conflict_explanations( $plugins_explanations ) {
-		// translators: %1$s = opening <a> tag, %2$s = closing </a> tag.
 		$plugins_explanations['ezoic'] = sprintf(
+			// translators: %1$s = opening <a> tag, %2$s = closing </a> tag.
 			__( 'This plugin blocks WP Rocket\'s caching and optimizations. Deactivate it and use %1$sEzoic\'s nameserver integration%2$s instead.', 'rocket' ),
 			'<a href="https://support.ezoic.com/support/solutions/articles/48000453926-name-server-integration" target="_blank" rel="noopener noreferrer">',
 			'</a>'

--- a/inc/ThirdParty/Plugins/Optimization/Ezoic.php
+++ b/inc/ThirdParty/Plugins/Optimization/Ezoic.php
@@ -35,11 +35,12 @@ class Ezoic implements Subscriber_Interface {
 	/**
 	 * Adds explanation for deactivation recommendation
 	 *
-	 * @param array $plugins List of recommended plugins to deactivate explanations.
+	 * @param array $plugins_explanations List of recommended plugins to deactivate explanations.
 	 *
 	 * @return array
 	 */
 	public function add_conflict_explanations( $plugins_explanations ) {
+		// translators: %1$s = opening <a> tag, %2$s = closing </a> tag.
 		$plugins_explanations['ezoic'] = sprintf(
 			__( 'This plugin blocks WP Rocket\'s caching and optimizations. Deactivate it and use %1$sEzoic\'s nameserver integration%2$s instead.', 'rocket' ),
 			'<a href="https://support.ezoic.com/support/solutions/articles/48000453926-name-server-integration" target="_blank" rel="noopener noreferrer">',

--- a/inc/ThirdParty/Plugins/Optimization/Ezoic.php
+++ b/inc/ThirdParty/Plugins/Optimization/Ezoic.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WP_Rocket\ThirdParty\Plugins\Optimization;
+
+use WP_Rocket\Event_Management\Subscriber_Interface;
+
+class Ezoic implements Subscriber_Interface {
+	/**
+	 * Return an array of events that this subscriber wants to listen to.
+	 *
+	 * @return array
+	 */
+	public static function get_subscribed_events() {
+		return [
+			'rocket_plugins_to_deactivate'              => 'add_conflict',
+			'rocket_plugins_to_deactivate_explanations' => 'add_conflict_explanations',
+		];
+	}
+
+	/**
+	 * Adds Ezoic plugin to plugins to deactivate array
+	 *
+	 * @param array $plugins List of recommended plugins to deactivate.
+	 *
+	 * @return array
+	 */
+	public function add_conflict( $plugins ) {
+		$plugins['ezoic'] = 'ezoic-integration/ezoic-integration.php';
+
+		return $plugins;
+	}
+
+	/**
+	 * Adds explanation for deactivation recommendation
+	 *
+	 * @param array $plugins List of recommended plugins to deactivate explanations.
+	 *
+	 * @return array
+	 */
+	public function add_conflict_explanations( $plugins_explanations ) {
+		$plugins_explanations['ezoic'] = sprintf(
+			__( 'This plugin blocks WP Rocket\'s caching and optimizations. Deactivate it and use %1$sEzoic\'s nameserver integration%2$s instead.', 'rocket' ),
+			'<a href="https://support.ezoic.com/support/solutions/articles/48000453926-name-server-integration" target="_blank" rel="noopener noreferrer">',
+			'</a>'
+		);
+
+		return $plugins_explanations;
+	}
+}

--- a/inc/ThirdParty/ServiceProvider.php
+++ b/inc/ThirdParty/ServiceProvider.php
@@ -43,6 +43,7 @@ class ServiceProvider extends AbstractServiceProvider {
 		'wp-meteor',
 		'revolution_slider_subscriber',
 		'wordfence_subscriber',
+		'ezoic',
 	];
 
 	/**
@@ -139,6 +140,9 @@ class ServiceProvider extends AbstractServiceProvider {
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
 			->share( 'wordfence_subscriber', 'WP_Rocket\ThirdParty\Plugins\Security\WordFenceCompatibility' )
+			->addTag( 'common_subscriber' );
+		$this->getContainer()
+			->share( 'ezoic', 'WP_Rocket\ThirdParty\Plugins\Optimization\Ezoic' )
 			->addTag( 'common_subscriber' );
 	}
 }

--- a/inc/admin/ui/notices.php
+++ b/inc/admin/ui/notices.php
@@ -126,7 +126,6 @@ function rocket_plugins_to_deactivate() {
 		'wp-http-compression'                        => 'wp-http-compression/wp-http-compression.php',
 		'wordpress-gzip-compression'                 => 'wordpress-gzip-compression/ezgz.php',
 		'gzip-ninja-speed-compression'               => 'gzip-ninja-speed-compression/gzip-ninja-speed.php',
-		'speed-booster-pack'                         => 'speed-booster-pack/speed-booster-pack.php',
 		'wp-performance-score-booster'               => 'wp-performance-score-booster/wp-performance-score-booster.php',
 		'remove-query-strings-from-static-resources' => 'remove-query-strings-from-static-resources/remove-query-strings.php',
 		'query-strings-remover'                      => 'query-strings-remover/query-strings-remover.php',
@@ -194,9 +193,18 @@ function rocket_plugins_to_deactivate() {
 	 *
 	 * @since 2.6.4
 	 *
-	 * @param string $plugins List of recommended plugins to deactivate
-	*/
+	 * @param array $plugins List of recommended plugins to deactivate.
+	 */
 	$plugins = apply_filters( 'rocket_plugins_to_deactivate', $plugins );
+
+	/**
+	 * Filter the recommended plugins to deactivate explanations
+	 *
+	 * @since 3.10.5
+	 *
+	 * @param array $plugins List of recommended plugins to deactivate explanations.
+	 */
+	$plugins_explanations = apply_filters( 'rocket_plugins_to_deactivate_explanations', $plugins_explanations );
 
 	$plugins = array_filter( $plugins, 'is_plugin_active' );
 

--- a/tests/Integration/inc/Engine/Preload/Links/AdminSubscriber/addIncompatiblePlugins.php
+++ b/tests/Integration/inc/Engine/Preload/Links/AdminSubscriber/addIncompatiblePlugins.php
@@ -14,6 +14,8 @@ class Test_AddIncompatiblePlugins extends TestCase {
         parent::tearDown();
 
         remove_filter( 'pre_get_rocket_option_preload_links', [ $this, 'set_preload_value' ] );
+
+		$this->restoreWpFilter( 'rocket_plugins_to_deactivate' );
     }
 
 	/**
@@ -21,6 +23,8 @@ class Test_AddIncompatiblePlugins extends TestCase {
 	 */
 	public function testShouldDoExpected( $option, $plugins, $expected ) {
         $this->preload_value = $option;
+
+		$this->unregisterAllCallbacksExcept( 'rocket_plugins_to_deactivate', 'add_incompatible_plugins' );
 
         add_filter( 'pre_get_rocket_option_preload_links', [ $this, 'set_preload_value' ] );
 

--- a/tests/Integration/inc/ThirdParty/Plugins/Optimization/Ezoic/addConflict.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Optimization/Ezoic/addConflict.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\Inc\ThirdParty\Plugins\Optimization\Ezoic;
+
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * @covers \WP_Rocket\ThirdParty\Plugins\Optimization\Ezoic::add_conflict
+ *
+ * @group Ezoic
+ * @group ThirdParty
+ */
+class Test_AddConflict extends TestCase {
+	public function testShouldReturnExpected() {
+		$plugins  = [];
+		$expected = [
+			'ezoic' => 'ezoic-integration/ezoic-integration.php',
+		];
+
+		$this->assertSame(
+			$expected,
+			apply_filters( 'rocket_plugins_to_deactivate', $plugins )
+		);
+	}
+}

--- a/tests/Integration/inc/ThirdParty/Plugins/Optimization/Ezoic/addExplanations.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Optimization/Ezoic/addExplanations.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\Inc\ThirdParty\Plugins\Optimization\Ezoic;
+
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * @covers \WP_Rocket\ThirdParty\Plugins\Optimization\Ezoic::add_explanations
+ *
+ * @group Ezoic
+ * @group ThirdParty
+ */
+class Test_Explanations extends TestCase {
+	public function testShouldReturnExpected() {
+		$plugins_explanations = [];
+		$expected             = [
+			'ezoic' => 'This plugin blocks WP Rocket\'s caching and optimizations. Deactivate it and use <a href="https://support.ezoic.com/support/solutions/articles/48000453926-name-server-integration" target="_blank" rel="noopener noreferrer">Ezoic\'s nameserver integration</a> instead.',
+		];
+
+		$this->assertSame(
+			$expected,
+			apply_filters( 'rocket_plugins_to_deactivate_explanations', $plugins_explanations )
+		);
+	}
+}


### PR DESCRIPTION
## Description

This PR adds a third party class for Ezoic, to display a conflict notice and explanation when the Ezoic plugin is enabled.

Fixes #2200

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

Yes, instead of adding a new notice, I used the filter we have in our plugins conflict notification, and also added a new one to be able to display the associated explanation.

## How Has This Been Tested?

- [x] Added integration tests for the new methods

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
