### PR TITLE
Fixes #4563 disable Google Fonts optimization on AMP pages

### DIFF
--- a/inc/ThirdParty/Plugins/Optimization/AMP.php
+++ b/inc/ThirdParty/Plugins/Optimization/AMP.php
@@ -121,6 +121,7 @@ class AMP implements Subscriber_Interface {
 		add_filter( 'pre_get_rocket_option_async_css', '__return_false' );
 		add_filter( 'pre_get_rocket_option_delay_js', '__return_false' );
 		add_filter( 'pre_get_rocket_option_preload_links', '__return_false' );
+		add_filter( 'pre_get_rocket_option_minify_google_fonts', '__return_false' );
 
 		unset( $wp_filter['rocket_buffer'] );
 


### PR DESCRIPTION
## Description
Used the filter to disable the option when on AMP pages in the disable_options_for_amp() method.
`add_filter( 'pre_get_rocket_option_minify_google_fonts', '__return_false' )`

Fixes #4563

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] This change requires a documentation update

## Is the solution different from the one proposed during the grooming?
no, exactly as https://github.com/wp-media/wp-rocket/issues/4563#issuecomment-996046746

## How Has This Been Tested?

- [ ] Unit tests
- [ ] phpcs

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
