### PR TITLE
Fixes #4740 Prevent cdn.jsdelivr.net/npm/hockeystack files from being stored locally

### DIFF
--- a/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
+++ b/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
@@ -256,6 +256,7 @@ abstract class AbstractJSOptimization extends AbstractOptimization {
 			'js-eu1.hsforms.net',
 			'statcounter.com/counter/counter.js',
 			'snapppt.com',
+			'cdn.jsdelivr.net/npm/hockeystack',
 		];
 
 		$excluded_external = array_merge( $defaults, $this->options->get( 'exclude_js', [] ) );


### PR DESCRIPTION
## Description

This PR excludes `cdn.jsdelivr.net/npm/hockeystack` files from being stored locally.
Fixes #4740 

## Type of change

Please delete options that are not relevant.

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

Not groomed.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] On the customer's website by adding the exclusion in WP Rocket's UI (Excluded JavaScript files text area)
- [x] On a test site, by adding the exclusion in WP Rocket's core.

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

