### PR TITLE
New preload: Fix a problem where the check from the `jetpack_sitemap_uri` function is done too early in the process.

### DIFF
--- a/inc/ThirdParty/Plugins/Jetpack.php
+++ b/inc/ThirdParty/Plugins/Jetpack.php
@@ -36,7 +36,7 @@ class Jetpack implements Subscriber_Interface {
 			return $events;
 		}
 
-		if ( \Jetpack::is_module_active( 'sitemaps' ) && function_exists( 'jetpack_sitemap_uri' ) ) {
+		if ( \Jetpack::is_module_active( 'sitemaps' ) ) {
 			$events['rocket_sitemap_preload_list'] = 'add_jetpack_sitemap';
 		}
 
@@ -50,6 +50,10 @@ class Jetpack implements Subscriber_Interface {
 	 * @return Array Updated Array of sitemaps to preload
 	 */
 	public function add_jetpack_sitemap( $sitemaps ) {
+		if ( ! function_exists( 'jetpack_sitemap_uri' ) ) {
+			return $sitemaps;
+		}
+
 		$sitemaps['jetpack'] = jetpack_sitemap_uri();
 
 		return $sitemaps;


### PR DESCRIPTION
## Description
This PR fix a bug where the check for the function is done too early in the process.
To fix that we moved the check in the callback directly to be sure the function exists at that moment.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] Manual Tests in local
- [ ] Automated tests

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
