### PR TITLE
Fix missing AS missing DB tables issue

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Admin/Settings.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Settings.php
@@ -278,6 +278,31 @@ class Settings {
 	}
 
 	/**
+	 * Display admin notice when detecting any missed Action scheduler tables.
+	 *
+	 * @since 3.11.0.2
+	 *
+	 * @return void
+	 */
+	public function display_AS_missed_tables_notice() {
+		$as_tools_link = menu_page_url( 'action-scheduler', false );
+		$message = sprintf(
+		// translators: %1$s = plugin name, %2$s = opening anchor tag, %3$s = closing anchor tag.
+			__( '%1$s: We detected missing database table related to Action Scheduler. Please visit the following %2$sURL%3$s to recreate it, as it\'s needed for WP Rocket to work correctly.', 'rocket' ),
+			'<strong>WP Rocket</strong>',
+			'<a href="' . $as_tools_link . '">',
+			'</a>'
+		);
+
+		rocket_notice_html(
+			[
+				'message' => $message,
+				'id'      => 'rocket-notice-as-missed-tables',
+			]
+		);
+	}
+
+	/**
 	 * Checks if we can display the RUCSS notices
 	 *
 	 * @since 3.11

--- a/inc/Engine/Optimization/RUCSS/Admin/Settings.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Settings.php
@@ -280,7 +280,7 @@ class Settings {
 	/**
 	 * Display admin notice when detecting any missed Action scheduler tables.
 	 *
-	 * @since 3.11.0.2
+	 * @since 3.11.0.3
 	 *
 	 * @return void
 	 */
@@ -288,7 +288,7 @@ class Settings {
 		$as_tools_link = menu_page_url( 'action-scheduler', false );
 		$message       = sprintf(
 		// translators: %1$s = plugin name, %2$s = opening anchor tag, %3$s = closing anchor tag.
-			__( '%1$s: We detected missing database table related to Action Scheduler. Please visit the following %2$sURL%3$s to recreate it, as it\'s needed for WP Rocket to work correctly.', 'rocket' ),
+			__( '%1$s: We detected missing database table related to Action Scheduler. Please visit the following %2$sURL%3$s to recreate it, as it is needed for WP Rocket to work correctly.', 'rocket' ),
 			'<strong>WP Rocket</strong>',
 			'<a href="' . $as_tools_link . '">',
 			'</a>'

--- a/inc/Engine/Optimization/RUCSS/Admin/Settings.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Settings.php
@@ -284,9 +284,9 @@ class Settings {
 	 *
 	 * @return void
 	 */
-	public function display_AS_missed_tables_notice() {
+	public function display_as_missed_tables_notice() {
 		$as_tools_link = menu_page_url( 'action-scheduler', false );
-		$message = sprintf(
+		$message       = sprintf(
 		// translators: %1$s = plugin name, %2$s = opening anchor tag, %3$s = closing anchor tag.
 			__( '%1$s: We detected missing database table related to Action Scheduler. Please visit the following %2$sURL%3$s to recreate it, as it\'s needed for WP Rocket to work correctly.', 'rocket' ),
 			'<strong>WP Rocket</strong>',

--- a/inc/Engine/Optimization/RUCSS/Admin/Settings.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Settings.php
@@ -296,6 +296,7 @@ class Settings {
 
 		rocket_notice_html(
 			[
+				'status'  => 'error',
 				'message' => $message,
 				'id'      => 'rocket-notice-as-missed-tables',
 			]

--- a/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
@@ -90,7 +90,7 @@ class Subscriber implements Subscriber_Interface {
 				[ 'clear_usedcss_result' ],
 				[ 'display_processing_notice' ],
 				[ 'display_success_notice' ],
-				[ 'display_AS_missed_tables_notice' ],
+				[ 'display_as_missed_tables_notice' ],
 			],
 			'rocket_admin_bar_items'               => [
 				[ 'add_clean_used_css_menu_item' ],
@@ -166,7 +166,7 @@ class Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function schedule_rucss_pending_jobs_cron() {
-		if ( ! $this->is_valid_AS_tables() ) {
+		if ( ! $this->is_valid_as_tables() ) {
 			return;
 		}
 
@@ -205,7 +205,7 @@ class Subscriber implements Subscriber_Interface {
 			return;
 		}
 
-		if ( ! $this->is_valid_AS_tables() ) {
+		if ( ! $this->is_valid_as_tables() ) {
 			return;
 		}
 
@@ -219,10 +219,20 @@ class Subscriber implements Subscriber_Interface {
 	 *
 	 * @return bool
 	 */
-	private function is_valid_AS_tables() {
+	private function is_valid_as_tables() {
+		$cached_count = get_transient( 'rocket_rucss_as_tables_count' );
+		if ( false !== $cached_count ) {
+			return $cached_count;
+		}
+
 		global $wpdb;
 
-		$found_as_tables = $wpdb->get_col( $wpdb->prepare( 'SHOW TABLES LIKE %s', $wpdb->prefix . 'actionscheduler%' ) );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$found_as_tables = $wpdb->get_col(
+			$wpdb->prepare( 'SHOW TABLES LIKE %s', $wpdb->prefix . 'actionscheduler%' )
+		);
+
+		set_transient( 'rocket_rucss_as_tables_count', count( $found_as_tables ), rocket_get_constant( 'DAY_IN_SECONDS', 24 * 60 * 60 ) );
 
 		return 4 === count( $found_as_tables );
 	}
@@ -546,12 +556,12 @@ class Subscriber implements Subscriber_Interface {
 	 *
 	 * @return void
 	 */
-	public function display_AS_missed_tables_notice() {
-		if ( $this->is_valid_AS_tables() ) {
+	public function display_as_missed_tables_notice() {
+		if ( $this->is_valid_as_tables() ) {
 			return;
 		}
 
-		$this->settings->display_AS_missed_tables_notice();
+		$this->settings->display_as_missed_tables_notice();
 	}
 
 	/**

--- a/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
@@ -221,7 +221,7 @@ class Subscriber implements Subscriber_Interface {
 	/**
 	 * Checks if Action scheduler tables are there or not.
 	 *
-	 * @since 3.11.0.2
+	 * @since 3.11.0.3
 	 *
 	 * @return bool
 	 */
@@ -558,7 +558,7 @@ class Subscriber implements Subscriber_Interface {
 	/**
 	 * Display admin notice when detecting any missed Action scheduler tables.
 	 *
-	 * @since 3.11.0.2
+	 * @since 3.11.0.3
 	 *
 	 * @return void
 	 */

--- a/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
@@ -227,7 +227,7 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	private function is_valid_as_tables() {
 		$cached_count = get_transient( 'rocket_rucss_as_tables_count' );
-		if ( false !== $cached_count ) {
+		if ( false !== $cached_count && ! is_admin() ) { // Stop caching in admin UI.
 			return 4 === (int) $cached_count;
 		}
 

--- a/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
@@ -215,10 +215,6 @@ class Subscriber implements Subscriber_Interface {
 			return;
 		}
 
-		if ( ! $this->is_valid_as_tables() ) {
-			return;
-		}
-
 		RUCSSQueueRunner::instance()->init();
 	}
 

--- a/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
@@ -79,10 +79,7 @@ class Subscriber implements Subscriber_Interface {
 			'wp_update_comment_count'              => 'delete_used_css_on_update_or_delete',
 			'edit_term'                            => 'delete_term_used_css',
 			'pre_delete_term'                      => 'delete_term_used_css',
-			'init'                                 => [
-				[ 'schedule_clean_not_commonly_used_rows' ],
-				[ 'schedule_rucss_pending_jobs_cron' ],
-			],
+			'init'                                 => 'schedule_clean_not_commonly_used_rows',
 			'rocket_rucss_clean_rows_time_event'   => 'cron_clean_rows',
 			'admin_post_rocket_clear_usedcss'      => 'truncate_used_css_handler',
 			'admin_post_rocket_clear_usedcss_url'  => 'clear_url_usedcss',
@@ -108,6 +105,7 @@ class Subscriber implements Subscriber_Interface {
 			],
 			'wp_ajax_rocket_spawn_cron'            => 'spawn_cron',
 			'rocket_deactivation'                  => 'cancel_queues',
+			'shutdown'                             => 'schedule_rucss_pending_jobs_cron',
 		];
 	}
 

--- a/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
@@ -79,7 +79,10 @@ class Subscriber implements Subscriber_Interface {
 			'wp_update_comment_count'              => 'delete_used_css_on_update_or_delete',
 			'edit_term'                            => 'delete_term_used_css',
 			'pre_delete_term'                      => 'delete_term_used_css',
-			'init'                                 => 'schedule_clean_not_commonly_used_rows',
+			'init'                                 => [
+				[ 'schedule_clean_not_commonly_used_rows' ],
+				[ 'initialize_rucss_queue_runner' ],
+			],
 			'rocket_rucss_clean_rows_time_event'   => 'cron_clean_rows',
 			'admin_post_rocket_clear_usedcss'      => 'truncate_used_css_handler',
 			'admin_post_rocket_clear_usedcss_url'  => 'clear_url_usedcss',
@@ -173,8 +176,6 @@ class Subscriber implements Subscriber_Interface {
 			return;
 		}
 
-		RUCSSQueueRunner::instance()->init();
-
 		/**
 		 * Filters the cron interval.
 		 *
@@ -187,6 +188,19 @@ class Subscriber implements Subscriber_Interface {
 		Logger::debug( "RUCSS: Schedule pending jobs Cron job with interval {$interval} seconds." );
 
 		$this->queue->schedule_pending_jobs_cron( $interval );
+	}
+
+	/**
+	 * Initialize the queue runner for our RUCSS.
+	 *
+	 * @return void
+	 */
+	public function initialize_rucss_queue_runner() {
+		if ( ! $this->settings->is_enabled() ) {
+			return;
+		}
+
+		RUCSSQueueRunner::instance()->init();
 	}
 
 	/**


### PR DESCRIPTION
## Description

In some cases when client updates to our latest version 3.11.0.2, they face fatal error because one or more tables related to Action Scheduler isn't there, the error is like the following:-

```
[05-Apr-2022 12:36:29 UTC] PHP Fatal error:  Uncaught RuntimeException: Error saving action: Table 'wordpress.wp_actionscheduler_actions' doesn't exist in /var/www/html/wordpress/wp-content/plugins/wp-rocket/inc/Dependencies/ActionScheduler/classes/data-stores/ActionScheduler_DBStore.php:86
Stack trace:
#0 /var/www/html/wordpress/wp-content/plugins/wp-rocket/inc/Dependencies/ActionScheduler/classes/ActionScheduler_ActionFactory.php(177): ActionScheduler_DBStore->save_action()
#1 /var/www/html/wordpress/wp-content/plugins/wp-rocket/inc/Dependencies/ActionScheduler/classes/ActionScheduler_ActionFactory.php(105): ActionScheduler_ActionFactory->store()
#2 /var/www/html/wordpress/wp-content/plugins/wp-rocket/inc/Dependencies/ActionScheduler/functions.php(54): ActionScheduler_ActionFactory->recurring()
#3 /var/www/html/wordpress/wp-content/plugins/wp-rocket/inc/Engine/Common/Queue/AbstractASQueue.php(51): as_schedule_recurring_action()
#4 /var/www/html/wordpress/wp-content/plugins/wp-rocket/inc/Engine/Optimization/RUCSS/Controller/Queue.php(57): WP_Rocket\Eng in /var/www/html/wordpress/wp-content/plugins/wp-rocket/inc/Dependencies/ActionScheduler/classes/data-stores/ActionScheduler_DBStore.php on line 86
```

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Is the solution different from the one proposed during the grooming?

Not groomed.

## How Has This Been Tested?

I need to test the queue runner by sending too much jobs from different groups and see if it'll handle our jobs with priority.

To test that you need to delete `wp_actionscheduler_actions` table from the DB and then check the site, with this PR you should see the admin area without a problem but in the log file you will still see the fatal error, but with the next refresh all tables are created and no fatal error should happen.

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
