### PR TITLE
Fixes #4527 Remove Rocket option to deactivate lazyload of iframes and YT videos when Autoptimize lazyload is enabled

### DIFF
--- a/inc/3rd-party/plugins/autoptimize.php
+++ b/inc/3rd-party/plugins/autoptimize.php
@@ -15,8 +15,6 @@ if ( class_exists( 'autoptimizeCache' ) ) :
 	function rocket_maybe_deactivate_lazyload( $old_value, $value ) {
 		if ( empty( $old_value['autoptimize_imgopt_checkbox_field_3'] ) && ! empty( $value['autoptimize_imgopt_checkbox_field_3'] ) ) {
 			update_rocket_option( 'lazyload', 0 );
-			update_rocket_option( 'lazyload_iframes', 0 );
-			update_rocket_option( 'lazyload_youtube', 0 );
 		}
 	}
 	add_action( 'update_option_autoptimize_imgopt_settings', 'rocket_maybe_deactivate_lazyload', 10, 2 );
@@ -107,8 +105,6 @@ function rocket_activate_autoptimize() {
 
 	if ( ! empty( $lazyload['autoptimize_imgopt_checkbox_field_3'] ) ) {
 		update_rocket_option( 'lazyload', 0 );
-		update_rocket_option( 'lazyload_iframes', 0 );
-		update_rocket_option( 'lazyload_youtube', 0 );
 	}
 }
 add_action( 'activate_autoptimize/autoptimize.php', 'rocket_activate_autoptimize', 11 );


### PR DESCRIPTION
## Description

Remove Rocket option to deactivate lazyload of iframes and youtube videos when autoptimize is activated and lazyload option is enabled.

Fixes #4527 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

The solution is no way different from the proposed one.

## How Has This Been Tested?

- Check all LL options in the media tab on WPR
- Check all LL options on autoptimize
- Deactivate autoptimize
- Activate autoptimze and see that LL options for iframes and videos remains checked.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
