### PR TITLE
Fixes #4894 Exclude LegalBlink's script from Defer JavaScript files 

### DIFF
--- a/inc/Engine/Optimization/DeferJS/DeferJS.php
+++ b/inc/Engine/Optimization/DeferJS/DeferJS.php
@@ -234,6 +234,7 @@ class DeferJS {
 			'yanovis.Voucher.js',
 			'/carousel-upsells-and-related-product-for-woocommerce/assets/js/glide.min.js',
 			'use.typekit.com',
+			'/api/scripts/lb_cs.js',
 		];
 
 		$exclude_defer_js = array_unique( array_merge( $exclude_defer_js, $this->options->get( 'exclude_defer_js', [] ) ) );


### PR DESCRIPTION
## Description

Added `/api/scripts/lb_cs.js` in the `$exclude_defer_js` array.

Fixes #4894.

## Type of change

Please delete options that are not relevant.

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

This hasn't been groomed.

## How Has This Been Tested?

- [x] On the customer's website, by adding `/api/scripts/lb_cs.js` in WP Rocket's UI.
- [x] On my test site, by adding the exclusion in WP Rocket's core.

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

