### PR TITLE
Prevent error when dropping resources table

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Admin/Database.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Database.php
@@ -92,7 +92,7 @@ class Database {
 	public function drop_resources_table(): bool {
 		global $wpdb;
 
-		$result = $wpdb->query( "DROP TABLE {$wpdb->prefix}wpr_rucss_resources" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
+		$result = $wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}wpr_rucss_resources" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
 
 		if ( false === $result ) {
 			return false;


### PR DESCRIPTION
## Description

Here we add `IF EXISTS` to the drop resources table query and from tests I need to keep the condition that we use to delete the version in options table because `DROP TABLE IF EXISTS` returns also `true` if the table isn't there.

Fixes #5347

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

Yes

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Locally

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
