### PR TITLE
Closes #4603 Increase svg expiration to 4 months

### DIFF
--- a/inc/functions/htaccess.php
+++ b/inc/functions/htaccess.php
@@ -474,7 +474,7 @@ function get_rocket_htaccess_mod_expires() { // phpcs:ignore WordPress.NamingCon
 	ExpiresByType font/otf                      "access plus 4 months"
 	ExpiresByType font/woff                     "access plus 4 months"
 	ExpiresByType font/woff2                    "access plus 4 months"
-	ExpiresByType image/svg+xml                 "access plus 1 month"
+	ExpiresByType image/svg+xml                 "access plus 4 months"
 	ExpiresByType application/vnd.ms-fontobject "access plus 1 month"
 	# CSS and JavaScript
 	ExpiresByType text/css                      "access plus 1 year"


### PR DESCRIPTION
## Description

Increase SVG expiration rule to 4 months in the htaccess, to avoid svg files from being flagged in PSI

Fixes #4603 

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
