### PR TITLE
Fixes #4364 exclude hcaptcha from JS minification

### DIFF
--- a/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
+++ b/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
@@ -249,6 +249,7 @@ abstract class AbstractJSOptimization extends AbstractOptimization {
 			'documentcloud.adobe.com/view-sdk/main.js',
 			'static.cleverpush.com',
 			'js.afterpay.com',
+			'hcaptcha.com/1/api.js',
 		];
 
 		$excluded_external = array_merge( $defaults, $this->options->get( 'exclude_js', [] ) );


### PR DESCRIPTION
## Description

Add hcaptcha.com/1/api.js to AbstractJSOptimization::get_excluded_external_file_path()

Fixes #4364 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?
No

## How Has This Been Tested?
- [ ] Unit and integration tests

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
