### PR TITLE
Fixes #2852 Update feeds cache exclusion pattern

### DIFF
--- a/inc/admin/upgrader.php
+++ b/inc/admin/upgrader.php
@@ -366,10 +366,6 @@ function rocket_new_upgrade( $wp_rocket_version, $actual_version ) {
 		rocket_clean_domain();
 	}
 
-	if ( version_compare( $actual_version, '3.6.1', '<' ) ) {
-		rocket_generate_config_file();
-	}
-
 	if ( version_compare( $actual_version, '3.7', '<' ) ) {
 		rocket_clean_minify( 'css' );
 		rocket_generate_advanced_cache_file();
@@ -401,6 +397,10 @@ function rocket_new_upgrade( $wp_rocket_version, $actual_version ) {
 			rocket_rrmdir( $cache_path . 'used-css' );
 			update_option( rocket_get_constant( 'WP_ROCKET_SLUG' ), $options );
 		}
+	}
+
+	if ( version_compare( $actual_version, '3.10.8', '<' ) ) {
+		rocket_generate_config_file();
 	}
 }
 add_action( 'wp_rocket_upgrade', 'rocket_new_upgrade', 10, 2 );

--- a/inc/functions/options.php
+++ b/inc/functions/options.php
@@ -276,7 +276,7 @@ function get_rocket_cache_reject_uri( $force = false ) { // phpcs:ignore WordPre
 	}
 
 	// Exclude feeds.
-	$uris[] = '/(.+/)?' . $wp_rewrite->feed_base . '/?.+/?';
+	$uris[] = '/(?:.+/)?' . $wp_rewrite->feed_base . '(?:/(?:.+/?)?)?$';
 
 	// Exlude embedded URLs.
 	$uris[] = '/(?:.+/)?embed/';


### PR DESCRIPTION
## Description

Update the feeds cache exclusion pattern to prevent unexpected matching when the URL contains `feed` in its slug, but is not a WordPress feed.

Performs an update of the config file on plugin update to 3.10.8, to make sure its using the new pattern.

Fixes #2852 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

No

## How Has This Been Tested?

- [x] Tested with RegEx101 with various URLs
- [x] Tested on user website by the support team

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes

@wp-media/tech-support This might require an update to the helper plugin to cache feed once this is released.
