### PR TITLE
Fixes #4789 Re-enable cache of feeds

### DIFF
--- a/inc/classes/Buffer/class-tests.php
+++ b/inc/classes/Buffer/class-tests.php
@@ -328,7 +328,7 @@ class Tests {
 			return false;
 		}
 
-		if ( http_response_code() !== 200 ) {
+		if ( $this->get_http_response_code() !== 200 ) {
 			// Only cache 200.
 			$this->set_error( 'Page is not a 200 HTTP response and cannot be cached.' );
 			return false;
@@ -371,6 +371,15 @@ class Tests {
 		$this->last_error = [];
 
 		return true;
+	}
+
+	/**
+	 * Return http response to prevent a bug while testing.
+	 *
+	 * @return bool|int
+	 */
+	public function get_http_response_code() {
+		return http_response_code();
 	}
 
 	/** ----------------------------------------------------------------------------------------- */

--- a/inc/classes/Buffer/class-tests.php
+++ b/inc/classes/Buffer/class-tests.php
@@ -352,12 +352,16 @@ class Tests {
 			return false;
 		}
 
+		if($this->has_test( 'is_html' )) {
+			if($this->is_feed_uri() || defined( 'REST_REQUEST' )) {
+				unset($this->tests['is_html']);
+			}
+		}
+
 		if (
 			$this->has_test( 'is_html' )
 			&&
 			! $this->is_html( $buffer )
-			&&
-			! defined( 'REST_REQUEST' )
 		) {
 			// Don't process if there isn't a closing </html>.
 			$this->set_error( 'No closing </html> was found.' );
@@ -442,6 +446,17 @@ class Tests {
 		$is_rejected = $extension && isset( $extensions[ $extension ] );
 
 		return self::memoize( __FUNCTION__, [], $is_rejected );
+	}
+
+	/**
+	 * Tell if the current url is a feed.
+	 *
+	 * @return bool
+	 */
+	public function is_feed_uri(){
+		global $wp_rewrite;
+		$feed_uri = '/(?:.+/)?' . $wp_rewrite->feed_base . '(?:/(?:.+/?)?)?$';
+		return (bool) preg_match( '#^(' . $feed_uri . ')$#i', $this->get_clean_request_uri() );
 	}
 
 	/**

--- a/inc/classes/Buffer/class-tests.php
+++ b/inc/classes/Buffer/class-tests.php
@@ -352,9 +352,9 @@ class Tests {
 			return false;
 		}
 
-		if($this->has_test( 'is_html' )) {
-			if($this->is_feed_uri() || defined( 'REST_REQUEST' )) {
-				unset($this->tests['is_html']);
+		if ( $this->has_test( 'is_html' ) ) {
+			if ( $this->is_feed_uri() || defined( 'REST_REQUEST' ) ) {
+				unset( $this->tests['is_html'] );
 			}
 		}
 
@@ -453,7 +453,7 @@ class Tests {
 	 *
 	 * @return bool
 	 */
-	public function is_feed_uri(){
+	public function is_feed_uri() {
 		global $wp_rewrite;
 		$feed_uri = '/(?:.+/)?' . $wp_rewrite->feed_base . '(?:/(?:.+/?)?)?$';
 		return (bool) preg_match( '#^(' . $feed_uri . ')$#i', $this->get_clean_request_uri() );

--- a/tests/Fixtures/WP_Rewrite.php
+++ b/tests/Fixtures/WP_Rewrite.php
@@ -1,0 +1,8 @@
+<?php
+
+if(! class_exists('WP_Rewrite')) {
+	class WP_Rewrite
+	{
+		public $wp_rewrite = '';
+	}
+}

--- a/tests/Fixtures/inc/classes/Buffer/Tests/canProcessBuffer.php
+++ b/tests/Fixtures/inc/classes/Buffer/Tests/canProcessBuffer.php
@@ -118,7 +118,7 @@ return [
 			],
 		],
 	],
-	'testShouldReturnTrueWhenIsFlux' => [
+	'testShouldReturnTrueWhenIsFeed' => [
 		'config' => [
 			'rocket_exist' => true,
 			'buffer' => "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",

--- a/tests/Fixtures/inc/classes/Buffer/Tests/canProcessBuffer.php
+++ b/tests/Fixtures/inc/classes/Buffer/Tests/canProcessBuffer.php
@@ -1,0 +1,164 @@
+<?php
+
+return [
+	'testShouldReturnFalseWhenBufferTooSmall' => [
+		'config' => [
+			'rocket_exist' => true,
+			'buffer' => ''
+		],
+		'expected' => [
+			'buffer_results' => false,
+			'error' => [
+				'message' => 'Buffer content under 255 caracters.',
+				'data' => [],
+			],
+		],
+	],
+	'testShouldReturnFalseWhenResponseNot200' => [
+		'config' => [
+			'rocket_exist' => true,
+			'buffer' => "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+			'response_code' => 400
+		],
+		'expected' => [
+			'buffer_results' => false,
+			'error' => [
+				'message' => 'Page is not a 200 HTTP response and cannot be cached.',
+				'data' => [],
+			],
+		],
+	],
+	'testShouldReturnFalseWhenFailDoNotCache' => [
+		'config' => [
+			'rocket_exist' => true,
+			'buffer' => "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+			'response_code' => 200,
+			'cache' => true,
+		],
+		'expected' => [
+			'buffer_results' => false,
+			'error' => [
+				'message' => 'DONOTCACHEPAGE is defined. Page cannot be cached.',
+				'data' => [],
+			],
+		],
+	],
+	'testShouldReturnFalseWhenFailIs404' => [
+		'config' => [
+			'rocket_exist' => true,
+			'buffer' => "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+			'response_code' => 200,
+			'cache' => false,
+			'404' => true,
+		],
+		'expected' => [
+			'buffer_results' => false,
+			'error' => [
+				'message' => 'WP 404 page is excluded.',
+				'data' => [],
+			],
+		],
+	],
+	'testShouldReturnFalseWhenFailIsSearch' => [
+		'config' => [
+			'rocket_exist' => true,
+			'buffer' => "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+			'response_code' => 200,
+			'cache' => false,
+			'404' => false,
+			'search' => true,
+		],
+		'expected' => [
+			'buffer_results' => false,
+			'error' => [
+				'message' => 'Search page is excluded.',
+				'data' => [],
+			],
+		],
+	],
+	'testShouldReturnFalseWhenIsHtmlAndFailIsHTML' => [
+		'config' => [
+			'rocket_exist' => true,
+			'buffer' => "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+			'response_code' => 200,
+			'cache' => false,
+			'404' => false,
+			'search' => false,
+			'html' => [
+				'is_html' => false,
+				'is_feed' => false,
+			],
+		],
+		'expected' => [
+			'buffer_results' => false,
+			'error' => [
+				'message' => 'No closing </html> was found.',
+				'data' => [],
+			],
+		],
+	],
+	'testShouldReturnTrueWhenIsHtmlAndSuccessIsHTML' => [
+		'config' => [
+			'rocket_exist' => true,
+			'buffer' => "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+			'response_code' => 200,
+			'cache' => false,
+			'404' => false,
+			'search' => false,
+			'html' => [
+				'is_html' => true,
+				'is_feed' => false,
+			],
+		],
+		'expected' => [
+			'buffer_results' => true,
+			'error' => [
+				'message' => '',
+				'data' => [],
+			],
+		],
+	],
+	'testShouldReturnTrueWhenIsFlux' => [
+		'config' => [
+			'rocket_exist' => true,
+			'buffer' => "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+			'response_code' => 200,
+			'cache' => false,
+			'404' => false,
+			'search' => false,
+			'html' => [
+				'is_html' => true,
+				'is_feed' => true,
+			],
+		],
+		'expected' => [
+			'buffer_results' => true,
+			'error' => [
+				'message' => '',
+				'data' => [],
+			],
+		],
+	],
+	'testShouldReturnTrueWhenIsAPI' => [
+		'config' => [
+			'rocket_exist' => true,
+			'buffer' => "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+			'response_code' => 200,
+			'cache' => false,
+			'404' => false,
+			'search' => false,
+			'html' => [
+				'is_html' => true,
+				'is_feed' => false,
+				'is_rest' => true,
+			],
+		],
+		'expected' => [
+			'buffer_results' => true,
+			'error' => [
+				'message' => '',
+				'data' => [],
+			],
+		],
+	],
+];

--- a/tests/Fixtures/inc/classes/Buffer/Tests/isFeedUri.php
+++ b/tests/Fixtures/inc/classes/Buffer/Tests/isFeedUri.php
@@ -1,0 +1,17 @@
+<?php
+return [
+	'testReturnTrueWhenFeed' => [
+		'config' => [
+			'feed_base' => 'feed',
+			'clean_uri' => '/feed/base',
+		],
+		'expected' => true,
+	],
+	'testReturnFalseWhenNotFeed' => [
+		'config' => [
+			'clean_uri' => '/example',
+			'feed_base' => 'feed',
+		],
+		'expected' => false,
+	],
+];

--- a/tests/Unit/bootstrap.php
+++ b/tests/Unit/bootstrap.php
@@ -36,6 +36,7 @@ function load_original_files_before_mocking() {
 		'/WP_Error.php',
 		'/WP_Theme.php',
 		'/WPDieException.php',
+		'/WP_Rewrite.php',
 	];
 	foreach ( $fixtures as $file ) {
 		require_once WP_ROCKET_TESTS_FIXTURES_DIR . $file;

--- a/tests/Unit/inc/classes/Buffer/Tests/canProcessBuffer.php
+++ b/tests/Unit/inc/classes/Buffer/Tests/canProcessBuffer.php
@@ -36,7 +36,7 @@ class Test_CanProcessBuffer extends TestCase {
 		$this->configure404($config);
 		$this->configureSearch($config);
 		$this->configureHTML($config);
-		$this->assertEquals($expected['buffer_results'], $this->tests->can_process_buffer($config['buffer']));
+		$this->assertSame($expected['buffer_results'], $this->tests->can_process_buffer($config['buffer']));
 		$this->assertEquals($expected['error'], $this->tests->get_last_error());
 	}
 

--- a/tests/Unit/inc/classes/Buffer/Tests/canProcessBuffer.php
+++ b/tests/Unit/inc/classes/Buffer/Tests/canProcessBuffer.php
@@ -37,7 +37,7 @@ class Test_CanProcessBuffer extends TestCase {
 		$this->configureSearch($config);
 		$this->configureHTML($config);
 		$this->assertSame($expected['buffer_results'], $this->tests->can_process_buffer($config['buffer']));
-		$this->assertEquals($expected['error'], $this->tests->get_last_error());
+		$this->assertSame($expected['error'], $this->tests->get_last_error());
 	}
 
 	protected function configureRocketFunction($config) {

--- a/tests/Unit/inc/classes/Buffer/Tests/canProcessBuffer.php
+++ b/tests/Unit/inc/classes/Buffer/Tests/canProcessBuffer.php
@@ -22,7 +22,7 @@ class Test_CanProcessBuffer extends TestCase {
 	{
 		parent::setUp();
 		$this->config = \Mockery::mock(Config::class);
-		$this->tests = Mockery::mock(Tests::class.'[has_donotcachepage,is_404,is_search,is_feed_uri,is_html]',
+		$this->tests = Mockery::mock(Tests::class.'[has_donotcachepage,is_404,is_search,is_feed_uri,is_html,get_http_response_code]',
 			[$this->config]);
 	}
 
@@ -30,7 +30,6 @@ class Test_CanProcessBuffer extends TestCase {
 	 * @dataProvider configTestData
 	 */
 	public function testShouldReturnAsExpected($config, $expected) {
-		$this->markTestIncomplete('Prevent fail');
 		$this->configureRocketFunction($config);
 		$this->configureHttpResponse($config);
 		$this->configureCache($config);
@@ -52,7 +51,7 @@ class Test_CanProcessBuffer extends TestCase {
 		if(! key_exists('response_code', $config)) {
 			return;
 		}
-		Functions\expect('http_response_code')->once()->andReturn($config['response_code']);
+		$this->tests->expects()->get_http_response_code()->andReturn($config['response_code']);
 	}
 
 	protected function configureCache($config) {

--- a/tests/Unit/inc/classes/Buffer/Tests/canProcessBuffer.php
+++ b/tests/Unit/inc/classes/Buffer/Tests/canProcessBuffer.php
@@ -30,6 +30,7 @@ class Test_CanProcessBuffer extends TestCase {
 	 * @dataProvider configTestData
 	 */
 	public function testShouldReturnAsExpected($config, $expected) {
+		$this->markTestIncomplete('Prevent fail');
 		$this->configureRocketFunction($config);
 		$this->configureHttpResponse($config);
 		$this->configureCache($config);

--- a/tests/Unit/inc/classes/Buffer/Tests/canProcessBuffer.php
+++ b/tests/Unit/inc/classes/Buffer/Tests/canProcessBuffer.php
@@ -1,10 +1,18 @@
 <?php
 
+namespace WP_Rocket\Tests\Unit\inc\classes\Buffer\Tests;
+
 use WP_Rocket\Buffer\Config;
 use WP_Rocket\Buffer\Tests;
 use WP_Rocket\Tests\Unit\TestCase;
 use Brain\Monkey\Functions;
+use Mockery;
 
+/**
+ * @covers \WP_Rocket\Buffer\Tests::can_process_buffer
+ *
+ * @group  Buffer
+ */
 class Test_CanProcessBuffer extends TestCase {
 
 	protected $tests;

--- a/tests/Unit/inc/classes/Buffer/Tests/canProcessBuffer.php
+++ b/tests/Unit/inc/classes/Buffer/Tests/canProcessBuffer.php
@@ -1,0 +1,82 @@
+<?php
+
+use WP_Rocket\Buffer\Config;
+use WP_Rocket\Buffer\Tests;
+use WP_Rocket\Tests\Unit\TestCase;
+use Brain\Monkey\Functions;
+
+class Test_CanProcessBuffer extends TestCase {
+
+	protected $tests;
+	protected $config;
+
+	public function setUp(): void
+	{
+		parent::setUp();
+		$this->config = \Mockery::mock(Config::class);
+		$this->tests = Mockery::mock(Tests::class.'[has_donotcachepage,is_404,is_search,is_feed_uri,is_html]',
+			[$this->config]);
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnAsExpected($config, $expected) {
+		$this->configureRocketFunction($config);
+		$this->configureHttpResponse($config);
+		$this->configureCache($config);
+		$this->configure404($config);
+		$this->configureSearch($config);
+		$this->configureHTML($config);
+		$this->assertEquals($expected['buffer_results'], $this->tests->can_process_buffer($config['buffer']));
+		$this->assertEquals($expected['error'], $this->tests->get_last_error());
+	}
+
+	protected function configureRocketFunction($config) {
+		if(! key_exists('rocket_exist', $config)) {
+			return;
+		}
+		Functions\when( 'rocket_mkdir_p' )->justReturn( '' );
+	}
+
+	protected function configureHttpResponse($config) {
+		if(! key_exists('response_code', $config)) {
+			return;
+		}
+		Functions\expect('http_response_code')->once()->andReturn($config['response_code']);
+	}
+
+	protected function configureCache($config) {
+		if(! key_exists('cache', $config)) {
+			return;
+		}
+		$this->tests->expects()->has_donotcachepage()->andReturn($config['cache']);
+	}
+
+	protected function configure404($config) {
+		if(! key_exists('404', $config)) {
+			return;
+		}
+		$this->tests->expects()->is_404()->andReturn($config['404']);
+	}
+
+	protected function configureSearch($config) {
+		if(! key_exists('search', $config)) {
+			return;
+		}
+		$this->tests->expects()->is_search()->once()->andReturn($config['search']);
+	}
+
+	protected function configureHTML($config) {
+		if(! key_exists('html', $config)) {
+			return;
+		}
+		$this->tests->expects()->is_feed_uri()->andReturn($config['html']['is_feed']);
+		if(key_exists('is_rest', $config['html']) ) {
+			define( 'REST_REQUEST', true );
+		}
+		if(!$config['html']['is_feed'] && !key_exists('is_rest', $config['html'])) {
+			$this->tests->expects()->is_html($config['buffer'])->andReturn($config['html']['is_html']);
+		}
+	}
+}

--- a/tests/Unit/inc/classes/Buffer/Tests/isFeedUri.php
+++ b/tests/Unit/inc/classes/Buffer/Tests/isFeedUri.php
@@ -24,6 +24,12 @@ class Test_IsFeedURI extends TestCase {
 	}
 
 
+	protected function tearDown(): void
+	{
+		unset($GLOBALS['wp_rewrite']);
+		parent::tearDown();
+	}
+
 	/**
 	 * @dataProvider configTestData
 	 */

--- a/tests/Unit/inc/classes/Buffer/Tests/isFeedUri.php
+++ b/tests/Unit/inc/classes/Buffer/Tests/isFeedUri.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\classes\Buffer\Tests;
+
+use WP_Rewrite;
+use WP_Rocket\Buffer\Config;
+use WP_Rocket\Buffer\Tests;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @covers \WP_Rocket\Buffer\Tests::is_feed_uri
+ *
+ * @group  Buffer
+ */
+class Test_IsFeedURI extends TestCase {
+	protected $tests;
+	protected $config;
+
+	public function setUp(): void
+	{
+		parent::setUp();
+		$this->config = \Mockery::mock(Config::class);
+		$this->tests = \Mockery::mock(Tests::class.'[get_clean_request_uri]', [$this->config]);
+	}
+
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnAsExpected($config, $expected)
+	{
+		$wp_rewrite = new WP_Rewrite();
+		$wp_rewrite->feed_base = $config['feed_base'];
+		$GLOBALS['wp_rewrite'] = $wp_rewrite;
+		$this->tests->expects()->get_clean_request_uri()->andReturn($config['clean_uri']);
+		$this->assertEquals($expected, $this->tests->is_feed_uri());
+	}
+}

--- a/tests/Unit/inc/classes/Buffer/Tests/isFeedUri.php
+++ b/tests/Unit/inc/classes/Buffer/Tests/isFeedUri.php
@@ -33,6 +33,6 @@ class Test_IsFeedURI extends TestCase {
 		$wp_rewrite->feed_base = $config['feed_base'];
 		$GLOBALS['wp_rewrite'] = $wp_rewrite;
 		$this->tests->expects()->get_clean_request_uri()->andReturn($config['clean_uri']);
-		$this->assertEquals($expected, $this->tests->is_feed_uri());
+		$this->assertSame($expected, $this->tests->is_feed_uri());
 	}
 }

--- a/tests/Unit/patchwork.json
+++ b/tests/Unit/patchwork.json
@@ -1,1 +1,0 @@
-{"redefinable-internals": ["http_response_code"]}

--- a/tests/Unit/patchwork.json
+++ b/tests/Unit/patchwork.json
@@ -1,0 +1,1 @@
+{"redefinable-internals": ["http_response_code"]}


### PR DESCRIPTION
## Description
This PR fix a problem concerning feeds caching.
For that the logic inside the Buffer\Tests class have been a bit changed to check if the uri is a feed before checking if the page is HTML.
This preventing the bug excluding feeds from cache.

Fixes #4789 

## Type of change

Please delete options that are not relevant.


- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

No

## How Has This Been Tested?

- [x] Automated tests
- [x] Manually in local

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
