### PR TITLE
Closes #5169 - Hide related RUCSS notices on denied folder permission

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Admin/Settings.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Settings.php
@@ -181,7 +181,7 @@ class Settings {
 	 * @return void
 	 */
 	public function display_processing_notice() {
-		if ( ! rocket_direct_filesystem()->is_writable( WP_ROCKET_CACHE_PATH ) ) {
+		if ( ! rocket_direct_filesystem()->is_writable( rocket_get_constant( 'WP_ROCKET_CACHE_PATH' ) ) ) {
 			return;
 		}
 
@@ -227,7 +227,7 @@ class Settings {
 	 * @return void
 	 */
 	public function display_success_notice() {
-		if ( ! rocket_direct_filesystem()->is_writable( WP_ROCKET_CACHE_PATH ) ) {
+		if ( ! rocket_direct_filesystem()->is_writable( rocket_get_constant( 'WP_ROCKET_CACHE_PATH' ) ) ) {
 			return;
 		}
 

--- a/inc/Engine/Optimization/RUCSS/Admin/Settings.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Settings.php
@@ -181,10 +181,6 @@ class Settings {
 	 * @return void
 	 */
 	public function display_processing_notice() {
-		if ( ! rocket_direct_filesystem()->is_writable( rocket_get_constant( 'WP_ROCKET_CACHE_PATH' ) ) ) {
-			return;
-		}
-
 		if ( ! $this->can_display_notice() ) {
 			return;
 		}
@@ -227,10 +223,6 @@ class Settings {
 	 * @return void
 	 */
 	public function display_success_notice() {
-		if ( ! rocket_direct_filesystem()->is_writable( rocket_get_constant( 'WP_ROCKET_CACHE_PATH' ) ) ) {
-			return;
-		}
-
 		if ( ! $this->can_display_notice() ) {
 			return;
 		}
@@ -322,6 +314,10 @@ class Settings {
 	 */
 	private function can_display_notice( $check_enabled = true ): bool {
 		$screen = get_current_screen();
+
+		if ( ! rocket_direct_filesystem()->is_writable( rocket_get_constant( 'WP_ROCKET_CACHE_PATH' ) ) ) {
+			return false;
+		}
 
 		if (
 			isset( $screen->id )

--- a/inc/Engine/Optimization/RUCSS/Admin/Settings.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Settings.php
@@ -181,6 +181,10 @@ class Settings {
 	 * @return void
 	 */
 	public function display_processing_notice() {
+		if ( ! rocket_direct_filesystem()->is_writable( WP_ROCKET_CACHE_PATH ) ) {
+			return;
+		}
+
 		if ( ! $this->can_display_notice() ) {
 			return;
 		}
@@ -223,6 +227,10 @@ class Settings {
 	 * @return void
 	 */
 	public function display_success_notice() {
+		if ( ! rocket_direct_filesystem()->is_writable( WP_ROCKET_CACHE_PATH ) ) {
+			return;
+		}
+
 		if ( ! $this->can_display_notice() ) {
 			return;
 		}

--- a/inc/Engine/Optimization/RUCSS/Admin/Settings.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Settings.php
@@ -315,7 +315,7 @@ class Settings {
 	private function can_display_notice( $check_enabled = true ): bool {
 		$screen = get_current_screen();
 
-		if ( ! rocket_direct_filesystem()->is_writable( rocket_get_constant( 'WP_ROCKET_CACHE_PATH' ) ) ) {
+		if ( ! rocket_direct_filesystem()->is_writable( rocket_get_constant( 'WP_ROCKET_USED_CSS_PATH' ) ) ) {
 			return false;
 		}
 

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Settings/displayProcessingNotice.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Settings/displayProcessingNotice.php
@@ -1,70 +1,74 @@
 <?php
 
 return [
-	'shouldDoNothingWhenNotWPRSettingsPage' => [
-		'config' => [
-			'current_screen'    => (object) [
-				'id' => 'dashboard',
+	'vfs_dir' => 'wp-content/',
+
+	'test_data' => [
+		'shouldDoNothingWhenNotWPRSettingsPage' => [
+			'config' => [
+				'current_screen'    => (object) [
+					'id' => 'dashboard',
+				],
+				'capability'        => true,
+				'remove_unused_css' => 1,
+				'transient'         => false,
 			],
-			'capability'        => true,
-			'remove_unused_css' => 1,
-			'transient'         => false,
+			'expected' => false,
 		],
-		'expected' => false,
-	],
-	'shouldDoNothingWhenNoCapability' => [
-		'config' => [
-			'current_screen'    => (object) [
-				'id' => 'settings_page_wprocket',
+		'shouldDoNothingWhenNoCapability' => [
+			'config' => [
+				'current_screen'    => (object) [
+					'id' => 'settings_page_wprocket',
+				],
+				'capability'        => false,
+				'remove_unused_css' => 1,
+				'transient'         => false,
 			],
-			'capability'        => false,
-			'remove_unused_css' => 1,
-			'transient'         => false,
+			'expected' => false,
 		],
-		'expected' => false,
-	],
-	'shouldDoNothingWhenRUCSSDisabled' => [
-		'config' => [
-			'current_screen'    => (object) [
-				'id' => 'settings_page_wprocket',
+		'shouldDoNothingWhenRUCSSDisabled' => [
+			'config' => [
+				'current_screen'    => (object) [
+					'id' => 'settings_page_wprocket',
+				],
+				'capability'        => true,
+				'remove_unused_css' => 0,
+				'transient'         => false,
 			],
-			'capability'        => true,
-			'remove_unused_css' => 0,
-			'transient'         => false,
+			'expected' => false,
 		],
-		'expected' => false,
-	],
-	'shouldDoNothingWhenTransientTimeLessThanCurrentTime' => [
-		'config' => [
-			'current_screen'    => (object) [
-				'id' => 'settings_page_wprocket',
+		'shouldDoNothingWhenTransientTimeLessThanCurrentTime' => [
+			'config' => [
+				'current_screen'    => (object) [
+					'id' => 'settings_page_wprocket',
+				],
+				'capability'        => true,
+				'remove_unused_css' => 1,
+				'transient'         => time() - 60,
 			],
-			'capability'        => true,
-			'remove_unused_css' => 1,
-			'transient'         => time() - 60,
+			'expected' => false,
 		],
-		'expected' => false,
-	],
-	'shouldDoNothingWhenNoTransient' => [
-		'config' => [
-			'current_screen'    => (object) [
-				'id' => 'settings_page_wprocket',
+		'shouldDoNothingWhenNoTransient' => [
+			'config' => [
+				'current_screen'    => (object) [
+					'id' => 'settings_page_wprocket',
+				],
+				'capability'        => true,
+				'remove_unused_css' => 1,
+				'transient'         => false,
 			],
-			'capability'        => true,
-			'remove_unused_css' => 1,
-			'transient'         => false,
+			'expected' => false,
 		],
-		'expected' => false,
-	],
-	'shouldShowNoticeWhenTransient' => [
-		'config' => [
-			'current_screen'    => (object) [
-				'id' => 'settings_page_wprocket',
+		'shouldShowNoticeWhenTransient' => [
+			'config' => [
+				'current_screen'    => (object) [
+					'id' => 'settings_page_wprocket',
+				],
+				'capability'        => true,
+				'remove_unused_css' => 1,
+				'transient'         => time() + 3600,
 			],
-			'capability'        => true,
-			'remove_unused_css' => 1,
-			'transient'         => time() + 3600,
+			'expected' => true,
 		],
-		'expected' => true,
 	],
 ];

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Settings/displaySuccessNotice.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Settings/displaySuccessNotice.php
@@ -1,96 +1,100 @@
 <?php
 
 return [
-	'shouldDoNothingWhenNotWPRSettingsPage' => [
-		'config' => [
-			'current_screen'    => (object) [
-				'id' => 'dashboard',
+	'vfs_dir' => 'wp-content/',
+
+	'test_data' => [
+		'shouldDoNothingWhenNotWPRSettingsPage' => [
+			'config' => [
+				'current_screen'    => (object) [
+					'id' => 'dashboard',
+				],
+				'capability'        => true,
+				'boxes'             => [],
+				'remove_unused_css' => 1,
+				'manual_preload'    => 1,
+				'transient'         => false,
 			],
-			'capability'        => true,
-			'boxes'             => [],
-			'remove_unused_css' => 1,
-			'manual_preload'    => 1,
-			'transient'         => false,
+			'expected' => false,
 		],
-		'expected' => false,
-	],
-	'shouldDoNothingWhenNoCapability' => [
-		'config' => [
-			'current_screen'    => (object) [
-				'id' => 'settings_page_wprocket',
+		'shouldDoNothingWhenNoCapability' => [
+			'config' => [
+				'current_screen'    => (object) [
+					'id' => 'settings_page_wprocket',
+				],
+				'capability'        => false,
+				'boxes'             => [],
+				'remove_unused_css' => 1,
+				'manual_preload'    => 1,
+				'transient'         => false,
 			],
-			'capability'        => false,
-			'boxes'             => [],
-			'remove_unused_css' => 1,
-			'manual_preload'    => 1,
-			'transient'         => false,
+			'expected' => false,
 		],
-		'expected' => false,
-	],
-	'shouldDoNothingWhenRUCSSDisabled' => [
-		'config' => [
-			'current_screen'    => (object) [
-				'id' => 'settings_page_wprocket',
+		'shouldDoNothingWhenRUCSSDisabled' => [
+			'config' => [
+				'current_screen'    => (object) [
+					'id' => 'settings_page_wprocket',
+				],
+				'capability'        => true,
+				'boxes'             => [],
+				'remove_unused_css' => 0,
+				'manual_preload'    => 1,
+				'transient'         => false,
 			],
-			'capability'        => true,
-			'boxes'             => [],
-			'remove_unused_css' => 0,
-			'manual_preload'    => 1,
-			'transient'         => false,
+			'expected' => false,
 		],
-		'expected' => false,
-	],
-	'shouldDoNothingWhenNoticeDismissed' => [
-		'config' => [
-			'current_screen'    => (object) [
-				'id' => 'settings_page_wprocket',
+		'shouldDoNothingWhenNoticeDismissed' => [
+			'config' => [
+				'current_screen'    => (object) [
+					'id' => 'settings_page_wprocket',
+				],
+				'capability'        => true,
+				'boxes'             => [
+					'rucss_success_notice',
+				],
+				'remove_unused_css' => 1,
+				'manual_preload'    => 1,
+				'transient'         => false,
 			],
-			'capability'        => true,
-			'boxes'             => [
-				'rucss_success_notice',
+			'expected' => false,
+		],
+		'shouldHideNoticeWhenTransient' => [
+			'config' => [
+				'current_screen'    => (object) [
+					'id' => 'settings_page_wprocket',
+				],
+				'capability'        => true,
+				'boxes'             => [],
+				'remove_unused_css' => 1,
+				'manual_preload'    => 0,
+				'transient'         => time(),
 			],
-			'remove_unused_css' => 1,
-			'manual_preload'    => 1,
-			'transient'         => false,
-		],
-		'expected' => false,
-	],
-	'shouldHideNoticeWhenTransient' => [
-		'config' => [
-			'current_screen'    => (object) [
-				'id' => 'settings_page_wprocket',
+			'expected' => [
+				'message'     => '<strong>WP Rocket</strong>: The Used CSS of your homepage has been processed. WP Rocket will continue to generate Used CSS for up to 100 URLs per 60 second(s). We suggest enabling <a href="#preload">Sitemap Preload</a> for the fastest results.<br>To learn more about the process check our <a href="http://example.org" data-beacon-article="123" rel="noopener noreferrer" target="_blank">documentation</a>.',
+				'dismissible' => 'hidden',
+				'id'          => 'rocket-notice-rucss-success',
+				'dismiss_button' => 'rucss_success_notice',
+				'dismiss_button_class' => 'button-primary',
 			],
-			'capability'        => true,
-			'boxes'             => [],
-			'remove_unused_css' => 1,
-			'manual_preload'    => 0,
-			'transient'         => time(),
 		],
-		'expected' => [
-			'message'     => '<strong>WP Rocket</strong>: The Used CSS of your homepage has been processed. WP Rocket will continue to generate Used CSS for up to 100 URLs per 60 second(s). We suggest enabling <a href="#preload">Sitemap Preload</a> for the fastest results.<br>To learn more about the process check our <a href="http://example.org" data-beacon-article="123" rel="noopener noreferrer" target="_blank">documentation</a>.',
-			'dismissible' => 'hidden',
-			'id'          => 'rocket-notice-rucss-success',
-			'dismiss_button' => 'rucss_success_notice',
-			'dismiss_button_class' => 'button-primary',
-		],
-	],
-	'shouldShowNoticeWhenNoTransient' => [
-		'config' => [
-			'current_screen'    => (object) [
-				'id' => 'settings_page_wprocket',
+		'shouldShowNoticeWhenNoTransient' => [
+			'config' => [
+				'current_screen'    => (object) [
+					'id' => 'settings_page_wprocket',
+				],
+				'capability'        => true,
+				'boxes'             => [],
+				'remove_unused_css' => 1,
+				'manual_preload'    => 0,
+				'transient'         => false,
 			],
-			'capability'        => true,
-			'boxes'             => [],
-			'remove_unused_css' => 1,
-			'manual_preload'    => 0,
-			'transient'         => false,
-		],
-		'expected' => [
-			'message'     => '<strong>WP Rocket</strong>: The Used CSS of your homepage has been processed. WP Rocket will continue to generate Used CSS for up to 100 URLs per 60 second(s). We suggest enabling <a href="#preload">Sitemap Preload</a> for the fastest results.<br>To learn more about the process check our <a href="http://example.org" data-beacon-article="123" rel="noopener noreferrer" target="_blank">documentation</a>.',
-			'dismissible' => '',
-			'id'          => 'rocket-notice-rucss-success',
-			'dismiss_button' => 'rucss_success_notice',
-			'dismiss_button_class' => 'button-primary',
+			'expected' => [
+				'message'     => '<strong>WP Rocket</strong>: The Used CSS of your homepage has been processed. WP Rocket will continue to generate Used CSS for up to 100 URLs per 60 second(s). We suggest enabling <a href="#preload">Sitemap Preload</a> for the fastest results.<br>To learn more about the process check our <a href="http://example.org" data-beacon-article="123" rel="noopener noreferrer" target="_blank">documentation</a>.',
+				'dismissible' => '',
+				'id'          => 'rocket-notice-rucss-success',
+				'dismiss_button' => 'rucss_success_notice',
+				'dismiss_button_class' => 'button-primary',
+			],
 		],
 	],
 ];

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Settings/displayProcessingNotice.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Settings/displayProcessingNotice.php
@@ -7,14 +7,16 @@ use Mockery;
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\Admin\Beacon\Beacon;
 use WP_Rocket\Engine\Optimization\RUCSS\Admin\Settings;
-use WP_Rocket\Tests\Unit\TestCase;
+use WP_Rocket\Tests\Unit\FilesystemTestCase;
 
 /**
  * @covers \WP_Rocket\Engine\Optimization\RUCSS\Admin\Settings::display_processing_notice
  *
  * @group  RUCSS
  */
-class Test_DisplayProcessingNotice extends TestCase {
+class Test_DisplayProcessingNotice extends FilesystemTestCase {
+	protected $path_to_test_data = '/inc/Engine/Optimization/RUCSS/Admin/Settings/displayProcessingNotice.php';
+
 	private $options;
 	private $settings;
 
@@ -28,9 +30,10 @@ class Test_DisplayProcessingNotice extends TestCase {
 	}
 
 	/**
-	 * @dataProvider configTestData
+	 * @dataProvider providerTestData
 	 */
 	public function testShouldDoExpected( $config, $expected ) {
+		
 		Functions\when( 'get_current_screen' )->justReturn( $config['current_screen'] );
 		Functions\when( 'current_user_can' )->justReturn( $config['capability'] );
 
@@ -47,6 +50,7 @@ class Test_DisplayProcessingNotice extends TestCase {
 			Functions\expect( 'rocket_notice_html' )->never();
 		}
 
+		$this->assertTrue( $this->filesystem->is_writable( rocket_get_constant( 'WP_ROCKET_CACHE_PATH' ) ) );
 
 		$this->settings->display_processing_notice();
 	}

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Settings/displayProcessingNotice.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Settings/displayProcessingNotice.php
@@ -50,7 +50,7 @@ class Test_DisplayProcessingNotice extends FilesystemTestCase {
 			Functions\expect( 'rocket_notice_html' )->never();
 		}
 
-		$this->assertTrue( $this->filesystem->is_writable( rocket_get_constant( 'WP_ROCKET_CACHE_PATH' ) ) );
+		$this->assertTrue( $this->filesystem->is_writable( rocket_get_constant( 'WP_ROCKET_USED_CSS_PATH' ) ) );
 
 		$this->settings->display_processing_notice();
 	}

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Settings/displaySuccessNotice.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Settings/displaySuccessNotice.php
@@ -68,7 +68,7 @@ class Test_DisplaySuccessNotice extends FilesystemTestCase {
 			Functions\expect( 'rocket_notice_html' )->never();
 		}
 
-		$this->assertTrue( $this->filesystem->is_writable( rocket_get_constant( 'WP_ROCKET_CACHE_PATH' ) ) );
+		$this->assertTrue( $this->filesystem->is_writable( rocket_get_constant( 'WP_ROCKET_USED_CSS_PATH' ) ) );
 
 		$this->settings->display_success_notice();
 	}

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Settings/displaySuccessNotice.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Settings/displaySuccessNotice.php
@@ -7,14 +7,16 @@ use Mockery;
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\Admin\Beacon\Beacon;
 use WP_Rocket\Engine\Optimization\RUCSS\Admin\Settings;
-use WP_Rocket\Tests\Unit\TestCase;
+use WP_Rocket\Tests\Unit\FilesystemTestCase;
 
 /**
  * @covers \WP_Rocket\Engine\Optimization\RUCSS\Admin\Settings::display_success_notice
  *
  * @group  RUCSS
  */
-class Test_DisplaySuccessNotice extends TestCase {
+class Test_DisplaySuccessNotice extends FilesystemTestCase {
+	protected $path_to_test_data = '/inc/Engine/Optimization/RUCSS/Admin/Settings/displaySuccessNotice.php';
+
 	private $options;
 	private $beacon;
 	private $settings;
@@ -31,7 +33,7 @@ class Test_DisplaySuccessNotice extends TestCase {
 	}
 
 	/**
-	 * @dataProvider configTestData
+	 * @dataProvider providerTestData
 	 */
 	public function testShouldDoExpected( $config, $expected ) {
 		Functions\when( 'get_current_screen' )->justReturn( $config['current_screen'] );
@@ -66,6 +68,7 @@ class Test_DisplaySuccessNotice extends TestCase {
 			Functions\expect( 'rocket_notice_html' )->never();
 		}
 
+		$this->assertTrue( $this->filesystem->is_writable( rocket_get_constant( 'WP_ROCKET_CACHE_PATH' ) ) );
 
 		$this->settings->display_success_notice();
 	}


### PR DESCRIPTION
## Description

This PR removes the related RUCSS notices when we have a denied permission on the `cache` folder.

Fixes #5169 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
