### PR TITLE
Closes #3520 Exclude PWA service worker URL from cache

### DIFF
--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -289,6 +289,7 @@ class Plugin {
 			'revolution_slider_subscriber',
 			'wordfence_subscriber',
 			'ezoic',
+			'pwa',
 		];
 
 		$host_type = HostResolver::get_host_service();

--- a/inc/ThirdParty/Plugins/PWA.php
+++ b/inc/ThirdParty/Plugins/PWA.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\ThirdParty\Plugins;
+
+use WP_Rocket\Event_Management\Subscriber_Interface;
+
+class PWA implements Subscriber_Interface {
+	/**
+	 * Subscribed events.
+	 */
+	public static function get_subscribed_events() {
+		return [
+			'rocket_cache_reject_uri' => 'exclude_service_worker',
+		];
+	}
+
+	/**
+	 * Excludes the PWA service worker URL
+	 *
+	 * @param array $excluded Array of excluded URLs.
+	 *
+	 * @return array
+	 */
+	public function exclude_service_worker( $excluded ): array {
+		if ( ! function_exists( 'wp_get_service_worker_url' ) ) {
+			return $excluded;
+		}
+
+		$excluded[] = '/wp.serviceworker';
+
+		return $excluded;
+	}
+}

--- a/inc/ThirdParty/Plugins/PWA.php
+++ b/inc/ThirdParty/Plugins/PWA.php
@@ -27,7 +27,7 @@ class PWA implements Subscriber_Interface {
 			return $excluded;
 		}
 
-		$excluded[] = '/wp.serviceworker';
+		$excluded[] = '/wp.serviceworker/?';
 
 		return $excluded;
 	}

--- a/inc/ThirdParty/ServiceProvider.php
+++ b/inc/ThirdParty/ServiceProvider.php
@@ -45,6 +45,7 @@ class ServiceProvider extends AbstractServiceProvider {
 		'revolution_slider_subscriber',
 		'wordfence_subscriber',
 		'ezoic',
+		'pwa',
 	];
 
 	/**
@@ -148,6 +149,9 @@ class ServiceProvider extends AbstractServiceProvider {
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
 			->share( 'ezoic', 'WP_Rocket\ThirdParty\Plugins\Optimization\Ezoic' )
+			->addTag( 'common_subscriber' );
+		$this->getContainer()
+			->share( 'pwa', 'WP_Rocket\ThirdParty\Plugins\PWA' )
 			->addTag( 'common_subscriber' );
 	}
 }

--- a/tests/Unit/inc/ThirdParty/Plugins/PWA/excludeServiceWorker.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/PWA/excludeServiceWorker.php
@@ -34,7 +34,7 @@ class Test_ExcludeServiceWorker extends TestCase {
 
 		$this->assertSame(
 			[
-				'/wp.serviceworker',
+				'/wp.serviceworker/?',
 			],
 			$this->pwa->exclude_service_worker( [] )
 		);

--- a/tests/Unit/inc/ThirdParty/Plugins/PWA/excludeServiceWorker.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/PWA/excludeServiceWorker.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\PWA;
+
+use WP_Rocket\Tests\Unit\TestCase;
+use WP_Rocket\ThirdParty\Plugins\PWA;
+
+/**
+ * @covers \WP_Rocket\ThirdParty\Plugins\PWA::exclude_service_worker
+ *
+ * @group PWA
+ * @group ThirdParty
+ */
+class Test_ExcludeServiceWorker extends TestCase {
+	public static $function_exists = false;
+
+	private $pwa;
+
+	protected function set_up() {
+		parent::set_up();
+
+		$this->pwa = new PWA();
+	}
+
+	public function testShouldDoNothingWhenFunctionDoesNotExist() {
+		$this->assertSame(
+			[],
+			$this->pwa->exclude_service_worker( [] )
+		);
+	}
+
+	public function testShouldAddExclusionWhenFunctionExists() {
+		self::$function_exists = true;
+
+		$this->assertSame(
+			[
+				'/wp.serviceworker',
+			],
+			$this->pwa->exclude_service_worker( [] )
+		);
+	}
+}
+
+namespace WP_Rocket\ThirdParty\Plugins;
+
+function function_exists( $function ) {
+    if ( $function === 'wp_get_service_worker_url' ) {
+        return \WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\PWA\Test_ExcludeServiceWorker::$function_exists;
+    }
+
+    return \function_exists( $function );
+}


### PR DESCRIPTION
## Description

Create a compatibility file for the PWA plugin, excluding the service worker URL from cache to prevent any issue.

Fixes #3520 

## Type of change

- [x] 3rd party compatibility

## Is the solution different from the one proposed during the grooming?

A difference on the conditional check to verify if the 3rd party plugin is enabled.

## How Has This Been Tested?

- [x] Added tests to validate the change

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
