### PR TITLE
Update #5027 add new Geo Maps plugin exclusion

### DIFF
--- a/inc/Engine/Optimization/Minify/JS/Combine.php
+++ b/inc/Engine/Optimization/Minify/JS/Combine.php
@@ -718,6 +718,7 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 			'urls_polylangREPLACETOID',
 			'e.setAttribute(\'unselectable\',on);',
 			'try{Typekit.load',
+			'iMapsData',
 		];
 
 		$excluded_inline = array_merge( $defaults, $this->options->get( 'exclude_inline_js', [] ) );


### PR DESCRIPTION
Update Geo Maps plugin exclusions based on new errors findings by QA team:
https://github.com/wp-media/wp-rocket/pull/5027#issuecomment-1160427356

Fixes #5026

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)


# Checklist:

Please delete the options that are not relevant.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
