### PR TITLE
Remove normalize_number() method from pricing

### DIFF
--- a/inc/Engine/CDN/RocketCDN/NoticesSubscriber.php
+++ b/inc/Engine/CDN/RocketCDN/NoticesSubscriber.php
@@ -199,7 +199,7 @@ class NoticesSubscriber extends Abstract_Render implements Subscriber_Interface 
 				'message'         => $pricing->get_error_message(),
 			];
 		} else {
-			$current_price      = number_format_i18n( $this->normalize_number( $pricing['monthly_price'] ), 2 );
+			$current_price      = number_format_i18n( $pricing['monthly_price'], 2 );
 			$promotion_campaign = '';
 			$end_date           = strtotime( $pricing['end_date'] );
 			$promotion_end_date = '';
@@ -211,7 +211,7 @@ class NoticesSubscriber extends Abstract_Render implements Subscriber_Interface 
 			) {
 				$promotion_campaign = $pricing['discount_campaign_name'];
 				$regular_price      = $current_price;
-				$current_price      = number_format_i18n( $this->normalize_number( $pricing['discounted_price_monthly'] ), 2 ) . '*';
+				$current_price      = number_format_i18n( $pricing['discounted_price_monthly'], 2 ) . '*';
 				$nopromo_variant    = '';
 				$promotion_end_date = date_i18n( get_option( 'date_format' ), $end_date );
 			}
@@ -222,7 +222,7 @@ class NoticesSubscriber extends Abstract_Render implements Subscriber_Interface 
 				'promotion_end_date' => $promotion_end_date,
 				'nopromo_variant'    => $nopromo_variant,
 				'regular_price'      => $regular_price,
-				'current_price'      => $this->normalize_number( $current_price ),
+				'current_price'      => $current_price,
 			];
 		}
 
@@ -296,16 +296,5 @@ class NoticesSubscriber extends Abstract_Render implements Subscriber_Interface 
 	 */
 	private function is_white_label_account() {
 		return (bool) rocket_get_constant( 'WP_ROCKET_WHITE_LABEL_ACCOUNT' );
-	}
-
-	/**
-	 * Normalize the number by replacing comma with a dot.
-	 *
-	 * @param string|int $number Number to be normalized.
-	 *
-	 * @return string|float
-	 */
-	private function normalize_number( $number ) {
-		return str_replace( ',', '.', $number );
 	}
 }


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed/closed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Remove `normalize_number()` method from pricing format to allow `number_format_i18n` format properly for internalization support.

Fixes #4596 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

This solution is no way different from the proposed one.

## How Has This Been Tested?

Enable Rocket CDN Campaign
On the CDN Tab, Check to see that appropriate pricing format is applied per user language selected.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
