### PR TITLE
Added WordPress redirection to buffer subscriber

### DIFF
--- a/inc/classes/subscriber/Optimization/class-buffer-subscriber.php
+++ b/inc/classes/subscriber/Optimization/class-buffer-subscriber.php
@@ -32,7 +32,10 @@ class Buffer_Subscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events() {
 		return [
-			'template_redirect' => [ 'start_content_process', 2 ],
+			'template_redirect' => [
+				[ 'redirect_canonical', 1 ],
+				[ 'start_content_process', 2 ],
+			],
 		];
 	}
 
@@ -45,5 +48,14 @@ class Buffer_Subscriber implements Subscriber_Interface {
 	 */
 	public function start_content_process() {
 		return $this->optimizer->maybe_init_process();
+	}
+
+	/**
+	 * Call the WordPress redirect canonical function.
+	 *
+	 * @return void
+	 */
+	public function redirect_canonical() {
+		redirect_canonical();
 	}
 }

--- a/tests/Unit/inc/classes/subscriber/Optimization/BufferSubscriber/redirectCanonical.php
+++ b/tests/Unit/inc/classes/subscriber/Optimization/BufferSubscriber/redirectCanonical.php
@@ -18,9 +18,9 @@ class Test_RedirectCanonical extends TestCase
 
 	public function setUp(): void
 	{
+		parent::setUp();
 		$this->optimizer = \Mockery::mock(Optimization::class);
 		$this->subscriber = new Buffer_Subscriber($this->optimizer);
-		parent::setUp();
 	}
 
 	public function testShouldCallRedirect() {

--- a/tests/Unit/inc/classes/subscriber/Optimization/BufferSubscriber/redirectCanonical.php
+++ b/tests/Unit/inc/classes/subscriber/Optimization/BufferSubscriber/redirectCanonical.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\classes\subscriber\Optimization\BufferSubscriber;
+
+use WP_Rocket\Buffer\Optimization;
+use WP_Rocket\Subscriber\Optimization\Buffer_Subscriber;
+use WP_Rocket\Tests\Unit\TestCase;
+use Brain\Monkey\Functions;
+
+/**
+ * @covers \WP_Rocket\Subscriber\Optimization\Buffer_Subscriber::redirect_canonical
+ * @group Subscriber
+ */
+class Test_RedirectCanonical extends TestCase
+{
+	protected $subscriber;
+	protected $optimizer;
+
+	public function setUp(): void
+	{
+		$this->optimizer = \Mockery::mock(Optimization::class);
+		$this->subscriber = new Buffer_Subscriber($this->optimizer);
+		parent::setUp();
+	}
+
+	public function testShouldCallRedirect() {
+		Functions\expect('redirect_canonical')->with();
+		$this->subscriber->redirect_canonical();
+	}
+
+}

--- a/tests/Unit/inc/classes/subscriber/Optimization/BufferSubscriber/redirectCanonical.php
+++ b/tests/Unit/inc/classes/subscriber/Optimization/BufferSubscriber/redirectCanonical.php
@@ -24,7 +24,7 @@ class Test_RedirectCanonical extends TestCase
 	}
 
 	public function testShouldCallRedirect() {
-		Functions\expect('redirect_canonical')->with();
+		Functions\expect('redirect_canonical')->once();
 		$this->subscriber->redirect_canonical();
 	}
 


### PR DESCRIPTION
### Note: 
An PR already exist for this https://github.com/wp-media/wp-rocket/issues/1392.
However due to the fact we saw that after the code was written and the fact this PR is 2 years old and implements some stuffs that needs to be deleted we preferred create a new one.

@Tabrisrp can you confirm this option is fine?

## Description

Fix a problem with redirection between slash ended url and non slash.
To fix this a new method has been attached to the `template_redirect` action  that calls the WordPress `redirect_canonical`.

Fixes #1392 

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

Only the first part of grooming has been implemented as requested by @piotrbak 

## How Has This Been Tested?

- [x] Automated Tests
- [x] Manually on local env

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


