### PR TITLE
Allow people to use v2 of composer/installers package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
 	],
 	"require": {
 		"php": ">=7.0",
-		"composer/installers": "~1.0",
+		"composer/installers": ">=1.0",
 		"monolog/monolog": "^1.0",
 		"woocommerce/action-scheduler": "^3.4"
 	},


### PR DESCRIPTION
## Description

Otherwise you cannot install WP Rocket if you're currently using v2 like this:

`"composer/installers": "^2.0",`

Fixes #(issue number)

## Type of change

Please delete options that are not relevant.

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

Please describe in this section if there is any change to the solution, and why.
