### PR TITLE
Closes #4972 RUCSS preserve inline CSS for the WP Recipe Maker

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -77,6 +77,7 @@ class UsedCSS {
 		'.wp-container-',
 		'.wp-elements-',
 		'#wpv-expandable-',
+		'.wprm-advanced-list-',
 	];
 
 	/**


### PR DESCRIPTION
Ticket - https://secure.helpscout.net/conversation/1848224170/337518/
Fixes - https://github.com/wp-media/wp-rocket/issues/4972