### PR TITLE
 Closes #5155 Change class mapping to remove string from Service Providers

### DIFF
--- a/inc/Addon/ServiceProvider.php
+++ b/inc/Addon/ServiceProvider.php
@@ -6,7 +6,7 @@ use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Addon\Sucuri\Subscriber as SucuriSubscriber;
 use WPMedia\Cloudflare\APIClient;
 use WPMedia\Cloudflare\Cloudflare;
-use WPMedia\Cloudflare\Subscriber as SubscriberAlias;
+use WPMedia\Cloudflare\Subscriber as CloudflareSubscriber;
 
 /**
  * Service provider for WP Rocket addons.

--- a/inc/Addon/ServiceProvider.php
+++ b/inc/Addon/ServiceProvider.php
@@ -66,7 +66,7 @@ class ServiceProvider extends AbstractServiceProvider {
 		$this->getContainer()->add( 'cloudflare', Cloudflare::class )
 			->addArgument( $options )
 			->addArgument( $this->getContainer()->get( 'cloudflare_api' ) );
-		$this->getContainer()->share( 'cloudflare_subscriber', SubscriberAlias::class )
+		$this->getContainer()->share( 'cloudflare_subscriber', CloudflareSubscriber::class )
 			->addArgument( $this->getContainer()->get( 'cloudflare' ) )
 			->addArgument( $options )
 			->addArgument( $this->getContainer()->get( 'options_api' ) )

--- a/inc/Addon/ServiceProvider.php
+++ b/inc/Addon/ServiceProvider.php
@@ -3,6 +3,10 @@ namespace WP_Rocket\Addon;
 
 use WP_Rocket\Dependencies\League\Container\ServiceProvider\AbstractServiceProvider;
 use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Addon\Sucuri\Subscriber as SucuriSubscriber;
+use WPMedia\Cloudflare\APIClient;
+use WPMedia\Cloudflare\Cloudflare;
+use WPMedia\Cloudflare\Subscriber as SubscriberAlias;
 
 /**
  * Service provider for WP Rocket addons.
@@ -34,7 +38,7 @@ class ServiceProvider extends AbstractServiceProvider {
 		$options = $this->getContainer()->get( 'options' );
 
 		// Sucuri Addon.
-		$this->getContainer()->share( 'sucuri_subscriber', 'WP_Rocket\Addon\Sucuri\Subscriber' )
+		$this->getContainer()->share( 'sucuri_subscriber', SucuriSubscriber::class )
 			->addArgument( $options )
 			->addTag( 'common_subscriber' );
 
@@ -57,12 +61,12 @@ class ServiceProvider extends AbstractServiceProvider {
 
 		$this->provides[] = 'cloudflare_subscriber';
 
-		$this->getContainer()->add( 'cloudflare_api', 'WPMedia\Cloudflare\APIClient' )
+		$this->getContainer()->add( 'cloudflare_api', APIClient::class )
 			->addArgument( rocket_get_constant( 'WP_ROCKET_VERSION' ) );
-		$this->getContainer()->add( 'cloudflare', 'WPMedia\Cloudflare\Cloudflare' )
+		$this->getContainer()->add( 'cloudflare', Cloudflare::class )
 			->addArgument( $options )
 			->addArgument( $this->getContainer()->get( 'cloudflare_api' ) );
-		$this->getContainer()->share( 'cloudflare_subscriber', 'WPMedia\Cloudflare\Subscriber' )
+		$this->getContainer()->share( 'cloudflare_subscriber', SubscriberAlias::class )
 			->addArgument( $this->getContainer()->get( 'cloudflare' ) )
 			->addArgument( $options )
 			->addArgument( $this->getContainer()->get( 'options_api' ) )

--- a/inc/Addon/Varnish/ServiceProvider.php
+++ b/inc/Addon/Varnish/ServiceProvider.php
@@ -28,8 +28,8 @@ class ServiceProvider extends AbstractServiceProvider {
 	 * @return void
 	 */
 	public function register() {
-		$this->getContainer()->add( 'varnish', 'WP_Rocket\Addon\Varnish\Varnish' );
-		$this->getContainer()->share( 'varnish_subscriber', 'WP_Rocket\Addon\Varnish\Subscriber' )
+		$this->getContainer()->add( 'varnish', Varnish::class );
+		$this->getContainer()->share( 'varnish_subscriber', Subscriber::class )
 			->addArgument( $this->getContainer()->get( 'varnish' ) )
 			->addArgument( $this->getContainer()->get( 'options' ) )
 			->addTag( 'common_subscriber' );

--- a/inc/Engine/Activation/ServiceProvider.php
+++ b/inc/Engine/Activation/ServiceProvider.php
@@ -3,6 +3,9 @@ namespace WP_Rocket\Engine\Activation;
 
 use WP_Rocket\Dependencies\League\Container\ServiceProvider\AbstractServiceProvider;
 use WP_Rocket\Dependencies\League\Container\ServiceProvider\BootableServiceProviderInterface;
+use WP_Rocket\Engine\Cache\AdvancedCache;
+use WP_Rocket\Engine\Cache\WPCache;
+use WP_Rocket\Engine\Capabilities\Manager;
 
 /**
  * Service Provider for the activation process.
@@ -33,7 +36,7 @@ class ServiceProvider extends AbstractServiceProvider implements BootableService
 	 */
 	public function boot() {
 		$this->getContainer()
-			->inflector( 'WP_Rocket\Engine\Activation\ActivationInterface' )
+			->inflector( ActivationInterface::class )
 			->invokeMethod( 'activate', [] );
 	}
 
@@ -43,11 +46,11 @@ class ServiceProvider extends AbstractServiceProvider implements BootableService
 	public function register() {
 		$filesystem = rocket_direct_filesystem();
 
-		$this->getContainer()->add( 'advanced_cache', 'WP_Rocket\Engine\Cache\AdvancedCache' )
+		$this->getContainer()->add( 'advanced_cache', AdvancedCache::class )
 			->addArgument( $this->getContainer()->get( 'template_path' ) . '/cache/' )
 			->addArgument( $filesystem );
-		$this->getContainer()->add( 'capabilities_manager', 'WP_Rocket\Engine\Capabilities\Manager' );
-		$this->getContainer()->add( 'wp_cache', 'WP_Rocket\Engine\Cache\WPCache' )
+		$this->getContainer()->add( 'capabilities_manager', Manager::class );
+		$this->getContainer()->add( 'wp_cache', WPCache::class )
 			->addArgument( $filesystem );
 	}
 }

--- a/inc/Engine/Admin/Beacon/ServiceProvider.php
+++ b/inc/Engine/Admin/Beacon/ServiceProvider.php
@@ -29,7 +29,7 @@ class ServiceProvider extends AbstractServiceProvider {
 	 * @return void
 	 */
 	public function register() {
-		$this->getContainer()->share( 'beacon',  Beacon::class )
+		$this->getContainer()->share( 'beacon', Beacon::class )
 			->addArgument( $this->getContainer()->get( 'options' ) )
 			->addArgument( $this->getContainer()->get( 'template_path' ) . '/settings' )
 			->addArgument( $this->getContainer()->get( 'support_data' ) )

--- a/inc/Engine/Admin/Beacon/ServiceProvider.php
+++ b/inc/Engine/Admin/Beacon/ServiceProvider.php
@@ -29,7 +29,7 @@ class ServiceProvider extends AbstractServiceProvider {
 	 * @return void
 	 */
 	public function register() {
-		$this->getContainer()->share( 'beacon', 'WP_Rocket\Engine\Admin\Beacon\Beacon' )
+		$this->getContainer()->share( 'beacon',  Beacon::class )
 			->addArgument( $this->getContainer()->get( 'options' ) )
 			->addArgument( $this->getContainer()->get( 'template_path' ) . '/settings' )
 			->addArgument( $this->getContainer()->get( 'support_data' ) )

--- a/inc/Engine/Admin/Database/ServiceProvider.php
+++ b/inc/Engine/Admin/Database/ServiceProvider.php
@@ -33,10 +33,10 @@ class ServiceProvider extends AbstractServiceProvider {
 	 * @return void
 	 */
 	public function register() {
-		$this->getContainer()->add( 'db_optimization_process', 'WP_Rocket\Engine\Admin\Database\OptimizationProcess' );
-		$this->getContainer()->add( 'db_optimization', 'WP_Rocket\Engine\Admin\Database\Optimization' )
+		$this->getContainer()->add( 'db_optimization_process', OptimizationProcess::class );
+		$this->getContainer()->add( 'db_optimization', Optimization::class )
 			->addArgument( $this->getContainer()->get( 'db_optimization_process' ) );
-		$this->getContainer()->share( 'db_optimization_subscriber', 'WP_Rocket\Engine\Admin\Database\Subscriber' )
+		$this->getContainer()->share( 'db_optimization_subscriber', Subscriber::class )
 			->addArgument( $this->getContainer()->get( 'db_optimization' ) )
 			->addArgument( $this->getContainer()->get( 'options' ) )
 			->addTag( 'common_subscriber' );

--- a/inc/Engine/Admin/ServiceProvider.php
+++ b/inc/Engine/Admin/ServiceProvider.php
@@ -2,6 +2,9 @@
 namespace WP_Rocket\Engine\Admin;
 
 use WP_Rocket\Dependencies\League\Container\ServiceProvider\AbstractServiceProvider;
+use WP_Rocket\Engine\Admin\Deactivation\DeactivationIntent;
+use WP_Rocket\Engine\Admin\Deactivation\Subscriber;
+use WP_Rocket\ThirdParty\Plugins\Optimization\Hummingbird;
 
 /**
  * Service Provider for admin subscribers.
@@ -33,14 +36,14 @@ class ServiceProvider extends AbstractServiceProvider {
 	public function register() {
 		$options = $this->getContainer()->get( 'options' );
 
-		$this->getContainer()->add( 'deactivation_intent', 'WP_Rocket\Engine\Admin\Deactivation\DeactivationIntent' )
+		$this->getContainer()->add( 'deactivation_intent', DeactivationIntent::class )
 			->addArgument( $this->getContainer()->get( 'template_path' ) . '/deactivation-intent' )
 			->addArgument( $this->getContainer()->get( 'options_api' ) )
 			->addArgument( $options );
-		$this->getContainer()->share( 'deactivation_intent_subscriber', 'WP_Rocket\Engine\Admin\Deactivation\Subscriber' )
+		$this->getContainer()->share( 'deactivation_intent_subscriber', Subscriber::class )
 			->addArgument( $this->getContainer()->get( 'deactivation_intent' ) )
 			->addTag( 'admin_subscriber' );
-		$this->getContainer()->share( 'hummingbird_subscriber', 'WP_Rocket\ThirdParty\Plugins\Optimization\Hummingbird' )
+		$this->getContainer()->share( 'hummingbird_subscriber', Hummingbird::class )
 			->addArgument( $options )
 			->addTag( 'admin_subscriber' );
 

--- a/inc/Engine/Admin/Settings/ServiceProvider.php
+++ b/inc/Engine/Admin/Settings/ServiceProvider.php
@@ -34,18 +34,18 @@ class ServiceProvider extends AbstractServiceProvider {
 	 */
 	public function register() {
 
-		$this->getContainer()->add( 'settings', 'WP_Rocket\Engine\Admin\Settings\Settings' )
+		$this->getContainer()->add( 'settings', Settings::class )
 			->addArgument( $this->getContainer()->get( 'options' ) );
-		$this->getContainer()->add( 'settings_render', 'WP_Rocket\Engine\Admin\Settings\Render' )
+		$this->getContainer()->add( 'settings_render', Render::class )
 			->addArgument( $this->getContainer()->get( 'template_path' ) . '/settings' );
-		$this->getContainer()->add( 'settings_page', 'WP_Rocket\Engine\Admin\Settings\Page' )
+		$this->getContainer()->add( 'settings_page', Page::class )
 			->addArgument( $this->getContainer()->get( 'settings_page_config' ) )
 			->addArgument( $this->getContainer()->get( 'settings' ) )
 			->addArgument( $this->getContainer()->get( 'settings_render' ) )
 			->addArgument( $this->getContainer()->get( 'beacon' ) )
 			->addArgument( $this->getContainer()->get( 'db_optimization' ) )
 			->addArgument( $this->getContainer()->get( 'user_client' ) );
-		$this->getContainer()->share( 'settings_page_subscriber', 'WP_Rocket\Engine\Admin\Settings\Subscriber' )
+		$this->getContainer()->share( 'settings_page_subscriber', Subscriber::class )
 			->addArgument( $this->getContainer()->get( 'settings_page' ) )
 			->addTag( 'admin_subscriber' );
 	}

--- a/inc/Engine/CDN/RocketCDN/ServiceProvider.php
+++ b/inc/Engine/CDN/RocketCDN/ServiceProvider.php
@@ -35,29 +35,29 @@ class ServiceProvider extends AbstractServiceProvider {
 	public function register() {
 		$options = $this->getContainer()->get( 'options' );
 		// RocketCDN API Client.
-		$this->getContainer()->add( 'rocketcdn_api_client', 'WP_Rocket\Engine\CDN\RocketCDN\APIClient' );
+		$this->getContainer()->add( 'rocketcdn_api_client', APIClient::class );
 		// RocketCDN CDN options manager.
-		$this->getContainer()->add( 'rocketcdn_options_manager', 'WP_Rocket\Engine\CDN\RocketCDN\CDNOptionsManager' )
+		$this->getContainer()->add( 'rocketcdn_options_manager', CDNOptionsManager::class )
 			->addArgument( $this->getContainer()->get( 'options_api' ) )
 			->addArgument( $options );
 		// RocketCDN Data manager subscriber.
-		$this->getContainer()->share( 'rocketcdn_data_manager_subscriber', 'WP_Rocket\Engine\CDN\RocketCDN\DataManagerSubscriber' )
+		$this->getContainer()->share( 'rocketcdn_data_manager_subscriber', DataManagerSubscriber::class )
 			->addArgument( $this->getContainer()->get( 'rocketcdn_api_client' ) )
 			->addArgument( $this->getContainer()->get( 'rocketcdn_options_manager' ) )
 			->addTag( 'admin_subscriber' );
 		// RocketCDN REST API Subscriber.
-		$this->getContainer()->share( 'rocketcdn_rest_subscriber', 'WP_Rocket\Engine\CDN\RocketCDN\RESTSubscriber' )
+		$this->getContainer()->share( 'rocketcdn_rest_subscriber', RESTSubscriber::class )
 			->addArgument( $this->getContainer()->get( 'rocketcdn_options_manager' ) )
 			->addArgument( $options )
 			->addTag( 'common_subscriber' );
 		// RocketCDN Notices Subscriber.
-		$this->getContainer()->share( 'rocketcdn_notices_subscriber', 'WP_Rocket\Engine\CDN\RocketCDN\NoticesSubscriber' )
+		$this->getContainer()->share( 'rocketcdn_notices_subscriber', NoticesSubscriber::class )
 			->addArgument( $this->getContainer()->get( 'rocketcdn_api_client' ) )
 			->addArgument( $this->getContainer()->get( 'beacon' ) )
 			->addArgument( __DIR__ . '/views' )
 			->addTag( 'admin_subscriber' );
 		// RocketCDN settings page subscriber.
-		$this->getContainer()->share( 'rocketcdn_admin_subscriber', 'WP_Rocket\Engine\CDN\RocketCDN\AdminPageSubscriber' )
+		$this->getContainer()->share( 'rocketcdn_admin_subscriber', AdminPageSubscriber::class )
 			->addArgument( $this->getContainer()->get( 'rocketcdn_api_client' ) )
 			->addArgument( $options )
 			->addArgument( $this->getContainer()->get( 'beacon' ) )

--- a/inc/Engine/CDN/ServiceProvider.php
+++ b/inc/Engine/CDN/ServiceProvider.php
@@ -31,9 +31,9 @@ class ServiceProvider extends AbstractServiceProvider {
 	public function register() {
 		$options = $this->getContainer()->get( 'options' );
 
-		$this->getContainer()->share( 'cdn', 'WP_Rocket\Engine\CDN\CDN' )
+		$this->getContainer()->share( 'cdn', CDN::class )
 			->addArgument( $options );
-		$this->getContainer()->share( 'cdn_subscriber', 'WP_Rocket\Engine\CDN\Subscriber' )
+		$this->getContainer()->share( 'cdn_subscriber', Subscriber::class )
 			->addArgument( $options )
 			->addArgument( $this->getContainer()->get( 'cdn' ) )
 			->addTag( 'common_subscriber' );

--- a/inc/Engine/Cache/ServiceProvider.php
+++ b/inc/Engine/Cache/ServiceProvider.php
@@ -2,6 +2,8 @@
 namespace WP_Rocket\Engine\Cache;
 
 use WP_Rocket\Dependencies\League\Container\ServiceProvider\AbstractServiceProvider;
+use WP_Rocket\Engine\Cache\PurgeExpired\PurgeExpiredCache;
+use WP_Rocket\Engine\Cache\PurgeExpired\Subscriber;
 
 /**
  * Service Provider for cache subscribers
@@ -38,29 +40,29 @@ class ServiceProvider extends AbstractServiceProvider {
 	public function register() {
 		$filesystem = rocket_direct_filesystem();
 
-		$this->getContainer()->add( 'advanced_cache', 'WP_Rocket\Engine\Cache\AdvancedCache' )
+		$this->getContainer()->add( 'advanced_cache', AdvancedCache::class )
 			->addArgument( $this->getContainer()->get( 'template_path' ) . '/cache/' )
 			->addArgument( $filesystem );
-		$this->getContainer()->add( 'wp_cache', 'WP_Rocket\Engine\Cache\WPCache' )
+		$this->getContainer()->add( 'wp_cache', WPCache::class )
 			->addArgument( $filesystem );
-		$this->getContainer()->add( 'purge', 'WP_Rocket\Engine\Cache\Purge' )
+		$this->getContainer()->add( 'purge', Purge::class )
 			->addArgument( $filesystem );
-		$this->getContainer()->share( 'purge_actions_subscriber', 'WP_Rocket\Engine\Cache\PurgeActionsSubscriber' )
+		$this->getContainer()->share( 'purge_actions_subscriber', PurgeActionsSubscriber::class )
 			->addArgument( $this->getContainer()->get( 'options' ) )
 			->addArgument( $this->getContainer()->get( 'purge' ) )
 			->addTag( 'common_subscriber' );
-		$this->getContainer()->share( 'admin_cache_subscriber', 'WP_Rocket\Engine\Cache\AdminSubscriber' )
+		$this->getContainer()->share( 'admin_cache_subscriber', AdminSubscriber::class )
 			->addArgument( $this->getContainer()->get( 'advanced_cache' ) )
 			->addArgument( $this->getContainer()->get( 'wp_cache' ) )
 			->addTag( 'admin_subscriber' );
 
-		$this->getContainer()->add( 'expired_cache_purge', 'WP_Rocket\Engine\Cache\PurgeExpired\PurgeExpiredCache' )
+		$this->getContainer()->add( 'expired_cache_purge', PurgeExpiredCache::class )
 			->addArgument( rocket_get_constant( 'WP_ROCKET_CACHE_PATH' ) );
-		$this->getContainer()->share( 'expired_cache_purge_subscriber', 'WP_Rocket\Engine\Cache\PurgeExpired\Subscriber' )
+		$this->getContainer()->share( 'expired_cache_purge_subscriber', Subscriber::class )
 			->addArgument( $this->getContainer()->get( 'options' ) )
 			->addArgument( $this->getContainer()->get( 'expired_cache_purge' ) )
 			->addTag( 'common_subscriber' );
-		$this->getContainer()->add( 'cache_config', 'WP_Rocket\Engine\Cache\Config\Subscriber' )
+		$this->getContainer()->add( 'cache_config', Config\Subscriber::class )
 			->addTag( 'common_subscriber' );
 	}
 }

--- a/inc/Engine/Capabilities/ServiceProvider.php
+++ b/inc/Engine/Capabilities/ServiceProvider.php
@@ -30,8 +30,8 @@ class ServiceProvider extends AbstractServiceProvider {
 	 * @return void
 	 */
 	public function register() {
-		$this->getContainer()->add( 'capabilities_manager', 'WP_Rocket\Engine\Capabilities\Manager' );
-		$this->getContainer()->share( 'capabilities_subscriber', 'WP_Rocket\Engine\Capabilities\Subscriber' )
+		$this->getContainer()->add( 'capabilities_manager', Manager::class );
+		$this->getContainer()->share( 'capabilities_subscriber', Subscriber::class )
 			->addArgument( $this->getContainer()->get( 'capabilities_manager' ) )
 			->addTag( 'common_subscriber' );
 	}

--- a/inc/Engine/CriticalPath/ServiceProvider.php
+++ b/inc/Engine/CriticalPath/ServiceProvider.php
@@ -3,6 +3,10 @@
 namespace WP_Rocket\Engine\CriticalPath;
 
 use WP_Rocket\Dependencies\League\Container\ServiceProvider\AbstractServiceProvider;
+use WP_Rocket\Engine\CriticalPath\Admin\Admin;
+use WP_Rocket\Engine\CriticalPath\Admin\Post;
+use WP_Rocket\Engine\CriticalPath\Admin\Settings;
+use WP_Rocket\Engine\CriticalPath\Admin\Subscriber;
 
 /**
  * Service provider for the Critical CSS classes
@@ -47,55 +51,55 @@ class ServiceProvider extends AbstractServiceProvider {
 		$beacon            = $this->getContainer()->get( 'beacon' );
 		$template_path     = $this->getContainer()->get( 'template_path' ) . '/cpcss';
 
-		$this->getContainer()->share( 'cpcss_api_client', 'WP_Rocket\Engine\CriticalPath\APIClient' );
-		$this->getContainer()->share( 'cpcss_data_manager', 'WP_Rocket\Engine\CriticalPath\DataManager' )
+		$this->getContainer()->share( 'cpcss_api_client', APIClient::class );
+		$this->getContainer()->share( 'cpcss_data_manager', DataManager::class )
 			->addArgument( $critical_css_path )
 			->addArgument( $filesystem );
-		$this->getContainer()->share( 'cpcss_service', 'WP_Rocket\Engine\CriticalPath\ProcessorService' )
+		$this->getContainer()->share( 'cpcss_service', ProcessorService::class )
 			->addArgument( $this->getContainer()->get( 'cpcss_data_manager' ) )
 			->addArgument( $this->getContainer()->get( 'cpcss_api_client' ) );
 
 		$processor_service = $this->getContainer()->get( 'cpcss_service' );
 
 		// REST CPCSS START.
-		$this->getContainer()->share( 'rest_cpcss_wp_post', 'WP_Rocket\Engine\CriticalPath\RESTWPPost' )
+		$this->getContainer()->share( 'rest_cpcss_wp_post', RESTWPPost::class )
 			->addArgument( $processor_service )
 			->addArgument( $options );
-		$this->getContainer()->share( 'rest_cpcss_subscriber', 'WP_Rocket\Engine\CriticalPath\RESTCSSSubscriber' )
+		$this->getContainer()->share( 'rest_cpcss_subscriber', RESTCSSSubscriber::class )
 			->addArgument( $this->getContainer()->get( 'rest_cpcss_wp_post' ) )
 			->addTag( 'common_subscriber' );
 		// REST CPCSS END.
 
-		$this->getContainer()->add( 'critical_css_generation', 'WP_Rocket\Engine\CriticalPath\CriticalCSSGeneration' )
+		$this->getContainer()->add( 'critical_css_generation', CriticalCSSGeneration::class )
 			->addArgument( $processor_service );
-		$this->getContainer()->add( 'critical_css', 'WP_Rocket\Engine\CriticalPath\CriticalCSS' )
+		$this->getContainer()->add( 'critical_css', CriticalCSS::class )
 			->addArgument( $this->getContainer()->get( 'critical_css_generation' ) )
 			->addArgument( $options )
 			->addArgument( $filesystem );
 
 		$critical_css = $this->getContainer()->get( 'critical_css' );
 
-		$this->getContainer()->share( 'critical_css_subscriber', 'WP_Rocket\Engine\CriticalPath\CriticalCSSSubscriber' )
+		$this->getContainer()->share( 'critical_css_subscriber', CriticalCSSSubscriber::class )
 			->addArgument( $critical_css )
 			->addArgument( $processor_service )
 			->addArgument( $options )
 			->addArgument( $filesystem )
 			->addTag( 'common_subscriber' );
 
-		$this->getContainer()->add( 'cpcss_post', 'WP_Rocket\Engine\CriticalPath\Admin\Post' )
+		$this->getContainer()->add( 'cpcss_post',  Post::class )
 			->addArgument( $options )
 			->addArgument( $beacon )
 			->addArgument( $critical_css_path )
 			->addArgument( $template_path );
-		$this->getContainer()->add( 'cpcss_settings', 'WP_Rocket\Engine\CriticalPath\Admin\Settings' )
+		$this->getContainer()->add( 'cpcss_settings', Settings::class )
 			->addArgument( $options )
 			->addArgument( $beacon )
 			->addArgument( $critical_css )
 			->addArgument( $template_path );
-		$this->getContainer()->add( 'cpcss_admin', 'WP_Rocket\Engine\CriticalPath\Admin\Admin' )
+		$this->getContainer()->add( 'cpcss_admin', Admin::class )
 			->addArgument( $options )
 			->addArgument( $processor_service );
-		$this->getContainer()->share( 'critical_css_admin_subscriber', 'WP_Rocket\Engine\CriticalPath\Admin\Subscriber' )
+		$this->getContainer()->share( 'critical_css_admin_subscriber', Subscriber::class )
 			->addArgument( $this->getContainer()->get( 'cpcss_post' ) )
 			->addArgument( $this->getContainer()->get( 'cpcss_settings' ) )
 			->addArgument( $this->getContainer()->get( 'cpcss_admin' ) )

--- a/inc/Engine/Deactivation/ServiceProvider.php
+++ b/inc/Engine/Deactivation/ServiceProvider.php
@@ -3,6 +3,9 @@ namespace WP_Rocket\Engine\Deactivation;
 
 use WP_Rocket\Dependencies\League\Container\ServiceProvider\AbstractServiceProvider;
 use WP_Rocket\Dependencies\League\Container\ServiceProvider\BootableServiceProviderInterface;
+use WP_Rocket\Engine\Cache\AdvancedCache;
+use WP_Rocket\Engine\Cache\WPCache;
+use WP_Rocket\Engine\Capabilities\Manager;
 
 /**
  * Service Provider for the activation process.
@@ -33,7 +36,7 @@ class ServiceProvider extends AbstractServiceProvider implements BootableService
 	 */
 	public function boot() {
 		$this->getContainer()
-			->inflector( 'WP_Rocket\Engine\Deactivation\DeactivationInterface' )
+			->inflector( DeactivationInterface::class )
 			->invokeMethod( 'deactivate', [] );
 	}
 
@@ -43,11 +46,11 @@ class ServiceProvider extends AbstractServiceProvider implements BootableService
 	public function register() {
 		$filesystem = rocket_direct_filesystem();
 
-		$this->getContainer()->add( 'advanced_cache', 'WP_Rocket\Engine\Cache\AdvancedCache' )
+		$this->getContainer()->add( 'advanced_cache', AdvancedCache::class )
 			->addArgument( $this->getContainer()->get( 'template_path' ) . '/cache/' )
 			->addArgument( $filesystem );
-		$this->getContainer()->add( 'capabilities_manager', 'WP_Rocket\Engine\Capabilities\Manager' );
-		$this->getContainer()->add( 'wp_cache', 'WP_Rocket\Engine\Cache\WPCache' )
+		$this->getContainer()->add( 'capabilities_manager', Manager::class );
+		$this->getContainer()->add( 'wp_cache', WPCache::class )
 			->addArgument( $filesystem );
 	}
 }

--- a/inc/Engine/HealthCheck/ServiceProvider.php
+++ b/inc/Engine/HealthCheck/ServiceProvider.php
@@ -30,10 +30,10 @@ class ServiceProvider extends AbstractServiceProvider {
 	 * @return void
 	 */
 	public function register() {
-		$this->getContainer()->share( 'health_check', 'WP_Rocket\Engine\HealthCheck\HealthCheck' )
+		$this->getContainer()->share( 'health_check', HealthCheck::class )
 			->addArgument( $this->getContainer()->get( 'options' ) )
 			->addTag( 'admin_subscriber' );
-		$this->getContainer()->share( 'cache_dir_size_check', 'WP_Rocket\Engine\HealthCheck\CacheDirSizeCheck' )
+		$this->getContainer()->share( 'cache_dir_size_check', CacheDirSizeCheck::class )
 			->addArgument( rocket_get_constant( 'WP_ROCKET_MINIFY_CACHE_PATH' ) )
 			->addArgument( rocket_get_constant( 'WP_ROCKET_WEB_MAIN' ) )
 			->addTag( 'common_subscriber' );

--- a/inc/Engine/Heartbeat/ServiceProvider.php
+++ b/inc/Engine/Heartbeat/ServiceProvider.php
@@ -29,7 +29,7 @@ class ServiceProvider extends AbstractServiceProvider {
 	 * @return void
 	 */
 	public function register() {
-		$this->getContainer()->share( 'heartbeat_subscriber', 'WP_Rocket\Engine\Heartbeat\HeartbeatSubscriber' )
+		$this->getContainer()->share( 'heartbeat_subscriber', HeartbeatSubscriber::class )
 			->addArgument( $this->getContainer()->get( 'options' ) )
 			->addTag( 'common_subscriber' );
 	}

--- a/inc/Engine/Media/ServiceProvider.php
+++ b/inc/Engine/Media/ServiceProvider.php
@@ -2,6 +2,15 @@
 namespace WP_Rocket\Engine\Media;
 
 use WP_Rocket\Dependencies\League\Container\ServiceProvider\AbstractServiceProvider;
+use WP_Rocket\Dependencies\RocketLazyload\Assets;
+use WP_Rocket\Dependencies\RocketLazyload\Iframe;
+use WP_Rocket\Dependencies\RocketLazyload\Image;
+use WP_Rocket\Engine\Media\Emojis\EmojisSubscriber;
+use WP_Rocket\Engine\Media\ImageDimensions\AdminSubscriber as ImageDimensionsAdminSubscriber;
+use WP_Rocket\Engine\Media\ImageDimensions\ImageDimensions;
+use WP_Rocket\Engine\Media\ImageDimensions\Subscriber as ImageDimensionsSubscriber;
+use WP_Rocket\Engine\Media\Lazyload\AdminSubscriber as AdminSubscriberAlias;
+use WP_Rocket\Engine\Media\Lazyload\Subscriber;
 
 /**
  * Service provider for Media module
@@ -39,26 +48,26 @@ class ServiceProvider extends AbstractServiceProvider {
 	public function register() {
 		$options = $this->getContainer()->get( 'options' );
 
-		$this->getContainer()->add( 'lazyload_assets', 'WP_Rocket\Dependencies\RocketLazyload\Assets' );
-		$this->getContainer()->add( 'lazyload_image', 'WP_Rocket\Dependencies\RocketLazyload\Image' );
-		$this->getContainer()->add( 'lazyload_iframe', 'WP_Rocket\Dependencies\RocketLazyload\Iframe' );
-		$this->getContainer()->share( 'lazyload_subscriber', 'WP_Rocket\Engine\Media\Lazyload\Subscriber' )
+		$this->getContainer()->add( 'lazyload_assets', Assets::class );
+		$this->getContainer()->add( 'lazyload_image', Image::class );
+		$this->getContainer()->add( 'lazyload_iframe', Iframe::class );
+		$this->getContainer()->share( 'lazyload_subscriber', Subscriber::class )
 			->addArgument( $options )
 			->addArgument( $this->getContainer()->get( 'lazyload_assets' ) )
 			->addArgument( $this->getContainer()->get( 'lazyload_image' ) )
 			->addArgument( $this->getContainer()->get( 'lazyload_iframe' ) )
 			->addTag( 'lazyload_subscriber' );
-		$this->getContainer()->share( 'lazyload_admin_subscriber', 'WP_Rocket\Engine\Media\Lazyload\AdminSubscriber' )
+		$this->getContainer()->share( 'lazyload_admin_subscriber', AdminSubscriberAlias::class )
 			->addTag( 'admin_subscriber' );
-		$this->getContainer()->share( 'emojis_subscriber', 'WP_Rocket\Engine\Media\Emojis\EmojisSubscriber' )
+		$this->getContainer()->share( 'emojis_subscriber', EmojisSubscriber::class )
 			->addArgument( $options )
 			->addTag( 'front_subscriber' );
-		$this->getContainer()->add( 'image_dimensions', 'WP_Rocket\Engine\Media\ImageDimensions\ImageDimensions' )
+		$this->getContainer()->add( 'image_dimensions', ImageDimensions::class )
 			->addArgument( $options );
-		$this->getContainer()->share( 'image_dimensions_subscriber', 'WP_Rocket\Engine\Media\ImageDimensions\Subscriber' )
+		$this->getContainer()->share( 'image_dimensions_subscriber', ImageDimensionsSubscriber::class )
 			->addArgument( $this->getContainer()->get( 'image_dimensions' ) )
 			->addTag( 'front_subscriber' );
-		$this->getContainer()->share( 'image_dimensions_admin_subscriber', 'WP_Rocket\Engine\Media\ImageDimensions\AdminSubscriber' )
+		$this->getContainer()->share( 'image_dimensions_admin_subscriber', ImageDimensionsAdminSubscriber::class )
 			->addArgument( $this->getContainer()->get( 'image_dimensions' ) )
 			->addTag( 'admin_subscriber' );
 	}

--- a/inc/Engine/Media/ServiceProvider.php
+++ b/inc/Engine/Media/ServiceProvider.php
@@ -9,7 +9,7 @@ use WP_Rocket\Engine\Media\Emojis\EmojisSubscriber;
 use WP_Rocket\Engine\Media\ImageDimensions\AdminSubscriber as ImageDimensionsAdminSubscriber;
 use WP_Rocket\Engine\Media\ImageDimensions\ImageDimensions;
 use WP_Rocket\Engine\Media\ImageDimensions\Subscriber as ImageDimensionsSubscriber;
-use WP_Rocket\Engine\Media\Lazyload\AdminSubscriber as AdminSubscriberAlias;
+use WP_Rocket\Engine\Media\Lazyload\AdminSubscriber as LazyloadAdminSubscriber;
 use WP_Rocket\Engine\Media\Lazyload\Subscriber;
 
 /**

--- a/inc/Engine/Media/ServiceProvider.php
+++ b/inc/Engine/Media/ServiceProvider.php
@@ -57,7 +57,7 @@ class ServiceProvider extends AbstractServiceProvider {
 			->addArgument( $this->getContainer()->get( 'lazyload_image' ) )
 			->addArgument( $this->getContainer()->get( 'lazyload_iframe' ) )
 			->addTag( 'lazyload_subscriber' );
-		$this->getContainer()->share( 'lazyload_admin_subscriber', AdminSubscriberAlias::class )
+		$this->getContainer()->share( 'lazyload_admin_subscriber', LazyloadAdminSubscriber::class )
 			->addTag( 'admin_subscriber' );
 		$this->getContainer()->share( 'emojis_subscriber', EmojisSubscriber::class )
 			->addArgument( $options )

--- a/inc/Engine/Optimization/DeferJS/ServiceProvider.php
+++ b/inc/Engine/Optimization/DeferJS/ServiceProvider.php
@@ -31,12 +31,12 @@ class ServiceProvider extends AbstractServiceProvider {
 	 * @return void
 	 */
 	public function register() {
-		$this->getContainer()->add( 'defer_js', 'WP_Rocket\Engine\Optimization\DeferJS\DeferJS' )
+		$this->getContainer()->add( 'defer_js', DeferJS::class )
 			->addArgument( $this->getContainer()->get( 'options' ) );
-		$this->getContainer()->share( 'defer_js_admin_subscriber', 'WP_Rocket\Engine\Optimization\DeferJS\AdminSubscriber' )
+		$this->getContainer()->share( 'defer_js_admin_subscriber', AdminSubscriber::class )
 			->addArgument( $this->getContainer()->get( 'defer_js' ) )
 			->addTag( 'admin_subscriber' );
-		$this->getContainer()->share( 'defer_js_subscriber', 'WP_Rocket\Engine\Optimization\DeferJS\Subscriber' )
+		$this->getContainer()->share( 'defer_js_subscriber', Subscriber::class )
 			->addArgument( $this->getContainer()->get( 'defer_js' ) )
 			->addTag( 'front_subscriber' );
 	}

--- a/inc/Engine/Optimization/DelayJS/ServiceProvider.php
+++ b/inc/Engine/Optimization/DelayJS/ServiceProvider.php
@@ -2,6 +2,8 @@
 namespace WP_Rocket\Engine\Optimization\DelayJS;
 
 use WP_Rocket\Dependencies\League\Container\ServiceProvider\AbstractServiceProvider;
+use WP_Rocket\Engine\Optimization\DelayJS\Admin\Settings;
+use WP_Rocket\Engine\Optimization\DelayJS\Admin\Subscriber as AdminSubscriber;
 
 /**
  * Service provider for the WP Rocket Delay JS
@@ -32,13 +34,13 @@ class ServiceProvider extends AbstractServiceProvider {
 	 * @return void
 	 */
 	public function register() {
-		$this->getContainer()->add( 'delay_js_settings', 'WP_Rocket\Engine\Optimization\DelayJS\Admin\Settings' );
-		$this->getContainer()->share( 'delay_js_admin_subscriber', 'WP_Rocket\Engine\Optimization\DelayJS\Admin\Subscriber' )
+		$this->getContainer()->add( 'delay_js_settings', Settings::class );
+		$this->getContainer()->share( 'delay_js_admin_subscriber', AdminSubscriber::class )
 			->addArgument( $this->getContainer()->get( 'delay_js_settings' ) )
 			->addTag( 'admin_subscriber' );
-		$this->getContainer()->add( 'delay_js_html', 'WP_Rocket\Engine\Optimization\DelayJS\HTML' )
+		$this->getContainer()->add( 'delay_js_html', HTML::class )
 			->addArgument( $this->getContainer()->get( 'options' ) );
-		$this->getContainer()->share( 'delay_js_subscriber', 'WP_Rocket\Engine\Optimization\DelayJS\Subscriber' )
+		$this->getContainer()->share( 'delay_js_subscriber', Subscriber::class )
 			->addArgument( $this->getContainer()->get( 'delay_js_html' ) )
 			->addArgument( rocket_direct_filesystem() )
 			->addArgument( $this->getContainer()->get( 'options' ) )

--- a/inc/Engine/Optimization/RUCSS/ServiceProvider.php
+++ b/inc/Engine/Optimization/RUCSS/ServiceProvider.php
@@ -2,6 +2,19 @@
 namespace WP_Rocket\Engine\Optimization\RUCSS;
 
 use WP_Rocket\Dependencies\League\Container\ServiceProvider\AbstractServiceProvider;
+use WP_Rocket\Engine\Optimization\RUCSS\Admin\Database;
+use WP_Rocket\Engine\Optimization\RUCSS\Admin\Settings;
+use WP_Rocket\Engine\Optimization\RUCSS\Admin\Subscriber as AdminSubscriber;
+use WP_Rocket\Engine\Optimization\RUCSS\Controller\Filesystem;
+use WP_Rocket\Engine\Optimization\RUCSS\Controller\Queue;
+use WP_Rocket\Engine\Optimization\RUCSS\Controller\UsedCSS as UsedCSSController;
+use WP_Rocket\Engine\Optimization\RUCSS\Cron\Subscriber as CronSubscriber;
+use WP_Rocket\Engine\Optimization\RUCSS\Database\Queries\ResourcesQuery;
+use WP_Rocket\Engine\Optimization\RUCSS\Database\Queries\UsedCSS as UsedCSSQuery;
+use WP_Rocket\Engine\Optimization\RUCSS\Database\Tables\Resources as ResourcesTable;
+use WP_Rocket\Engine\Optimization\RUCSS\Database\Tables\UsedCSS as UsedCSSTable;
+use WP_Rocket\Engine\Optimization\RUCSS\Frontend\APIClient;
+use WP_Rocket\Engine\Optimization\RUCSS\Frontend\Subscriber as FrontendSubscriber;
 
 /**
  * Service provider for the WP Rocket RUCSS
@@ -40,25 +53,25 @@ class ServiceProvider extends AbstractServiceProvider {
 	 * @return void
 	 */
 	public function register() {
-		$this->getContainer()->add( 'rucss_settings', 'WP_Rocket\Engine\Optimization\RUCSS\Admin\Settings' )
+		$this->getContainer()->add( 'rucss_settings', Settings::class )
 			->addArgument( $this->getContainer()->get( 'options' ) )
 			->addArgument( $this->getContainer()->get( 'beacon' ) );
 		// Instantiate the RUCSS Resources Table class.
-		$this->getContainer()->add( 'rucss_resources_table', 'WP_Rocket\Engine\Optimization\RUCSS\Database\Tables\Resources' );
-		$this->getContainer()->add( 'rucss_usedcss_table', 'WP_Rocket\Engine\Optimization\RUCSS\Database\Tables\UsedCSS' );
-		$this->getContainer()->add( 'rucss_resources_query', 'WP_Rocket\Engine\Optimization\RUCSS\Database\Queries\ResourcesQuery' );
-		$this->getContainer()->add( 'rucss_database', 'WP_Rocket\Engine\Optimization\RUCSS\Admin\Database' )
+		$this->getContainer()->add( 'rucss_resources_table', ResourcesTable::class );
+		$this->getContainer()->add( 'rucss_usedcss_table', UsedCSSTable::class );
+		$this->getContainer()->add( 'rucss_resources_query', ResourcesQuery::class );
+		$this->getContainer()->add( 'rucss_database', Database::class )
 			->addArgument( $this->getContainer()->get( 'rucss_resources_table' ) )
 			->addArgument( $this->getContainer()->get( 'rucss_usedcss_table' ) );
 
-		$this->getContainer()->add( 'rucss_used_css_query', 'WP_Rocket\Engine\Optimization\RUCSS\Database\Queries\UsedCSS' );
-		$this->getContainer()->add( 'rucss_frontend_api_client', 'WP_Rocket\Engine\Optimization\RUCSS\Frontend\APIClient' )
+		$this->getContainer()->add( 'rucss_used_css_query', UsedCSSQuery::class );
+		$this->getContainer()->add( 'rucss_frontend_api_client', APIClient::class )
 			->addArgument( $this->getContainer()->get( 'options' ) );
-		$this->getContainer()->add( 'rucss_queue', 'WP_Rocket\Engine\Optimization\RUCSS\Controller\Queue' );
-		$this->getContainer()->add( 'rucss_filesystem', 'WP_Rocket\Engine\Optimization\RUCSS\Controller\Filesystem' )
+		$this->getContainer()->add( 'rucss_queue', Queue::class );
+		$this->getContainer()->add( 'rucss_filesystem', Filesystem::class )
 			->addArgument( rocket_get_constant( 'WP_ROCKET_USED_CSS_PATH' ) )
 			->addArgument( rocket_direct_filesystem() );
-		$this->getContainer()->add( 'rucss_used_css_controller', 'WP_Rocket\Engine\Optimization\RUCSS\Controller\UsedCSS' )
+		$this->getContainer()->add( 'rucss_used_css_controller', UsedCSSController::class )
 			->addArgument( $this->getContainer()->get( 'options' ) )
 			->addArgument( $this->getContainer()->get( 'rucss_used_css_query' ) )
 			->addArgument( $this->getContainer()->get( 'rucss_resources_query' ) )
@@ -66,14 +79,14 @@ class ServiceProvider extends AbstractServiceProvider {
 			->addArgument( $this->getContainer()->get( 'rucss_queue' ) )
 			->addArgument( $this->getContainer()->get( 'rucss_filesystem' ) );
 
-		$this->getContainer()->share( 'rucss_admin_subscriber', 'WP_Rocket\Engine\Optimization\RUCSS\Admin\Subscriber' )
+		$this->getContainer()->share( 'rucss_admin_subscriber', AdminSubscriber::class )
 			->addArgument( $this->getContainer()->get( 'rucss_settings' ) )
 			->addArgument( $this->getContainer()->get( 'rucss_database' ) )
 			->addArgument( $this->getContainer()->get( 'rucss_used_css_controller' ) )
 			->addArgument( $this->getContainer()->get( 'rucss_queue' ) );
-		$this->getContainer()->share( 'rucss_frontend_subscriber', 'WP_Rocket\Engine\Optimization\RUCSS\Frontend\Subscriber' )
+		$this->getContainer()->share( 'rucss_frontend_subscriber', FrontendSubscriber::class )
 			->addArgument( $this->getContainer()->get( 'rucss_used_css_controller' ) );
-		$this->getContainer()->share( 'rucss_cron_subscriber', 'WP_Rocket\Engine\Optimization\RUCSS\Cron\Subscriber' )
+		$this->getContainer()->share( 'rucss_cron_subscriber', CronSubscriber::class )
 			->addArgument( $this->getContainer()->get( 'rucss_used_css_controller' ) )
 			->addArgument( $this->getContainer()->get( 'rucss_database' ) );
 	}

--- a/inc/Engine/Optimization/ServiceProvider.php
+++ b/inc/Engine/Optimization/ServiceProvider.php
@@ -1,7 +1,14 @@
 <?php
 namespace WP_Rocket\Engine\Optimization;
 
+use WP_Rocket\Buffer\Config;
+use WP_Rocket\Buffer\Optimization;
+use WP_Rocket\Buffer\Tests;
 use WP_Rocket\Dependencies\League\Container\ServiceProvider\AbstractServiceProvider;
+use WP_Rocket\Engine\Optimization\GoogleFonts\Combine;
+use WP_Rocket\Engine\Optimization\GoogleFonts\CombineV2;
+use WP_Rocket\Engine\Optimization\GoogleFonts\Subscriber;
+use WP_Rocket\Subscriber\Optimization\Buffer_Subscriber;
 
 /**
  * Service provider for the WP Rocket optimizations
@@ -43,36 +50,36 @@ class ServiceProvider extends AbstractServiceProvider {
 		$options    = $this->getContainer()->get( 'options' );
 		$filesystem = rocket_direct_filesystem();
 
-		$this->getContainer()->add( 'config', 'WP_Rocket\Buffer\Config' )
+		$this->getContainer()->add( 'config', Config::class )
 			->addArgument( [ 'config_dir_path' => rocket_get_constant( 'WP_ROCKET_CONFIG_PATH' ) ] );
-		$this->getContainer()->add( 'tests', 'WP_Rocket\Buffer\Tests' )
+		$this->getContainer()->add( 'tests', Tests::class )
 			->addArgument( $this->getContainer()->get( 'config' ) );
-		$this->getContainer()->add( 'buffer_optimization', 'WP_Rocket\Buffer\Optimization' )
+		$this->getContainer()->add( 'buffer_optimization', Optimization::class )
 			->addArgument( $this->getContainer()->get( 'tests' ) );
-		$this->getContainer()->share( 'buffer_subscriber', 'WP_Rocket\Subscriber\Optimization\Buffer_Subscriber' )
+		$this->getContainer()->share( 'buffer_subscriber', Buffer_Subscriber::class )
 			->addArgument( $this->getContainer()->get( 'buffer_optimization' ) )
 			->addTag( 'front_subscriber' );
-		$this->getContainer()->share( 'cache_dynamic_resource', 'WP_Rocket\Engine\Optimization\CacheDynamicResource' )
+		$this->getContainer()->share( 'cache_dynamic_resource', CacheDynamicResource::class )
 			->addArgument( $options )
 			->addArgument( WP_ROCKET_CACHE_BUSTING_PATH )
 			->addArgument( WP_ROCKET_CACHE_BUSTING_URL )
 			->addTag( 'front_subscriber' );
-		$this->getContainer()->add( 'optimize_google_fonts', 'WP_Rocket\Engine\Optimization\GoogleFonts\Combine' );
-		$this->getContainer()->add( 'optimize_google_fonts_v2', 'WP_Rocket\Engine\Optimization\GoogleFonts\CombineV2' );
-		$this->getContainer()->share( 'combine_google_fonts_subscriber', 'WP_Rocket\Engine\Optimization\GoogleFonts\Subscriber' )
+		$this->getContainer()->add( 'optimize_google_fonts', Combine::class );
+		$this->getContainer()->add( 'optimize_google_fonts_v2', CombineV2::class );
+		$this->getContainer()->share( 'combine_google_fonts_subscriber', Subscriber::class )
 			->addArgument( $this->getContainer()->get( 'optimize_google_fonts' ) )
 			->addArgument( $this->getContainer()->get( 'optimize_google_fonts_v2' ) )
 			->addArgument( $options )
 			->addTag( 'front_subscriber' );
-		$this->getContainer()->share( 'minify_css_subscriber', 'WP_Rocket\Engine\Optimization\Minify\CSS\Subscriber' )
+		$this->getContainer()->share( 'minify_css_subscriber', Minify\CSS\Subscriber::class )
 			->addArgument( $options )
 			->addArgument( $filesystem )
 			->addTag( 'front_subscriber' );
-		$this->getContainer()->share( 'minify_js_subscriber', 'WP_Rocket\Engine\Optimization\Minify\JS\Subscriber' )
+		$this->getContainer()->share( 'minify_js_subscriber', Minify\JS\Subscriber::class )
 			->addArgument( $options )
 			->addArgument( $filesystem )
 			->addTag( 'front_subscriber' );
-		$this->getContainer()->share( 'ie_conditionals_subscriber', 'WP_Rocket\Engine\Optimization\IEConditionalSubscriber' )
+		$this->getContainer()->share( 'ie_conditionals_subscriber', IEConditionalSubscriber::class )
 			->addTag( 'front_subscriber' );
 	}
 }

--- a/inc/Engine/Plugin/ServiceProvider.php
+++ b/inc/Engine/Plugin/ServiceProvider.php
@@ -31,7 +31,7 @@ class ServiceProvider extends AbstractServiceProvider {
 	public function register() {
 		$api_url = wp_parse_url( WP_ROCKET_WEB_INFO );
 
-		$this->getContainer()->share( 'plugin_updater_common_subscriber', 'WP_Rocket\Engine\Plugin\UpdaterApiCommonSubscriber' )
+		$this->getContainer()->share( 'plugin_updater_common_subscriber', UpdaterApiCommonSubscriber::class )
 			->addArgument(
 				[
 					'api_host'           => $api_url['host'],
@@ -43,7 +43,7 @@ class ServiceProvider extends AbstractServiceProvider {
 				]
 			)
 			->addTag( 'common_subscriber' );
-		$this->getContainer()->share( 'plugin_information_subscriber', 'WP_Rocket\Engine\Plugin\InformationSubscriber' )
+		$this->getContainer()->share( 'plugin_information_subscriber', InformationSubscriber::class )
 			->addArgument(
 				[
 					'plugin_file' => WP_ROCKET_FILE,
@@ -51,7 +51,7 @@ class ServiceProvider extends AbstractServiceProvider {
 				]
 			)
 			->addTag( 'common_subscriber' );
-		$this->getContainer()->share( 'plugin_updater_subscriber', 'WP_Rocket\Engine\Plugin\UpdaterSubscriber' )
+		$this->getContainer()->share( 'plugin_updater_subscriber', UpdaterSubscriber::class )
 			->addArgument(
 				[
 					'plugin_file'    => WP_ROCKET_FILE,

--- a/inc/Engine/Preload/Links/ServiceProvider.php
+++ b/inc/Engine/Preload/Links/ServiceProvider.php
@@ -29,10 +29,10 @@ class ServiceProvider extends AbstractServiceProvider {
 	public function register() {
 		$options = $this->getContainer()->get( 'options' );
 
-		$this->getContainer()->share( 'preload_links_admin_subscriber', 'WP_Rocket\Engine\Preload\Links\AdminSubscriber' )
+		$this->getContainer()->share( 'preload_links_admin_subscriber', AdminSubscriber::class )
 			->addArgument( $options )
 			->addTag( 'common_subscriber' );
-		$this->getContainer()->share( 'preload_links_subscriber', 'WP_Rocket\Engine\Preload\Links\Subscriber' )
+		$this->getContainer()->share( 'preload_links_subscriber', Subscriber::class )
 			->addArgument( $options )
 			->addArgument( rocket_direct_filesystem() )
 			->addTag( 'common_subscriber' );

--- a/inc/Engine/Preload/ServiceProvider.php
+++ b/inc/Engine/Preload/ServiceProvider.php
@@ -38,31 +38,31 @@ class ServiceProvider extends AbstractServiceProvider {
 	 * @return void
 	 */
 	public function register() {
-		$this->getContainer()->add( 'full_preload_process', 'WP_Rocket\Engine\Preload\FullProcess' );
-		$this->getContainer()->add( 'partial_preload_process', 'WP_Rocket\Engine\Preload\PartialProcess' );
+		$this->getContainer()->add( 'full_preload_process', FullProcess::class );
+		$this->getContainer()->add( 'partial_preload_process', PartialProcess::class );
 
 		$full_preload_process = $this->getContainer()->get( 'full_preload_process' );
-		$this->getContainer()->add( 'homepage_preload', 'WP_Rocket\Engine\Preload\Homepage' )
+		$this->getContainer()->add( 'homepage_preload', Homepage::class )
 			->addArgument( $full_preload_process );
-		$this->getContainer()->add( 'sitemap_preload', 'WP_Rocket\Engine\Preload\Sitemap' )
+		$this->getContainer()->add( 'sitemap_preload', Sitemap::class )
 			->addArgument( $full_preload_process );
 
 		// Subscribers.
 		$options = $this->getContainer()->get( 'options' );
 
-		$this->getContainer()->share( 'preload_subscriber', 'WP_Rocket\Engine\Preload\PreloadSubscriber' )
+		$this->getContainer()->share( 'preload_subscriber', PreloadSubscriber::class )
 			->addArgument( $this->getContainer()->get( 'homepage_preload' ) )
 			->addArgument( $options )
 			->addTag( 'common_subscriber' );
-		$this->getContainer()->share( 'sitemap_preload_subscriber', 'WP_Rocket\Engine\Preload\SitemapPreloadSubscriber' )
+		$this->getContainer()->share( 'sitemap_preload_subscriber', SitemapPreloadSubscriber::class )
 			->addArgument( $this->getContainer()->get( 'sitemap_preload' ) )
 			->addArgument( $options )
 			->addTag( 'common_subscriber' );
-		$this->getContainer()->share( 'partial_preload_subscriber', 'WP_Rocket\Engine\Preload\PartialPreloadSubscriber' )
+		$this->getContainer()->share( 'partial_preload_subscriber', PartialPreloadSubscriber::class )
 			->addArgument( $this->getContainer()->get( 'partial_preload_process' ) )
 			->addArgument( $options )
 			->addTag( 'common_subscriber' );
-		$this->getContainer()->share( 'fonts_preload_subscriber', 'WP_Rocket\Engine\Preload\Fonts' )
+		$this->getContainer()->share( 'fonts_preload_subscriber', Fonts::class )
 			->addArgument( $options )
 			->addArgument( $this->getContainer()->get( 'cdn' ) )
 			->addTag( 'common_subscriber' );

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -129,7 +129,7 @@ class Plugin {
 
 		$this->container->addServiceProvider( AdminDatabaseServiceProvider::class );
 		$this->container->addServiceProvider( SupportServiceProvider::class );
-		$this->container->addServiceProvider( BaconServiceProvider::class );
+		$this->container->addServiceProvider( BeaconServiceProvider::class );
 		$this->container->addServiceProvider( RocketCDNServiceProvider::class );
 		$this->container->addServiceProvider( CacheServiceProvider::class );
 		$this->container->addServiceProvider( CriticalPathServiceProvider::class );

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -9,7 +9,7 @@ use WP_Rocket\Event_Management\Event_Manager;
 use WP_Rocket\ThirdParty\Hostings\HostResolver;
 use WP_Rocket\Addon\ServiceProvider as AddonServiceProvider;
 use WP_Rocket\Addon\Varnish\ServiceProvider as VarnishServiceProvider;
-use WP_Rocket\Engine\Admin\Beacon\ServiceProvider as BaconServiceProvider;
+use WP_Rocket\Engine\Admin\Beacon\ServiceProvider as BeaconServiceProvider;
 use WP_Rocket\Engine\Admin\Database\ServiceProvider as AdminDatabaseServiceProvider;
 use WP_Rocket\Engine\Admin\ServiceProvider as EngineAdminServiceProvider;
 use WP_Rocket\Engine\Admin\Settings\ServiceProvider as SettingsServiceProvider;

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -7,6 +7,34 @@ use WP_Rocket\Dependencies\League\Container\Container;
 use WP_Rocket\Admin\Options;
 use WP_Rocket\Event_Management\Event_Manager;
 use WP_Rocket\ThirdParty\Hostings\HostResolver;
+use WP_Rocket\Addon\ServiceProvider as AddonServiceProvider;
+use WP_Rocket\Addon\Varnish\ServiceProvider as VarnishServiceProvider;
+use WP_Rocket\Engine\Admin\Beacon\ServiceProvider as BaconServiceProvider;
+use WP_Rocket\Engine\Admin\Database\ServiceProvider as AdminDatabaseServiceProvider;
+use WP_Rocket\Engine\Admin\ServiceProvider as EngineAdminServiceProvider;
+use WP_Rocket\Engine\Admin\Settings\ServiceProvider as SettingsServiceProvider;
+use WP_Rocket\Engine\Cache\ServiceProvider as CacheServiceProvider;
+use WP_Rocket\Engine\Capabilities\ServiceProvider as CapabilitiesServiceProvider;
+use WP_Rocket\Engine\CDN\RocketCDN\ServiceProvider as RocketCDNServiceProvider;
+use WP_Rocket\Engine\CDN\ServiceProvider as CDNServiceProvider;
+use WP_Rocket\Engine\CriticalPath\ServiceProvider as CriticalPathServiceProvider;
+use WP_Rocket\Engine\HealthCheck\ServiceProvider as HealthCheckServiceProvider;
+use WP_Rocket\Engine\Heartbeat\ServiceProvider as ServiceProviderAlias;
+use WP_Rocket\Engine\License\ServiceProvider as LicenseServiceProvider;
+use WP_Rocket\Engine\Media\ServiceProvider as MediaServiceProvider;
+use WP_Rocket\Engine\Optimization\AdminServiceProvider as OptimizationAdminServiceProvider;
+use WP_Rocket\Engine\Optimization\DeferJS\ServiceProvider as DeferJSServiceProvider;
+use WP_Rocket\Engine\Optimization\DelayJS\ServiceProvider as DelayJSServiceProvider;
+use WP_Rocket\Engine\Optimization\RUCSS\ServiceProvider as RUCSSServiceProvider;
+use WP_Rocket\Engine\Optimization\ServiceProvider as OptimizationServiceProvider;
+use WP_Rocket\Engine\Plugin\ServiceProvider as PluginServiceProvider;
+use WP_Rocket\Engine\Preload\Links\ServiceProvider as PreloadLinksServiceProvider;
+use WP_Rocket\Engine\Preload\ServiceProvider as PreloadServiceProvider;
+use WP_Rocket\Engine\Support\ServiceProvider as SupportServiceProvider;
+use WP_Rocket\ServiceProvider\Common_Subscribers;
+use WP_Rocket\ServiceProvider\Options as OptionsServiceProvider;
+use WP_Rocket\ThirdParty\Hostings\ServiceProvider as HostingsServiceProvider;
+use WP_Rocket\ThirdParty\ServiceProvider as ThirdPartyServiceProvider;
 
 /**
  * Plugin Manager.
@@ -96,18 +124,18 @@ class Plugin {
 
 		$this->options_api = new Options( 'wp_rocket_' );
 		$this->container->add( 'options_api', $this->options_api );
-		$this->container->addServiceProvider( 'WP_Rocket\ServiceProvider\Options' );
+		$this->container->addServiceProvider( OptionsServiceProvider::class );
 		$this->options = $this->container->get( 'options' );
 
-		$this->container->addServiceProvider( 'WP_Rocket\Engine\Admin\Database\ServiceProvider' );
-		$this->container->addServiceProvider( 'WP_Rocket\Engine\Support\ServiceProvider' );
-		$this->container->addServiceProvider( 'WP_Rocket\Engine\Admin\Beacon\ServiceProvider' );
-		$this->container->addServiceProvider( 'WP_Rocket\Engine\CDN\RocketCDN\ServiceProvider' );
-		$this->container->addServiceProvider( 'WP_Rocket\Engine\Cache\ServiceProvider' );
-		$this->container->addServiceProvider( 'WP_Rocket\Engine\CriticalPath\ServiceProvider' );
-		$this->container->addServiceProvider( 'WP_Rocket\Engine\HealthCheck\ServiceProvider' );
-		$this->container->addServiceProvider( 'WP_Rocket\Engine\Media\ServiceProvider' );
-		$this->container->addServiceProvider( 'WP_Rocket\Engine\Optimization\DeferJS\ServiceProvider' );
+		$this->container->addServiceProvider( AdminDatabaseServiceProvider::class );
+		$this->container->addServiceProvider( SupportServiceProvider::class );
+		$this->container->addServiceProvider( BaconServiceProvider::class );
+		$this->container->addServiceProvider( RocketCDNServiceProvider::class );
+		$this->container->addServiceProvider( CacheServiceProvider::class );
+		$this->container->addServiceProvider( CriticalPathServiceProvider::class );
+		$this->container->addServiceProvider( HealthCheckServiceProvider::class );
+		$this->container->addServiceProvider( MediaServiceProvider::class );
+		$this->container->addServiceProvider( DeferJSServiceProvider::class );
 
 		$this->is_valid_key = rocket_valid_key();
 
@@ -157,10 +185,10 @@ class Plugin {
 				'capability' => 'rocket_manage_options',
 			]
 		);
-		$this->container->addServiceProvider( 'WP_Rocket\Engine\Admin\Settings\ServiceProvider' );
-		$this->container->addServiceProvider( 'WP_Rocket\Engine\Admin\ServiceProvider' );
-		$this->container->addServiceProvider( 'WP_Rocket\Engine\Optimization\AdminServiceProvider' );
-		$this->container->addServiceProvider( 'WP_Rocket\Engine\License\ServiceProvider' );
+		$this->container->addServiceProvider( SettingsServiceProvider::class );
+		$this->container->addServiceProvider( EngineAdminServiceProvider::class );
+		$this->container->addServiceProvider( OptimizationAdminServiceProvider::class );
+		$this->container->addServiceProvider( LicenseServiceProvider::class );
 
 		return [
 			'beacon',
@@ -191,7 +219,7 @@ class Plugin {
 	 * @return array array of subscribers.
 	 */
 	private function init_valid_key_subscribers() {
-		$this->container->addServiceProvider( 'WP_Rocket\Engine\Optimization\ServiceProvider' );
+		$this->container->addServiceProvider( OptimizationServiceProvider::class );
 
 		$subscribers = [
 			'buffer_subscriber',
@@ -222,19 +250,19 @@ class Plugin {
 	 * @return array array of common subscribers.
 	 */
 	private function init_common_subscribers() {
-		$this->container->addServiceProvider( 'WP_Rocket\Engine\Capabilities\ServiceProvider' );
-		$this->container->addServiceProvider( 'WP_Rocket\Addon\ServiceProvider' );
-		$this->container->addServiceProvider( 'WP_Rocket\Addon\Varnish\ServiceProvider' );
-		$this->container->addServiceProvider( 'WP_Rocket\Engine\Preload\ServiceProvider' );
-		$this->container->addServiceProvider( 'WP_Rocket\Engine\Preload\Links\ServiceProvider' );
-		$this->container->addServiceProvider( 'WP_Rocket\Engine\CDN\ServiceProvider' );
-		$this->container->addServiceProvider( 'WP_Rocket\ServiceProvider\Common_Subscribers' );
-		$this->container->addServiceProvider( 'WP_Rocket\ThirdParty\ServiceProvider' );
-		$this->container->addServiceProvider( 'WP_Rocket\ThirdParty\Hostings\ServiceProvider' );
-		$this->container->addServiceProvider( 'WP_Rocket\Engine\Plugin\ServiceProvider' );
-		$this->container->addServiceProvider( 'WP_Rocket\Engine\Optimization\DelayJS\ServiceProvider' );
-		$this->container->addServiceProvider( 'WP_Rocket\Engine\Optimization\RUCSS\ServiceProvider' );
-		$this->container->addServiceProvider( 'WP_Rocket\Engine\Heartbeat\ServiceProvider' );
+		$this->container->addServiceProvider( CapabilitiesServiceProvider::class );
+		$this->container->addServiceProvider( AddonServiceProvider::class );
+		$this->container->addServiceProvider( VarnishServiceProvider::class );
+		$this->container->addServiceProvider( PreloadServiceProvider::class );
+		$this->container->addServiceProvider( PreloadLinksServiceProvider::class );
+		$this->container->addServiceProvider( CDNServiceProvider::class );
+		$this->container->addServiceProvider( Common_Subscribers::class );
+		$this->container->addServiceProvider( ThirdPartyServiceProvider::class );
+		$this->container->addServiceProvider( HostingsServiceProvider::class );
+		$this->container->addServiceProvider( PluginServiceProvider::class );
+		$this->container->addServiceProvider( DelayJSServiceProvider::class );
+		$this->container->addServiceProvider( RUCSSServiceProvider::class );
+		$this->container->addServiceProvider( ServiceProviderAlias::class );
 
 		$common_subscribers = [
 			'cdn_subscriber',

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -262,7 +262,7 @@ class Plugin {
 		$this->container->addServiceProvider( PluginServiceProvider::class );
 		$this->container->addServiceProvider( DelayJSServiceProvider::class );
 		$this->container->addServiceProvider( RUCSSServiceProvider::class );
-		$this->container->addServiceProvider( ServiceProviderAlias::class );
+		$this->container->addServiceProvider( HeartbeatServiceProvider::class );
 
 		$common_subscribers = [
 			'cdn_subscriber',

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -19,7 +19,7 @@ use WP_Rocket\Engine\CDN\RocketCDN\ServiceProvider as RocketCDNServiceProvider;
 use WP_Rocket\Engine\CDN\ServiceProvider as CDNServiceProvider;
 use WP_Rocket\Engine\CriticalPath\ServiceProvider as CriticalPathServiceProvider;
 use WP_Rocket\Engine\HealthCheck\ServiceProvider as HealthCheckServiceProvider;
-use WP_Rocket\Engine\Heartbeat\ServiceProvider as ServiceProviderAlias;
+use WP_Rocket\Engine\Heartbeat\ServiceProvider as HeartbeatServiceProvider;
 use WP_Rocket\Engine\License\ServiceProvider as LicenseServiceProvider;
 use WP_Rocket\Engine\Media\ServiceProvider as MediaServiceProvider;
 use WP_Rocket\Engine\Optimization\AdminServiceProvider as OptimizationAdminServiceProvider;

--- a/inc/ThirdParty/ServiceProvider.php
+++ b/inc/ThirdParty/ServiceProvider.php
@@ -2,6 +2,39 @@
 namespace WP_Rocket\ThirdParty;
 
 use WP_Rocket\Dependencies\League\Container\ServiceProvider\AbstractServiceProvider;
+use WP_Rocket\Subscriber\Third_Party\Plugins\Ecommerce\BigCommerce_Subscriber;
+use WP_Rocket\Subscriber\Third_Party\Plugins\Images\Webp\EWWW_Subscriber;
+use WP_Rocket\Subscriber\Third_Party\Plugins\Images\Webp\Imagify_Subscriber;
+use WP_Rocket\Subscriber\Third_Party\Plugins\Images\Webp\Optimus_Subscriber;
+use WP_Rocket\Subscriber\Third_Party\Plugins\Images\Webp\ShortPixel_Subscriber;
+use WP_Rocket\Subscriber\Third_Party\Plugins\Mobile_Subscriber;
+use WP_Rocket\Subscriber\Third_Party\Plugins\NGG_Subscriber;
+use WP_Rocket\Subscriber\Third_Party\Plugins\SyntaxHighlighter_Subscriber;
+use WP_Rocket\ThirdParty\Plugins\Ads\Adthrive;
+use WP_Rocket\ThirdParty\Plugins\ConvertPlug;
+use WP_Rocket\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber;
+use WP_Rocket\ThirdParty\Plugins\I18n\WPML;
+use WP_Rocket\ThirdParty\Plugins\InlineRelatedPosts;
+use WP_Rocket\ThirdParty\Plugins\ModPagespeed;
+use WP_Rocket\ThirdParty\Plugins\Optimization\AMP;
+use WP_Rocket\ThirdParty\Plugins\Optimization\Autoptimize;
+use WP_Rocket\ThirdParty\Plugins\Optimization\Ezoic;
+use WP_Rocket\ThirdParty\Plugins\Optimization\WPMeteor;
+use WP_Rocket\ThirdParty\Plugins\PageBuilder\BeaverBuilder;
+use WP_Rocket\ThirdParty\Plugins\PageBuilder\Elementor;
+use WP_Rocket\ThirdParty\Plugins\PDFEmbedder;
+use WP_Rocket\ThirdParty\Plugins\PWA;
+use WP_Rocket\ThirdParty\Plugins\RevolutionSlider;
+use WP_Rocket\ThirdParty\Plugins\Security\WordFenceCompatibility;
+use WP_Rocket\ThirdParty\Plugins\SEO\Yoast;
+use WP_Rocket\ThirdParty\Plugins\SimpleCustomCss;
+use WP_Rocket\ThirdParty\Plugins\Smush;
+use WP_Rocket\ThirdParty\Plugins\ThirstyAffiliates;
+use WP_Rocket\ThirdParty\Plugins\UnlimitedElements;
+use WP_Rocket\ThirdParty\Themes\Avada;
+use WP_Rocket\ThirdParty\Themes\Bridge;
+use WP_Rocket\ThirdParty\Themes\Divi;
+use WP_Rocket\ThirdParty\Themes\Flatsome;
 
 /**
  * Service provider for WP Rocket third party compatibility
@@ -64,121 +97,122 @@ class ServiceProvider extends AbstractServiceProvider {
 		$options = $this->getContainer()->get( 'options' );
 
 		$this->getContainer()
-			->share( 'mobile_subscriber', 'WP_Rocket\Subscriber\Third_Party\Plugins\Mobile_Subscriber' )
+			->share( 'mobile_subscriber', Mobile_Subscriber::class )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'elementor_subscriber', 'WP_Rocket\ThirdParty\Plugins\PageBuilder\Elementor' )
+			->share( 'elementor_subscriber', Elementor::class )
 			->addArgument( $options )
 			->addArgument( rocket_direct_filesystem() )
 			->addArgument( $this->getContainer()->get( 'delay_js_html' ) )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'woocommerce_subscriber', 'WP_Rocket\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber' )
+			->share( 'woocommerce_subscriber', WooCommerceSubscriber::class )
 			->addArgument( $this->getContainer()->get( 'delay_js_html' ) )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'syntaxhighlighter_subscriber', 'WP_Rocket\Subscriber\Third_Party\Plugins\SyntaxHighlighter_Subscriber' )
+			->share( 'syntaxhighlighter_subscriber', SyntaxHighlighter_Subscriber::class )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'bridge_subscriber', 'WP_Rocket\ThirdParty\Themes\Bridge' )
+			->share( 'bridge_subscriber', Bridge::class )
 			->addArgument( $options )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'divi', 'WP_Rocket\ThirdParty\Themes\Divi' )
+			->share( 'divi', Divi::class )
 			->addArgument( $this->getContainer()->get( 'options_api' ) )
 			->addArgument( $options )
 			->addArgument( $this->getContainer()->get( 'delay_js_html' ) )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'avada_subscriber', 'WP_Rocket\ThirdParty\Themes\Avada' )
+			->share( 'avada_subscriber', Avada::class )
 			->addArgument( $options )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'ngg_subscriber', 'WP_Rocket\Subscriber\Third_Party\Plugins\NGG_Subscriber' )
+			->share( 'ngg_subscriber', NGG_Subscriber::class )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'smush_subscriber', 'WP_Rocket\ThirdParty\Plugins\Smush' )
+			->share( 'smush_subscriber', Smush::class )
 			->addArgument( $this->getContainer()->get( 'options_api' ) )
 			->addArgument( $this->getContainer()->get( 'options' ) )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'imagify_webp_subscriber', 'WP_Rocket\Subscriber\Third_Party\Plugins\Images\Webp\Imagify_Subscriber' )
+			->share( 'imagify_webp_subscriber', Imagify_Subscriber::class )
 			->addArgument( $options )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'shortpixel_webp_subscriber', 'WP_Rocket\Subscriber\Third_Party\Plugins\Images\Webp\ShortPixel_Subscriber' )
+			->share( 'shortpixel_webp_subscriber', ShortPixel_Subscriber::class )
 			->addArgument( $options )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'ewww_webp_subscriber', 'WP_Rocket\Subscriber\Third_Party\Plugins\Images\Webp\EWWW_Subscriber' )
+			->share( 'ewww_webp_subscriber', EWWW_Subscriber::class )
 			->addArgument( $options )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'optimus_webp_subscriber', 'WP_Rocket\Subscriber\Third_Party\Plugins\Images\Webp\Optimus_Subscriber' )
+			->share( 'optimus_webp_subscriber', Optimus_Subscriber::class )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'bigcommerce_subscriber', 'WP_Rocket\Subscriber\Third_Party\Plugins\Ecommerce\BigCommerce_Subscriber' )
+			->share( 'bigcommerce_subscriber', BigCommerce_Subscriber::class )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'beaverbuilder_subscriber', 'WP_Rocket\ThirdParty\Plugins\PageBuilder\BeaverBuilder' )
+			->share( 'beaverbuilder_subscriber', BeaverBuilder::class )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'amp_subscriber', 'WP_Rocket\ThirdParty\Plugins\Optimization\AMP' )
+			->share( 'amp_subscriber', AMP::class )
 			->addArgument( $options )->addArgument( $this->getContainer()->get( 'cdn_subscriber' ) )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'simple_custom_css', 'WP_Rocket\ThirdParty\Plugins\SimpleCustomCss' )
+			->share( 'simple_custom_css', SimpleCustomCss::class )
 			->addArgument( WP_ROCKET_CACHE_BUSTING_PATH )->addArgument( WP_ROCKET_CACHE_BUSTING_URL )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'pdfembedder', 'WP_Rocket\ThirdParty\Plugins\PDFEmbedder' )
+			->share( 'pdfembedder', PDFEmbedder::class )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'mod_pagespeed', 'WP_Rocket\ThirdParty\Plugins\ModPagespeed' )
+			->share( 'mod_pagespeed', ModPagespeed::class )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'adthrive', 'WP_Rocket\ThirdParty\Plugins\Ads\Adthrive' )
+			->share( 'adthrive', Adthrive::class )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'autoptimize', 'WP_Rocket\ThirdParty\Plugins\Optimization\Autoptimize' )
+			->share( 'autoptimize', Autoptimize::class )
 			->addArgument( $options )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'wp-meteor', 'WP_Rocket\ThirdParty\Plugins\Optimization\WPMeteor' )
+			->share( 'wp-meteor', WPMeteor::class )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'revolution_slider_subscriber', 'WP_Rocket\ThirdParty\Plugins\RevolutionSlider' )
+			->share( 'revolution_slider_subscriber', RevolutionSlider::class )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'wordfence_subscriber', 'WP_Rocket\ThirdParty\Plugins\Security\WordFenceCompatibility' )
+			->share( 'wordfence_subscriber', WordFenceCompatibility::class )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'ezoic', 'WP_Rocket\ThirdParty\Plugins\Optimization\Ezoic' )
+			->share( 'ezoic', Ezoic::class )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'thirstyaffiliates', 'WP_Rocket\ThirdParty\Plugins\ThirstyAffiliates' )
+			->share( 'thirstyaffiliates', ThirstyAffiliates::class )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'pwa', 'WP_Rocket\ThirdParty\Plugins\PWA' )
+			->share( 'pwa', PWA::class )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'yoast_seo', 'WP_Rocket\ThirdParty\Plugins\SEO\Yoast' )
+			->share( 'yoast_seo', Yoast::class )
 			->addArgument( $options )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'flatsome', 'WP_Rocket\ThirdParty\Themes\Flatsome' )
+			->share( 'flatsome', Flatsome::class )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'convertplug', 'WP_Rocket\ThirdParty\Plugins\ConvertPlug' )
+			->share( 'convertplug', ConvertPlug::class )
+			->addTag( 'common_subscriber' );
+
+		$this->getContainer()
+			->share( 'unlimited_elements', UnlimitedElements::class )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'unlimited_elements', 'WP_Rocket\ThirdParty\Plugins\UnlimitedElements' )
+			->share( 'inline_related_posts', InlineRelatedPosts::class )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'inline_related_posts', 'WP_Rocket\ThirdParty\Plugins\InlineRelatedPosts' )
-			->addTag( 'common_subscriber' );
-		$this->getContainer()
-			->share( 'wpml', 'WP_Rocket\ThirdParty\Plugins\I18n\WPML' )
+			->share( 'wpml', WPML::class )
 			->addTag( 'common_subscriber' );
 	}
 }


### PR DESCRIPTION
## Description

Changed mapping to use `::class` instead of string with the class path in every service providers.

Fixes #5155 

## Type of change

- [ ] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

No.

## How Has This Been Tested?

- [ ] Automated Tests

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
