### PR TITLE
Fixes #3464 Remove empty values in terms urls array

### DIFF
--- a/inc/Engine/Cache/Purge.php
+++ b/inc/Engine/Cache/Purge.php
@@ -47,6 +47,10 @@ class Purge {
 	 * @return void
 	 */
 	public function purge_url( $url, $pagination = false ) {
+		if ( ! is_string( $url ) ) {
+			return;
+		}
+
 		global $wp_rewrite;
 
 		$parsed_url = $this->parse_url( $url );

--- a/inc/Engine/Cache/Purge.php
+++ b/inc/Engine/Cache/Purge.php
@@ -211,6 +211,10 @@ class Purge {
 				}
 			}
 		}
+		
+		// Remove entries with empty values in array.
+		$urls = array_filter( $urls, 'is_string' );
+		
 		/**
 		 * Filter the list of taxonomies URLs
 		 *

--- a/inc/Engine/Cache/Purge.php
+++ b/inc/Engine/Cache/Purge.php
@@ -211,10 +211,10 @@ class Purge {
 				}
 			}
 		}
-		
+
 		// Remove entries with empty values in array.
 		$urls = array_filter( $urls, 'is_string' );
-		
+
 		/**
 		 * Filter the list of taxonomies URLs
 		 *


### PR DESCRIPTION
## Description

This PR will remove entries with empty or other non-valid values in terms archives `$urls` array in `Purge::get_post_terms_urls()` to prevent the following PHP Notice:

`PHP Notice:  Trying to access array offset on value of type null in /home4/nataliad/testsite.nataliadrause.com/wp-content/plugins/wp-rocket/inc/Engine/Cache/Purge.php on line 55`

Fixes #3464 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

No.

## How Has This Been Tested?

On my test site with the following steps:

1. Hard-coded the $urls array with different values including empty and unexpected values:

Test 1:
`$urls = ["https:\\/\\/example.test\\/shop","https:\\/\\/example.test\\?product_cat=skonhedsprodukter", "https:\\/\\/example.test\\/shop","https:\\/\\/example.test\\/shopkatalog\\/?product_cat=dame",null,null, false, 1, 0, true];`

Test 2:
`$urls = [null];`

Test 3:
`$urls = ["https:\\/\\/example.com\\/shop"];`

2. Updated a post and product page for the code to run.
3. `debug.log` had no errors/notices logged.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
