### PR TITLE
Fixes #4898 Exclude usercentrics script from JavaScript minification

### DIFF
--- a/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
+++ b/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
@@ -260,6 +260,7 @@ abstract class AbstractJSOptimization extends AbstractOptimization {
 			'secure.gravatar.com/js/gprofiles.js',
 			'cdn.jsdelivr.net/npm/hockeystack',
 			'widget.prod.faslet.net',
+			'usercentrics.eu',
 		];
 
 		$excluded_external = array_merge( $defaults, $this->options->get( 'exclude_js', [] ) );


### PR DESCRIPTION
## Description

Added `usercentrics.eu` to the `get_excluded_external_file_path()` method.

Fixes #4898 

## Type of change

Please delete options that are not relevant.

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

No grooming has been performed.

## How Has This Been Tested?

- [x] On the customer's website, by adding `usercentrics.eu` in WP Rocket's UI.
- [x] On my test site, by adding the exclusion in WP Rocket's core.

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

