### PR TITLE
Close 4588 - Enable auto-compatibility XL WooCommerce Sales Triggers with DelayJS

### DIFF
--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -248,6 +248,7 @@ class Plugin {
 			'db_optimization_subscriber',
 			'mobile_subscriber',
 			'woocommerce_subscriber',
+			'xl_woocommerce_sales_triggers_subscriber',
 			'bigcommerce_subscriber',
 			'syntaxhighlighter_subscriber',
 			'elementor_subscriber',

--- a/inc/ThirdParty/Plugins/Ecommerce/XLWooCommerceSalesTriggersSubscriber.php
+++ b/inc/ThirdParty/Plugins/Ecommerce/XLWooCommerceSalesTriggersSubscriber.php
@@ -32,15 +32,19 @@ class XLWooCommerceSalesTriggersSubscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events() {
 		return [
-			'rocket_delay_js_exclusions' => [ 'modify_delayjs_exclusions_on_product_pages', 10, 2 ]
+			'rocket_delay_js_exclusions' => [ 'modify_delayjs_exclusions_on_product_pages', 10, 2 ],
 		];
 	}
 
 	/**
 	 * Modify delay JS excluded scripts for compatibility.
+	 *
+	 * @param array $exclusions The initial Delay JS exclusion list.
+	 *
+	 * @return array The filtered Delay JS exclusion list.
 	 */
 	public function modify_delayjs_exclusions_on_product_pages( array $exclusions ) {
-		if ( empty( rocket_get_constant('WCST_VERSION' ) ) ) {
+		if ( empty( rocket_get_constant( 'WCST_VERSION' ) ) ) {
 			return $exclusions;
 		}
 
@@ -55,7 +59,7 @@ class XLWooCommerceSalesTriggersSubscriber implements Subscriber_Interface {
 					'xl-woocommerce-sales-triggers/assets/js/wcst_combined.min.js',
 					'/jquery-?[0-9.](.*)(.min|.slim|.slim.min)?.js',
 					'js-(before|after)',
-					'(?:/wp-content/|/wp-includes/)(.*)'
+					'(?:/wp-content/|/wp-includes/)(.*)',
 				]
 			)
 		);

--- a/inc/ThirdParty/Plugins/Ecommerce/XLWooCommerceSalesTriggersSubscriber.php
+++ b/inc/ThirdParty/Plugins/Ecommerce/XLWooCommerceSalesTriggersSubscriber.php
@@ -1,0 +1,63 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace WP_Rocket\ThirdParty\Plugins\Ecommerce;
+
+use WP_Rocket\Engine\Optimization\DelayJS\HTML;
+use WP_Rocket\Event_Management\Subscriber_Interface;
+
+class XLWooCommerceSalesTriggersSubscriber implements Subscriber_Interface {
+
+	/**
+	 * Delay JS HTML class.
+	 *
+	 * @var HTML
+	 */
+	private $delayjs_html;
+
+	/**
+	 * WooCommerceSubscriber constructor.
+	 *
+	 * @param HTML $delayjs_html DelayJS HTML class.
+	 */
+	public function __construct( HTML $delayjs_html ) {
+		$this->delayjs_html = $delayjs_html;
+	}
+
+	/**
+	 * Get the subscribed events array.
+	 *
+	 * @return array|array[]
+	 */
+	public static function get_subscribed_events() {
+		return [
+			'rocket_delay_js_exclusions' => [ 'modify_delayjs_exclusions_on_product_pages', 10, 2 ]
+		];
+	}
+
+	/**
+	 * Modify delay JS excluded scripts for compatibility.
+	 */
+	public function modify_delayjs_exclusions_on_product_pages( array $exclusions ) {
+		if ( empty( rocket_get_constant('WCST_VERSION' ) ) ) {
+			return $exclusions;
+		}
+
+		if ( 'product' !== get_post_type() || ! is_single() ) {
+			return $exclusions;
+		}
+
+		return array_unique(
+			array_merge(
+				$exclusions,
+				[
+					'xl-woocommerce-sales-triggers/assets/js/wcst_combined.min.js',
+					'/jquery-?[0-9.](.*)(.min|.slim|.slim.min)?.js',
+					'js-(before|after)',
+					'(?:/wp-content/|/wp-includes/)(.*)'
+				]
+			)
+		);
+	}
+}

--- a/inc/ThirdParty/Plugins/Ecommerce/XLWooCommerceSalesTriggersSubscriber.php
+++ b/inc/ThirdParty/Plugins/Ecommerce/XLWooCommerceSalesTriggersSubscriber.php
@@ -48,7 +48,7 @@ class XLWooCommerceSalesTriggersSubscriber implements Subscriber_Interface {
 			return $exclusions;
 		}
 
-		if ( 'product' !== get_post_type() || ! is_single() ) {
+		if ( ! is_product() || ! is_single() ) {
 			return $exclusions;
 		}
 
@@ -58,8 +58,6 @@ class XLWooCommerceSalesTriggersSubscriber implements Subscriber_Interface {
 				[
 					'xl-woocommerce-sales-triggers/assets/js/wcst_combined.min.js',
 					'/jquery-?[0-9.](.*)(.min|.slim|.slim.min)?.js',
-					'js-(before|after)',
-					'(?:/wp-content/|/wp-includes/)(.*)',
 				]
 			)
 		);

--- a/inc/ThirdParty/Plugins/Ecommerce/XLWooCommerceSalesTriggersSubscriber.php
+++ b/inc/ThirdParty/Plugins/Ecommerce/XLWooCommerceSalesTriggersSubscriber.php
@@ -48,7 +48,7 @@ class XLWooCommerceSalesTriggersSubscriber implements Subscriber_Interface {
 			return $exclusions;
 		}
 
-		if ( ! is_product() || ! is_single() ) {
+		if ( ! is_product() ) {
 			return $exclusions;
 		}
 

--- a/inc/ThirdParty/ServiceProvider.php
+++ b/inc/ThirdParty/ServiceProvider.php
@@ -22,6 +22,7 @@ class ServiceProvider extends AbstractServiceProvider {
 	protected $provides = [
 		'mobile_subscriber',
 		'woocommerce_subscriber',
+		'xl_woocommerce_sales_triggers_subscriber',
 		'syntaxhighlighter_subscriber',
 		'elementor_subscriber',
 		'bridge_subscriber',
@@ -68,6 +69,10 @@ class ServiceProvider extends AbstractServiceProvider {
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
 			->share( 'woocommerce_subscriber', 'WP_Rocket\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber' )
+			->addArgument( $this->getContainer()->get( 'delay_js_html' ) )
+			->addTag( 'common_subscriber' );
+		$this->getContainer()
+			->share( 'xl_woocommerce_sales_triggers_subscriber', 'WP_Rocket\ThirdParty\Plugins\Ecommerce\XLWoocommerceSalesTriggersSubscriber' )
 			->addArgument( $this->getContainer()->get( 'delay_js_html' ) )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()

--- a/inc/ThirdParty/ServiceProvider.php
+++ b/inc/ThirdParty/ServiceProvider.php
@@ -72,7 +72,7 @@ class ServiceProvider extends AbstractServiceProvider {
 			->addArgument( $this->getContainer()->get( 'delay_js_html' ) )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'xl_woocommerce_sales_triggers_subscriber', 'WP_Rocket\ThirdParty\Plugins\Ecommerce\XLWoocommerceSalesTriggersSubscriber' )
+			->share( 'xl_woocommerce_sales_triggers_subscriber', 'WP_Rocket\ThirdParty\Plugins\Ecommerce\XLWooCommerceSalesTriggersSubscriber' )
 			->addArgument( $this->getContainer()->get( 'delay_js_html' ) )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()

--- a/tests/Fixtures/inc/ThirdParty/Plugins/Ecommerce/XLWooCommerceSalesTriggersSubscriber/modifyDelayJsExclusionsOnProductPages.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/Ecommerce/XLWooCommerceSalesTriggersSubscriber/modifyDelayJsExclusionsOnProductPages.php
@@ -44,7 +44,7 @@ DELAYEXCLUDEDHTML;
 return [
 	'test_data' => [
 
-		'shouldNotExcludeFromDelayJsWhenNotIsProduct' => [
+		'shouldNotExcludeFromDelayJsWhenSingleButNotIsProduct' => [
 			'is_product' => false,
 			'initial_html'        => $original_html,
 			'expected_html'       => $delay_js_html

--- a/tests/Fixtures/inc/ThirdParty/Plugins/Ecommerce/XLWooCommerceSalesTriggersSubscriber/modifyDelayJsExclusionsOnProductPages.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/Ecommerce/XLWooCommerceSalesTriggersSubscriber/modifyDelayJsExclusionsOnProductPages.php
@@ -1,0 +1,59 @@
+<?php
+
+declare( strict_types=1 );
+
+$original_html = <<<HTML
+<!doctype html>
+<html lang="en">
+<head>
+<script src="http://example.com/wp-includes/js/jquery/jquery.min.js?ver=3.6.0" id="jquery-core-js"></script>
+</head>
+<body>
+<script src="http://example.com/wp-content/plugins/xl-woocommerce-sales-triggers/assets/js/wcst_combined.min.js?ver=2.11.0" id="wcst_public_js-js"></script>
+</body>
+</html>
+HTML;
+
+$delay_js_html = <<<DELAYJSHTML
+<!doctype html>
+<html lang="en">
+<head>
+<script>if(navigator.userAgent.match(/MSIE|Internet Explorer/i)||navigator.userAgent.match(/Trident\/7\..*?rv:11/i)){var href=document.location.href;if(!href.match(/[?&]nowprocket/)){if(href.indexOf("?")==-1){if(href.indexOf("#")==-1){document.location.href=href+"?nowprocket=1"}else{document.location.href=href.replace("#","?nowprocket=1#")}}else{if(href.indexOf("#")==-1){document.location.href=href+"&nowprocket=1"}else{document.location.href=href.replace("#","&nowprocket=1#")}}}}</script>
+<script type="rocketlazyloadscript" src="http://example.com/wp-includes/js/jquery/jquery.min.js?ver=3.6.0" id="jquery-core-js"></script>
+</head>
+<body>
+<script type="rocketlazyloadscript" src="http://example.com/wp-content/plugins/xl-woocommerce-sales-triggers/assets/js/wcst_combined.min.js?ver=2.11.0" id="wcst_public_js-js"></script>
+</body>
+</html>
+DELAYJSHTML;
+
+$delay_with_exclusions_html = <<<DELAYEXCLUDEDHTML
+<!doctype html>
+<html lang="en">
+<head>
+<script>if(navigator.userAgent.match(/MSIE|Internet Explorer/i)||navigator.userAgent.match(/Trident\/7\..*?rv:11/i)){var href=document.location.href;if(!href.match(/[?&]nowprocket/)){if(href.indexOf("?")==-1){if(href.indexOf("#")==-1){document.location.href=href+"?nowprocket=1"}else{document.location.href=href.replace("#","?nowprocket=1#")}}else{if(href.indexOf("#")==-1){document.location.href=href+"&nowprocket=1"}else{document.location.href=href.replace("#","&nowprocket=1#")}}}}</script>
+<script src="http://example.com/wp-includes/js/jquery/jquery.min.js?ver=3.6.0" id="jquery-core-js"></script>
+</head>
+<body>
+<script src="http://example.com/wp-content/plugins/xl-woocommerce-sales-triggers/assets/js/wcst_combined.min.js?ver=2.11.0" id="wcst_public_js-js"></script>
+</body>
+</html>
+DELAYEXCLUDEDHTML;
+
+
+return [
+	'test_data' => [
+
+		'shouldNotExcludeFromDelayJsWhenNotIsProduct' => [
+			'is_product' => false,
+			'initial_html'        => $original_html,
+			'expected_html'       => $delay_js_html
+		],
+
+		'shouldExcludeFromDelayJsWhenIsProduct' => [
+			'is_product' => true,
+			'initial_html'        => $original_html,
+			'expected_html'       => $delay_with_exclusions_html
+		]
+	]
+];

--- a/tests/Integration/inc/ThirdParty/Plugins/Ecommerce/XLWooCommerceSalesTriggersSubscriber/modifyDelayJsExclusionsOnProductPages.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Ecommerce/XLWooCommerceSalesTriggersSubscriber/modifyDelayJsExclusionsOnProductPages.php
@@ -17,11 +17,13 @@ class Test_ModifyDelayJsExclusionsOnProductPages extends TestCase {
 	use WooTrait;
 
 	private $product;
+	private $single;
 
 	public function setUp(): void {
 		parent::setUp();
 
 		$this->product = $this->create_product();
+		$this->single = get_post( $this->factory->post->create() );
 		$this->unregisterAllCallbacksExcept(
 			'rocket_delay_js_exclusions',
 			'modify_delayjs_exclusions_on_product_pages'
@@ -46,7 +48,7 @@ class Test_ModifyDelayJsExclusionsOnProductPages extends TestCase {
 		string $original_html,
 		string $expected_html
 	) {
-		$this->go_to( $is_product ? $this->product->get_permalink() : home_url() );
+		$this->go_to( $is_product ? $this->product->get_permalink() : get_permalink( $this->single ) );
 
 		$actual_html = apply_filters( 'rocket_buffer', $original_html );
 

--- a/tests/Integration/inc/ThirdParty/Plugins/Ecommerce/XLWooCommerceSalesTriggersSubscriber/modifyDelayJsExclusionsOnProductPages.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Ecommerce/XLWooCommerceSalesTriggersSubscriber/modifyDelayJsExclusionsOnProductPages.php
@@ -1,0 +1,58 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace WP_Rocket\Tests\Integration\inc\ThirdParty\Plugins\Ecommerce\XLWooCommerceSalesTriggerSubscriber;
+
+use WP_Rocket\Tests\Integration\inc\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber\WooTrait;
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * @covers  \WP_Rocket\ThirdParty\Plugins\Ecommerce\XLWooCommerceSalesTriggersSubscriber::modify_delayjs_exclusions_on_product_pages
+ * @group   ThirdParty
+ * @group   WithWoo
+ */
+class Test_ModifyDelayJsExclusionsOnProductPages extends TestCase {
+
+	use WooTrait;
+
+	private $product;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->product = $this->create_product();
+		$this->unregisterAllCallbacksExcept(
+			'rocket_delay_js_exclusions',
+			'modify_delayjs_exclusions_on_product_pages'
+		);
+		add_filter( 'pre_get_rocket_option_delay_js', [ $this, 'return_true' ] );
+		$this->constants['WCST_VERSION'] = '2.3.4';
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+
+		$this->restoreWpFilter( 'rocket_delay_js_exclusions' );
+		remove_filter( 'pre_get_rocket_option_delay_js', [ $this, 'return_true' ] );
+		unset( $this->constants['WCST_VERSION'] );
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function test_should_modify_delay_js_exclusions_when_expected(
+		bool $is_product,
+		string $original_html,
+		string $expected_html
+	) {
+		$this->go_to( $is_product ? $this->product->get_permalink() : home_url() );
+
+		$actual_html = apply_filters( 'rocket_buffer', $original_html );
+
+		$this->assertEquals(
+			$this->format_the_html( $expected_html ),
+			$this->format_the_html( $actual_html )
+		);
+	}
+}


### PR DESCRIPTION
## Description

This adds a new ThirdParty compatibility to correctly exclude the XL WooCommerce Sales Triggers combined js and the dependent jQuery on WooCommerce single product pages.

Fixes #4588

## Type of change

Please delete options that are not relevant.

- [X] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

Yes. Initial grooming plan was to simply add the sales triggers script to the default exclusions list. However, the script is dependent on jQuery, which requires delaying that also, but ONLY on single WC product pages.

## How Has This Been Tested?
- [X] Integration test and fixtures are added for new expected behavior
- [X] Confirmed that scripts are excluded as expected on Product pages, but not on other (homepage) in local environment.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
