### PR TITLE
Temporary Add use_cache argument to the query get_items method in berlinDB code

### DIFF
--- a/inc/Dependencies/Database/Query.php
+++ b/inc/Dependencies/Database/Query.php
@@ -344,10 +344,10 @@ class Query extends Base {
 	 * @param string|array $query Array or URL query string of parameters.
 	 * @return array|int List of items, or number of items when 'count' is passed as a query var.
 	 */
-	public function query( $query = array() ) {
+	public function query( $query = array(), bool $use_cache = true ) {
 		$this->parse_query( $query );
 
-		return $this->get_items();
+		return $this->get_items( $use_cache );
 	}
 
 	/** Private Setters *******************************************************/
@@ -842,7 +842,7 @@ class Query extends Base {
 	 *
 	 * @return array|int List of items, or number of items when 'count' is passed as a query var.
 	 */
-	private function get_items() {
+	private function get_items( bool $use_cache = true ) {
 
 		/**
 		 * Fires before object items are retrieved.
@@ -863,7 +863,7 @@ class Query extends Base {
 
 		// Check the cache
 		$cache_key   = $this->get_cache_key();
-		$cache_value = $this->cache_get( $cache_key, $this->cache_group );
+		$cache_value = $use_cache ? $this->cache_get( $cache_key, $this->cache_group ) : false;
 
 		// No cache value
 		if ( false === $cache_value ) {
@@ -872,14 +872,16 @@ class Query extends Base {
 			// Set the number of found items
 			$this->set_found_items( $item_ids );
 
-			// Format the cached value
-			$cache_value = array(
-				'item_ids'    => $item_ids,
-				'found_items' => intval( $this->found_items ),
-			);
+			if ( $use_cache ) {
+				// Format the cached value
+				$cache_value = array(
+					'item_ids'    => $item_ids,
+					'found_items' => intval( $this->found_items ),
+				);
 
-			// Add value to the cache
-			$this->cache_add( $cache_key, $cache_value, $this->cache_group );
+				// Add value to the cache
+				$this->cache_add( $cache_key, $cache_value, $this->cache_group );
+			}
 
 		// Value exists in cache
 		} else {

--- a/inc/Engine/Preload/Database/Queries/Cache.php
+++ b/inc/Engine/Preload/Database/Queries/Cache.php
@@ -187,7 +187,8 @@ class Cache extends Query {
 		$rows = $this->query(
 			[
 				'url' => untrailingslashit( $resource['url'] ),
-			]
+			],
+			false
 		);
 
 		if ( count( $rows ) > 0 ) {

--- a/inc/Engine/Preload/Database/Queries/Cache.php
+++ b/inc/Engine/Preload/Database/Queries/Cache.php
@@ -128,7 +128,8 @@ class Cache extends Query {
 		$rows = $this->query(
 			[
 				'url' => $url,
-			]
+			],
+			false
 		);
 
 		if ( count( $rows ) === 0 ) {


### PR DESCRIPTION
## Description

To make the process of 3.12 release faster we agreed to change BerlinDB code in our codebase to enable/disable the cache for query get_items so we can use in preload.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

Please delete the options that are not relevant.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
