### PR TITLE
New Preload: Removed check for reset preload

### DIFF
--- a/inc/Engine/Preload/Admin/Subscriber.php
+++ b/inc/Engine/Preload/Admin/Subscriber.php
@@ -105,10 +105,6 @@ class Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function clean_full_cache() {
-		if ( ! $this->options->get( 'manual_preload' ) ) {
-			return;
-		}
-
 		$this->controller->full_clean();
 	}
 
@@ -121,10 +117,6 @@ class Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function clean_partial_cache( $object, array $urls, $lang ) {
-		if ( ! $this->options->get( 'manual_preload' ) ) {
-			return;
-		}
-
 		// Add Homepage URL to $purge_urls for preload.
 		$urls[] = get_rocket_i18n_home_url( $lang );
 

--- a/tests/Fixtures/inc/Engine/Preload/Admin/Subscriber/cleanFullCache.php
+++ b/tests/Fixtures/inc/Engine/Preload/Admin/Subscriber/cleanFullCache.php
@@ -28,32 +28,4 @@ return [
 			]
 		]
 	],
-	'preloadDisabledShouldDoNothing' => [
-		'config' => [
-			'manual_preload' => false,
-			'data' => [
-				[
-					'url' => 'https://example.org/url',
-					'status' => 'completed',
-				],
-				[
-					'url' => 'https://example.org',
-					'status' => 'completed',
-				],
-			]
-		],
-		'expected' => [
-			'exists' => true,
-			'data' => [
-				[
-					'url' => 'https://example.org/url',
-					'status' => 'completed',
-				],
-				[
-					'url' => 'https://example.org',
-					'status' => 'completed',
-				],
-			]
-		]
-	]
 ];

--- a/tests/Integration/AjaxTestCase.php
+++ b/tests/Integration/AjaxTestCase.php
@@ -25,6 +25,8 @@ abstract class AjaxTestCase extends WPMediaAjaxTestCase {
 
 		CapTrait::hasAdminCapBeforeClass();
 
+		self::installFresh();
+
 		if ( static::$use_settings_trait ) {
 			SettingsTrait::getOriginalSettings();
 		}
@@ -38,6 +40,8 @@ abstract class AjaxTestCase extends WPMediaAjaxTestCase {
 
 	public static function tear_down_after_class() {
 		CapTrait::resetAdminCap();
+
+		self::uninstallAll();
 
 		if ( static::$use_settings_trait ) {
 			SettingsTrait::resetOriginalSettings();

--- a/tests/Integration/inc/Engine/Admin/Settings/Settings/sanitizeCallback.php
+++ b/tests/Integration/inc/Engine/Admin/Settings/Settings/sanitizeCallback.php
@@ -17,7 +17,6 @@ class Test_SanitizeCallback extends AdminTestCase {
 
 	public function set_up() {
 		DBTrait::removeDBHooks();
-
 		parent::set_up();
 	}
 

--- a/tests/Integration/inc/Engine/CriticalPath/Admin/Subscriber/cpcssHeartbeat.php
+++ b/tests/Integration/inc/Engine/CriticalPath/Admin/Subscriber/cpcssHeartbeat.php
@@ -7,6 +7,7 @@ use WP_Error;
 use WP_Rocket\Engine\CriticalPath\APIClient;
 use WP_Rocket\Tests\Integration\AjaxTestCase;
 use WP_Rocket\Tests\Integration\CapTrait;
+use WP_Rocket\Tests\Integration\DBTrait;
 
 /**
  * @covers \WP_Rocket\Engine\CriticalPath\Admin\Subscriber::cpcss_heartbeat
@@ -25,7 +26,7 @@ use WP_Rocket\Tests\Integration\CapTrait;
  * @group  CriticalPathAdminSubscriber
  */
 class Test_CpcssHeartbeat extends AjaxTestCase {
-	use ProviderTrait;
+	use ProviderTrait, DBTrait;
 	protected static $provider_class = 'Admin';
 
 	private static   $admin_user_id      = 0;
@@ -42,9 +43,15 @@ class Test_CpcssHeartbeat extends AjaxTestCase {
 		parent::set_up_before_class();
 
 		CapTrait::setAdminCap();
-
+		self::installFresh();
 		//create an editor user that has the capability
 		self::$admin_user_id = static::factory()->user->create( [ 'role' => 'administrator' ] );
+	}
+
+	public static function tear_down_after_class()
+	{
+		parent::tear_down_after_class();
+		self::uninstallAll();
 	}
 
 	public function set_up() {
@@ -91,7 +98,6 @@ class Test_CpcssHeartbeat extends AjaxTestCase {
 
 		$_POST['_nonce'] = wp_create_nonce( 'cpcss_heartbeat_nonce' );
 		$response        = $this->callAjaxAction();
-
 		if ( $expected['bailout'] ) {
 			$this->assertFalse( $response->success );
 		} else {

--- a/tests/Integration/inc/Engine/CriticalPath/Admin/Subscriber/enableMobileCpcss.php
+++ b/tests/Integration/inc/Engine/CriticalPath/Admin/Subscriber/enableMobileCpcss.php
@@ -4,6 +4,7 @@ namespace WP_Rocket\Tests\Integration\inc\Engine\CriticalPath\Admin\Subscriber;
 
 use WP_Rocket\Tests\Integration\AjaxTestCase;
 use WP_Rocket\Tests\Integration\CapTrait;
+use WP_Rocket\Tests\Integration\DBTrait;
 
 /**
  * @covers \WP_Rocket\Engine\CriticalPath\Admin\Subscriber::enable_mobile_cpcss
@@ -14,7 +15,7 @@ use WP_Rocket\Tests\Integration\CapTrait;
  * @group  CriticalPathAdminSubscriber
  */
 class Test_EnableMobileCpcss extends AjaxTestCase {
-	use ProviderTrait;
+	use ProviderTrait, DBTrait;
 	protected static $provider_class = 'Settings';
 
 	protected static $use_settings_trait = true;
@@ -25,12 +26,20 @@ class Test_EnableMobileCpcss extends AjaxTestCase {
 	public static function set_up_before_class() {
 		parent::set_up_before_class();
 
+		self::installFresh();
+
 		CapTrait::setAdminCap();
 
 		//create an editor user that has the capability
 		self::$admin_user_id = static::factory()->user->create( [ 'role' => 'administrator' ] );
 		//create an editor user that has no capability
 		self::$editor_user_id = static::factory()->user->create( [ 'role' => 'editor' ] );
+	}
+
+	public static function tear_down_after_class()
+	{
+		parent::tear_down_after_class();
+		self::uninstallAll();
 	}
 
 	public function set_up() {

--- a/tests/Integration/inc/Engine/Preload/Subscriber/loadInitialSitemap.php
+++ b/tests/Integration/inc/Engine/Preload/Subscriber/loadInitialSitemap.php
@@ -18,12 +18,14 @@ class Test_LoadInitialSitemap extends AdminTestCase
 	public function setUp(): void
 	{
 		parent::setUp();
+		self::installFresh();
 		add_filter('rocket_sitemap_preload_list', [$this, 'return_sitemaps']);
 	}
 
 	public function tearDown(): void
 	{
 		remove_filter('rocket_sitemap_preload_list', [$this, 'return_sitemaps']);
+		self::uninstallAll();
 		parent::tearDown();
 	}
 

--- a/tests/Integration/inc/admin/rocketNewUpgrade.php
+++ b/tests/Integration/inc/admin/rocketNewUpgrade.php
@@ -3,6 +3,7 @@
 namespace WP_Rocket\Tests\Unit\Inc\admin;
 
 use Brain\Monkey\Functions;
+use WP_Rocket\Tests\Integration\DBTrait;
 use WP_Rocket\Tests\Integration\TestCase;
 
 /**
@@ -12,6 +13,20 @@ use WP_Rocket\Tests\Integration\TestCase;
  * @group AdminOnly
  */
 class Test_RocketNewUpgrade extends TestCase {
+	use DBTrait;
+
+	public static function set_up_before_class()
+	{
+		parent::set_up_before_class();
+		self::installFresh();
+	}
+
+	public static function tear_down_after_class()
+	{
+		self::uninstallAll();
+		parent::tear_down_after_class();
+	}
+
 	public function testShouldRegenerateAdvancedCacheFile() {
 		Functions\expect( 'rocket_generate_advanced_cache_file' )
 			->atLeast()


### PR DESCRIPTION
## Description

Removed check on preload enable when clearing cache or partial clear from cache.
This fix a bug that occurs when we clear cache when preload is disactivated.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Automated Tests.
- [ ] Test on local env.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
