### PR TITLE
Fixed problems related to an outdated fixture file for RocketCDN CTA

### DIFF
--- a/tests/Fixtures/inc/Engine/CDN/RocketCDN/NoticesSubscriber/displayRocketcdnCta.php
+++ b/tests/Fixtures/inc/Engine/CDN/RocketCDN/NoticesSubscriber/displayRocketcdnCta.php
@@ -28,16 +28,26 @@ return [
 				<li class="wpr-rocketcdn-feature wpr-rocketcdn-bandwidth">High performance Content Delivery Network (CDN) with <strong>unlimited bandwith</strong></li>
 				<li class="wpr-rocketcdn-feature wpr-rocketcdn-configuration">Easy configuration: the <strong>best CDN settings</strong> are automatically applied</li>
 				<li class="wpr-rocketcdn-feature wpr-rocketcdn-automatic">WP Rocket integration: the CDN option is <strong>automatically configured</strong> in our plugin</li>
+				<li class="wpr-rocketcdn-cta-footer">
+					<a href="https://wp-rocket.me/rocketcdn/" target="_blank" rel="noopener noreferrer">
+					Learn more about RocketCDN</a>
+				</li>
 			</ul>
 			<div class="wpr-rocketcdn-pricing">
-				<h4 class="wpr-rocketcdn-pricing-current"><span class="wpr-title1">$7.99</span> / month</h4>
+				<h4 class="wpr-rocketcdn-pricing-current">
+					<span class="wpr-rocketcdn-cta-currency-minor">
+				$</span>
+				<span class="wpr-rocketcdn-cta-currency-major">
+				7</span>
+				<span class="wpr-rocketcdn-cta-currency-minor">
+				.99</span>
+				</h4>
+				<p class="wpr-rocketcdn-cta-billing-detail">
+				Billed monthly</p>
 				<button class="wpr-button wpr-rocketcdn-open" data-micromodal-trigger="wpr-rocketcdn-modal">Get Started</button>
 			</div>
 		</div>
 	</section>
-	<div class="wpr-rocketcdn-cta-footer">
-		<a href="https://wp-rocket.me/rocketcdn/" target="_blank" rel="noopener noreferrer">Learn more about RocketCDN</a>
-	</div>
 	<button class="wpr-rocketcdn-cta-close--no-promo" id="wpr-rocketcdn-close-cta">
 		<span class="screen-reader-text">Reduce this banner</span>
 	</button>
@@ -78,16 +88,26 @@ HTML
 				<li class="wpr-rocketcdn-feature wpr-rocketcdn-bandwidth">High performance Content Delivery Network (CDN) with <strong>unlimited bandwith</strong></li>
 				<li class="wpr-rocketcdn-feature wpr-rocketcdn-configuration">Easy configuration: the <strong>best CDN settings</strong> are automatically applied</li>
 				<li class="wpr-rocketcdn-feature wpr-rocketcdn-automatic">WP Rocket integration: the CDN option is <strong>automatically configured</strong> in our plugin</li>
+				<li class="wpr-rocketcdn-cta-footer">
+					<a href="https://wp-rocket.me/rocketcdn/" target="_blank" rel="noopener noreferrer">
+					Learn more about RocketCDN</a>
+				</li>
 			</ul>
 			<div class="wpr-rocketcdn-pricing">
-				<h4 class="wpr-rocketcdn-pricing-current"><span class="wpr-title1">$7.99</span> / month</h4>
+				<h4 class="wpr-rocketcdn-pricing-current">
+					<span class="wpr-rocketcdn-cta-currency-minor">
+				$</span>
+				<span class="wpr-rocketcdn-cta-currency-major">
+				7</span>
+				<span class="wpr-rocketcdn-cta-currency-minor">
+				.99</span>
+				</h4>
+				<p class="wpr-rocketcdn-cta-billing-detail">
+				Billed monthly</p>
 				<button class="wpr-button wpr-rocketcdn-open" data-micromodal-trigger="wpr-rocketcdn-modal">Get Started</button>
 			</div>
 		</div>
 	</section>
-	<div class="wpr-rocketcdn-cta-footer">
-		<a href="https://wp-rocket.me/rocketcdn/" target="_blank" rel="noopener noreferrer">Learn more about RocketCDN</a>
-	</div>
 	<button class="wpr-rocketcdn-cta-close--no-promo" id="wpr-rocketcdn-close-cta">
 		<span class="screen-reader-text">Reduce this banner</span>
 	</button>
@@ -179,16 +199,26 @@ HTML
 				<li class="wpr-rocketcdn-feature wpr-rocketcdn-bandwidth">High performance Content Delivery Network (CDN) with <strong>unlimited bandwith</strong></li>
 				<li class="wpr-rocketcdn-feature wpr-rocketcdn-configuration">Easy configuration: the <strong>best CDN settings</strong> are automatically applied</li>
 				<li class="wpr-rocketcdn-feature wpr-rocketcdn-automatic">WP Rocket integration: the CDN option is <strong>automatically configured</strong> in our plugin</li>
+				<li class="wpr-rocketcdn-cta-footer">
+					<a href="https://wp-rocket.me/rocketcdn/" target="_blank" rel="noopener noreferrer">
+					Learn more about RocketCDN</a>
+				</li>
 			</ul>
 			<div class="wpr-rocketcdn-pricing">
-				<h4 class="wpr-rocketcdn-pricing-current"><span class="wpr-title1">$7.99</span> / month</h4>
+				<h4 class="wpr-rocketcdn-pricing-current">
+					<span class="wpr-rocketcdn-cta-currency-minor">
+				$</span>
+				<span class="wpr-rocketcdn-cta-currency-major">
+				7</span>
+				<span class="wpr-rocketcdn-cta-currency-minor">
+				.99</span>
+				</h4>
+				<p class="wpr-rocketcdn-cta-billing-detail">
+				Billed monthly</p>
 				<button class="wpr-button wpr-rocketcdn-open" data-micromodal-trigger="wpr-rocketcdn-modal">Get Started</button>
 			</div>
 		</div>
 	</section>
-	<div class="wpr-rocketcdn-cta-footer">
-		<a href="https://wp-rocket.me/rocketcdn/" target="_blank" rel="noopener noreferrer">Learn more about RocketCDN</a>
-	</div>
 	<button class="wpr-rocketcdn-cta-close--no-promo" id="wpr-rocketcdn-close-cta">
 		<span class="screen-reader-text">Reduce this banner</span>
 	</button>
@@ -254,16 +284,26 @@ HTML
 				<li class="wpr-rocketcdn-feature wpr-rocketcdn-bandwidth">High performance Content Delivery Network (CDN) with <strong>unlimited bandwith</strong></li>
 				<li class="wpr-rocketcdn-feature wpr-rocketcdn-configuration">Easy configuration: the <strong>best CDN settings</strong> are automatically applied</li>
 				<li class="wpr-rocketcdn-feature wpr-rocketcdn-automatic">WP Rocket integration: the CDN option is <strong>automatically configured</strong> in our plugin</li>
+				<li class="wpr-rocketcdn-cta-footer">
+					<a href="https://wp-rocket.me/rocketcdn/" target="_blank" rel="noopener noreferrer">
+					Learn more about RocketCDN</a>
+				</li>
 			</ul>
 			<div class="wpr-rocketcdn-pricing">
-				<h4 class="wpr-rocketcdn-pricing-current"><span class="wpr-title1">$7.99</span> / month</h4>
+				<h4 class="wpr-rocketcdn-pricing-current">
+					<span class="wpr-rocketcdn-cta-currency-minor">
+				$</span>
+				<span class="wpr-rocketcdn-cta-currency-major">
+				7</span>
+				<span class="wpr-rocketcdn-cta-currency-minor">
+				.99</span>
+				</h4>
+				<p class="wpr-rocketcdn-cta-billing-detail">
+				Billed monthly</p>
 				<button class="wpr-button wpr-rocketcdn-open" data-micromodal-trigger="wpr-rocketcdn-modal">Get Started</button>
 			</div>
 		</div>
 	</section>
-	<div class="wpr-rocketcdn-cta-footer">
-		<a href="https://wp-rocket.me/rocketcdn/" target="_blank" rel="noopener noreferrer">Learn more about RocketCDN</a>
-	</div>
 	<button class="wpr-rocketcdn-cta-close--no-promo" id="wpr-rocketcdn-close-cta">
 		<span class="screen-reader-text">Reduce this banner</span>
 	</button>
@@ -329,16 +369,26 @@ HTML
 				<li class="wpr-rocketcdn-feature wpr-rocketcdn-bandwidth">High performance Content Delivery Network (CDN) with <strong>unlimited bandwith</strong></li>
 				<li class="wpr-rocketcdn-feature wpr-rocketcdn-configuration">Easy configuration: the <strong>best CDN settings</strong> are automatically applied</li>
 				<li class="wpr-rocketcdn-feature wpr-rocketcdn-automatic">WP Rocket integration: the CDN option is <strong>automatically configured</strong> in our plugin</li>
+				<li class="wpr-rocketcdn-cta-footer">
+					<a href="https://wp-rocket.me/rocketcdn/" target="_blank" rel="noopener noreferrer">
+					Learn more about RocketCDN</a>
+				</li>
 			</ul>
 			<div class="wpr-rocketcdn-pricing">
-				<h4 class="wpr-rocketcdn-pricing-current"><span class="wpr-title1">$7.99</span> / month</h4>
+				<h4 class="wpr-rocketcdn-pricing-current">
+					<span class="wpr-rocketcdn-cta-currency-minor">
+				$</span>
+				<span class="wpr-rocketcdn-cta-currency-major">
+				7</span>
+				<span class="wpr-rocketcdn-cta-currency-minor">
+				.99</span>
+				</h4>
+				<p class="wpr-rocketcdn-cta-billing-detail">
+				Billed monthly</p>
 				<button class="wpr-button wpr-rocketcdn-open" data-micromodal-trigger="wpr-rocketcdn-modal">Get Started</button>
 			</div>
 		</div>
 	</section>
-	<div class="wpr-rocketcdn-cta-footer">
-		<a href="https://wp-rocket.me/rocketcdn/" target="_blank" rel="noopener noreferrer">Learn more about RocketCDN</a>
-	</div>
 	<button class="wpr-rocketcdn-cta-close--no-promo" id="wpr-rocketcdn-close-cta">
 		<span class="screen-reader-text">Reduce this banner</span>
 	</button>
@@ -404,16 +454,26 @@ HTML
 				<li class="wpr-rocketcdn-feature wpr-rocketcdn-bandwidth">High performance Content Delivery Network (CDN) with <strong>unlimited bandwith</strong></li>
 				<li class="wpr-rocketcdn-feature wpr-rocketcdn-configuration">Easy configuration: the <strong>best CDN settings</strong> are automatically applied</li>
 				<li class="wpr-rocketcdn-feature wpr-rocketcdn-automatic">WP Rocket integration: the CDN option is <strong>automatically configured</strong> in our plugin</li>
+				<li class="wpr-rocketcdn-cta-footer">
+					<a href="https://wp-rocket.me/rocketcdn/" target="_blank" rel="noopener noreferrer">
+					Learn more about RocketCDN</a>
+				</li>
 			</ul>
 			<div class="wpr-rocketcdn-pricing">
-				<h4 class="wpr-rocketcdn-pricing-current"><span class="wpr-title1">$7.99</span> / month</h4>
+				<h4 class="wpr-rocketcdn-pricing-current">
+					<span class="wpr-rocketcdn-cta-currency-minor">
+				$</span>
+				<span class="wpr-rocketcdn-cta-currency-major">
+				7</span>
+				<span class="wpr-rocketcdn-cta-currency-minor">
+				.99</span>
+				</h4>
+				<p class="wpr-rocketcdn-cta-billing-detail">
+				Billed monthly</p>
 				<button class="wpr-button wpr-rocketcdn-open" data-micromodal-trigger="wpr-rocketcdn-modal">Get Started</button>
 			</div>
 		</div>
 	</section>
-	<div class="wpr-rocketcdn-cta-footer">
-		<a href="https://wp-rocket.me/rocketcdn/" target="_blank" rel="noopener noreferrer">Learn more about RocketCDN</a>
-	</div>
 	<button class="wpr-rocketcdn-cta-close--no-promo" id="wpr-rocketcdn-close-cta">
 		<span class="screen-reader-text">Reduce this banner</span>
 	</button>
@@ -471,7 +531,7 @@ HTML
 </div>
 <div class="wpr-rocketcdn-cta " id="wpr-rocketcdn-cta">
 	<div class="wpr-flex wpr-rocketcdn-promo">
-		<h3 class="wpr-title1">Launch</h3>
+		<h3 class="wpr-rocketcdn-promo-title">Launch</h3>
 		<p class="wpr-title2 wpr-rocketcdn-promo-date">Valid until 2022-11-03 only!</p>
 	</div>
 	<section class="wpr-rocketcdn-cta-content">
@@ -482,21 +542,31 @@ HTML
 				<li class="wpr-rocketcdn-feature wpr-rocketcdn-bandwidth">High performance Content Delivery Network (CDN) with <strong>unlimited bandwith</strong></li>
 				<li class="wpr-rocketcdn-feature wpr-rocketcdn-configuration">Easy configuration: the <strong>best CDN settings</strong> are automatically applied</li>
 				<li class="wpr-rocketcdn-feature wpr-rocketcdn-automatic">WP Rocket integration: the CDN option is <strong>automatically configured</strong> in our plugin</li>
+				<li class="wpr-rocketcdn-cta-footer">
+					<a href="https://wp-rocket.me/rocketcdn/" target="_blank" rel="noopener noreferrer">
+					Learn more about RocketCDN</a>
+				</li>
+				<li class="wpr-rocketcdn-cta-promo-footer">
+				*$5.99/month for 12 months then $7.99/month. You can cancel your subscription at any time.</li>
 			</ul>
 			<div class="wpr-rocketcdn-pricing">
 				<h4 class="wpr-title2 wpr-rocketcdn-pricing-regular"><del>$7.99</del></h4>
-				<h4 class="wpr-rocketcdn-pricing-current"><span class="wpr-title1">$5.99*</span> / month</h4>
+				<h4 class="wpr-rocketcdn-pricing-current"><span class="wpr-rocketcdn-cta-currency-minor">
+					$</span>
+					<span class="wpr-rocketcdn-cta-currency-major">
+					5</span>
+					<span class="wpr-rocketcdn-cta-currency-minor">
+					.99*</span>
+				</h4>
+				<p class="wpr-rocketcdn-cta-billing-detail">
+				Billed monthly</p>
 				<button class="wpr-button wpr-rocketcdn-open" data-micromodal-trigger="wpr-rocketcdn-modal">Get Started</button>
 			</div>
 		</div>
 	</section>
-	<div class="wpr-rocketcdn-cta-footer">
-		<a href="https://wp-rocket.me/rocketcdn/" target="_blank" rel="noopener noreferrer">Learn more about RocketCDN</a>
-	</div>
 	<button class="wpr-rocketcdn-cta-close" id="wpr-rocketcdn-close-cta">
 		<span class="screen-reader-text">Reduce this banner</span>
 	</button>
-	<p>* $5.99/month for 12 months then $7.99/month. You can cancel your subscription at any time.</p>
 </div>
 HTML
 			,
@@ -549,15 +619,17 @@ HTML
 				<li class="wpr-rocketcdn-feature wpr-rocketcdn-bandwidth">High performance Content Delivery Network (CDN) with <strong>unlimited bandwith</strong></li>
 				<li class="wpr-rocketcdn-feature wpr-rocketcdn-configuration">Easy configuration: the <strong>best CDN settings</strong> are automatically applied</li>
 				<li class="wpr-rocketcdn-feature wpr-rocketcdn-automatic">WP Rocket integration: the CDN option is <strong>automatically configured</strong> in our plugin</li>
+				<li class="wpr-rocketcdn-cta-footer">
+					<a href="https://wp-rocket.me/rocketcdn/" target="_blank" rel="noopener noreferrer">
+					Learn more about RocketCDN</a>
+				</li>
 			</ul>
 			<div class="wpr-rocketcdn-pricing">
-				<p>RocketCDN is not available at the moment. Please retry later</p>
+				<p>
+				RocketCDN is not available at the moment. Please retry later</p>
 			</div>
 		</div>
 	</section>
-	<div class="wpr-rocketcdn-cta-footer">
-		<a href="https://wp-rocket.me/rocketcdn/" target="_blank" rel="noopener noreferrer">Learn more about RocketCDN</a>
-	</div>
 	<button class="wpr-rocketcdn-cta-close--no-promo" id="wpr-rocketcdn-close-cta">
 		<span class="screen-reader-text">Reduce this banner</span>
 	</button>


### PR DESCRIPTION
## Description

Since 16/03/2022 tests broke because of what seems like an actualization from the HTML code from the CTA for RocketCDN.
This PR update the fixture in question () to make it match the new HTML structure.

Fixes #(issue number)
None
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

There was no grooming for this issue as it is a problem directly in the tests.

## How Has This Been Tested?

- [x] Running automatic tests

# Checklist:

Please delete the options that are not relevant.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
