### PR TITLE
Fixes #5363 Guard against empty value before passing it to the delete url method in preload

### DIFF
--- a/inc/Engine/Preload/Subscriber.php
+++ b/inc/Engine/Preload/Subscriber.php
@@ -300,7 +300,7 @@ class Subscriber implements Subscriber_Interface {
 
 		$url = get_permalink( $post_id );
 
-		if ( false === $url ) {
+		if ( empty( $url ) ) {
 			return;
 		}
 
@@ -320,7 +320,7 @@ class Subscriber implements Subscriber_Interface {
 
 		$url = get_term_link( (int) $term_id );
 
-		if ( false === $url ) {
+		if ( empty( $url ) ) {
 			return;
 		}
 


### PR DESCRIPTION
## Description

Use `empty()` function to check the `$url` value instead of a strict comparison with `false`, to be able to catch other empty values like `null`.

Fixes #5363

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
