### PR TITLE
Fix fatal error of mod_pagespeed detection code in WP Engine

### DIFF
--- a/inc/ThirdParty/Plugins/ModPagespeed.php
+++ b/inc/ThirdParty/Plugins/ModPagespeed.php
@@ -49,10 +49,12 @@ class ModPagespeed implements Subscriber_Interface {
 	 * @return bool
 	 */
 	private function has_pagespeed(): bool {
-		$apache_module_loaded = apache_mod_loaded( 'mod_pagespeed', false );
+		if ( false === strpos( ini_get( 'disable_functions' ), 'apache_get_modules' ) ) {
+			$apache_module_loaded = apache_mod_loaded( 'mod_pagespeed', false );
 
-		if ( $apache_module_loaded ) {
-			return true;
+			if ( $apache_module_loaded ) {
+				return true;
+			}
 		}
 
 		$home_request = wp_remote_get(


### PR DESCRIPTION
## Description

In our code:

https://github.com/wp-media/wp-rocket/blob/c353a69ebbc941c80a7418b17954cb1bb6c629a7/inc/ThirdParty/Plugins/ModPagespeed.php#L52

we are calling WP Core function called [apache_mod_loaded](https://github.com/WordPress/WordPress/blob/master/wp-includes/functions.php#L5889
) which throws the error because it calls the PHP function `apache_get_modules` that is disabled by WP Engine as stated here:
https://wpengine.com/support/platform-settings/

So this PR will check if `apache_get_modules` is in the disabled functions to make the homepage call directly without calling the WP Core function at all and search for the headers instead.

Fixes #5156

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Is the solution different from the one proposed during the grooming?

No Grooming

## How Has This Been Tested?

Tested it in the customer's staging site.

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
