### PR TITLE
Fixes #2849 Ignore inline scripts content when applying the CDN rewrite

### DIFF
--- a/inc/Engine/CDN/CDN.php
+++ b/inc/Engine/CDN/CDN.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace WP_Rocket\Engine\CDN;
 
 use WP_Rocket\Admin\Options_Data;
@@ -41,14 +43,44 @@ class CDN {
 	 * @return string
 	 */
 	public function rewrite( $html ) {
-		$pattern = '#[("\']\s*(?<url>(?:(?:https?:|)' . preg_quote( $this->get_base_url(), '#' ) . ')\/(?:(?:(?:' . $this->get_allowed_paths() . ')[^"\',)]+))|\/[^/](?:[^"\')\s>]+\.[[:alnum:]]+))\s*["\')]#i';
-		return preg_replace_callback(
-			$pattern,
-			function( $matches ) {
-				return str_replace( $matches['url'], $this->rewrite_url( $matches['url'] ), $matches[0] );
-			},
-			$html
-		);
+		$relative_path_pattern = '';
+
+		$buffer = $html;
+
+		/**
+		 * Filters the exclusion of CDN rewritting inside inline scripts
+		 *
+		 * @since 3.10.5
+		 *
+		 * @param bool $enable True to exclude, false otherwise.
+		 */
+		if ( apply_filters( 'rocket_cdn_exclude_inline_scripts', true ) ) {
+			$buffer = $this->remove_inline_scripts( $html );
+		}
+
+		/**
+		 * Filters the CDN rewritting of relative paths
+		 *
+		 * @since 3.10.5
+		 *
+		 * @param bool $enable True to enable, false otherwise.
+		 */
+		if ( apply_filters( 'rocket_cdn_relative_paths', true ) ) {
+			$relative_path_pattern = '|\/[^/](?:[^"\')\s>]+\.[[:alnum:]]+)';
+		}
+
+		$pattern = '#[("\']\s*(?<url>(?:(?:https?:|)' . preg_quote( $this->get_base_url(), '#' ) . ')\/(?:(?:(?:' . $this->get_allowed_paths() . ')[^"\',)]+))' . $relative_path_pattern . ')\s*["\')]#i';
+
+		if ( ! preg_match_all( $pattern, $buffer, $matches, PREG_SET_ORDER ) ) {
+			return $html;
+		}
+
+		foreach ( $matches as $match ) {
+			$cdn_url = str_replace( $match['url'], $this->rewrite_url( $match['url'] ), $match[0] );
+			$html    = str_replace( $match[0], $cdn_url, $html );
+		}
+
+		return $html;
 	}
 
 	/**
@@ -207,7 +239,6 @@ class CDN {
 	 * Gets the base URL for the website
 	 *
 	 * @since 3.4
-	 * @author Remy Perona
 	 *
 	 * @return string
 	 */
@@ -219,7 +250,6 @@ class CDN {
 	 * Gets the allowed paths as a regex pattern for the CDN rewrite
 	 *
 	 * @since 3.4
-	 * @author Remy Perona
 	 *
 	 * @return string
 	 */
@@ -241,7 +271,6 @@ class CDN {
 	 * Checks if the provided URL can be rewritten with the CDN URL
 	 *
 	 * @since 3.4
-	 * @author Remy Perona
 	 *
 	 * @param string $url URL to check.
 	 * @return boolean
@@ -293,7 +322,6 @@ class CDN {
 	 * Gets the CDN zones for the provided URL
 	 *
 	 * @since 3.4
-	 * @author Remy Perona
 	 *
 	 * @param string $url URL to check.
 	 * @return array
@@ -393,5 +421,34 @@ class CDN {
 			]
 		);
 		return implode( '|', $srcset_attributes );
+	}
+
+	/**
+	 * Removes inline scripts from the HTML
+	 *
+	 * @since 3.10.5
+	 *
+	 * @param string $html HTML content.
+	 *
+	 * @return string
+	 */
+	private function remove_inline_scripts( $html ): string {
+		if ( ! preg_match_all( '#<script(?:[^>]*)>(?<content>[\s\S]*?)</script>#msi', $html, $matches, PREG_SET_ORDER ) ) {
+			return $html;
+		}
+
+		if ( empty( $matches ) ) {
+			return $html;
+		}
+
+		foreach ( $matches as $inline_js ) {
+			if ( empty( $inline_js['content'] ) ) {
+				continue;
+			}
+
+			$html = str_replace( $inline_js[0], '', $html );
+		}
+
+		return $html;
 	}
 }

--- a/inc/Engine/CDN/CDN.php
+++ b/inc/Engine/CDN/CDN.php
@@ -59,7 +59,7 @@ class CDN {
 		}
 
 		/**
-		 * Filters the CDN rewritting of relative paths
+		 * Filters the CDN rewriting of relative paths
 		 *
 		 * @since 3.10.5
 		 *

--- a/tests/Fixtures/inc/Engine/CDN/CDN/HTML/siteURL/original.html
+++ b/tests/Fixtures/inc/Engine/CDN/CDN/HTML/siteURL/original.html
@@ -3,9 +3,20 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=2.0">
-<meta name="p:domain_verify" content="0c53e57f0897b1179d2318f8a4eda4cf"/> 
-	
-<!-- Global site tag (gtag.js) - Google Analytics 
+<meta name="p:domain_verify" content="0c53e57f0897b1179d2318f8a4eda4cf"/>
+<script type="text/javascript">
+	(function(d,s,i,r) {
+	if (d.getElementById(i)){return;}
+	var n=d.createElement(s),e=d.getElementsByTagName(s)[0];
+	n.id=i;n.src='//js.hs-analytics.net/analytics/'+(Math.ceil(new Date()/r)*r)+'/1867782.js';
+	e.parentNode.insertBefore(n, e);
+	})(document,"script","hs-analytics",300000);
+</script>
+<script>s.src = 'https://webchat.missiveapp.com/' + w.MissiveChatConfig.id + '/missive.js';</script>
+<script>if (/filter/.test(window.location.href)) {};</script>
+<script>if ( /Mobi|Android/i.test(navigator.userAgent)) {};</script>
+<script async="true" type="text/javascript" src="https://s.adroll.com/j/roundtrip.js"></script>
+<!-- Global site tag (gtag.js) - Google Analytics
 
 	<script async src="https://www.googletagmanager.com/gtag/js?id=UA-133192293-1"></script>
 
@@ -21,7 +32,7 @@
 			window[disableStr] = true;
 			alert('Das Tracking durch Google Analytics wurde in Ihrem Browser für diese Website deaktiviert.');
 		}
-		
+
 		window.dataLayer = window.dataLayer || [];
 		function gtag(){dataLayer.push(arguments);}
 		gtag('js', new Date());
@@ -55,18 +66,18 @@
 			features.push('left=' + left);
 			features.push('top=' + right);
 			features.push('scrollbars=1');
-		
+
 			var newWindow = window.open(url, title, features.join(','));
-		
+
 			if (window.focus) {
 				newWindow.focus();
 			}
-		
+
 			return newWindow;
 		};
-		
+
 		var isWebView = null;
-		
+
 		function checkWebView() {
 			if (isWebView === null) {
 				function _detectOS(ua) {
@@ -86,10 +97,10 @@
 					}
 					return "";
 				}
-		
+
 				function _detectBrowser(ua) {
 					var android = /Android/.test(ua);
-		
+
 					switch (true) {
 						case /CriOS/.test(ua):
 							return "Chrome for iOS";
@@ -112,7 +123,7 @@
 					}
 					return "";
 				}
-		
+
 				function _detectBrowserVersion(ua, browser) {
 					switch (browser) {
 						case "Chrome for iOS":
@@ -139,7 +150,7 @@
 					}
 					return "0.0.0";
 				}
-		
+
 				function _getVersion(ua, token) {
 					try {
 						return _normalizeSemverString(ua.split(token)[1].trim().split(/[^\w\.]/)[0]);
@@ -147,14 +158,14 @@
 					}
 					return "0.0.0";
 				}
-		
+
 				function _normalizeSemverString(version) {
 					var ary = version.split(/[\._]/);
 					return (parseInt(ary[0], 10) || 0) + "." +
 						(parseInt(ary[1], 10) || 0) + "." +
 						(parseInt(ary[2], 10) || 0);
 				}
-		
+
 				function _isWebView(ua, os, browser, version, options) {
 					switch (os + browser) {
 						case "iOSSafari":
@@ -168,39 +179,39 @@
 					}
 					return false;
 				}
-		
+
 				function _isWebView_iOS(options) {
 					var document = (window["document"] || {});
-		
+
 					if ("WEB_VIEW" in options) {
 						return options["WEB_VIEW"];
 					}
 					return !("fullscreenEnabled" in document || "webkitFullscreenEnabled" in document || false);
 				}
-		
+
 				function _isWebView_Android(options) {
 					if ("WEB_VIEW" in options) {
 						return options["WEB_VIEW"];
 					}
 					return !("requestFileSystem" in window || "webkitRequestFileSystem" in window || false);
 				}
-		
+
 				var options = {};
 				var nav = window.navigator || {};
 				var ua = nav.userAgent || "";
 				var os = _detectOS(ua);
 				var browser = _detectBrowser(ua);
 				var browserVersion = _detectBrowserVersion(ua, browser);
-		
+
 				isWebView = _isWebView(ua, os, browser, browserVersion, options);
 			}
-		
+
 			return isWebView;
 		}
-		
+
 		window._nsl.push(function ($) {
 			var targetWindow = _targetWindow || 'prefer-popup';
-		
+
 			$('a[data-plugin="nsl"][data-action="connect"],a[data-plugin="nsl"][data-action="link"]').on('click', function (e) {
 				var $target = $(this),
 					href = $target.attr('href'),
@@ -216,11 +227,11 @@
 				} else if (redirectTo && redirectTo !== '') {
 					href += 'redirect=' + encodeURIComponent(redirectTo) + '&';
 				}
-		
+
 				if (targetWindow !== 'prefer-same-window' && checkWebView()) {
 					targetWindow = 'prefer-same-window';
 				}
-		
+
 				if (targetWindow === 'prefer-popup') {
 					if (NSLPopupCenter(href + 'display=popup', 'nsl-social-connect', $target.data('popupwidth'), $target.data('popupheight'))) {
 						success = true;
@@ -236,13 +247,13 @@
 						e.preventDefault();
 					}
 				}
-		
+
 				if (!success) {
 					window.location = href;
 					e.preventDefault();
 				}
 			});
-		
+
 			var googleLoginButton = $('a[data-plugin="nsl"][data-provider="google"]');
 			if (googleLoginButton.length && checkWebView()) {
 				googleLoginButton.remove();
@@ -258,7 +269,7 @@ var htmlTag = document.getElementsByTagName("html")[0];
             htmlTag.className += ' ie10';
         }
 
-        if ( !!navigator.userAgent.match(/Trident.*rv\:11\./) ) { 
+        if ( !!navigator.userAgent.match(/Trident.*rv\:11\./) ) {
             htmlTag.className += ' ie11';
         }
 
@@ -400,7 +411,7 @@ img.emoji {
 				.wp-block-cover .wp-block-cover__inner-container h6 {
 					color: #000000;
 				}
-			
+
 </style>
 <link rel='stylesheet' id='storefront-style-css'  href='http://example.org/wp-content/themes/storefront/style.css?ver=2.5.0' type='text/css' media='all' />
 <style id='storefront-style-inline-css' type='text/css'>
@@ -584,7 +595,7 @@ img.emoji {
 <link rel='stylesheet' id='storefront-fonts-css'  href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,300,300italic,400italic,600,700,900&#038;subset=latin%2Clatin-ext' type='text/css' media='all' />
 <link rel='https://api.w.org/' href='http://example.org/wp-json/' />
 <link rel="EditURI" type="application/rsd+xml" title="RSD" href="http://example.org/xmlrpc.php?rsd" />
-<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="http://example.org/wp-includes/wlwmanifest.xml" /> 
+<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="http://example.org/wp-includes/wlwmanifest.xml" />
 <meta name="generator" content="WordPress 5.2.2" />
 <link rel="canonical" href="http://example.org/about/page-image-alignment" />
 <link rel='shortlink' href='http://example.org/?p=1133' />
@@ -601,7 +612,7 @@ img.emoji {
 
 
 <div id="page" class="hfeed site">
-	
+
 	<header id="masthead" class="site-header" role="banner" style="">
 
 		<div class="col-full">      <a class="skip-link screen-reader-text" href="#site-navigation">Aller à la navigation</a>
@@ -742,15 +753,15 @@ img.emoji {
 		</div></div>
 	</header><!-- #masthead -->
 
-	
+
 	<div id="content" class="site-content" tabindex="-1">
 		<div class="col-full">
 
-		
+
 	<div id="primary" class="content-area">
 		<main id="main" class="site-main" role="main">
 
-			
+
 <article id="post-1133" class="post-1133 page type-page status-publish hentry">
 			<header class="entry-header">
 			<h1 class="entry-title">Page Image Alignment</h1>       </header><!-- .entry-header -->
@@ -814,7 +825,7 @@ img.emoji {
 <input type='hidden' name='comment_parent' id='comment_parent' value='0' />
 </p>            </form>
 			</div><!-- #respond -->
-	
+
 </section><!-- #comments -->
 
 		</main><!-- #main -->
@@ -1008,18 +1019,18 @@ img.emoji {
 		</div><!-- .col-full -->
 	</div><!-- #content -->
 
-	
+
 	<footer id="colophon" class="site-footer" role="contentinfo">
 		<div class="col-full">
 
 					<div class="site-info">
 			&copy; tests 2019                       <br />
 								<a href="https://woocommerce.com" target="_blank" title="WooCommerce - La meilleure plateforme eCommerce pour WordPress" rel="author">Construit avec Storefront &amp; WooCommerce</a>.                  </div><!-- .site-info -->
-		
+
 		</div><!-- .col-full -->
 	</footer><!-- #colophon -->
 
-	
+
 </div><!-- #page -->
 
 <script type='text/javascript'>

--- a/tests/Fixtures/inc/Engine/CDN/CDN/HTML/siteURL/rewrite.html
+++ b/tests/Fixtures/inc/Engine/CDN/CDN/HTML/siteURL/rewrite.html
@@ -3,9 +3,20 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=2.0">
-<meta name="p:domain_verify" content="0c53e57f0897b1179d2318f8a4eda4cf"/> 
-	
-<!-- Global site tag (gtag.js) - Google Analytics 
+<meta name="p:domain_verify" content="0c53e57f0897b1179d2318f8a4eda4cf"/>
+<script type="text/javascript">
+	(function(d,s,i,r) {
+	if (d.getElementById(i)){return;}
+	var n=d.createElement(s),e=d.getElementsByTagName(s)[0];
+	n.id=i;n.src='//js.hs-analytics.net/analytics/'+(Math.ceil(new Date()/r)*r)+'/1867782.js';
+	e.parentNode.insertBefore(n, e);
+	})(document,"script","hs-analytics",300000);
+</script>
+<script>s.src = 'https://webchat.missiveapp.com/' + w.MissiveChatConfig.id + '/missive.js';</script>
+<script>if (/filter/.test(window.location.href)) {};</script>
+<script>if ( /Mobi|Android/i.test(navigator.userAgent)) {};</script>
+<script async="true" type="text/javascript" src="https://s.adroll.com/j/roundtrip.js"></script>
+<!-- Global site tag (gtag.js) - Google Analytics
 
 	<script async src="https://www.googletagmanager.com/gtag/js?id=UA-133192293-1"></script>
 
@@ -21,7 +32,7 @@
 			window[disableStr] = true;
 			alert('Das Tracking durch Google Analytics wurde in Ihrem Browser für diese Website deaktiviert.');
 		}
-		
+
 		window.dataLayer = window.dataLayer || [];
 		function gtag(){dataLayer.push(arguments);}
 		gtag('js', new Date());
@@ -55,18 +66,18 @@
 			features.push('left=' + left);
 			features.push('top=' + right);
 			features.push('scrollbars=1');
-		
+
 			var newWindow = window.open(url, title, features.join(','));
-		
+
 			if (window.focus) {
 				newWindow.focus();
 			}
-		
+
 			return newWindow;
 		};
-		
+
 		var isWebView = null;
-		
+
 		function checkWebView() {
 			if (isWebView === null) {
 				function _detectOS(ua) {
@@ -86,10 +97,10 @@
 					}
 					return "";
 				}
-		
+
 				function _detectBrowser(ua) {
 					var android = /Android/.test(ua);
-		
+
 					switch (true) {
 						case /CriOS/.test(ua):
 							return "Chrome for iOS";
@@ -112,7 +123,7 @@
 					}
 					return "";
 				}
-		
+
 				function _detectBrowserVersion(ua, browser) {
 					switch (browser) {
 						case "Chrome for iOS":
@@ -139,7 +150,7 @@
 					}
 					return "0.0.0";
 				}
-		
+
 				function _getVersion(ua, token) {
 					try {
 						return _normalizeSemverString(ua.split(token)[1].trim().split(/[^\w\.]/)[0]);
@@ -147,14 +158,14 @@
 					}
 					return "0.0.0";
 				}
-		
+
 				function _normalizeSemverString(version) {
 					var ary = version.split(/[\._]/);
 					return (parseInt(ary[0], 10) || 0) + "." +
 						(parseInt(ary[1], 10) || 0) + "." +
 						(parseInt(ary[2], 10) || 0);
 				}
-		
+
 				function _isWebView(ua, os, browser, version, options) {
 					switch (os + browser) {
 						case "iOSSafari":
@@ -168,39 +179,39 @@
 					}
 					return false;
 				}
-		
+
 				function _isWebView_iOS(options) {
 					var document = (window["document"] || {});
-		
+
 					if ("WEB_VIEW" in options) {
 						return options["WEB_VIEW"];
 					}
 					return !("fullscreenEnabled" in document || "webkitFullscreenEnabled" in document || false);
 				}
-		
+
 				function _isWebView_Android(options) {
 					if ("WEB_VIEW" in options) {
 						return options["WEB_VIEW"];
 					}
 					return !("requestFileSystem" in window || "webkitRequestFileSystem" in window || false);
 				}
-		
+
 				var options = {};
 				var nav = window.navigator || {};
 				var ua = nav.userAgent || "";
 				var os = _detectOS(ua);
 				var browser = _detectBrowser(ua);
 				var browserVersion = _detectBrowserVersion(ua, browser);
-		
+
 				isWebView = _isWebView(ua, os, browser, browserVersion, options);
 			}
-		
+
 			return isWebView;
 		}
-		
+
 		window._nsl.push(function ($) {
 			var targetWindow = _targetWindow || 'prefer-popup';
-		
+
 			$('a[data-plugin="nsl"][data-action="connect"],a[data-plugin="nsl"][data-action="link"]').on('click', function (e) {
 				var $target = $(this),
 					href = $target.attr('href'),
@@ -216,11 +227,11 @@
 				} else if (redirectTo && redirectTo !== '') {
 					href += 'redirect=' + encodeURIComponent(redirectTo) + '&';
 				}
-		
+
 				if (targetWindow !== 'prefer-same-window' && checkWebView()) {
 					targetWindow = 'prefer-same-window';
 				}
-		
+
 				if (targetWindow === 'prefer-popup') {
 					if (NSLPopupCenter(href + 'display=popup', 'nsl-social-connect', $target.data('popupwidth'), $target.data('popupheight'))) {
 						success = true;
@@ -236,13 +247,13 @@
 						e.preventDefault();
 					}
 				}
-		
+
 				if (!success) {
 					window.location = href;
 					e.preventDefault();
 				}
 			});
-		
+
 			var googleLoginButton = $('a[data-plugin="nsl"][data-provider="google"]');
 			if (googleLoginButton.length && checkWebView()) {
 				googleLoginButton.remove();
@@ -258,7 +269,7 @@ var htmlTag = document.getElementsByTagName("html")[0];
             htmlTag.className += ' ie10';
         }
 
-        if ( !!navigator.userAgent.match(/Trident.*rv\:11\./) ) { 
+        if ( !!navigator.userAgent.match(/Trident.*rv\:11\./) ) {
             htmlTag.className += ' ie11';
         }
 
@@ -400,7 +411,7 @@ img.emoji {
 				.wp-block-cover .wp-block-cover__inner-container h6 {
 					color: #000000;
 				}
-			
+
 </style>
 <link rel='stylesheet' id='storefront-style-css'  href='http://cdn.example.org/wp-content/themes/storefront/style.css?ver=2.5.0' type='text/css' media='all' />
 <style id='storefront-style-inline-css' type='text/css'>
@@ -584,7 +595,7 @@ img.emoji {
 <link rel='stylesheet' id='storefront-fonts-css'  href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,300,300italic,400italic,600,700,900&#038;subset=latin%2Clatin-ext' type='text/css' media='all' />
 <link rel='https://api.w.org/' href='http://example.org/wp-json/' />
 <link rel="EditURI" type="application/rsd+xml" title="RSD" href="http://example.org/xmlrpc.php?rsd" />
-<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="http://cdn.example.org/wp-includes/wlwmanifest.xml" /> 
+<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="http://cdn.example.org/wp-includes/wlwmanifest.xml" />
 <meta name="generator" content="WordPress 5.2.2" />
 <link rel="canonical" href="http://example.org/about/page-image-alignment" />
 <link rel='shortlink' href='http://example.org/?p=1133' />
@@ -601,7 +612,7 @@ img.emoji {
 
 
 <div id="page" class="hfeed site">
-	
+
 	<header id="masthead" class="site-header" role="banner" style="">
 
 		<div class="col-full">      <a class="skip-link screen-reader-text" href="#site-navigation">Aller à la navigation</a>
@@ -742,15 +753,15 @@ img.emoji {
 		</div></div>
 	</header><!-- #masthead -->
 
-	
+
 	<div id="content" class="site-content" tabindex="-1">
 		<div class="col-full">
 
-		
+
 	<div id="primary" class="content-area">
 		<main id="main" class="site-main" role="main">
 
-			
+
 <article id="post-1133" class="post-1133 page type-page status-publish hentry">
 			<header class="entry-header">
 			<h1 class="entry-title">Page Image Alignment</h1>       </header><!-- .entry-header -->
@@ -814,7 +825,7 @@ img.emoji {
 <input type='hidden' name='comment_parent' id='comment_parent' value='0' />
 </p>            </form>
 			</div><!-- #respond -->
-	
+
 </section><!-- #comments -->
 
 		</main><!-- #main -->
@@ -1008,18 +1019,18 @@ img.emoji {
 		</div><!-- .col-full -->
 	</div><!-- #content -->
 
-	
+
 	<footer id="colophon" class="site-footer" role="contentinfo">
 		<div class="col-full">
 
 					<div class="site-info">
 			&copy; tests 2019                       <br />
 								<a href="https://woocommerce.com" target="_blank" title="WooCommerce - La meilleure plateforme eCommerce pour WordPress" rel="author">Construit avec Storefront &amp; WooCommerce</a>.                  </div><!-- .site-info -->
-		
+
 		</div><!-- .col-full -->
 	</footer><!-- #colophon -->
 
-	
+
 </div><!-- #page -->
 
 <script type='text/javascript'>


### PR DESCRIPTION
## Description

With this PR, by default we now remove inline scripts from the content to parse, to avoid unexpected rewritting of cases reported by the support.

This behaviour can be reverted by using the new filter `rocket_cdn_exclude_inline_scripts`.

We also introduce another filter `rocket_cdn_relative_paths`, which can prevent complete rewrite of relative paths.

Fixes #2849 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

No

## How Has This Been Tested?

- [x] Added snippets to the automated tests to check for reported use case and verify they are correctly passing now

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
