### PR TITLE
Fix some failing integration tests where current screen is not set

### DIFF
--- a/tests/Fixtures/inc/ThirdParty/Plugins/ModPagespeed/showAdminNotice.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/ModPagespeed/showAdminNotice.php
@@ -19,7 +19,8 @@ return [
 
 	'shouldNotShowNoticeWhenNoCapability' => [
 		'config' => [
-			'capability' => false,
+			'capability'     => false,
+			'current_screen' => 'front'
 		],
 		'expected' => [
 			'show_notice' => 0,

--- a/tests/Integration/inc/Engine/CriticalPath/Admin/Subscriber/enqueueAdminCpcssHeartbeatScript.php
+++ b/tests/Integration/inc/Engine/CriticalPath/Admin/Subscriber/enqueueAdminCpcssHeartbeatScript.php
@@ -39,6 +39,7 @@ class Test_EnqueueAdminCpcssHeartbeatScript extends TestCase {
 	 */
 	public function testShouldEnqueueAdminScript( $config, $expected ) {
 		wp_set_current_user( static::$user_id );
+		set_current_screen( 'post.php' );
 
 		Functions\when( 'wp_create_nonce' )->justReturn( 'wp_cpcss_heartbeat_nonce' );
 


### PR DESCRIPTION
## Description

Some tests were failing because the current screen was not set, so the `get_current_screen()` function was returning a null/non-object.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
