### PR TITLE
Fix 4622: Add Bridge theme static file exclusions

### DIFF
--- a/inc/ThirdParty/Themes/Bridge.php
+++ b/inc/ThirdParty/Themes/Bridge.php
@@ -34,8 +34,9 @@ class Bridge implements Subscriber_Interface {
 		}
 
 		return [
-			'rocket_lazyload_background_images' => 'disable_lazyload_background_images',
-			'update_option_qode_options_proya'  => [ 'maybe_clear_cache', 10, 2 ],
+			'rocket_lazyload_background_images'       => 'disable_lazyload_background_images',
+			'update_option_qode_options_proya'        => [ 'maybe_clear_cache', 10, 2 ],
+			'rocket_exclude_static_dynamic_resources' => 'exclude_static_file_generation',
 		];
 	}
 
@@ -63,11 +64,9 @@ class Bridge implements Subscriber_Interface {
 	/**
 	 * Maybe clear WP Rocket cache when Bridge custom CSS/JS is updated
 	 *
-	 * @since 3.3.7
-	 * @author Remy Perona
-	 *
 	 * @param array $old_value Previous option values.
 	 * @param array $new_value New option values.
+	 *
 	 * @return void
 	 */
 	public function maybe_clear_cache( $old_value, $new_value ) {
@@ -93,5 +92,19 @@ class Bridge implements Subscriber_Interface {
 			rocket_clean_domain();
 			rocket_clean_minify();
 		}
+	}
+
+	/**
+	 * Excludes Bridge statically generated files.
+	 *
+	 * @param array $files Array of static files to be excluded.
+	 *
+	 * @return array Excluded files with Bridge entries to be excluded.
+	 */
+	public function exclude_static_file_generation( $files ) {
+		$files[] = 'wp-content/themes/bridge/js/default_dynamic_callback.php';
+		$files[] = 'wp-content/themes/bridge/css/style_dynamic_callback.php';
+
+		return $files;
 	}
 }

--- a/inc/ThirdParty/Themes/Bridge.php
+++ b/inc/ThirdParty/Themes/Bridge.php
@@ -102,8 +102,14 @@ class Bridge implements Subscriber_Interface {
 	 * @return array Excluded files with Bridge entries to be excluded.
 	 */
 	public function exclude_static_file_generation( $files ) {
-		$files[] = 'wp-content/themes/bridge/js/default_dynamic_callback.php';
-		$files[] = 'wp-content/themes/bridge/css/style_dynamic_callback.php';
+		$base_path = wp_parse_url( get_stylesheet_directory_uri(), PHP_URL_PATH );
+
+		if ( empty( $base_path ) ) {
+			return $files;
+		}
+
+		$files[] = $base_path . '/js/default_dynamic_callback.php';
+		$files[] = $base_path . '/css/style_dynamic_callback.php';
 
 		return $files;
 	}

--- a/tests/Integration/inc/ThirdParty/Themes/Bridge/excludeStaticFileGeneration.php
+++ b/tests/Integration/inc/ThirdParty/Themes/Bridge/excludeStaticFileGeneration.php
@@ -70,8 +70,8 @@ class excludeStaticFileGeneration extends TestCase
 	{
 		$this->assertSame(
 			[
-				'wp-content/themes/bridge/js/default_dynamic_callback.php',
-				'wp-content/themes/bridge/css/style_dynamic_callback.php',
+				'/wp-content/themes/Bridge/js/default_dynamic_callback.php',
+				'/wp-content/themes/Bridge/css/style_dynamic_callback.php',
 			],
 			apply_filters('rocket_exclude_static_dynamic_resources', [])
 		);

--- a/tests/Integration/inc/ThirdParty/Themes/Bridge/excludeStaticFileGeneration.php
+++ b/tests/Integration/inc/ThirdParty/Themes/Bridge/excludeStaticFileGeneration.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Integration\inc\ThirdParty\Themes\Bridge;
+
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * @covers \WP_Rocket\ThirdParty\Themes\Bridge::exclude_static_file_generation
+ * @group  BridgeTheme
+ * @group  ThirdParty
+ */
+class excludeStaticFileGeneration extends TestCase
+{
+	private static $container;
+
+	public static function setUpBeforeClass(): void
+	{
+		parent::setUpBeforeClass();
+
+		self::$container = apply_filters('rocket_container', '');
+	}
+
+	public static function tearDownAfterClass()
+	{
+		parent::tearDownAfterClass();
+
+		self::$container->get('event_manager')->remove_subscriber(self::$container->get('bridge_subscriber'));
+	}
+
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		add_filter('pre_option_stylesheet', [$this, 'set_stylesheet']);
+		add_filter('pre_option_stylesheet_root', [$this, 'set_stylesheet_root']);
+
+		self::$container->get('event_manager')->add_subscriber(self::$container->get('bridge_subscriber'));
+		$this->unregisterAllCallbacksExcept('rocket_exclude_static_dynamic_resources', 'exclude_static_file_generation');
+	}
+
+	public function tearDown()
+	{
+		global $wp_theme_directories;
+		unset($wp_theme_directories['virtual']);
+
+		$this->restoreWpFilter('rocket_exclude_static_dynamic_resources');
+		remove_filter('pre_option_stylesheet', [$this, 'set_stylesheet']);
+		remove_filter('pre_option_stylesheet_root', [$this, 'set_stylesheet_root']);
+
+		parent::tearDown();
+	}
+
+	public function set_stylesheet()
+	{
+		return 'Bridge';
+	}
+
+	public function set_stylesheet_root()
+	{
+		global $wp_theme_directories;
+
+		$wp_theme_directories['virtual'] = 'http://example.org/wp-content/themes';
+
+		return 'http://example.org/wp-content/themes';
+	}
+
+	public function testShouldReturnExpected()
+	{
+		$this->assertSame(
+			[
+				'wp-content/themes/bridge/js/default_dynamic_callback.php',
+				'wp-content/themes/bridge/css/style_dynamic_callback.php',
+			],
+			apply_filters('rocket_exclude_static_dynamic_resources', [])
+		);
+	}
+}


### PR DESCRIPTION
## Description

This adds a new method to the `ThirdParty/Bridge` subscriber: `exclude_static_file_generation(array $files): array`.
The new method is a filter hooked to `rocket_exclude_static_dynamic_resources` that will add certain static files generated by Bridge in some edge cases. (See discussion on #4622.)

Corresponding integration test is included.

Fixes #4622

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

Same solution outlined in the grooming notes.

## How Has This Been Tested?
Integration test added to confirm filter includes specified Bridge-generated files.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
