### PR TITLE
v3.11.0.3

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Admin/Settings.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Settings.php
@@ -278,6 +278,32 @@ class Settings {
 	}
 
 	/**
+	 * Display admin notice when detecting any missed Action scheduler tables.
+	 *
+	 * @since 3.11.0.3
+	 *
+	 * @return void
+	 */
+	public function display_as_missed_tables_notice() {
+		$as_tools_link = menu_page_url( 'action-scheduler', false );
+		$message       = sprintf(
+		// translators: %1$s = plugin name, %2$s = opening anchor tag, %3$s = closing anchor tag.
+			__( '%1$s: We detected missing database table related to Action Scheduler. Please visit the following %2$sURL%3$s to recreate it, as it is needed for WP Rocket to work correctly.', 'rocket' ),
+			'<strong>WP Rocket</strong>',
+			'<a href="' . $as_tools_link . '">',
+			'</a>'
+		);
+
+		rocket_notice_html(
+			[
+				'status'  => 'error',
+				'message' => $message,
+				'id'      => 'rocket-notice-as-missed-tables',
+			]
+		);
+	}
+
+	/**
 	 * Checks if we can display the RUCSS notices
 	 *
 	 * @since 3.11

--- a/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
@@ -65,49 +65,52 @@ class Subscriber implements Subscriber_Interface {
 		$slug = rocket_get_constant( 'WP_ROCKET_SLUG', 'wp_rocket_settings' );
 
 		return [
-			'rocket_first_install_options'         => 'add_options_first_time',
-			'rocket_input_sanitize'                => [ 'sanitize_options', 14, 2 ],
-			'update_option_' . $slug               => [
+			'rocket_first_install_options'           => 'add_options_first_time',
+			'rocket_input_sanitize'                  => [ 'sanitize_options', 14, 2 ],
+			'update_option_' . $slug                 => [
 				[ 'clean_used_css_and_cache', 9, 2 ],
 				[ 'clean_used_css_with_cdn', 9, 2 ],
 				[ 'maybe_set_processing_transient', 50, 2 ],
 			],
-			'switch_theme'                         => 'truncate_used_css',
-			'wp_trash_post'                        => 'delete_used_css_on_update_or_delete',
-			'delete_post'                          => 'delete_used_css_on_update_or_delete',
-			'clean_post_cache'                     => 'delete_used_css_on_update_or_delete',
-			'wp_update_comment_count'              => 'delete_used_css_on_update_or_delete',
-			'edit_term'                            => 'delete_term_used_css',
-			'pre_delete_term'                      => 'delete_term_used_css',
-			'init'                                 => [
+			'switch_theme'                           => 'truncate_used_css',
+			'wp_trash_post'                          => 'delete_used_css_on_update_or_delete',
+			'delete_post'                            => 'delete_used_css_on_update_or_delete',
+			'clean_post_cache'                       => 'delete_used_css_on_update_or_delete',
+			'wp_update_comment_count'                => 'delete_used_css_on_update_or_delete',
+			'edit_term'                              => 'delete_term_used_css',
+			'pre_delete_term'                        => 'delete_term_used_css',
+			'init'                                   => [
 				[ 'schedule_clean_not_commonly_used_rows' ],
-				[ 'schedule_rucss_pending_jobs_cron' ],
+				[ 'initialize_rucss_queue_runner' ],
 			],
-			'rocket_rucss_clean_rows_time_event'   => 'cron_clean_rows',
-			'admin_post_rocket_clear_usedcss'      => 'truncate_used_css_handler',
-			'admin_post_rocket_clear_usedcss_url'  => 'clear_url_usedcss',
-			'admin_notices'                        => [
+			'rocket_rucss_clean_rows_time_event'     => 'cron_clean_rows',
+			'admin_post_rocket_clear_usedcss'        => 'truncate_used_css_handler',
+			'admin_post_rocket_clear_usedcss_url'    => 'clear_url_usedcss',
+			'admin_notices'                          => [
 				[ 'clear_usedcss_result' ],
 				[ 'display_processing_notice' ],
 				[ 'display_success_notice' ],
+				[ 'display_as_missed_tables_notice' ],
 			],
-			'rocket_admin_bar_items'               => [
+			'rocket_admin_bar_items'                 => [
 				[ 'add_clean_used_css_menu_item' ],
 				[ 'add_clear_usedcss_bar_item' ],
 			],
-			'rocket_before_add_field_to_settings'  => [
+			'rocket_before_add_field_to_settings'    => [
 				[ 'set_optimize_css_delivery_value', 10, 1 ],
 				[ 'set_optimize_css_delivery_method_value', 10, 1 ],
 			],
-			'rocket_localize_admin_script'         => 'add_localize_script_data',
+			'rocket_localize_admin_script'           => 'add_localize_script_data',
 			'action_scheduler_queue_runner_concurrent_batches' => 'adjust_as_concurrent_batches',
-			'pre_update_option_wp_rocket_settings' => [ 'maybe_disable_combine_css', 11, 2 ],
-			'wp_rocket_upgrade'                    => [
+			'pre_update_option_wp_rocket_settings'   => [ 'maybe_disable_combine_css', 11, 2 ],
+			'wp_rocket_upgrade'                      => [
 				[ 'set_option_on_update', 14, 2 ],
 				[ 'update_safelist_items', 15, 2 ],
 			],
-			'wp_ajax_rocket_spawn_cron'            => 'spawn_cron',
-			'rocket_deactivation'                  => 'cancel_queues',
+			'wp_ajax_rocket_spawn_cron'              => 'spawn_cron',
+			'rocket_deactivation'                    => 'cancel_queues',
+			'shutdown'                               => 'schedule_rucss_pending_jobs_cron',
+			'admin_head-tools_page_action-scheduler' => 'delete_as_tables_transient_on_tools_page',
 		];
 	}
 
@@ -164,6 +167,19 @@ class Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function schedule_rucss_pending_jobs_cron() {
+		$error = error_get_last();
+
+		// Delete the transient when any error happens.
+		if ( null !== $error ) {
+			delete_transient( 'rocket_rucss_as_tables_count' );
+
+			return;
+		}
+
+		if ( ! $this->is_valid_as_tables() ) {
+			return;
+		}
+
 		if ( ! $this->settings->is_enabled() ) {
 			if ( ! $this->queue->is_pending_jobs_cron_scheduled() ) {
 				return;
@@ -174,8 +190,6 @@ class Subscriber implements Subscriber_Interface {
 			$this->queue->cancel_pending_jobs_cron();
 			return;
 		}
-
-		RUCSSQueueRunner::instance()->init();
 
 		/**
 		 * Filters the cron interval.
@@ -189,6 +203,44 @@ class Subscriber implements Subscriber_Interface {
 		Logger::debug( "RUCSS: Schedule pending jobs Cron job with interval {$interval} seconds." );
 
 		$this->queue->schedule_pending_jobs_cron( $interval );
+	}
+
+	/**
+	 * Initialize the queue runner for our RUCSS.
+	 *
+	 * @return void
+	 */
+	public function initialize_rucss_queue_runner() {
+		if ( ! $this->settings->is_enabled() ) {
+			return;
+		}
+
+		RUCSSQueueRunner::instance()->init();
+	}
+
+	/**
+	 * Checks if Action scheduler tables are there or not.
+	 *
+	 * @since 3.11.0.3
+	 *
+	 * @return bool
+	 */
+	private function is_valid_as_tables() {
+		$cached_count = get_transient( 'rocket_rucss_as_tables_count' );
+		if ( false !== $cached_count && ! is_admin() ) { // Stop caching in admin UI.
+			return 4 === (int) $cached_count;
+		}
+
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$found_as_tables = $wpdb->get_col(
+			$wpdb->prepare( 'SHOW TABLES LIKE %s', $wpdb->prefix . 'actionscheduler%' )
+		);
+
+		set_transient( 'rocket_rucss_as_tables_count', count( $found_as_tables ), rocket_get_constant( 'DAY_IN_SECONDS', 24 * 60 * 60 ) );
+
+		return 4 === count( $found_as_tables );
 	}
 
 	/**
@@ -504,6 +556,25 @@ class Subscriber implements Subscriber_Interface {
 	}
 
 	/**
+	 * Display admin notice when detecting any missed Action scheduler tables.
+	 *
+	 * @since 3.11.0.3
+	 *
+	 * @return void
+	 */
+	public function display_as_missed_tables_notice() {
+		if ( function_exists( 'get_current_screen' ) && 'tools_page_action-scheduler' === get_current_screen()->id ) {
+			return;
+		}
+
+		if ( $this->is_valid_as_tables() ) {
+			return;
+		}
+
+		$this->settings->display_as_missed_tables_notice();
+	}
+
+	/**
 	 * Adds the notice end time to WP Rocket localize script data
 	 *
 	 * @since 3.11
@@ -692,5 +763,14 @@ class Subscriber implements Subscriber_Interface {
 		}
 
 		wp_clear_scheduled_hook( 'rocket_rucss_clean_rows_time_event' );
+	}
+
+	/**
+	 * Delete the transient for Action scheduler once admin visits the AS tools page.
+	 *
+	 * @return void
+	 */
+	public function delete_as_tables_transient_on_tools_page() {
+		delete_transient( 'rocket_rucss_as_tables_count' );
 	}
 }

--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -65,6 +65,7 @@ class UsedCSS {
 		'woodmart-inline-css-inline-css',
 		'woodmart_shortcodes-custom-css',
 		'rs-plugin-settings-inline-css', // For revolution slider, it saves settings for each slider.
+		'divi-style-inline-inline-css',
 	];
 
 	/**

--- a/inc/ThirdParty/Plugins/Optimization/AMP.php
+++ b/inc/ThirdParty/Plugins/Optimization/AMP.php
@@ -53,7 +53,8 @@ class AMP implements Subscriber_Interface {
 		];
 
 		if ( function_exists( 'is_amp_endpoint' ) ) {
-			$events['update_option_amp-options'] = 'generate_config_file';
+			$events['update_option_amp-options']  = 'generate_config_file';
+			$events['rocket_delay_js_exclusions'] = 'exclude_script_from_delay_js';
 		}
 
 		return $events;
@@ -176,5 +177,18 @@ class AMP implements Subscriber_Interface {
 				'(.*).js',
 			]
 		);
+	}
+
+	/**
+	 * Adds the switching script from AMP to delay JS excluded files
+	 *
+	 * @since 3.11.1
+	 *
+	 * @param  array $excluded List of excluded files.
+	 * @return array        List of excluded files.
+	 */
+	public function exclude_script_from_delay_js( $excluded ) {
+		$excluded[] = 'amp-mobile-version-switcher';
+		return $excluded;
 	}
 }

--- a/tests/Fixtures/inc/ThirdParty/Plugins/Optimization/AMP/excludeScriptFromDelayJs.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/Optimization/AMP/excludeScriptFromDelayJs.php
@@ -1,0 +1,11 @@
+<?php
+return [
+	'testShouldDoExpected'      => [
+		'config' => [
+			'excluded' => [],
+		],
+		'expected' => [
+			'excluded' => ['amp-mobile-version-switcher'],
+		],
+	],
+];

--- a/tests/Integration/inc/ThirdParty/Plugins/Optimization/AMP/excludeScriptFromDelayJs.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Optimization/AMP/excludeScriptFromDelayJs.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\Optimization\AMP;
+
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * @covers \WP_Rocket\ThirdParty\Plugins\Optimization\AMP::exclude_script_from_delay_js
+ * @group  ThirdParty
+ * @group  WithAmp
+ */
+class Test_ExcludeScriptFromDelayJs extends TestCase
+{
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldExcludeScriptWhenAmpPresent($config, $expected) {
+		$this->assertEquals($expected['excluded'], apply_filters( 'rocket_delay_js_exclusions', $config['excluded']));
+	}
+
+}

--- a/tests/Unit/inc/ThirdParty/Plugins/Optimization/AMP/excludeScriptFromDelayJs.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/Optimization/AMP/excludeScriptFromDelayJs.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\Optimization\AMP;
+
+use Mockery;
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Engine\CDN\Subscriber;
+use WP_Rocket\ThirdParty\Plugins\Optimization\AMP;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @covers \WP_Rocket\ThirdParty\Plugins\Optimization\AMP::exclude_script_from_delay_js
+ * @group  ThirdParty
+ * @group  WithAmp
+ */
+class Test_ExcludeScriptFromDelayJs extends TestCase
+{
+
+	private $amp;
+	private $options;
+	private $cdn_subscriber;
+
+	public function setUp() : void {
+		parent::setUp();
+
+		$this->options        = Mockery::mock( Options_Data::class );
+		$this->cdn_subscriber = Mockery::mock( Subscriber::class );
+		$this->amp            = new AMP( $this->options, $this->cdn_subscriber );
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldDoExpected($config, $expected) {
+		$this->assertEquals($expected['excluded'], $this->amp->exclude_script_from_delay_js($config['excluded']));
+	}
+
+}

--- a/wp-rocket.php
+++ b/wp-rocket.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Rocket
  * Plugin URI: https://wp-rocket.me
  * Description: The best WordPress performance plugin.
- * Version: 3.11.0.2
+ * Version: 3.11.0.3
  * Requires at least: 5.5
  * Requires PHP: 7.1
  * Code Name: Iego
@@ -20,7 +20,7 @@
 defined( 'ABSPATH' ) || exit;
 
 // Rocket defines.
-define( 'WP_ROCKET_VERSION',               '3.11.0.2' );
+define( 'WP_ROCKET_VERSION',               '3.11.0.3' );
 define( 'WP_ROCKET_WP_VERSION',            '5.5' );
 define( 'WP_ROCKET_WP_VERSION_TESTED',     '5.9' );
 define( 'WP_ROCKET_PHP_VERSION',           '7.1' );


### PR DESCRIPTION
- Bugfix: Prevent a fatal error if one of the Action Scheduler tables is missing (#4897)
- 3rd party compatibility: Preserve Divi inline CSS when Remove unused CSS is enabled to prevent a JS error (#4598)
- 3rd party compatibility: Exclude the AMP mobile redirection script from delay JS (#4757)