### PR TITLE
Closes #4640 Disable OPCache purge if using file_cache_only

### DIFF
--- a/inc/admin/upgrader.php
+++ b/inc/admin/upgrader.php
@@ -99,8 +99,7 @@ add_action( 'upgrader_process_complete', 'rocket_maybe_reset_opcache', 20, 2 );
 /**
  * Reset PHP opcache.
  *
- * @since  3.1
- * @author Grégory Viguier
+ * @since 3.1
  */
 function rocket_reset_opcache() {
 	static $can_reset;
@@ -109,7 +108,6 @@ function rocket_reset_opcache() {
 	 * Triggers before WP Rocket tries to reset OPCache
 	 *
 	 * @since 3.2.5
-	 * @author Remy Perona
 	 */
 	do_action( 'rocket_before_reset_opcache' );
 
@@ -117,6 +115,10 @@ function rocket_reset_opcache() {
 		if ( ! function_exists( 'opcache_reset' ) ) {
 			$can_reset = false;
 
+			return false;
+		}
+
+		if ( true === (bool) ini_get( 'opcache.file_cache_only' ) ) {
 			return false;
 		}
 
@@ -141,7 +143,6 @@ function rocket_reset_opcache() {
 	 * Triggers after WP Rocket tries to reset OPCache
 	 *
 	 * @since 3.2.5
-	 * @author Remy Perona
 	 */
 	do_action( 'rocket_after_reset_opcache' );
 

--- a/inc/common/admin-bar.php
+++ b/inc/common/admin-bar.php
@@ -177,12 +177,13 @@ function rocket_admin_bar( $wp_admin_bar ) {
 		 */
 		$opcache_enabled  = filter_var( ini_get( 'opcache.enable' ), FILTER_VALIDATE_BOOLEAN );
 		$restrict_api     = ini_get( 'opcache.restrict_api' );
+		$file_cache_only  = ini_get( 'opcache.file_cache_only' );
 		$can_restrict_api = true;
 		if ( $restrict_api && strpos( __FILE__, $restrict_api ) !== 0 ) {
 			$can_restrict_api = false;
 		}
 
-		if ( function_exists( 'opcache_reset' ) && $opcache_enabled && $can_restrict_api ) {
+		if ( function_exists( 'opcache_reset' ) && $opcache_enabled && $can_restrict_api && ! $file_cache_only ) {
 			$action = 'rocket_purge_opcache';
 
 			$wp_admin_bar->add_menu(

--- a/views/settings/page-sections/dashboard.php
+++ b/views/settings/page-sections/dashboard.php
@@ -173,11 +173,12 @@ defined( 'ABSPATH' ) || exit;
 					<?php
 					$opcache_enabled  = filter_var( ini_get( 'opcache.enable' ), FILTER_VALIDATE_BOOLEAN ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
 					$restrict_api     = ini_get( 'opcache.restrict_api' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+					$file_cache_only  = ini_get( 'opcache.file_cache_only' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
 					$can_restrict_api = true; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
 					if ( $restrict_api && strpos( __FILE__, $restrict_api ) !== 0 ) {
 						$can_restrict_api = false; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
 					}
-					if ( function_exists( 'opcache_reset' ) && $opcache_enabled && current_user_can( 'rocket_purge_opcache' ) && $can_restrict_api ) :
+					if ( function_exists( 'opcache_reset' ) && $opcache_enabled && current_user_can( 'rocket_purge_opcache' ) && $can_restrict_api && ! $file_cache_only ) :
 						?>
 					<div class="wpr-field">
 						<h4 class="wpr-title3"><?php esc_html_e( 'Purge OPCache content', 'rocket' ); ?></h4>


### PR DESCRIPTION
## Description

`opcache_reset()` can only purge cache in memory. When using the `file_cache_only` directive, it has no effect.

To avoid unexpected results in the plugin when using the purge OPCache function, we prevent display of purge links when OPCache is using `file_cache_only`.

Fixes #4640 

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)


## Is the solution different from the one proposed during the grooming?

No

## How Has This Been Tested?

- [x] This can be tested by changing the `file_cache_only` PHP configuration value 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
