### PR TITLE
Fix incorrect reference to heartbeat.js

### DIFF
--- a/inc/Engine/Heartbeat/HeartbeatSubscriber.php
+++ b/inc/Engine/Heartbeat/HeartbeatSubscriber.php
@@ -66,7 +66,7 @@ class HeartbeatSubscriber implements Subscriber_Interface {
 		 * Enqueue an empty heartbeat script to prevent query monitor error
 		 * Added to the footer
 		 */
-		wp_enqueue_script( 'heartbeat', WP_ROCKET_ASSETS_JS_URL . 'assets/js/heartbeat.js', null, WP_ROCKET_VERSION, true );
+		wp_enqueue_script( 'heartbeat', WP_ROCKET_ASSETS_JS_URL . 'heartbeat.js', null, WP_ROCKET_VERSION, true );
 	}
 
 	/**


### PR DESCRIPTION
## Description

Correcting incorrect reference to heartbeat.js

from 
`wp_enqueue_script( 'heartbeat', WP_ROCKET_ASSETS_JS_URL . 'assets/js/heartbeat.js', null, WP_ROCKET_VERSION, true );
`
to 
`wp_enqueue_script( 'heartbeat', WP_ROCKET_ASSETS_JS_URL . 'heartbeat.js', null, WP_ROCKET_VERSION, true );
`
Fixes #4999 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

no, groomed via DM with @piotrbak 


# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
