### PR TITLE
Pass JSON_PRETTY_PRINT to wp_json_encode() to unminify JSON

### DIFF
--- a/inc/admin/admin.php
+++ b/inc/admin/admin.php
@@ -186,7 +186,7 @@ function rocket_do_options_export() {
 	$site_name = $site_name['host'] . $site_name['path'];
 	$filename  = sprintf( 'wp-rocket-settings-%s-%s-%s.json', $site_name, date( 'Y-m-d' ), uniqid() ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
 	$gz        = 'gz' . strrev( 'etalfed' );
-	$options   = wp_json_encode( get_option( WP_ROCKET_SLUG ) ); // do not use get_rocket_option() here.
+	$options   = wp_json_encode( get_option( WP_ROCKET_SLUG ), JSON_PRETTY_PRINT ); // do not use get_rocket_option() here.
 	nocache_headers();
 	@header( 'Content-Type: application/json' );
 	@header( 'Content-Disposition: attachment; filename="' . $filename . '"' );


### PR DESCRIPTION
## Description

Passed JSON_PRETTY_PRINT as second argument to the wp_json_encode() to print JSON in pretty format.

Fixes #4578 

## Type of change

Please delete options that are not relevant.

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

Solution is no way different from the proposed one.

## How Has This Been Tested?

Click on the Tools tab and click on Download Settings to see the unminified exported settings in JSON

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
