### PR TITLE
3.11.0.2

### DIFF
--- a/.github/workflows/deploy_plugin.yml
+++ b/.github/workflows/deploy_plugin.yml
@@ -38,6 +38,14 @@ jobs:
         run: composer install --no-scripts --no-dev
         working-directory: /tmp/wp-rocket
 
+      - name: Remove composer installers
+        run: composer remove composer/installers
+        working-directory: /tmp/wp-rocket
+
+      - name: Optimize autoloader
+        run: composer dumpautoload -o
+        working-directory: /tmp/wp-rocket
+
       - name: Zip Folder
         run: zip -r __wp-rocket_${GITHUB_REF##*v}.zip wp-rocket
         working-directory: /tmp

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
 	],
 	"require": {
 		"php": ">=7.0",
-		"composer/installers": "~1.0",
+		"composer/installers": "^1.0 || ^2.0",
 		"monolog/monolog": "^1.0"
 	},
 	"require-dev": {

--- a/inc/Engine/Common/Queue/AbstractASQueue.php
+++ b/inc/Engine/Common/Queue/AbstractASQueue.php
@@ -60,6 +60,10 @@ abstract class AbstractASQueue implements QueueInterface {
 	 * @return bool
 	 */
 	public function is_scheduled( $hook, $args = [] ) {
+		if ( ! function_exists( 'as_has_scheduled_action' ) ) {
+			return ! is_null( $this->get_next( $hook, $args ) );
+		}
+
 		return as_has_scheduled_action( $hook, $args, $this->group );
 	}
 
@@ -83,7 +87,7 @@ abstract class AbstractASQueue implements QueueInterface {
 	 * @return string The action ID
 	 */
 	public function schedule_cron( $timestamp, $cron_schedule, $hook, $args = [] ) {
-		if ( as_has_scheduled_action( $hook ) ) {
+		if ( $this->is_scheduled( $hook, $args ) ) {
 			return '';
 		}
 		return as_schedule_cron_action( $timestamp, $cron_schedule, $hook, $args, $this->group );

--- a/inc/Engine/Optimization/RUCSS/Admin/Settings.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Settings.php
@@ -407,4 +407,39 @@ class Settings {
 
 		update_option( 'wp_rocket_settings', $options );
 	}
+
+	/**
+	 * Updates safelist items for new SaaS compatibility
+	 *
+	 * @since 3.11.0.2
+	 *
+	 * @param string $old_version Previous plugin version.
+	 *
+	 * @return void
+	 */
+	public function update_safelist_items( $old_version ) {
+		if ( version_compare( $old_version, '3.11.0.2', '>=' ) ) {
+			return;
+		}
+
+		$options = get_option( 'wp_rocket_settings', [] );
+
+		if ( empty( $options['remove_unused_css_safelist'] ) ) {
+			return;
+		}
+
+		foreach ( $options['remove_unused_css_safelist'] as $key => $value ) {
+			if ( str_contains( $value, '.css' ) ) {
+				continue;
+			}
+
+			if ( str_starts_with( $value, '(' ) ) {
+				continue;
+			}
+
+			$options['remove_unused_css_safelist'][ $key ] = '(.*)' . $value;
+		}
+
+		update_option( 'wp_rocket_settings', $options );
+	}
 }

--- a/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
@@ -102,7 +102,10 @@ class Subscriber implements Subscriber_Interface {
 			'rocket_localize_admin_script'         => 'add_localize_script_data',
 			'action_scheduler_queue_runner_concurrent_batches' => 'adjust_as_concurrent_batches',
 			'pre_update_option_wp_rocket_settings' => [ 'maybe_disable_combine_css', 11, 2 ],
-			'wp_rocket_upgrade'                    => [ 'set_option_on_update', 14, 2 ],
+			'wp_rocket_upgrade'                    => [
+				[ 'set_option_on_update', 14, 2 ],
+				[ 'update_safelist_items', 15, 2 ],
+			],
 			'wp_ajax_rocket_spawn_cron'            => 'spawn_cron',
 			'rocket_deactivation'                  => 'cancel_queues',
 		];
@@ -597,6 +600,20 @@ class Subscriber implements Subscriber_Interface {
 				'sslverify'  => apply_filters( 'https_local_ssl_verify', false ), // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 			]
 		);
+	}
+
+	/**
+	 * Updates safelist items for new SaaS compatibility
+	 *
+	 * @since 3.11.0.2
+	 *
+	 * @param string $new_version New plugin version.
+	 * @param string $old_version Previous plugin version.
+	 *
+	 * @return void
+	 */
+	public function update_safelist_items( $new_version, $old_version ) {
+		$this->settings->update_safelist_items( $old_version );
 	}
 
 	/**

--- a/inc/Engine/Optimization/RUCSS/Database/Tables/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Database/Tables/UsedCSS.php
@@ -144,6 +144,10 @@ class UsedCSS extends Table {
 			return $this->is_success( false );
 		}
 
+		if ( $this->index_exists( 'queue_name_index' ) ) {
+			return $this->is_success( true );
+		}
+
 		$index_added = $this->get_db()->query( "ALTER TABLE {$this->table_name} ADD INDEX `queue_name_index` (`queue_name`) " );
 		return $this->is_success( $index_added );
 	}

--- a/inc/compat.php
+++ b/inc/compat.php
@@ -1,3 +1,34 @@
 <?php
 
 defined( 'ABSPATH' ) || exit;
+
+if ( ! function_exists( 'str_starts_with' ) ) {
+	/**
+	 * Polyfill for str_starts_with() function added in PHP 8.0.
+	 *
+	 * @param string $haystack The string to search in.
+	 * @param string $needle The substring to search for in the haystack.
+	 *
+	 * @return bool True if $needle is in $haystack, otherwise false.
+	 */
+	function str_starts_with( $haystack, $needle ) {
+		if ( '' === $needle ) {
+			return true;
+		}
+		return 0 === strpos( $haystack, $needle );
+	}
+}
+
+if ( ! function_exists( 'str_contains' ) ) {
+	/**
+	 * Polyfill for str_contains() function added in PHP 8.0.
+	 *
+	 * @param string $haystack The string to search in.
+	 * @param string $needle The substring to search for in the haystack.
+	 *
+	 * @return bool True if $needle is in $haystack, otherwise false.
+	 */
+	function str_contains( $haystack, $needle ) {
+		return ( '' === $needle || false !== strpos( $haystack, $needle ) );
+	}
+}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -64,6 +64,9 @@
             <property name="strict_class_file_names" value="false" />
         </properties>
     </rule>
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound">
+		<exclude-pattern>inc/compat.php</exclude-pattern>
+	</rule>
 	<rule ref="WordPress.WP.AlternativeFunctions.file_system_read_readfile">
 		<exclude-pattern>inc/classes/buffer/class-cache.php</exclude-pattern>
 	</rule>

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Settings/displayProcessingNotice.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Settings/displayProcessingNotice.php
@@ -63,7 +63,7 @@ return [
 			],
 			'capability'        => true,
 			'remove_unused_css' => 1,
-			'transient'         => time() + 60,
+			'transient'         => time() + 3600,
 		],
 		'expected' => true,
 	],

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Settings/updateSafelistItems.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Settings/updateSafelistItems.php
@@ -1,0 +1,54 @@
+<?php
+
+return [
+	'testShouldDoNothingWhenAbove3.11.0.2' => [
+		'config' => [
+			'version' => '3.11.1',
+			'options' => [
+				'remove_unused_css_safelist' => [
+					'.class',
+					'/wp-content/themes/style.css',
+					'div',
+					'#id',
+					'(.*).class2',
+					'[attribute]',
+				],
+			],
+		],
+		'expected' => false,
+	],
+	'testShouldDoNothingWhenEmptySafelist' => [
+		'config' => [
+			'version' => '3.11.0.1',
+			'options' => [
+				'remove_unused_css_safelist' => [],
+			],
+		],
+		'expected' => false,
+	],
+	'testShouldUpdateSafelist' => [
+		'config' => [
+			'version' => '3.11.0.1',
+			'options' => [
+				'remove_unused_css_safelist' => [
+					'.class',
+					'/wp-content/themes/style.css',
+					'div',
+					'#id',
+					'(.*).class2',
+					'[attribute]',
+				],
+			],
+		],
+		'expected' => [
+			'remove_unused_css_safelist' => [
+				'(.*).class',
+				'/wp-content/themes/style.css',
+				'(.*)div',
+				'(.*)#id',
+				'(.*).class2',
+				'(.*)[attribute]',
+			],
+		],
+	],
+];

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/maybeDisableCombineCss.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/maybeDisableCombineCss.php
@@ -1,0 +1,130 @@
+<?php
+
+return [
+	'testShouldReturnSameWhenOptionsNotSet' => [
+		'config' => [
+			'value'     => [
+				'minify_css' => 0,
+				'cdn'       => 0,
+			],
+			'old_value' => [
+				'minify_css' => 1,
+				'cdn'       => 0,
+			],
+		],
+		'expected' => [
+			'minify_css' => 0,
+			'cdn'       => 0,
+		],
+	],
+	'testShouldReturnSameWhenOptionsEqualZero' => [
+		'config' => [
+			'value'     => [
+				'minify_css'             => 0,
+				'minify_concatenate_css' => 0,
+				'remove_unused_css'      => 0,
+				'cdn'                   => 0,
+			],
+			'old_value' => [
+				'minify_css'             => 1,
+				'minify_concatenate_css' => 0,
+				'remove_unused_css'      => 1,
+				'cdn'                   => 0,
+			],
+		],
+		'expected' => [
+			'minify_css'             => 0,
+			'minify_concatenate_css' => 0,
+			'remove_unused_css'      => 0,
+			'cdn'                   => 0,
+		],
+	],
+	'testShouldReturnSameWhenRUCSSEnabled' => [
+		'config' => [
+			'value'     => [
+				'minify_css'             => 0,
+				'minify_concatenate_css' => 0,
+				'remove_unused_css'      => 1,
+				'cdn'                   => 0,
+			],
+			'old_value' => [
+				'minify_css'             => 1,
+				'minify_concatenate_css' => 0,
+				'remove_unused_css'      => 1,
+				'cdn'                   => 0,
+			],
+		],
+		'expected' => [
+			'minify_css'             => 0,
+			'minify_concatenate_css' => 0,
+			'remove_unused_css'      => 1,
+			'cdn'                   => 0,
+		],
+	],
+	'testShouldReturnSameWhenCombineCSSEnabled' => [
+		'config' => [
+			'value'     => [
+				'minify_css'             => 1,
+				'minify_concatenate_css' => 1,
+				'remove_unused_css'      => 0,
+				'cdn'                   => 0,
+			],
+			'old_value' => [
+				'minify_css'             => 1,
+				'minify_concatenate_css' => 0,
+				'remove_unused_css'      => 0,
+				'cdn'                   => 0,
+			],
+		],
+		'expected' => [
+			'minify_css'             => 1,
+			'minify_concatenate_css' => 1,
+			'remove_unused_css'      => 0,
+			'cdn'                   => 0,
+		],
+	],
+	'testShouldReturnUpdatedWhenCombineCssAndRUCSSEnabled' => [
+		'config' => [
+			'value'     => [
+				'minify_css'             => 1,
+				'minify_concatenate_css' => 1,
+				'remove_unused_css'      => 1,
+				'cdn'                   => 0,
+			],
+			'old_value' => [
+				'minify_css'             => 1,
+				'minify_concatenate_css' => 0,
+				'remove_unused_css'      => 0,
+				'cdn'                   => 0,
+			],
+		],
+		'expected' => [
+			'minify_css'             => 1,
+			'minify_concatenate_css' => 0,
+			'remove_unused_css'      => 1,
+			'cdn'                   => 0,
+		],
+	],
+	'testShouldReturnUpdatedWhenCombineCssAndRUCSSEnabledBefore' => [
+		'config' => [
+			'value'     => [
+				'minify_css'             => 1,
+				'minify_concatenate_css' => 1,
+				'remove_unused_css'      => 1,
+				'cdn'                   => 0,
+			],
+			'old_value' => [
+				'minify_css'             => 1,
+				'minify_concatenate_css' => 1,
+				'remove_unused_css'      => 1,
+				'cdn'                   => 0,
+			],
+		],
+		'expected' => [
+			'minify_css'             => 1,
+			'minify_concatenate_css' => 0,
+			'remove_unused_css'      => 1,
+			'cdn'                   => 0,
+		],
+	],
+];

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/updateSafelistItems.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/updateSafelistItems.php
@@ -1,0 +1,54 @@
+<?php
+
+return [
+	'testShouldDoNothingWhenAbove3.11.0.2' => [
+		'config' => [
+			'version' => '3.11.1',
+			'options' => [
+				'remove_unused_css_safelist' => [
+					'.class',
+					'/wp-content/themes/style.css',
+					'div',
+					'#id',
+					'(.*).class2',
+					'[attribute]',
+				],
+			],
+		],
+		'expected' => false,
+	],
+	'testShouldDoNothingWhenEmptySafelist' => [
+		'config' => [
+			'version' => '3.11.0.1',
+			'options' => [
+				'remove_unused_css_safelist' => [],
+			],
+		],
+		'expected' => false,
+	],
+	'testShouldUpdateSafelist' => [
+		'config' => [
+			'version' => '3.11.0.1',
+			'options' => [
+				'remove_unused_css_safelist' => [
+					'.class',
+					'/wp-content/themes/style.css',
+					'div',
+					'#id',
+					'(.*).class2',
+					'[attribute]',
+				],
+			],
+		],
+		'expected' => [
+			'remove_unused_css_safelist' => [
+				'(.*).class',
+				'/wp-content/themes/style.css',
+				'(.*)div',
+				'(.*)#id',
+				'(.*).class2',
+				'(.*)[attribute]',
+			],
+		],
+	],
+];

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/updateSafelistItems.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/updateSafelistItems.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\Optimization\RUCSS\Admin\Subscriber;
+
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Optimization\RUCSS\Admin\Subscriber::update_safelist_items
+ *
+ * @group  RUCSS
+ * @group  AdminOnly
+ */
+class Test_UpdateSafelistItems extends TestCase {
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->setUpSettings();
+		$this->unregisterAllCallbacksExcept( 'wp_rocket_upgrade', 'update_safelist_items', 15 );
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+
+		$this->tearDownSettings();
+		$this->restoreWpFilter( 'wp_rocket_upgrade' );
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldDoExpected( $config, $expected ) {
+		$this->mergeExistingSettingsAndUpdate( $config['options'] );
+
+		do_action( 'wp_rocket_upgrade', '', $config['version'] );
+
+		$updated = get_option( 'wp_rocket_settings' );
+
+		if ( $expected ) {
+			$this->assertSame(
+				$expected['remove_unused_css_safelist'],
+				$updated['remove_unused_css_safelist']
+			);
+		} else {
+			$this->assertIsArray( $updated );
+		}
+	}
+}

--- a/tests/Unit/bootstrap.php
+++ b/tests/Unit/bootstrap.php
@@ -43,3 +43,4 @@ function load_original_files_before_mocking() {
 }
 
 load_original_files_before_mocking();
+require_once WP_ROCKET_PLUGIN_ROOT . 'inc/compat.php';

--- a/tests/Unit/inc/Engine/Cache/WPCache/maybePreventDeactivation.php
+++ b/tests/Unit/inc/Engine/Cache/WPCache/maybePreventDeactivation.php
@@ -7,7 +7,6 @@ use Brain\Monkey\Filters;
 
 /**
  * @covers \WP_Rocket\Engine\Cache\WPCache::maybe_prevent_deactivation
- * @uses   \WP_Rocket\Engine\Cache\WPCache::find_wp_config_path
  *
  * @group  WPCache
  */

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Settings/updateSafelistItems.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Settings/updateSafelistItems.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\RUCSS\Admin\Settings;
+
+use Brain\Monkey\Functions;
+use Mockery;
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Engine\Admin\Beacon\Beacon;
+use WP_Rocket\Engine\Optimization\RUCSS\Admin\Settings;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Optimization\RUCSS\Admin\Settings::update_safelist_items
+ *
+ * @group  RUCSS
+ */
+class Test_UpdateSafelistItems extends TestCase {
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldDoExpected( $config, $expected ) {
+		$settings = new Settings( Mockery::mock( Options_Data::class ), Mockery::mock( Beacon::class ) );
+
+		Functions\when( 'get_option' )->justReturn( $config['options'] );
+
+		if ( $expected ) {
+			Functions\expect( 'update_option' )
+				->once()
+				->with( 'wp_rocket_settings', $expected );
+		} else {
+			Functions\expect( 'update_option' )->never();
+		}
+
+
+		$settings->update_safelist_items( $config['version'] );
+
+	}
+}

--- a/wp-rocket.php
+++ b/wp-rocket.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Rocket
  * Plugin URI: https://wp-rocket.me
  * Description: The best WordPress performance plugin.
- * Version: 3.11.0.1
+ * Version: 3.11.0.2
  * Requires at least: 5.5
  * Requires PHP: 7.1
  * Code Name: Iego
@@ -20,7 +20,7 @@
 defined( 'ABSPATH' ) || exit;
 
 // Rocket defines.
-define( 'WP_ROCKET_VERSION',               '3.11.0.1' );
+define( 'WP_ROCKET_VERSION',               '3.11.0.2' );
 define( 'WP_ROCKET_WP_VERSION',            '5.5' );
 define( 'WP_ROCKET_WP_VERSION_TESTED',     '5.9' );
 define( 'WP_ROCKET_PHP_VERSION',           '7.1' );


### PR DESCRIPTION
- 3rd party compatibility: Avoid fatal error when an old version of Action Scheduler is loaded on the user website
- Bugfix: Prevent error related to duplicate key name `queue_name_index`
- Enhancement: Update Remove unused CSS safelist items for compatibility with new API