### PR TITLE
Closes #4547 Exclude new google ios related query strings

### DIFF
--- a/inc/admin/upgrader.php
+++ b/inc/admin/upgrader.php
@@ -306,12 +306,9 @@ function rocket_new_upgrade( $wp_rocket_version, $actual_version ) {
 		}
 	}
 
-	if ( version_compare( $actual_version, '3.10.8', '<' ) ) {
+	if ( version_compare( $actual_version, '3.11.1', '<' ) ) {
 		rocket_generate_config_file();
 	}
 
-	if ( version_compare( $actual_version, '3.10.9', '<' ) ) {
-		rocket_generate_config_file();
-	}
 }
 add_action( 'wp_rocket_upgrade', 'rocket_new_upgrade', 10, 2 );

--- a/inc/admin/upgrader.php
+++ b/inc/admin/upgrader.php
@@ -309,5 +309,9 @@ function rocket_new_upgrade( $wp_rocket_version, $actual_version ) {
 	if ( version_compare( $actual_version, '3.10.8', '<' ) ) {
 		rocket_generate_config_file();
 	}
+
+	if ( version_compare( $actual_version, '3.10.9', '<' ) ) {
+		rocket_generate_config_file();
+	}
 }
 add_action( 'wp_rocket_upgrade', 'rocket_new_upgrade', 10, 2 );

--- a/inc/functions/options.php
+++ b/inc/functions/options.php
@@ -217,6 +217,8 @@ function rocket_get_ignored_parameters() {
 		'dm_i'                  => 1,
 		'epik'                  => 1,
 		'pp'                    => 1,
+		'gbraid'                => 1,
+		'wbraid'                => 1,
 	];
 
 	/**


### PR DESCRIPTION
## Description

Added gbraid & wbraid to ignored parameters to be cached when checking query string and also generate config file with new parameters.

Fixes #4547 

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

This Solution is in no way different from the proposed one.

## How Has This Been Tested?
Append gbraid & wbraid as query string to url and see that the page get cached without adding parameters in the advanced rules tab on settings.

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
