### PR TITLE
Closes #4654 Exclude StatsCounter from minify JS and delay JS execution

### DIFF
--- a/inc/Engine/Optimization/DelayJS/HTML.php
+++ b/inc/Engine/Optimization/DelayJS/HTML.php
@@ -67,6 +67,8 @@ class HTML {
 		'wpformsRecaptchaCallback', // WPForms reCAPTCHA v2.
 		'booking-suedtirol-js', // bookingsuedtirol.com widgets.
 		'/gravityforms/js/conditional_logic.min.js', // Gravity forms conditions.
+		'statcounter.com/counter/counter.js', // StatsCounter.
+		'var sc_project', // Statscounter.
 	];
 
 	/**

--- a/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
+++ b/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
@@ -253,6 +253,7 @@ abstract class AbstractJSOptimization extends AbstractOptimization {
 			'hcaptcha.com/1/api.js',
 			'voucher.getavo.it/public/js/yanovis.Voucher.js',
 			'js-eu1.hsforms.net',
+			'statcounter.com/counter/counter.js',
 		];
 
 		$excluded_external = array_merge( $defaults, $this->options->get( 'exclude_js', [] ) );


### PR DESCRIPTION
## Description

Exclude StatsCounter scripts from minify JS and delay JS execution

Fixes #4654 

## Type of change
- [x] Enhancement (non-breaking change which improves an existing functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
