### PR TITLE
Changed the function call to find the uri in the method can_process_uri

### DIFF
--- a/inc/classes/Buffer/class-tests.php
+++ b/inc/classes/Buffer/class-tests.php
@@ -577,7 +577,7 @@ class Tests {
 			return self::memoize( __FUNCTION__, [], true );
 		}
 
-		$can = ! preg_match( '#^(' . $uri_pattern . ')$#i', $this->get_clean_request_uri() );
+		$can = ! preg_match( '#^(' . $uri_pattern . ')$#i', $this->get_request_uri_base() );
 
 		return self::memoize( __FUNCTION__, [], $can );
 	}


### PR DESCRIPTION
## Description

Fix a problem with caching a page when a page is excluded but it also has a query parameter that is forcing page to be cached.
Now the behavior is the expected one: the page should be cached.

For this the function for getting the URI has been changed in method can_process_uri from the Tests class.

Fixes #4765

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

No the grooming was right

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Tested on local environment

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
