### PR TITLE
Fixes #4804 Use absint values for width/height values when setting image dimensions of SVG files

### DIFF
--- a/inc/Engine/Media/ImageDimensions/ImageDimensions.php
+++ b/inc/Engine/Media/ImageDimensions/ImageDimensions.php
@@ -506,7 +506,7 @@ class ImageDimensions {
 			$size[0] = $width;
 			$size[1] = $height;
 			$size[2] = 0;
-			$size[3] = 'width="' . absint($width) . '" height="' . absint($height) . '"';
+			$size[3] = 'width="' . absint( $width ) . '" height="' . absint( $height ) . '"';
 
 			return $size;
 		}

--- a/inc/Engine/Media/ImageDimensions/ImageDimensions.php
+++ b/inc/Engine/Media/ImageDimensions/ImageDimensions.php
@@ -506,7 +506,7 @@ class ImageDimensions {
 			$size[0] = $width;
 			$size[1] = $height;
 			$size[2] = 0;
-			$size[3] = 'width="' . $width . '" height="' . $height . '"';
+			$size[3] = 'width="' . absint($width) . '" height="' . absint($height) . '"';
 
 			return $size;
 		}
@@ -522,7 +522,7 @@ class ImageDimensions {
 				$size[0] = $view_box[2];
 				$size[1] = $view_box[3];
 				$size[2] = 0;
-				$size[3] = 'width="' . $size[0] . '" height="' . $size[1] . '"';
+				$size[3] = 'width="' . absint($size[0]) . '" height="' . absint($size[1]) . '"';
 
 				return $size;
 			}

--- a/inc/Engine/Media/ImageDimensions/ImageDimensions.php
+++ b/inc/Engine/Media/ImageDimensions/ImageDimensions.php
@@ -522,7 +522,7 @@ class ImageDimensions {
 				$size[0] = $view_box[2];
 				$size[1] = $view_box[3];
 				$size[2] = 0;
-				$size[3] = 'width="' . absint($size[0]) . '" height="' . absint($size[1]) . '"';
+				$size[3] = 'width="' . absint( $size[0] ) . '" height="' . absint( $size[1] ) . '"';
 
 				return $size;
 			}


### PR DESCRIPTION
## Description

Display integers as width and height values for SVG (instead of decimals) to prevent errors.

Fixes #4804

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

Please describe in this section if there is any change to the solution, and why.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Load a SVG with decimals in viewBox and check DOM if width and height values are converted to integers (needs "Add Missing Image Dimensions" option enabled)

# Checklist:

Please delete the options that are not relevant.