### PR TITLE
Fixes #4507 Exclude WhatsApp UA from cache

### DIFF
--- a/inc/functions/options.php
+++ b/inc/functions/options.php
@@ -405,6 +405,7 @@ function get_rocket_cache_dynamic_cookies() { // phpcs:ignore WordPress.NamingCo
 function get_rocket_cache_reject_ua() { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
 	$ua   = get_rocket_option( 'cache_reject_ua', [] );
 	$ua[] = 'facebookexternalhit';
+	$ua[] = 'WhatsApp';
 
 	/**
 	 * Filter the rejected User-Agent


### PR DESCRIPTION
## Description
Exclude WhatsApp user agent, by adding $ua[] = 'WhatsApp'; on line 408
Fixes #4507

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] This change requires a documentation update

## Is the solution different from the one proposed during the grooming?
no

## How Has This Been Tested?
on my local environment. 

- [x] Unit tests
- [x ] Integration tests 
- [x] phpcs

# Checklist:

Please delete the options that are not relevant.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
