### PR TITLE
Fixes #4358 exclude wpformsRecaptchaCallback from delayJS

### DIFF
--- a/inc/Engine/Optimization/DelayJS/HTML.php
+++ b/inc/Engine/Optimization/DelayJS/HTML.php
@@ -64,7 +64,7 @@ class HTML {
 		'/jetpack-boost/vendor/automattic/jetpack-lazy-images/(.*)', // Jetpack Boost plugin lazyload.
 		'jetpack-lazy-images-js-enabled',  // Jetpack Boost plugin lazyload.
 		'jetpack-boost-critical-css', // Jetpack Boost plugin critical CSS.
-		'wpformsRecaptchaCallback',// WPForms reCAPTCHA v2
+		'wpformsRecaptchaCallback', // WPForms reCAPTCHA v2.
 	];
 
 	/**
@@ -162,10 +162,14 @@ class HTML {
 	 * @return string
 	 */
 	private function parse( $html ): string {
-		$replaced_html = preg_replace_callback( '/<\s*script\s*(?<attr>[^>]*?)?>(?<content>.*?)?<\s*\/\s*script\s*>/ims', [
-			$this,
-			'replace_scripts'
-		], $html );
+		$replaced_html = preg_replace_callback(
+			'/<\s*script\s*(?<attr>[^>]*?)?>(?<content>.*?)?<\s*\/\s*script\s*>/ims',
+			[
+				$this,
+				'replace_scripts',
+			],
+			$html
+		);
 
 		if ( empty( $replaced_html ) ) {
 			return $html;

--- a/inc/Engine/Optimization/DelayJS/HTML.php
+++ b/inc/Engine/Optimization/DelayJS/HTML.php
@@ -1,5 +1,5 @@
 <?php
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace WP_Rocket\Engine\Optimization\DelayJS;
 
@@ -64,6 +64,7 @@ class HTML {
 		'/jetpack-boost/vendor/automattic/jetpack-lazy-images/(.*)', // Jetpack Boost plugin lazyload.
 		'jetpack-lazy-images-js-enabled',  // Jetpack Boost plugin lazyload.
 		'jetpack-boost-critical-css', // Jetpack Boost plugin critical CSS.
+		'wpformsRecaptchaCallback',// WPForms reCAPTCHA v2
 	];
 
 	/**
@@ -103,7 +104,7 @@ class HTML {
 		 */
 		$this->excluded = apply_filters( 'rocket_delay_js_exclusions', $this->excluded );
 		$this->excluded = array_map(
-			function( $value ) {
+			function ( $value ) {
 				return str_replace(
 					[ '+', '?ver', '#' ],
 					[ '\+', '\?ver', '\#' ],
@@ -161,7 +162,10 @@ class HTML {
 	 * @return string
 	 */
 	private function parse( $html ): string {
-		$replaced_html = preg_replace_callback( '/<\s*script\s*(?<attr>[^>]*?)?>(?<content>.*?)?<\s*\/\s*script\s*>/ims', [ $this, 'replace_scripts' ], $html );
+		$replaced_html = preg_replace_callback( '/<\s*script\s*(?<attr>[^>]*?)?>(?<content>.*?)?<\s*\/\s*script\s*>/ims', [
+			$this,
+			'replace_scripts'
+		], $html );
 
 		if ( empty( $replaced_html ) ) {
 			return $html;


### PR DESCRIPTION
## Description
add wpformsRecaptchaCallback, to the DelayJS\HTML::$excluded array

Fixes #4358 

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)


## Is the solution different from the one proposed during the grooming?
No

# Checklist:


- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
