### PR TITLE
Hotfix: Adjust beacon article ID for invalid exclusions

### DIFF
--- a/inc/Engine/Admin/Beacon/Beacon.php
+++ b/inc/Engine/Admin/Beacon/Beacon.php
@@ -657,6 +657,16 @@ class Beacon extends Abstract_Render implements Subscriber_Interface {
 					'url' => 'https://docs.wp-rocket.me/article/15-disabling-lazy-load-on-specific-images/?utm_source=wp_plugin&utm_medium=wp_rocket',
 				],
 			],
+			'invalid_exclusions'         => [
+				'en' => [
+					'id'  => '619e90a3d3efbe495c3b26b8',
+					'url' => 'https://docs.wp-rocket.me/article/1657-invalid-patterns-of-exclusions',
+				],
+				'fr' => [
+					'id'  => '61b21c1297682b790dad345a',
+					'url' => 'https://fr.docs.wp-rocket.me/article/1659-motifs-exclusion-non-valables',
+				],
+			],
 		];
 
 		return isset( $suggest[ $doc_id ][ $this->get_user_locale() ] )

--- a/inc/Engine/CDN/RocketCDN/views/cta-big.php
+++ b/inc/Engine/CDN/RocketCDN/views/cta-big.php
@@ -79,8 +79,8 @@ defined( 'ABSPATH' ) || die( 'Cheatin&#8217; uh?' );
 					<?php endif; ?>
 					<h4 class="wpr-rocketcdn-pricing-current">
 						<span class="wpr-rocketcdn-cta-currency-minor">$</span>
-						<span class="wpr-rocketcdn-cta-currency-major"><?php esc_html_e( substr( $data['current_price'], 0, strpos( $data['current_price'], '.' ) ) ); ?></span>
-						<span class="wpr-rocketcdn-cta-currency-minor"><?php esc_html_e( substr( $data['current_price'], strpos( $data['current_price'], '.' ) ) ); ?>
+						<span class="wpr-rocketcdn-cta-currency-major"><?php esc_html( substr( $data['current_price'], 0, strpos( $data['current_price'], '.' ) ) ); ?></span>
+						<span class="wpr-rocketcdn-cta-currency-minor"><?php esc_html( substr( $data['current_price'], strpos( $data['current_price'], '.' ) ) ); ?>
 						</span>
 					</h4>
 					<p class="wpr-rocketcdn-cta-billing-detail"><?php esc_html_e( 'Billed monthly', 'rocket' ); ?></p>

--- a/inc/admin/options.php
+++ b/inc/admin/options.php
@@ -165,10 +165,13 @@ function rocket_pre_main_option( $newvalue, $oldvalue ) {
 		}
 
 		$error_message .= '<p><strong>'; // Re-open tags that WP's settings_errors() will close at end of notice box.
-		$error_message .= sprintf(
+
+		$container                 = apply_filters( 'rocket_container', [] );
+		$invalid_exclusions_beacon = $container->get( 'beacon' )->get_suggest( 'invalid_exclusions' );
+		$error_message            .= sprintf(
 			'<a href="%1$s" data-beacon-article="%2$s" rel="noopener noreferrer" target="_blank">%3$s</a>',
-			'https://docs.wp-rocket.me/article/1657-invalid-patterns-of-exclusions',
-			'619e90a3d3efbe495c3b26b8',
+			$invalid_exclusions_beacon['url'],
+			$invalid_exclusions_beacon['id'],
 			__( 'More info', 'rocket' )
 		);
 

--- a/inc/admin/options.php
+++ b/inc/admin/options.php
@@ -166,8 +166,9 @@ function rocket_pre_main_option( $newvalue, $oldvalue ) {
 
 		$error_message .= '<p><strong>'; // Re-open tags that WP's settings_errors() will close at end of notice box.
 		$error_message .= sprintf(
-			'<a href="%1$s" data-beacon-article="%1$s" rel="noopener noreferrer" target="_blank">%2$s</a>',
+			'<a href="%1$s" data-beacon-article="%2$s" rel="noopener noreferrer" target="_blank">%3$s</a>',
 			'https://docs.wp-rocket.me/article/1657-invalid-patterns-of-exclusions',
+			'619e90a3d3efbe495c3b26b8',
 			__( 'More info', 'rocket' )
 		);
 


### PR DESCRIPTION
## Description

The beacon article is not shown when clicking on `More Info` link at the notice when the user enters invalid regex into exclusion list.

https://wp-media.slack.com/archives/C08N8J6VC/p1638546225145100

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Is the solution different from the one proposed during the grooming?

Not groomed

## How Has This Been Tested?

- Add `ga(` into any exclusion field and save settings then click on `More Info` link at the admin notice, you should see the beacon article.

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- x ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
