### PR TITLE
Patch 4558 - Improve autoptimize notices

### DIFF
--- a/inc/ThirdParty/Plugins/Optimization/Autoptimize.php
+++ b/inc/ThirdParty/Plugins/Optimization/Autoptimize.php
@@ -70,8 +70,8 @@ class Autoptimize implements Subscriber_Interface {
 			return;
 		}
 
-		$message =  sprintf(
-		/** Translators: %1$s is an opening <strong> tag; %2$s is a closing </strong> tag */
+		$message = sprintf(
+		/* Translators: %1$s is an opening <strong> tag; %2$s is a closing </strong> tag */
 			__(
 				'%1$sWP Rocket: %2$sWe have detected that Autoptimize\'s JavaScript Aggregation feature is enabled. WP Rocket\'s Delay JavaScript Execution will not be applied to the file it creates. We suggest disabling %1$sJavaScript Aggregation%2$s to take full advantage of Delay JavaScript Execution.',
 				'rocket'
@@ -126,7 +126,7 @@ class Autoptimize implements Subscriber_Interface {
 		}
 
 		$message = sprintf(
-		/** Translators: %1$s is an opening <strong> tag; %2$s is a closing </strong> tag */
+		/* Translators: %1$s is an opening <strong> tag; %2$s is a closing </strong> tag */
 			__(
 				'%1$sWP Rocket: %2$sWe have detected that Autoptimize\'s Aggregate Inline CSS feature is enabled. WP Rocket\'s Load CSS Asynchronously will not work correctly. We suggest disabling %1$sAggregate Inline CSS%2$s to take full advantage of Load CSS Asynchronously Execution.',
 				'rocket'

--- a/inc/ThirdParty/Plugins/Optimization/Autoptimize.php
+++ b/inc/ThirdParty/Plugins/Optimization/Autoptimize.php
@@ -77,7 +77,7 @@ class Autoptimize implements Subscriber_Interface {
 
 		rocket_notice_html(
 			[
-				'status'         => 'warning',
+				'status'         => 'info',
 				'message'        => $message,
 				'dismissible'    => '',
 				'dismiss_button' => __FUNCTION__,
@@ -130,7 +130,7 @@ class Autoptimize implements Subscriber_Interface {
 
 		rocket_notice_html(
 			[
-				'status'         => 'warning',
+				'status'         => 'info',
 				'message'        => $message,
 				'dismissible'    => '',
 				'dismiss_button' => __FUNCTION__,

--- a/inc/ThirdParty/Plugins/Optimization/Autoptimize.php
+++ b/inc/ThirdParty/Plugins/Optimization/Autoptimize.php
@@ -144,9 +144,15 @@ class Autoptimize implements Subscriber_Interface {
 	 * @return bool
 	 */
 	private function can_notify() {
+		if ( 'settings_page_wprocket' !== get_current_screen()->id ) {
+			return false;
+		}
+
 		return rocket_get_constant( 'AUTOPTIMIZE_PLUGIN_VERSION', false )
 			&&
 			current_user_can( 'rocket_manage_options' );
+
+
 	}
 
 	/**

--- a/inc/ThirdParty/Plugins/Optimization/Autoptimize.php
+++ b/inc/ThirdParty/Plugins/Optimization/Autoptimize.php
@@ -70,10 +70,15 @@ class Autoptimize implements Subscriber_Interface {
 			return;
 		}
 
-		$message = '<strong>' . __(
-				'We have detected that Autoptimize\'s JavaScript Aggregation feature is enabled. The Delay JavaScript Execution will not be applied to the file it creates. We suggest disabling it to take full advantage of Delay JavaScript Execution.',
+		$message =  sprintf(
+		/** Translators: %1$s is an opening <strong> tag; %2$s is a closing </strong> tag */
+			__(
+				'%1$sWP Rocket: %2$sWe have detected that Autoptimize\'s JavaScript Aggregation feature is enabled. WP Rocket\'s Delay JavaScript Execution will not be applied to the file it creates. We suggest disabling %1$sJavaScript Aggregation%2$s to take full advantage of Delay JavaScript Execution.',
 				'rocket'
-			) . '</strong>';
+			),
+			'<strong>',
+			'</strong>'
+		);
 
 		rocket_notice_html(
 			[
@@ -121,11 +126,13 @@ class Autoptimize implements Subscriber_Interface {
 		}
 
 		$message = sprintf(
-			'<strong>%s</strong>',
+		/** Translators: %1$s is an opening <strong> tag; %2$s is a closing </strong> tag */
 			__(
-				"We have detected that Autoptimize's Aggregate Inline CSS feature is enabled. WP Rocket's Load CSS Asynchronously will not be applied to the file it creates. We suggest disabling it to take full advantage of WP Rocket's Load CSS Asynchronously Execution.",
+				'%1$sWP Rocket: %2$sWe have detected that Autoptimize\'s Aggregate Inline CSS feature is enabled. WP Rocket\'s Load CSS Asynchronously will not work correctly. We suggest disabling %1$sAggregate Inline CSS%2$s to take full advantage of Load CSS Asynchronously Execution.',
 				'rocket'
-			)
+			),
+			'<strong>',
+			'</strong>'
 		);
 
 		rocket_notice_html(
@@ -151,8 +158,6 @@ class Autoptimize implements Subscriber_Interface {
 		return rocket_get_constant( 'AUTOPTIMIZE_PLUGIN_VERSION', false )
 			&&
 			current_user_can( 'rocket_manage_options' );
-
-
 	}
 
 	/**

--- a/tests/Fixtures/inc/ThirdParty/Plugins/Optimization/Autoptimize/warnWhenAggregateInlineCssAndCPCSSActive.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/Optimization/Autoptimize/warnWhenAggregateInlineCssAndCPCSSActive.php
@@ -4,12 +4,11 @@ declare( strict_types=1 );
 
 $expected_html = <<<HTML
 <div class="notice notice-info ">
-<p><strong>
-We have detected that Autoptimize's Aggregate Inline CSS feature is enabled. WP Rocket's Load CSS Asynchronously will not be applied to the file it creates. We suggest disabling it to take full advantage of WP Rocket's Load CSS Asynchronously Execution.
-</strong></p>
-<p><a class="rocket-dismiss" href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=warn_when_aggregate_inline_css_and_cpcss_active&amp;_wpnonce=123456">
-Dismiss this notice.</a></p>
-</div>
+<p><strong>WP Rocket: </strong>
+We have detected that Autoptimize's Aggregate Inline CSS feature is enabled. WP Rocket's Load CSS Asynchronously will not work correctly. We suggest disabling <strong>Aggregate Inline CSS</strong> to take full advantage of Load CSS Asynchronously Execution.
+</p><p>
+<a class="rocket-dismiss" href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=warn_when_aggregate_inline_css_and_cpcss_active&amp;_wpnonce=123456">
+Dismiss this notice.</a></p></div>
 HTML;
 
 return [

--- a/tests/Fixtures/inc/ThirdParty/Plugins/Optimization/Autoptimize/warnWhenAggregateInlineCssAndCPCSSActive.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/Optimization/Autoptimize/warnWhenAggregateInlineCssAndCPCSSActive.php
@@ -3,7 +3,7 @@
 declare( strict_types=1 );
 
 $expected_html = <<<HTML
-<div class="notice notice-warning ">
+<div class="notice notice-info ">
 <p><strong>
 We have detected that Autoptimize's Aggregate Inline CSS feature is enabled. WP Rocket's Load CSS Asynchronously will not be applied to the file it creates. We suggest disabling it to take full advantage of WP Rocket's Load CSS Asynchronously Execution.
 </strong></p>
@@ -15,54 +15,64 @@ HTML;
 return [
 	'shouldAddNoticeWhenAutoptimizeAggregateInlineCssOnAndCPCSSActivated' => [
 		'config'   => [
-			'cpcssActive'                => true,
+			'cpcssActive'                         => true,
 			'autoptimizeAggregateInlineCSSActive' => 'on',
-			'dismissed'                    => false,
+			'dismissed'                           => false,
 		],
 		'expected' => $expected_html
 	],
 
+	'shouldSkipWhenNotOnWPRDashboardPage' => [
+		'config' => [
+			'cpcssActive'                         => true,
+			'autoptimizeAggregateInlineCSSActive' => 'on',
+			'dismissed'                           => false,
+			'notWPRDashboard'                     => true,
+		],
+		'expected' => '',
+	],
+
 	'shouldSkipWhenAutoptimizeAggregateInlineCssOffAndCPCSSNotActivated' => [
 		'config'   => [
-			'cpcssActive'                => false,
+			'cpcssActive'                         => false,
 			'autoptimizeAggregateInlineCSSActive' => 'off',
-			'dismissed'                    => false,
+			'dismissed'                           => false,
 		],
 		'expected' => '',
 	],
 
 	'shouldSkipWhenAutoptimizeAggregateInlineCssOffAndCPCSSActivated' => [
 		'config'   => [
-			'cpcssActive'                => true,
+			'cpcssActive'                         => true,
 			'autoptimizeAggregateInlineCSSActive' => 'off',
-			'dismissed'                    => false,
+			'dismissed'                           => false,
 		],
 		'expected' => '',
 	],
 
 	'shouldSkipWhenAutoptimizeAggregateInlineCssOnAndCPCSSNotActivated' => [
 		'config'   => [
-			'cpcssActive'                => false,
+			'cpcssActive'                         => false,
 			'autoptimizeAggregateInlineCSSActive' => 'on',
-			'dismissed'                    => false,
+			'dismissed'                           => false,
 		],
 		'expected' => '',
 	],
 
 	'shouldSkipWhenUserHasDismissedNotice' => [
 		'config'   => [
-			'cpcssActive'                => true,
+			'cpcssActive'                         => true,
 			'autoptimizeAggregateInlineCSSActive' => 'on',
-			'dismissed'                    => true,
+			'dismissed'                           => true,
 		],
 		'expected' => '',
 	],
 
 	'shouldClearDismissalWhenUserDeactivatesCPCSS' => [
 		'config'   => [
-			'cpcssActive'                => false,
+			'cpcssActive'                         => false,
 			'autoptimizeAggregateInlineCSSActive' => 'on',
-			'dismissed'                    => true,
+			'dismissed'                           => true,
 		],
 		'expected' => '',
 	],

--- a/tests/Fixtures/inc/ThirdParty/Plugins/Optimization/Autoptimize/warnWhenJsAggregationAndDelayJsActive.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/Optimization/Autoptimize/warnWhenJsAggregationAndDelayJsActive.php
@@ -3,7 +3,7 @@
 declare( strict_types=1 );
 
 $expected_html = <<<HTML
-<div class="notice notice-warning ">
+<div class="notice notice-info ">
 <p>
 <strong>
 We have detected that Autoptimize's JavaScript Aggregation feature is enabled. The Delay JavaScript Execution will not be applied to the file it creates. We suggest disabling it to take full advantage of Delay JavaScript Execution.</strong>
@@ -21,6 +21,16 @@ return [
 			'dismissed'                    => false,
 		],
 		'expected' => $expected_html
+	],
+
+	'shouldSkipWhenNotOnWPRDashboardPage' => [
+		'config' => [
+			'delayJSActive'                => true,
+			'autoptimizeAggregateJSActive' => 'on',
+			'dismissed'                    => false,
+			'notWPRDashboard'              => true,
+		],
+		'expected' => '',
 	],
 
 	'shouldSkipWhenAutoptimizeAggregateJsOffAndDelayJsNotActivated' => [

--- a/tests/Fixtures/inc/ThirdParty/Plugins/Optimization/Autoptimize/warnWhenJsAggregationAndDelayJsActive.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/Optimization/Autoptimize/warnWhenJsAggregationAndDelayJsActive.php
@@ -5,10 +5,8 @@ declare( strict_types=1 );
 $expected_html = <<<HTML
 <div class="notice notice-info ">
 <p>
-<strong>
-We have detected that Autoptimize's JavaScript Aggregation feature is enabled. The Delay JavaScript Execution will not be applied to the file it creates. We suggest disabling it to take full advantage of Delay JavaScript Execution.</strong>
-</p>
-<p>
+<strong>WP Rocket: </strong>
+We have detected that Autoptimize's JavaScript Aggregation feature is enabled. WP Rocket's Delay JavaScript Execution will not be applied to the file it creates. We suggest disabling <strong>JavaScript Aggregation</strong> to take full advantage of Delay JavaScript Execution.</p><p>
 <a class="rocket-dismiss" href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=warn_when_js_aggregation_and_delay_js_active&amp;_wpnonce=123456">
 Dismiss this notice.</a></p></div>
 HTML;

--- a/tests/Integration/inc/ThirdParty/Plugins/Optimization/Autoptimize/warnWhenAggregateInlineCssAndCPCSSActive.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Optimization/Autoptimize/warnWhenAggregateInlineCssAndCPCSSActive.php
@@ -57,6 +57,12 @@ class Test_WarnWhenAggregateInlineCssAndCPCSSActive extends TestCase {
 			return $config['cpcssActive'];
 		} );
 
+		if ( isset( $config['notWPRDashboard'] ) && $config['notWPRDashboard'] ) {
+			set_current_screen( 'post' );
+		} else {
+			set_current_screen( 'settings_page_wprocket' );
+		}
+
 		if ( $config['dismissed'] ) {
 			update_user_meta(
 				$current_user,

--- a/tests/Integration/inc/ThirdParty/Plugins/Optimization/Autoptimize/warnWhenJsAggregationAndDelayJsActive.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Optimization/Autoptimize/warnWhenJsAggregationAndDelayJsActive.php
@@ -36,6 +36,9 @@ class Test_WarnWhenJsAggregationAndDelayJsActive extends TestCase {
 	}
 
 	public function tearDown() {
+		global $current_screen;
+
+		unset ($current_screen);
 		$this->restoreWpFilter( 'admin_notices' );
 		parent::tearDown();
 	}
@@ -55,6 +58,12 @@ class Test_WarnWhenJsAggregationAndDelayJsActive extends TestCase {
 		add_filter( 'pre_get_rocket_option_delay_js', function () use ( $config ) {
 			return $config[ 'delayJSActive' ];
 		} );
+
+		if ( isset( $config['notWPRDashboard'] ) && $config['notWPRDashboard'] ) {
+			set_current_screen( 'post' );
+		} else {
+			set_current_screen( 'settings_page_wprocket' );
+		}
 
 		if ( $config['dismissed'] ) {
 			update_user_meta(


### PR DESCRIPTION
## Description
This is to improve the display of notices for conflicting WPR/Autoptimize settings.
- [X] Downgrades the notices from `warning` to `info` level.
- [X] Shows notices only on the WPR Dashboard.
- [x] Updates the text of notices to be more clear for end users.

Fixes #4558

## Type of change
- [X] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?
Same as grooming.

## How Has This Been Tested?
- Updated Integration tests to confirm new conditions and notice HTML meets new expectations.
- Varified notice display on local development environment.

# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
