### PR TITLE
Close #5098 - Fixed warning in Image dimensions when loading certain SVG

### DIFF
--- a/inc/Engine/Media/ImageDimensions/ImageDimensions.php
+++ b/inc/Engine/Media/ImageDimensions/ImageDimensions.php
@@ -493,7 +493,7 @@ class ImageDimensions {
 	 * @return array|false
 	 */
 	private function svg_getimagesize( string $filename ) {
-		$svgfile = simplexml_load_file( rawurlencode( $filename ), 'SimpleXMLElement', LIBXML_NOERROR | LIBXML_NOWARNING );
+		$svgfile = simplexml_load_file( rawurlencode( $filename ), 'SimpleXMLElement', rocket_get_constant( 'LIBXML_NOERROR', 32 ) | rocket_get_constant( 'LIBXML_NOWARNING', 64 ) );
 
 		if ( ! $svgfile ) {
 			return false;

--- a/inc/Engine/Media/ImageDimensions/ImageDimensions.php
+++ b/inc/Engine/Media/ImageDimensions/ImageDimensions.php
@@ -493,7 +493,7 @@ class ImageDimensions {
 	 * @return array|false
 	 */
 	private function svg_getimagesize( string $filename ) {
-		$svgfile = simplexml_load_file( rawurlencode( $filename ) );
+		$svgfile = simplexml_load_file( rawurlencode( $filename ), 'SimpleXMLElement', LIBXML_NOERROR | LIBXML_NOWARNING );
 
 		if ( ! $svgfile ) {
 			return false;


### PR DESCRIPTION
## Description

This issue fix a warning that comes from Image Dimensions when loading certain SVG for that we add configuration to ignore warnings on the function loading the SVG.

Fixes #5098

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

No.

## How Has This Been Tested?

- [ ] Manual Test in local 

# Checklist:

Please delete the options that are not relevant.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
