### PR TITLE
set default empty array when getting "cache_reject_uri" option

### DIFF
--- a/inc/admin/ui/meta-boxes.php
+++ b/inc/admin/ui/meta-boxes.php
@@ -127,7 +127,7 @@ function rocket_save_metabox_options() {
 
 		// No cache field.
 		if ( isset( $_POST['post_status'] ) && 'publish' === $_POST['post_status'] ) {
-			$new_cache_reject_uri = $cache_reject_uri = get_rocket_option( 'cache_reject_uri' ); // phpcs:ignore Squiz.PHP.DisallowMultipleAssignments.Found
+			$new_cache_reject_uri = $cache_reject_uri = get_rocket_option( 'cache_reject_uri', [] ); // phpcs:ignore Squiz.PHP.DisallowMultipleAssignments.Found
 			$rejected_uris        = array_flip( $cache_reject_uri );
 			$path                 = rocket_clean_exclude_file( get_permalink( (int) $_POST['post_ID'] ) );
 


### PR DESCRIPTION
## Description

Because when empty it triggers an fatal array because `array_flip` requires and Array and nothing else.
![Screenshot 2022-05-24 at 16 35 20](https://user-images.githubusercontent.com/145887/170062275-4f6cd153-c578-482c-b00a-d4fc4967ced5.png)

No outstanding issue was opened herefor.

This fix applies the same logic as already is implemented by wp-media like on this line in the same file:  https://github.com/wp-media/wp-rocket/blob/develop/inc/admin/ui/meta-boxes.php#L57

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

No grooming done by me :)

## How Has This Been Tested?

I saved a post on my website where this option was empty.

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings