### PR TITLE
Update the container dependency & move psr/container to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,8 +37,7 @@
 	"require": {
 		"php": ">=7.0",
 		"composer/installers": "~1.0",
-		"monolog/monolog": "^1.0",
-		"psr/container": "1.0.0"
+		"monolog/monolog": "^1.0"
 	},
 	"require-dev": {
 		"php": "^7 || ^8",
@@ -53,6 +52,7 @@
 		"phpstan/phpstan": "^0.12",
 		"phpunit/phpunit": "^7.5",
 		"phpunit/php-file-iterator": "2.0.3",
+		"psr/container": "1.0.0",
 		"roave/security-advisories": "dev-master",
 		"szepeviktor/phpstan-wordpress": "^0.7.0",
 		"wp-coding-standards/wpcs": "^2",

--- a/inc/Dependencies/League/Container/Container.php
+++ b/inc/Dependencies/League/Container/Container.php
@@ -191,7 +191,7 @@ class Container implements ContainerInterface
     /**
      * {@inheritdoc}
      */
-    public function has($id) : bool
+    public function has($id)
     {
         if ($this->definitions->has($id)) {
             return true;

--- a/inc/Dependencies/League/Container/ReflectionContainer.php
+++ b/inc/Dependencies/League/Container/ReflectionContainer.php
@@ -47,6 +47,12 @@ class ReflectionContainer implements ArgumentResolverInterface, ContainerInterfa
         $reflector = new ReflectionClass($id);
         $construct = $reflector->getConstructor();
 
+        if ($construct && !$construct->isPublic()) {
+            throw new NotFoundException(
+                sprintf('Alias (%s) has a non-public constructor and therefore cannot be instantiated', $id)
+            );
+        }
+
         $resolution = $construct === null
             ? new $id
             : $resolution = $reflector->newInstanceArgs($this->reflectArguments($construct, $args))
@@ -62,7 +68,7 @@ class ReflectionContainer implements ArgumentResolverInterface, ContainerInterfa
     /**
      * {@inheritdoc}
      */
-    public function has($id) : bool
+    public function has($id)
     {
         return class_exists($id);
     }


### PR DESCRIPTION
## Description

This PR moves the `psr/container` dependency to `require-dev`, as it doesn't need to be part of the global `require` (the files are already moved by Mozart).

It also updates the container dependency to the latest minor version.

Fixes #4244 

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

No grooming done

## How Has This Been Tested?

- [x] Checked that the plugin is still running correctly

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
