### PR TITLE
Preserve Unlimited Timeline inline style

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -82,6 +82,7 @@ class UsedCSS {
 		'.jet-listing-dynamic-post-',
 		'.vcex_',
 		'.wprm-advanced-list-',
+		'#uc_unlimited_timeline_elementor',
 	];
 
 	/**


### PR DESCRIPTION
Fixes #5083

## Description

Preserves dynamic selectors added with Unlimited Timeline widget inline style

Fixes #5083 

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

n/a

## How Has This Been Tested?

Tested on a customer site by preserving `#uc_unlimited_timeline_elementor` with `rocket_rucss_inline_content_exclusions` filter in [helper plugin](https://docs.wp-rocket.me/article/1694-prevent-inline-styles-from-being-removed-by-remove-unused-css).
Ticket: https://secure.helpscout.net/conversation/1896704647/344944?folderId=3864740

The automatic exclusion within the plugin was tested on my testing site by using the customer's site HTML template. The inline style was preserved.
No errors in debug.

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
