### PR TITLE
Fix/issue 4977

### DIFF
--- a/inc/front/regenerate-folders-and-cache.php
+++ b/inc/front/regenerate-folders-and-cache.php
@@ -1,4 +1,5 @@
 <?php
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -22,7 +23,7 @@ function wp_rocket_regenerate_cache_filesystem_and_config() {
 	if ( ! file_exists( ABSPATH . 'wp-content/cache/wp-rocket-config/' ) ) {
 		rocket_generate_config_file();
 	}
-	
+
 	// If advanced-cache.php is missing, then regenerate.
 	if ( ! file_exists( ABSPATH . 'wp-content/cache/advanced-cache.php' ) ) {
 		rocket_generate_advanced_cache_file();

--- a/inc/front/regenerate-folders-and-cache.php
+++ b/inc/front/regenerate-folders-and-cache.php
@@ -1,0 +1,35 @@
+<?php
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * After restart of docker container (or deleting files anyhow) missing file needs to be recreated without need to enter admin panel.
+ * This should happen right after first visit on any page.
+ *
+ * @since  3.11.2
+ * @author Hubert Badura
+ * @author Jarosław Krawczyk
+ *
+ */
+
+function wp_rocket_regenerate_cache_filesystem_and_config(){
+    // If cache folders are missing, then regenerate.
+    if (!file_exists(ABSPATH . 'wp-content/cache/wp-rocket/') || 
+        !file_exists(ABSPATH . 'wp-content/cache/min/') ||
+        !file_exists(ABSPATH . 'wp-content/cache/busting/') ||
+        !file_exists(ABSPATH . 'wp-content/cache/critical-css/')){
+        rocket_init_cache_dir();
+    }
+    
+    // If config folder is missing, then regenerate.
+    if (!file_exists(ABSPATH . 'wp-content/cache/wp-rocket-config/')){
+        rocket_generate_config_file();
+    }
+
+    // If advanced-cache.php is missing, then regenerate.
+    if (!file_exists(ABSPATH . 'wp-content/cache/advanced-cache.php')){
+        rocket_generate_advanced_cache_file();
+    }    
+}
+
+add_action( 'wp_loaded', 'wp_rocket_regenerate_cache_filesystem_and_config' );

--- a/inc/front/regenerate-folders-and-cache.php
+++ b/inc/front/regenerate-folders-and-cache.php
@@ -9,27 +9,25 @@ defined( 'ABSPATH' ) || exit;
  * @since  3.11.2
  * @author Hubert Badura
  * @author Jarosław Krawczyk
- *
  */
-
-function wp_rocket_regenerate_cache_filesystem_and_config(){
-    // If cache folders are missing, then regenerate.
-    if (!file_exists(ABSPATH . 'wp-content/cache/wp-rocket/') || 
-        !file_exists(ABSPATH . 'wp-content/cache/min/') ||
-        !file_exists(ABSPATH . 'wp-content/cache/busting/') ||
-        !file_exists(ABSPATH . 'wp-content/cache/critical-css/')){
-        rocket_init_cache_dir();
-    }
-    
-    // If config folder is missing, then regenerate.
-    if (!file_exists(ABSPATH . 'wp-content/cache/wp-rocket-config/')){
-        rocket_generate_config_file();
-    }
-
-    // If advanced-cache.php is missing, then regenerate.
-    if (!file_exists(ABSPATH . 'wp-content/cache/advanced-cache.php')){
-        rocket_generate_advanced_cache_file();
-    }    
+function wp_rocket_regenerate_cache_filesystem_and_config() {
+	// If cache folders are missing, then regenerate.
+	if ( ! file_exists(ABSPATH . 'wp-content/cache/wp-rocket/' ) ||
+		!file_exists(ABSPATH . 'wp-content/cache/min/' ) ||
+		!file_exists(ABSPATH . 'wp-content/cache/busting/' ) ||
+		!file_exists(ABSPATH . 'wp-content/cache/critical-css/' ) ) {
+		rocket_init_cache_dir();
+	}
+	
+	// If config folder is missing, then regenerate.
+	if ( ! file_exists(ABSPATH . 'wp-content/cache/wp-rocket-config/' ) ) {
+		rocket_generate_config_file();
+	}
+	
+	// If advanced-cache.php is missing, then regenerate.
+	if ( ! file_exists(ABSPATH . 'wp-content/cache/advanced-cache.php' ) ) {
+		rocket_generate_advanced_cache_file();
+	}    
 }
 
 add_action( 'wp_loaded', 'wp_rocket_regenerate_cache_filesystem_and_config' );

--- a/inc/front/regenerate-folders-and-cache.php
+++ b/inc/front/regenerate-folders-and-cache.php
@@ -12,22 +12,22 @@ defined( 'ABSPATH' ) || exit;
  */
 function wp_rocket_regenerate_cache_filesystem_and_config() {
 	// If cache folders are missing, then regenerate.
-	if ( ! file_exists(ABSPATH . 'wp-content/cache/wp-rocket/' ) ||
-		!file_exists(ABSPATH . 'wp-content/cache/min/' ) ||
-		!file_exists(ABSPATH . 'wp-content/cache/busting/' ) ||
-		!file_exists(ABSPATH . 'wp-content/cache/critical-css/' ) ) {
+	if ( ! file_exists( ABSPATH . 'wp-content/cache/wp-rocket/' ) ||
+		! file_exists( ABSPATH . 'wp-content/cache/min/' ) ||
+		! file_exists( ABSPATH . 'wp-content/cache/busting/' ) ||
+		! file_exists( ABSPATH . 'wp-content/cache/critical-css/' ) ) {
 		rocket_init_cache_dir();
 	}
 	
 	// If config folder is missing, then regenerate.
-	if ( ! file_exists(ABSPATH . 'wp-content/cache/wp-rocket-config/' ) ) {
+	if ( ! file_exists( ABSPATH . 'wp-content/cache/wp-rocket-config/' ) ) {
 		rocket_generate_config_file();
 	}
 	
 	// If advanced-cache.php is missing, then regenerate.
-	if ( ! file_exists(ABSPATH . 'wp-content/cache/advanced-cache.php' ) ) {
+	if ( ! file_exists( ABSPATH . 'wp-content/cache/advanced-cache.php' ) ) {
 		rocket_generate_advanced_cache_file();
-	}    
+	}
 }
 
 add_action( 'wp_loaded', 'wp_rocket_regenerate_cache_filesystem_and_config' );

--- a/inc/front/regenerate-folders-and-cache.php
+++ b/inc/front/regenerate-folders-and-cache.php
@@ -1,5 +1,4 @@
 <?php
-
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -18,7 +17,7 @@ function wp_rocket_regenerate_cache_filesystem_and_config() {
 		! file_exists( ABSPATH . 'wp-content/cache/critical-css/' ) ) {
 		rocket_init_cache_dir();
 	}
-	
+
 	// If config folder is missing, then regenerate.
 	if ( ! file_exists( ABSPATH . 'wp-content/cache/wp-rocket-config/' ) ) {
 		rocket_generate_config_file();

--- a/inc/main.php
+++ b/inc/main.php
@@ -91,6 +91,7 @@ function rocket_init() {
 		require WP_ROCKET_FRONT_PATH . 'cookie.php';
 		require WP_ROCKET_FRONT_PATH . 'dns-prefetch.php';
 		require WP_ROCKET_FRONT_PATH . 'protocol.php';
+		require WP_ROCKET_FRONT_PATH . 'regenerate-folders-and-cache.php';
 	}
 
 	// You can hook this to trigger any action when WP Rocket is correctly loaded, so, not in AUTOSAVE mode.


### PR DESCRIPTION
## Description

After restart of docker container, files are restored to their default state. It is likely, that there is no WP Rocket config files and/or WP Rocket Cache dir after such restart. These files and directiories must be recreated after first visit on page, doesn't matter if its admin panel or not, because restart of app may occur on any time. Before that change regeneration worked, but only after entering admin panel.

Fixes #4977

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Is the solution different from the one proposed during the grooming?

Honetly, i don't know.

## How Has This Been Tested?

All you have to do is to restart docker app or delete files manually. After that files should not be generated before fix and be generated after fix when entering any page without login.

- [x] Test A
- [x] Test B

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
