### PR TITLE
exclude jquery delay JS if Avada lazyload is active

### DIFF
--- a/inc/ThirdParty/Themes/Avada.php
+++ b/inc/ThirdParty/Themes/Avada.php
@@ -34,6 +34,7 @@ class Avada implements Subscriber_Interface {
 			'update_option_fusion_options'         => [ 'maybe_deactivate_lazyload', 10, 2 ],
 			'rocket_wc_product_gallery_delay_js_exclusions' => 'exclude_delay_js',
 			'init'                                 => 'disable_compilers',
+			'rocket_exclude_delay_js'              => 'maybe_exclude_jquery_delay_js',
 		];
 	}
 
@@ -142,6 +143,23 @@ class Avada implements Subscriber_Interface {
 		return $exclusions;
 	}
 
+	/**
+	 * Excludes Jquery from delay JS execution when Avada LazyLoad is enabled
+	 *
+	 * @since 3.11.5
+	 *
+	 * @param array $exclusions Array of exclusion patterns.
+	 *
+	 * @return array
+	 */
+	public function maybe_exclude_jquery_delay_js( $exclusions ): array {
+		$avada_options = get_option( 'fusion_options' );
+		if ( ! empty( $avada_options['lazy_load'] && 'avada' !== $avada_options['lazy_load'] ) ) {
+			return $exclusions;
+		}
+		$exclusions[] = '/jquery-?[0-9.](.*)(.min|.slim|.slim.min)?.js';
+		return $exclusions;
+	}
 	/**
 	 * Disable CSS and JS combine file from Avada.
 	 */

--- a/tests/Fixtures/inc/ThirdParty/Themes/Avada/excludeJqueryDelayJs.php
+++ b/tests/Fixtures/inc/ThirdParty/Themes/Avada/excludeJqueryDelayJs.php
@@ -1,0 +1,32 @@
+<?php
+return [
+	'vfs_dir' => 'wp-content/',
+
+	'structure' => [
+		'wp-content' => [
+			'cache'  => [
+				'wp-rocket' => [
+					'example.org'                                => [
+						'index.html'      => '',
+						'index.html_gzip' => '',
+					],
+					'example.org-wpmedia-594d03f6ae698691165999' => [
+						'about' => [
+							'index.html'      => '',
+							'index.html_gzip' => '',
+						],
+					],
+				],
+			],
+			'themes' => [
+				'avada' => [
+					'style.css' => '
+					/**
+					 * Theme Name: Avada
+					 */',
+					'index.php' => '',
+				],
+			],
+		],
+	],
+];

--- a/tests/Integration/inc/ThirdParty/Themes/Avada/excludeJqueryDelayJs.php
+++ b/tests/Integration/inc/ThirdParty/Themes/Avada/excludeJqueryDelayJs.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\ThirdParty\Themes\Avada;
+
+/**
+ * @covers \WP_Rocket\ThirdParty\Avada::maybe_exclude_jquery_delay_js
+ *
+ * @group  AvadaTheme
+ * @group  ThirdParty
+ */
+class Test_ExcludeJqueryDelayJs extends TestCase {
+	protected      $path_to_test_data = '/inc/ThirdParty/Themes/Avada/excludeJqueryDelayJs.php';
+
+	public function set_up() {
+		parent::set_up();
+		add_option( 'fusion_options', [ 'lazy_load' => 'avada' ] );
+	}
+
+	public function tear_down() {
+		delete_option( 'fusion_options' );
+		parent::tear_down();
+	}
+
+
+	public function testShouldReturnExpected() {
+		$expected = [
+			'/jquery-?[0-9.](.*)(.min|.slim|.slim.min)?.js',
+		];
+		$this->assertSame(
+			$expected,
+			apply_filters( 'rocket_exclude_delay_js', [] )
+		);
+	}
+}


### PR DESCRIPTION
## Description

Updata Avada Thirdpaty class to exclude jquery delay JS if Avada lazyload is active

Fixes #5294 

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)


## Is the solution different from the one proposed during the grooming?

No

## How Has This Been Tested?

- [x] Integration test

# Checklist:


- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
