### PR TITLE
By default keep the style tags after applying RUCSS and remove only the content

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -424,7 +424,7 @@ class UsedCSS {
 			 * @param bool $preserve_status Status of preserve.
 			 * @param array $style Full match style tag.
 			 */
-			if ( apply_filters( 'rocket_rucss_preserve_inline_style_tags', false, $style ) ) {
+			if ( apply_filters( 'rocket_rucss_preserve_inline_style_tags', true, $style ) ) {
 				$html = str_replace( $style['content'], '', $html );
 
 				continue;

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Controller/UsedCSS/HTML/filtred.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Controller/UsedCSS/HTML/filtred.php
@@ -2,7 +2,9 @@
 <head>
 	<title>Test</title>
 	<style id="wpr-usedcss">h1{color:red;}</style>
+	<style></style>
 </head>
 <body>
+<style></style>
 </body>
 </html>


### PR DESCRIPTION
## Description

To continue in that: https://github.com/wp-media/wp-rocket/pull/5095#issuecomment-1157402686

I agreed with @piotrbak to change the default value for the filter `rocket_rucss_preserve_inline_style_tags` to be true so by default we will keep all style tags in the page and this will solve this issue: #5064

Fixes #5064

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which improves an existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Is the solution different from the one proposed during the grooming?

Yes

## How Has This Been Tested?

By checking the page source, you will see that all style tags are being preserved and the CSS content only is being removed.

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
