### PR TITLE
Fix #4231 Remove params from url to prevent JS to be interpeted as internal instead of external

### DIFF
--- a/inc/Engine/Optimization/AbstractOptimization.php
+++ b/inc/Engine/Optimization/AbstractOptimization.php
@@ -126,18 +126,17 @@ abstract class AbstractOptimization {
 		if ( empty( $hosts ) ) {
 			return true;
 		}
-
 		// URL has domain and domain is part of the internal domains.
 		if ( ! empty( $file['host'] ) ) {
 			foreach ( $hosts as $host ) {
-				if ( false !== strpos( $url, $host ) ) {
+				$check_url = strtok( $url, '?' );
+				if ( false !== strpos( $check_url, $host ) ) {
 					return false;
 				}
 			}
 
 			return true;
 		}
-
 		// URL has no domain and doesn't contain the WP_CONTENT path or wp-includes.
 		return ! preg_match( '#(' . $wp_content['path'] . '|wp-includes)#', $file['path'] );
 	}
@@ -230,4 +229,13 @@ abstract class AbstractOptimization {
 
 		return add_query_arg( 'ver', $version, $minified_url );
 	}
+
+	/**
+	 * Gets the CDN zones.
+	 *
+	 * @since  3.1
+	 *
+	 * @return array
+	 */
+	abstract public function get_zones();
 }

--- a/tests/Fixtures/inc/Engine/Optimization/AbstractOptimization/isExternalFile.php
+++ b/tests/Fixtures/inc/Engine/Optimization/AbstractOptimization/isExternalFile.php
@@ -1,10 +1,219 @@
 <?php
 
 return [
-	'test' => [
+	'testEmptyFilePathShouldReturnTrue' => [
 		'config' => [
-			'url' => 'url'
+			'url' => 'url',
+			'file' => [
+				'path' => ''
+			],
+			'content_url' => 'content_url',
+			'url_host' => 'url_host',
+			'url_parsed' => [
+				'host' => 'host',
+				'path' => '',
+			],
+			'zones' => [
+				'js'
+			],
+			'cdn_hosts' => [
+				'exmaple.com'
+			],
+			'lang_url' => 'en.exmaple.com',
+			'lang_hosts' => [
+				'en.exmaple.com'
+			]
+		],
+		'expected' => true,
+	],
+	'testEmptyContentURLPathShouldReturnTrue' => [
+		'config' => [
+			'url' => 'url',
+			'file' => [
+				'path' => 'path'
+			],
+			'parse_content' => true,
+			'content_url' => 'content_url',
+			'url_host' => 'url_host',
+			'url_parsed' => [
+				'host' => 'host',
+				'path' => '',
+			],
+			'zones' => [
+				'js'
+			],
+			'cdn_hosts' => [
+				'exmaple.com'
+			],
+			'lang_url' => 'en.exmaple.com',
+			'lang_hosts' => [
+				'en.exmaple.com'
+			]
+		],
+		'expected' => true,
+	],
+	'testEmptyContentURLHostShouldReturnTrue' => [
+		'config' => [
+			'url' => 'url',
+			'file' => [
+				'path' => 'path'
+			],
+			'parse_content' => true,
+			'content_url' => 'content_url',
+			'url_host' => 'url_host',
+			'url_parsed' => [
+				'host' => '',
+				'path' => 'path',
+			],
+			'zones' => [
+				'js'
+			],
+			'cdn_hosts' => [
+				'exmaple.com'
+			],
+			'lang_url' => 'en.exmaple.com',
+			'lang_hosts' => [
+				'en.exmaple.com'
+			]
+		],
+		'expected' => true,
+	],
+	'testNoHostFileShouldReturnTrue' => [
+		'config' => [
+			'url' => 'url',
+			'file' => [
+				'path' => 'random'
+			],
+			'parse_content' => true,
+			'collect_hosts' => true,
+			'content_url' => 'content_url',
+			'url_host' => 'url_host',
+			'url_parsed' => [
+				'host' => 'host',
+				'path' => 'path',
+			],
+			'zones' => [
+				'js'
+			],
+			'cdn_hosts' => [
+
+			],
+			'lang_url' => 'en.exmaple.com',
+			'lang_hosts' => [
+
+			]
+		],
+		'expected' => true,
+	],
+	'testNoHostFileShouldReturnFalse' => [
+		'config' => [
+			'url' => 'url',
+			'file' => [
+				'path' => 'path'
+			],
+			'parse_content' => true,
+			'collect_hosts' => true,
+			'content_url' => 'content_url',
+			'url_host' => 'url_host',
+			'url_parsed' => [
+				'host' => 'host',
+				'path' => 'path',
+			],
+			'zones' => [
+				'js'
+			],
+			'cdn_hosts' => [
+
+			],
+			'lang_url' => 'en.exmaple.com',
+			'lang_hosts' => [
+
+			]
 		],
 		'expected' => false,
-	]
+	],
+	'testHostFileShouldReturnFalse' => [
+		'config' => [
+			'url' => 'host',
+			'file' => [
+				'path' => 'path',
+				'host' => 'host',
+			],
+			'parse_content' => true,
+			'collect_hosts' => true,
+			'content_url' => 'content_url',
+			'url_host' => 'url_host',
+			'url_parsed' => [
+				'host' => 'host',
+				'path' => 'path',
+			],
+			'zones' => [
+				'js'
+			],
+			'cdn_hosts' => [
+
+			],
+			'lang_url' => 'en.exmaple.com',
+			'lang_hosts' => [
+
+			]
+		],
+		'expected' => false,
+	],
+	'testHostFileShouldReturnTrue' => [
+		'config' => [
+			'url' => 'url',
+			'file' => [
+				'path' => 'path',
+				'host' => 'host',
+			],
+			'parse_content' => true,
+			'collect_hosts' => true,
+			'content_url' => 'content_url',
+			'url_host' => 'url_host',
+			'url_parsed' => [
+				'host' => 'host',
+				'path' => 'path',
+			],
+			'zones' => [
+				'js'
+			],
+			'cdn_hosts' => [
+
+			],
+			'lang_url' => 'en.exmaple.com',
+			'lang_hosts' => [
+
+			]
+		],
+		'expected' => true,
+	],
+	'testHostFileEvenWithLocalAsParamShouldReturnTrue' => [
+		'config' => [
+			'url' => 'url?domain=host',
+			'file' => [
+				'path' => 'path',
+				'host' => 'host',
+			],
+			'parse_content' => true,
+			'collect_hosts' => true,
+			'content_url' => 'content_url',
+			'url_host' => 'url_host',
+			'url_parsed' => [
+				'host' => 'host',
+				'path' => 'path',
+			],
+			'zones' => [
+				'js'
+			],
+			'cdn_hosts' => [
+
+			],
+			'lang_url' => 'en.exmaple.com',
+			'lang_hosts' => [
+
+			]
+		],
+		'expected' => true,
+	],
 ];

--- a/tests/Fixtures/inc/Engine/Optimization/AbstractOptimization/isExternalFile.php
+++ b/tests/Fixtures/inc/Engine/Optimization/AbstractOptimization/isExternalFile.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+	'test' => [
+		'config' => [
+			'url' => 'url'
+		],
+		'expected' => false,
+	]
+];

--- a/tests/Unit/inc/Engine/Optimization/AbstractOptimization/isExternalFile.php
+++ b/tests/Unit/inc/Engine/Optimization/AbstractOptimization/isExternalFile.php
@@ -1,0 +1,32 @@
+<?php
+namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\AbstractOptimization;
+
+use ReflectionClass;
+use WP_Rocket\Engine\Optimization\AbstractOptimization;
+use function Brain\Monkey\Functions;
+
+class Test_IsExternalFile extends \WP_Rocket\Tests\Unit\TestCase {
+
+	protected $optimization;
+
+	public function setUp(): void
+	{
+		parent::setUp();
+		$this->optimization = $this->getMockForAbstractClass(AbstractOptimization::class);
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnAsExpected($config, $expected) {
+		Functions\expect('get_rocket_parse_url')->with($config['url'])-->andReturn($config['file']);
+		$this->assertEquals($expected, self::callProtectedMethod($this->optimization, 'is_external_file', array($config['url'])));
+	}
+
+	public static function callProtectedMethod($object, $method, array $args=array()) {
+		$class = new ReflectionClass(get_class($object));
+		$method = $class->getMethod($method);
+		$method->setAccessible(true);
+		return $method->invokeArgs($object, $args);
+	}
+}

--- a/tests/Unit/inc/Engine/Optimization/AbstractOptimization/isExternalFile.php
+++ b/tests/Unit/inc/Engine/Optimization/AbstractOptimization/isExternalFile.php
@@ -1,11 +1,11 @@
 <?php
 namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\AbstractOptimization;
 
-use ReflectionClass;
 use WP_Rocket\Engine\Optimization\AbstractOptimization;
 use Brain\Monkey\Functions;
+use WP_Rocket\Tests\Unit\TestCase;
 
-class Test_IsExternalFile extends \WP_Rocket\Tests\Unit\TestCase {
+class Test_IsExternalFile extends TestCase {
 
 	protected $optimization;
 
@@ -22,7 +22,8 @@ class Test_IsExternalFile extends \WP_Rocket\Tests\Unit\TestCase {
 		Functions\expect('get_rocket_parse_url')->with($config['url'])->andReturn($config['file']);
 		$this->configureParseContent($config);
 		$this->configureCollectHosts($config);
-		$this->assertEquals($expected, self::callProtectedMethod($this->optimization, 'is_external_file', array($config['url'])));
+		$this->assertEquals($expected, $this->callProtectedMethod($this->optimization, 'is_external_file', array
+		($config['url'])));
 	}
 
 	protected function configureParseContent($config) {
@@ -43,9 +44,8 @@ class Test_IsExternalFile extends \WP_Rocket\Tests\Unit\TestCase {
 		Functions\expect('wp_parse_url')->with($config['lang_url'], PHP_URL_HOST)->andReturn($config['url_host']);
 	}
 
-	public static function callProtectedMethod($object, $method, array $args=array()) {
-		$class = new ReflectionClass(get_class($object));
-		$method = $class->getMethod($method);
+	public function callProtectedMethod($object, $method, array $args=array()) {
+		$method = self::get_reflective_method($method, get_class($object));
 		$method->setAccessible(true);
 		return $method->invokeArgs($object, $args);
 	}

--- a/tests/Unit/inc/Engine/Optimization/AbstractOptimization/isExternalFile.php
+++ b/tests/Unit/inc/Engine/Optimization/AbstractOptimization/isExternalFile.php
@@ -22,7 +22,7 @@ class Test_IsExternalFile extends TestCase {
 		Functions\expect('get_rocket_parse_url')->with($config['url'])->andReturn($config['file']);
 		$this->configureParseContent($config);
 		$this->configureCollectHosts($config);
-		$this->assertEquals($expected, $this->callProtectedMethod($this->optimization, 'is_external_file', array
+		$this->assertSame($expected, $this->callProtectedMethod($this->optimization, 'is_external_file', array
 		($config['url'])));
 	}
 
@@ -46,7 +46,6 @@ class Test_IsExternalFile extends TestCase {
 
 	public function callProtectedMethod($object, $method, array $args=array()) {
 		$method = self::get_reflective_method($method, get_class($object));
-		$method->setAccessible(true);
 		return $method->invokeArgs($object, $args);
 	}
 }


### PR DESCRIPTION
## Description
This fix an issue where some JS had the domain had in their params resulting being interpreted as internal files instead of external.
To fix that we remove params from the url of the script before the check.

Fixes #4231

## Type of change
- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?
No.

## How Has This Been Tested?

- [x] Automated Tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
