### PR TITLE
Fix clearing usedcss table in random cases

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Database/Queries/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Database/Queries/UsedCSS.php
@@ -139,6 +139,7 @@ class UsedCSS extends Query {
 			'queue_name' => $queue_name,
 			'status'     => 'pending',
 			'retries'    => 0,
+			'last_accessed' => current_time( 'mysql', true ),
 		];
 		return $this->add_item( $item );
 	}

--- a/inc/Engine/Optimization/RUCSS/Database/Queries/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Database/Queries/UsedCSS.php
@@ -133,12 +133,12 @@ class UsedCSS extends Query {
 	 */
 	public function create_new_job( string $url, string $job_id, string $queue_name, bool $is_mobile = false ) {
 		$item = [
-			'url'        => untrailingslashit( $url ),
-			'is_mobile'  => $is_mobile,
-			'job_id'     => $job_id,
-			'queue_name' => $queue_name,
-			'status'     => 'pending',
-			'retries'    => 0,
+			'url'           => untrailingslashit( $url ),
+			'is_mobile'     => $is_mobile,
+			'job_id'        => $job_id,
+			'queue_name'    => $queue_name,
+			'status'        => 'pending',
+			'retries'       => 0,
 			'last_accessed' => current_time( 'mysql', true ),
 		];
 		return $this->add_item( $item );


### PR DESCRIPTION
## Description

In some cases, usedcss rows are deleted just after creation in random basis, after investigation, I found that the problem is that we don't initialize `last_accessed` column whenb creating a new row there so once the CRON that is responsible for deleting not accessed rows from DB fires, it deletes all rows as this query returns all rows in this case:

https://github.com/wp-media/wp-rocket/blob/b1d16b7bd8ddfb0a998330fea09cd3fd687fb92f/inc/Engine/Optimization/RUCSS/Database/Tables/UsedCSS.php#L84

Fixes https://github.com/wp-media/nodejs-treeshaker/issues/26

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Is the solution different from the one proposed during the grooming?

Yes

## How Has This Been Tested?

1. Enable Preload cache.
2. Enable RUCSS.
3. Wait till used CSS is completed.
4. Refresh any admin page.
5. All rows in the used CSS table shouldn't be deleted.

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
