### PR TITLE
Guard RUCSS filter returns against array of null

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -365,6 +365,10 @@ class UsedCSS {
 
 		$external_exclusions = (array) array_map(
 			function ( $item ) {
+				if ( ! is_string( $item ) ) {
+					return $item;
+				}
+
 				return preg_quote( $item, '/' );
 			},
 			/**
@@ -415,6 +419,10 @@ class UsedCSS {
 
 		$inline_atts_exclusions = (array) array_map(
 			function ( $item ) {
+				if ( ! is_string( $item ) ) {
+					return $item;
+				}
+
 				return preg_quote( $item, '/' );
 			},
 			/**
@@ -429,6 +437,10 @@ class UsedCSS {
 
 		$inline_content_exclusions = (array) array_map(
 			function ( $item ) {
+				if ( ! is_string( $item ) ) {
+					return $item;
+				}
+
 				return preg_quote( $item, '/' );
 			},
 			/**

--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -930,7 +930,7 @@ class UsedCSS {
 		$items_array = array_filter( $items, 'is_string' );
 
 		return array_map(
-			function ( $item ) {
+			static function ( $item ) {
 				return preg_quote( $item, '/' );
 			},
 			$items_array

--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -363,20 +363,13 @@ class UsedCSS {
 
 		$preserve_google_font = apply_filters( 'rocket_rucss_preserve_google_font', false );
 
-		$external_exclusions = (array) array_map(
-			function ( $item ) {
-				if ( ! is_string( $item ) ) {
-					return $item;
-				}
-
-				return preg_quote( $item, '/' );
-			},
+		$external_exclusions = $this->validate_array_and_quote(
 			/**
 			 * Filters the array of external exclusions.
 			 *
 			 * @since 3.11.4
 			 *
-			 * @param array $inline_atts_exclusions Array of patterns used to match against the external style tag.
+			 * @param array $external_exclusions Array of patterns used to match against the external style tag.
 			 */
 			(array) apply_filters( 'rocket_rucss_external_exclusions', $this->external_exclusions )
 		);
@@ -417,14 +410,7 @@ class UsedCSS {
 			$clean_html
 		);
 
-		$inline_atts_exclusions = (array) array_map(
-			function ( $item ) {
-				if ( ! is_string( $item ) ) {
-					return $item;
-				}
-
-				return preg_quote( $item, '/' );
-			},
+		$inline_atts_exclusions = $this->validate_array_and_quote(
 			/**
 			 * Filters the array of inline CSS attributes patterns to preserve
 			 *
@@ -435,14 +421,7 @@ class UsedCSS {
 			apply_filters( 'rocket_rucss_inline_atts_exclusions', $this->inline_atts_exclusions )
 		);
 
-		$inline_content_exclusions = (array) array_map(
-			function ( $item ) {
-				if ( ! is_string( $item ) ) {
-					return $item;
-				}
-
-				return preg_quote( $item, '/' );
-			},
+		$inline_content_exclusions = $this->validate_array_and_quote(
 			/**
 			 * Filters the array of inline CSS content patterns to preserve
 			 *
@@ -939,4 +918,23 @@ class UsedCSS {
 			]
 		);
 	}
+
+	/**
+	 * Validate the items in array to be strings only and preg_quote them.
+	 *
+	 * @param array $items Array to be validated and quoted.
+	 *
+	 * @return array|string[]
+	 */
+	private function validate_array_and_quote( array $items ) {
+		$items_array = array_filter( $items, 'is_string' );
+
+		return array_map(
+			function ( $item ) {
+				return preg_quote( $item, '/' );
+			},
+			$items_array
+		);
+	}
+
 }


### PR DESCRIPTION
## Description

Guarding RUCSS `preg_quote` first argument in three places against being not string.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Is the solution different from the one proposed during the grooming?

Not groomed, just got a warning from @Mai-Saad that this may return fatal errors.

## How Has This Been Tested?

```
add_filter( 'rocket_rucss_external_exclusions', function ( $exclusions ){
        $exclusions[] = null;
	return $exclusions;
} );
```

OR

```
add_filter( 'rocket_rucss_inline_atts_exclusions', function ( $exclusions ){
        $exclusions[] = null;
	return $exclusions;
} );
```

OR

```
add_filter( 'rocket_rucss_inline_content_exclusions', function ( $exclusions ){
        $exclusions[] = null;
	return $exclusions;
} );
```

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
