### PR TITLE
Fixes 5318 mysql error on the preload

### DIFF
--- a/inc/Engine/Preload/Database/Schemas/Cache.php
+++ b/inc/Engine/Preload/Database/Schemas/Cache.php
@@ -29,12 +29,11 @@ class Cache extends Schema {
 		[
 			'name'       => 'url',
 			'type'       => 'varchar',
-			'length'     => '255',
+			'length'     => '2000',
 			'default'    => null,
 			'cache_key'  => true,
 			'searchable' => true,
 			'sortable'   => false,
-			'unique'     => true,
 		],
 
 		// STATUS    column.

--- a/inc/Engine/Preload/Database/Tables/Cache.php
+++ b/inc/Engine/Preload/Database/Tables/Cache.php
@@ -45,11 +45,12 @@ class Cache extends Table {
 	protected function set_schema() {
 		$this->schema = "
 			id               bigint(20) unsigned NOT NULL AUTO_INCREMENT,
-			url              varchar(255)       NOT NULL default '' UNIQUE,
+			url              varchar(2000)       NOT NULL default '',
 			status           varchar(255)        NOT NULL default '',
 			modified         timestamp           NOT NULL default '0000-00-00 00:00:00',
 			last_accessed    timestamp           NOT NULL default '0000-00-00 00:00:00',
 			PRIMARY KEY (id),
+			KEY url (url(191)),
 			KEY modified (modified),
 			KEY last_accessed (last_accessed)";
 	}

--- a/inc/Engine/Preload/Database/Tables/Cache.php
+++ b/inc/Engine/Preload/Database/Tables/Cache.php
@@ -35,7 +35,7 @@ class Cache extends Table {
 	 *
 	 * @var int
 	 */
-	protected $version = 20220205;
+	protected $version = 20220818;
 
 	/**
 	 * Setup the database schema


### PR DESCRIPTION
## Description

Change the Mysql definition from the cache table to prevent a configuration issue with Mysql 5.6.

Fixes #5318 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

No.

## How Has This Been Tested?

- [x] Local env

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
