### PR TITLE
Add exclusion for  Carousel Upsells and Related Product for WC

### DIFF
--- a/inc/Engine/Optimization/DeferJS/DeferJS.php
+++ b/inc/Engine/Optimization/DeferJS/DeferJS.php
@@ -227,6 +227,7 @@ class DeferJS {
 			'/wp-includes/js/dist/hooks(.min)?.js',
 			'www.paypal.com/sdk/js',
 			'js-eu1.hsforms.net',
+			'/carousel-upsells-and-related-product-for-woocommerce/assets/js/glide.min.js',
 		];
 
 		$exclude_defer_js = array_unique( array_merge( $exclude_defer_js, $this->options->get( 'exclude_defer_js', [] ) ) );


### PR DESCRIPTION
## Description

Addition of the following in the `get_excluded()` method:
```
/carousel-upsells-and-related-product-for-woocommerce/assets/js/glide.min.js
```
Fixes #4553

## Type of change

Please delete options that are not relevant.

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

No.

## How Has This Been Tested?

Not tested given that the issue was resolved on the customer's website, by excluding the specific file through the UI.

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

