### PR TITLE
Fixes #5055 exclude popt.in JS from JS minification

### DIFF
--- a/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
+++ b/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
@@ -263,6 +263,7 @@ abstract class AbstractJSOptimization extends AbstractOptimization {
 			'ga.getresponse.com/script/ga.js',
 			'cognitoforms.com',
 			'usercentrics.eu',
+			'cdn.popt.in/pixel.js',
 		];
 
 		$excluded_external = array_merge( $defaults, $this->options->get( 'exclude_js', [] ) );


### PR DESCRIPTION
## Description

I added `cdn.popt.in/pixel.js` to the `$defaults` array.

Fixes #5055 

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?
N/A
## How Has This Been Tested?

- [x] On the customer site using the UI
- [x] On my test site by adding the exclusion in the core

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings