### PR TITLE
Fixes #4792: Added a method to remove `et_dynamic_late_assets_generated` action for Divi

### DIFF
--- a/inc/ThirdParty/Themes/Divi.php
+++ b/inc/ThirdParty/Themes/Divi.php
@@ -63,7 +63,8 @@ class Divi implements Subscriber_Interface {
 
 		$events['rocket_exclude_css'] = 'exclude_css_from_combine';
 
-		$events['wp'] = 'disable_dynamic_css_on_rucss';
+		$events['wp']                = 'disable_dynamic_css_on_rucss';
+		$events['after_setup_theme'] = 'remove_assets_generated';
 
 		return $events;
 	}
@@ -212,5 +213,14 @@ class Divi implements Subscriber_Interface {
 		}
 		add_filter( 'et_use_dynamic_css', '__return_false' );
 
+	}
+
+	/**
+	 * Remove dynamic late assets action.
+	 *
+	 * @return void
+	 */
+	public function remove_assets_generated() {
+		remove_all_actions( 'et_dynamic_late_assets_generated' );
 	}
 }

--- a/tests/Fixtures/inc/ThirdParty/Themes/Divi/removeAssetsGenerated.php
+++ b/tests/Fixtures/inc/ThirdParty/Themes/Divi/removeAssetsGenerated.php
@@ -1,0 +1,28 @@
+<?php
+return [
+	'vfs_dir' => 'wp-content/themes/',
+
+	'test_data' => [
+
+		'shouldDisableSettingWhenThemeDivi' => [
+			'config'   => [
+				'stylesheet' => 'divi',
+				'theme-name' => 'Divi',
+				'is-child'   => '',
+				'set-lazy'   => 1,
+			],
+			'expected' => false,
+		],
+
+		'shouldDisableSettingWhenChildThemeDiviParent' => [
+			'config'   => [
+				'stylesheet'  => 'divi-child',
+				'theme-name'  => 'Divi Child',
+				'is-child'    => 'divi',
+				'parent-name' => 'Divi',
+				'set-lazy'    => 1,
+			],
+			'expected' => false,
+		],
+	],
+];

--- a/tests/Integration/inc/ThirdParty/Themes/Divi/removeAssetsGenerated.php
+++ b/tests/Integration/inc/ThirdParty/Themes/Divi/removeAssetsGenerated.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\ThirdParty\Themes\Divi;
+
+use WP_Rocket\Tests\Integration\WPThemeTestcase;
+use WP_Rocket\ThirdParty\Themes\Divi;
+
+/**
+ * @covers \WP_Rocket\ThirdParty\Divi::remove_assets_generated
+ * @uses   ::is_divi
+ *
+ * @group  ThirdParty
+ */
+class Test_RemoveAssetsGenerated extends WPThemeTestcase
+{
+	protected $path_to_test_data = '/inc/ThirdParty/Themes/Divi/removeAssetsGenerated.php';
+
+	private static $container;
+
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		self::$container = apply_filters( 'rocket_container', '' );
+	}
+
+	public static function tear_down_after_class() {
+		parent::tear_down_after_class();
+
+		self::$container->get( 'event_manager' )->remove_subscriber( self::$container->get( 'divi' ) );
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		self::$container->get( 'event_manager' )->add_subscriber( self::$container->get( 'divi' ) );
+	}
+
+	/**
+	 * @dataProvider ProviderTestData
+	 */
+	public function testShouldRemoveCallback( $config, $expected ) {
+		add_action('et_dynamic_late_assets_generated', '__return_true');
+		$this->assertTrue(has_action('et_dynamic_late_assets_generated'));
+		$options     = self::$container->get( 'options' );
+		$options_api = self::$container->get( 'options_api' );
+		$delayjs_html = self::$container->get( 'delay_js_html' );
+		$options_api->set( 'settings', [] );
+
+		$divi        = new Divi( $options_api, $options, $delayjs_html );
+
+		switch_theme( $config['stylesheet'] );
+		$divi->remove_assets_generated();
+		$this->assertSame($expected, has_action('et_dynamic_late_assets_generated'));
+	}
+
+}

--- a/tests/Unit/inc/ThirdParty/Themes/Divi/removeAssetsGenerated.php
+++ b/tests/Unit/inc/ThirdParty/Themes/Divi/removeAssetsGenerated.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Themes\Divi;
+
+use Mockery;
+use WP_Rocket\Admin\Options;
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Engine\Optimization\DelayJS\HTML;
+use WP_Rocket\Tests\Unit\TestCase;
+use WP_Rocket\ThirdParty\Themes\Divi;
+use WP_Theme;
+use Brain\Monkey\Functions;
+
+/**
+ * @covers \WP_Rocket\ThirdParty\Themes\Divi::remove_assets_generated
+ * @uses   \WP_Rocket\ThirdParty\Themes\Divi::is_divi
+ *
+ * @group  ThirdParty
+ */
+class Test_RemoveAssetsGenerated extends TestCase
+{
+	protected $subscriber;
+	protected $options;
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$options_api = Mockery::mock( Options::class );
+		$this->options     = Mockery::mock( Options_Data::class );
+		$delayjs_html     = Mockery::mock( HTML::class );
+		$theme       = new WP_Theme( 'Divi', 'wp-content/themes/' );
+		Functions\when( 'wp_get_theme' )->justReturn( $theme );
+		$this->subscriber = new Divi($options_api, $this->options, $delayjs_html);
+	}
+
+
+	public function testShouldReturnAsExpected() {
+		Functions\expect('remove_all_actions')->with('et_dynamic_late_assets_generated');
+		$this->subscriber->remove_assets_generated();
+	}
+}


### PR DESCRIPTION
## Description

Removed callback from an action in charge of adding dynamic stylesheets for Divi theme.

Fixes #4792 

## Type of change

Please delete options that are not relevant.
- [ ] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

No.

## How Has This Been Tested?

- [x] Automated Tests.
- [x] Local Tests.

# Checklist:

Please delete the options that are not relevant.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
