### PR TITLE
Fix/4590 adjust rocketcdn pricing issue

### DIFF
--- a/inc/Engine/CDN/RocketCDN/NoticesSubscriber.php
+++ b/inc/Engine/CDN/RocketCDN/NoticesSubscriber.php
@@ -199,7 +199,7 @@ class NoticesSubscriber extends Abstract_Render implements Subscriber_Interface 
 				'message'         => $pricing->get_error_message(),
 			];
 		} else {
-			$current_price      = number_format_i18n( $pricing['monthly_price'], 2 );
+			$current_price      = number_format_i18n( $this->normalize_number( $pricing['monthly_price'] ), 2 );
 			$promotion_campaign = '';
 			$end_date           = strtotime( $pricing['end_date'] );
 			$promotion_end_date = '';
@@ -211,7 +211,7 @@ class NoticesSubscriber extends Abstract_Render implements Subscriber_Interface 
 			) {
 				$promotion_campaign = $pricing['discount_campaign_name'];
 				$regular_price      = $current_price;
-				$current_price      = number_format_i18n( str_replace( ',', '.', $pricing['discounted_price_monthly']), 2 ) . '*';
+				$current_price      = number_format_i18n( $this->normalize_number( $pricing['discounted_price_monthly'] ), 2 ) . '*';
 				$nopromo_variant    = '';
 				$promotion_end_date = date_i18n( get_option( 'date_format' ), $end_date );
 			}
@@ -222,7 +222,7 @@ class NoticesSubscriber extends Abstract_Render implements Subscriber_Interface 
 				'promotion_end_date' => $promotion_end_date,
 				'nopromo_variant'    => $nopromo_variant,
 				'regular_price'      => $regular_price,
-				'current_price'      => str_replace( ',', '.', $current_price ),
+				'current_price'      => $this->normalize_number( $current_price ),
 			];
 		}
 
@@ -296,5 +296,16 @@ class NoticesSubscriber extends Abstract_Render implements Subscriber_Interface 
 	 */
 	private function is_white_label_account() {
 		return (bool) rocket_get_constant( 'WP_ROCKET_WHITE_LABEL_ACCOUNT' );
+	}
+
+	/**
+	 * Normalize the number by replacing comma with a dot.
+	 *
+	 * @param string|int $number Number to be normalized.
+	 *
+	 * @return string|float
+	 */
+	private function normalize_number( $number ) {
+		return str_replace( ',', '.', $number );
 	}
 }

--- a/inc/Engine/CDN/RocketCDN/NoticesSubscriber.php
+++ b/inc/Engine/CDN/RocketCDN/NoticesSubscriber.php
@@ -222,7 +222,7 @@ class NoticesSubscriber extends Abstract_Render implements Subscriber_Interface 
 				'promotion_end_date' => $promotion_end_date,
 				'nopromo_variant'    => $nopromo_variant,
 				'regular_price'      => $regular_price,
-				'current_price'      => $current_price,
+				'current_price'      => str_replace( ',', '.', $current_price ),
 			];
 		}
 

--- a/inc/Engine/CDN/RocketCDN/NoticesSubscriber.php
+++ b/inc/Engine/CDN/RocketCDN/NoticesSubscriber.php
@@ -211,7 +211,7 @@ class NoticesSubscriber extends Abstract_Render implements Subscriber_Interface 
 			) {
 				$promotion_campaign = $pricing['discount_campaign_name'];
 				$regular_price      = $current_price;
-				$current_price      = number_format_i18n( $pricing['discounted_price_monthly'], 2 ) . '*';
+				$current_price      = number_format_i18n( str_replace( ',', '.', $pricing['discounted_price_monthly']), 2 ) . '*';
 				$nopromo_variant    = '';
 				$promotion_end_date = date_i18n( get_option( 'date_format' ), $end_date );
 			}

--- a/inc/Engine/CDN/RocketCDN/views/cta-big.php
+++ b/inc/Engine/CDN/RocketCDN/views/cta-big.php
@@ -79,8 +79,8 @@ defined( 'ABSPATH' ) || die( 'Cheatin&#8217; uh?' );
 					<?php endif; ?>
 					<h4 class="wpr-rocketcdn-pricing-current">
 						<span class="wpr-rocketcdn-cta-currency-minor">$</span>
-						<span class="wpr-rocketcdn-cta-currency-major"><?php esc_html( substr( $data['current_price'], 0, strpos( $data['current_price'], '.' ) ) ); ?></span>
-						<span class="wpr-rocketcdn-cta-currency-minor"><?php esc_html( substr( $data['current_price'], strpos( $data['current_price'], '.' ) ) ); ?>
+						<span class="wpr-rocketcdn-cta-currency-major"><?php echo esc_html( substr( $data['current_price'], 0, strpos( $data['current_price'], '.' ) ) ); ?></span>
+						<span class="wpr-rocketcdn-cta-currency-minor"><?php echo esc_html( substr( $data['current_price'], strpos( $data['current_price'], '.' ) ) ); ?>
 						</span>
 					</h4>
 					<p class="wpr-rocketcdn-cta-billing-detail"><?php esc_html_e( 'Billed monthly', 'rocket' ); ?></p>

--- a/wp-rocket.php
+++ b/wp-rocket.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Rocket
  * Plugin URI: https://wp-rocket.me
  * Description: The best WordPress performance plugin.
- * Version: 3.10.5
+ * Version: 3.10.5.1
  * Requires at least: 5.4
  * Requires PHP: 7.0
  * Code Name: Iego
@@ -20,7 +20,7 @@
 defined( 'ABSPATH' ) || exit;
 
 // Rocket defines.
-define( 'WP_ROCKET_VERSION',               '3.10.5' );
+define( 'WP_ROCKET_VERSION',               '3.10.5.1' );
 define( 'WP_ROCKET_WP_VERSION',            '5.4' );
 define( 'WP_ROCKET_WP_VERSION_TESTED',     '5.8' );
 define( 'WP_ROCKET_PHP_VERSION',           '7.0' );


### PR DESCRIPTION
## Description

By mistake we changed `esc_html_e` to `esc_html` at this PR https://github.com/wp-media/wp-rocket/pull/4575 to fix phpcs errors but we forgot to add echo.

Fixes #4590

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Is the solution different from the one proposed during the grooming?

Please describe in this section if there is any change to the solution, and why.

## How Has This Been Tested?

Open RocketCDN banner at CDN tab and u can see the pricing correctly.

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
