### PR TITLE
Closes #5261 on PHP deprecated notice for yoast seo on v3.9.5.1

### DIFF
--- a/inc/3rd-party/plugins/seo/yoast-seo.php
+++ b/inc/3rd-party/plugins/seo/yoast-seo.php
@@ -7,6 +7,7 @@ if ( defined( 'WPSEO_VERSION' ) && class_exists( 'WPSEO_Sitemaps_Router' ) ) :
 
 	if ( version_compare( WPSEO_VERSION, '7.0' ) >= 0 ) {
 		$yoast_seo                         = get_option( 'wpseo' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
+		$yoast_seo_xml                     = ! is_array( $yoast_seo_xml ) ? [] : $yoast_seo_xml; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
 		$yoast_seo_xml['enablexmlsitemap'] = isset( $yoast_seo['enable_xml_sitemap'] ) && $yoast_seo['enable_xml_sitemap']; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
 	}
 

--- a/inc/3rd-party/plugins/seo/yoast-seo.php
+++ b/inc/3rd-party/plugins/seo/yoast-seo.php
@@ -3,11 +3,10 @@
 defined( 'ABSPATH' ) || exit;
 
 if ( defined( 'WPSEO_VERSION' ) && class_exists( 'WPSEO_Sitemaps_Router' ) ) :
-	$yoast_seo_xml = get_option( 'wpseo_xml' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
+	$yoast_seo_xml = get_option( 'wpseo_xml', [] ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
 
 	if ( version_compare( WPSEO_VERSION, '7.0' ) >= 0 ) {
 		$yoast_seo                         = get_option( 'wpseo' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
-		$yoast_seo_xml                     = ! is_array( $yoast_seo_xml ) ? [] : $yoast_seo_xml; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
 		$yoast_seo_xml['enablexmlsitemap'] = isset( $yoast_seo['enable_xml_sitemap'] ) && $yoast_seo['enable_xml_sitemap']; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
 	}
 


### PR DESCRIPTION
## Description

This PR fixes the deprecated notice for yoast seo 3rd party compatibility on 3.9.5.1

Fixes #5261 

## Type of change
- [x] Enhancement (non-breaking change which improves an existing functionality)

## How Has This Been Tested?

Manually

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
