### PR TITLE
Cancel queue with rocket deactivation

### DIFF
--- a/inc/Engine/Deactivation/Deactivation.php
+++ b/inc/Engine/Deactivation/Deactivation.php
@@ -90,7 +90,6 @@ class Deactivation {
 		delete_site_transient( 'wp_rocket_update_data' );
 
 		// Unschedule WP Cron events.
-		wp_clear_scheduled_hook( 'rocket_rucss_clean_rows_time_event' );
 		wp_clear_scheduled_hook( 'rocket_cache_dir_size_check' );
 
 		/**

--- a/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
@@ -102,6 +102,7 @@ class Subscriber implements Subscriber_Interface {
 			'action_scheduler_queue_runner_concurrent_batches' => 'adjust_as_concurrent_batches',
 			'pre_update_option_wp_rocket_settings' => [ 'maybe_disable_combine_css', 11, 2 ],
 			'wp_rocket_upgrade'                    => [ 'set_option_on_update', 14, 2 ],
+			'rocket_deactivation'                  => 'cancel_queues',
 		];
 	}
 
@@ -581,5 +582,20 @@ class Subscriber implements Subscriber_Interface {
 			time() + 60,
 			MINUTE_IN_SECONDS
 		);
+	}
+
+	/**
+	 * Cancel queues and crons for RUCSS.
+	 *
+	 * @return void
+	 */
+	public function cancel_queues() {
+		$this->queue->cancel_pending_jobs_cron();
+
+		if ( ! wp_next_scheduled( 'rocket_rucss_clean_rows_time_event' ) ) {
+			return;
+		}
+
+		wp_clear_scheduled_hook( 'rocket_rucss_clean_rows_time_event' );
 	}
 }


### PR DESCRIPTION
## Description

Guard against the following fatal error:
```
[10-Mar-2022 14:13:06 UTC] PHP Fatal error:  Uncaught InvalidArgumentException: The group "rocket-rucss" does not exist. in /var/www/XXX.XXX/htdocs/wp-content/plugins/woocommerce/packages/action-scheduler/classes/data-stores/ActionScheduler_wpPostStore.php:717
Stack trace:
#0 /var/www/XXX.XXX/htdocs/wp-content/plugins/woocommerce/packages/action-scheduler/classes/data-stores/ActionScheduler_wpPostStore.php(638): ActionScheduler_wpPostStore->get_actions_by_group('rocket-rucss', 25, Object(ActionScheduler_DateTime))
#1 /var/www/XXX.XXX/htdocs/wp-content/plugins/woocommerce/packages/action-scheduler/classes/data-stores/ActionScheduler_wpPostStore.php(588): ActionScheduler_wpPostStore->claim_actions('5aa4c8092c6dba7...', 25, NULL, Array, 'rocket-rucss')
#2 /var/www/XXX.XXX/htdocs/wp-content/plugins/woocommerce/packages/action-scheduler/classes/data-stores/ActionScheduler_HybridStore.php(212): ActionScheduler_wpPostStore->stake_claim(25, NULL, Array, 'rocket-rucss')
#3 /var/www/XXX.XXX/htdocs/w in /var/www/XXX.XXX/htdocs/wp-content/plugins/woocommerce/packages/action-scheduler/classes/data-stores/ActionScheduler_wpPostStore.php on line 717
```

this error was happening when we deactivate WP Rocket when there are some pending jobs into the queue.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Is the solution different from the one proposed during the grooming?

Not groomed

## How Has This Been Tested?

Manually

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
