### PR TITLE
Fixes #5117 Preserve original query string when redirecting

### DIFF
--- a/inc/classes/Buffer/class-cache.php
+++ b/inc/classes/Buffer/class-cache.php
@@ -706,7 +706,7 @@ class Cache extends Abstract_Buffer {
 		}
 
 		// Prepare query string.
-		$query_string = $this->tests->get_query_string();
+		$query_string = $this->tests->get_original_query_string();
 		$query_string = empty( $query_string ) ? '' : '?' . $query_string;
 		$protocol     = $this->tests->is_ssl() ? 'https://' : 'http://';
 

--- a/inc/classes/Buffer/class-tests.php
+++ b/inc/classes/Buffer/class-tests.php
@@ -1123,6 +1123,17 @@ class Tests {
 		return http_build_query( $this->get_query_params() );
 	}
 
+	/**
+	 * Get the original query string
+	 *
+	 * @since  3.11.4
+	 *
+	 * @return string
+	 */
+	public function get_original_query_string() {
+		return http_build_query( $this->get_get() );
+	}
+
 	/** ----------------------------------------------------------------------------------------- */
 	/** PROPERTY GETTERS ======================================================================== */
 	/** ----------------------------------------------------------------------------------------- */


### PR DESCRIPTION
## Description

Preserve the original query string when redirecting depending on the trailing slash.

Fixes #5117

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
