### PR TITLE
Fixes #4576 Add back skip-lazy exclusions

### DIFF
--- a/inc/Dependencies/RocketLazyload/Image.php
+++ b/inc/Dependencies/RocketLazyload/Image.php
@@ -409,6 +409,8 @@ class Image {
 				'data-height-percentage',
 				'data-large_image',
 				'avia-bg-style-fixed',
+				'data-skip-lazy',
+				'skip-lazy',
 				'image-compare__',
 			]
 		);


### PR DESCRIPTION
## Description

Add back skip-lazy exclusions for lazyload for images.

Fixes #4576

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

No

## How Has This Been Tested?

- [x] Automated tests in the common library

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
