### PR TITLE
Fixes #4593 Exclude additional Hubspot domain from Minify and Defer JS

### DIFF
--- a/inc/Engine/Optimization/DeferJS/DeferJS.php
+++ b/inc/Engine/Optimization/DeferJS/DeferJS.php
@@ -225,6 +225,7 @@ class DeferJS {
 			'/wp-includes/js/dist/url(.min)?.js',
 			'/wp-includes/js/dist/hooks(.min)?.js',
 			'www.paypal.com/sdk/js',
+			'js-eu1.hsforms.net',
 		];
 
 		$exclude_defer_js = array_unique( array_merge( $exclude_defer_js, $this->options->get( 'exclude_defer_js', [] ) ) );

--- a/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
+++ b/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
@@ -251,6 +251,7 @@ abstract class AbstractJSOptimization extends AbstractOptimization {
 			'js.afterpay.com',
 			'cdn.enable.co.il/licenses/enable-',
 			'hcaptcha.com/1/api.js',
+			'js-eu1.hsforms.net',
 		];
 
 		$excluded_external = array_merge( $defaults, $this->options->get( 'exclude_js', [] ) );


### PR DESCRIPTION
## Description

This PR will fix a console error when `js-eu1.hsforms.net` is minified or deferred.

Fixes #4593 

## Type of change

Please delete options that are not relevant.

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

Yes.
Additionally excluding the `js-eu1.hsforms.net` from Minify/Combine JS to resolve the following console error:
![image](https://user-images.githubusercontent.com/60236665/147682631-69316f75-f5b1-40c3-8b70-47c8bf5ee934.png)

We do the same for the `js.hsforms.net` here: https://github.com/wp-media/wp-rocket/blob/c4c5571c35c5cd388916d3ac5b2fcb497fe86ef5/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php#L209

## How Has This Been Tested?

On testing site:
1. Added the following script in Head:
```
<script charset="utf-8" type="text/javascript" src="//js-eu1.hsforms.net/forms/shell.js"></script>
<script>
  hbspt.forms.create({
	region: "eu1",
	portalId: "25164403",
	formId: "dfed4d9e-e999-4272-a287-8fabd2e0fdd7"
});
</script>
```
2. Enabled Minify JS and Load JavaScript Deferred options
3. Console errors were resolved with the proposed solution.


# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
