### PR TITLE
Closes #5178 - RUCSS jobs created when used-css folder is not created

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -154,6 +154,10 @@ class UsedCSS {
 			return false;
 		}
 
+		if ( ! $this->filesystem->is_writable_folder() ) {
+			return false;
+		}
+
 		return true;
 	}
 


### PR DESCRIPTION
## Description

This PR fixes the issue we have with RUCSS jobs being created when the used-css folder is not writable

Fixes #5178

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
