### PR TITLE
Fixes #4059 Update info link for fallback critical css

### DIFF
--- a/inc/Engine/Admin/Beacon/Beacon.php
+++ b/inc/Engine/Admin/Beacon/Beacon.php
@@ -687,6 +687,16 @@ class Beacon extends Abstract_Render implements Subscriber_Interface {
 					'url' => 'https://fr.docs.wp-rocket.me/article/1521-utiliser-wp-rocket-sur-un-intranet-prive-ou-hors-ligne?utm_source=wp_plugin&utm_medium=wp_rocket',
 				],
 			],
+			'fallback_css'             => [
+				'en' => [
+					'id'  => '5ec5c4072c7d3a5ea54b7de7',
+					'url' => 'https://docs.wp-rocket.me/article/1321-critical-css-issues-fouc#use-fallback-critical-css',
+				],
+				'fr' => [
+					'id'  => '5edf8a5504286306f804e1dc',
+					'url' => 'https://fr.docs.wp-rocket.me/article/1327-problemes-critical-css-fouc#critical-path-css-de-secours',
+				],
+			],
 		];
 
 		return isset( $suggest[ $doc_id ][ $this->get_user_locale() ] )

--- a/inc/Engine/Admin/Beacon/Beacon.php
+++ b/inc/Engine/Admin/Beacon/Beacon.php
@@ -362,7 +362,7 @@ class Beacon extends Abstract_Render implements Subscriber_Interface {
 				],
 				'fr' => [
 					'id'  => '60d499a705ff892e6bc2a89e',
-					'url' => 'https://fr.docs.wp-rocket.me/article/1577-supprimer-les-ressources-css-inutilisees?utm_source=wp_plugin&utm_medium=wp_rocket'
+					'url' => 'https://fr.docs.wp-rocket.me/article/1577-supprimer-les-ressources-css-inutilisees?utm_source=wp_plugin&utm_medium=wp_rocket',
 				],
 			],
 			'exclude_inline_js'          => [

--- a/inc/Engine/Admin/Beacon/Beacon.php
+++ b/inc/Engine/Admin/Beacon/Beacon.php
@@ -687,7 +687,7 @@ class Beacon extends Abstract_Render implements Subscriber_Interface {
 					'url' => 'https://fr.docs.wp-rocket.me/article/1521-utiliser-wp-rocket-sur-un-intranet-prive-ou-hors-ligne?utm_source=wp_plugin&utm_medium=wp_rocket',
 				],
 			],
-			'fallback_css'             => [
+			'fallback_css'               => [
 				'en' => [
 					'id'  => '5ec5c4072c7d3a5ea54b7de7',
 					'url' => 'https://docs.wp-rocket.me/article/1321-critical-css-issues-fouc#use-fallback-critical-css',

--- a/inc/Engine/Admin/Beacon/Beacon.php
+++ b/inc/Engine/Admin/Beacon/Beacon.php
@@ -360,6 +360,10 @@ class Beacon extends Abstract_Render implements Subscriber_Interface {
 					'id'  => '6076083ff8c0ef2d98df1f97',
 					'url' => 'https://docs.wp-rocket.me/article/1529-remove-unused-css?utm_source=wp_plugin&utm_medium=wp_rocket',
 				],
+				'fr' => [
+					'id'  => '60d499a705ff892e6bc2a89e',
+					'url' => 'https://fr.docs.wp-rocket.me/article/1577-supprimer-les-ressources-css-inutilisees?utm_source=wp_plugin&utm_medium=wp_rocket'
+				],
 			],
 			'exclude_inline_js'          => [
 				'en' => [

--- a/inc/Engine/Admin/Settings/Page.php
+++ b/inc/Engine/Admin/Settings/Page.php
@@ -562,6 +562,7 @@ class Page {
 		$exclude_defer_js           = $this->beacon->get_suggest( 'exclude_defer_js' );
 		$rucss_beacon               = $this->beacon->get_suggest( 'remove_unused_css' );
 		$offline_beacon             = $this->beacon->get_suggest( 'offline' );
+		$fallback_css_beacon        = $this->beacon->get_suggest( 'fallback_css' );
 
 		$disable_combine_js  = $this->disable_combine_js();
 		$disable_combine_css = $this->disable_combine_css();
@@ -756,7 +757,7 @@ class Page {
 										'type'        => 'textarea',
 										'label'       => __( 'Fallback critical CSS', 'rocket' ),
 										// translators: %1$s = opening <a> tag, %2$s = closing </a> tag.
-										'helper'      => sprintf( __( 'Provides a fallback if auto-generated critical path CSS is incomplete. %1$sMore info%2$s', 'rocket' ), '<a href="' . esc_url( $async_beacon['url'] ) . '#fallback" data-beacon-article="' . esc_attr( $async_beacon['id'] ) . '" target="_blank">', '</a>' ),
+										'helper'      => sprintf( __( 'Provides a fallback if auto-generated critical path CSS is incomplete. %1$sMore info%2$s', 'rocket' ), '<a href="' . esc_url( $fallback_css_beacon['url'] ) . '#fallback" data-beacon-article="' . esc_attr( $fallback_css_beacon['id'] ) . '" target="_blank">', '</a>' ),
 										'sanitize_callback' => 'sanitize_textarea',
 										'parent'      => '',
 										'section'     => 'css',


### PR DESCRIPTION
## Description

Added `fallback_css` element with right doc link to `suggest `array` to replace `async_beacon in `Engine\Admin\Settings\Page::assets_section()`

Fixes #4059 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

This solution is in no way different from the proposed one.

## How Has This Been Tested?

Testing on a Local Env where Optimize CSS Delivery feature is disabled but hidden element being inspected shows changes below
```
<div class="wpr-field-description wpr-field-description-helper">
  Provides a fallback if auto-generated critical path CSS is incomplete. <a href="https://docs.wp-rocket.me/article/1321-critical-css-issues-fouc#use-fallback-critical-css#fallback" data-beacon-article="5ec5c4072c7d3a5ea54b7de7" target="_blank">More info</a>		
</div>
```
# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
