### PR TITLE
Close 5235: Added one.com env detection

### DIFF
--- a/inc/ThirdParty/Hostings/HostResolver.php
+++ b/inc/ThirdParty/Hostings/HostResolver.php
@@ -31,6 +31,11 @@ class HostResolver {
 			return self::$hostname;
 		}
 
+		if ( isset( $_SERVER['ONECOM_DOMAIN_NAME'] ) ) {
+			self::$hostname = 'onecom';
+			return 'onecom';
+		}
+
 		if ( isset( $_SERVER['cw_allowed_ip'] ) ) {
 			self::$hostname = 'cloudways';
 

--- a/tests/Fixtures/inc/ThirdParty/Hostings/HostResolver/getHostService.php
+++ b/tests/Fixtures/inc/ThirdParty/Hostings/HostResolver/getHostService.php
@@ -17,5 +17,8 @@ return [
 		'testShouldReturnSavvii' => [
 			'expected' => 'savvii',
 		],
+		'testShouldReturnOnecom' => [
+			'expected' => 'onecom',
+		],
 	],
 ];

--- a/tests/Unit/inc/ThirdParty/Hostings/HostResolver/getHostService.php
+++ b/tests/Unit/inc/ThirdParty/Hostings/HostResolver/getHostService.php
@@ -15,6 +15,7 @@ use WP_Rocket\Tests\Unit\TestCase;
 class Test_GetHostResolver extends TestCase {
 	protected function tearDown(): void {
 		unset( $_SERVER['cw_allowed_ip'] );
+		unset( $_SERVER['ONECOM_DOMAIN_NAME'] );
 		putenv( 'SPINUPWP_CACHE_PATH=' );
 
 		parent::tearDown();

--- a/tests/Unit/inc/ThirdParty/Hostings/HostResolver/getHostService.php
+++ b/tests/Unit/inc/ThirdParty/Hostings/HostResolver/getHostService.php
@@ -38,6 +38,9 @@ class Test_GetHostResolver extends TestCase {
 				$this->constants['\Savvii\CacheFlusherPlugin::NAME_FLUSH_NOW']       = true;
 				$this->constants['\Savvii\CacheFlusherPlugin::NAME_DOMAINFLUSH_NOW'] = true;
 				break;
+			case 'onecom':
+				$this->constants['ONECOM_DOMAIN_NAME'] = true;
+				break;
 			default:
 				break;
 		}

--- a/tests/Unit/inc/ThirdParty/Hostings/HostResolver/getHostService.php
+++ b/tests/Unit/inc/ThirdParty/Hostings/HostResolver/getHostService.php
@@ -39,7 +39,7 @@ class Test_GetHostResolver extends TestCase {
 				$this->constants['\Savvii\CacheFlusherPlugin::NAME_DOMAINFLUSH_NOW'] = true;
 				break;
 			case 'onecom':
-				$this->constants['ONECOM_DOMAIN_NAME'] = true;
+				$_SERVER['ONECOM_DOMAIN_NAME'] = true;
 				break;
 			default:
 				break;


### PR DESCRIPTION
## Description

Added detection from One.com.
For this we checked the key `ONECOM_DOMAIN_NAME` in the `$_SERVER` variable.

Fixes #5235

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Is the solution different from the one proposed during the grooming?

No.

## How Has This Been Tested?

- [ ] Automated Tests. 

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
