### PR TITLE
Fixes #4701 Prevent console error when using Elementor with combine JS and user cache

### DIFF
--- a/inc/ThirdParty/Plugins/PageBuilder/Elementor.php
+++ b/inc/ThirdParty/Plugins/PageBuilder/Elementor.php
@@ -165,7 +165,7 @@ class Elementor implements Subscriber_Interface {
 			return $excluded_files;
 		}
 
-		$excluded_files[] = '/wp-includes/js/dist/hooks.min.js';
+		$excluded_files[] = '/wp-includes/js/dist/hooks(.min)?.js';
 
 		return $excluded_files;
 	}

--- a/inc/ThirdParty/Plugins/PageBuilder/Elementor.php
+++ b/inc/ThirdParty/Plugins/PageBuilder/Elementor.php
@@ -1,16 +1,14 @@
 <?php
+declare(strict_types=1);
+
 namespace WP_Rocket\ThirdParty\Plugins\PageBuilder;
 
 use WP_Rocket\Admin\Options_Data;
-use WP_Rocket\Event_Management\Subscriber_Interface;
 use WP_Rocket\Engine\Optimization\DelayJS\HTML;
-
+use WP_Rocket\Event_Management\Subscriber_Interface;
 
 /**
  * Compatibility file for Elementor plugin
- *
- * @since 3.3.1
- * @author Remy Perona
  */
 class Elementor implements Subscriber_Interface {
 	/**
@@ -37,9 +35,6 @@ class Elementor implements Subscriber_Interface {
 	/**
 	 * Constructor
 	 *
-	 * @since 3.3.1
-	 * @author Remy Perona
-	 *
 	 * @param Options_Data          $options WP Rocket options.
 	 * @param \WP_Filesystem_Direct $filesystem The Filesystem object.
 	 * @param HTML                  $delayjs_html DelayJS HTML class.
@@ -52,9 +47,6 @@ class Elementor implements Subscriber_Interface {
 
 	/**
 	 * Return an array of events that this subscriber wants to listen to.
-	 *
-	 * @since  3.3.1
-	 * @author Remy Perona
 	 *
 	 * @return array
 	 */
@@ -71,14 +63,12 @@ class Elementor implements Subscriber_Interface {
 			'update_option__elementor_global_css' => 'clear_cache',
 			'delete_option__elementor_global_css' => 'clear_cache',
 			'rocket_buffer'                       => [ 'add_fix_animation_script', 28 ],
+			'rocket_exclude_js'                   => 'exclude_js',
 		];
 	}
 
 	/**
 	 * Remove the callback to clear the cache on widget update
-	 *
-	 * @since 3.3.1
-	 * @author Remy Perona
 	 *
 	 * @return void
 	 */
@@ -88,9 +78,6 @@ class Elementor implements Subscriber_Interface {
 
 	/**
 	 * Clears WP Rocket caches if the combine CSS option is active.
-	 *
-	 * @since 3.3.1
-	 * @author Remy Perona
 	 *
 	 * @param int    $meta_id   The meta ID.
 	 * @param int    $object_id Object ID.
@@ -112,9 +99,6 @@ class Elementor implements Subscriber_Interface {
 	/**
 	 * Clear WP Rocket caches when Elementor changes the CSS
 	 *
-	 * @since 3.3.1
-	 * @author Remy Perona
-	 *
 	 * @return void
 	 */
 	public function clear_cache() {
@@ -128,9 +112,6 @@ class Elementor implements Subscriber_Interface {
 
 	/**
 	 * Checks whether elementor is set use external CSS file or not.
-	 *
-	 * @since 3.3.1
-	 * @author Remy Perona
 	 *
 	 * @return bool
 	 */
@@ -160,5 +141,32 @@ class Elementor implements Subscriber_Interface {
 		}
 
 		return $html;
+	}
+
+	/**
+	 * Excludes JS files from minify/combine JS
+	 *
+	 * @since 3.10.9
+	 *
+	 * @param array $excluded_files Array of excluded patterns.
+	 *
+	 * @return array
+	 */
+	public function exclude_js( $excluded_files ): array {
+		if ( ! $this->options->get( 'minify_concatenate_js', false ) ) {
+			return $excluded_files;
+		}
+
+		if ( ! $this->options->get( 'cache_logged_user', false ) ) {
+			return $excluded_files;
+		}
+
+		if ( ! is_user_logged_in() ) {
+			return $excluded_files;
+		}
+
+		$excluded_files[] = '/wp-includes/js/dist/hooks.min.js';
+
+		return $excluded_files;
 	}
 }

--- a/tests/Fixtures/inc/ThirdParty/Plugins/PageBuilder/Elementor/excludeJs.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/PageBuilder/Elementor/excludeJs.php
@@ -32,7 +32,7 @@ return [
 			'logged_in'  => true,
 		],
 		'expected' => [
-			'/wp-includes/js/dist/hooks.min.js',
+			'/wp-includes/js/dist/hooks(.min)?.js',
 		],
 	],
 ];

--- a/tests/Fixtures/inc/ThirdParty/Plugins/PageBuilder/Elementor/excludeJs.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/PageBuilder/Elementor/excludeJs.php
@@ -1,0 +1,38 @@
+<?php
+
+return [
+	'shouldReturnDefaultWhenCombineJSDisabled' => [
+		'config' => [
+			'combine_js' => false,
+			'user_cache' => false,
+			'logged_in'  => false,
+		],
+		'expected' => [],
+	],
+	'shouldReturnDefaultUserCacheDisabled' => [
+		'config' => [
+			'combine_js' => true,
+			'user_cache' => false,
+			'logged_in'  => false,
+		],
+		'expected' => [],
+	],
+	'shouldReturnDefaultUserNotLoggedIn' => [
+		'config' => [
+			'combine_js' => true,
+			'user_cache' => true,
+			'logged_in'  => false,
+		],
+		'expected' => [],
+	],
+	'shouldReturnUpdated' => [
+		'config' => [
+			'combine_js' => true,
+			'user_cache' => true,
+			'logged_in'  => true,
+		],
+		'expected' => [
+			'/wp-includes/js/dist/hooks.min.js',
+		],
+	],
+];

--- a/tests/Integration/inc/ThirdParty/Plugins/PageBuilder/Elementor/excludeJs.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/PageBuilder/Elementor/excludeJs.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\ThirdParty\Plugins\PageBuilder\Elementor;
+
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * @covers \WP_Rocket\ThirdParty\Plugins\PageBuilder\Elementor::exclude_js
+ *
+ * @group Elementor
+ * @group ThirdParty
+ */
+class Test_ExcludeJs extends TestCase {
+	private $combine_js = false;
+	private $user_cache = false;
+
+	public function setUp(): void {
+		$this->unregisterAllCallbacksExcept( 'rocket_buffer', 'add_fix_animation_script', 28 );
+	}
+
+	public function tearDown() {
+		remove_filter( 'pre_get_rocket_option_minify_concatenate_js', [ $this, 'set_combine_js' ] );
+		remove_filter( 'pre_get_rocket_option_cache_logged_user', [ $this, 'set_user_cache' ] );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnExpected( $config, $expected ) {
+		$this->combine_js = $config['combine_js'];
+		$this->user_cache = $config['user_cache'];
+
+		add_filter( 'pre_get_rocket_option_minify_concatenate_js', [ $this, 'set_combine_js' ] );
+		add_filter( 'pre_get_rocket_option_cache_logged_user', [ $this, 'set_user_cache' ] );
+
+		if ( $config['logged_in'] ) {
+			$user_id = $this->factory->user->create( [ 'role' => 'contributor' ] );
+			wp_set_current_user( $user_id );
+		}
+
+		$this->assertSame(
+			$expected,
+			apply_filters( 'rocket_exclude_js', [] )
+		);
+	}
+
+	public function set_combine_js() {
+		return $this->combine_js;
+	}
+
+	public function set_user_cache() {
+		return $this->user_cache;
+	}
+}

--- a/tests/Unit/inc/ThirdParty/Plugins/PageBuilder/Elementor/excludeJs.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/PageBuilder/Elementor/excludeJs.php
@@ -1,0 +1,47 @@
+<?php
+namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\PageBuilder\Elementor;
+
+use Mockery;
+use Brain\Monkey\Functions;
+use WP_Rocket\Tests\Unit\TestCase;
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Engine\Optimization\DelayJS\HTML;
+use WP_Rocket\ThirdParty\Plugins\PageBuilder\Elementor;
+
+/**
+ * @covers WP_Rocket\ThirdParty\Plugins\PageBuilder\Elementor::exclude_js
+ *
+ * @group Elementor
+ * @group ThirdParty
+ */
+class Test_ExcludeJs extends TestCase {
+	private $options;
+	private $elementor;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->options   = Mockery::mock( Options_Data::class );
+		$this->elementor = new Elementor( $this->options, null, Mockery::mock( HTML::class ));
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnExpected( $config, $expected ) {
+		$this->options->shouldReceive( 'get' )
+			->with( 'minify_concatenate_js', false )
+			->andReturn( $config['combine_js'] );
+
+		$this->options->shouldReceive( 'get' )
+			->with( 'cache_logged_user', false )
+			->andReturn( $config['user_cache'] );
+
+		Functions\when( 'is_user_logged_in' )->justReturn( $config['logged_in'] );
+
+		$this->assertSame(
+			$expected,
+			$this->elementor->exclude_js( [] )
+		);
+	}
+}


### PR DESCRIPTION
## Description

Add a new method to exclude the `hooks.min.js` file from combine JS when using:
- Elementor
- Combine JS
- User cache and the user is logged in

Fixes #4701 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

No

## How Has This Been Tested?

- [x] Added unit/integration tests for the new method

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
