### PR TITLE
Closes #4881 Added constant in Avada subscriber to deactivate combined CSS and JS from Avada theme

### DIFF
--- a/inc/ThirdParty/Themes/Avada.php
+++ b/inc/ThirdParty/Themes/Avada.php
@@ -33,7 +33,7 @@ class Avada implements Subscriber_Interface {
 			'fusion_cache_reset_after'             => 'clean_domain',
 			'update_option_fusion_options'         => [ 'maybe_deactivate_lazyload', 10, 2 ],
 			'rocket_wc_product_gallery_delay_js_exclusions' => 'exclude_delay_js',
-			'init' => 'disable_compilers',
+			'init'                                 => 'disable_compilers',
 		];
 	}
 

--- a/inc/ThirdParty/Themes/Avada.php
+++ b/inc/ThirdParty/Themes/Avada.php
@@ -26,7 +26,6 @@ class Avada implements Subscriber_Interface {
 		if ( ! self::is_avada() ) {
 			return [];
 		}
-		self::disable_compilers();
 		return [
 			'avada_clear_dynamic_css_cache'        => 'clean_domain',
 			'rocket_exclude_defer_js'              => 'exclude_defer_js',
@@ -34,6 +33,7 @@ class Avada implements Subscriber_Interface {
 			'fusion_cache_reset_after'             => 'clean_domain',
 			'update_option_fusion_options'         => [ 'maybe_deactivate_lazyload', 10, 2 ],
 			'rocket_wc_product_gallery_delay_js_exclusions' => 'exclude_delay_js',
+			'init' => 'disable_compilers',
 		];
 	}
 
@@ -145,8 +145,8 @@ class Avada implements Subscriber_Interface {
 	/**
 	 * Disable CSS and JS combine file from Avada.
 	 */
-	public static function disable_compilers() {
-		if ( ! defined( 'FUSION_DISABLE_COMPILERS' ) ) {
+	public function disable_compilers() {
+		if ( $this->options->get( 'remove_unused_css', false ) && ! defined( 'FUSION_DISABLE_COMPILERS' ) ) {
 			define( 'FUSION_DISABLE_COMPILERS', true ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
 		}
 	}

--- a/inc/ThirdParty/Themes/Avada.php
+++ b/inc/ThirdParty/Themes/Avada.php
@@ -26,7 +26,7 @@ class Avada implements Subscriber_Interface {
 		if ( ! self::is_avada() ) {
 			return [];
 		}
-
+		self::disable_compilers();
 		return [
 			'avada_clear_dynamic_css_cache'        => 'clean_domain',
 			'rocket_exclude_defer_js'              => 'exclude_defer_js',
@@ -140,5 +140,14 @@ class Avada implements Subscriber_Interface {
 		$exclusions[] = $base_path . '/assets/min/js/general/avada-woo-product-images.js';
 
 		return $exclusions;
+	}
+
+	/**
+	 * Disable CSS and JS combine file from Avada.
+	 */
+	public static function disable_compilers() {
+		if ( ! defined( 'FUSION_DISABLE_COMPILERS' ) ) {
+			define( 'FUSION_DISABLE_COMPILERS', true ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
+		}
 	}
 }

--- a/tests/Fixtures/inc/ThirdParty/Themes/Avada/disableCompilers.php
+++ b/tests/Fixtures/inc/ThirdParty/Themes/Avada/disableCompilers.php
@@ -1,0 +1,16 @@
+<?php
+
+return [
+	'RUCSSEnableShouldDisable' => [
+		'config' => [
+			'rucss_enable' => true
+		],
+		'expected' => true
+	],
+	'RUCSSDisableShouldEnable' => [
+		'config' => [
+			'rucss_enable' => false
+		],
+		'expected' => false
+	],
+];

--- a/tests/Unit/inc/ThirdParty/Themes/Avada/disableCompilers.php
+++ b/tests/Unit/inc/ThirdParty/Themes/Avada/disableCompilers.php
@@ -3,7 +3,7 @@ namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Themes\Avada;
 
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\ThirdParty\Themes\Avada;
-use WPMedia\PHPUnit\Unit\TestCase;
+use WP_Rocket\Tests\Unit\TestCase;
 
 /**
  * @covers \WP_Rocket\ThirdParty\Avada::disable_compilers
@@ -22,10 +22,14 @@ class Test_DisableCompilers extends TestCase {
 		$this->subscriber = new Avada($this->options);
 	}
 
-	public function testShouldDefinedConstant() {
+	/**
+	 * @dataProvider providerTestData
+	 */
+	public function testShouldDefinedConstant($config, $expected) {
+		$this->options->expects()->get('remove_unused_css' , false)->andReturn($config['rucss_enable']);
 		$this->assertFalse(defined('FUSION_DISABLE_COMPILERS'));
 		$this->subscriber->disable_compilers();
-		$this->assertTrue(defined('FUSION_DISABLE_COMPILERS'));
+		$this->assertSame($expected, defined('FUSION_DISABLE_COMPILERS'));
 
 	}
 }

--- a/tests/Unit/inc/ThirdParty/Themes/Avada/disableCompilers.php
+++ b/tests/Unit/inc/ThirdParty/Themes/Avada/disableCompilers.php
@@ -1,0 +1,31 @@
+<?php
+namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Themes\Avada;
+
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\ThirdParty\Themes\Avada;
+use WPMedia\PHPUnit\Unit\TestCase;
+
+/**
+ * @covers \WP_Rocket\ThirdParty\Avada::disable_compilers
+ *
+ * @group  AvadaTheme
+ * @group  ThirdParty
+ */
+class Test_DisableCompilers extends TestCase {
+	protected $options;
+	protected $subscriber;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->options = \Mockery::mock(Options_Data::class);
+		$this->subscriber = new Avada($this->options);
+	}
+
+	public function testShouldDefinedConstant() {
+		$this->assertFalse(defined('FUSION_DISABLE_COMPILERS'));
+		$this->subscriber->disable_compilers();
+		$this->assertTrue(defined('FUSION_DISABLE_COMPILERS'));
+
+	}
+}


### PR DESCRIPTION
## Description

Fix an issue where Avada combined CSS file and prevent RUCSS to work sucessfully.
For that a constant `FUSION_DISABLE_COMPILERS` is set to prevent Avada from combining files.

Fixes #4881 
## Type of change 



- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

No

## How Has This Been Tested?

- [x] Automated Test
- [x] On my local env

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
