### PR TITLE
Guard the backslashes before passing the css content to preg_replace

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -450,7 +450,8 @@ class UsedCSS {
 	 * @return string
 	 */
 	private function get_used_css_markup( UsedCSS_Row $used_css ): string {
-		$used_css_contents = $this->handle_charsets( $used_css->css, false );
+		$css               = str_replace( '\\', '\\\\', $used_css->css );// Guard the backslashes before passing the content to preg_replace.
+		$used_css_contents = $this->handle_charsets( $css, false );
 		return sprintf(
 			'<style id="wpr-usedcss">%s</style>',
 			$used_css_contents


### PR DESCRIPTION
## Description

This PR solves the issue of having backslashes in the CSS content like the following CSS
```
#test:before {content: '\2605';}
```

when passing this content to this line: 
https://github.com/wp-media/wp-rocket/blob/6225cafed859756a4cb7817de7cb06bbed3b14b3/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php#L372

it adds the following CSS into the page:
```
#test:before {content: '05';}
```

and this will affect all icon fonts like fontawesome and others.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Is the solution different from the one proposed during the grooming?

Not groomed, just talk about it with @Tabrisrp and @mostafa-hisham .

## How Has This Been Tested?

As described above, use mentioned CSS into the page and check the generated used CSS.

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
