### PR TITLE
Fixes #4506 Exclude ai-uncode.js from defer js

### DIFF
--- a/inc/3rd-party/themes/uncode.php
+++ b/inc/3rd-party/themes/uncode.php
@@ -78,7 +78,7 @@ if ( 'uncode' === strtolower( $current_theme->get( 'Name' ) ) || 'uncode' === st
 		$exclude_delay_js[] = rocket_clean_exclude_file( get_template_directory_uri() . '/library/js/init.js' );
 		$exclude_delay_js[] = rocket_clean_exclude_file( get_template_directory_uri() . '/library/js/min/init.min.js' );
 		$exclude_delay_js[] = rocket_clean_exclude_file( get_template_directory_uri() . '/library/js/init.min.js' );
-		$exclude_defer_js[] = rocket_clean_exclude_file( get_template_directory_uri() . '/library/js/min/ai-uncode.min.js' );
+		$exclude_delay_js[] = rocket_clean_exclude_file( get_template_directory_uri() . '/library/js/min/ai-uncode.min.js' );
 		$exclude_delay_js[] = rocket_clean_exclude_file( get_template_directory_uri() . '/library/js/ai-uncode.min.js' );
 		$exclude_delay_js[] = rocket_clean_exclude_file( get_template_directory_uri() . '/library/js/ai-uncode.js' );
 		$exclude_delay_js[] = 'UNCODE\.';

--- a/inc/3rd-party/themes/uncode.php
+++ b/inc/3rd-party/themes/uncode.php
@@ -74,7 +74,7 @@ if ( 'uncode' === strtolower( $current_theme->get( 'Name' ) ) || 'uncode' === st
 	 * @param array $exclude_delay_js Array of JS to be excluded.
 	 * @return array
 	 */
-	function rocket_exclude_defer_js_uncode( $exclude_delay_js ) {
+	function rocket_exclude_delay_js_uncode( $exclude_delay_js ) {
 		$exclude_delay_js[] = rocket_clean_exclude_file( get_template_directory_uri() . '/library/js/init.js' );
 		$exclude_delay_js[] = rocket_clean_exclude_file( get_template_directory_uri() . '/library/js/min/init.min.js' );
 		$exclude_delay_js[] = rocket_clean_exclude_file( get_template_directory_uri() . '/library/js/init.min.js' );

--- a/inc/3rd-party/themes/uncode.php
+++ b/inc/3rd-party/themes/uncode.php
@@ -59,6 +59,9 @@ if ( 'uncode' === strtolower( $current_theme->get( 'Name' ) ) || 'uncode' === st
 		$exclude_defer_js[] = rocket_clean_exclude_file( get_template_directory_uri() . '/library/js/init.js' );
 		$exclude_defer_js[] = rocket_clean_exclude_file( get_template_directory_uri() . '/library/js/min/init.min.js' );
 		$exclude_defer_js[] = rocket_clean_exclude_file( get_template_directory_uri() . '/library/js/init.min.js' );
+		$exclude_defer_js[] = rocket_clean_exclude_file( get_template_directory_uri() . '/library/js/min/ai-uncode.min.js' );
+		$exclude_defer_js[] = rocket_clean_exclude_file( get_template_directory_uri() . '/library/js/ai-uncode.min.js' );
+		$exclude_defer_js[] = rocket_clean_exclude_file( get_template_directory_uri() . '/library/js/ai-uncode.js' );
 		return $exclude_defer_js;
 	}
 	add_filter( 'rocket_exclude_defer_js', 'rocket_exclude_defer_js_uncode' );

--- a/inc/3rd-party/themes/uncode.php
+++ b/inc/3rd-party/themes/uncode.php
@@ -84,6 +84,6 @@ if ( 'uncode' === strtolower( $current_theme->get( 'Name' ) ) || 'uncode' === st
 		$exclude_delay_js[] = 'UNCODE\.';
 		return $exclude_delay_js;
 	}
-	add_filter( 'exclude_delay_js', 'rocket_exclude_delay_js_uncode' );
+	add_filter( 'rocket_delay_js_exclusions', 'rocket_exclude_delay_js_uncode' );
 
 }

--- a/inc/3rd-party/themes/uncode.php
+++ b/inc/3rd-party/themes/uncode.php
@@ -66,7 +66,15 @@ if ( 'uncode' === strtolower( $current_theme->get( 'Name' ) ) || 'uncode' === st
 	}
 	add_filter( 'rocket_exclude_defer_js', 'rocket_exclude_defer_js_uncode' );
 
-	function rocket_exclude_defer_js_uncode( $exclude_defer_js ) {
+	/**
+	 * Excludes Uncode JS files from delay JS
+	 *
+	 * @since 3.10.5
+	 *
+	 * @param array $exclude_delay_js Array of JS to be excluded.
+	 * @return array
+	 */
+	function rocket_exclude_defer_js_uncode( $exclude_delay_js ) {
 		$exclude_delay_js[] = rocket_clean_exclude_file( get_template_directory_uri() . '/library/js/init.js' );
 		$exclude_delay_js[] = rocket_clean_exclude_file( get_template_directory_uri() . '/library/js/min/init.min.js' );
 		$exclude_delay_js[] = rocket_clean_exclude_file( get_template_directory_uri() . '/library/js/init.min.js' );

--- a/inc/3rd-party/themes/uncode.php
+++ b/inc/3rd-party/themes/uncode.php
@@ -66,4 +66,16 @@ if ( 'uncode' === strtolower( $current_theme->get( 'Name' ) ) || 'uncode' === st
 	}
 	add_filter( 'rocket_exclude_defer_js', 'rocket_exclude_defer_js_uncode' );
 
+	function rocket_exclude_defer_js_uncode( $exclude_defer_js ) {
+		$exclude_delay_js[] = rocket_clean_exclude_file( get_template_directory_uri() . '/library/js/init.js' );
+		$exclude_delay_js[] = rocket_clean_exclude_file( get_template_directory_uri() . '/library/js/min/init.min.js' );
+		$exclude_delay_js[] = rocket_clean_exclude_file( get_template_directory_uri() . '/library/js/init.min.js' );
+		$exclude_defer_js[] = rocket_clean_exclude_file( get_template_directory_uri() . '/library/js/min/ai-uncode.min.js' );
+		$exclude_delay_js[] = rocket_clean_exclude_file( get_template_directory_uri() . '/library/js/ai-uncode.min.js' );
+		$exclude_delay_js[] = rocket_clean_exclude_file( get_template_directory_uri() . '/library/js/ai-uncode.js' );
+		$exclude_delay_js[] = 'UNCODE\.';
+		return $exclude_delay_js;
+	}
+	add_filter( 'exclude_delay_js', 'rocket_exclude_delay_js_uncode' );
+
 }


### PR DESCRIPTION
## Description

Add `/library/js/ai-uncode.js` , `/library/js/min/ai-uncode.min.js`, `/library/js/ai-uncode.min.js`  to the function rocket_exclude_defer_js_uncode()

Fixes #4506 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


## Is the solution different from the one proposed during the grooming?
No

## How Has This Been Tested?

- [x] Unit and integration test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes