### PR TITLE
Fixes #4252 Removed css from the regex to include non .css files in RUCSS

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -298,7 +298,7 @@ class UsedCSS {
 		$clean_html = $this->hide_scripts( $clean_html );
 
 		$link_styles = $this->find(
-			'<link\s+([^>]+[\s"\'])?href\s*=\s*[\'"]\s*?(?<url>[^\'"]+\.css(?:\?[^\'"]*)?)\s*?[\'"]([^>]+)?\/?>',
+			'<link\s+([^>]+[\s"\'])?href\s*=\s*[\'"]\s*?(?<url>[^\'"]+(?:\?[^\'"]*)?)\s*?[\'"]([^>]+)?\/?>',
 			$clean_html,
 			'Uis'
 		);


### PR DESCRIPTION
## Description

Fix a problem where css files not finishing with .css where not deleted from html.

Fixes #4252 

## Type of change


- [ ] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

No.

## How Has This Been Tested?

- [x] Test on my dev env

# Checklist:


- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
