### PR TITLE
Fix 5216 Exclude 'var wpforms_user_journey'  from combine JS

### DIFF
--- a/inc/Engine/Optimization/Minify/JS/Combine.php
+++ b/inc/Engine/Optimization/Minify/JS/Combine.php
@@ -719,6 +719,7 @@ class Combine extends AbstractJSOptimization implements ProcessorInterface {
 			'e.setAttribute(\'unselectable\',on);',
 			'try{Typekit.load',
 			'iMapsData',
+			'var wpforms_user_journey',
 		];
 
 		$excluded_inline = array_merge( $defaults, $this->options->get( 'exclude_inline_js', [] ) );


### PR DESCRIPTION
## Description

Add 'var wpforms_user_journey'  to our inline Combien JS exclusions to prevent a cache dir size issue.

Fixes #5216 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?
This is an exclusion

## How Has This Been Tested?
On my local setup


# Checklist:

Please delete the options that are not relevant.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
