### PR TITLE
Fix preloading the sitemap with update from any version less than or equals 3.12.0.2

### DIFF
--- a/inc/Engine/Preload/Activation/Activation.php
+++ b/inc/Engine/Preload/Activation/Activation.php
@@ -76,7 +76,7 @@ class Activation implements ActivationInterface {
 	 * @return void
 	 */
 	public function refresh_on_update( $new_version, $old_version ) {
-		if ( version_compare( $old_version, '3.12.0.2', '>=' ) ) {
+		if ( version_compare( $old_version, '3.12.0.2', '>' ) ) {
 			return;
 		}
 		$this->queue->add_job_preload_job_load_initial_sitemap_async();

--- a/inc/Engine/Preload/Activation/Activation.php
+++ b/inc/Engine/Preload/Activation/Activation.php
@@ -76,7 +76,7 @@ class Activation implements ActivationInterface {
 	 * @return void
 	 */
 	public function refresh_on_update( $new_version, $old_version ) {
-		if ( version_compare( $new_version, '3.12.0', '>=' ) ) {
+		if ( version_compare( $old_version, '3.12.0.2', '>=' ) ) {
 			return;
 		}
 		$this->queue->add_job_preload_job_load_initial_sitemap_async();

--- a/tests/Fixtures/inc/Engine/Preload/Activation/refreshOnUpdate.php
+++ b/tests/Fixtures/inc/Engine/Preload/Activation/refreshOnUpdate.php
@@ -1,20 +1,20 @@
 <?php
 return [
-	'versionInferiorShouldDoNothing' => [
+	'updatingFromVersionAfter3.12.0.2ShouldDoNothing' => [
 		'config' => [
 			'new_version' => '3.14.0',
 			'old_version' => '3.13.0',
 		],
 		'result' => false,
 	],
-	'versionSuperiorShouldReload' => [
+	'updatingFromVersionBefore3.12.0.2ShouldReload' => [
 		'config' => [
 			'new_version' => '3.12.2',
 			'old_version' => '3.11.0',
 		],
 		'result' => true,
 	],
-	'versionExactlyShouldReload' => [
+	'updatingFromVersionExactly3.12.0.2ShouldReload' => [
 		'config' => [
 			'new_version' => '3.12.0.3',
 			'old_version' => '3.12.0.2',

--- a/tests/Fixtures/inc/Engine/Preload/Activation/refreshOnUpdate.php
+++ b/tests/Fixtures/inc/Engine/Preload/Activation/refreshOnUpdate.php
@@ -2,14 +2,23 @@
 return [
 	'versionInferiorShouldDoNothing' => [
 		'config' => [
-			'new_version' => '3.12.0',
+			'new_version' => '3.14.0',
 			'old_version' => '3.13.0',
 		],
+		'result' => false,
 	],
 	'versionSuperiorShouldReload' => [
 		'config' => [
-			'new_version' => '3.11.0',
-			'old_version' => '3.12.0',
+			'new_version' => '3.12.2',
+			'old_version' => '3.11.0',
 		],
-	]
+		'result' => true,
+	],
+	'versionExactlyShouldReload' => [
+		'config' => [
+			'new_version' => '3.12.0.3',
+			'old_version' => '3.12.0.2',
+		],
+		'result' => true,
+	],
 ];

--- a/tests/Unit/inc/Engine/Preload/Activation/refreshOnUpdate.php
+++ b/tests/Unit/inc/Engine/Preload/Activation/refreshOnUpdate.php
@@ -29,14 +29,14 @@ class Test_RefreshOnUpdate extends TestCase
 	/**
 	 * @dataProvider configTestData
 	 */
-	public function testShouldDoAsExpected($config) {
+	public function testShouldDoAsExpected($config, $result) {
 
-		$this->configureReloadSitemap($config);
+		$this->configureReloadSitemap($result);
 		$this->activation->refresh_on_update($config['new_version'], $config['old_version']);
 	}
 
-	public function configureReloadSitemap($config) {
-		if($config['new_version'] !== '3.11.0') {
+	public function configureReloadSitemap($should_preload) {
+		if( ! $should_preload ) {
 			$this->queue->expects()->add_job_preload_job_load_initial_sitemap_async()->never();
 			return;
 		}


### PR DESCRIPTION
## Description

We had a problem with this condition
https://github.com/wp-media/wp-rocket/blob/a036f3c3949fb5ba10d5b651d9e80197bcfb4d1a/inc/Engine/Preload/Activation/Activation.php#L79

Which means that if the new version is less than `3.12` we will preload the sitemap and this will never happen.

So this PR to solve that.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Locally and fixed the fixtures

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
