### PR TITLE
Exclude Google Site Kit files from JavaScript minification to fix JavaScript errors

### DIFF
--- a/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
+++ b/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
@@ -53,6 +53,7 @@ abstract class AbstractJSOptimization extends AbstractOptimization {
 		$excluded_files[] = '/interactive-3d-flipbook-powered-physics-engine/assets/js/pdf.min.js';
 		$excluded_files[] = '/interactive-3d-flipbook-powered-physics-engine/assets/js/three.min.js';
 		$excluded_files[] = '/interactive-3d-flipbook-powered-physics-engine/assets/js/3d-flip-book.min.js';
+		$excluded_files[] = '/google-site-kit/dist/assets/js/googlesitekit-modules-(.*).js';
 
 		/**
 		 * Filter JS files to exclude from minification/concatenation.

--- a/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
+++ b/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
@@ -54,6 +54,8 @@ abstract class AbstractJSOptimization extends AbstractOptimization {
 		$excluded_files[] = '/interactive-3d-flipbook-powered-physics-engine/assets/js/three.min.js';
 		$excluded_files[] = '/interactive-3d-flipbook-powered-physics-engine/assets/js/3d-flip-book.min.js';
 		$excluded_files[] = '/google-site-kit/dist/assets/js/googlesitekit-modules-(.*).js';
+		$excluded_files[] = '/google-site-kit/dist/assets/js/googlesitekit-data-(.*).js';
+		$excluded_files[] = '/google-site-kit/dist/assets/js/googlesitekit-widgets-(.*).js';
 
 		/**
 		 * Filter JS files to exclude from minification/concatenation.

--- a/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
+++ b/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
@@ -53,9 +53,7 @@ abstract class AbstractJSOptimization extends AbstractOptimization {
 		$excluded_files[] = '/interactive-3d-flipbook-powered-physics-engine/assets/js/pdf.min.js';
 		$excluded_files[] = '/interactive-3d-flipbook-powered-physics-engine/assets/js/three.min.js';
 		$excluded_files[] = '/interactive-3d-flipbook-powered-physics-engine/assets/js/3d-flip-book.min.js';
-		$excluded_files[] = '/google-site-kit/dist/assets/js/googlesitekit-modules-(.*).js';
-		$excluded_files[] = '/google-site-kit/dist/assets/js/googlesitekit-data-(.*).js';
-		$excluded_files[] = '/google-site-kit/dist/assets/js/googlesitekit-widgets-(.*).js';
+		$excluded_files[] = '/google-site-kit/dist/assets/js/(.*)\.js';
 
 		/**
 		 * Filter JS files to exclude from minification/concatenation.


### PR DESCRIPTION
## Description

I've added the following:
```
$excluded_files[] = '/google-site-kit/dist/assets/js/googlesitekit-modules-(.*).js';
```
in the `get_excluded_files()` method.

Fixes #4656 

## Type of change

Please delete options that are not relevant.

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

This wasn't groomed.

## How Has This Been Tested?

I've tested this locally by installing Google Site Kit, and checking that the JavaScript errors were resolved.

# Checklist:

Please delete the options that are not relevant.

- [x My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

