### PR TITLE
Fixes #4639 Prevent removal of IE conditionals when using async CSS

### DIFF
--- a/inc/Engine/CriticalPath/CriticalCSSSubscriber.php
+++ b/inc/Engine/CriticalPath/CriticalCSSSubscriber.php
@@ -642,10 +642,10 @@ JS;
 		);
 
 		// Remove comments from the buffer.
-		$buffer = $this->hide_comments( $buffer );
+		$buffer_nocomments = $this->hide_comments( $buffer );
 
 		// Get all css files with this regex.
-		preg_match_all( $css_pattern, $buffer, $tags_match );
+		preg_match_all( $css_pattern, $buffer_nocomments, $tags_match );
 		if ( ! isset( $tags_match[0] ) ) {
 			return $buffer;
 		}


### PR DESCRIPTION
## Description

The previous change was completely removing the conditionals from the buffer, which is causing the issue.

Instead, we create a new variable with the comments removed, and we use it to perform the pattern matching, keeping the original variable intact.

Fixes #4639

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
