### PR TITLE
Display RUCSS processing notice after switching theme

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
@@ -245,6 +245,7 @@ class Subscriber implements Subscriber_Interface {
 		}
 
 		$this->delete_used_css_rows();
+		$this->set_notice_transient();
 	}
 
 	/**


### PR DESCRIPTION
## Description

Displays the RUCSS processing notice after switching theme.

Fixes https://github.com/wp-media/nodejs-treeshaker/issues/45

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
