### PR TITLE
Fixes #4876 Update RUCSS safelist on update to 3.11.0.2

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Admin/Settings.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Settings.php
@@ -433,11 +433,11 @@ class Settings {
 				continue;
 			}
 
-			if ( str_starts_with( $value, '(') ) {
+			if ( str_starts_with( $value, '(' ) ) {
 				continue;
 			}
 
-			$options['remove_unused_css_safelist'][$key] = '(.*)' . $value;
+			$options['remove_unused_css_safelist'][ $key ] = '(.*)' . $value;
 		}
 
 		update_option( 'wp_rocket_settings', $options );

--- a/inc/Engine/Optimization/RUCSS/Admin/Settings.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Settings.php
@@ -407,4 +407,39 @@ class Settings {
 
 		update_option( 'wp_rocket_settings', $options );
 	}
+
+	/**
+	 * Updates safelist items for new SaaS compatibility
+	 *
+	 * @since 3.11.0.2
+	 *
+	 * @param string $old_version Previous plugin version.
+	 *
+	 * @return void
+	 */
+	public function update_safelist_items( $old_version ) {
+		if ( version_compare( $old_version, '3.11.0.2', '>=' ) ) {
+			return;
+		}
+
+		$options = get_option( 'wp_rocket_settings', [] );
+
+		if ( empty( $options['remove_unused_css_safelist'] ) ) {
+			return;
+		}
+
+		foreach ( $options['remove_unused_css_safelist'] as $key => $value ) {
+			if ( str_contains( $value, '.css' ) ) {
+				continue;
+			}
+
+			if ( str_starts_with( $value, '(') ) {
+				continue;
+			}
+
+			$options['remove_unused_css_safelist'][$key] = '(.*)' . $value;
+		}
+
+		update_option( 'wp_rocket_settings', $options );
+	}
 }

--- a/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
@@ -102,7 +102,10 @@ class Subscriber implements Subscriber_Interface {
 			'rocket_localize_admin_script'         => 'add_localize_script_data',
 			'action_scheduler_queue_runner_concurrent_batches' => 'adjust_as_concurrent_batches',
 			'pre_update_option_wp_rocket_settings' => [ 'maybe_disable_combine_css', 11, 2 ],
-			'wp_rocket_upgrade'                    => [ 'set_option_on_update', 14, 2 ],
+			'wp_rocket_upgrade'                    => [
+				[ 'set_option_on_update', 14, 2 ],
+				[ 'update_safelist_items', 15, 2 ],
+			],
 			'wp_ajax_rocket_spawn_cron'            => 'spawn_cron',
 			'rocket_deactivation'                  => 'cancel_queues',
 		];
@@ -597,6 +600,20 @@ class Subscriber implements Subscriber_Interface {
 				'sslverify'  => apply_filters( 'https_local_ssl_verify', false ), // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 			]
 		);
+	}
+
+	/**
+	 * Updates safelist items for new SaaS compatibility
+	 *
+	 * @since 3.11.0.2
+	 *
+	 * @param string $new_version New plugin version.
+	 * @param string $old_version Previous plugin version.
+	 *
+	 * @return void
+	 */
+	public function update_safelist_items( $new_version, $old_version ) {
+		$this->settings->update_safelist_items( $old_version );
 	}
 
 	/**

--- a/inc/compat.php
+++ b/inc/compat.php
@@ -1,3 +1,34 @@
 <?php
 
 defined( 'ABSPATH' ) || exit;
+
+if ( ! function_exists( 'str_starts_with' ) ) {
+	/**
+	 * Polyfill for str_starts_with() function added in PHP 8.0.
+	 *
+	 * @param string $haystack The string to search in.
+	 * @param string $needle The substring to search for in the haystack.
+	 *
+	 * @return bool True if $needle is in $haystack, otherwise false.
+	 */
+	function str_starts_with( $haystack, $needle ) {
+		if ( '' === $needle ) {
+			return true;
+		}
+		return 0 === strpos( $haystack, $needle );
+	}
+}
+
+if ( ! function_exists( 'str_contains' ) ) {
+	/**
+	 * Polyfill for str_contains() function added in PHP 8.0.
+	 *
+	 * @param string $haystack The string to search in.
+	 * @param string $needle The substring to search for in the haystack.
+	 *
+	 * @return bool True if $needle is in $haystack, otherwise false.
+	 */
+	function str_contains( $haystack, $needle ) {
+		return ( '' === $needle || false !== strpos( $haystack, $needle ) );
+	}
+}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -64,6 +64,9 @@
             <property name="strict_class_file_names" value="false" />
         </properties>
     </rule>
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound">
+		<exclude-pattern>inc/compat.php</exclude-pattern>
+	</rule>
 	<rule ref="WordPress.WP.AlternativeFunctions.file_system_read_readfile">
 		<exclude-pattern>inc/classes/buffer/class-cache.php</exclude-pattern>
 	</rule>

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Settings/updateSafelistItems.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Settings/updateSafelistItems.php
@@ -1,0 +1,54 @@
+<?php
+
+return [
+	'testShouldDoNothingWhenAbove3.11.0.2' => [
+		'config' => [
+			'version' => '3.11.1',
+			'options' => [
+				'remove_unused_css_safelist' => [
+					'.class',
+					'/wp-content/themes/style.css',
+					'div',
+					'#id',
+					'(.*).class2',
+					'[attribute]',
+				],
+			],
+		],
+		'expected' => false,
+	],
+	'testShouldDoNothingWhenEmptySafelist' => [
+		'config' => [
+			'version' => '3.11.0.1',
+			'options' => [
+				'remove_unused_css_safelist' => [],
+			],
+		],
+		'expected' => false,
+	],
+	'testShouldUpdateSafelist' => [
+		'config' => [
+			'version' => '3.11.0.1',
+			'options' => [
+				'remove_unused_css_safelist' => [
+					'.class',
+					'/wp-content/themes/style.css',
+					'div',
+					'#id',
+					'(.*).class2',
+					'[attribute]',
+				],
+			],
+		],
+		'expected' => [
+			'remove_unused_css_safelist' => [
+				'(.*).class',
+				'/wp-content/themes/style.css',
+				'(.*)div',
+				'(.*)#id',
+				'(.*).class2',
+				'(.*)[attribute]',
+			],
+		],
+	],
+];

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/maybeDisableCombineCss.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/maybeDisableCombineCss.php
@@ -1,0 +1,130 @@
+<?php
+
+return [
+	'testShouldReturnSameWhenOptionsNotSet' => [
+		'config' => [
+			'value'     => [
+				'minify_css' => 0,
+				'cdn'       => 0,
+			],
+			'old_value' => [
+				'minify_css' => 1,
+				'cdn'       => 0,
+			],
+		],
+		'expected' => [
+			'minify_css' => 0,
+			'cdn'       => 0,
+		],
+	],
+	'testShouldReturnSameWhenOptionsEqualZero' => [
+		'config' => [
+			'value'     => [
+				'minify_css'             => 0,
+				'minify_concatenate_css' => 0,
+				'remove_unused_css'      => 0,
+				'cdn'                   => 0,
+			],
+			'old_value' => [
+				'minify_css'             => 1,
+				'minify_concatenate_css' => 0,
+				'remove_unused_css'      => 1,
+				'cdn'                   => 0,
+			],
+		],
+		'expected' => [
+			'minify_css'             => 0,
+			'minify_concatenate_css' => 0,
+			'remove_unused_css'      => 0,
+			'cdn'                   => 0,
+		],
+	],
+	'testShouldReturnSameWhenRUCSSEnabled' => [
+		'config' => [
+			'value'     => [
+				'minify_css'             => 0,
+				'minify_concatenate_css' => 0,
+				'remove_unused_css'      => 1,
+				'cdn'                   => 0,
+			],
+			'old_value' => [
+				'minify_css'             => 1,
+				'minify_concatenate_css' => 0,
+				'remove_unused_css'      => 1,
+				'cdn'                   => 0,
+			],
+		],
+		'expected' => [
+			'minify_css'             => 0,
+			'minify_concatenate_css' => 0,
+			'remove_unused_css'      => 1,
+			'cdn'                   => 0,
+		],
+	],
+	'testShouldReturnSameWhenCombineCSSEnabled' => [
+		'config' => [
+			'value'     => [
+				'minify_css'             => 1,
+				'minify_concatenate_css' => 1,
+				'remove_unused_css'      => 0,
+				'cdn'                   => 0,
+			],
+			'old_value' => [
+				'minify_css'             => 1,
+				'minify_concatenate_css' => 0,
+				'remove_unused_css'      => 0,
+				'cdn'                   => 0,
+			],
+		],
+		'expected' => [
+			'minify_css'             => 1,
+			'minify_concatenate_css' => 1,
+			'remove_unused_css'      => 0,
+			'cdn'                   => 0,
+		],
+	],
+	'testShouldReturnUpdatedWhenCombineCssAndRUCSSEnabled' => [
+		'config' => [
+			'value'     => [
+				'minify_css'             => 1,
+				'minify_concatenate_css' => 1,
+				'remove_unused_css'      => 1,
+				'cdn'                   => 0,
+			],
+			'old_value' => [
+				'minify_css'             => 1,
+				'minify_concatenate_css' => 0,
+				'remove_unused_css'      => 0,
+				'cdn'                   => 0,
+			],
+		],
+		'expected' => [
+			'minify_css'             => 1,
+			'minify_concatenate_css' => 0,
+			'remove_unused_css'      => 1,
+			'cdn'                   => 0,
+		],
+	],
+	'testShouldReturnUpdatedWhenCombineCssAndRUCSSEnabledBefore' => [
+		'config' => [
+			'value'     => [
+				'minify_css'             => 1,
+				'minify_concatenate_css' => 1,
+				'remove_unused_css'      => 1,
+				'cdn'                   => 0,
+			],
+			'old_value' => [
+				'minify_css'             => 1,
+				'minify_concatenate_css' => 1,
+				'remove_unused_css'      => 1,
+				'cdn'                   => 0,
+			],
+		],
+		'expected' => [
+			'minify_css'             => 1,
+			'minify_concatenate_css' => 0,
+			'remove_unused_css'      => 1,
+			'cdn'                   => 0,
+		],
+	],
+];

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/updateSafelistItems.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/updateSafelistItems.php
@@ -1,0 +1,54 @@
+<?php
+
+return [
+	'testShouldDoNothingWhenAbove3.11.0.2' => [
+		'config' => [
+			'version' => '3.11.1',
+			'options' => [
+				'remove_unused_css_safelist' => [
+					'.class',
+					'/wp-content/themes/style.css',
+					'div',
+					'#id',
+					'(.*).class2',
+					'[attribute]',
+				],
+			],
+		],
+		'expected' => false,
+	],
+	'testShouldDoNothingWhenEmptySafelist' => [
+		'config' => [
+			'version' => '3.11.0.1',
+			'options' => [
+				'remove_unused_css_safelist' => [],
+			],
+		],
+		'expected' => false,
+	],
+	'testShouldUpdateSafelist' => [
+		'config' => [
+			'version' => '3.11.0.1',
+			'options' => [
+				'remove_unused_css_safelist' => [
+					'.class',
+					'/wp-content/themes/style.css',
+					'div',
+					'#id',
+					'(.*).class2',
+					'[attribute]',
+				],
+			],
+		],
+		'expected' => [
+			'remove_unused_css_safelist' => [
+				'(.*).class',
+				'/wp-content/themes/style.css',
+				'(.*)div',
+				'(.*)#id',
+				'(.*).class2',
+				'(.*)[attribute]',
+			],
+		],
+	],
+];

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/updateSafelistItems.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/updateSafelistItems.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\Optimization\RUCSS\Admin\Subscriber;
+
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Optimization\RUCSS\Admin\Subscriber::update_safelist_items
+ *
+ * @group  RUCSS
+ * @group  AdminOnly
+ */
+class Test_UpdateSafelistItems extends TestCase {
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->setUpSettings();
+		$this->unregisterAllCallbacksExcept( 'wp_rocket_upgrade', 'update_safelist_items', 15 );
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+
+		$this->tearDownSettings();
+		$this->restoreWpFilter( 'wp_rocket_upgrade' );
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldDoExpected( $config, $expected ) {
+		$this->mergeExistingSettingsAndUpdate( $config['options'] );
+
+		do_action( 'wp_rocket_upgrade', '', $config['old_version'] );
+
+		$updated = get_option( 'wp_rocket_settings' );
+
+		if ( $expected ) {
+			$this->assertSame(
+				$expected['remove_unused_css_safelist'],
+				$updated['remove_unused_css_safelist']
+			);
+		} else {
+			$this->assertIsArray( $updated );
+		}
+	}
+}

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/updateSafelistItems.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/updateSafelistItems.php
@@ -31,7 +31,7 @@ class Test_UpdateSafelistItems extends TestCase {
 	public function testShouldDoExpected( $config, $expected ) {
 		$this->mergeExistingSettingsAndUpdate( $config['options'] );
 
-		do_action( 'wp_rocket_upgrade', '', $config['old_version'] );
+		do_action( 'wp_rocket_upgrade', '', $config['version'] );
 
 		$updated = get_option( 'wp_rocket_settings' );
 

--- a/tests/Unit/bootstrap.php
+++ b/tests/Unit/bootstrap.php
@@ -43,3 +43,4 @@ function load_original_files_before_mocking() {
 }
 
 load_original_files_before_mocking();
+require_once WP_ROCKET_PLUGIN_ROOT . 'inc/compat.php';

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Settings/updateSafelistItems.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Settings/updateSafelistItems.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\RUCSS\Admin\Settings;
+
+use Brain\Monkey\Functions;
+use Mockery;
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Engine\Admin\Beacon\Beacon;
+use WP_Rocket\Engine\Optimization\RUCSS\Admin\Settings;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Optimization\RUCSS\Admin\Settings::update_safelist_items
+ *
+ * @group  RUCSS
+ */
+class Test_UpdateSafelistItems extends TestCase {
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldDoExpected( $config, $expected ) {
+		$settings = new Settings( Mockery::mock( Options_Data::class ), Mockery::mock( Beacon::class ) );
+
+		Functions\when( 'get_option' )->justReturn( $config['options'] );
+
+		if ( $expected ) {
+			Functions\expect( 'update_option' )
+				->once()
+				->with( 'wp_rocket_settings', $expected );
+		} else {
+			Functions\expect( 'update_option' )->never();
+		}
+
+
+		$settings->update_safelist_items( $config['version'] );
+
+	}
+}


### PR DESCRIPTION
## Description

Update the safelist items to be compatible with the new used CSS generator.

Fixes #4876 

## Type of change
- [x] Enhancement (non-breaking change which improves an existing functionality)

## How Has This Been Tested?

- [x] Automated tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
