### PR TITLE
Fix 4089 Stop applying defer JS exclusions to combine js when defer JS is inactive

### DIFF
--- a/inc/Engine/Optimization/DeferJS/DeferJS.php
+++ b/inc/Engine/Optimization/DeferJS/DeferJS.php
@@ -197,6 +197,10 @@ class DeferJS {
 	 * @return array
 	 */
 	public function get_excluded() : array {
+		if ( ! $this->can_defer_js() ) {
+			return [];
+		}
+
 		$exclude_defer_js = [
 			'gist.github.com',
 			'content.jwplatform.com',

--- a/tests/Unit/inc/Engine/Optimization/DeferJS/DeferJS/getExcluded.php
+++ b/tests/Unit/inc/Engine/Optimization/DeferJS/DeferJS/getExcluded.php
@@ -29,6 +29,7 @@ class Test_GetExcluded extends TestCase {
 
 	public function testShouldReturnEmptyWhenCannotDefer() {
 		$this->options->shouldReceive( 'get' )
+		              ->with( 'defer_all_js', 0 )
 		              ->once()
 		              ->andReturn( false );
 
@@ -84,7 +85,7 @@ class Test_GetExcluded extends TestCase {
 		              ->once()
 		              ->andReturn(
 			              [
-							  // user adds an item already in default list.
+				              // user adds an item already in default list.
 				              'gist.github.com'
 			              ]
 		              );

--- a/tests/Unit/inc/Engine/Optimization/DeferJS/DeferJS/getExcluded.php
+++ b/tests/Unit/inc/Engine/Optimization/DeferJS/DeferJS/getExcluded.php
@@ -1,0 +1,98 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\DeferJS\DeferJS;
+
+use Brain\Monkey\Functions;
+use Mockery;
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Engine\Optimization\DeferJS\DeferJS;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Optimization\DeferJS\DeferJS::get_excluded
+ *
+ * @group  DeferJS
+ */
+class Test_GetExcluded extends TestCase {
+
+	private $options;
+	private $defer_js;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->options  = Mockery::mock( Options_Data::class );
+		$this->defer_js = new DeferJS( $this->options );
+	}
+
+	public function testShouldReturnEmptyWhenCannotDefer() {
+		$this->options->shouldReceive( 'get' )
+		              ->once()
+		              ->andReturn( false );
+
+		$this->assertEmpty( $this->defer_js->get_excluded() );
+	}
+
+	public function testShouldDeferDefaultItems() {
+		$this->options->shouldReceive( 'get' )
+		              ->with( 'defer_all_js', 0 )
+		              ->once()
+		              ->andReturn( true );
+
+		$this->options->shouldReceive( 'get' )
+		              ->with( 'exclude_defer_js', [] )
+		              ->once()
+		              ->andReturn( [] );
+
+		$this->assertContains(
+			'gist.github.com',
+			$this->defer_js->get_excluded()
+		);
+	}
+
+	public function testShouldDeferUserExcludedItems() {
+		$this->options->shouldReceive( 'get' )
+		              ->with( 'defer_all_js', 0 )
+		              ->once()
+		              ->andReturn( true );
+
+		$this->options->shouldReceive( 'get' )
+		              ->with( 'exclude_defer_js', [] )
+		              ->once()
+		              ->andReturn(
+			              [
+				              '/path/to/my/userfile.js'
+			              ]
+		              );
+
+		$this->assertContains(
+			'/path/to/my/userfile.js',
+			$this->defer_js->get_excluded()
+		);
+	}
+
+	public function testShouldUniquelyMergeDefaultAndUserExclusions() {
+		$this->options->shouldReceive( 'get' )
+		              ->with( 'defer_all_js', 0 )
+		              ->once()
+		              ->andReturn( true );
+
+		$this->options->shouldReceive( 'get' )
+		              ->with( 'exclude_defer_js', [] )
+		              ->once()
+		              ->andReturn(
+			              [
+							  // user adds an item already in default list.
+				              'gist.github.com'
+			              ]
+		              );
+
+		$excluded_items = $this->defer_js->get_excluded();
+
+		$this->assertFalse(
+			count( array_unique( $excluded_items ) ) < count( $excluded_items )
+		);
+	}
+}

--- a/tests/Unit/inc/Engine/Optimization/DeferJS/DeferJS/getExcluded.php
+++ b/tests/Unit/inc/Engine/Optimization/DeferJS/DeferJS/getExcluded.php
@@ -36,7 +36,7 @@ class Test_GetExcluded extends TestCase {
 		$this->assertEmpty( $this->defer_js->get_excluded() );
 	}
 
-	public function testShouldDeferDefaultItems() {
+	public function testShouldNotDeferDefaultItems() {
 		$this->options->shouldReceive( 'get' )
 		              ->with( 'defer_all_js', 0 )
 		              ->once()
@@ -53,7 +53,7 @@ class Test_GetExcluded extends TestCase {
 		);
 	}
 
-	public function testShouldDeferUserExcludedItems() {
+	public function testShouldNotDeferUserExcludedItems() {
 		$this->options->shouldReceive( 'get' )
 		              ->with( 'defer_all_js', 0 )
 		              ->once()


### PR DESCRIPTION
## Description

Adds a check for whether defer JS is allowed before returning deferJS exclusions. This will stop them being added to combined JS when defer is not active.

Fixes #4089

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?
This solution is same as groomed.

## How Has This Been Tested?

After some discussion with Remy on other tests for similar "hard-coded" default exclusion lists, I'm taking a different approach to these tests, so some remarks here. (They are also included on commit message for a5adb348.)

On a recent PR from one of the lvl 2s, I noticed that changes were made to an exclusion list, and tests continued to pass without any modifications. It could pass because, as an exclusion, it didn't change either the expected or the actual HTML without hard-coding the new exclusion into the text fixture as well.

With these kinds of tests, we are not really testing anything other than "I hard-coded what I hard-coded." This is not useful, and has resulted in massively long test fixtures that provide little or no in-code documentation of what is supposed to be under test or why.

It's similar to testing a calculator function by trying to create a fixture that will hard-code every possible combination of integers that might be added together in calls from some other part of the codebase. What we really want to know is "does it add", not "does it add 1+1".

In the present case, what we want to know is exactly 4 things:
1. Does it bail out early when we're not supposed to defer JS? We don't care why we can't, as that's for another method to determine and we might add/remove those conditions. So we're not testing the specifics. Just that it bails and returns empty array.

2. Does it include items from the default list? Again, we don't care how many or what the specific items are in the default list. Just that it includes them. So pick any item, and assert that it's included. Done.

3. Does it include items added from the user option? Again, we don't care what the user adds, only that it includes the item in the return array.

4. Does it de-duplicate items, should the user add an item that is already excluded some other way?

The approach here is to construct 4 tests for those 4 concerns. Each has a cyclomatic complexity of 1 -- it will pass/fail for one reason only.

Note also that there are no fixtures necessary here. Each test tests a different thing. Fixtures are ideally for when you need sevaral data sets to cover instances of the same concern, and since we have 1 dataset for each concern, using a fixture and increasing the cyclomatic complexity of a single test to check for disparate concerns (as we have been doing) is a violation of separation of concerns.

As it is here, it's clear immediately from the test name in each case what is under test.

That said, this is a different approach, so feedback and discussion below is invited.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes