### PR TITLE
Fixes #4765 Prevent query string caching from overridding page exclusion

### DIFF
--- a/inc/classes/Buffer/class-tests.php
+++ b/inc/classes/Buffer/class-tests.php
@@ -577,7 +577,7 @@ class Tests {
 			return self::memoize( __FUNCTION__, [], true );
 		}
 
-		$can = ! preg_match( '#^(' . $uri_pattern . ')$#i', $this->get_clean_request_uri() );
+		$can = ! preg_match( '#^(' . $uri_pattern . ')$#i', $this->get_request_uri_base() );
 
 		return self::memoize( __FUNCTION__, [], $can );
 	}


### PR DESCRIPTION
## Description

Per grooming: Instead of using `get_clean_request_uri()` as the subject in which to match, change it to use `get_request_uri_base()`, which doesn't contain the query string.


Fixes #4765

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

No, exactly as groomed 
https://github.com/wp-media/wp-rocket/issues/4765#issuecomment-1060886331

## How Has This Been Tested?

On my lab site.

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
