### PR TITLE
Fixes #4492 Exclude Jetpack's lazyload library from delay JS execution

### DIFF
--- a/inc/Engine/Optimization/DelayJS/HTML.php
+++ b/inc/Engine/Optimization/DelayJS/HTML.php
@@ -69,7 +69,7 @@ class HTML {
 		'/gravityforms/js/conditional_logic.min.js', // Gravity forms conditions.
 		'statcounter.com/counter/counter.js', // StatsCounter.
 		'var sc_project', // Statscounter.
-		'/jetpack/jetpack_vendor/automattic/jetpack-lazy-images/(.*)', //Jetpack plugin lazyload.
+		'/jetpack/jetpack_vendor/automattic/jetpack-lazy-images/(.*)', // Jetpack plugin lazyload.
 	];
 
 	/**

--- a/inc/Engine/Optimization/DelayJS/HTML.php
+++ b/inc/Engine/Optimization/DelayJS/HTML.php
@@ -69,6 +69,7 @@ class HTML {
 		'/gravityforms/js/conditional_logic.min.js', // Gravity forms conditions.
 		'statcounter.com/counter/counter.js', // StatsCounter.
 		'var sc_project', // Statscounter.
+		'/jetpack/jetpack_vendor/automattic/jetpack-lazy-images/(.*)', //Jetpack plugin lazyload.
 	];
 
 	/**


### PR DESCRIPTION
## Description

I've added the following in the automatic exclusion's list:
`/jetpack/jetpack_vendor/automattic/jetpack-lazy-images/(.*)`

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

This hasn't been groomed.

## How Has This Been Tested?

- [x] On the customer's website, where [Jetpack 10.5.1](https://wordpress.org/plugins/jetpack/) was installed.

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
