### PR TITLE
Update format method signature to match Monolog V2 

### DIFF
--- a/inc/classes/logger/class-html-formatter.php
+++ b/inc/classes/logger/class-html-formatter.php
@@ -24,7 +24,7 @@ class HTML_Formatter extends HtmlFormatter {
 	 * @param  array $record A record to format.
 	 * @return mixed         The formatted record.
 	 */
-	public function format( array $record ) {
+	public function format( array $record ): string {
 		$output  = $this->addTitle( $record['level_name'], $record['level'] );
 		$output .= '<table cellspacing="1" width="100%" class="monolog-output">';
 


### PR DESCRIPTION
## Description

Fix the following error
```
[24-Aug-2022 11:59:51 UTC] PHP Fatal error:  Declaration of WP_Rocket\Logger\HTML_Formatter::format(array $record) must be compatible with Monolog\Formatter\HtmlFormatter::format(array $record): string in /home/wpquicki/mega/flatsome/wp-content/plugins/wp-rocket/inc/classes/logger/class-html-formatter.php on line 27
```