### PR TITLE
Fixes #4869 Disable combine CSS when RUCSS & combine CSS are enabled at the same time

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Admin/Settings.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Settings.php
@@ -363,7 +363,7 @@ class Settings {
 			&&
 			$value['remove_unused_css'] === $old_value['remove_unused_css']
 			&&
-			1 === $value['remove_unused_css']
+			$value['minify_concatenate_css'] === $old_value['minify_concatenate_css']
 			&&
 			0 === $old_value['minify_concatenate_css']
 		) {

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Settings/maybeDisableCombineCss.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Settings/maybeDisableCombineCss.php
@@ -127,4 +127,26 @@ return [
 			'cdn'                   => 0,
 		],
 	],
+	'testShouldReturnUpdatedWhenCombineCssAndRUCSSEnabledAtTheSameTime' => [
+		'config' => [
+			'value'     => [
+				'minify_css'             => 1,
+				'minify_concatenate_css' => 1,
+				'remove_unused_css'      => 1,
+				'cdn'                   => 0,
+			],
+			'old_value' => [
+				'minify_css'             => 0,
+				'minify_concatenate_css' => 0,
+				'remove_unused_css'      => 1,
+				'cdn'                   => 0,
+			],
+		],
+		'expected' => [
+			'minify_css'             => 1,
+			'minify_concatenate_css' => 0,
+			'remove_unused_css'      => 1,
+			'cdn'                   => 0,
+		],
+	],
 ];


### PR DESCRIPTION
## Description

Update the conditional checking for combine CSS & RUCSS being enabled together, and disable combine CSS in this case.

Fixes #4869

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

No grooming, small issue quick to fix

## How Has This Been Tested?

- [x] Added new test fixture for this case

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
