### PR TITLE
Fixes #4743 Prevent saving locally Gravatar Hovercards script

### DIFF
--- a/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
+++ b/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
@@ -256,6 +256,7 @@ abstract class AbstractJSOptimization extends AbstractOptimization {
 			'js-eu1.hsforms.net',
 			'statcounter.com/counter/counter.js',
 			'snapppt.com',
+			'secure.gravatar.com/js/gprofiles.js',
 		];
 
 		$excluded_external = array_merge( $defaults, $this->options->get( 'exclude_js', [] ) );


### PR DESCRIPTION
## Description

Adds the following script:
`secure.gravatar.com/js/gprofiles.js`

in the `$defaults` array of the `get_excluded_external_file_path()` method.

Fixes #4743 

## Type of change

Please delete options that are not relevant.

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

This hasn't been groomed.

## How Has This Been Tested?

- [x] On the customer's website by adding the exclusion in WP Rocket's UI (Excluded JavaScript files text area)
- [x] On a test site, by adding the exclusion in WP Rocket's core.

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
