### PR TITLE
Change RUCSS to Remove Unused CSS in CRON interval name

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Cron/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Cron/Subscriber.php
@@ -142,7 +142,7 @@ class Subscriber implements Subscriber_Interface {
 
 		$schedules['rocket_rucss_pending_jobs'] = [
 			'interval' => $interval,
-			'display'  => esc_html__( 'WP Rocket RUCSS pending jobs', 'rocket' ),
+			'display'  => esc_html__( 'WP Rocket Remove Unused CSS pending jobs', 'rocket' ),
 		];
 
 		return $schedules;


### PR DESCRIPTION
Replace RUCSS in the message by Remove Unused CSS

## Description

It could work for customers familiar with the feature. But the vast majority won't understand the abbreviation. Better keep the full name.

## Type of change

- [ ] Enhancement (non-breaking change which improves an existing functionality)

# Checklist:

Please delete the options that are not relevant.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
