### PR TITLE
Changed Divi thirdparty class to disable dynamic js on RUCSS active and added its tests

### DIFF
--- a/inc/ThirdParty/Themes/Divi.php
+++ b/inc/ThirdParty/Themes/Divi.php
@@ -207,8 +207,7 @@ class Divi implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function disable_dynamic_css_on_rucss() {
-
-		if ( ! apply_filters( 'pre_get_rocket_option_remove_unused_css', false ) ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+		if (! $this->options->get('remove_unused_css', false) ) {
 			return;
 		}
 		add_filter( 'et_use_dynamic_css', '__return_false' );

--- a/inc/ThirdParty/Themes/Divi.php
+++ b/inc/ThirdParty/Themes/Divi.php
@@ -207,7 +207,7 @@ class Divi implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function disable_dynamic_css_on_rucss() {
-		if (! $this->options->get('remove_unused_css', false) ) {
+		if ( ! $this->options->get( 'remove_unused_css', false ) ) {
 			return;
 		}
 		add_filter( 'et_use_dynamic_css', '__return_false' );

--- a/inc/ThirdParty/Themes/Divi.php
+++ b/inc/ThirdParty/Themes/Divi.php
@@ -63,6 +63,8 @@ class Divi implements Subscriber_Interface {
 
 		$events['rocket_exclude_css'] = 'exclude_css_from_combine';
 
+		$events['wp'] = 'disable_dynamic_css_on_rucss';
+
 		return $events;
 	}
 
@@ -197,5 +199,19 @@ class Divi implements Subscriber_Interface {
 		}
 
 		return $exclude_css;
+	}
+
+	/**
+	 * Disable Divi dynamic CSS when RUCSS is activated
+	 *
+	 * @return void
+	 */
+	public function disable_dynamic_css_on_rucss() {
+
+		if ( ! apply_filters( 'pre_get_rocket_option_remove_unused_css', false ) ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+			return;
+		}
+		add_filter( 'et_use_dynamic_css', '__return_false' );
+
 	}
 }

--- a/tests/Fixtures/inc/ThirdParty/Themes/Divi/disableDynamicCssOnRucss.php
+++ b/tests/Fixtures/inc/ThirdParty/Themes/Divi/disableDynamicCssOnRucss.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+	'test_data' => [
+		'shouldDisableOnRUCSSActivated' => [
+			'config' => [
+				'rucss_enabled' => true,
+				'stylesheet'  => 'divi',
+				'theme-name'  => 'Divi',
+			],
+			'expected' => 10
+		],
+		'shouldBeEnabledOnRUCSSDisabled' => [
+			'config' => [
+				'rucss_enabled' => false,
+				'stylesheet'  => 'divi',
+				'theme-name'  => 'Divi',
+			],
+			'expected' => false
+		]
+	]
+];

--- a/tests/Integration/inc/ThirdParty/Themes/Divi/disableDynamicCssOnRucss.php
+++ b/tests/Integration/inc/ThirdParty/Themes/Divi/disableDynamicCssOnRucss.php
@@ -1,0 +1,53 @@
+<?php
+namespace WP_Rocket\Tests\Integration\inc\ThirdParty\Themes\Divi;
+
+use WP_Rocket\Tests\Integration\WPThemeTestcase;
+use WP_Rocket\ThirdParty\Themes\Divi;
+
+/**
+ * @covers \WP_Rocket\ThirdParty\Themes\Divi::disable_dynamic_css_on_rucss
+ * @uses   ::is_divi
+ *
+ * @group  ThirdParty
+ */
+class Test_DisableDynamicCssOnRucss extends WPThemeTestcase {
+	protected $path_to_test_data = '/inc/ThirdParty/Themes/Divi/disableDynamicCssOnRucss.php';
+	private static $container;
+	private $rucss_enable = false;
+
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		self::$container = apply_filters( 'rocket_container', '' );
+	}
+
+	public function set_up() {
+		parent::set_up();
+		add_filter( 'pre_get_rocket_option_remove_unused_css', [$this, 'get_rucss_value'] );
+	}
+
+	public function tear_down()
+	{
+		remove_filter( 'pre_get_rocket_option_remove_unused_css', [$this, 'get_rucss_value'] );
+		parent::tear_down();
+	}
+
+	/**
+	 * @dataProvider ProviderTestData
+	 */
+	public function testShouldReturnAsExpected($config, $expected) {
+		$this->set_theme( $config['stylesheet'], $config['theme-name'] );
+		$this->rucss_enable = $config['rucss_enabled'];
+		$options     = self::$container->get( 'options' );
+		$options_api = self::$container->get( 'options_api' );
+		$delayjs_html = self::$container->get( 'delay_js_html' );
+		$options_api->set( 'settings', [] );
+		$divi        = new Divi( $options_api, $options, $delayjs_html );
+		$divi->disable_dynamic_css_on_rucss();
+		$this->assertSame($expected, has_filter( 'et_use_dynamic_css', '__return_false' ));
+	}
+
+	public function get_rucss_value() {
+		return $this->rucss_enable;
+	}
+}

--- a/tests/Unit/inc/ThirdParty/Themes/Divi/disableDynamicCssOnRucss.php
+++ b/tests/Unit/inc/ThirdParty/Themes/Divi/disableDynamicCssOnRucss.php
@@ -19,16 +19,16 @@ use WP_Theme;
 class Test_DisableDynamicCssOnRucss extends TestCase {
 
 	protected $subscriber;
-
+	protected $options;
 	protected function setUp(): void
 	{
 		parent::setUp();
 		$options_api = Mockery::mock( Options::class );
-		$options     = Mockery::mock( Options_Data::class );
+		$this->options     = Mockery::mock( Options_Data::class );
 		$delayjs_html     = Mockery::mock( HTML::class );
 		$theme       = new WP_Theme( 'Divi', 'wp-content/themes/' );
 		Functions\when( 'wp_get_theme' )->justReturn( $theme );
-		$this->subscriber = new Divi($options_api, $options , $delayjs_html);
+		$this->subscriber = new Divi($options_api, $this->options, $delayjs_html);
 	}
 
 	/**
@@ -36,7 +36,7 @@ class Test_DisableDynamicCssOnRucss extends TestCase {
 	 */
 	public function testShouldReturnAsExpected($config, $expected) {
 
-		Filters\expectApplied('pre_get_rocket_option_remove_unused_css')->andReturn($config['rucss_enabled']);
+		$this->options->expects()->get('remove_unused_css', false)->andReturn($config['rucss_enabled']);
 		if($config['rucss_enabled']) {
 			Filters\expectAdded('et_use_dynamic_css')->with('__return_false');
 		}

--- a/tests/Unit/inc/ThirdParty/Themes/Divi/disableDynamicCssOnRucss.php
+++ b/tests/Unit/inc/ThirdParty/Themes/Divi/disableDynamicCssOnRucss.php
@@ -1,0 +1,46 @@
+<?php
+namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Themes\Divi;
+
+use Mockery;
+use WP_Rocket\Admin\Options;
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Engine\Optimization\DelayJS\HTML;
+use WP_Rocket\ThirdParty\Themes\Divi;
+use WP_Rocket\Tests\Unit\TestCase;
+use Brain\Monkey\Functions;
+use Brain\Monkey\Filters;
+use WP_Theme;
+
+/**
+ * @covers \WP_Rocket\ThirdParty\Divi::disable_dynamic_css_on_rucss
+ *
+ * @group  ThirdParty
+ */
+class Test_DisableDynamicCssOnRucss extends TestCase {
+
+	protected $subscriber;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$options_api = Mockery::mock( Options::class );
+		$options     = Mockery::mock( Options_Data::class );
+		$delayjs_html     = Mockery::mock( HTML::class );
+		$theme       = new WP_Theme( 'Divi', 'wp-content/themes/' );
+		Functions\when( 'wp_get_theme' )->justReturn( $theme );
+		$this->subscriber = new Divi($options_api, $options , $delayjs_html);
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnAsExpected($config, $expected) {
+
+		Filters\expectApplied('pre_get_rocket_option_remove_unused_css')->andReturn($config['rucss_enabled']);
+		if($config['rucss_enabled']) {
+			Filters\expectAdded('et_use_dynamic_css')->with('__return_false');
+		}
+
+		$this->subscriber->disable_dynamic_css_on_rucss();
+	}
+}


### PR DESCRIPTION
…

## Description
Fix a problem where RUCSS has incompatibilities with a feature from Divi theme.
For that we disabled the feature when RUCSS is activated inside the thirdparty class.

Fixes #4792 

## Type of change

- [ ] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

No.

## How Has This Been Tested?


- [x] Automated tests
- [x] Tested on local env

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
