### PR TITLE
For RUCSS check zlib library before encoding/decoding the used CSS content

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Controller/Filesystem.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/Filesystem.php
@@ -33,6 +33,17 @@ class Filesystem {
 	}
 
 	/**
+	 * Get the file path for the used CSS file.
+	 *
+	 * @param string $hash Hash of the file contents.
+	 *
+	 * @return string Path for the used CSS file.
+	 */
+	private function get_usedcss_full_path( string $hash ) {
+		return $this->path . $this->hash_to_path( $hash ) . '.css' . ( function_exists( 'gzdecode' ) ? '.gz' : '' );
+	}
+
+	/**
 	 * Gets the used CSS content corresponding to the provided hash
 	 *
 	 * @param string $hash Hash of the corresponding used CSS.
@@ -40,13 +51,14 @@ class Filesystem {
 	 * @return string
 	 */
 	public function get_used_css( string $hash ): string {
-		$file = $this->path . $this->hash_to_path( $hash ) . '.css.gz';
+		$file = $this->get_usedcss_full_path( $hash );
 
 		if ( ! $this->filesystem->exists( $file ) ) {
 			return '';
 		}
 
-		$css = gzdecode( $this->filesystem->get_contents( $file ) );
+		$file_contents = $this->filesystem->get_contents( $file );
+		$css           = function_exists( 'gzdecode' ) ? gzdecode( $file_contents ) : $file_contents;
 
 		if ( ! $css ) {
 			return '';
@@ -64,14 +76,14 @@ class Filesystem {
 	 * @return bool
 	 */
 	public function write_used_css( string $hash, string $used_css ): bool {
-		$file = $this->path . $this->hash_to_path( $hash ) . '.css.gz';
+		$file = $this->get_usedcss_full_path( $hash );
 
 		if ( ! rocket_mkdir_p( dirname( $file ) ) ) {
 			return false;
 		}
 
 		// This filter is documented in inc/classes/Buffer/class-cache.php.
-		$css = gzencode( $used_css, apply_filters( 'rocket_gzencode_level_compression', 6 ) );
+		$css = function_exists( 'gzencode' ) ? gzencode( $used_css, apply_filters( 'rocket_gzencode_level_compression', 6 ) ) : $used_css;
 
 		if ( ! $css ) {
 			return false;
@@ -90,7 +102,7 @@ class Filesystem {
 	 * @return bool
 	 */
 	public function delete_used_css( string $hash ): bool {
-		$file = $this->path . $this->hash_to_path( $hash ) . '.css.gz';
+		$file = $this->get_usedcss_full_path( $hash );
 
 		return $this->filesystem->delete( $file, false, 'f' );
 	}


### PR DESCRIPTION
## Description

Here we are guarding our RUCSS filesystem code if the host disabled zlib or both functions `gzdecode` and `gzencode` are disabled.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I'm discussing with @piotrbak now how will we test it but seems like we will put the following line in php.ini and see how it goes
```
disable_functions="gzdecode, gzencode"
```

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
