### PR TITLE
Fix the conflict when loading old Action Scheduler version

### DIFF
--- a/inc/Engine/Common/Queue/AbstractASQueue.php
+++ b/inc/Engine/Common/Queue/AbstractASQueue.php
@@ -60,6 +60,10 @@ abstract class AbstractASQueue implements QueueInterface {
 	 * @return bool
 	 */
 	public function is_scheduled( $hook, $args = [] ) {
+		if ( ! function_exists( 'as_has_scheduled_action' ) ) {
+			return ! is_null( $this->get_next( $hook, $args ) );
+		}
+
 		return as_has_scheduled_action( $hook, $args, $this->group );
 	}
 
@@ -83,7 +87,7 @@ abstract class AbstractASQueue implements QueueInterface {
 	 * @return string The action ID
 	 */
 	public function schedule_cron( $timestamp, $cron_schedule, $hook, $args = [] ) {
-		if ( as_has_scheduled_action( $hook ) ) {
+		if ( $this->is_scheduled( $hook, $args ) ) {
 			return '';
 		}
 		return as_schedule_cron_action( $timestamp, $cron_schedule, $hook, $args, $this->group );


### PR DESCRIPTION
## Description

In this PR, we are checking if the function `as_has_scheduled_action` exists (it exists from version 3.3 and above) otherwise use the function `as_next_scheduled_action` instead, this will do the same functionality.

Fixes #4877

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Is the solution different from the one proposed during the grooming?

Yes, exactly the same

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Install the plugin [imageseo](https://wordpress.org/plugins/imageseo) before installing WPR and check the fatal error.

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
