### PR TITLE
Fixes #4104 Exclude static.cleverpush.com from Minify JS

### DIFF
--- a/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
+++ b/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
@@ -247,6 +247,7 @@ abstract class AbstractJSOptimization extends AbstractOptimization {
 			'www.vbt.io/ext/vbtforms.js',
 			'cdn.callrail.com',
 			'documentcloud.adobe.com/view-sdk/main.js',
+			'static.cleverpush.com',
 		];
 
 		$excluded_external = array_merge( $defaults, $this->options->get( 'exclude_js', [] ) );


### PR DESCRIPTION
Excludes `static.cleverpush.com` from Minify/Combine JS

Fixes #4104 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

Please describe in this section if there is any change to the solution, and why.

## How Has This Been Tested?

On customer's site and my testing environment.

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
