### PR TITLE
Fixes #3617 Clean busting directory when purging cache

### DIFF
--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -437,6 +437,7 @@ function do_admin_post_rocket_purge_cache() { // phpcs:ignore WordPress.NamingCo
 				if ( '' === $lang ) {
 					// Remove all minify cache files.
 					rocket_clean_minify();
+					rocket_clean_cache_busting();
 
 					// Generate a new random key for minify cache file.
 					$options                   = get_option( WP_ROCKET_SLUG );

--- a/tests/Fixtures/inc/functions/rocketCleanCacheBusting.php
+++ b/tests/Fixtures/inc/functions/rocketCleanCacheBusting.php
@@ -1,0 +1,53 @@
+<?php
+
+return [
+	'vfs_dir'   => 'wp-content/cache/busting/1/',
+
+	// Test data.
+	'test_data' => [
+		'shouldNotCleanWhenNoExtensionsGiven'     => [
+			'extensions' => '',
+			'expected'   => [
+				'cleaned' => [],
+			],
+		],
+		'shouldNotCleanWhenExtensionDoesNotExist' => [
+			'extensions' => [ 'php', 'html' ],
+			'expected'   => [
+				'cleaned' => [],
+			],
+		],
+		'shouldClean_css'                         => [
+			'extensions' => 'css',
+			'expected'   => [
+				'cleaned' => [
+					'vfs://public/wp-content/cache/busting/1/wp-content/test.css'    => null,
+					'vfs://public/wp-content/cache/busting/1/wp-content/test.css.gz' => null,
+					'vfs://public/wp-content/cache/busting/1/wp-content/'            => null,
+				],
+			],
+		],
+		'shouldClean_js'                          => [
+			'extensions' => 'js',
+			'expected'   => [
+				'cleaned'      => [
+					'vfs://public/wp-content/cache/busting/1/wp-content/test.js'    => null,
+					'vfs://public/wp-content/cache/busting/1/wp-content/test.js.gz' => null,
+					'vfs://public/wp-content/cache/busting/1/wp-content/'           => null,
+				],
+			],
+		],
+		'shouldCleanCssAndJs'                     => [
+			'extensions' => [ 'css', 'js' ],
+			'expected'   => [
+				'cleaned' => [
+					'vfs://public/wp-content/cache/busting/1/wp-content/test.js'     => null,
+					'vfs://public/wp-content/cache/busting/1/wp-content/test.js.gz'  => null,
+					'vfs://public/wp-content/cache/busting/1/wp-content/test.css'    => null,
+					'vfs://public/wp-content/cache/busting/1/wp-content/test.css.gz' => null,
+					'vfs://public/wp-content/cache/busting/1/wp-content/'            => null,
+				],
+			],
+		],
+	],
+];

--- a/tests/Fixtures/vfs-structure/default.php
+++ b/tests/Fixtures/vfs-structure/default.php
@@ -8,6 +8,10 @@ return [
 			'busting'      => [
 				'1' => [
 					'ga-123456.js' => '',
+					'test.css'     => '',
+					'test.css.gz'  => '',
+					'test.js'      => '',
+					'test.js.gz'   => '',
 				],
 			],
 			// CPCSS cache.

--- a/tests/Integration/inc/functions/rocketCleanCacheBusting.php
+++ b/tests/Integration/inc/functions/rocketCleanCacheBusting.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\Functions;
+
+use WP_Rocket\Tests\Integration\FilesystemTestCase;
+
+/**
+ * @covers ::rocket_clean_cache_busting
+ * @uses  ::rocket_direct_filesystem
+ *
+ * @group Functions
+ * @group Files
+ * @group vfs
+ */
+class Test_RocketCleanCacheBusting extends FilesystemTestCase {
+	protected $path_to_test_data = '/inc/functions/rocketCleanCacheBusting.php';
+
+	/**
+	 * @dataProvider providerTestData
+	 */
+	public function testShouldCleanMinified( $extensions, $expected ) {
+		$this->dumpResults = isset( $expected['dump_results'] ) ? $expected['dump_results'] : false;
+		$this->generateEntriesShouldExistAfter( $expected['cleaned'] );
+
+		// Run it.
+		rocket_clean_cache_busting( $extensions );
+
+		$this->checkEntriesDeleted( $expected['cleaned'] );
+		$this->checkShouldNotDeleteEntries();
+	}
+}

--- a/tests/StubTrait.php
+++ b/tests/StubTrait.php
@@ -116,6 +116,9 @@ trait StubTrait {
 			case 'WP_ROCKET_MINIFY_CACHE_URL':
 				return 'http://example.org/wp-content/cache/min/';
 
+			case 'WP_ROCKET_CACHE_BUSTING_PATH':
+				return "{$this->wp_content_dir}/cache/busting/";
+
 			case 'WP_ROCKET_PATH':
 				return "{$this->wp_content_dir}/plugins/wp-rocket/";
 

--- a/tests/Unit/inc/functions/rocketCleanCacheBusting.php
+++ b/tests/Unit/inc/functions/rocketCleanCacheBusting.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\functions;
+
+use Brain\Monkey\Actions;
+use Brain\Monkey\Functions;
+use WP_Rocket\Tests\Unit\FilesystemTestCase;
+
+/**
+ * @covers ::rocket_clean_cache_busting
+ * @uses  ::rocket_direct_filesystem
+ *
+ * @group Functions
+ * @group Files
+ * @group vfs
+ */
+class Test_RocketCleanCacheBusting extends FilesystemTestCase {
+	protected $path_to_test_data = '/inc/functions/rocketCleanCacheBusting.php';
+	private   $valid_extensions  = [ 'css', 'css.gz', 'js', 'js.gz' ];
+
+	public function setUp(): void {
+		parent::setUp();
+
+		Functions\when( 'get_current_blog_id' )->justReturn( 1 );
+	}
+
+	/**
+	 * @dataProvider providerTestData
+	 */
+	public function testShouldCleanBustingFiles( $extensions, $expected ) {
+		$this->dumpResults = isset( $expected['dump_results'] ) ? $expected['dump_results'] : false;
+		$this->generateEntriesShouldExistAfter( $expected['cleaned'] );
+
+		foreach ( (array) $extensions as $ext ) {
+			if ( ! in_array( $ext, $this->valid_extensions, true ) ) {
+				continue;
+			}
+			Actions\expectDone( 'before_rocket_clean_busting' )->once()->with( $ext );
+			Actions\expectDone( 'after_rocket_clean_cache_busting' )->once()->with( $ext );
+		}
+
+		// Run it.
+		rocket_clean_cache_busting( $extensions );
+
+		$this->checkEntriesDeleted( $expected['cleaned'] );
+		$this->checkShouldNotDeleteEntries();
+	}
+}


### PR DESCRIPTION
## Description

Add a call to `rocket_clean_cache_busting()` when purging the whole cache, to make sure it's updated correctly.

Fixes #3617 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

No

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
