### PR TITLE
New preload: Removed `wpr-isParent` class that added a useless margin on the configs

### DIFF
--- a/inc/Engine/Admin/Settings/Page.php
+++ b/inc/Engine/Admin/Settings/Page.php
@@ -1166,9 +1166,7 @@ class Page {
 					'section'           => 'preload_section',
 					'page'              => 'preload',
 					'default'           => 1,
-					'container_class'   => [
-						'wpr-isParent',
-					],
+					'container_class'   => [],
 					'sanitize_callback' => 'sanitize_checkbox',
 				],
 				'dns_prefetch'   => [


### PR DESCRIPTION
## Description
Removed a CSS class to remove an unnecessary margin.

## Type of change


- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] Local Test env

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
