### PR TITLE
Closes #5076 Preserve RUCSS clean rows event if RUCSS option is disabled

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Cron/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Cron/Subscriber.php
@@ -61,16 +61,6 @@ class Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function schedule_clean_not_commonly_used_rows() {
-		if (
-			! $this->used_css->is_enabled()
-			&&
-			wp_next_scheduled( 'rocket_rucss_clean_rows_time_event' )
-		) {
-			wp_clear_scheduled_hook( 'rocket_rucss_clean_rows_time_event' );
-
-			return;
-		}
-
 		if ( ! $this->used_css->is_enabled() ) {
 			return;
 		}
@@ -112,10 +102,6 @@ class Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function cron_clean_rows() {
-		if ( ! $this->used_css->is_enabled() ) {
-			return;
-		}
-
 		$this->database->delete_old_used_css();
 		$this->database->delete_old_resources();
 	}

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Cron/Subscriber/cronCleanRows.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Cron/Subscriber/cronCleanRows.php
@@ -45,18 +45,10 @@ $resources = [
 
 return [
 	'test_data' => [
-		'shouldNotDeleteOnUpdateDueToMissingSettings' => [
-			'input' => [
-				'remove_unused_css'      => false,
-				'used_css'               => $used_css,
-				'resources'              => $resources,
-			]
-		],
 		'shouldDeleteOnUpdate' => [
 			'input' => [
-				'remove_unused_css' => true,
-				'used_css'          => $used_css,
-				'resources'         => $resources,
+				'used_css'  => $used_css,
+				'resources' => $resources,
 			]
 		],
 	],

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Cron/Subscriber/cronCleanRows.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Cron/Subscriber/cronCleanRows.php
@@ -28,16 +28,10 @@ class Test_CronCleanRows extends TestCase {
 		self::uninstallAll();
 	}
 
-	public function tear_down() : void {
-		remove_filter( 'pre_get_rocket_option_remove_unused_css', [ $this, 'set_rucss_option' ] );
-
-		parent::tear_down();
-	}
-
 	/**
 	 * @dataProvider configTestData
 	 */
-	public function testShouldDoExpected( $input ){
+	public function testShouldDoExpected( $input ) {
 		$container              = apply_filters( 'rocket_container', null );
 		$rucss_usedcss_query   = $container->get( 'rucss_used_css_query' );
 		$rucss_resources_query = $container->get( 'rucss_resources_query' );
@@ -45,7 +39,6 @@ class Test_CronCleanRows extends TestCase {
 		$old_date              = strtotime( $current_date. ' - 32 days' );
 
 		$this->input = $input;
-		add_filter( 'pre_get_rocket_option_remove_unused_css', [ $this, 'set_rucss_option' ] );
 		$this->set_permalink_structure( "/%postname%/" );
 
 		$count_remain_used_css = 0;
@@ -79,16 +72,7 @@ class Test_CronCleanRows extends TestCase {
 		$resultResourcesAfterClean = $rucss_resources_query->query();
 
 
-		if ( $this->input['remove_unused_css'] ) {
-			$this->assertCount( $count_remain_used_css,$resultUsedCssAfterClean );
-			$this->assertCount( $count_remain_resources, $resultResourcesAfterClean );
-		} else {
-			$this->assertCount( count( $input['used_css'] ), $resultUsedCssAfterClean );
-			$this->assertCount( count( $input['resources'] ), $resultResourcesAfterClean );
-		}
-	}
-
-	public function set_rucss_option() {
-		return $this->input['remove_unused_css'] ?? false;
+		$this->assertCount( $count_remain_used_css, $resultUsedCssAfterClean );
+		$this->assertCount( $count_remain_resources, $resultResourcesAfterClean );
 	}
 }

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Cron/Subscriber/scheduleCleanNotCommonlyUsedRows.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Cron/Subscriber/scheduleCleanNotCommonlyUsedRows.php
@@ -10,19 +10,20 @@ use WP_Rocket\Tests\Integration\TestCase;
  *
  * @group  RUCSS
  */
-class Test_ScheduleCleanNotCommonlyUsedRows extends TestCase{
-
-	public function tear_down() : void {
+class Test_ScheduleCleanNotCommonlyUsedRows extends TestCase {
+	public function tear_down() {
 		remove_filter( 'pre_get_rocket_option_remove_unused_css', [ $this, 'set_rucss_option' ] );
 		wp_clear_scheduled_hook( 'rocket_rucss_clean_rows_time_event' );
+
 		parent::tear_down();
 	}
 
 	/**
 	 * @dataProvider configTestData
 	 */
-	public function testShouldDoExpected( $input ){
+	public function testShouldDoExpected( $input ) {
 		$this->input = $input;
+
 		add_filter( 'pre_get_rocket_option_remove_unused_css', [ $this, 'set_rucss_option' ] );
 
 		do_action( 'init' );


### PR DESCRIPTION
## Description

Preserve the RUCSS clean rows event if RUCSS option is disabled, to avoid stale data in the database.

Fixes #5076 

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## How Has This Been Tested?

- [x] Automated tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
