### PR TITLE
Clean our RUCSS action scheduler jobs periodically without affecting others

### DIFF
--- a/inc/Engine/Common/Queue/AbstractASQueue.php
+++ b/inc/Engine/Common/Queue/AbstractASQueue.php
@@ -45,7 +45,7 @@ abstract class AbstractASQueue implements QueueInterface {
 	 * @return string The action ID.
 	 */
 	public function schedule_recurring( $timestamp, $interval_in_seconds, $hook, $args = [] ) {
-		if ( $this->is_scheduled( $hook, $args, $this->group ) ) {
+		if ( $this->is_scheduled( $hook, $args ) ) {
 			return '';
 		}
 		return as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args, $this->group );

--- a/inc/Engine/Common/Queue/Cleaner.php
+++ b/inc/Engine/Common/Queue/Cleaner.php
@@ -56,7 +56,7 @@ class Cleaner extends \ActionScheduler_QueueCleaner {
 		 *
 		 * @return array
 		 */
-		$lifespan = apply_filters( 'rocket_action_scheduler_retention_period', (int) $lifespan );
+		$lifespan = apply_filters( 'rocket_action_scheduler_retention_period', (int) $lifespan, $this->group );
 		$cutoff   = as_get_datetime_object( $lifespan . ' seconds ago' );
 
 		$statuses_to_purge = [

--- a/inc/Engine/Common/Queue/Cleaner.php
+++ b/inc/Engine/Common/Queue/Cleaner.php
@@ -50,11 +50,11 @@ class Cleaner extends \ActionScheduler_QueueCleaner {
 		/**
 		 * Filters the retention period for our tasks only.
 		 *
-		 * @since 3.11.1
+		 * @since 3.11.0.5
 		 *
 		 * @param int $lifespan Lifespan in seconds.
 		 *
-		 * @return array
+		 * @return int
 		 */
 		$lifespan = (int) apply_filters( 'rocket_action_scheduler_retention_period', $lifespan, $this->group );
 		$cutoff   = as_get_datetime_object( $lifespan . ' seconds ago' );

--- a/inc/Engine/Common/Queue/Cleaner.php
+++ b/inc/Engine/Common/Queue/Cleaner.php
@@ -1,0 +1,103 @@
+<?php
+declare( strict_types=1 );
+
+namespace WP_Rocket\Engine\Common\Queue;
+
+class Cleaner extends \ActionScheduler_QueueCleaner {
+
+	/**
+	 * The duration of clean Hour In seconds.
+	 *
+	 * @var int
+	 */
+	protected $hour_in_seconds = 60 * 60;
+
+	/**
+	 * Store instance.
+	 *
+	 * @var \ActionScheduler_Store
+	 */
+	private $store = null;
+
+	/**
+	 * Group name to be cleaned.
+	 *
+	 * @var string
+	 */
+	private $group;
+
+	/**
+	 * Cleaner constructor.
+	 *
+	 * @param \ActionScheduler_Store|null $store The store instance.
+	 * @param int                         $batch_size The batch size.
+	 * @param string                      $group Current queue group.
+	 */
+	public function __construct( \ActionScheduler_Store $store = null, $batch_size = 20, $group = '' ) {
+		parent::__construct( $store, $batch_size );
+		$this->store = $store ? $store : \ActionScheduler_Store::instance();
+		$this->group = $group;
+	}
+
+	/**
+	 * Overrides the base method of action scheduler to do the clean process for our actions only.
+	 *
+	 * @return void
+	 */
+	public function delete_old_actions() {
+		$lifespan = apply_filters( 'action_scheduler_retention_period', $this->hour_in_seconds );// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+
+		/**
+		 * Filters the retention period for our tasks only.
+		 *
+		 * @since 3.11.1
+		 *
+		 * @param int $lifespan Lifespan in seconds.
+		 *
+		 * @return array
+		 */
+		$lifespan = apply_filters( 'rocket_action_scheduler_retention_period', (int) $lifespan );
+		$cutoff   = as_get_datetime_object( $lifespan . ' seconds ago' );
+
+		$statuses_to_purge = [
+			\ActionScheduler_Store::STATUS_COMPLETE,
+			\ActionScheduler_Store::STATUS_CANCELED,
+		];
+
+		foreach ( $statuses_to_purge as $status ) {
+			$actions_to_delete = $this->store->query_actions(
+				[
+					'status'           => $status,
+					'modified'         => $cutoff,
+					'modified_compare' => '<=',
+					'per_page'         => $this->get_batch_size(),
+					'orderby'          => 'none',
+					'group'            => $this->group,
+				]
+			);
+
+			foreach ( $actions_to_delete as $action_id ) {
+				try {
+					$this->store->delete_action( $action_id );
+				} catch ( \Exception $e ) {
+
+					/**
+					 * Notify 3rd party code of exceptions when deleting a completed action older than the retention period
+					 *
+					 * This hook provides a way for 3rd party code to log or otherwise handle exceptions relating to their
+					 * actions.
+					 *
+					 * @since 2.0.0
+					 *
+					 * @param int $action_id The scheduled actions ID in the data store
+					 * @param \Exception $e The exception thrown when attempting to delete the action from the data store
+					 * @param int $lifespan The retention period, in seconds, for old actions
+					 * @param int $count_of_actions_to_delete The number of old actions being deleted in this batch
+					 */
+					do_action( 'action_scheduler_failed_old_action_deletion', $action_id, $e, $lifespan, count( $actions_to_delete ) );// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+				}
+			}
+		}
+	}
+
+}

--- a/inc/Engine/Common/Queue/Cleaner.php
+++ b/inc/Engine/Common/Queue/Cleaner.php
@@ -45,7 +45,7 @@ class Cleaner extends \ActionScheduler_QueueCleaner {
 	 * @return void
 	 */
 	public function delete_old_actions() {
-		$lifespan = apply_filters( 'action_scheduler_retention_period', $this->hour_in_seconds );// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+		$lifespan = (int) apply_filters( 'action_scheduler_retention_period', $this->hour_in_seconds );// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 
 		/**
 		 * Filters the retention period for our tasks only.
@@ -56,7 +56,7 @@ class Cleaner extends \ActionScheduler_QueueCleaner {
 		 *
 		 * @return array
 		 */
-		$lifespan = apply_filters( 'rocket_action_scheduler_retention_period', (int) $lifespan, $this->group );
+		$lifespan = (int) apply_filters( 'rocket_action_scheduler_retention_period', $lifespan, $this->group );
 		$cutoff   = as_get_datetime_object( $lifespan . ' seconds ago' );
 
 		$statuses_to_purge = [

--- a/inc/Engine/Common/Queue/RUCSSQueueRunner.php
+++ b/inc/Engine/Common/Queue/RUCSSQueueRunner.php
@@ -56,12 +56,22 @@ class RUCSSQueueRunner extends \ActionScheduler_Abstract_QueueRunner {
 	 *
 	 * @param \ActionScheduler_Store|null                    $store Store Instance.
 	 * @param \ActionScheduler_FatalErrorMonitor|null        $monitor Fatal Error monitor instance.
-	 * @param \ActionScheduler_QueueCleaner|null             $cleaner Cleaner instance.
+	 * @param Cleaner|null                                   $cleaner Cleaner instance.
 	 * @param \ActionScheduler_AsyncRequest_QueueRunner|null $async_request Async Request Queue Runner instance.
 	 */
 	public function __construct( \ActionScheduler_Store $store = null, \ActionScheduler_FatalErrorMonitor $monitor = null, Cleaner $cleaner = null, \ActionScheduler_AsyncRequest_QueueRunner $async_request = null ) {
 		if ( is_null( $cleaner ) ) {
-			$cleaner = new Cleaner( $store, 20, $this->group );
+			/**
+			 * Filters the clean batch size.
+			 *
+			 * @since 3.11.0.5
+			 *
+			 * @param int $batch_size Batch size.
+			 *
+			 * @return int
+			 */
+			$batch_size = (int) apply_filters( 'rocket_action_scheduler_clean_batch_size', 100, $this->group );
+			$cleaner    = new Cleaner( $store, $batch_size, $this->group );
 		}
 
 		parent::__construct( $store, $monitor, $cleaner );

--- a/inc/Engine/Common/Queue/RUCSSQueueRunner.php
+++ b/inc/Engine/Common/Queue/RUCSSQueueRunner.php
@@ -59,7 +59,11 @@ class RUCSSQueueRunner extends \ActionScheduler_Abstract_QueueRunner {
 	 * @param \ActionScheduler_QueueCleaner|null             $cleaner Cleaner instance.
 	 * @param \ActionScheduler_AsyncRequest_QueueRunner|null $async_request Async Request Queue Runner instance.
 	 */
-	public function __construct( \ActionScheduler_Store $store = null, \ActionScheduler_FatalErrorMonitor $monitor = null, \ActionScheduler_QueueCleaner $cleaner = null, \ActionScheduler_AsyncRequest_QueueRunner $async_request = null ) {
+	public function __construct( \ActionScheduler_Store $store = null, \ActionScheduler_FatalErrorMonitor $monitor = null, Cleaner $cleaner = null, \ActionScheduler_AsyncRequest_QueueRunner $async_request = null ) {
+		if ( is_null( $cleaner ) ) {
+			$cleaner = new Cleaner( $store, 20, $this->group );
+		}
+
 		parent::__construct( $store, $monitor, $cleaner );
 
 		if ( is_null( $async_request ) ) {


### PR DESCRIPTION
## Description

We needed a way to clean our RUCSS action scheduler jobs after 1 hour without affecting the other jobs from other plugins.
Also added a new filter `rocket_action_scheduler_retention_period` so we can manage the clean lifespan for ours only.

Fixes #4940

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which improves an existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?



# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
