### PR TITLE
Update declaration of write return to match with monolog v2

### DIFF
--- a/inc/classes/logger/class-stream-handler.php
+++ b/inc/classes/logger/class-stream-handler.php
@@ -1,58 +1,53 @@
 <?php
 namespace WP_Rocket\Logger;
 
+use UnexpectedValueException;
 use Monolog\Handler\StreamHandler;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * Class used to log records into a local file.
  *
- * @since  3.2
- * @author Grégory Viguier
+ * @since 3.2
  */
 class Stream_Handler extends StreamHandler {
 
 	/**
 	 * Tell if the .htaccess file exists.
 	 *
-	 * @var    bool
-	 * @since  3.2
-	 * @access private
-	 * @author Grégory Viguier
+	 * @var bool
+	 *
+	 * @since 3.2
 	 */
 	private $htaccess_exists;
 
 	/**
 	 * Tell if there is an error.
 	 *
-	 * @var    bool
-	 * @since  3.2
-	 * @access private
-	 * @author Grégory Viguier
+	 * @var bool
+	 *
+	 * @since 3.2
 	 */
 	private $has_error;
 
 	/**
 	 * Contains an error message.
 	 *
-	 * @var    string
-	 * @since  3.2
-	 * @access private
-	 * @author Grégory Viguier
+	 * @var string
+	 *
+	 * @since 3.2
 	 */
 	private $error_message;
 
 	/**
 	 * Writes the record down to the log of the implementing handler.
 	 *
-	 * @since  3.2
-	 * @access protected
-	 * @author Grégory Viguier
+	 * @since 3.2
 	 *
 	 * @param array $record Log contents.
+	 *
+	 * @return void
 	 */
-	protected function write( array $record ) {
+	protected function write( array $record ): void {
 		parent::write( $record );
 		$this->create_htaccess_file();
 	}
@@ -60,10 +55,9 @@ class Stream_Handler extends StreamHandler {
 	/**
 	 * Create a .htaccess file in the log folder, to prevent direct access and directory listing.
 	 *
-	 * @since  3.2
-	 * @access protected
+	 * @since 3.2
+	 *
 	 * @throws \UnexpectedValueException When the .htaccess file could not be created.
-	 * @author Grégory Viguier
 	 *
 	 * @return bool True if the file exists or has been created. False on failure.
 	 */
@@ -100,7 +94,7 @@ class Stream_Handler extends StreamHandler {
 
 		if ( ! is_resource( $file_resource ) ) {
 			$this->has_error = true;
-			throw new \UnexpectedValueException( sprintf( 'The file "%s" could not be opened: ' . $this->error_message, $file_path ) );
+			throw new UnexpectedValueException( sprintf( 'The file "%s" could not be opened: ' . $this->error_message, $file_path ) );
 		}
 
 		$new_content = "<Files ~ \"\.log$\">\nOrder allow,deny\nDeny from all\n</Files>\nOptions -Indexes";
@@ -117,15 +111,14 @@ class Stream_Handler extends StreamHandler {
 	/**
 	 * Temporary error handler that "cleans" the error messages.
 	 *
-	 * @since  3.2
-	 * @access private
-	 * @see    parent::customErrorHandler()
-	 * @author Grégory Viguier
+	 * @since 3.2
+	 *
+	 * @see parent::customErrorHandler()
 	 *
 	 * @param int    $code Error code.
 	 * @param string $msg  Error message.
 	 */
-	private function custom_error_handler( $code, $msg ) {
+	private function custom_error_handler( int $code, string $msg ) {
 		$this->error_message = preg_replace( '{^(fopen|mkdir)\(.*?\): }', '', $msg );
 	}
 
@@ -133,14 +126,14 @@ class Stream_Handler extends StreamHandler {
 	 * A dirname() that also works for streams, by removing the protocol.
 	 *
 	 * @since  3.2
-	 * @access private
-	 * @see    parent::getDirFromStream()
-	 * @author Grégory Viguier
+	 *
+	 * @see parent::getDirFromStream()
 	 *
 	 * @param  string $stream Path to a file.
+	 *
 	 * @return null|string
 	 */
-	private function get_dir_from_stream( $stream ) {
+	private function get_dir_from_stream( string $stream ) {
 		$pos = strpos( $stream, '://' );
 
 		if ( false === $pos ) {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -27,8 +27,8 @@
 
 	<!-- Rules: Check PHP version compatibility - see https://github.com/PHPCompatibility/PHPCompatibilityWP -->
 	<rule ref="PHPCompatibility"/>
-	<config name="testVersion" value="7.0-"/>
-	<config name="minimum_supported_wp_version" value="5.2"/>
+	<config name="testVersion" value="7.2-"/>
+	<config name="minimum_supported_wp_version" value="5.6"/>
 
 	<rule ref="WordPress">
         <exclude name="Generic.Functions.FunctionCallArgumentSpacing.TooMuchSpaceAfterComma"/>


### PR DESCRIPTION
## Description

Prevent the following fatal error:

```
Fatal error: Declaration of WP_Rocket\Logger\Stream_Handler::write(array $record) must be compatible with Monolog\Handler\StreamHandler::write(array $record): void in wp-rocket/inc/classes/logger/class-stream-handler.php on line 55
```

By updating the return typehint of the `write` method

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream module