### PR TITLE
Preload mobile homepage after changing options that require a cache purge

### DIFF
--- a/inc/Engine/Preload/PreloadSubscriber.php
+++ b/inc/Engine/Preload/PreloadSubscriber.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace WP_Rocket\Engine\Preload;
 
@@ -6,19 +7,10 @@ use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\Optimization\RUCSS\Warmup\Status\Checker;
 use WP_Rocket\Event_Management\Subscriber_Interface;
 
-/**
- * Preload Subscriber
- *
- * @since 3.2
- * @author Remy Perona
- */
 class PreloadSubscriber implements Subscriber_Interface {
 
 	/**
 	 * Homepage Preload instance
-	 *
-	 * @since 3.2
-	 * @author Remy Perona
 	 *
 	 * @var Homepage
 	 */
@@ -26,9 +18,6 @@ class PreloadSubscriber implements Subscriber_Interface {
 
 	/**
 	 * WP Rocket Options instance.
-	 *
-	 * @since 3.2
-	 * @author Remy Perona
 	 *
 	 * @var Options_Data
 	 */
@@ -44,9 +33,6 @@ class PreloadSubscriber implements Subscriber_Interface {
 	/**
 	 * Constructor.
 	 *
-	 * @since 3.2
-	 * @author Remy Perona
-	 *
 	 * @param Homepage     $homepage_preloader Homepage Preload instance.
 	 * @param Options_Data $options            WP Rocket Options instance.
 	 * @param Checker      $checker            Pre-Warmup Status Checker.
@@ -59,9 +45,6 @@ class PreloadSubscriber implements Subscriber_Interface {
 
 	/**
 	 * Return an array of events that this subscriber wants to listen to.
-	 *
-	 * @since  3.2
-	 * @author Remy Perona
 	 *
 	 * @return array
 	 */
@@ -84,6 +67,7 @@ class PreloadSubscriber implements Subscriber_Interface {
 			],
 			'admin_post_rocket_rollback'             => [ 'stop_homepage_preload', 9 ],
 			'wp_rocket_upgrade'                      => [ 'stop_homepage_preload', 9 ],
+			'rocket_options_changed'                 => 'preload_homepage'
 		];
 	}
 
@@ -91,9 +75,9 @@ class PreloadSubscriber implements Subscriber_Interface {
 	 * Launches the homepage preload
 	 *
 	 * @since 3.2
-	 * @author Remy Perona
 	 *
 	 * @param string $lang The language code to preload.
+	 *
 	 * @return void
 	 */
 	protected function preload( $lang = '' ) {
@@ -110,7 +94,8 @@ class PreloadSubscriber implements Subscriber_Interface {
 	 * Launches the homepage preload if the option is active
 	 *
 	 * @since 3.2
-	 * @author Remy Perona
+	 *
+	 * @return void
 	 */
 	public function run_preload() {
 		if ( ! $this->options->get( 'manual_preload' ) ) {
@@ -125,10 +110,10 @@ class PreloadSubscriber implements Subscriber_Interface {
 	 * Cancels any preload currently running if the option is deactivated
 	 *
 	 * @since 3.2
-	 * @author Remy Perona
 	 *
 	 * @param array $old_value Previous option values.
 	 * @param array $value     New option values.
+	 *
 	 * @return void
 	 */
 	public function maybe_cancel_preload( $old_value, $value ) {
@@ -142,10 +127,10 @@ class PreloadSubscriber implements Subscriber_Interface {
 	 * Launches the preload if the option is activated
 	 *
 	 * @since 3.2
-	 * @author Remy Perona
 	 *
 	 * @param array $old_value Previous option values.
 	 * @param array $value     New option values.
+	 *
 	 * @return void
 	 */
 	public function maybe_launch_preload( $old_value, $value ) {
@@ -206,11 +191,12 @@ class PreloadSubscriber implements Subscriber_Interface {
 	 * After automatically preloading the homepage (after purging the cache), also preload the homepage for mobile.
 	 *
 	 * @since  3.5
-	 * @author Grégory Viguier
 	 *
 	 * @param string $home_url URL to the homepage being preloaded.
 	 * @param string $lang     The lang of the homepage.
 	 * @param array  $args     Arguments used for the preload request.
+	 *
+	 * @return void
 	 */
 	public function maybe_preload_mobile_homepage( $home_url, $lang, $args ) {
 		if ( ! $this->homepage_preloader->is_mobile_preload_enabled() ) {
@@ -230,7 +216,8 @@ class PreloadSubscriber implements Subscriber_Interface {
 	 * This notice is displayed when the preload is triggered from a different page than WP Rocket settings page
 	 *
 	 * @since 3.2
-	 * @author Remy Perona
+	 *
+	 * @return void
 	 */
 	public function notice_preload_triggered() {
 		if ( ! current_user_can( 'rocket_preload_cache' ) ) {
@@ -272,7 +259,8 @@ class PreloadSubscriber implements Subscriber_Interface {
 	 * This notice is displayed when the preload is running
 	 *
 	 * @since 3.2
-	 * @author Remy Perona
+	 *
+	 * @return void
 	 */
 	public function notice_preload_running() {
 		if ( ! current_user_can( 'rocket_preload_cache' ) ) {
@@ -326,7 +314,8 @@ class PreloadSubscriber implements Subscriber_Interface {
 	 * This notice is displayed after the sitemap preload is complete
 	 *
 	 * @since 3.2
-	 * @author Remy Perona
+	 *
+	 * @return void
 	 */
 	public function notice_preload_complete() {
 		if ( ! current_user_can( 'rocket_preload_cache' ) ) {
@@ -370,7 +359,8 @@ class PreloadSubscriber implements Subscriber_Interface {
 	 * Stops currently running preload from the notice action button
 	 *
 	 * @since 3.2
-	 * @author Remy Perona
+	 *
+	 * @return void
 	 */
 	public function do_admin_post_stop_preload() {
 		if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( sanitize_key( $_GET['_wpnonce'] ), 'rocket_stop_preload' ) ) {
@@ -397,5 +387,42 @@ class PreloadSubscriber implements Subscriber_Interface {
 	 */
 	public function stop_homepage_preload() {
 		$this->homepage_preloader->cancel_preload();
+	}
+
+	/**
+	 * Preloads the homepage (desktop & mobile if enabled)
+	 *
+	 * @since 3.11
+	 *
+	 * @param array $value An array of submitted values for the settings.
+	 *
+	 * @return void
+	 */
+	public function preload_homepage( $value ) {
+		wp_safe_remote_get(
+			home_url(),
+			[
+				'timeout'    => 0.01,
+				'blocking'   => false,
+				'user-agent' => 'WP Rocket/Homepage Preload',
+				'sslverify'  => apply_filters( 'https_local_ssl_verify', false ), // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+			]
+		);
+
+		if (
+			isset( $value['do_caching_mobile_files'] )
+			&&
+			1 === $value['do_caching_mobile_files']
+		) {
+			wp_safe_remote_get(
+				home_url(),
+				[
+					'timeout'    => 0.01,
+					'blocking'   => false,
+					'user-agent' => $this->homepage_preloader->get_mobile_user_agent_prefix() . ' WP Rocket/Homepage Preload',
+					'sslverify'  => apply_filters( 'https_local_ssl_verify', false ), // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+				]
+			);
+		}
 	}
 }

--- a/inc/Engine/Preload/PreloadSubscriber.php
+++ b/inc/Engine/Preload/PreloadSubscriber.php
@@ -67,7 +67,7 @@ class PreloadSubscriber implements Subscriber_Interface {
 			],
 			'admin_post_rocket_rollback'             => [ 'stop_homepage_preload', 9 ],
 			'wp_rocket_upgrade'                      => [ 'stop_homepage_preload', 9 ],
-			'rocket_options_changed'                 => 'preload_homepage'
+			'rocket_options_changed'                 => 'preload_homepage',
 		];
 	}
 

--- a/inc/admin/options.php
+++ b/inc/admin/options.php
@@ -62,15 +62,14 @@ function rocket_after_save_options( $oldvalue, $value ) {
 		// Purge all cache files.
 		rocket_clean_domain();
 
-		wp_remote_get(
-			home_url(),
-			[
-				'timeout'    => 0.01,
-				'blocking'   => false,
-				'user-agent' => 'WP Rocket/Homepage Preload',
-				'sslverify'  => apply_filters( 'https_local_ssl_verify', false ), // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
-			]
-		);
+		/**
+		 * Fires after WP Rocket options that require a cache purge have changed
+		 *
+		 * @since 3.11
+		 *
+		 * @param array $value An array of submitted values for the settings.
+		 */
+		do_action( 'rocket_options_changed', $value );
 	}
 
 	// phpcs:ignore WordPress.Security.NonceVerification.Missing

--- a/tests/Unit/inc/Engine/Preload/PreloadSubscriber/preloadHomepage.php
+++ b/tests/Unit/inc/Engine/Preload/PreloadSubscriber/preloadHomepage.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\Preload\PreloadSubscriber;
+
+use Mockery;
+use Brain\Monkey\Functions;
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Engine\Optimization\RUCSS\Warmup\Status\Checker;
+use WP_Rocket\Engine\Preload\Homepage;
+use WP_Rocket\Engine\Preload\PreloadSubscriber;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Preload\PreloadSubscriber::preload_homepage
+ *
+ * @group  Preload
+ */
+class Test_PreloadHomepage extends TestCase {
+	private $subscriber;
+	private $homepage_preloader;
+	private $home_url   = 'https://example.org/';
+	private $user_agent = 'WP Rocket/Homepage Preload';
+	private $prefix     = 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1';
+
+	protected function set_up() {
+		parent::set_up();
+
+		$this->homepage_preloader = Mockery::mock( Homepage::class );
+		$this->subscriber         = new PreloadSubscriber(
+			$this->homepage_preloader,
+			Mockery::mock( Options_Data::class ),
+			Mockery::mock( Checker::class )
+		);
+
+		Functions\when( 'home_url' )->justReturn( $this->home_url );
+	}
+
+	public function testShouldPreloadDesktopHomepageOnly() {
+		Functions\expect( 'wp_safe_remote_get' )
+			->once()
+			->with(
+				$this->home_url,
+				[
+					'timeout'    => 0.01,
+					'blocking'   => false,
+					'user-agent' => $this->user_agent,
+					'sslverify'  => false,
+				]
+			);
+
+		$this->subscriber->preload_homepage( [] );
+	}
+
+	public function testShouldPreloadDesktopAndMobileHomepage() {
+		$this->homepage_preloader
+			->shouldReceive( 'get_mobile_user_agent_prefix' )
+			->once()
+			->andReturn( $this->prefix );
+
+		Functions\expect( 'wp_safe_remote_get' )
+			->once()
+			->with(
+				$this->home_url,
+				[
+					'timeout'    => 0.01,
+					'blocking'   => false,
+					'user-agent' => $this->user_agent,
+					'sslverify'  => false,
+				]
+			);
+
+		Functions\expect( 'wp_safe_remote_get' )
+			->once()
+			->with(
+				$this->home_url,
+				[
+					'timeout'    => 0.01,
+					'blocking'   => false,
+					'user-agent' => $this->prefix . ' ' . $this->user_agent,
+					'sslverify'  => false,
+				]
+			);
+
+		$this->subscriber->preload_homepage(
+			[
+				'do_caching_mobile_files' => 1,
+			]
+		);
+	}
+}

--- a/tests/Unit/inc/admin/rocketAfterSaveOptions.php
+++ b/tests/Unit/inc/admin/rocketAfterSaveOptions.php
@@ -54,19 +54,6 @@ class Test_RocketAfterSaveOptions extends FilesystemTestCase {
 	private function rocket_clean_domain() {
 		if ( isset( $this->expected['rocket_clean_domain'] ) ) {
 			Functions\expect( 'rocket_clean_domain' )->once()->andReturnNull();
-			Functions\expect( 'home_url' )->andReturn( 'http://example.org' );
-			Functions\expect( 'wp_remote_get' )
-				->once()
-				->with(
-					'http://example.org',
-					[
-						'timeout'    => 0.01,
-						'blocking'   => false,
-						'user-agent' => 'WP Rocket/Homepage Preload',
-						'sslverify'  => false,
-					]
-				)
-				->andReturnNull();
 		} else {
 			Functions\expect( 'rocket_clean_domain' )->never();
 		}


### PR DESCRIPTION
## Description

In this PR, we add the preloading of the mobile homepage after changing options that require a cache purge. To do so, it adds a new filter `rocket_options_changed`, and a new callback method in the preload subscriber.

This only applies if the option for a separate cache for mobile is enabled.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## How Has This Been Tested?

- [x] Manual testing by changing options and checking the generation of the cache files
- [x] Unit tests added for the new method 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
