### PR TITLE
New RUCSS compatibility with revolution slider

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -64,6 +64,7 @@ class UsedCSS {
 		'extra-style-inline-inline-css',
 		'woodmart-inline-css-inline-css',
 		'woodmart_shortcodes-custom-css',
+		'rs-plugin-settings-inline-css', // For revolution slider, it saves settings for each slider.
 	];
 
 	/**


### PR DESCRIPTION
## Description

@piotrbak found that we need to preserve the style inside the id `rs-plugin-settings-inline-css` as it contains a specific CSS for each slider like the following:

![image](https://user-images.githubusercontent.com/15707971/159938419-fcb20fb3-f7c2-4f30-a01e-e613393fe685.png)

and as revolution slider is widely used inside themes and on a dedicated plugin so we will add it to the global list without third party compatibility file.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

@piotrbak tested that on our test site and I trust him :D 

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
