### PR TITLE
Fix code coverage reporting

### DIFF
--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Settings/displayProcessingNotice.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Settings/displayProcessingNotice.php
@@ -63,7 +63,7 @@ return [
 			],
 			'capability'        => true,
 			'remove_unused_css' => 1,
-			'transient'         => time() + 60,
+			'transient'         => time() + 3600,
 		],
 		'expected' => true,
 	],

--- a/tests/Unit/inc/Engine/Cache/WPCache/maybePreventDeactivation.php
+++ b/tests/Unit/inc/Engine/Cache/WPCache/maybePreventDeactivation.php
@@ -7,7 +7,6 @@ use Brain\Monkey\Filters;
 
 /**
  * @covers \WP_Rocket\Engine\Cache\WPCache::maybe_prevent_deactivation
- * @uses   \WP_Rocket\Engine\Cache\WPCache::find_wp_config_path
  *
  * @group  WPCache
  */


### PR DESCRIPTION
## Description

The code coverage reporting is failing since 3.11 because one of the fixtures was setting a short time value, but the code coverage run takes a long time. Increasing the value fixes the issue.

It's also removing warning generated during the run, because of an `@uses` annotation for a private method.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Ran the `composer code-coverage` command locally to see the result with no errors/warnings anymore

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
