### PR TITLE
Revise logic for determining AMP or Web Story page in AMP compatibility mode.

### DIFF
--- a/inc/ThirdParty/Plugins/Optimization/AMP.php
+++ b/inc/ThirdParty/Plugins/Optimization/AMP.php
@@ -112,7 +112,7 @@ class AMP implements Subscriber_Interface {
 		if ( ! function_exists( 'is_amp_endpoint' ) || ! is_amp_endpoint()
 			||
 			// Web stories uses this condition as a substitute function for is_amp_endpoint().
-			// As it is not yet registered when we get here, we do our own check.
+			// When both plugins are active, we have the AMP version, so we do our own check for web-stories.
 			 ( is_plugin_active('web-stories') && ! ( is_singular( 'web-story' ) && ! is_embed() && ! post_password_required() ) )
 		) {
 			return;

--- a/inc/ThirdParty/Plugins/Optimization/AMP.php
+++ b/inc/ThirdParty/Plugins/Optimization/AMP.php
@@ -109,7 +109,12 @@ class AMP implements Subscriber_Interface {
 	 * @since  3.5.2
 	 */
 	public function disable_options_on_amp() {
-		if ( ! function_exists( 'is_amp_endpoint' ) || ! is_amp_endpoint() ) {
+		if ( ! function_exists( 'is_amp_endpoint' ) || ! is_amp_endpoint()
+			||
+			// Web stories uses this condition as a substitute function for is_amp_endpoint().
+			// As it is not yet registered when we get here, we do our own check.
+			! ( is_singular( 'web-stories' ) && ! is_embed() && ! post_password_required() )
+		) {
 			return;
 		}
 

--- a/inc/ThirdParty/Plugins/Optimization/AMP.php
+++ b/inc/ThirdParty/Plugins/Optimization/AMP.php
@@ -115,14 +115,14 @@ class AMP implements Subscriber_Interface {
 		}
 
 		// We can get a false negative from is_amp_endpoint when web stories is active, so we have to make sure neither is in play.
-		if ( ! is_amp_endpoint() && ! is_plugin_active( 'web-stories' ) ) {
+		if ( ! is_amp_endpoint() && ! is_plugin_active( 'web-stories/web-stories.php' ) ) {
 			return;
 		}
 
 		// We don't know yet whether we made it this far because AMP's endpoint check passed or if it's a webstories thing.
 		// If web stories is active BUT this is NOT a web story singular page, we bail out now.
 		if (
-			is_plugin_active( 'web-stories' )
+			is_plugin_active( 'web-stories/web-stories.php' )
 			&&
 			! ( is_singular( 'web-story' ) && ! is_embed() && ! post_password_required() )
 			) {

--- a/inc/ThirdParty/Plugins/Optimization/AMP.php
+++ b/inc/ThirdParty/Plugins/Optimization/AMP.php
@@ -113,7 +113,7 @@ class AMP implements Subscriber_Interface {
 			||
 			// Web stories uses this condition as a substitute function for is_amp_endpoint().
 			// As it is not yet registered when we get here, we do our own check.
-			! ( is_singular( 'web-story' ) && ! is_embed() && ! post_password_required() )
+			 ( is_plugin_active('web-stories') && ! ( is_singular( 'web-story' ) && ! is_embed() && ! post_password_required() ) )
 		) {
 			return;
 		}

--- a/inc/ThirdParty/Plugins/Optimization/AMP.php
+++ b/inc/ThirdParty/Plugins/Optimization/AMP.php
@@ -113,7 +113,7 @@ class AMP implements Subscriber_Interface {
 			||
 			// Web stories uses this condition as a substitute function for is_amp_endpoint().
 			// As it is not yet registered when we get here, we do our own check.
-			! ( is_singular( 'web-stories' ) && ! is_embed() && ! post_password_required() )
+			! ( is_singular( 'web-story' ) && ! is_embed() && ! post_password_required() )
 		) {
 			return;
 		}

--- a/inc/ThirdParty/Plugins/Optimization/AMP.php
+++ b/inc/ThirdParty/Plugins/Optimization/AMP.php
@@ -109,12 +109,23 @@ class AMP implements Subscriber_Interface {
 	 * @since  3.5.2
 	 */
 	public function disable_options_on_amp() {
-		if ( ! function_exists( 'is_amp_endpoint' ) || ! is_amp_endpoint()
-			||
-			// Web stories uses this condition as a substitute function for is_amp_endpoint().
-			// When both plugins are active, we have the AMP version, so we do our own check for web-stories.
-			 ( is_plugin_active('web-stories') && ! ( is_singular( 'web-story' ) && ! is_embed() && ! post_password_required() ) )
-		) {
+		// No endpoint function means we're not running amp here.
+		if ( ! function_exists( 'is_amp_endpoint' ) ) {
+			return;
+		}
+
+		// We can get a false negative from is_amp_endpoint when web stories is active, so we have to make sure neither is in play.
+		if ( ! is_amp_endpoint() && ! is_plugin_active( 'web-stories' ) ) {
+			return;
+		}
+
+		// We don't know yet whether we made it this far because AMP's endpoint check passed or if it's a webstories thing.
+		// If web stories is active BUT this is NOT a web story singular page, we bail out now.
+		if (
+			is_plugin_active( 'web-stories' )
+			&&
+			! ( is_singular( 'web-story' ) && ! is_embed() && ! post_password_required() )
+			) {
 			return;
 		}
 

--- a/tests/Fixtures/inc/ThirdParty/Plugins/Optimization/AMP/disableOptionsOnAmp.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/Optimization/AMP/disableOptionsOnAmp.php
@@ -10,6 +10,47 @@ return [
 			'bailout' => true,
 		],
 	],
+	'testShouldBailOutIfNotAmpEndpointAndWebStoriesNotActive' => [
+		'config'   => [
+			'is_amp_endpoint'             => false,
+			'web-stories-active'          => false,
+			'do_cloudflare'               => 0,
+			'cloudflare_protocol_rewrite' => -1, // -1 - means Expect never
+			'do_rocket_protocol_rewrite'  => -1, // -1 - means Expect never
+			'amp_options'                 => ['theme_support' => 'standard'],
+		],
+		'expected' => [
+			'bailout'       => true,
+		]
+	],
+	'testShouldBailOutIfWebStoriesActiveButNotWebStoryPage'   => [
+		'config'   => [
+			'is_amp_endpoint'             => false,
+			'web-stories-active'          => true,
+			'do_cloudflare'               => 0,
+			'cloudflare_protocol_rewrite' => -1, // -1 - means Expect never
+			'do_rocket_protocol_rewrite'  => -1, // -1 - means Expect never
+			'amp_options'                 => ['theme_support' => 'standard'],
+		],
+		'expected' => [
+			'bailout' => true,
+		]
+	],
+	'testShouldDisableOptionsForWebStory' => [
+		'config' => [
+			'is_amp_endpoint' => false,
+			'web-stories-active' => true,
+			'is-web-story' => true,
+			'do_cloudflare'               => 0,
+			'cloudflare_protocol_rewrite' => -1, // -1 - means Expect never
+			'do_rocket_protocol_rewrite'  => -1, // -1 - means Expect never
+			'amp_options' => [ 'theme_support' => 'standard' ],
+		],
+		'expected' => [
+			'bailout' => false,
+			'remove_filter' => false,
+		]
+	],
 	'testShouldDisableOptionForAmpExceptImageSrcSet'      => [
 		'config'  => [
 			'is_amp_endpoint'             => true,

--- a/tests/Fixtures/inc/ThirdParty/Plugins/Optimization/AMP/disableOptionsOnAmpIntegration.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/Optimization/AMP/disableOptionsOnAmpIntegration.php
@@ -17,7 +17,7 @@ return [
 			'bailout' => false,
 		],
 	],
-	'testShouldDisableOptionForAmpExceptImageSrcSetAndThemeSupport'      => [
+	'testShouldDisableOptionForAmpExceptImageSrcSetAndThemeSupportTransitional'      => [
 		'config'  => [
 			'amp_options' => [ 'theme_support' => 'transitional' ],
 		],
@@ -25,7 +25,7 @@ return [
 			'bailout' => false,
 		],
 	],
-	'testShouldDisableOptionForAmpExceptImageSrcSetAndThemeSupport'      => [
+	'testShouldDisableOptionForAmpExceptImageSrcSetAndThemeSupportReader'      => [
 		'config'  => [
 			'amp_options' => [ 'theme_support' => 'reader' ],
 		],

--- a/tests/Unit/inc/ThirdParty/Plugins/Optimization/AMP/disableOptionsOnAmp.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/Optimization/AMP/disableOptionsOnAmp.php
@@ -35,6 +35,20 @@ class Test_DisableOptionsOnAmp extends TestCase {
 		Functions\expect( 'is_amp_endpoint' )
 			->once()
 			->andReturn( $config[ 'is_amp_endpoint' ]  );
+		Functions\expect( 'is_plugin_active' )
+			->atMost()->twice()
+			->with( 'web-stories' )
+			->andReturn( ! empty( $config['web-stories-active'] ) );
+		Functions\expect( 'is_singular' )
+			->atMost()->once()
+			->with( 'web-story')
+			->andReturn( ! empty( $config['is-web-story'] ) );
+		Functions\expect( 'is_embed' )
+			->atMost()->once()
+			->andReturn( false );
+		Functions\expect( 'post_password_required' )
+			->atMost()->once()
+			->andReturn( false );
 
 		if ( $expected[ 'bailout' ] ) {
 			Functions\expect( 'remove_filter' )->never();

--- a/tests/Unit/inc/ThirdParty/Plugins/Optimization/AMP/disableOptionsOnAmp.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/Optimization/AMP/disableOptionsOnAmp.php
@@ -37,7 +37,7 @@ class Test_DisableOptionsOnAmp extends TestCase {
 			->andReturn( $config[ 'is_amp_endpoint' ]  );
 		Functions\expect( 'is_plugin_active' )
 			->atMost()->twice()
-			->with( 'web-stories' )
+			->with( 'web-stories/web-stories.php' )
 			->andReturn( ! empty( $config['web-stories-active'] ) );
 		Functions\expect( 'is_singular' )
 			->atMost()->once()


### PR DESCRIPTION
This revises the way we check for whether a given page is an AMP page or a Web Stories page.

See discussion on #3879, following the previous PR.

When AMP's `is_amp_endpoint()` function is not defined, Web Stories creates it's own version of the function. Therefore, when we check the results of that function, we cannot know which version of it (and therefore which criteria) are in play.
If AMP has defined it, but this is a web story singular page, we get a false negative.

Therefore we need to check first that it is NEITHER a native AMP endpoint NOR web stories is in play. If either of those is the case:
Then, second, we need to check that if Web stories is in play, this is NOT a singular web story page.

Fixes #3879

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

This was not groomed.

## How Has This Been Tested?

- Integration tests are confirmed to still pass with these changes.
- Additional Unit Test cases concerning the bailout logic for `ThirdParty/Plugins/Optimization/Amp::disable_options_on_amp()` are added and pass.

# Checklist:

Please delete the options that are not relevant.

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes