### PR TITLE
Send nowprocket only when calling SaaS without saving it into the DB

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -193,7 +193,7 @@ class UsedCSS {
 		}
 
 		global $wp;
-		$url       = untrailingslashit( home_url( add_query_arg( [ 'nowprocket' => 1 ], $wp->request ) ) );
+		$url       = untrailingslashit( home_url( add_query_arg( [], $wp->request ) ) );
 		$is_mobile = $this->is_mobile();
 		$used_css  = $this->used_css_query->get_row( $url, $is_mobile );
 

--- a/inc/Engine/Optimization/RUCSS/Frontend/APIClient.php
+++ b/inc/Engine/Optimization/RUCSS/Frontend/APIClient.php
@@ -25,7 +25,7 @@ class APIClient extends AbstractAPIClient {
 	public function add_to_queue( string $url, array $options ): array {
 		$args = [
 			'body'    => [
-				'url'    => $url,
+				'url'    => add_query_arg( [ 'nowprocket' => 1 ], $url ),
 				'config' => $options,
 			],
 			'timeout' => 5,


### PR DESCRIPTION
## Description

We need to send `nowprocket` argument only when calling SaaS only without saving it into the DB as we are doing some queries using the url and also we are checking if the url is_home to send to SaaS and doing those checks with nowprocket are failing

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Check the DB urls, it shouldn't contain nowprocket query string at all.

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
