### PR TITLE
Fixes #5213 Improve removal of inline style content when using RUCSS

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -450,7 +450,14 @@ class UsedCSS {
 			 * @param array $style Full match style tag.
 			 */
 			if ( apply_filters( 'rocket_rucss_preserve_inline_style_tags', true, $style ) ) {
-				$html = str_replace( $style['content'], '', $html );
+				$content = trim( $style['content'] );
+
+				if ( empty( $content ) ) {
+					continue;
+				}
+
+				$empty_tag = str_replace( $style['content'], '', $style[0] );
+				$html      = str_replace( $style[0], $empty_tag, $html );
 
 				continue;
 			}


### PR DESCRIPTION
## Description

Only remove inline style content if it's not empty, and only do it on the current style instead of the whole HTML.

Fixes #5213

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
