### PR TITLE
Preserve Divi's "divi-style-inline-inline-css" attribute after treeshaking to prevent console error

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -65,6 +65,7 @@ class UsedCSS {
 		'woodmart-inline-css-inline-css',
 		'woodmart_shortcodes-custom-css',
 		'rs-plugin-settings-inline-css', // For revolution slider, it saves settings for each slider.
+		'divi-style-inline-inline-css',
 	];
 
 	/**

--- a/inc/ThirdParty/Plugins/Optimization/AMP.php
+++ b/inc/ThirdParty/Plugins/Optimization/AMP.php
@@ -53,7 +53,8 @@ class AMP implements Subscriber_Interface {
 		];
 
 		if ( function_exists( 'is_amp_endpoint' ) ) {
-			$events['update_option_amp-options'] = 'generate_config_file';
+			$events['update_option_amp-options']  = 'generate_config_file';
+			$events['rocket_delay_js_exclusions'] = 'exclude_script_from_delay_js';
 		}
 
 		return $events;
@@ -176,5 +177,18 @@ class AMP implements Subscriber_Interface {
 				'(.*).js',
 			]
 		);
+	}
+
+	/**
+	 * Adds the switching script from AMP to delay JS excluded files
+	 *
+	 * @since 3.11.1
+	 *
+	 * @param  array $excluded List of excluded files.
+	 * @return array        List of excluded files.
+	 */
+	public function exclude_script_from_delay_js( $excluded ) {
+		$excluded[] = 'amp-mobile-version-switcher';
+		return $excluded;
 	}
 }

--- a/tests/Fixtures/inc/ThirdParty/Plugins/Optimization/AMP/excludeScriptFromDelayJs.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/Optimization/AMP/excludeScriptFromDelayJs.php
@@ -1,0 +1,11 @@
+<?php
+return [
+	'testShouldDoExpected'      => [
+		'config' => [
+			'excluded' => [],
+		],
+		'expected' => [
+			'excluded' => ['amp-mobile-version-switcher'],
+		],
+	],
+];

--- a/tests/Integration/inc/ThirdParty/Plugins/Optimization/AMP/excludeScriptFromDelayJs.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Optimization/AMP/excludeScriptFromDelayJs.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\Optimization\AMP;
+
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * @covers \WP_Rocket\ThirdParty\Plugins\Optimization\AMP::exclude_script_from_delay_js
+ * @group  ThirdParty
+ * @group  WithAmp
+ */
+class Test_ExcludeScriptFromDelayJs extends TestCase
+{
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldExcludeScriptWhenAmpPresent($config, $expected) {
+		$this->assertEquals($expected['excluded'], apply_filters( 'rocket_delay_js_exclusions', $config['excluded']));
+	}
+
+}

--- a/tests/Unit/inc/ThirdParty/Plugins/Optimization/AMP/excludeScriptFromDelayJs.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/Optimization/AMP/excludeScriptFromDelayJs.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\Optimization\AMP;
+
+use Mockery;
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Engine\CDN\Subscriber;
+use WP_Rocket\ThirdParty\Plugins\Optimization\AMP;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @covers \WP_Rocket\ThirdParty\Plugins\Optimization\AMP::exclude_script_from_delay_js
+ * @group  ThirdParty
+ * @group  WithAmp
+ */
+class Test_ExcludeScriptFromDelayJs extends TestCase
+{
+
+	private $amp;
+	private $options;
+	private $cdn_subscriber;
+
+	public function setUp() : void {
+		parent::setUp();
+
+		$this->options        = Mockery::mock( Options_Data::class );
+		$this->cdn_subscriber = Mockery::mock( Subscriber::class );
+		$this->amp            = new AMP( $this->options, $this->cdn_subscriber );
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldDoExpected($config, $expected) {
+		$this->assertEquals($expected['excluded'], $this->amp->exclude_script_from_delay_js($config['excluded']));
+	}
+
+}


### PR DESCRIPTION
## Description

Added `divi-style-inline-inline-css` to the `$inline_atts_exclusions` attributes array.

Fixes #4598 

## Type of change

Please delete options that are not relevant.

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

It hasn't been groomed.

## How Has This Been Tested?

- [x] Using a helper plugin (`rocket_rucss_inline_atts_exclusions` filter) on the customer's website.

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

