### PR TITLE
Closes #5028 on RUCSS not rewriting prloaded fonts url to CDN

### DIFF
--- a/inc/Engine/CDN/Subscriber.php
+++ b/inc/Engine/CDN/Subscriber.php
@@ -57,6 +57,7 @@ class Subscriber implements Subscriber_Interface {
 			'rocket_js_url'           => [ 'add_cdn_url', 10, 2 ],
 			'rocket_asset_url'        => [ 'maybe_replace_url', 10, 2 ],
 			'wp_resource_hints'       => [ 'add_preconnect_cdn', 10, 2 ],
+			'rocket_font_url'         => [ 'add_cdn_url', 10, 2 ],
 		];
 	}
 

--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -655,7 +655,7 @@ class UsedCSS {
 
 			$font_url = $this->extract_first_font( $font_face['content'] );
 
-			$font_url = apply_filters( 'rocket_asset_url', $font_url, [ 'all' ] );
+			$font_url = apply_filters( 'rocket_font_url', $font_url );
 
 			if ( empty( $font_url ) ) {
 				continue;

--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -655,6 +655,8 @@ class UsedCSS {
 
 			$font_url = $this->extract_first_font( $font_face['content'] );
 
+			$font_url = apply_filters( 'rocket_asset_url', $font_url, [ 'all' ] );
+
 			if ( empty( $font_url ) ) {
 				continue;
 			}

--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -655,6 +655,13 @@ class UsedCSS {
 
 			$font_url = $this->extract_first_font( $font_face['content'] );
 
+			/**
+			 * Filters font URL with CDN hostname
+			 *
+			 * @since 3.11.4
+			 *
+			 * @param type  $url url to be rewritten.
+			 */
 			$font_url = apply_filters( 'rocket_font_url', $font_url );
 
 			if ( empty( $font_url ) ) {


### PR DESCRIPTION
## Description

Added filter to rewrite fonts to cdn.

Fixes #5028 

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

Slightly different from the proposed.

## How Has This Been Tested?

Tested online
- Enable RUCCSS
- Enable CDN Rewriting
- Inspect element of page and see preloaded fonts url rewritten.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
