### PR TITLE
Change Action Scheduler concurrent batches number only when it's less than two

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
@@ -539,7 +539,7 @@ class Subscriber implements Subscriber_Interface {
 	 * @return int
 	 */
 	public function adjust_as_concurrent_batches( int $num = 1 ) {
-		return 2;
+		return ( 2 < $num ) ? $num : 2;
 	}
 
 	/**


### PR DESCRIPTION
## Description

We always override the `action_scheduler_queue_runner_concurrent_batches` filter return to be 2.

And we need to return the batch number when it's more than 2 otherwise return 2

https://wp-media.slack.com/archives/GUT7FLHF1/p1648213301376429

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Use the following snippet to change the number of concurrent patches at your current theme's `functions.php`
```
add_filter( 'action_scheduler_queue_runner_concurrent_batches', function( $number ){
    return 10;
} );
```

You should see that the concurrent batches should be `10`.

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
