### PR TITLE
Closes #5262 - for deprecated notice on type of null passed to json_decode in v3.10.10.1

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Database/Row/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Database/Row/UsedCSS.php
@@ -20,7 +20,7 @@ class UsedCSS extends Row {
 		$this->id             = (int) $this->id;
 		$this->url            = (string) $this->url;
 		$this->css            = (string) $this->css;
-		$this->unprocessedcss = json_decode( $this->unprocessedcss, true );
+		$this->unprocessedcss = json_decode( null === $this->unprocessedcss ? '' : $this->unprocessedcss, true );
 		$this->retries        = (int) $this->retries;
 		$this->is_mobile      = (bool) $this->is_mobile;
 		$this->modified       = false === $this->modified ? 0 : strtotime( $this->modified );


### PR DESCRIPTION
## Description

This PR closes the notice when type of null is passed to json_decode in v3.10.10.1

Fixes #5262 

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## How Has This Been Tested?

Manual test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
