### PR TITLE
Remove additional languages referenced in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you are not a developer, visit our [documentation](http://docs.wp-rocket.me/?
 Need detailed setup instructions?
 
 We are very proud of WP Rocket’s knowledge base.
-We have [documentation](http://docs.wp-rocket.me/?utm_source=github&utm_medium=wp_rocket_profile) in English, French, Italian, Spanish and German.
+We have [documentation](http://docs.wp-rocket.me/?utm_source=github&utm_medium=wp_rocket_profile) in English and French.
 
 You can also check out our [changelog](https://wp-rocket.me/changelog/?utm_source=github&utm_medium=wp_rocket_profile).
 


### PR DESCRIPTION
I've removed the additional languages that were referenced in the README file, because we no longer have the documentation for them (line 16).

Original text: We are very proud of WP Rocket's knowledge base. We have documentation in English, French, Italian, Spanish and German.

## Description

Please include a summary of the change and which issue is fixed/closed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #(issue number)

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Is the solution different from the one proposed during the grooming?

Please describe in this section if there is any change to the solution, and why.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

Please delete the options that are not relevant.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
