### PR TITLE
Closes #2950 Deprecate rocket_maybe_reset_opcache()

### DIFF
--- a/inc/admin/upgrader.php
+++ b/inc/admin/upgrader.php
@@ -56,47 +56,6 @@ function rocket_upgrader() {
 add_action( 'admin_init', 'rocket_upgrader' );
 
 /**
- * Maybe reset opcache after WP Rocket update.
- *
- * @since  3.1
- * @author Grégory Viguier
- *
- * @param object $wp_upgrader Plugin_Upgrader instance.
- * @param array  $hook_extra  {
- *     Array of bulk item update data.
- *
- *     @type string $action  Type of action. Default 'update'.
- *     @type string $type    Type of update process. Accepts 'plugin', 'theme', 'translation', or 'core'.
- *     @type bool   $bulk    Whether the update process is a bulk update. Default true.
- *     @type array  $plugins Array of the basename paths of the plugins' main files.
- * }
- */
-function rocket_maybe_reset_opcache( $wp_upgrader, $hook_extra ) {
-	static $rocket_path;
-
-	if ( ! isset( $hook_extra['action'], $hook_extra['type'], $hook_extra['plugins'] ) ) {
-		return;
-	}
-
-	if ( 'update' !== $hook_extra['action'] || 'plugin' !== $hook_extra['type'] || ! is_array( $hook_extra['plugins'] ) ) {
-		return;
-	}
-
-	$plugins = array_flip( $hook_extra['plugins'] );
-
-	if ( ! isset( $rocket_path ) ) {
-		$rocket_path = plugin_basename( WP_ROCKET_FILE );
-	}
-
-	if ( ! isset( $plugins[ $rocket_path ] ) ) {
-		return;
-	}
-
-	rocket_reset_opcache();
-}
-add_action( 'upgrader_process_complete', 'rocket_maybe_reset_opcache', 20, 2 );
-
-/**
  * Reset PHP opcache.
  *
  * @since  3.1

--- a/inc/deprecated/3.10.php
+++ b/inc/deprecated/3.10.php
@@ -7,3 +7,45 @@ class_alias( '\WP_Rocket\Engine\Admin\Database\Optimization','\WP_Rocket\Admin\D
 class_alias( '\WP_Rocket\Engine\Admin\Database\OptimizationProcess','\WP_Rocket\Admin\Database\Optimization_Process'  );
 class_alias( '\WP_Rocket\Engine\Admin\Database\ServiceProvider','\WP_Rocket\ServiceProvider\Database' );
 class_alias( '\WP_Rocket\Engine\Admin\Database\Subscriber','\WP_Rocket\Subscriber\Admin\Database\Optimization_Subscriber' );
+
+/**
+ * Maybe reset opcache after WP Rocket update.
+ *
+ * @since 3.10.8 deprecated
+ * @since  3.1
+ * @author Grégory Viguier
+ *
+ * @param object $wp_upgrader Plugin_Upgrader instance.
+ * @param array  $hook_extra  {
+ *     Array of bulk item update data.
+ *
+ *     @type string $action  Type of action. Default 'update'.
+ *     @type string $type    Type of update process. Accepts 'plugin', 'theme', 'translation', or 'core'.
+ *     @type bool   $bulk    Whether the update process is a bulk update. Default true.
+ *     @type array  $plugins Array of the basename paths of the plugins' main files.
+ * }
+ */
+function rocket_maybe_reset_opcache( $wp_upgrader, $hook_extra ) {
+	_deprecated_function( __FUNCTION__ . '()', '3.10.8' );
+	static $rocket_path;
+
+	if ( ! isset( $hook_extra['action'], $hook_extra['type'], $hook_extra['plugins'] ) ) {
+		return;
+	}
+
+	if ( 'update' !== $hook_extra['action'] || 'plugin' !== $hook_extra['type'] || ! is_array( $hook_extra['plugins'] ) ) {
+		return;
+	}
+
+	$plugins = array_flip( $hook_extra['plugins'] );
+
+	if ( ! isset( $rocket_path ) ) {
+		$rocket_path = plugin_basename( WP_ROCKET_FILE );
+	}
+
+	if ( ! isset( $plugins[ $rocket_path ] ) ) {
+		return;
+	}
+
+	rocket_reset_opcache();
+}


### PR DESCRIPTION
## Description

Deprecate `rocket_maybe_reset_opcache()`, as the OPCache invalidation on plugin update is handled by WP core directly since v5.5. It will also avoid clearing the whole OPCache at that time, when only the cache for the plugin was needed to be deleted.

Fixes #2950

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

No grooming done, it's a very small change

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
