### PR TITLE
Bugfix: Remove last error check

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
@@ -171,15 +171,6 @@ class Subscriber implements Subscriber_Interface {
 			return;
 		}
 
-		$error = error_get_last();
-
-		// Delete the transient when any error happens.
-		if ( null !== $error ) {
-			delete_transient( 'rocket_rucss_as_tables_count' );
-
-			return;
-		}
-
 		if ( ! $this->is_valid_as_tables() ) {
 			return;
 		}


### PR DESCRIPTION
## Description

Here
https://github.com/wp-media/wp-rocket/blob/86260dd09afd4ac15f44ad64b0219baf723a5f1c/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php#L170-L177
we used this check to delete the transient that has the number of Action Scheduler's tables not to make this query with each `init` but now disabled this caching in admin side so no need to use this code.

Also @vmanthos told me today the following (Many thanks Boss):
> I've seen at least two tickets where no used CSS was generated because there was some kind of error: ` Constant WP_CACHE already defined`

So with any error in the log, we are bailing out there and this may lead the CRON JOB not to be scheduled especially when the customer has `php8` so many errors are in the log.


## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

1. Define `WP_CACHE` twice into `wp-config.php` before enabling RUCSS
2. Enable RUCSS
3. Check the CRON JOB if it's scheduled or not inside action scheduler tools page

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
