### PR TITLE
Preserve JNews theme inline CSS with dynamic selectors

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -95,6 +95,7 @@ class UsedCSS {
 		'.jet-listing-dynamic-post-',
 		'.vcex_',
 		'.wprm-advanced-list-',
+		'.jnews_', // For JNews theme.
 	];
 
 	/**


### PR DESCRIPTION
## Description

Preserves dynamic selectors added with JNews theme inline style.

Fixes #5270 

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

n/a

## How Has This Been Tested?

The automatic exclusion within the plugin was tested on my testing site by using the customer's site HTML template. The inline style was preserved.
No errors in debug.log.

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
