### PR TITLE
Fixing the typo in the use declaration

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Admin/Settings.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Settings.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace WP_Rocket\Engine\Optimization\RUCSS\Admin;
 
 use WP_Rocket\Admin\Options_Data;
-use WP_Rocket\ENgine\Admin\Beacon\Beacon;
+use WP_Rocket\Engine\Admin\Beacon\Beacon;
 use WP_Rocket\Engine\Admin\Settings\Settings as AdminSettings;
 
 class Settings {


### PR DESCRIPTION
## Description

Just fixing a typo, from 
` Use WP_Rocket\ENgine\Admin\Beacon\Beacon declaration
`to
` Use WP_Rocket\Engine\Admin\Beacon\Beacon declaration
`
Fixes #5122

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?
No

## How Has This Been Tested?
On my test site



# Checklist:

Please delete the options that are not relevant.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
