### PR TITLE
Change the admin_notices callbacks order

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
@@ -80,11 +80,11 @@ class Subscriber implements Subscriber_Interface {
 			'admin_post_rocket_clear_usedcss_url'     => 'clear_url_usedcss',
 			'admin_notices'                           => [
 				[ 'clear_usedcss_result' ],
+				[ 'notice_write_permissions' ],
 				[ 'display_processing_notice' ],
 				[ 'display_success_notice' ],
 				[ 'display_as_missed_tables_notice' ],
 				[ 'display_wrong_license_notice' ],
-				[ 'notice_write_permissions' ],
 			],
 			'rocket_admin_bar_items'                  => [
 				[ 'add_clean_used_css_menu_item' ],

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Cron/Subscriber/addInterval.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Cron/Subscriber/addInterval.php
@@ -15,7 +15,7 @@ return [
 		],
 		'expected' => [
 			'interval' => 60,
-			'display'  => 'WP Rocket RUCSS pending jobs',
+			'display'  => 'WP Rocket Remove Unused CSS pending jobs',
 		],
 	],
 	'shouldAddFilteredIntervalWhenRUCSSEnabledAndFilter' => [
@@ -25,7 +25,7 @@ return [
 		],
 		'expected' => [
 			'interval' => 120,
-			'display'  => 'WP Rocket RUCSS pending jobs',
+			'display'  => 'WP Rocket Remove Unused CSS pending jobs',
 		],
 	],
 ];


### PR DESCRIPTION
## Description

We changed here the order of the admin_notices hook callbacks to make notice_write_permissions be before display_processing_notice.

This will only affect the order of admin notices appear to the admin user, to show the used_css write permissions notice before all other notices.

Fixes #5195 

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Is the solution different from the one proposed during the grooming?

No

## How Has This Been Tested?

Tested in my local.

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
