### PR TITLE
Fixes #5194 - PHP Deprecated warning for null type passed as argument to preg_match

### DIFF
--- a/inc/Engine/Optimization/Minify/CSS/AbstractCSSOptimization.php
+++ b/inc/Engine/Optimization/Minify/CSS/AbstractCSSOptimization.php
@@ -126,8 +126,8 @@ abstract class AbstractCSSOptimization extends AbstractOptimization {
 		}
 
 		$file      = wp_parse_url( $tag['url'] );
-		$file_path = isset( $file['path'] ) ? $file['path'] : null;
-		$host      = isset( $file['host'] ) ? $file['host'] : null;
+		$file_path = isset( $file['path'] ) ? $file['path'] : '';
+		$host      = isset( $file['host'] ) ? $file['host'] : '';
 
 		// File extension is not css.
 		if ( pathinfo( $file_path, PATHINFO_EXTENSION ) !== self::FILE_TYPE ) {


### PR DESCRIPTION
## Description

This PR fixes the Deprecated warning thrown on debug.log when null is passed as argument to preg_match

Fixes #5194 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
