### PR TITLE
Fixes #4866 Duplicate key name 'queue_name_index' with update

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Database/Tables/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Database/Tables/UsedCSS.php
@@ -144,6 +144,10 @@ class UsedCSS extends Table {
 			return $this->is_success( false );
 		}
 
+		if ( $this->index_exists( 'queue_name_index' ) ) {
+			return $this->is_success( true );
+		}
+
 		$index_added = $this->get_db()->query( "ALTER TABLE {$this->table_name} ADD INDEX `queue_name_index` (`queue_name`) " );
 		return $this->is_success( $index_added );
 	}


### PR DESCRIPTION
## Description

In this PR we will guard against Duplicate key name 'queue_name_index' with update by bailing out if this index exists otherwise create it.

Fixes #4866

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I wasn't able to reproduce the exact issue but I simulated this error by the following steps:-
1. Open the Database.
2. Open the table `wp_options`.
3. Get the row with `option_key` equals `wpr_rucss_used_css_version`.
4. Change this row's `option_value` with the value `20220121`.
5. Open the admin page
6. With this PR, you shouldn't see the warning into `debug.log`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
