### PR TITLE
Fixes #5168 Set is_from_one_dot_com index in case license data is not available

### DIFF
--- a/inc/Engine/Admin/Settings/Page.php
+++ b/inc/Engine/Admin/Settings/Page.php
@@ -244,9 +244,10 @@ class Page {
 	public function customer_data() {
 		$user = $this->user_client->get_user_data();
 		$data = [
-			'license_type'       => __( 'Unavailable', 'rocket' ),
-			'license_expiration' => __( 'Unavailable', 'rocket' ),
-			'license_class'      => 'wpr-isInvalid',
+			'license_type'        => __( 'Unavailable', 'rocket' ),
+			'license_expiration'  => __( 'Unavailable', 'rocket' ),
+			'license_class'       => 'wpr-isInvalid',
+			'is_from_one_dot_com' => false,
 		];
 
 		if (


### PR DESCRIPTION
## Description

Prevent a PHP notice related to an undefined index `is_from_one_dot_com` if the license data is unavailable

Fixes #5168

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
