### PR TITLE
RUCSS: preserve inline style tags on the page with a filter and only delete the CSS content

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -53,6 +53,13 @@ class UsedCSS {
 	private $queue;
 
 	/**
+	 * External exclusions list, can be urls or attributes.
+	 *
+	 * @var array
+	 */
+	private $external_exclusions = [];
+
+	/**
 	 * Inline CSS attributes exclusions patterns to be preserved on the page after treeshaking.
 	 *
 	 * @var string[]
@@ -300,18 +307,41 @@ class UsedCSS {
 		$clean_html = $this->hide_noscripts( $clean_html );
 		$clean_html = $this->hide_scripts( $clean_html );
 
+		$html = $this->remove_external_styles_from_html( $clean_html, $html );
+
+		return $this->remove_internal_styles_from_html( $clean_html, $html );
+	}
+
+	/**
+	 * Remove external styles from the page's HTML.
+	 *
+	 * @param string $clean_html Cleaned HTML after removing comments, noscripts and scripts.
+	 * @param string $html Actual page's HTML.
+	 *
+	 * @return string
+	 */
+	private function remove_external_styles_from_html( string $clean_html, string $html ) {
 		$link_styles = $this->find(
 			'<link\s+([^>]+[\s"\'])?href\s*=\s*[\'"]\s*?(?<url>[^\'"]+(?:\?[^\'"]*)?)\s*?[\'"]([^>]+)?\/?>',
 			$clean_html,
 			'Uis'
 		);
 
-		$inline_styles = $this->find(
-			'<style(?<atts>.*)>(?<content>.*)<\/style\s*>',
-			$clean_html
-		);
-
 		$preserve_google_font = apply_filters( 'rocket_rucss_preserve_google_font', false );
+
+		$external_exclusions = (array) array_map(
+			function ( $item ) {
+				return preg_quote( $item, '/' );
+			},
+			/**
+			 * Filters the array of external exclusions.
+			 *
+			 * @since 3.11.4
+			 *
+			 * @param array $inline_atts_exclusions Array of patterns used to match against the external style tag.
+			 */
+			(array) apply_filters( 'rocket_rucss_external_exclusions', $this->external_exclusions )
+		);
 
 		foreach ( $link_styles as $style ) {
 			if (
@@ -324,8 +354,30 @@ class UsedCSS {
 			) {
 				continue;
 			}
+
+			if ( ! empty( $external_exclusions ) && $this->find( implode( '|', $external_exclusions ), $style[0] ) ) {
+				continue;
+			}
+
 			$html = str_replace( $style[0], '', $html );
 		}
+
+		return (string) $html;
+	}
+
+	/**
+	 * Remove internal styles from the page's HTML.
+	 *
+	 * @param string $clean_html Cleaned HTML after removing comments, noscripts and scripts.
+	 * @param string $html Actual page's HTML.
+	 *
+	 * @return string
+	 */
+	private function remove_internal_styles_from_html( string $clean_html, string $html ) {
+		$inline_styles = $this->find(
+			'<style(?<atts>.*)>(?<content>.*)<\/style\s*>',
+			$clean_html
+		);
 
 		$inline_atts_exclusions = (array) array_map(
 			function ( $item ) {
@@ -374,9 +426,12 @@ class UsedCSS {
 			 */
 			if ( apply_filters( 'rocket_rucss_preserve_inline_style_tags', false, $style ) ) {
 				$html = str_replace( $style['content'], '', $html );
-			}else {
-				$html = str_replace( $style[0], '', $html );
+
+				continue;
 			}
+
+			$html = str_replace( $style[0], '', $html );
+
 		}
 
 		return $html;

--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -374,7 +374,7 @@ class UsedCSS {
 			 */
 			if ( apply_filters( 'rocket_rucss_preserve_inline_style_tags', false, $style ) ) {
 				$html = str_replace( $style['content'], '', $html );
-			}else{
+			}else {
 				$html = str_replace( $style[0], '', $html );
 			}
 		}

--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -364,7 +364,19 @@ class UsedCSS {
 				continue;
 			}
 
-			$html = str_replace( $style[0], '', $html );
+			/**
+			 * Filters the status of preserving inline style tags.
+			 *
+			 * @since 3.11.4
+			 *
+			 * @param bool $preserve_status Status of preserve.
+			 * @param array $style Full match style tag.
+			 */
+			if ( apply_filters( 'rocket_rucss_preserve_inline_style_tags', false, $style ) ) {
+				$html = str_replace( $style['content'], '', $html );
+			}else{
+				$html = str_replace( $style[0], '', $html );
+			}
 		}
 
 		return $html;


### PR DESCRIPTION
## Description

Here we want to preserve the style tag with its attributes on the page when this filter is used as some plugins/themes are depending on the existence of those styles so instead of keeping the whole styles we want only to keep the style tags.

Fixes #5064
Fixes #4969

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which improves an existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Is the solution different from the one proposed during the grooming?

No, we combined both issues in one PR as both are related to each others.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Use the following filters to be able to test
```
add_filter( 'rocket_rucss_external_exclusions', function ( $exclusions ){
	$exclusions[] = 'wp-includes/css/dist/block-library/style.min.css';//here u can add any string from the link style url or attributes like below.
	$exclusions[] = 'wc-blocks-vendors-style-css';

	return $exclusions;
} );

add_filter( 'rocket_rucss_preserve_inline_style_tags', function ( $excluded, $style ){
	//If you want, $style[0] has the full style tag so u can search for a thing on the style to decide which styles to preserve its style tag.

	return true;
}, 10, 2 );
```

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
