### PR TITLE
Add flatsome compatibility for RUCSS inline CSS preserve

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -72,9 +72,6 @@ class UsedCSS {
 	 * @var string[]
 	 */
 	private $inline_content_exclusions = [
-		'#text-box-',
-		'#banner-',
-		'#slider-',
 		'.wp-container-',
 		'.wp-elements-',
 	];

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -290,6 +290,7 @@ class Plugin {
 			'ezoic',
 			'thirstyaffiliates',
 			'pwa',
+			'flatsome',
 		];
 
 		$host_type = HostResolver::get_host_service();

--- a/inc/ThirdParty/ServiceProvider.php
+++ b/inc/ThirdParty/ServiceProvider.php
@@ -46,6 +46,7 @@ class ServiceProvider extends AbstractServiceProvider {
 		'wordfence_subscriber',
 		'ezoic',
 		'pwa',
+		'flatsome',
 	];
 
 	/**
@@ -155,6 +156,9 @@ class ServiceProvider extends AbstractServiceProvider {
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
 			->share( 'pwa', 'WP_Rocket\ThirdParty\Plugins\PWA' )
+			->addTag( 'common_subscriber' );
+		$this->getContainer()
+			->share( 'flatsome', 'WP_Rocket\ThirdParty\Themes\Flatsome' )
 			->addTag( 'common_subscriber' );
 	}
 }

--- a/inc/ThirdParty/Themes/Flatsome.php
+++ b/inc/ThirdParty/Themes/Flatsome.php
@@ -51,6 +51,7 @@ class Flatsome implements Subscriber_Interface {
 	private static function is_flatsome( $theme = null ) {
 		$theme = $theme instanceof \WP_Theme ? $theme : wp_get_theme();
 
-		return 'flatsome' === ( strtolower( $theme->get( 'Name' ) ) || strtolower( $theme->get_template() ) );
+		return 'flatsome' ===  strtolower( $theme->get( 'Name' ) )
+                || 'flatsome' ===  strtolower( $theme->get_template() );
 	}
 }

--- a/inc/ThirdParty/Themes/Flatsome.php
+++ b/inc/ThirdParty/Themes/Flatsome.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\ThirdParty\Themes;
+
+use WP_Rocket\Event_Management\Subscriber_Interface;
+
+class Flatsome implements Subscriber_Interface {
+	/**
+	 * Return an array of events that this subscriber wants to listen to.
+	 *
+	 * @return array
+	 */
+	public static function get_subscribed_events() {
+		return [
+			'rocket_rucss_inline_content_exclusions' => 'preserve_patterns',
+		];
+	}
+
+	/**
+	 * Preserves the CSS patterns when adding the used CSS to the page
+	 *
+	 * @since 3.11
+	 *
+	 * @param array $patterns Array of patterns to preserve.
+	 *
+	 * @return array
+	 */
+	public function preserve_patterns( $patterns ): array {
+		if ( ! self::is_flatsome() ) {
+			return $patterns;
+		}
+
+		$preserve = [
+			'#section_',
+			'#text-box-',
+			'#banner-',
+			'#slider-',
+		];
+
+		return array_merge( $patterns, $preserve );
+	}
+
+	/**
+	 * Checks if the current theme (or parent) is Flatsome
+	 *
+	 * @since 3.11
+	 *
+	 * @param WP_Theme $theme Instance of the theme.
+	 */
+	private static function is_flatsome( $theme = null ) {
+		$theme = $theme instanceof \WP_Theme ? $theme : wp_get_theme();
+
+		return 'flatsome' === ( strtolower( $theme->get( 'Name' ) ) || strtolower( $theme->get_template() ) );
+	}
+}

--- a/inc/ThirdParty/Themes/Flatsome.php
+++ b/inc/ThirdParty/Themes/Flatsome.php
@@ -36,6 +36,7 @@ class Flatsome implements Subscriber_Interface {
 			'#text-box-',
 			'#banner-',
 			'#slider-',
+			'#gap-',
 		];
 
 		return array_merge( $patterns, $preserve );

--- a/inc/ThirdParty/Themes/Flatsome.php
+++ b/inc/ThirdParty/Themes/Flatsome.php
@@ -51,7 +51,6 @@ class Flatsome implements Subscriber_Interface {
 	private static function is_flatsome( $theme = null ) {
 		$theme = $theme instanceof \WP_Theme ? $theme : wp_get_theme();
 
-		return 'flatsome' ===  strtolower( $theme->get( 'Name' ) )
-                || 'flatsome' ===  strtolower( $theme->get_template() );
+		return 'flatsome' === strtolower( $theme->get( 'Name' ) ) || 'flatsome' === strtolower( $theme->get_template() );
 	}
 }


### PR DESCRIPTION
## Description

Add a compatibility file for Flatsome, to add specific patterns to the inline CSS content to preserve when using remove unused CSS

Fixes https://github.com/wp-media/nodejs-treeshaker/issues/39

## Type of change

- [x] Third-Party compatibility

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
