### PR TITLE
Fix 3967 PHP warning generated when unescaped regex character in deferJS field

### DIFF
--- a/inc/Engine/Optimization/DeferJS/DeferJS.php
+++ b/inc/Engine/Optimization/DeferJS/DeferJS.php
@@ -75,6 +75,10 @@ class DeferJS {
 
 		$exclude_defer_js = implode( '|', $this->get_excluded() );
 
+		if ( ! @preg_replace( '#(' . $exclude_defer_js . ')#i', '', 'dummy-string' ) ) {
+			return $html;
+		}
+
 		foreach ( $matches as $tag ) {
 			if ( preg_match( '#(' . $exclude_defer_js . ')#i', $tag['url'] ) ) {
 				continue;

--- a/inc/Engine/Optimization/DeferJS/DeferJS.php
+++ b/inc/Engine/Optimization/DeferJS/DeferJS.php
@@ -75,7 +75,7 @@ class DeferJS {
 
 		$exclude_defer_js = implode( '|', $this->get_excluded() );
 
-		if ( ! @preg_replace( '#(' . $exclude_defer_js . ')#i', '', 'dummy-string' ) ) {
+		if ( ! @preg_replace( '#(' . $exclude_defer_js . ')#i', '', 'dummy-string' ) ) { // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 			return $html;
 		}
 

--- a/inc/Engine/Optimization/DeferJS/DeferJS.php
+++ b/inc/Engine/Optimization/DeferJS/DeferJS.php
@@ -222,7 +222,13 @@ class DeferJS {
 			'www.paypal.com/sdk/js',
 		];
 
-		$exclude_defer_js = array_unique( array_merge( $exclude_defer_js, $this->options->get( 'exclude_defer_js', [] ) ) );
+		$exclude_defer_js_option = $this->options->get( 'exclude_defer_js', [] );
+
+		foreach ( $exclude_defer_js_option as $i => $exclude ) {
+			$exclude_defer_js_option[ $i ] = preg_quote( $exclude, '/' );
+		}
+
+		$exclude_defer_js = array_unique( array_merge( $exclude_defer_js, $exclude_defer_js_option ) );
 
 		/**
 		 * Filter list of Deferred JavaScript files
@@ -232,10 +238,6 @@ class DeferJS {
 		 * @param array $exclude_defer_js An array of URLs for the JS files to be excluded.
 		 */
 		$exclude_defer_js = apply_filters( 'rocket_exclude_defer_js', $exclude_defer_js );
-
-		foreach ( $exclude_defer_js as $i => $exclude ) {
-			$exclude_defer_js[ $i ] = str_replace( '#', '\#', $exclude );
-		}
 
 		return $exclude_defer_js;
 	}

--- a/inc/Engine/Optimization/DeferJS/DeferJS.php
+++ b/inc/Engine/Optimization/DeferJS/DeferJS.php
@@ -222,13 +222,7 @@ class DeferJS {
 			'www.paypal.com/sdk/js',
 		];
 
-		$exclude_defer_js_option = $this->options->get( 'exclude_defer_js', [] );
-
-		foreach ( $exclude_defer_js_option as $i => $exclude ) {
-			$exclude_defer_js_option[ $i ] = preg_quote( $exclude, '/' );
-		}
-
-		$exclude_defer_js = array_unique( array_merge( $exclude_defer_js, $exclude_defer_js_option ) );
+		$exclude_defer_js = array_unique( array_merge( $exclude_defer_js, $this->options->get( 'exclude_defer_js', [] ) ) );
 
 		/**
 		 * Filter list of Deferred JavaScript files
@@ -238,6 +232,10 @@ class DeferJS {
 		 * @param array $exclude_defer_js An array of URLs for the JS files to be excluded.
 		 */
 		$exclude_defer_js = apply_filters( 'rocket_exclude_defer_js', $exclude_defer_js );
+
+		foreach ( $exclude_defer_js as $i => $exclude ) {
+			$exclude_defer_js[ $i ] = str_replace( '#', '\#', $exclude );
+		}
 
 		return $exclude_defer_js;
 	}

--- a/inc/admin/options.php
+++ b/inc/admin/options.php
@@ -123,6 +123,7 @@ function rocket_pre_main_option( $newvalue, $oldvalue ) {
 		'exclude_css'         => __( 'Excluded CSS Files', 'rocket' ),
 		'exclude_inline_js'   => __( 'Excluded Inline JavaScript', 'rocket' ),
 		'exclude_js'          => __( 'Excluded JavaScript Files', 'rocket' ),
+		'exclude_defer_js'    => __( 'Defer JavaScript Files', 'rocket' ),
 		'delay_js_exclusions' => __( 'Excluded Delay JavaScript Files', 'rocket' ),
 		'cache_reject_uri'    => __( 'Never Cache URL(s)', 'rocket' ),
 		'cache_reject_ua'     => __( 'Never Cache User Agent(s)', 'rocket' ),

--- a/tests/Fixtures/inc/Engine/Optimization/DeferJS/Subscriber/deferJs.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DeferJS/Subscriber/deferJs.php
@@ -102,4 +102,32 @@ return [
 		'html'     => $html,
 		'expected' => $expected_exclusion,
 	],
+	'testShouldEvaluateRegexPatternInOptions' => [
+		'config' => [
+			'donotrocketoptimize' => false,
+			'post_meta'           => false,
+			'options'             => [
+				'defer_all_js'      => 1,
+				'exclude_defer_js'  => [
+					'/wp-content/plugins/(.*)/script.js',
+				],
+			],
+		],
+		'html'     => $html,
+		'expected' => $expected_exclusion,
+	],
+	'testShouldReturnOriginalWithoutThrowingWarningWhenBadPatternInOptions' => [
+		'config' => [
+			'donotrocketoptimize' => false,
+			'post_meta'           => false,
+			'options'             => [
+				'defer_all_js'      => 1,
+				'exclude_defer_js'  => [
+					'/wp-content/bad(pattern/script.js',
+				],
+			],
+		],
+		'html'     => $html,
+		'expected' => $html,
+	],
 ];

--- a/tests/Integration/inc/Engine/Optimization/DeferJS/Subscriber/deferJs.php
+++ b/tests/Integration/inc/Engine/Optimization/DeferJS/Subscriber/deferJs.php
@@ -2,6 +2,8 @@
 
 namespace WP_Rocket\Tests\Integration\inc\Engine\Optimization\DeferJS\Subscriber;
 
+use ErrorException;
+use mysql_xdevapi\Exception;
 use WP_Rocket\Tests\Integration\ContentTrait;
 use WP_Rocket\Tests\Integration\TestCase;
 
@@ -9,6 +11,7 @@ use WP_Rocket\Tests\Integration\TestCase;
  * @covers \WP_Rocket\Engine\Optimization\DeferJS\Subscriber::defer_js
  *
  * @group  DeferJS
+ * @group cg
  */
 class Test_DeferJs extends TestCase {
 	use ContentTrait;

--- a/tests/Integration/inc/Engine/Optimization/DeferJS/Subscriber/deferJs.php
+++ b/tests/Integration/inc/Engine/Optimization/DeferJS/Subscriber/deferJs.php
@@ -2,8 +2,6 @@
 
 namespace WP_Rocket\Tests\Integration\inc\Engine\Optimization\DeferJS\Subscriber;
 
-use ErrorException;
-use mysql_xdevapi\Exception;
 use WP_Rocket\Tests\Integration\ContentTrait;
 use WP_Rocket\Tests\Integration\TestCase;
 
@@ -11,7 +9,6 @@ use WP_Rocket\Tests\Integration\TestCase;
  * @covers \WP_Rocket\Engine\Optimization\DeferJS\Subscriber::defer_js
  *
  * @group  DeferJS
- * @group cg
  */
 class Test_DeferJs extends TestCase {
 	use ContentTrait;


### PR DESCRIPTION
## Description

This preg_replaces all regex special characters when retrieving defer JS options to allow expressions such as `gtag(` to be used without generating PHP warnings.

Fixes #3967 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?
No.
Escaping all the regex special characters has the side-effect of not allowing any legitimate regex to be used in the field, so entries like `/wp-content/plugins/(.*)/script.js` will not be included in exclusions where expected.

Instead, this does 3 things:
- Adds a testcase for properly evaluating regex entries to the integration tests.
- Adds a testcase for the expectation that if an invalid regex does sneak through, we guard it from triggering warning, and return early without trying to defer js patterns from the UI.
- Adds the `exclude_defer_js` to the set of pattern fields, which will remove invalid patterns from the field on save and trigger the notice that the pattern was invalid.

## How Has This Been Tested?

Confirmed that no warnings are generated in development environment.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New integration testcases are added to cover when regex entries are included in the UI field.
- [X] New and existing unit tests pass locally with my changes

Further Context: 
Per note on 3967 regarding warnings also being generated in combineJS fields, the warnings on combine were being generated by DeferJS field entries being passed through to combineJS when Combine was active. Escaping once in the Defer JS process resolves also the combine warnings.