### PR TITLE
Exclude snapppt.com domain from Minify JS

### DIFF
--- a/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
+++ b/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
@@ -255,6 +255,7 @@ abstract class AbstractJSOptimization extends AbstractOptimization {
 			'voucher.getavo.it/public/js/yanovis.Voucher.js',
 			'js-eu1.hsforms.net',
 			'statcounter.com/counter/counter.js',
+			'snapppt.com',
 		];
 
 		$excluded_external = array_merge( $defaults, $this->options->get( 'exclude_js', [] ) );


### PR DESCRIPTION
fixes #4720

## Description

Resolves issues with snapppt.com embeds.

Fixes #4720 

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?
n/a

## How Has This Been Tested?

Tested by the developers of the widget.
Ticket: https://secure.helpscout.net/conversation/1780561644/324712?folderId=3864740

The exclusion itself was tested on my testing site. The script from snapppt.com is successfully excluded.

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
