### PR TITLE
Fix metadata cleanup error in rocket_renew_all_boxes function

### DIFF
--- a/inc/functions/admin.php
+++ b/inc/functions/admin.php
@@ -39,7 +39,7 @@ function rocket_need_api_key() {
  */
 function rocket_renew_all_boxes( $uid = null, $keep_this = [] ) {
 	// Delete a user meta for 1 user or all at a time.
-	delete_metadata( 'user', $uid, 'rocket_boxes', null === $uid );
+	delete_metadata( 'user', $uid, 'rocket_boxes', '', null === $uid );
 
 	// $keep_this works only for the current user.
 	if ( ! empty( $keep_this ) && null !== $uid ) {

--- a/inc/functions/admin.php
+++ b/inc/functions/admin.php
@@ -39,7 +39,7 @@ function rocket_need_api_key() {
  */
 function rocket_renew_all_boxes( $uid = null, $keep_this = [] ) {
 	// Delete a user meta for 1 user or all at a time.
-	delete_metadata( 'user', $uid, 'rocket_boxes', '', null === $uid );
+	delete_metadata( 'user', $uid, 'rocket_boxes', '', ! $uid );
 
 	// $keep_this works only for the current user.
 	if ( ! empty( $keep_this ) && null !== $uid ) {


### PR DESCRIPTION
## Description

The rocket_renew_all_boxes function didn't delete user metadata due to an error in the parameters passed to delete_metadata.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes