### PR TITLE
Preserve Smart Slider 3 inline CSS with dynamic selectors

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -79,6 +79,7 @@ class UsedCSS {
 		'woodmart_shortcodes-custom-css',
 		'rs-plugin-settings-inline-css', // For revolution slider, it saves settings for each slider.
 		'divi-style-inline-inline-css',
+		'n2-ss-', // For Smart Slider 3 dynamic selectors.
 	];
 
 	/**


### PR DESCRIPTION
## Description

Fixes #5219 

Preserves dynamic selectors added with Smart Slider 3 inline style.

## Type of change

Please delete options that are not relevant.

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

n/a

## How Has This Been Tested?

The automatic exclusion within the plugin was tested on my testing site by using the customer's site HTML template. The inline style was preserved.
No errors in debug.log.

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
