### PR TITLE
Fixes #4753 Allow usage of `composer/installers` v2

### DIFF
--- a/.github/workflows/deploy_plugin.yml
+++ b/.github/workflows/deploy_plugin.yml
@@ -38,6 +38,14 @@ jobs:
         run: composer install --no-scripts --no-dev
         working-directory: /tmp/wp-rocket
 
+      - name: Remove composer installers
+        run: composer remove composer/installers
+        working-directory: /tmp/wp-rocket
+
+      - name: Optimize autoloader
+        run: composer dumpautoload -o
+        working-directory: /tmp/wp-rocket
+
       - name: Zip Folder
         run: zip -r __wp-rocket_${GITHUB_REF##*v}.zip wp-rocket
         working-directory: /tmp

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
 	],
 	"require": {
 		"php": ">=7.0",
-		"composer/installers": "~1.0",
+		"composer/installers": "^1.0 || ^2.0",
 		"monolog/monolog": "^1.0"
 	},
 	"require-dev": {


### PR DESCRIPTION
## Description

In this PR, we update the compatible versions of `composer/installers` to add the v2.0 and above. This will make installation of the plugin via composer working again for users using the new version of the installer.

At the same time, since the v2 requires a minimum of PHP 7.2, and we currently require a minimum of PHP 7.1, if the package is included in the final zip file that users can download, it could potentially cause errors.

To avoid that, in the GH action to deploy the plugin, we remove `composer/installers` from the dependencies. This package is anyway only needed for users using composer to manage dependencies, not for the ones downloading the plugin from their account or updating from the WordPress system.

Fixes #4753

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

