### PR TITLE
Fixes #4917 Prevent notice undefined AS property

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
@@ -167,6 +167,10 @@ class Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function schedule_rucss_pending_jobs_cron() {
+		if ( ! did_action( 'init' ) ) {
+			return;
+		}
+
 		$error = error_get_last();
 
 		// Delete the transient when any error happens.

--- a/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber.php
+++ b/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber.php
@@ -80,7 +80,7 @@ class WooCommerceSubscriber implements Event_Manager_Aware_Subscriber_Interface 
 			 * @param bool true to activate, false to deactivate.
 			 */
 			if ( apply_filters( 'rocket_cache_wc_empty_cart', true ) ) {
-				$events['after_setup_theme'] = [ 'serve_cache_empty_cart', 11 ];
+				$events['init']              = [ 'serve_cache_empty_cart', 11 ];
 				$events['template_redirect'] = [ 'cache_empty_cart', -1 ];
 				$events['switch_theme']      = 'delete_cache_empty_cart';
 			}

--- a/wp-rocket.php
+++ b/wp-rocket.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Rocket
  * Plugin URI: https://wp-rocket.me
  * Description: The best WordPress performance plugin.
- * Version: 3.11.0.3
+ * Version: 3.11.0.4
  * Requires at least: 5.5
  * Requires PHP: 7.1
  * Code Name: Iego
@@ -20,7 +20,7 @@
 defined( 'ABSPATH' ) || exit;
 
 // Rocket defines.
-define( 'WP_ROCKET_VERSION',               '3.11.0.3' );
+define( 'WP_ROCKET_VERSION',               '3.11.0.4' );
 define( 'WP_ROCKET_WP_VERSION',            '5.5' );
 define( 'WP_ROCKET_WP_VERSION_TESTED',     '5.9' );
 define( 'WP_ROCKET_PHP_VERSION',           '7.1' );


### PR DESCRIPTION
## Description

We found that this issue happened on calls to `?wc_ajax=get_refreshed_fragments`, and our method in the WC subscriber to serve a cache of the empty cart.

Because the method is hooked on `after_setup_theme` and then dies, `init` is not called, so the AS tables are not added to `$wpdb`. But the `shutdown` action is still called, so the scheduling method is trying to read from something that was not initialized.

To fix this, 2 things:
- use `init` instead of `after_setup_theme` for the serve cache empty cart method
- check if `init` fired in the scheduling method before going further, in case any other 3rd party would be "dying" early and prevent `init` from firing.

Fixes #4917 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Do requests to `?wc_ajax=get_refreshed_fragments` and checked that there is no error in the log. An easy way to have this request is to use the customizer and move between pages from there, as it's not going to create the empty cart cache in local storage

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
