### PR TITLE
Fixes #4961 Remove loading attribute when using JS lazyload

### DIFF
--- a/inc/Dependencies/RocketLazyload/Image.php
+++ b/inc/Dependencies/RocketLazyload/Image.php
@@ -445,6 +445,10 @@ class Image {
 	 * @return string
 	 */
 	private function replaceImage( $image, $use_native = true ) {
+		if ( empty( $image ) ) {
+			return '';
+		}
+
 		$native_pattern = '@\sloading\s*=\s*(\'|")(?:lazy|auto)\1@i';
 		$image_lazyload = $image[0];
 
@@ -470,7 +474,7 @@ class Image {
 
 			$image_lazyload = str_replace( $image['atts'], $placeholder_atts . ' data-lazy-src="' . $image['src'] . '"', $image_lazyload );
 
-			if ( preg_match( $native_pattern, $image[0] ) ) {
+			if ( preg_match( $native_pattern, $image_lazyload ) ) {
 				$image_lazyload = preg_replace( $native_pattern, '', $image_lazyload );
 			}
 		}

--- a/inc/Dependencies/RocketLazyload/Image.php
+++ b/inc/Dependencies/RocketLazyload/Image.php
@@ -445,12 +445,15 @@ class Image {
 	 * @return string
 	 */
 	private function replaceImage( $image, $use_native = true ) {
+		$native_pattern = '@\sloading\s*=\s*(\'|")(?:lazy|auto)\1@i';
+		$image_lazyload = $image[0];
+
 		if ( $use_native ) {
-			if ( preg_match( '@\sloading\s*=\s*(\'|")(?:lazy|auto)\1@i', $image[0] ) ) {
+			if ( preg_match( $native_pattern, $image[0] ) ) {
 				return $image[0];
 			}
 
-			$image_lazyload = str_replace( '<img', '<img loading="lazy"', $image[0] );
+			$image_lazyload = str_replace( '<img', '<img loading="lazy"', $image_lazyload );
 		} else {
 			$width  = 0;
 			$height = 0;
@@ -465,7 +468,11 @@ class Image {
 
 			$placeholder_atts = preg_replace( '@\ssrc\s*=\s*(\'|")(?<src>.*)\1@iUs', ' src="' . $this->getPlaceholder( $width, $height ) . '"', $image['atts'] );
 
-			$image_lazyload = str_replace( $image['atts'], $placeholder_atts . ' data-lazy-src="' . $image['src'] . '"', $image[0] );
+			$image_lazyload = str_replace( $image['atts'], $placeholder_atts . ' data-lazy-src="' . $image['src'] . '"', $image_lazyload );
+
+			if ( preg_match( $native_pattern, $image[0] ) ) {
+				$image_lazyload = preg_replace( $native_pattern, '', $image_lazyload );
+			}
 		}
 
 		/**


### PR DESCRIPTION
## Description

Remove the loading attribute from images when using JS lazyload to prevent display issues on iOS webkit

Fixes #4961 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Automated tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
