### PR TITLE
Load the correct config file in multisite

### DIFF
--- a/inc/classes/Buffer/class-config.php
+++ b/inc/classes/Buffer/class-config.php
@@ -194,18 +194,6 @@ class Config {
 
 		$host = $this->get_host();
 
-		if ( realpath( self::$config_dir_path . $host . '.php' ) && 0 === stripos( realpath( self::$config_dir_path . $host . '.php' ), $config_dir_real_path ) ) {
-			$config_file_path = self::$config_dir_path . $host . '.php';
-			return self::memoize(
-				__FUNCTION__,
-				[],
-				[
-					'success' => true,
-					'path'    => $config_file_path,
-				]
-			);
-		}
-
 		$path = str_replace( '\\', '/', strtok( $this->get_server_input( 'REQUEST_URI', '' ), '?' ) );
 		$path = preg_replace( '|(?<=.)/+|', '/', $path );
 		$path = explode( '%2F', preg_replace( '/^(?:%2F)*(.*?)(?:%2F)*$/', '$1', rawurlencode( $path ) ) );
@@ -238,6 +226,18 @@ class Config {
 			}
 
 			$dir .= $p . '.';
+		}
+
+		if ( realpath( self::$config_dir_path . $host . '.php' ) && 0 === stripos( realpath( self::$config_dir_path . $host . '.php' ), $config_dir_real_path ) ) {
+			$config_file_path = self::$config_dir_path . $host . '.php';
+			return self::memoize(
+				__FUNCTION__,
+				[],
+				[
+					'success' => true,
+					'path'    => $config_file_path,
+				]
+			);
 		}
 
 		return self::memoize(


### PR DESCRIPTION
## Description

When we install WP Rocket in site level in a multisite which uses the sub directory pattern, we always load the main site config file and this is wrong as we need to load its corresponding config file instead.

Fixes #3477

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

We did it as a team (thanks @CrochetFeve0251 and @jeawhanlee ).
This change may affect the performance as we load the config file in each page load, @Tabrisrp what do u think?

## How Has This Been Tested?

- [x] Locally

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
