### PR TITLE
Fixes #5017 Remove Unused CSS clears only up to 100 rows in specific conditions

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Admin/Database.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Database.php
@@ -92,4 +92,17 @@ class Database {
 		}
 		return $this->rucss_usedcss_table->get_old_used_css();
 	}
+
+	/**
+	 * Remove all completed rows.
+	 *
+	 * @return bool|int
+	 */
+	public function remove_all_completed_rows() {
+		if ( ! $this->rucss_usedcss_table->exists() ) {
+			return false;
+		}
+
+		return $this->rucss_usedcss_table->remove_all_completed_rows();
+	}
 }

--- a/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
@@ -203,7 +203,7 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	private function delete_used_css_rows() {
 		if ( 0 < $this->used_css->get_not_completed_count() ) {
-			$this->used_css->remove_all_completed_rows();
+			$this->database->remove_all_completed_rows();
 		} else {
 			$this->database->truncate_used_css_table();
 		}

--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -606,15 +606,6 @@ class UsedCSS {
 	}
 
 	/**
-	 * Remove all completed rows one by one.
-	 *
-	 * @return void
-	 */
-	public function remove_all_completed_rows() {
-		$this->used_css_query->remove_all_completed_rows();
-	}
-
-	/**
 	 * Get the count of not completed rows.
 	 *
 	 * @return int

--- a/inc/Engine/Optimization/RUCSS/Database/Queries/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Database/Queries/UsedCSS.php
@@ -310,24 +310,4 @@ class UsedCSS extends Query {
 		);
 	}
 
-	/**
-	 * Remove all completed rows one by one.
-	 *
-	 * @return void
-	 */
-	public function remove_all_completed_rows() {
-		$rows = $this->query(
-			[
-				'status__in' => [ 'failed', 'completed' ],
-				'fields'     => [
-					'id',
-				],
-			]
-		);
-
-		foreach ( $rows as $row ) {
-			$this->delete_item( $row->id );
-		}
-	}
-
 }

--- a/inc/Engine/Optimization/RUCSS/Database/Tables/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Database/Tables/UsedCSS.php
@@ -152,4 +152,22 @@ class UsedCSS extends Table {
 		return $this->is_success( $index_added );
 	}
 
+	/**
+	 * Remove all completed rows.
+	 *
+	 * @return bool|int
+	 */
+	public function remove_all_completed_rows() {
+		// Get the database interface.
+		$db = $this->get_db();
+
+		// Bail if no database interface is available.
+		if ( empty( $db ) ) {
+			return false;
+		}
+
+		$prefixed_table_name = $this->apply_prefix( $this->table_name );
+		return $db->query( "DELETE FROM `$prefixed_table_name` WHERE status IN ( 'failed', 'completed' )" );
+	}
+
 }

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cleanUsedCssAndCache.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/cleanUsedCssAndCache.php
@@ -49,7 +49,7 @@ class Test_CleanUsedCssAndCache extends FilesystemTestCase {
 			$this->usedCSS->shouldReceive( 'get_not_completed_count' )->once()->andReturn( $input['not_completed_count'] );
 
 			if ( $input['not_completed_count'] > 0 ) {
-				$this->usedCSS->shouldReceive( 'remove_all_completed_rows' )->once();
+				$this->database->shouldReceive( 'remove_all_completed_rows' )->once();
 			} else {
 				$this->database->shouldReceive( 'truncate_used_css_table' )->once();
 			}

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/truncateUsedCSSHandler.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/truncateUsedCSSHandler.php
@@ -114,7 +114,7 @@ class Test_TruncateUsedCSSHandler extends TestCase {
 			$this->usedCSS->shouldReceive( 'get_not_completed_count' )->once()->andReturn( $input['not_completed_count'] );
 
 			if ( $input['not_completed_count'] > 0 ) {
-				$this->usedCSS->shouldReceive( 'remove_all_completed_rows' )->once();
+				$this->database->shouldReceive( 'remove_all_completed_rows' )->once();
 			} else {
 				$this->database->shouldReceive( 'truncate_used_css_table' )->once();
 			}


### PR DESCRIPTION
## Description

Here we are deleting completed rows (with completed or failed statuses) from usedcss DB table in one query.

Fixes #5017

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Is the solution different from the one proposed during the grooming?

No, they are the same.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I used the following code to add some rows into the DB (more than 100)
```
add_action( 'admin_init', function() {
    global $wpdb;

    for ($i=0;$i<=100;$i++) {
	    $wpdb->insert( 'wp_wpr_rucss_used_css', [
		    'url' => home_url( uniqid() ),
		    'css' => '.test{color: red;}',
		    'status' => 'failed',
            'last_accessed' => date( 'Y-m-d H:i:s', time() ),
	    ] );
	    $wpdb->insert( 'wp_wpr_rucss_used_css', [
		    'url' => home_url( uniqid() ),
		    'css' => '.test{color: red;}',
		    'status' => 'completed',
		    'last_accessed' => date( 'Y-m-d H:i:s', time() ),
	    ] );
    }
	$wpdb->insert( 'wp_wpr_rucss_used_css', [
		'url' => home_url( uniqid() ),
		'css' => '.test{color: red;}',
		'status' => 'pending',
		'last_accessed' => date( 'Y-m-d H:i:s', time() ),
	] );
	$wpdb->insert( 'wp_wpr_rucss_used_css', [
		'url' => home_url( uniqid() ),
		'css' => '.test{color: red;}',
		'status' => 'in-progress',
		'last_accessed' => date( 'Y-m-d H:i:s', time() ),
	] );
} );
```
and then tested all actions that clears the whole used CSS.

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
