### PR TITLE
New Preload: Added new hooks to delete a post is deleted or when a raising a 404

### DIFF
--- a/inc/Engine/Preload/Admin/Subscriber.php
+++ b/inc/Engine/Preload/Admin/Subscriber.php
@@ -86,6 +86,9 @@ class Subscriber implements Subscriber_Interface {
 			'after_rocket_clean_term'   => [ 'clean_partial_cache', 10, 3 ],
 			'rocket_after_clean_terms'  => 'clean_urls',
 			'after_rocket_clean_domain' => 'clean_full_cache',
+			'wp_trash_post'             => 'delete_post_preload_cache',
+			'delete_post'               => 'delete_post_preload_cache',
+			'pre_delete_term'           => 'delete_term_preload_cache',
 			'init'                      => [ 'maybe_init_preload_queue' ],
 		];
 	}
@@ -155,5 +158,45 @@ class Subscriber implements Subscriber_Interface {
 
 		$this->queue_runner->init();
 
+	}
+
+	/**
+	 * Delete URL from a post from the preload.
+	 *
+	 * @param int $post_id ID from the post.
+	 * @return void
+	 */
+	public function delete_post_preload_cache( $post_id ) {
+		if ( ! $this->settings->is_enabled() ) {
+			return;
+		}
+
+		$url = get_permalink( $post_id );
+
+		if ( false === $url ) {
+			return;
+		}
+
+		$this->controller->delete_url( $url );
+	}
+
+	/**
+	 * Delete URL from a term from the preload.
+	 *
+	 * @param int $term_id ID from the term.
+	 * @return void
+	 */
+	public function delete_term_preload_cache( $term_id ) {
+		if ( ! $this->settings->is_enabled() ) {
+			return;
+		}
+
+		$url = get_term_link( (int) $term_id );
+
+		if ( false === $url ) {
+			return;
+		}
+
+		$this->controller->delete_url( $url );
 	}
 }

--- a/inc/Engine/Preload/Controller/ClearCache.php
+++ b/inc/Engine/Preload/Controller/ClearCache.php
@@ -49,4 +49,14 @@ class ClearCache {
 	public function full_clean() {
 		$this->query->set_all_to_pending();
 	}
+
+	/**
+	 * Delete a URL from the preload.
+	 *
+	 * @param string $url URL to delete.
+	 * @return void
+	 */
+	public function delete_url( string $url ) {
+		$this->query->delete_by_url( $url );
+	}
 }

--- a/inc/Engine/Preload/Subscriber.php
+++ b/inc/Engine/Preload/Subscriber.php
@@ -45,7 +45,6 @@ class Subscriber implements Subscriber_Interface {
 			'update_option_' . WP_ROCKET_SLUG => [
 				[ 'maybe_load_initial_sitemap', 10, 2 ],
 				[ 'maybe_cancel_preload', 10, 2 ],
-				[ 'maybe_cancel_preload', 10, 2 ],
 			],
 			'rocket_after_process_buffer'     => 'update_cache_row',
 			'set_404'                         => 'delete_url_on_not_found',

--- a/inc/Engine/Preload/Subscriber.php
+++ b/inc/Engine/Preload/Subscriber.php
@@ -45,8 +45,10 @@ class Subscriber implements Subscriber_Interface {
 			'update_option_' . WP_ROCKET_SLUG => [
 				[ 'maybe_load_initial_sitemap', 10, 2 ],
 				[ 'maybe_cancel_preload', 10, 2 ],
+				[ 'maybe_cancel_preload', 10, 2 ],
 			],
 			'rocket_after_process_buffer'     => 'update_cache_row',
+			'set_404'                         => 'delete_url_on_not_found',
 		];
 	}
 
@@ -112,5 +114,16 @@ class Subscriber implements Subscriber_Interface {
 				'status' => 'completed',
 			]
 		);
+	}
+
+	/**
+	 * Delete url from the Preload when a 404 is risen.
+	 *
+	 * @return void
+	 */
+	public function delete_url_on_not_found() {
+		global $wp;
+		$url = home_url( $wp->request );
+		$this->query->delete_by_url( $url );
 	}
 }


### PR DESCRIPTION
## Description
This PR tries to solve the problem of in-progress stuck in the database.
Added hook to delete a post from preload DB when a post is deleted.
Added hook to delete a post from preload DB when 404 is raised.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [ ] Test on my local env


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
