### PR TITLE
Fixess #3570 Use WP tested version from our API

### DIFF
--- a/inc/Engine/Deactivation/Deactivation.php
+++ b/inc/Engine/Deactivation/Deactivation.php
@@ -87,6 +87,7 @@ class Deactivation {
 		delete_transient( 'rocket_check_licence_30' );
 		delete_transient( 'rocket_check_licence_1' );
 		delete_site_transient( 'update_wprocket_response' );
+		delete_site_transient( 'wp_rocket_update_data' );
 
 		// Unschedule WP Cron events.
 		wp_clear_scheduled_hook( 'rocket_rucss_clean_rows_time_event' );

--- a/inc/Engine/Plugin/InformationSubscriber.php
+++ b/inc/Engine/Plugin/InformationSubscriber.php
@@ -54,8 +54,8 @@ class InformationSubscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events() {
 		return [
-			'plugins_api'        => [ 'exclude_rocket_from_wp_info', 10, 3 ],
-			'plugins_api_result' => [ 'add_rocket_info', 10, 3 ],
+			'plugins_api'              => [ 'exclude_rocket_from_wp_info', 10, 3 ],
+			'plugins_api_result'       => [ 'add_rocket_info', 10, 3 ],
 			'rocket_wp_tested_version' => 'add_wp_tested_version',
 		];
 	}

--- a/inc/Engine/Plugin/InformationSubscriber.php
+++ b/inc/Engine/Plugin/InformationSubscriber.php
@@ -1,53 +1,37 @@
 <?php
-namespace WP_Rocket\Subscriber\Plugin;
+namespace WP_Rocket\Engine\Plugin;
 
 use WP_Rocket\Event_Management\Subscriber_Interface;
 
 /**
  * Manages the plugin information.
- *
- * @since  3.3.6
- * @author Grégory Viguier
  */
-class Information_Subscriber implements Subscriber_Interface {
-	use \WP_Rocket\Traits\Updater_Api_Tools;
+class InformationSubscriber implements Subscriber_Interface {
+	use UpdaterApiTools;
 
 	/**
 	 * Plugin slug.
 	 *
-	 * @var    string
-	 * @since  3.3.6
-	 * @access private
-	 * @author Grégory Viguier
+	 * @var string
 	 */
 	private $plugin_slug;
 
 	/**
 	 * URL to contact to get plugin info.
 	 *
-	 * @var    string
-	 * @since  3.3.6
-	 * @access private
-	 * @author Grégory Viguier
+	 * @var string
 	 */
 	private $api_url;
 
 	/**
 	 * An ID to use when a API request fails.
 	 *
-	 * @var    string
-	 * @since  3.3.6
-	 * @access protected
-	 * @author Grégory Viguier
+	 * @var string
 	 */
 	protected $request_error_id = 'plugins_api_failed';
 
 	/**
 	 * Constructor
-	 *
-	 * @since  3.3.6
-	 * @access public
-	 * @author Grégory Viguier
 	 *
 	 * @param array $args {
 	 *     Required arguments to populate the class properties.
@@ -72,20 +56,12 @@ class Information_Subscriber implements Subscriber_Interface {
 		return [
 			'plugins_api'        => [ 'exclude_rocket_from_wp_info', 10, 3 ],
 			'plugins_api_result' => [ 'add_rocket_info', 10, 3 ],
+			'rocket_wp_tested_version' => 'add_wp_tested_version',
 		];
 	}
 
-	/** ----------------------------------------------------------------------------------------- */
-	/** PLUGIN INFO ============================================================================= */
-	/** ----------------------------------------------------------------------------------------- */
-
 	/**
 	 * Don’t ask for plugin info to the repository.
-	 *
-	 * @since  3.3.6
-	 * @access public
-	 * @see    plugins_api()
-	 * @author Grégory Viguier
 	 *
 	 * @param  false|object|array $bool   The result object or array. Default false.
 	 * @param  string             $action The type of information being requested from the Plugin Install API.
@@ -102,11 +78,6 @@ class Information_Subscriber implements Subscriber_Interface {
 	/**
 	 * Insert WP Rocket plugin info.
 	 *
-	 * @since  3.3.6
-	 * @access public
-	 * @see    plugins_api()
-	 * @author Grégory Viguier
-	 *
 	 * @param  object|\WP_Error $res    Response object or WP_Error.
 	 * @param  string           $action The type of information being requested from the Plugin Install API.
 	 * @param  object           $args   Plugin API arguments.
@@ -117,39 +88,28 @@ class Information_Subscriber implements Subscriber_Interface {
 			return $res;
 		}
 
-		$request = wp_remote_post(
-			$this->api_url,
-			[
-				'timeout' => 30,
-				'action'  => 'plugin_information',
-				'request' => maybe_serialize( $args ),
-			]
-		);
-
-		if ( is_wp_error( $request ) ) {
-			return $this->get_request_error( $request->get_error_message() );
-		}
-
-		$res  = maybe_unserialize( wp_remote_retrieve_body( $request ) );
-		$code = wp_remote_retrieve_response_code( $request );
-
-		if ( 200 !== $code || ! ( is_object( $res ) || is_array( $res ) ) ) {
-			return $this->get_request_error( wp_remote_retrieve_body( $request ) );
-		}
-
-		return $res;
+		return $this->get_plugin_information();
 	}
 
-	/** ----------------------------------------------------------------------------------------- */
-	/** TOOLS =================================================================================== */
-	/** ----------------------------------------------------------------------------------------- */
+	/**
+	 * Adds the WP tested version value from our API
+	 *
+	 * @param string $wp_tested_version WP tested version.
+	 *
+	 * @return string
+	 */
+	public function add_wp_tested_version( $wp_tested_version ): string {
+		$info = $this->get_plugin_information();
+
+		if ( empty( $info->tested ) ) {
+			return $wp_tested_version;
+		}
+
+		return $info->tested;
+	}
 
 	/**
 	 * Tell if requesting WP Rocket plugin info.
-	 *
-	 * @since  3.3.6
-	 * @access private
-	 * @author Grégory Viguier
 	 *
 	 * @param  string $action The type of information being requested from the Plugin Install API.
 	 * @param  object $args   Plugin API arguments.
@@ -157,5 +117,31 @@ class Information_Subscriber implements Subscriber_Interface {
 	 */
 	private function is_requesting_rocket_info( $action, $args ) {
 		return ( 'query_plugins' === $action || 'plugin_information' === $action ) && isset( $args->slug ) && $args->slug === $this->plugin_slug;
+	}
+
+	/**
+	 * Gets the plugin information data
+	 *
+	 * @return object|\WP_Error
+	 */
+	private function get_plugin_information() {
+		$response = wp_remote_get( $this->api_url );
+
+		if ( is_wp_error( $response ) ) {
+			return $this->get_request_error( $response->get_error_message() );
+		}
+
+		$res  = maybe_unserialize( wp_remote_retrieve_body( $response ) );
+		$code = wp_remote_retrieve_response_code( $response );
+
+		if (
+			200 !== $code
+			||
+			! ( is_object( $res ) || is_array( $res ) )
+		) {
+			return $this->get_request_error( wp_remote_retrieve_body( $response ) );
+		}
+
+		return $res;
 	}
 }

--- a/inc/Engine/Plugin/ServiceProvider.php
+++ b/inc/Engine/Plugin/ServiceProvider.php
@@ -1,14 +1,12 @@
 <?php
-namespace WP_Rocket\ServiceProvider;
+namespace WP_Rocket\Engine\Plugin;
 
 use WP_Rocket\Dependencies\League\Container\ServiceProvider\AbstractServiceProvider;
 
 /**
  * Service provider for the WP Rocket updates.
- *
- * @since  3.3.6
  */
-class Updater_Subscribers extends AbstractServiceProvider {
+class ServiceProvider extends AbstractServiceProvider {
 
 	/**
 	 * The provided array is a way to let the container
@@ -17,8 +15,7 @@ class Updater_Subscribers extends AbstractServiceProvider {
 	 * this service provider must have an alias added
 	 * to this array or it will be ignored.
 	 *
-	 * @var    array
-	 * @since  3.3.6
+	 * @var array
 	 */
 	protected $provides = [
 		'plugin_updater_common_subscriber',
@@ -34,7 +31,7 @@ class Updater_Subscribers extends AbstractServiceProvider {
 	public function register() {
 		$api_url = wp_parse_url( WP_ROCKET_WEB_INFO );
 
-		$this->getContainer()->share( 'plugin_updater_common_subscriber', 'WP_Rocket\Subscriber\Plugin\Updater_Api_Common_Subscriber' )
+		$this->getContainer()->share( 'plugin_updater_common_subscriber', 'WP_Rocket\Engine\Plugin\UpdaterApiCommonSubscriber' )
 			->addArgument(
 				[
 					'api_host'           => $api_url['host'],
@@ -46,7 +43,7 @@ class Updater_Subscribers extends AbstractServiceProvider {
 				]
 			)
 			->addTag( 'common_subscriber' );
-		$this->getContainer()->share( 'plugin_information_subscriber', 'WP_Rocket\Subscriber\Plugin\Information_Subscriber' )
+		$this->getContainer()->share( 'plugin_information_subscriber', 'WP_Rocket\Engine\Plugin\InformationSubscriber' )
 			->addArgument(
 				[
 					'plugin_file' => WP_ROCKET_FILE,
@@ -54,7 +51,7 @@ class Updater_Subscribers extends AbstractServiceProvider {
 				]
 			)
 			->addTag( 'common_subscriber' );
-		$this->getContainer()->share( 'plugin_updater_subscriber', 'WP_Rocket\Subscriber\Plugin\Updater_Subscriber' )
+		$this->getContainer()->share( 'plugin_updater_subscriber', 'WP_Rocket\Engine\Plugin\UpdaterSubscriber' )
 			->addArgument(
 				[
 					'plugin_file'    => WP_ROCKET_FILE,

--- a/inc/Engine/Plugin/UpdaterApiCommonSubscriber.php
+++ b/inc/Engine/Plugin/UpdaterApiCommonSubscriber.php
@@ -1,82 +1,57 @@
 <?php
-namespace WP_Rocket\Subscriber\Plugin;
+namespace WP_Rocket\Engine\Plugin;
 
 use WP_Rocket\Event_Management\Subscriber_Interface;
 
 /**
  * Manages common hooks for the plugin updater.
- *
- * @since  3.3.6
- * @author Grégory Viguier
  */
-class Updater_Api_Common_Subscriber implements Subscriber_Interface {
+class UpdaterApiCommonSubscriber implements Subscriber_Interface {
 
 	/**
 	 * API’s URL domain.
 	 *
-	 * @var    string
-	 * @since  3.3.6
-	 * @access private
-	 * @author Grégory Viguier
+	 * @var string
 	 */
 	private $api_host;
 
 	/**
 	 * URL to the site’s home.
 	 *
-	 * @var    string
-	 * @since  3.3.6
-	 * @access private
-	 * @author Grégory Viguier
+	 * @var string
 	 */
 	private $site_url;
 
 	/**
 	 * Current version of the plugin.
 	 *
-	 * @var    string
-	 * @since  3.3.6
-	 * @access private
-	 * @author Grégory Viguier
+	 * @var string
 	 */
 	private $plugin_version;
 
 	/**
 	 * Key slug used when submitting new settings (POST).
 	 *
-	 * @var    string
-	 * @since  3.3.6
-	 * @access private
-	 * @author Grégory Viguier
+	 * @var string
 	 */
 	private $settings_slug;
 
 	/**
 	 * The key (1st part of the action) used for the nonce field used on the settings page. It is also used in the page URL.
 	 *
-	 * @var    string
-	 * @since  3.3.6
-	 * @access private
-	 * @author Grégory Viguier
+	 * @var string
 	 */
 	private $settings_nonce_key;
 
 	/**
 	 * Options instance.
 	 *
-	 * @var    \WP_Rocket\Admin\Options
-	 * @since  3.3.6
-	 * @access private
-	 * @author Grégory Viguier
+	 * @var \WP_Rocket\Admin\Options
 	 */
 	private $plugin_options;
 
 	/**
 	 * Constructor
-	 *
-	 * @since  3.3.6
-	 * @access public
-	 * @author Grégory Viguier
 	 *
 	 * @param array $args {
 	 *     Required arguments to populate the class properties.
@@ -106,15 +81,8 @@ class Updater_Api_Common_Subscriber implements Subscriber_Interface {
 		];
 	}
 
-	/** ----------------------------------------------------------------------------------------- */
-	/** HOOKS =================================================================================== */
-	/** ----------------------------------------------------------------------------------------- */
-
 	/**
 	 * Force our user agent header when we hit our URLs.
-	 *
-	 * @since  3.3.6
-	 * @access public
 	 *
 	 * @param  array  $request An array of request arguments.
 	 * @param  string $url     Requested URL.
@@ -132,16 +100,8 @@ class Updater_Api_Common_Subscriber implements Subscriber_Interface {
 		return $request;
 	}
 
-	/** ----------------------------------------------------------------------------------------- */
-	/** TOOLS =================================================================================== */
-	/** ----------------------------------------------------------------------------------------- */
-
 	/**
 	 * Get the user agent to use when requesting the API.
-	 *
-	 * @since  3.3.6
-	 * @access protected
-	 * @author Grégory Viguier
 	 *
 	 * @return string WP Rocket user agent
 	 */
@@ -155,10 +115,6 @@ class Updater_Api_Common_Subscriber implements Subscriber_Interface {
 
 	/**
 	 * Get a plugin option. If the value is currently being posted through the settings page, it is returned instead of the one stored in the database.
-	 *
-	 * @since  3.3.6
-	 * @access protected
-	 * @author Grégory Viguier
 	 *
 	 * @param  string $field_name Name of a plugin option.
 	 * @return string

--- a/inc/Engine/Plugin/UpdaterApiTools.php
+++ b/inc/Engine/Plugin/UpdaterApiTools.php
@@ -1,35 +1,14 @@
 <?php
-namespace WP_Rocket\Traits;
+namespace WP_Rocket\Engine\Plugin;
 
 use WP_Rocket\Logger\Logger;
 
 /**
  * Trait for the plugin updater.
- *
- * @since  3.3.6
- * @author Grégory Viguier
  */
-trait Updater_Api_Tools {
-	/**
-	 * An ID to use when a API request fails.
-	 *
-	 * @var    string
-	 * @since  3.3.6
-	 * @access protected
-	 * @author Grégory Viguier
-	 */
-	/*protected $request_error_id;*/
-
-	/** ----------------------------------------------------------------------------------------- */
-	/** TOOLS =================================================================================== */
-	/** ----------------------------------------------------------------------------------------- */
-
+trait UpdaterApiTools {
 	/**
 	 * Get a \WP_Error object to use when the request to WP Rocket’s server fails.
-	 *
-	 * @since  3.3.6
-	 * @access protected
-	 * @author Grégory Viguier
 	 *
 	 * @param  mixed $data Error data to pass along the \WP_Error object.
 	 * @return \WP_Error
@@ -60,10 +39,6 @@ trait Updater_Api_Tools {
 	/**
 	 * Get support URL.
 	 *
-	 * @since  3.3.6
-	 * @access protected
-	 * @author Grégory Viguier
-	 *
 	 * @return string
 	 */
 	protected function get_support_url() {
@@ -78,10 +53,6 @@ trait Updater_Api_Tools {
 
 	/**
 	 * Get a plugin slug, given its full path.
-	 *
-	 * @since  3.3.6
-	 * @access protected
-	 * @author Grégory Viguier
 	 *
 	 * @param  string $plugin_file Full path to the plugin.
 	 * @return string

--- a/inc/Engine/Plugin/UpdaterSubscriber.php
+++ b/inc/Engine/Plugin/UpdaterSubscriber.php
@@ -1,82 +1,70 @@
 <?php
-namespace WP_Rocket\Subscriber\Plugin;
+namespace WP_Rocket\Engine\Plugin;
 
 use WP_Rocket\Event_Management\Subscriber_Interface;
-use WP_Rocket\Traits\Updater_Api_Tools;
 
 /**
  * Manages the plugin updates.
- *
- * @since  3.3.6
  */
-class Updater_Subscriber implements Subscriber_Interface {
-	use Updater_Api_Tools;
+class UpdaterSubscriber implements Subscriber_Interface {
+	use UpdaterApiTools;
 
 	/**
 	 * Full path to the plugin.
 	 *
-	 * @var    string
-	 * @since  3.3.6
+	 * @var string
 	 */
 	private $plugin_file;
 
 	/**
 	 * Current version of the plugin.
 	 *
-	 * @var    string
-	 * @since  3.3.6
+	 * @var string
 	 */
 	private $plugin_version;
 
 	/**
 	 * URL to the plugin provider.
 	 *
-	 * @var    string
-	 * @since  3.3.6
+	 * @var string
 	 */
 	private $vendor_url;
 
 	/**
 	 * URL to contact to get update info.
 	 *
-	 * @var    string
-	 * @since  3.3.6
+	 * @var string
 	 */
 	private $api_url;
 
 	/**
 	 * A list of plugin’s icon URLs.
 	 *
-	 * @var    array {
+	 * @var array {
 	 *     @type string $2x  URL to the High-DPI size (png or jpg). Optional.
 	 *     @type string $1x  URL to the normal icon size (png or jpg). Mandatory.
 	 *     @type string $svg URL to the svg version of the icon. Optional.
 	 * }
-	 * @since  3.3.6
-	 * @see    https://developer.wordpress.org/plugins/wordpress-org/plugin-assets/#plugin-icons
+	 * @see https://developer.wordpress.org/plugins/wordpress-org/plugin-assets/#plugin-icons
 	 */
 	private $icons;
 
 	/**
 	 * An ID to use when a API request fails.
 	 *
-	 * @var    string
-	 * @since  3.3.6
+	 * @var string
 	 */
 	protected $request_error_id = 'rocket_update_failed';
 
 	/**
 	 * Name of the transient that caches the update data.
 	 *
-	 * @var    string
-	 * @since  3.3.6
+	 * @var string
 	 */
 	protected $cache_transient_name = 'wp_rocket_update_data';
 
 	/**
 	 * Constructor
-	 *
-	 * @since  3.3.6
 	 *
 	 * @param array $args {
 	 *     Required arguments to populate the class properties.
@@ -108,14 +96,9 @@ class Updater_Subscriber implements Subscriber_Interface {
 		];
 	}
 
-	/** ----------------------------------------------------------------------------------------- */
-	/** PLUGIN UPDATE DATA ====================================================================== */
-	/** ----------------------------------------------------------------------------------------- */
-
 	/**
 	 * When WP checks plugin versions against the latest versions hosted on WordPress.org, remove WPR from the list.
 	 *
-	 * @since  3.3.6
 	 * @see    wp_update_plugins()
 	 *
 	 * @param  array  $request An array of HTTP request arguments.
@@ -194,8 +177,6 @@ class Updater_Subscriber implements Subscriber_Interface {
 	/**
 	 * Add WPR update data to the "WP update" transient.
 	 *
-	 * @since  3.3.6
-	 *
 	 * @param  \stdClass $transient_value New value of site transient.
 	 * @return \stdClass
 	 */
@@ -237,8 +218,6 @@ class Updater_Subscriber implements Subscriber_Interface {
 	/**
 	 * Delete WPR update data cache when the "WP update" transient is deleted.
 	 *
-	 * @since  3.3.6
-	 *
 	 * @param string $transient_name Deleted transient name.
 	 */
 	public function maybe_delete_rocket_update_data_cache( $transient_name ) {
@@ -249,8 +228,6 @@ class Updater_Subscriber implements Subscriber_Interface {
 
 	/**
 	 * If the `rocket_force_update` query arg is set, force WP to refresh the list of plugins to update.
-	 *
-	 * @since  3.3.6
 	 */
 	public function maybe_force_check() {
 		if ( is_string( filter_input( INPUT_GET, 'rocket_force_update' ) ) ) {
@@ -260,8 +237,6 @@ class Updater_Subscriber implements Subscriber_Interface {
 
 	/**
 	 * Disable auto-updates for WP Rocket
-	 *
-	 * @since 3.7.5
 	 *
 	 * @param bool|null $update Whether to update. The value of null is internally used to detect whether nothing has hooked into this filter.
 	 * @param object    $item The update offer.
@@ -275,14 +250,8 @@ class Updater_Subscriber implements Subscriber_Interface {
 		return $update;
 	}
 
-	/** ----------------------------------------------------------------------------------------- */
-	/** TOOLS =================================================================================== */
-	/** ----------------------------------------------------------------------------------------- */
-
 	/**
 	 * Get the latest WPR update data from our server.
-	 *
-	 * @since  3.3.6
 	 *
 	 * @return \stdClass|\WP_Error {
 	 *     A \WP_Error object on failure. An object on success:
@@ -352,7 +321,15 @@ class Updater_Subscriber implements Subscriber_Interface {
 		$obj->new_version = $match['user_version'];
 		$obj->url         = $this->vendor_url;
 		$obj->package     = $match['package'];
-		$obj->tested      = WP_ROCKET_WP_VERSION_TESTED;
+
+		/**
+		 * Filters the WP tested version value
+		 *
+		 * @since 3.10.7
+		 *
+		 * @param string $wp_tested_version WP tested version value.
+		 */
+		$obj->tested = apply_filters( 'rocket_wp_tested_version', WP_ROCKET_WP_VERSION_TESTED );
 
 		if ( $this->icons && ! empty( $this->icons['1x'] ) ) {
 			$obj->icons = $this->icons;
@@ -363,8 +340,6 @@ class Updater_Subscriber implements Subscriber_Interface {
 
 	/**
 	 * Get the cached version of the latest WPR update data.
-	 *
-	 * @since  3.3.6
 	 *
 	 * @return \stdClass|\WP_Error {
 	 *     A \WP_Error object on failure. An object on success:
@@ -426,8 +401,6 @@ class Updater_Subscriber implements Subscriber_Interface {
 
 	/**
 	 * Delete WP Rocket update data cache.
-	 *
-	 * @since  3.3.6
 	 */
 	public function delete_rocket_update_data_cache() {
 		delete_site_transient( $this->cache_transient_name );

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -230,7 +230,7 @@ class Plugin {
 		$this->container->addServiceProvider( 'WP_Rocket\ServiceProvider\Common_Subscribers' );
 		$this->container->addServiceProvider( 'WP_Rocket\ThirdParty\ServiceProvider' );
 		$this->container->addServiceProvider( 'WP_Rocket\ThirdParty\Hostings\ServiceProvider' );
-		$this->container->addServiceProvider( 'WP_Rocket\ServiceProvider\Updater_Subscribers' );
+		$this->container->addServiceProvider( 'WP_Rocket\Engine\Plugin\ServiceProvider' );
 		$this->container->addServiceProvider( 'WP_Rocket\Engine\Optimization\DelayJS\ServiceProvider' );
 		$this->container->addServiceProvider( 'WP_Rocket\Engine\Optimization\RUCSS\ServiceProvider' );
 		$this->container->addServiceProvider( 'WP_Rocket\Engine\Heartbeat\ServiceProvider' );


### PR DESCRIPTION
## Description

- Move the files to the new architecture
- Add a new method `add_wp_tested_version()` to update the value of the `tested` field, maintaining a fallback to the constant if needed

Fixes #3570 

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

No

## How Has This Been Tested?

- [x] Manual test by changing the WP Rocket version to an old one, and checking the compatibility value on the updates screen

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
