### PR TITLE
Update RUCSS notices

### DIFF
--- a/inc/Engine/License/views/promo-banner.php
+++ b/inc/Engine/License/views/promo-banner.php
@@ -33,5 +33,5 @@ defined( 'ABSPATH' ) || exit;
 		</ul>
 		<button class="rocket-promo-cta wpr-popin-upgrade-toggle"><?php esc_html_e( 'Upgrade now', 'rocket' ); ?></button>
 	</div>
-	<button class="wpr-notice-close wpr-icon-close" id="rocket-dismiss-promotion"><span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice.', 'rocket' ); ?></span></button>
+	<button class="wpr-notice-close wpr-icon-close" id="rocket-dismiss-promotion"><span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice', 'rocket' ); ?></span></button>
 </div>

--- a/inc/Engine/License/views/renewal-expired-banner.php
+++ b/inc/Engine/License/views/renewal-expired-banner.php
@@ -34,5 +34,5 @@ defined( 'ABSPATH' ) || exit;
 	<div class="rocket-expired-cta-container">
 		<a href="<?php echo esc_url( $data['renewal_url'] ); ?>" class="rocket-renew-cta" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Renew now', 'rocket' ); ?></a>
 	</div>
-	<button class="wpr-notice-close wpr-icon-close" id="rocket-dismiss-renewal"><span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice.', 'rocket' ); ?></span></button>
+	<button class="wpr-notice-close wpr-icon-close" id="rocket-dismiss-renewal"><span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice', 'rocket' ); ?></span></button>
 </div>

--- a/inc/Engine/Optimization/RUCSS/Admin/Settings.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Settings.php
@@ -201,7 +201,7 @@ class Settings {
 
 		$message = sprintf(
 			// translators: %1$s = plugin name, %2$s = number of seconds.
-			__( '%1$s: please wait %2$s seconds. The Remove Unused CSS service is processing your pages.', 'rocket' ),
+			__( '%1$s: Please wait %2$s seconds. The Remove Unused CSS service is processing your pages.', 'rocket' ),
 			'<strong>WP Rocket</strong>',
 			'<span id="rocket-rucss-timer">' . $remaining . '</span>'
 		);
@@ -242,7 +242,7 @@ class Settings {
 
 		$message = sprintf(
 			// translators: %1$s = plugin name, %2$s = number of URLs, %3$s = number of seconds.
-			__( '%1$s: Your homepage has been processed. WP Rocket will continue to generate Used CSS for up to %2$s URLs per %3$s second(s).', 'rocket' ),
+			__( '%1$s: The Used CSS of your homepage has been processed. WP Rocket will continue to generate Used CSS for up to %2$s URLs per %3$s second(s).', 'rocket' ),
 			'<strong>WP Rocket</strong>',
 			apply_filters( 'rocket_rucss_pending_jobs_cron_rows_count', 100 ),
 			apply_filters( 'rocket_rucss_pending_jobs_cron_interval', MINUTE_IN_SECONDS )
@@ -268,10 +268,11 @@ class Settings {
 
 		rocket_notice_html(
 			[
-				'message'        => $message,
-				'dismissible'    => $class,
-				'id'             => 'rocket-notice-rucss-success',
-				'dismiss_button' => 'rucss_success_notice',
+				'message'              => $message,
+				'dismissible'          => $class,
+				'id'                   => 'rocket-notice-rucss-success',
+				'dismiss_button'       => 'rucss_success_notice',
+				'dismiss_button_class' => 'button-primary',
 			]
 		);
 	}

--- a/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
@@ -600,8 +600,8 @@ class Subscriber implements Subscriber_Interface {
 	private function set_notice_transient() {
 		set_transient(
 			'rocket_rucss_processing',
-			time() + 60,
-			MINUTE_IN_SECONDS
+			time() + 90,
+			1.5 * MINUTE_IN_SECONDS
 		);
 
 		rocket_renew_box( 'rucss_success_notice' );

--- a/inc/admin/ui/notices.php
+++ b/inc/admin/ui/notices.php
@@ -799,7 +799,7 @@ function rocket_notice_html( $args ) {
 		<p>
 			<?php echo $args['action']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			<?php if ( $args['dismiss_button'] ) : ?>
-			<a class="rocket-dismiss" href="<?php echo wp_nonce_url( admin_url( 'admin-post.php?action=rocket_ignore&box=' . $args['dismiss_button'] ), 'rocket_ignore_' . $args['dismiss_button'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>"><?php esc_html_e( 'Dismiss this notice.', 'rocket' ); ?></a>
+			<a class="rocket-dismiss <?php echo $args['dismiss_button_class'] ?? ''; ?>" href="<?php echo wp_nonce_url( admin_url( 'admin-post.php?action=rocket_ignore&box=' . $args['dismiss_button'] ), 'rocket_ignore_' . $args['dismiss_button'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>"><?php esc_html_e( 'Dismiss this notice.', 'rocket' ); ?></a>
 			<?php endif; ?>
 		</p>
 		<?php endif; ?>

--- a/inc/admin/ui/notices.php
+++ b/inc/admin/ui/notices.php
@@ -799,7 +799,7 @@ function rocket_notice_html( $args ) {
 		<p>
 			<?php echo $args['action']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			<?php if ( $args['dismiss_button'] ) : ?>
-			<a class="rocket-dismiss <?php echo $args['dismiss_button_class'] ?? ''; ?>" href="<?php echo wp_nonce_url( admin_url( 'admin-post.php?action=rocket_ignore&box=' . $args['dismiss_button'] ), 'rocket_ignore_' . $args['dismiss_button'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>"><?php esc_html_e( 'Dismiss this notice.', 'rocket' ); ?></a>
+			<a class="rocket-dismiss <?php echo $args['dismiss_button_class'] ?? ''; ?>" href="<?php echo wp_nonce_url( admin_url( 'admin-post.php?action=rocket_ignore&box=' . $args['dismiss_button'] ), 'rocket_ignore_' . $args['dismiss_button'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>"><?php esc_html_e( 'Dismiss this notice', 'rocket' ); ?></a>
 			<?php endif; ?>
 		</p>
 		<?php endif; ?>

--- a/tests/Fixtures/inc/Engine/Cache/AdvancedCache/noticePermissions.php
+++ b/tests/Fixtures/inc/Engine/Cache/AdvancedCache/noticePermissions.php
@@ -95,7 +95,7 @@ HTML
 		<br>Troubleshoot:<a href="https://docs.wp-rocket.me/article/626-how-to-make-system-files-htaccess-wp-config-writeable/?utm_source=wp_plugin&utm_medium=wp_rocket" target="_blank">How to make system files writeable</a>
 	</p>
 	<p>
-		<a class="rocket-dismiss" href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=rocket_warning_advanced_cache_permissions&amp;_wpnonce=123456">Dismiss this notice.</a>
+		<a class="rocket-dismiss" href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=rocket_warning_advanced_cache_permissions&amp;_wpnonce=123456">Dismiss this notice</a>
 	</p>
 </div>
 HTML

--- a/tests/Fixtures/inc/Engine/Cache/AdvancedCache/noticePermissions.php
+++ b/tests/Fixtures/inc/Engine/Cache/AdvancedCache/noticePermissions.php
@@ -95,7 +95,7 @@ HTML
 		<br>Troubleshoot:<a href="https://docs.wp-rocket.me/article/626-how-to-make-system-files-htaccess-wp-config-writeable/?utm_source=wp_plugin&utm_medium=wp_rocket" target="_blank">How to make system files writeable</a>
 	</p>
 	<p>
-		<a class="rocket-dismiss" href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=rocket_warning_advanced_cache_permissions&amp;_wpnonce=123456">Dismiss this notice</a>
+		<a class="rocket-dismiss " href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=rocket_warning_advanced_cache_permissions&amp;_wpnonce=123456">Dismiss this notice</a>
 	</p>
 </div>
 HTML

--- a/tests/Fixtures/inc/Engine/Cache/WPCache/noticeWpConfigPermissions.php
+++ b/tests/Fixtures/inc/Engine/Cache/WPCache/noticeWpConfigPermissions.php
@@ -105,7 +105,7 @@ HTML
 	<textarea readonly="readonly" id="rules" name="rules" class="large-text readonly" rows="6">define( &#039;WP_CACHE&#039;, true ); // Added by WP Rocket</textarea>
 	</p>
 	<p>
-		<a class="rocket-dismiss" href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=rocket_warning_wp_config_permissions&amp;_wpnonce=123456">Dismiss this notice.</a>
+		<a class="rocket-dismiss" href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=rocket_warning_wp_config_permissions&amp;_wpnonce=123456">Dismiss this notice</a>
 	</p>
 </div>
 HTML

--- a/tests/Fixtures/inc/Engine/Cache/WPCache/noticeWpConfigPermissions.php
+++ b/tests/Fixtures/inc/Engine/Cache/WPCache/noticeWpConfigPermissions.php
@@ -105,7 +105,7 @@ HTML
 	<textarea readonly="readonly" id="rules" name="rules" class="large-text readonly" rows="6">define( &#039;WP_CACHE&#039;, true ); // Added by WP Rocket</textarea>
 	</p>
 	<p>
-		<a class="rocket-dismiss" href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=rocket_warning_wp_config_permissions&amp;_wpnonce=123456">Dismiss this notice</a>
+		<a class="rocket-dismiss " href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=rocket_warning_wp_config_permissions&amp;_wpnonce=123456">Dismiss this notice</a>
 	</p>
 </div>
 HTML

--- a/tests/Fixtures/inc/Engine/HealthCheck/HealthCheck/missedCron.php
+++ b/tests/Fixtures/inc/Engine/HealthCheck/HealthCheck/missedCron.php
@@ -165,7 +165,7 @@ return [
 	<ul>
 		<li>Scheduled Cache Purge</li>
 	</ul>
-	<p>Please contact your host to check if CRON is working.</p>	<p><a class="rocket-dismiss" href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=rocket_warning_cron&amp;_wpnonce=123456">Dismiss this notice.</a></p>
+	<p>Please contact your host to check if CRON is working.</p>	<p><a class="rocket-dismiss" href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=rocket_warning_cron&amp;_wpnonce=123456">Dismiss this notice</a></p>
 </div>
 HTML
 		,
@@ -199,7 +199,7 @@ HTML
 		<li>Scheduled Database Optimization</li>
 	</ul>
 	<p>Please contact your host to check if CRON is working.</p>
-	<p><a class="rocket-dismiss" href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=rocket_warning_cron&amp;_wpnonce=123456">Dismiss this notice.</a></p>
+	<p><a class="rocket-dismiss" href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=rocket_warning_cron&amp;_wpnonce=123456">Dismiss this notice</a></p>
 </div>
 HTML
 		,
@@ -232,7 +232,7 @@ HTML
 		<li>Scheduled Cache Purge</li>
 	</ul>
 	<p>Please contact your host to check if CRON is working.</p>
-	<p><a class="rocket-dismiss" href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=rocket_warning_cron&amp;_wpnonce=123456">Dismiss this notice.</a></p>
+	<p><a class="rocket-dismiss" href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=rocket_warning_cron&amp;_wpnonce=123456">Dismiss this notice</a></p>
 </div>
 HTML
 		,
@@ -266,7 +266,7 @@ HTML
 		<li>Scheduled Database Optimization</li>
 	</ul>
 	<p>Please contact your host to check if CRON is working.</p>
-	<p><a class="rocket-dismiss" href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=rocket_warning_cron&amp;_wpnonce=123456">Dismiss this notice.</a></p>
+	<p><a class="rocket-dismiss" href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=rocket_warning_cron&amp;_wpnonce=123456">Dismiss this notice</a></p>
 </div>
 HTML
 	,

--- a/tests/Fixtures/inc/Engine/HealthCheck/HealthCheck/missedCron.php
+++ b/tests/Fixtures/inc/Engine/HealthCheck/HealthCheck/missedCron.php
@@ -165,7 +165,7 @@ return [
 	<ul>
 		<li>Scheduled Cache Purge</li>
 	</ul>
-	<p>Please contact your host to check if CRON is working.</p>	<p><a class="rocket-dismiss" href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=rocket_warning_cron&amp;_wpnonce=123456">Dismiss this notice</a></p>
+	<p>Please contact your host to check if CRON is working.</p>	<p><a class="rocket-dismiss " href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=rocket_warning_cron&amp;_wpnonce=123456">Dismiss this notice</a></p>
 </div>
 HTML
 		,
@@ -199,7 +199,7 @@ HTML
 		<li>Scheduled Database Optimization</li>
 	</ul>
 	<p>Please contact your host to check if CRON is working.</p>
-	<p><a class="rocket-dismiss" href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=rocket_warning_cron&amp;_wpnonce=123456">Dismiss this notice</a></p>
+	<p><a class="rocket-dismiss " href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=rocket_warning_cron&amp;_wpnonce=123456">Dismiss this notice</a></p>
 </div>
 HTML
 		,
@@ -232,7 +232,7 @@ HTML
 		<li>Scheduled Cache Purge</li>
 	</ul>
 	<p>Please contact your host to check if CRON is working.</p>
-	<p><a class="rocket-dismiss" href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=rocket_warning_cron&amp;_wpnonce=123456">Dismiss this notice</a></p>
+	<p><a class="rocket-dismiss " href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=rocket_warning_cron&amp;_wpnonce=123456">Dismiss this notice</a></p>
 </div>
 HTML
 		,
@@ -266,7 +266,7 @@ HTML
 		<li>Scheduled Database Optimization</li>
 	</ul>
 	<p>Please contact your host to check if CRON is working.</p>
-	<p><a class="rocket-dismiss" href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=rocket_warning_cron&amp;_wpnonce=123456">Dismiss this notice</a></p>
+	<p><a class="rocket-dismiss " href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=rocket_warning_cron&amp;_wpnonce=123456">Dismiss this notice</a></p>
 </div>
 HTML
 	,

--- a/tests/Fixtures/inc/Engine/License/Subscriber/displayPromoBanner.php
+++ b/tests/Fixtures/inc/Engine/License/Subscriber/displayPromoBanner.php
@@ -182,7 +182,7 @@ return [
 		</div>
 		<button class="wpr-notice-close wpr-icon-close" id="rocket-dismiss-promotion">
 		<span class="screen-reader-text">
-		Dismiss this notice.</span>
+		Dismiss this notice</span>
 		</button>
 		</div>',
 	],
@@ -265,7 +265,7 @@ return [
 		</div>
 		<button class="wpr-notice-close wpr-icon-close" id="rocket-dismiss-promotion">
 		<span class="screen-reader-text">
-		Dismiss this notice.</span>
+		Dismiss this notice</span>
 		</button>
 		</div>',
 	],

--- a/tests/Fixtures/inc/Engine/License/Subscriber/displayRenewalExpiredBanner.php
+++ b/tests/Fixtures/inc/Engine/License/Subscriber/displayRenewalExpiredBanner.php
@@ -44,7 +44,7 @@ return [
 		<div class="rocket-expired-cta-container">
 			<a href="https://wp-rocket.me/checkout/renew/roger@wp-rocket.me/da5891162a3bc2d8a9670267fd07c9eb/" class="rocket-renew-cta" target="_blank" rel="noopener noreferrer">Renew now</a>
 		</div>
-		<button class="wpr-notice-close wpr-icon-close" id="rocket-dismiss-renewal"><span class="screen-reader-text">Dismiss this notice.</span></button>
+		<button class="wpr-notice-close wpr-icon-close" id="rocket-dismiss-renewal"><span class="screen-reader-text">Dismiss this notice</span></button>
 	</div>',
 	],
 ];

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Settings/displaySuccessNotice.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Settings/displaySuccessNotice.php
@@ -67,7 +67,7 @@ return [
 			'transient'         => time(),
 		],
 		'expected' => [
-			'message'     => '<strong>WP Rocket</strong>: Your homepage has been processed. WP Rocket will continue to generate Used CSS for up to 100 URLs per 90 second(s). We suggest enabling <a href="#preload">Sitemap Preload</a> for the fastest results.<br>To learn more about the process check our <a href="http://example.org" data-beacon-article="123" rel="noopener noreferrer" target="_blank">documentation</a>.',
+			'message'     => '<strong>WP Rocket</strong>: The Used CSS of your homepage has been processed. WP Rocket will continue to generate Used CSS for up to 100 URLs per 60 second(s). We suggest enabling <a href="#preload">Sitemap Preload</a> for the fastest results.<br>To learn more about the process check our <a href="http://example.org" data-beacon-article="123" rel="noopener noreferrer" target="_blank">documentation</a>.',
 			'dismissible' => 'hidden',
 			'id'          => 'rocket-notice-rucss-success',
 			'dismiss_button' => 'rucss_success_notice',
@@ -86,7 +86,7 @@ return [
 			'transient'         => false,
 		],
 		'expected' => [
-			'message'     => '<strong>WP Rocket</strong>: Your homepage has been processed. WP Rocket will continue to generate Used CSS for up to 100 URLs per 90 second(s). We suggest enabling <a href="#preload">Sitemap Preload</a> for the fastest results.<br>To learn more about the process check our <a href="http://example.org" data-beacon-article="123" rel="noopener noreferrer" target="_blank">documentation</a>.',
+			'message'     => '<strong>WP Rocket</strong>: The Used CSS of your homepage has been processed. WP Rocket will continue to generate Used CSS for up to 100 URLs per 60 second(s). We suggest enabling <a href="#preload">Sitemap Preload</a> for the fastest results.<br>To learn more about the process check our <a href="http://example.org" data-beacon-article="123" rel="noopener noreferrer" target="_blank">documentation</a>.',
 			'dismissible' => '',
 			'id'          => 'rocket-notice-rucss-success',
 			'dismiss_button' => 'rucss_success_notice',

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Settings/displaySuccessNotice.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Settings/displaySuccessNotice.php
@@ -71,6 +71,7 @@ return [
 			'dismissible' => 'hidden',
 			'id'          => 'rocket-notice-rucss-success',
 			'dismiss_button' => 'rucss_success_notice',
+			'dismiss_button_class' => 'button-primary',
 		],
 	],
 	'shouldShowNoticeWhenNoTransient' => [
@@ -89,6 +90,7 @@ return [
 			'dismissible' => '',
 			'id'          => 'rocket-notice-rucss-success',
 			'dismiss_button' => 'rucss_success_notice',
+			'dismiss_button_class' => 'button-primary','
 		],
 	],
 ];

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Settings/displaySuccessNotice.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Settings/displaySuccessNotice.php
@@ -90,7 +90,7 @@ return [
 			'dismissible' => '',
 			'id'          => 'rocket-notice-rucss-success',
 			'dismiss_button' => 'rucss_success_notice',
-			'dismiss_button_class' => 'button-primary','
+			'dismiss_button_class' => 'button-primary',
 		],
 	],
 ];

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Settings/displaySuccessNotice.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Settings/displaySuccessNotice.php
@@ -67,7 +67,7 @@ return [
 			'transient'         => time(),
 		],
 		'expected' => [
-			'message'     => '<strong>WP Rocket</strong>: Your homepage has been processed. WP Rocket will continue to generate Used CSS for up to 100 URLs per 60 second(s). We suggest enabling <a href="#preload">Sitemap Preload</a> for the fastest results.<br>To learn more about the process check our <a href="http://example.org" data-beacon-article="123" rel="noopener noreferrer" target="_blank">documentation</a>.',
+			'message'     => '<strong>WP Rocket</strong>: Your homepage has been processed. WP Rocket will continue to generate Used CSS for up to 100 URLs per 90 second(s). We suggest enabling <a href="#preload">Sitemap Preload</a> for the fastest results.<br>To learn more about the process check our <a href="http://example.org" data-beacon-article="123" rel="noopener noreferrer" target="_blank">documentation</a>.',
 			'dismissible' => 'hidden',
 			'id'          => 'rocket-notice-rucss-success',
 			'dismiss_button' => 'rucss_success_notice',
@@ -86,7 +86,7 @@ return [
 			'transient'         => false,
 		],
 		'expected' => [
-			'message'     => '<strong>WP Rocket</strong>: Your homepage has been processed. WP Rocket will continue to generate Used CSS for up to 100 URLs per 60 second(s). We suggest enabling <a href="#preload">Sitemap Preload</a> for the fastest results.<br>To learn more about the process check our <a href="http://example.org" data-beacon-article="123" rel="noopener noreferrer" target="_blank">documentation</a>.',
+			'message'     => '<strong>WP Rocket</strong>: Your homepage has been processed. WP Rocket will continue to generate Used CSS for up to 100 URLs per 90 second(s). We suggest enabling <a href="#preload">Sitemap Preload</a> for the fastest results.<br>To learn more about the process check our <a href="http://example.org" data-beacon-article="123" rel="noopener noreferrer" target="_blank">documentation</a>.',
 			'dismissible' => '',
 			'id'          => 'rocket-notice-rucss-success',
 			'dismiss_button' => 'rucss_success_notice',

--- a/tests/Fixtures/inc/ThirdParty/Plugins/ModPagespeed/showAdminNotice.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/ModPagespeed/showAdminNotice.php
@@ -8,7 +8,7 @@ WP Rocket</strong>
 More Info</a>
 </p>
 <p>
-<a class="rocket-dismiss" href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=rocket_error_mod_pagespeed&amp;_wpnonce={{nonce}}">
+<a class="rocket-dismiss " href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=rocket_error_mod_pagespeed&amp;_wpnonce={{nonce}}">
 Dismiss this notice</a>
 </p>
 </div>

--- a/tests/Fixtures/inc/ThirdParty/Plugins/ModPagespeed/showAdminNotice.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/ModPagespeed/showAdminNotice.php
@@ -9,7 +9,7 @@ More Info</a>
 </p>
 <p>
 <a class="rocket-dismiss" href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=rocket_error_mod_pagespeed&amp;_wpnonce={{nonce}}">
-Dismiss this notice.</a>
+Dismiss this notice</a>
 </p>
 </div>
 HTML;

--- a/tests/Fixtures/inc/ThirdParty/Plugins/Optimization/Autoptimize/warnWhenAggregateInlineCssAndCPCSSActive.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/Optimization/Autoptimize/warnWhenAggregateInlineCssAndCPCSSActive.php
@@ -7,7 +7,7 @@ $expected_html = <<<HTML
 <p><strong>WP Rocket: </strong>
 We have detected that Autoptimize's Aggregate Inline CSS feature is enabled. WP Rocket's Load CSS Asynchronously will not work correctly. We suggest disabling <strong>Aggregate Inline CSS</strong> to take full advantage of Load CSS Asynchronously Execution.
 </p><p>
-<a class="rocket-dismiss" href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=warn_when_aggregate_inline_css_and_cpcss_active&amp;_wpnonce=123456">
+<a class="rocket-dismiss " href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=warn_when_aggregate_inline_css_and_cpcss_active&amp;_wpnonce=123456">
 Dismiss this notice</a></p></div>
 HTML;
 

--- a/tests/Fixtures/inc/ThirdParty/Plugins/Optimization/Autoptimize/warnWhenAggregateInlineCssAndCPCSSActive.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/Optimization/Autoptimize/warnWhenAggregateInlineCssAndCPCSSActive.php
@@ -8,7 +8,7 @@ $expected_html = <<<HTML
 We have detected that Autoptimize's Aggregate Inline CSS feature is enabled. WP Rocket's Load CSS Asynchronously will not work correctly. We suggest disabling <strong>Aggregate Inline CSS</strong> to take full advantage of Load CSS Asynchronously Execution.
 </p><p>
 <a class="rocket-dismiss" href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=warn_when_aggregate_inline_css_and_cpcss_active&amp;_wpnonce=123456">
-Dismiss this notice.</a></p></div>
+Dismiss this notice</a></p></div>
 HTML;
 
 return [

--- a/tests/Fixtures/inc/ThirdParty/Plugins/Optimization/Autoptimize/warnWhenJsAggregationAndDelayJsActive.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/Optimization/Autoptimize/warnWhenJsAggregationAndDelayJsActive.php
@@ -7,7 +7,7 @@ $expected_html = <<<HTML
 <p>
 <strong>WP Rocket: </strong>
 We have detected that Autoptimize's JavaScript Aggregation feature is enabled. WP Rocket's Delay JavaScript Execution will not be applied to the file it creates. We suggest disabling <strong>JavaScript Aggregation</strong> to take full advantage of Delay JavaScript Execution.</p><p>
-<a class="rocket-dismiss" href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=warn_when_js_aggregation_and_delay_js_active&amp;_wpnonce=123456">
+<a class="rocket-dismiss " href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=warn_when_js_aggregation_and_delay_js_active&amp;_wpnonce=123456">
 Dismiss this notice</a></p></div>
 HTML;
 

--- a/tests/Fixtures/inc/ThirdParty/Plugins/Optimization/Autoptimize/warnWhenJsAggregationAndDelayJsActive.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/Optimization/Autoptimize/warnWhenJsAggregationAndDelayJsActive.php
@@ -8,7 +8,7 @@ $expected_html = <<<HTML
 <strong>WP Rocket: </strong>
 We have detected that Autoptimize's JavaScript Aggregation feature is enabled. WP Rocket's Delay JavaScript Execution will not be applied to the file it creates. We suggest disabling <strong>JavaScript Aggregation</strong> to take full advantage of Delay JavaScript Execution.</p><p>
 <a class="rocket-dismiss" href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=warn_when_js_aggregation_and_delay_js_active&amp;_wpnonce=123456">
-Dismiss this notice.</a></p></div>
+Dismiss this notice</a></p></div>
 HTML;
 
 return [

--- a/tests/Unit/inc/Engine/HealthCheck/HealthCheck/missedCron.php
+++ b/tests/Unit/inc/Engine/HealthCheck/HealthCheck/missedCron.php
@@ -48,7 +48,7 @@ class Test_MissedCron extends TestCase {
 
 		Functions\when( 'rocket_notice_html' )->alias(
 			function ( $args ) {
-				echo '<div class="notice notice-warning ">' . $args['message'] . '<p><a class="rocket-dismiss" href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=rocket_warning_cron&amp;_wpnonce=123456">Dismiss this notice</a></p></div>';
+				echo '<div class="notice notice-warning ">' . $args['message'] . '<p><a class="rocket-dismiss " href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=rocket_warning_cron&amp;_wpnonce=123456">Dismiss this notice</a></p></div>';
 			}
 		);
 

--- a/tests/Unit/inc/Engine/HealthCheck/HealthCheck/missedCron.php
+++ b/tests/Unit/inc/Engine/HealthCheck/HealthCheck/missedCron.php
@@ -48,7 +48,7 @@ class Test_MissedCron extends TestCase {
 
 		Functions\when( 'rocket_notice_html' )->alias(
 			function ( $args ) {
-				echo '<div class="notice notice-warning ">' . $args['message'] . '<p><a class="rocket-dismiss" href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=rocket_warning_cron&amp;_wpnonce=123456">Dismiss this notice.</a></p></div>';
+				echo '<div class="notice notice-warning ">' . $args['message'] . '<p><a class="rocket-dismiss" href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=rocket_warning_cron&amp;_wpnonce=123456">Dismiss this notice</a></p></div>';
 			}
 		);
 

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cleanUsedCssAndCache.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cleanUsedCssAndCache.php
@@ -59,7 +59,7 @@ class Test_CleanUsedCssAndCache extends FilesystemTestCase {
 				->with(
 					'rocket_rucss_processing',
 					Mockery::type( 'int' ),
-					60
+					90
 				);
 
 			Functions\expect( 'rocket_renew_box' )

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/maybeSetProcessingTransient.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/maybeSetProcessingTransient.php
@@ -37,7 +37,7 @@ class Test_MaybeSetProcessingTransient extends TestCase {
 				->with(
 					'rocket_rucss_processing',
 					Mockery::type( 'int' ),
-					60
+					90
 				);
 
 			Functions\expect( 'rocket_renew_box' )

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/truncateUsedCSSHandler.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/truncateUsedCSSHandler.php
@@ -124,7 +124,7 @@ class Test_TruncateUsedCSSHandler extends TestCase {
 				->with(
 					'rocket_rucss_processing',
 					Mockery::type( 'int' ),
-					60
+					90
 				);
 
 			Functions\expect( 'rocket_renew_box' )

--- a/tests/Unit/inc/ThirdParty/Plugins/ModPagespeed/showAdminNotice.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/ModPagespeed/showAdminNotice.php
@@ -73,7 +73,7 @@ class Test_ShowAdminNotice extends TestCase {
 		if ( $expected['show_notice'] ) {
 			Functions\when( 'rocket_notice_html' )->alias(
 				function ( $args ) {
-					echo '<div class="notice notice-' . $args['status'] . ' "><p>' . $args['message'] . '</p><p><a class="rocket-dismiss" href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=rocket_error_mod_pagespeed&amp;_wpnonce=123456">Dismiss this notice.</a></p></div>';
+					echo '<div class="notice notice-' . $args['status'] . ' "><p>' . $args['message'] . '</p><p><a class="rocket-dismiss" href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=rocket_error_mod_pagespeed&amp;_wpnonce=123456">Dismiss this notice</a></p></div>';
 				}
 			);
 		}

--- a/tests/Unit/inc/ThirdParty/Plugins/ModPagespeed/showAdminNotice.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/ModPagespeed/showAdminNotice.php
@@ -73,7 +73,7 @@ class Test_ShowAdminNotice extends TestCase {
 		if ( $expected['show_notice'] ) {
 			Functions\when( 'rocket_notice_html' )->alias(
 				function ( $args ) {
-					echo '<div class="notice notice-' . $args['status'] . ' "><p>' . $args['message'] . '</p><p><a class="rocket-dismiss" href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=rocket_error_mod_pagespeed&amp;_wpnonce=123456">Dismiss this notice</a></p></div>';
+					echo '<div class="notice notice-' . $args['status'] . ' "><p>' . $args['message'] . '</p><p><a class="rocket-dismiss " href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=rocket_error_mod_pagespeed&amp;_wpnonce=123456">Dismiss this notice</a></p></div>';
 				}
 			);
 		}

--- a/views/settings/page-sections/dashboard.php
+++ b/views/settings/page-sections/dashboard.php
@@ -43,7 +43,7 @@ defined( 'ABSPATH' ) || exit;
 			</h2>
 				<div class="wpr-notice-description"><?php esc_html_e( 'To guarantee fast websites, WP Rocket automatically applies 80% of web performance best practices.', 'rocket' ); ?><br> <?php esc_html_e( 'We also enable options that provide immediate benefits to your website.', 'rocket' ); ?></div>
 				<div class="wpr-notice-continue"><?php esc_html_e( 'Continue to the options to further optimize your site!', 'rocket' ); ?></div>
-				<a id="wpr-congratulations-notice" class="wpr-notice-close wpr-icon-close rocket-dismiss" href="<?php echo esc_url( wp_nonce_url( admin_url( 'admin-post.php?action=rocket_ignore&box=rocket_activation_notice' ), 'rocket_ignore_rocket_activation_notice' ) ); ?>"><span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice.', 'rocket' ); ?></span></a>
+				<a id="wpr-congratulations-notice" class="wpr-notice-close wpr-icon-close rocket-dismiss" href="<?php echo esc_url( wp_nonce_url( admin_url( 'admin-post.php?action=rocket_ignore&box=rocket_activation_notice' ), 'rocket_ignore_rocket_activation_notice' ) ); ?>"><span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice', 'rocket' ); ?></span></a>
 		</div>
 	</div>
 	<?php endif; ?>


### PR DESCRIPTION
## Description

- Add a capital P on Please wait X seconds
- Increase the time to 90 seconds instead of 60. Even with the new version, we still need to wait 10/20 seconds before getting the Used CSS on the homepage. To be sure, let’s just increase the counter to 90 seconds.
- Replace Your homepage has been processed by The Used CSS of your homepage has been processed
- Replace the Dismiss this notice link by a cross CTA

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
