### PR TITLE
Whitelist Dynamics TRX Addons CSS (Qwery Theme)

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -59,6 +59,7 @@ class UsedCSS {
 	 */
 	private $inline_exclusions = [
 		'rocket-lazyload-inline-css',
+		'trx_addons-inline-styles-inline-css',
 	];
 
 	/**


### PR DESCRIPTION
TRX Addons can insert a set of dynamic inline styles for their Qwery theme

Example: 
'<style type="text/css" id="trx_addons-inline-styles-inline-css">.trx_addons_inline_529971131 img.logo_image{max-height:40px;}.trx_addons_inline_440549226{width:388px;}.trx_addons_inline_1332311984 img.logo_image{max-height:40px;}.trx_addons_inline_1372596208 img.logo_image{max-height:40px;}.qwery_inline_353060239{background-image: url();}.qwery_inline_1487386268{background-image: url();}.qwery_inline_812331634{background-image: url();}.qwery_inline_1290916620{background-image: url(2022/03/IMG_6114-resized-840x473.jpg);}.qwery_inline_164226815{background-image: url();}.qwery_inline_1767828476{background-image: url();}.qwery_inline_1528500557{background-image: url();}.trx_addons_inline_1311240512 img.logo_image{max-height:40px;}</style>'

TLDR; any instance of qwery_inline_(some random number) the random number is generated on page load so when I was first using the remove unused CSS it was not loading the background images because the ID changed on the class, but the unused CSS no longer match it. I simply added this as an exclusion to resolve the issue and it worked perfectly.