### PR TITLE
Fixes #5369 bail out when user is logged to prevent changing preload status

### DIFF
--- a/inc/Engine/Preload/Subscriber.php
+++ b/inc/Engine/Preload/Subscriber.php
@@ -166,6 +166,11 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	public function update_cache_row() {
 		global $wp;
+
+		if ( is_user_logged_in() ) {
+			return;
+		}
+
 		$url = home_url( add_query_arg( [], $wp->request ) );
 
 		if ( $this->query->is_preloaded( $url ) ) {


### PR DESCRIPTION
## Description

Fix a problem where logged users trigger preload status.
For that we bailed out in the method `update_cache_row` from the preload subscriber if the user is logged.

Fixes #5369

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

No.

## How Has This Been Tested?

- [ ] Test Manually

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
