### PR TITLE
Closes #5041 on rucss compatibility with inline related posts dynamic selectors

### DIFF
--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -294,6 +294,7 @@ class Plugin {
 			'yoast_seo',
 			'flatsome',
 			'convertplug',
+			'inline_related_posts',
 		];
 
 		$host_type = HostResolver::get_host_service();

--- a/inc/ThirdParty/Plugins/InlineRelatedPosts.php
+++ b/inc/ThirdParty/Plugins/InlineRelatedPosts.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace WP_Rocket\ThirdParty\Plugins;
+
+use WP_Rocket\Event_Management\Subscriber_Interface;
+
+/**
+ * Subscriber for compatibility with Inline Related Posts.
+ */
+class InlineRelatedPosts implements Subscriber_Interface {
+
+
+	/**
+	 * Subscriber for Inline Related Posts.
+	 *
+	 * @return array
+	 */
+	public static function get_subscribed_events() {
+		if ( ! defined( 'IRP_PLUGIN_SLUG' ) ) {
+			return [];
+		}
+
+		$events['rocket_rucss_inline_content_exclusions'] = 'excluded_inline_from_rucss';
+
+		return $events;
+	}
+
+	/**
+	 * Exclude inline style from RUCSS.
+	 *
+	 * @param array $excluded excluded css.
+	 * @return array
+	 */
+	public function excluded_inline_from_rucss( $excluded ) {
+		$excluded[] = '.centered-text-area';
+		$excluded[] = '.ctaText';
+
+		return $excluded;
+	}
+}

--- a/inc/ThirdParty/Plugins/InlineRelatedPosts.php
+++ b/inc/ThirdParty/Plugins/InlineRelatedPosts.php
@@ -20,9 +20,7 @@ class InlineRelatedPosts implements Subscriber_Interface {
 			return [];
 		}
 
-		$events['rocket_rucss_inline_content_exclusions'] = 'exclude_inline_from_rucss';
-
-		return $events;
+		return [ 'rocket_rucss_inline_content_exclusions' => 'exclude_inline_from_rucss' ];
 	}
 
 	/**

--- a/inc/ThirdParty/Plugins/InlineRelatedPosts.php
+++ b/inc/ThirdParty/Plugins/InlineRelatedPosts.php
@@ -20,7 +20,7 @@ class InlineRelatedPosts implements Subscriber_Interface {
 			return [];
 		}
 
-		$events['rocket_rucss_inline_content_exclusions'] = 'excluded_inline_from_rucss';
+		$events['rocket_rucss_inline_content_exclusions'] = 'exclude_inline_from_rucss';
 
 		return $events;
 	}
@@ -31,7 +31,7 @@ class InlineRelatedPosts implements Subscriber_Interface {
 	 * @param array $excluded excluded css.
 	 * @return array
 	 */
-	public function excluded_inline_from_rucss( $excluded ) {
+	public function exclude_inline_from_rucss( $excluded ) {
 		$excluded[] = '.centered-text-area';
 		$excluded[] = '.ctaText';
 

--- a/inc/ThirdParty/ServiceProvider.php
+++ b/inc/ThirdParty/ServiceProvider.php
@@ -48,6 +48,7 @@ class ServiceProvider extends AbstractServiceProvider {
 		'pwa',
 		'flatsome',
 		'convertplug',
+		'inline_related_posts',
 	];
 
 	/**
@@ -167,6 +168,9 @@ class ServiceProvider extends AbstractServiceProvider {
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
 			->share( 'convertplug', 'WP_Rocket\ThirdParty\Plugins\ConvertPlug' )
+			->addTag( 'common_subscriber' );
+		$this->getContainer()
+			->share( 'inline_related_posts', 'WP_Rocket\ThirdParty\Plugins\InlineRelatedPosts' )
 			->addTag( 'common_subscriber' );
 	}
 }

--- a/tests/Fixtures/inc/ThirdParty/Plugins/InlineRelatedPosts/excludeInlineFromRucss.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/InlineRelatedPosts/excludeInlineFromRucss.php
@@ -1,0 +1,13 @@
+<?php
+
+return [
+	'shouldExcludeInlineFromRUCSS' => [
+		'config' => [
+			'excluded' => []
+		],
+		'excluded' => [
+			'.centered-text-area',
+			'.ctaText',
+		]
+	]
+];

--- a/tests/Integration/inc/ThirdParty/Plugins/InlineRelatedPosts/excludeInlineFromRucss.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/InlineRelatedPosts/excludeInlineFromRucss.php
@@ -1,0 +1,18 @@
+<?php
+
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * @covers  \WP_Rocket\ThirdParty\Plugins\InlineRelatedPosts::exclude_inline_from_rucss
+ * @group   InlineRelatedPosts
+ */
+class Test_ExcludeInlineFromRucss extends TestCase {
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnExpected( $config, $expected ) {
+		$this->assertSame( $expected, apply_filters( 'rocket_rucss_inline_content_exclusions', $config['excluded'] ));
+	}
+
+}

--- a/tests/Integration/inc/ThirdParty/Plugins/InlineRelatedPosts/excludeInlineFromRucss.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/InlineRelatedPosts/excludeInlineFromRucss.php
@@ -1,6 +1,8 @@
 <?php
+namespace WP_Rocket\Tests\Integration\inc\ThirdParty\Plugins;
 
 use WP_Rocket\Tests\Integration\TestCase;
+use WP_Rocket\ThirdParty\Plugins\InlineRelatedPosts;
 
 /**
  * @covers  \WP_Rocket\ThirdParty\Plugins\InlineRelatedPosts::exclude_inline_from_rucss
@@ -8,11 +10,18 @@ use WP_Rocket\Tests\Integration\TestCase;
  */
 class Test_ExcludeInlineFromRucss extends TestCase {
 
+	public function tear_down() {
+		remove_filter( 'rocket_rucss_inline_content_exclusions', [ $this, 'return_false' ] );
+
+		parent::tear_down();
+	}
+
 	/**
 	 * @dataProvider configTestData
 	 */
 	public function testShouldReturnExpected( $config, $expected ) {
-		$this->assertSame( $expected, apply_filters( 'rocket_rucss_inline_content_exclusions', $config['excluded'] ));
+        $inline_related_posts = new InlineRelatedPosts();
+		$this->assertSame( $expected, apply_filters( 'rocket_rucss_inline_content_exclusions', $inline_related_posts->exclude_inline_from_rucss($config['excluded'] ) ) );
 	}
 
 }

--- a/tests/Integration/inc/ThirdParty/Plugins/InlineRelatedPosts/excludeInlineFromRucss.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/InlineRelatedPosts/excludeInlineFromRucss.php
@@ -10,18 +10,12 @@ use WP_Rocket\ThirdParty\Plugins\InlineRelatedPosts;
  */
 class Test_ExcludeInlineFromRucss extends TestCase {
 
-	public function tear_down() {
-		remove_filter( 'rocket_rucss_inline_content_exclusions', [ $this, 'return_false' ] );
-
-		parent::tear_down();
-	}
-
 	/**
 	 * @dataProvider configTestData
 	 */
 	public function testShouldReturnExpected( $config, $expected ) {
         $inline_related_posts = new InlineRelatedPosts();
-		$this->assertSame( $expected, apply_filters( 'rocket_rucss_inline_content_exclusions', $inline_related_posts->exclude_inline_from_rucss($config['excluded'] ) ) );
+		$this->assertSame( $expected, $inline_related_posts->exclude_inline_from_rucss($config['excluded'] ) );
 	}
 
 }

--- a/tests/Unit/inc/ThirdParty/Plugins/InlineRelatedPosts/excludeInlineFromRucss.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/InlineRelatedPosts/excludeInlineFromRucss.php
@@ -1,0 +1,28 @@
+<?php
+namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins;
+
+use WP_Rocket\Tests\Unit\TestCase;
+use WP_Rocket\ThirdParty\Plugins\InlineRelatedPosts;
+
+/**
+ * @covers \WP_Rocket\ThirdParty\Plugins\InlineRelatedPosts::exclude_inline_from_rucss
+ * @group InlineRelatedPosts
+ * @group ThirdParty
+ */
+class Test_ExcludeInlineFromRucss extends TestCase {
+	protected $inline_related_posts;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->inline_related_posts = new InlineRelatedPosts();
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnAsExpected($config, $expected) {
+
+		$this->assertSame($expected, $this->inline_related_posts->exclude_inline_from_rucss($config['excluded']));
+	}
+}


### PR DESCRIPTION
## Description

Preserve dynamic inline styles for inline related posts plugin.

Fixes #5041 

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

This solution is in no way different from the proposed.

## How Has This Been Tested?

- Install & Activate inline related posts.
- Activate RUCSS
- Created Identical Posts.
- Then inspect page to see that dynamic inline styles are preserved

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
