### PR TITLE
Fixes #4770 Exclude widget.prod.faslet.net from Minify/Combine JS

### DIFF
--- a/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
+++ b/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
@@ -259,6 +259,7 @@ abstract class AbstractJSOptimization extends AbstractOptimization {
 			'use.typekit.com',
 			'secure.gravatar.com/js/gprofiles.js',
 			'cdn.jsdelivr.net/npm/hockeystack',
+			'widget.prod.faslet.net',
 		];
 
 		$excluded_external = array_merge( $defaults, $this->options->get( 'exclude_js', [] ) );


### PR DESCRIPTION
## Description

Resolves issues with widget.prod.faslet.net widget.

Fixes #4770 

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

n/a

## How Has This Been Tested?

Tested on a demo site provided by the developers of the widget.
Ticket: https://secure.helpscout.net/conversation/1790617660/326819/

The exclusion itself was tested on my testing site. The script from `widget.prod.faslet.net` is successfully excluded.
No errors in debug.

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
