### PR TITLE
Extract minify from option function to prevent a bug with minify JS

### DIFF
--- a/inc/Engine/Optimization/AdminServiceProvider.php
+++ b/inc/Engine/Optimization/AdminServiceProvider.php
@@ -21,6 +21,7 @@ class AdminServiceProvider extends AbstractServiceProvider {
 	 */
 	protected $provides = [
 		'minify_css_admin_subscriber',
+		'minify_js_admin_subscriber',
 		'google_fonts_settings',
 		'google_fonts_admin_subscriber',
 	];
@@ -32,6 +33,8 @@ class AdminServiceProvider extends AbstractServiceProvider {
 	 */
 	public function register() {
 		$this->getContainer()->share( 'minify_css_admin_subscriber', 'WP_Rocket\Engine\Optimization\Minify\CSS\AdminSubscriber' )
+			->addTag( 'admin_subscriber' );
+		$this->getContainer()->share( 'minify_js_admin_subscriber', 'WP_Rocket\Engine\Optimization\Minify\JS\AdminSubscriber' )
 			->addTag( 'admin_subscriber' );
 		$this->getContainer()->add( 'google_fonts_settings', 'WP_Rocket\Engine\Optimization\GoogleFonts\Admin\Settings' )
 			->addArgument( $this->getContainer()->get( 'options' ) )

--- a/inc/Engine/Optimization/Minify/JS/AdminSubscriber.php
+++ b/inc/Engine/Optimization/Minify/JS/AdminSubscriber.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace WP_Rocket\Engine\Optimization\Minify\JS;
+
+use WP_Rocket\Event_Management\Subscriber_Interface;
+
+class AdminSubscriber implements Subscriber_Interface
+{
+
+    /**
+     * @inheritDoc
+     */
+    public static function get_subscribed_events()
+    {
+		$slug = rocket_get_constant( 'WP_ROCKET_SLUG', 'wp_rocket_settings' );
+
+		return [
+			"update_option_{$slug}"     => [ 'clean_minify', 10, 2 ],
+			"pre_update_option_{$slug}" => [ 'regenerate_minify_js_key', 10, 2 ],
+		];
+    }
+
+	/**
+	 * Clean minify JS files when options change.
+	 *
+	 * @param array $old An array of previous settings.
+	 * @param array $new An array of submitted settings.
+	 */
+	public function clean_minify( $old, $new ) {
+		if ( ! is_array( $old ) || ! is_array( $new ) ) {
+			return;
+		}
+
+		if ( ! $this->maybe_minify_regenerate( $new, $old ) ) {
+			return;
+		}
+		// Purge all minify cache files.
+		rocket_clean_minify( 'js' );
+	}
+
+	/**
+	 * Regenerate the minify key if JS files have been modified.
+	 *
+	 * @since  3.5.4
+	 *
+	 * @param array $new An array of submitted settings.
+	 * @param array $old An array of previous settings.
+	 *
+	 * @return array Updates 'minify_css_key' setting when regenerated; else, original submitted settings.
+	 */
+	public function regenerate_minify_js_key( $new, $old ) {
+		if ( ! is_array( $old ) || ! is_array( $new ) ) {
+			return $new;
+		}
+
+		if ( ! $this->maybe_minify_regenerate( $new, $old ) ) {
+			return $new;
+		}
+
+		$new['minify_js_key'] = create_rocket_uniqid();
+
+		return $new;
+	}
+
+	/**
+	 * Checks minify JS condition when options change.
+	 *
+	 * @since  3.5.4
+	 *
+	 * @param array $new An array of submitted settings.
+	 * @param array $old An array of previous settings.
+	 *
+	 * @return bool true when should regenerate; else false.
+	 */
+	protected function maybe_minify_regenerate( array $new, array $old ) {
+		$settings_to_check = [
+			'minify_css',
+			'exclude_css',
+			'cdn',
+		];
+
+		foreach ( $settings_to_check as $setting ) {
+			if ( $this->did_setting_change( $setting, $new, $old ) ) {
+				return true;
+			}
+		}
+
+		return (
+			array_key_exists( 'cdn', $new )
+			&&
+			1 === (int) $new['cdn']
+			&&
+			$this->did_setting_change( 'cdn_cnames', $new, $old )
+		);
+	}
+
+}

--- a/inc/Engine/Optimization/Minify/JS/AdminSubscriber.php
+++ b/inc/Engine/Optimization/Minify/JS/AdminSubscriber.php
@@ -4,6 +4,10 @@ namespace WP_Rocket\Engine\Optimization\Minify\JS;
 
 use WP_Rocket\Event_Management\Subscriber_Interface;
 
+/**
+ * Minify/Combine JS Admin subscriber
+ *
+ */
 class AdminSubscriber implements Subscriber_Interface {
 
 

--- a/inc/Engine/Optimization/Minify/JS/AdminSubscriber.php
+++ b/inc/Engine/Optimization/Minify/JS/AdminSubscriber.php
@@ -46,7 +46,7 @@ class AdminSubscriber implements Subscriber_Interface
 	 * @param array $new An array of submitted settings.
 	 * @param array $old An array of previous settings.
 	 *
-	 * @return array Updates 'minify_css_key' setting when regenerated; else, original submitted settings.
+	 * @return array Updates 'minify_js_key' setting when regenerated; else, original submitted settings.
 	 */
 	public function regenerate_minify_js_key( $new, $old ) {
 		if ( ! is_array( $old ) || ! is_array( $new ) ) {
@@ -74,8 +74,8 @@ class AdminSubscriber implements Subscriber_Interface
 	 */
 	protected function maybe_minify_regenerate( array $new, array $old ) {
 		$settings_to_check = [
-			'minify_css',
-			'exclude_css',
+			'minify_js',
+			'exclude_js',
 			'cdn',
 		];
 
@@ -94,4 +94,24 @@ class AdminSubscriber implements Subscriber_Interface
 		);
 	}
 
+	/**
+	 * Checks if the given setting's value changed.
+	 *
+	 * @since 3.5.4
+	 *
+	 * @param string $setting The settings's value to check in the old and new values.
+	 * @param array  $new     An array of submitted settings.
+	 * @param array  $old     An array of previous settings.
+	 *
+	 * @return bool
+	 */
+	protected function did_setting_change( $setting, array $new, array $old ) {
+		return (
+			array_key_exists( $setting, $old )
+			&&
+			array_key_exists( $setting, $new )
+			&&
+			$old[ $setting ] !== $new[ $setting ]
+		);
+	}
 }

--- a/inc/Engine/Optimization/Minify/JS/AdminSubscriber.php
+++ b/inc/Engine/Optimization/Minify/JS/AdminSubscriber.php
@@ -5,14 +5,15 @@ namespace WP_Rocket\Engine\Optimization\Minify\JS;
 use WP_Rocket\Event_Management\Subscriber_Interface;
 
 /**
- * Minify/Combine JS Admin subscriber
- *
+ * Minify/Combine JS Admin subscriber.
  */
 class AdminSubscriber implements Subscriber_Interface {
 
 
 	/**
-	 * @inheritDoc
+	 * Return an array of events that this subscriber wants to listen to.
+	 *
+	 * @return array
 	 */
 	public static function get_subscribed_events() {
 		$slug = rocket_get_constant( 'WP_ROCKET_SLUG', 'wp_rocket_settings' );

--- a/inc/Engine/Optimization/Minify/JS/AdminSubscriber.php
+++ b/inc/Engine/Optimization/Minify/JS/AdminSubscriber.php
@@ -4,21 +4,20 @@ namespace WP_Rocket\Engine\Optimization\Minify\JS;
 
 use WP_Rocket\Event_Management\Subscriber_Interface;
 
-class AdminSubscriber implements Subscriber_Interface
-{
+class AdminSubscriber implements Subscriber_Interface {
 
-    /**
-     * @inheritDoc
-     */
-    public static function get_subscribed_events()
-    {
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function get_subscribed_events() {
 		$slug = rocket_get_constant( 'WP_ROCKET_SLUG', 'wp_rocket_settings' );
 
 		return [
 			"update_option_{$slug}"     => [ 'clean_minify', 10, 2 ],
 			"pre_update_option_{$slug}" => [ 'regenerate_minify_js_key', 10, 2 ],
 		];
-    }
+	}
 
 	/**
 	 * Clean minify JS files when options change.

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -173,6 +173,7 @@ class Plugin {
 			'critical_css_admin_subscriber',
 			'health_check',
 			'minify_css_admin_subscriber',
+			'minify_js_admin_subscriber',
 			'admin_cache_subscriber',
 			'google_fonts_admin_subscriber',
 			'license_subscriber',

--- a/inc/admin/options.php
+++ b/inc/admin/options.php
@@ -57,18 +57,6 @@ function rocket_after_save_options( $oldvalue, $value ) {
 	$oldvalue_diff = array_diff_key( $oldvalue, $removed );
 	$value_diff    = array_diff_key( $value, $removed );
 
-	// phpcs:ignore WordPress.Security.NonceVerification.Missing
-	if ( ( array_key_exists( 'minify_js', $oldvalue ) && array_key_exists( 'minify_js', $value ) && $oldvalue['minify_js'] !== $value['minify_js'] )
-		||
-		( array_key_exists( 'exclude_js', $oldvalue ) && array_key_exists( 'exclude_js', $value ) && $oldvalue['exclude_js'] !== $value['exclude_js'] )
-		||
-		( array_key_exists( 'cdn', $oldvalue ) && array_key_exists( 'cdn', $value ) && $oldvalue['cdn'] !== $value['cdn'] )
-		||
-		( array_key_exists( 'cdn_cnames', $oldvalue ) && array_key_exists( 'cdn_cnames', $value ) && $oldvalue['cdn_cnames'] !== $value['cdn_cnames'] )
-	) {
-		rocket_clean_minify( 'js' );
-	}
-
 	// Regenerate advanced-cache.php file.
 	// phpcs:ignore WordPress.Security.NonceVerification.Missing
 	if ( ! empty( $_POST ) && ( ( isset( $oldvalue['do_caching_mobile_files'] ) && ! isset( $value['do_caching_mobile_files'] ) ) || ( ! isset( $oldvalue['do_caching_mobile_files'] ) && isset( $value['do_caching_mobile_files'] ) ) || ( isset( $oldvalue['do_caching_mobile_files'], $value['do_caching_mobile_files'] ) ) && $oldvalue['do_caching_mobile_files'] !== $value['do_caching_mobile_files'] ) ) {
@@ -189,14 +177,6 @@ function rocket_pre_main_option( $newvalue, $oldvalue ) {
 		if ( wp_next_scheduled( 'rocket_database_optimization_time_event' ) ) {
 			wp_clear_scheduled_hook( 'rocket_database_optimization_time_event' );
 		}
-	}
-
-	// Regenerate the minify key if JS files have been modified.
-	if ( ( isset( $newvalue['minify_js'], $oldvalue['minify_js'] ) && $newvalue['minify_js'] !== $oldvalue['minify_js'] )
-		|| ( isset( $newvalue['exclude_js'], $oldvalue['exclude_js'] ) && $newvalue['exclude_js'] !== $oldvalue['exclude_js'] )
-		|| ( isset( $oldvalue['cdn'] ) && ! isset( $newvalue['cdn'] ) || ! isset( $oldvalue['cdn'] ) && isset( $newvalue['cdn'] ) )
-	) {
-		$newvalue['minify_js_key'] = create_rocket_uniqid();
 	}
 
 	// Checked the SSL option if the whole website is on SSL.

--- a/tests/Fixtures/inc/Engine/Optimization/Minify/JS/AdminSubscriber/cleanMinify.php
+++ b/tests/Fixtures/inc/Engine/Optimization/Minify/JS/AdminSubscriber/cleanMinify.php
@@ -1,0 +1,114 @@
+<?php
+
+return [
+	'vfs_dir'   => 'wp-content/cache/min/',
+
+	// Default settings.
+	'settings'  => [
+		'minify_js'  => false,
+		'exclude_js' => [],
+		'cdn'         => false,
+		'cdn_cnames'  => [],
+	],
+
+	'test_data' => [
+		'shouldNotCleanMinify'             => [
+			'settings'     => [
+				'minify_js'  => false,
+				'exclude_js' => [],
+				'cdn'         => false,
+				'cdn_cnames'  => [],
+			],
+			'expected'   => [
+				'cleaned' => [],
+			],
+		],
+		'shouldNotCleanMinifyNewCname'     => [
+			'settings'     => [
+				'minify_js'  => false,
+				'exclude_js' => [],
+				'cdn'         => false,
+				'cdn_cnames'  => [ 'cname' ],
+			],
+			'expected'   => [
+				'cleaned' => [],
+			],
+		],
+		'shouldCleanMinifyJS'             => [
+			'settings'     => [
+				'minify_js'  => true,
+				'exclude_js' => [],
+				'cdn'         => false,
+				'cdn_cnames'  => [],
+			],
+			'expected'   => [
+				'cleaned' => [
+					'vfs://public/wp-content/cache/min/1/fa2965d41f1515951de523cecb81f85e.js'    => null,
+					'vfs://public/wp-content/cache/min/1/fa2965d41f1515951de523cecb81f85e.js.gz' => null,
+					'vfs://public/wp-content/cache/min/1/wp-content/js/'                         => null,
+					'vfs://public/wp-content/cache/min/1/wp-includes/plugins/imagify/assets/js/' => null,
+
+					'vfs://public/wp-content/cache/min/3rd-party/2n7x3vd41f1515951de523cecb81f85e.js'    => null,
+					'vfs://public/wp-content/cache/min/3rd-party/2n7x3vd41f1515951de523cecb81f85e.js.gz' => null,
+				],
+			],
+		],
+		'shouldCleanMinifyExcludeJS'      => [
+			'settings'     => [
+				'minify_js'  => true,
+				'exclude_js' => [ '/wp-content/plugins/some-plugin/file.js' ],
+				'cdn'         => false,
+				'cdn_cnames'  => [],
+			],
+			'expected'   => [
+				'cleaned' => [
+					'vfs://public/wp-content/cache/min/1/fa2965d41f1515951de523cecb81f85e.js'    => null,
+					'vfs://public/wp-content/cache/min/1/fa2965d41f1515951de523cecb81f85e.js.gz' => null,
+					'vfs://public/wp-content/cache/min/1/wp-content/js/'                         => null,
+					'vfs://public/wp-content/cache/min/1/wp-includes/plugins/imagify/assets/js/' => null,
+
+					'vfs://public/wp-content/cache/min/3rd-party/2n7x3vd41f1515951de523cecb81f85e.js'    => null,
+					'vfs://public/wp-content/cache/min/3rd-party/2n7x3vd41f1515951de523cecb81f85e.js.gz' => null,
+				],
+			],
+		],
+		'shouldCleanMinifyCDN'             => [
+			'settings'     => [
+				'minify_js'  => false,
+				'exclude_js' => [],
+				'cdn'         => true,
+				'cdn_cnames'  => [],
+			],
+			'expected'   => [
+				'cleaned' => [
+					'vfs://public/wp-content/cache/min/1/fa2965d41f1515951de523cecb81f85e.js'    => null,
+					'vfs://public/wp-content/cache/min/1/fa2965d41f1515951de523cecb81f85e.js.gz' => null,
+					'vfs://public/wp-content/cache/min/1/wp-content/js/'                         => null,
+					'vfs://public/wp-content/cache/min/1/wp-includes/plugins/imagify/assets/js/' => null,
+
+					'vfs://public/wp-content/cache/min/3rd-party/2n7x3vd41f1515951de523cecb81f85e.js'    => null,
+					'vfs://public/wp-content/cache/min/3rd-party/2n7x3vd41f1515951de523cecb81f85e.js.gz' => null,
+				],
+			],
+		],
+		'shouldCleanMinifyCDNCname'        => [
+			'settings'     => [
+				'minify_js'  => false,
+				'exclude_js' => [],
+				'cdn'         => true,
+				'cdn_cnames'  => [ 'cname' ],
+			],
+			'expected'   => [
+				'cleaned' => [
+					'vfs://public/wp-content/cache/min/1/fa2965d41f1515951de523cecb81f85e.js'    => null,
+					'vfs://public/wp-content/cache/min/1/fa2965d41f1515951de523cecb81f85e.js.gz' => null,
+					'vfs://public/wp-content/cache/min/1/wp-content/js/'                         => null,
+					'vfs://public/wp-content/cache/min/1/wp-includes/plugins/imagify/assets/js/' => null,
+
+					'vfs://public/wp-content/cache/min/3rd-party/2n7x3vd41f1515951de523cecb81f85e.js'    => null,
+					'vfs://public/wp-content/cache/min/3rd-party/2n7x3vd41f1515951de523cecb81f85e.js.gz' => null,
+				],
+			],
+		],
+	],
+];

--- a/tests/Fixtures/inc/Engine/Optimization/Minify/JS/AdminSubscriber/regenerateMinifyJsKey.php
+++ b/tests/Fixtures/inc/Engine/Optimization/Minify/JS/AdminSubscriber/regenerateMinifyJsKey.php
@@ -1,0 +1,108 @@
+<?php
+
+return [
+	// Default settings.
+	'settings' => [
+		'minify_js'  => false,
+		'exclude_js' => [],
+		'cdn'         => false,
+		'cdn_cnames'  => [],
+	],
+
+	'test_data' => [
+		'shouldNotRegenerateKey'         => [
+			'settings'   => [
+				'minify_js'  => false,
+				'exclude_js' => [],
+				'cdn'         => false,
+				'cdn_cnames'  => [],
+			],
+			'expected'   => [
+				'minify_js'  => false,
+				'exclude_js' => [],
+				'cdn'         => false,
+				'cdn_cnames'  => [],
+			],
+			'should_run' => false,
+		],
+		'shouldNotRegenerateKeyNewCname' => [
+			'settings'   => [
+				'minify_js'  => false,
+				'exclude_js' => [],
+				'cdn'         => false,
+				'cdn_cnames'  => [ 'cname' ],
+			],
+			'expected'   => [
+				'minify_js'  => false,
+				'exclude_js' => [],
+				'cdn'         => false,
+				'cdn_cnames'  => [ 'cname' ],
+			],
+			'should_run' => false,
+		],
+		'shouldRegenerateKey'            => [
+			'settings'   => [
+				'minify_js'  => true,
+				'exclude_js' => [],
+				'cdn'         => false,
+				'cdn_cnames'  => [],
+			],
+			'expected'   => [
+				'minify_js'     => true,
+				'exclude_js'    => [],
+				'cdn'            => false,
+				'cdn_cnames'     => [],
+				'minify_js_key' => 'minify_js_key',
+			],
+			'should_run' => true,
+		],
+		'shouldRegenerateKeyExcludeJS'  => [
+			'settings'   => [
+				'minify_js'  => true,
+				'exclude_js' => [ '/wp-content/plugins/some-plugin/file.js' ],
+				'cdn'         => false,
+				'cdn_cnames'  => [],
+			],
+			'expected'   => [
+				'minify_js'     => true,
+				'exclude_js'    => [ '/wp-content/plugins/some-plugin/file.js' ],
+				'cdn'            => false,
+				'cdn_cnames'     => [],
+				'minify_js_key' => 'minify_js_key',
+			],
+			'should_run' => true,
+		],
+		'shouldRegenerateKeyCDN'         => [
+			'settings'   => [
+				'minify_js'  => false,
+				'exclude_js' => [],
+				'cdn'         => true,
+				'cdn_cnames'  => [],
+			],
+			'expected'   => [
+				'minify_js'     => false,
+				'exclude_js'    => [],
+				'cdn'            => true,
+				'cdn_cnames'     => [],
+				'minify_js_key' => 'minify_js_key',
+			],
+			'should_run' => true,
+		],
+		'shouldRegenerateKeyCDNCname'    => [
+			'settings'   => [
+				'minify_js'  => false,
+				'exclude_js' => [],
+				'cdn'         => true,
+				'cdn_cnames'  => [ 'cname' ],
+			],
+			'expected'   => [
+				'minify_js'     => false,
+				'exclude_js'    => [],
+				'cdn'            => true,
+				'cdn_cnames'     => [ 'cname' ],
+				'minify_js_key' => 'minify_js_key',
+			],
+			'should_run' => true,
+		],
+	],
+];

--- a/tests/Integration/inc/Engine/Optimization/Minify/JS/AdminSubscriber/cleanMinify.php
+++ b/tests/Integration/inc/Engine/Optimization/Minify/JS/AdminSubscriber/cleanMinify.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\Optimization\Minify\JS\AdminSubscriber;
+
+use WP_Rocket\Tests\Integration\inc\Engine\Optimization\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Optimization\Minify\JS\AdminSubscriber::clean_minify
+ * @uses   ::rocket_clean_minify
+ * @uses   ::rocket_direct_filesystem
+ *
+ * @group  Optimize
+ * @group  Minify
+ * @group  AdminSubscriber
+ * @group  AdminOnly
+ */
+class Test_CleanMinify extends TestCase {
+	protected $path_to_test_data = '/inc/Engine/Optimization/Minify/JS/AdminSubscriber/cleanMinify.php';
+
+	/**
+	 * @dataProvider providerTestData
+	 */
+	public function testCleanMinify( $settings, $expected ) {
+		$this->dumpResults = isset( $expected['dump_results'] ) ? $expected['dump_results'] : false;
+		$this->generateEntriesShouldExistAfter( $expected['cleaned'] );
+
+		// Run it.
+		$this->mergeExistingSettingsAndUpdate( $settings );
+
+		$this->checkEntriesDeleted( $expected['cleaned'] );
+		$this->checkShouldNotDeleteEntries();
+	}
+}

--- a/tests/Integration/inc/Engine/Optimization/Minify/JS/AdminSubscriber/regenerateMinifyJsKey.php
+++ b/tests/Integration/inc/Engine/Optimization/Minify/JS/AdminSubscriber/regenerateMinifyJsKey.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\Optimization\Minify\JS\AdminSubscriber;
+
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Optimization\Minify\JS\AdminSubscriber::regenerate_minify_js_key
+ * @uses   ::create_rocket_uniqid
+ *
+ * @group  Optimize
+ * @group  Minify
+ * @group  AdminSubscriber
+ * @group  AdminOnly
+ */
+class Test_RegenerateMinifyJsKey extends TestCase {
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testRegenerateMinifyCssKey( $settings, $expected, $should_run ) {
+		$this->mergeExistingSettingsAndUpdate( $settings );
+
+		$options = get_option( 'wp_rocket_settings', [] );
+
+		if ( $should_run ) {
+			$this->assertArrayHasKey( 'minify_js_key', $options );
+			$this->assertEquals( strlen( '5ea8b0bf1b875099188739' ), strlen( $options['minify_js_key'] ) );
+			unset( $expected['minify_js_key'] );
+		}
+
+		foreach ( $expected as $key => $value ) {
+			$this->assertSame( $value, $options[ $key ] );
+		}
+	}
+}

--- a/tests/Unit/inc/Engine/Optimization/Minify/JS/AdminSubscriber/cleanMinify.php
+++ b/tests/Unit/inc/Engine/Optimization/Minify/JS/AdminSubscriber/cleanMinify.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\Minify\JS\AdminSubscriber;
+
+use Brain\Monkey\Functions;
+use WP_Rocket\Tests\Unit\FilesystemTestCase;
+use WP_Rocket\Engine\Optimization\Minify\JS\AdminSubscriber;
+
+/**
+ * @covers \WP_Rocket\Engine\Optimization\Minify\JS\AdminSubscriber::clean_minify
+ * @uses   ::rocket_clean_minify
+ * @uses   ::rocket_direct_filesystem
+ *
+ * @group  Optimize
+ * @group  Minify
+ * @group  AdminSubscriber
+ */
+class Test_RocketCleanMinify extends FilesystemTestCase {
+	protected $path_to_test_data = '/inc/Engine/Optimization/Minify/JS/AdminSubscriber/cleanMinify.php';
+
+	/**
+	 * @dataProvider providerTestData
+	 */
+	public function testCleanMinify( $settings, $expected ) {
+		if ( ! empty( $expected['cleaned'] ) ) {
+			Functions\expect( 'rocket_clean_minify' )
+				->once()
+				->with( 'js' );
+		} else {
+			Functions\expect( 'rocket_clean_minify' )->never();
+		}
+
+		$subcriber = new AdminSubscriber();
+		$subcriber->clean_minify( $this->config['settings'], $settings );
+	}
+}

--- a/tests/Unit/inc/Engine/Optimization/Minify/JS/AdminSubscriber/regenerateMinifyJsKey.php
+++ b/tests/Unit/inc/Engine/Optimization/Minify/JS/AdminSubscriber/regenerateMinifyJsKey.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\Minify\JS\AdminSubscriber;
+
+use Brain\Monkey\Functions;
+use WP_Rocket\Tests\Unit\TestCase;
+use WP_Rocket\Engine\Optimization\Minify\JS\AdminSubscriber;
+
+/**
+ * @covers \WP_Rocket\Engine\Optimization\Minify\JS\AdminSubscriber::regenerate_minify_css_key
+ *
+ * @group  Optimize
+ * @group  Minify
+ * @group  AdminSubscriber
+ */
+class Test_RegenerateMinifyJsKey extends TestCase {
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testRegenerateMinifyJsKey( $value, $expected, $should_run ) {
+		if ( $should_run ) {
+			Functions\expect( 'create_rocket_uniqid' )
+				->once()
+				->andReturn( 'minify_js_key' );
+		} else {
+			Functions\expect( 'create_rocket_uniqid' )->never();
+		}
+
+		$subcriber = new AdminSubscriber();
+		$this->assertSame(
+			$expected,
+			$subcriber->regenerate_minify_js_key( $value, $this->config['settings'] )
+		);
+	}
+}

--- a/tests/Unit/inc/admin/rocketAfterSaveOptions.php
+++ b/tests/Unit/inc/admin/rocketAfterSaveOptions.php
@@ -60,11 +60,7 @@ class Test_RocketAfterSaveOptions extends FilesystemTestCase {
 	}
 
 	private function rocket_clean_minify() {
-		if ( isset( $this->expected['rocket_clean_minify'] ) ) {
-			Functions\expect( 'rocket_clean_minify' )->once()->with( 'js' )->andReturnNull();
-		} else {
-			Functions\expect( 'rocket_clean_minify' )->never();
-		}
+		Functions\expect( 'rocket_clean_minify' )->never();
 	}
 
 	private function flush_rocket_htaccess() {


### PR DESCRIPTION
## Description

Fix a problem where minified JS where created and deleted right after creating 404 errors.
To fix this the logic to delete minify JS has been moved to a Subcriber and removed from the `rocket_after_save_options` function.

Fixes #2973 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

No,  the solution was right

## How Has This Been Tested?

- [x] Automated tests
- [x] Manually on local env

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
