### PR TITLE
Closes #4957 on compatibility for themify woocommerce product filter with defer js

### DIFF
--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -292,6 +292,7 @@ class Plugin {
 			'pwa',
 			'yoast_seo',
 			'flatsome',
+			'themify_woocommerce_product_filter',
 		];
 
 		$host_type = HostResolver::get_host_service();

--- a/inc/ThirdParty/Plugins/Ecommerce/ThemifyWooCommerceProductFilter.php
+++ b/inc/ThirdParty/Plugins/Ecommerce/ThemifyWooCommerceProductFilter.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace WP_Rocket\ThirdParty\Plugins\Ecommerce;
+
+use WP_Rocket\Event_Management\Subscriber_Interface;
+
+/**
+ * Subscriber for compatibility with Themify WooCommerce Product Filter.
+ *
+ * @since  3.11.0.5
+ */
+class ThemifyWooCommerceProductFilter implements Subscriber_Interface {
+
+	/**
+	 * Plguin
+	 *
+	 * @var string
+	 */
+	private $plugin = 'themify-wc-product-filter/themify-wc-product-filter.php';
+
+	/**
+	 * Subscribed events for Themify WooCommerce Product Filter.
+	 *
+	 * @since  3.11.0.5
+	 *
+	 * @return array
+	 */
+	public static function get_subscribed_events(): array {
+		return [
+			'rocket_exclude_defer_js' => 'exclude_defer_js',
+		];
+	}
+
+	/**
+	 * Exclude jquery
+	 *
+	 * @since 3.11.0.5
+	 *
+	 * @param array $exclude_defer_js Files paths to be excluded.
+	 * @return array
+	 */
+	public function exclude_defer_js( array $exclude_defer_js ): array {
+
+		if ( ! is_plugin_active( $this->plugin ) ) {
+			return $exclude_defer_js;
+		}
+
+		$exclude_defer_js[] = '/wp-includes/js/jquery/jquery.min.js';
+
+		return $exclude_defer_js;
+	}
+}

--- a/inc/ThirdParty/Plugins/Ecommerce/ThemifyWooCommerceProductFilter.php
+++ b/inc/ThirdParty/Plugins/Ecommerce/ThemifyWooCommerceProductFilter.php
@@ -7,7 +7,7 @@ use WP_Rocket\Event_Management\Subscriber_Interface;
 /**
  * Subscriber for compatibility with Themify WooCommerce Product Filter.
  *
- * @since  3.11.0.5
+ * @since  3.11.3
  */
 class ThemifyWooCommerceProductFilter implements Subscriber_Interface {
 
@@ -21,7 +21,7 @@ class ThemifyWooCommerceProductFilter implements Subscriber_Interface {
 	/**
 	 * Subscribed events for Themify WooCommerce Product Filter.
 	 *
-	 * @since  3.11.0.5
+	 * @since  3.11.3
 	 *
 	 * @return array
 	 */
@@ -34,7 +34,7 @@ class ThemifyWooCommerceProductFilter implements Subscriber_Interface {
 	/**
 	 * Exclude jquery
 	 *
-	 * @since 3.11.0.5
+	 * @since 3.11.3
 	 *
 	 * @param array $exclude_defer_js Files paths to be excluded.
 	 * @return array

--- a/inc/ThirdParty/ServiceProvider.php
+++ b/inc/ThirdParty/ServiceProvider.php
@@ -47,6 +47,7 @@ class ServiceProvider extends AbstractServiceProvider {
 		'ezoic',
 		'pwa',
 		'flatsome',
+		'themify_woocommerce_product_filter',
 	];
 
 	/**
@@ -163,6 +164,9 @@ class ServiceProvider extends AbstractServiceProvider {
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
 			->share( 'flatsome', 'WP_Rocket\ThirdParty\Themes\Flatsome' )
+			->addTag( 'common_subscriber' );
+		$this->getContainer()
+			->share( 'themify_woocommerce_product_filter', 'WP_Rocket\ThirdParty\Plugins\Ecommerce\ThemifyWooCommerceProductFilter' )
 			->addTag( 'common_subscriber' );
 	}
 }

--- a/tests/Fixtures/inc/ThirdParty/Plugins/Ecommerce/ThemifyWooCommerceProductFilter/excludeDeferJs.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/Ecommerce/ThemifyWooCommerceProductFilter/excludeDeferJs.php
@@ -1,0 +1,30 @@
+<?php
+
+return [
+    'test_data' => [
+        'testShouldNotAddTestToExclusionList' => [
+            'is_plugin_active' => 0,
+            'tests' => [
+                'simplybook.(.*)/v2/widget/widget.js',
+                '/wp-includes/js/dist/i18n.min.js',
+                '/wp-content/plugins/wpfront-notification-bar/js/wpfront-notification-bar(.*).js',
+                '/wp-content/plugins/oxygen/component-framework/vendor/aos/aos.js',
+                '/wp-content/plugins/ewww-image-optimizer/includes/check-webp(.min)?.js',
+            ],
+            'expected' => [],
+        ],
+        'testShouldAddTestToExclusionList' => [
+            'is_plugin_active' => 1,
+            'tests' => [
+                'simplybook.(.*)/v2/widget/widget.js',
+                '/wp-includes/js/dist/i18n.min.js',
+                '/wp-content/plugins/wpfront-notification-bar/js/wpfront-notification-bar(.*).js',
+                '/wp-content/plugins/oxygen/component-framework/vendor/aos/aos.js',
+                '/wp-content/plugins/ewww-image-optimizer/includes/check-webp(.min)?.js',
+            ],
+            'expected' => [
+                '/wp-includes/js/jquery/jquery.min.js',
+            ]
+        ],
+    ]
+];

--- a/tests/Integration/inc/ThirdParty/Plugins/Ecommerce/ThemifyWooCommerceProductFilter/excludeDeferJs.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Ecommerce/ThemifyWooCommerceProductFilter/excludeDeferJs.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\ThirdParty\Plugins\Ecommerce\ThemifyWooCommerceProductFilter;
+
+use Brain\Monkey\Functions;
+use WP_Rocket\ThirdParty\Plugins\Ecommerce\ThemifyWooCommerceProductFilter;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\inc\ThirdParty\Plugins\Ecommerce\ThemifyWooCommerceProductFilter::exclude_defer_js
+ * @group ThirdParty
+ */
+
+class Test_ExcludeDeferJs extends TestCase {
+    public function setUp() : void {
+		parent::setUp();
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+
+	public function testShouldExcludeDeferJs( $option, $tests, $expected ) {
+		$exclude_defer_js = new ThemifyWooCommerceProductFilter();
+
+        Functions\when( 'is_plugin_active' )->justReturn( $option );
+
+		$result = $exclude_defer_js->exclude_defer_js( $tests );
+
+        if( $option == 1 ){
+            $this->assertContains( $expected[0], $result );
+        }
+	}
+}

--- a/tests/Unit/inc/ThirdParty/Plugins/Ecommerce/ThemifyWooCommerceProductFilter/excludeDeferJs.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/Ecommerce/ThemifyWooCommerceProductFilter/excludeDeferJs.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\Ecommerce\ThemifyWooCommerceProductFilter;
+
+use Brain\Monkey\Functions;
+use WP_Rocket\ThirdParty\Plugins\Ecommerce\ThemifyWooCommerceProductFilter;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\inc\ThirdParty\Plugins\Ecommerce\ThemifyWooCommerceProductFilter::exclude_defer_js
+ * @group ThirdParty
+ */
+
+class Test_ExcludeDeferJs extends TestCase {
+    public function setUp() : void {
+		parent::setUp();
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+
+	public function testShouldExcludeDeferJs( $option, $tests, $expected ) {
+		$exclude_defer_js = new ThemifyWooCommerceProductFilter();
+
+        Functions\expect( 'is_plugin_active' )
+				->once()->andReturn( $option );
+
+		$result = $exclude_defer_js->exclude_defer_js( $tests );
+
+        if( $option == 1 ){
+            $this->assertContains( $expected[0], $result );
+        }
+	}
+}


### PR DESCRIPTION
## Description

Created a ThirdParty class for to handle exclusion for deferjs for themify wc product filter.

Fixes #4957 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

This solution is no way different from the proposed one.

## How Has This Been Tested?

Tested locally
- Install and activate woocommerce
- install and activate themify wc product filter
- Add product filter shortcode to sidebar widget
- Then load page and check console to see that no error is thrown.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
