### PR TITLE
Close 4219 - Re-apply font display filter for combined Google Fonts

### DIFF
--- a/inc/Engine/Optimization/GoogleFonts/Combine.php
+++ b/inc/Engine/Optimization/GoogleFonts/Combine.php
@@ -139,6 +139,8 @@ class Combine extends AbstractGFOptimization {
 	 * @return string
 	 */
 	private function get_combined_url(): string {
-		return esc_url( "https://fonts.googleapis.com/css?family={$this->fonts}{$this->subsets}&display=swap" );
+		$display = $this->get_font_display_value();
+
+		return esc_url( "https://fonts.googleapis.com/css?family={$this->fonts}{$this->subsets}&display={$display}" );
 	}
 }

--- a/inc/Engine/Optimization/GoogleFonts/CombineV2.php
+++ b/inc/Engine/Optimization/GoogleFonts/CombineV2.php
@@ -130,7 +130,9 @@ class CombineV2 extends AbstractGFOptimization {
 	 * @return string
 	 */
 	private function get_combined_url( array $families ): string {
-		return esc_url( "https://fonts.googleapis.com/css2{$this->get_concatenated_families( $families )}&display=swap" );
+		$display = $this->get_font_display_value();
+
+		return esc_url( "https://fonts.googleapis.com/css2{$this->get_concatenated_families( $families )}&display={$display}" );
 	}
 
 	/**

--- a/tests/Fixtures/inc/Engine/Optimization/GoogleFonts/Combine/optimize.php
+++ b/tests/Fixtures/inc/Engine/Optimization/GoogleFonts/Combine/optimize.php
@@ -20,6 +20,26 @@ return [
 			</body>
 		</html>',
 	],
+	'testShouldUseFilteredDisplayValue' => [
+		'html' => '<html>
+			<head>
+				<title>Sample Page</title>
+				<link rel="stylesheet" id="dt-web-fonts-css"  href="//fonts.googleapis.com/css?family=Josefin+Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica+One%3A400%2C600%2C700&#038;ver=7.3.2" type="text/css" media="all" />
+				<link rel="stylesheet" id="ultimate-google-fonts-css"  href="https://fonts.googleapis.com/css?family=Josefin+Sans:regular,300|" type="text/css" media="all" />
+				<link href="https://fonts.googleapis.com/css?family=Josefin+Sans:300" rel="stylesheet" property="stylesheet" type"text/css" media="all">
+			</head>
+			<body>
+			</body>
+		</html>',
+		'expected' => '<html>
+			<head>
+				<title>Sample Page</title><link rel="preload" as="style" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=optional" /><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=optional" media="print" onload="this.media=\'all\'" /><noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=optional" /></noscript>
+			</head>
+			<body>
+			</body>
+		</html>',
+		'filtered' => 'optional',
+	],
 	'testShouldCombineGoogleFontsWithSubsets' => [
 		'html' => '<html>
 			<head>

--- a/tests/Fixtures/inc/Engine/Optimization/GoogleFonts/CombineV1V2/optimize.php
+++ b/tests/Fixtures/inc/Engine/Optimization/GoogleFonts/CombineV1V2/optimize.php
@@ -28,6 +28,35 @@ return [
 				</body>
 			</html>'
 	],
+	'shouldUseFilteredDisplayValue' => [
+		'given' =>
+			'<!doctype html>
+			<html>
+				<head>
+					<title>Sample Page</title>
+					<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@450" type="text/css" media="all" />
+					<link rel="stylesheet" href="//fonts.googleapis.com/css?family=Josefin+Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica+One%3A400%2C600%2C700&#038;ver=7.3.2" type="text/css" media="all" />
+					<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin+Sans:regular,300|" type="text/css" media="all" />
+					<link href="https://fonts.googleapis.com/css?family=Josefin+Sans:300" rel="stylesheet" property="stylesheet" type"text/css" media="all">
+				</head>
+				<body>
+				</body>
+			</html>'
+		,
+		'expected' =>
+			'<!doctype html>
+			<html>
+				<head>
+					<title>Sample Page</title>
+					<link rel="preload" as="style" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=optional" /><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=optional" media="print" onload="this.media=\'all\'" /><noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=optional" /></noscript>
+					<link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@450&#038;display=optional" /><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@450&#038;display=optional" media="print" onload="this.media=\'all\'" /><noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@450&#038;display=optional" /></noscript>
+				</head>
+				<body>
+				</body>
+			</html>'
+		,
+		'filtered' => 'optional',
+	],
 	'shouldNotCombineMultipleTagsWithTextParam' => [
 		'given' =>
 			'<!doctype html>

--- a/tests/Fixtures/inc/Engine/Optimization/GoogleFonts/CombineV2/optimize.php
+++ b/tests/Fixtures/inc/Engine/Optimization/GoogleFonts/CombineV2/optimize.php
@@ -149,4 +149,32 @@ return [
 			</body>
 			</html>'
 	],
+	'shouldReplaceDisplayValueWithFilteredValue' => [
+		'given' =>
+			'<!doctype html>
+			<html>
+			<head>
+			<title>Sample Page</title>
+			<link rel="preconnect" href="https://fonts.gstatic.com">
+			<link href="https://fonts.googleapis.com/css2?family=Goldman:wght@700&family=Roboto:ital,wght@0,100;0,400;0,500;1,500;1,900&display=auto" rel="stylesheet">
+			<link rel="stylesheet" id="dt-more-fonts-css" href="https://fonts.googleapis.com/css2?family=Comfortaa" type="text/css" media="all" />
+			</head>
+			<body>
+			</body>
+			</html>'
+		,
+		'expected' =>
+			'<!doctype html>
+			<html>
+			<head>
+			<title>Sample Page</title>
+			<link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Goldman:wght@700&#038;family=Roboto:ital,wght@0,100;0,400;0,500;1,500;1,900&#038;family=Comfortaa&#038;display=optional" /><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Goldman:wght@700&#038;family=Roboto:ital,wght@0,100;0,400;0,500;1,500;1,900&#038;family=Comfortaa&#038;display=optional" media="print" onload="this.media=\'all\'" /><noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Goldman:wght@700&#038;family=Roboto:ital,wght@0,100;0,400;0,500;1,500;1,900&#038;family=Comfortaa&#038;display=optional" /></noscript>
+			<link rel="preconnect" href="https://fonts.gstatic.com">
+			</head>
+			<body>
+			</body>
+			</html>'
+		,
+		'filtered' => 'optional'
+	],
 ];

--- a/tests/Integration/inc/Engine/Optimization/GoogleFonts/Combine/optimize.php
+++ b/tests/Integration/inc/Engine/Optimization/GoogleFonts/Combine/optimize.php
@@ -14,6 +14,8 @@ use WP_Rocket\Tests\Integration\TestCase;
  */
 class Test_Optimize extends TestCase {
 
+	private $filter_value;
+
 	public function setUp(): void {
 		parent::setUp();
 		$GLOBALS['wp'] = (object) [
@@ -27,32 +29,41 @@ class Test_Optimize extends TestCase {
 
 	public function tearDown() {
 		remove_filter( 'pre_get_rocket_option_minify_google_fonts', [ $this, 'return_true' ] );
+		remove_filter( 'rocket_combined_google_fonts_display', [ $this, 'set_display_value' ] );
+
+		unset( $this->filter_value );
+
 		parent::tearDown();
 	}
 
 	/**
      * @dataProvider addDataProviderV1
      */
-	public function testShouldCombineGoogleFontsV1( $original, $combined ) {
-		$this->doTest( $original, $combined );
+	public function testShouldCombineGoogleFontsV1( $original, $combined, $filtered = false ) {
+		$this->doTest( $original, $combined, $filtered );
 	}
 
 	/**
      * @dataProvider addDataProviderV2
      */
-	public function testShouldCombineGoogleFontsV2( $original, $combined ) {
-		$this->doTest( $original, $combined );
+	public function testShouldCombineGoogleFontsV2( $original, $combined, $filtered = false ) {
+		$this->doTest( $original, $combined, $filtered );
 	}
 
 	/**
      * @dataProvider addDataProviderV1V2
      */
-	public function testShouldCombineGoogleFontsV1V2( $original, $combined ) {
-		$this->doTest( $original, $combined );
+	public function testShouldCombineGoogleFontsV1V2( $original, $combined, $filtered = false ) {
+		$this->doTest( $original, $combined, $filtered );
 	}
 
-	private function doTest( $original, $expected ) {
+	private function doTest( $original, $expected, $filtered ) {
 		add_filter( 'pre_get_rocket_option_minify_google_fonts', [ $this, 'return_true' ] );
+
+		if ( $filtered ) {
+			$this->filter_value = $filtered;
+			add_filter( 'rocket_combined_google_fonts_display', [ $this, 'set_display_value' ] );
+		}
 
 		$actual = apply_filters( 'rocket_buffer', $original );
 
@@ -72,5 +83,9 @@ class Test_Optimize extends TestCase {
 
 	public function addDataProviderV1V2() {
 		return $this->getTestData( __DIR__ . 'V1V2', 'optimize' );
+	}
+
+	public function set_display_value( $filtered ) {
+		return $this->filter_value;
 	}
 }

--- a/tests/Unit/inc/Engine/Optimization/GoogleFonts/Combine/optimize.php
+++ b/tests/Unit/inc/Engine/Optimization/GoogleFonts/Combine/optimize.php
@@ -3,7 +3,10 @@
 namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\GoogleFonts\Combine;
 
 use Brain\Monkey\Functions;
+use Brain\Monkey\Filters;
+use Mockery;
 use WP_Rocket\Engine\Optimization\GoogleFonts\Combine;
+use WP_Rocket\Engine\Optimization\RUCSS\AbstractAPIClient;
 use WP_Rocket\Tests\Unit\TestCase;
 
 /**
@@ -22,7 +25,7 @@ class Test_Optimize extends TestCase {
 	/**
 	 * @dataProvider configTestData
 	 */
-	public function testShouldCombineGoogleFonts( $html, $expected ) {
+	public function testShouldCombineGoogleFonts( $html, $expected, $filtered = false ) {
 		Functions\when( 'wp_parse_url' )->alias( function( $url, $component ) {
 			return parse_url( $url, $component );
 		} );
@@ -36,6 +39,12 @@ class Test_Optimize extends TestCase {
 		Functions\when( 'esc_url' )->alias( function( $url ) {
 			return str_replace( [ '&amp;', '&' ], '&#038;', $url );
 		} );
+
+		if ( false !== $filtered ) {
+			Filters\expectApplied('rocket_combined_google_fonts_display')
+				->with('swap', Mockery::type(AbstractAPIClient::class))
+				->andReturn( $filtered );
+		}
 
 		$combine = new Combine();
 

--- a/tests/Unit/inc/Engine/Optimization/GoogleFonts/Combine/optimize.php
+++ b/tests/Unit/inc/Engine/Optimization/GoogleFonts/Combine/optimize.php
@@ -6,7 +6,7 @@ use Brain\Monkey\Functions;
 use Brain\Monkey\Filters;
 use Mockery;
 use WP_Rocket\Engine\Optimization\GoogleFonts\Combine;
-use WP_Rocket\Engine\Optimization\RUCSS\AbstractAPIClient;
+use WP_Rocket\Engine\Optimization\GoogleFonts\AbstractGFOptimization;
 use WP_Rocket\Tests\Unit\TestCase;
 
 /**
@@ -42,7 +42,7 @@ class Test_Optimize extends TestCase {
 
 		if ( false !== $filtered ) {
 			Filters\expectApplied('rocket_combined_google_fonts_display')
-				->with('swap', Mockery::type(AbstractAPIClient::class))
+				->with('swap', Mockery::type(AbstractGFOptimization::class))
 				->andReturn( $filtered );
 		}
 

--- a/tests/Unit/inc/Engine/Optimization/GoogleFonts/CombineV2/optimize.php
+++ b/tests/Unit/inc/Engine/Optimization/GoogleFonts/CombineV2/optimize.php
@@ -3,7 +3,10 @@
 namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\GoogleFonts\CombineV2;
 
 use Brain\Monkey\Functions;
+use Brain\Monkey\Filters;
+use Mockery;
 use WP_Rocket\Engine\Optimization\GoogleFonts\CombineV2;
+use WP_Rocket\Engine\Optimization\RUCSS\AbstractAPIClient;
 use WP_Rocket\Tests\Unit\TestCase;
 
 /**
@@ -22,7 +25,7 @@ class Test_OptimizeV2 extends TestCase {
 	/**
 	 * @dataProvider configTestData
 	 */
-	public function testShouldCombineV2GoogleFonts( $html, $expected ) {
+	public function testShouldCombineV2GoogleFonts( $html, $expected, $filtered = false ) {
 		Functions\when( 'wp_parse_url' )->alias( function ( $url, $component ) {
 			return parse_url( $url, $component );
 		} );
@@ -35,6 +38,12 @@ class Test_OptimizeV2 extends TestCase {
 		Functions\when( 'esc_url' )->alias( function( $url ) {
 			return str_replace( [ '&amp;', '&' ], '&#038;', $url );
 		} );
+
+		if ( false !== $filtered ) {
+			Filters\expectApplied('rocket_combined_google_fonts_display')
+				->with('swap', Mockery::type(AbstractAPIClient::class))
+				->andReturn( $filtered );
+		}
 
 		$combiner = new CombineV2();
 

--- a/tests/Unit/inc/Engine/Optimization/GoogleFonts/CombineV2/optimize.php
+++ b/tests/Unit/inc/Engine/Optimization/GoogleFonts/CombineV2/optimize.php
@@ -5,8 +5,8 @@ namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\GoogleFonts\CombineV2;
 use Brain\Monkey\Functions;
 use Brain\Monkey\Filters;
 use Mockery;
+use WP_Rocket\Engine\Optimization\GoogleFonts\AbstractGFOptimization;
 use WP_Rocket\Engine\Optimization\GoogleFonts\CombineV2;
-use WP_Rocket\Engine\Optimization\RUCSS\AbstractAPIClient;
 use WP_Rocket\Tests\Unit\TestCase;
 
 /**
@@ -41,7 +41,7 @@ class Test_OptimizeV2 extends TestCase {
 
 		if ( false !== $filtered ) {
 			Filters\expectApplied('rocket_combined_google_fonts_display')
-				->with('swap', Mockery::type(AbstractAPIClient::class))
+				->with('swap', Mockery::type(AbstractGFOptimization::class))
 				->andReturn( $filtered );
 		}
 


### PR DESCRIPTION
## Description
The application of the `rocket_combined_google_fonts_display` filter to allow using font display values other than swap was removed in a previous update of combining Google Fonts.

This PR restores the filter in those combinations and adds unit and integration test cases for checking filtered values are applied.

Fixes #4219

## Type of change
- [X] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?
No. But rather than apply the filter directly to both Combine classes individually, we make use of the method applying the filter already available via the AbstractCombine class, so that we can verify that a valid display value is returned from the filter as well.

## How Has This Been Tested?
- [X] Unit and integration test cases are added to check that the filter is applied correctly.

# Checklist:

Please delete the options that are not relevant.

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes