### PR TITLE
Fixes #4711 Do not add preload link script if user is logged in

### DIFF
--- a/inc/Engine/Preload/Links/Subscriber.php
+++ b/inc/Engine/Preload/Links/Subscriber.php
@@ -63,7 +63,7 @@ class Subscriber implements Subscriber_Interface {
 		 * bail out if user is logged in
 		 * don't add preload link script
 		 */
-		if( is_user_logged_in() ) { 
+		if ( is_user_logged_in() ) {
 			return;
 		}
 

--- a/inc/Engine/Preload/Links/Subscriber.php
+++ b/inc/Engine/Preload/Links/Subscriber.php
@@ -58,6 +58,15 @@ class Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function add_preload_script() {
+
+		/**
+		 * bail out if user is logged in
+		 * don't add preload link script
+		 */
+		if( is_user_logged_in() ) { 
+			return;
+		}
+
 		if ( $this->is_enqueued ) {
 			return;
 		}

--- a/inc/Engine/Preload/Links/Subscriber.php
+++ b/inc/Engine/Preload/Links/Subscriber.php
@@ -60,8 +60,8 @@ class Subscriber implements Subscriber_Interface {
 	public function add_preload_script() {
 
 		/**
-		 * bail out if user is logged in
-		 * don't add preload link script
+		 * Bail out if user is logged in
+		 * Don't add preload link script
 		 */
 		if ( is_user_logged_in() ) {
 			return;


### PR DESCRIPTION
## Description

Preload link script will not be added if user is logged in; Link prefetch will not be executed.

Fixes #4711 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

Solution is in no way different from the proposed one in grooming

## How Has This Been Tested?

- Disable Cache for logged in users
- Enable Preload links
- Visit page while logged in and check the network tab to see that hovered link is not prefetched


# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
