### PR TITLE
adding Convert Plus plugin to $inline_content_exclusions

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -98,6 +98,7 @@ class UsedCSS {
 		'.wprm-advanced-list-',
 		'.adsslot_', // For Advanced Ads plugin ads.
 		'.jnews_', // For JNews theme.
+		'.cp-info-bar.content-', // For Convert Plus plugin.
 	];
 
 	/**


### PR DESCRIPTION
## Description

adding '.cp-info-bar.content-' for Convert Plus plugin.

Fixes #5290

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

is inline CSS exclusion: 
adding '.cp-info-bar.content-' for Convert Plus plugin into rocket_rucss_inline_content_exclusions

## How Has This Been Tested?

On the customer site

# Checklist:

Please delete the options that are not relevant.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
