### PR TITLE
Fix warnings from integration test due to preload table

### DIFF
--- a/tests/Integration/ApiTestCase.php
+++ b/tests/Integration/ApiTestCase.php
@@ -6,6 +6,19 @@ use WPMedia\PHPUnit\Integration\RESTfulTestCase as WPMediaRESTfulTestCase;
 
 abstract class ApiTestCase extends WPMediaRESTfulTestCase {
 	protected static $api_credentials_config_file = 'rocketcdn.php';
+	use DBTrait;
+
+	public static function set_up_before_class()
+	{
+		parent::set_up_before_class();
+		self::installFresh();
+	}
+
+	public static function tear_down_after_class()
+	{
+		self::uninstallAll();
+		parent::tear_down_after_class();
+	}
 
 	/**
 	 * Runs the RESTful endpoint which invokes WordPress to run in an integrated fashion. Callback will be fired.

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -12,6 +12,7 @@ abstract class TestCase extends BaseTestCase {
 	use SettingsTrait;
 	use StubTrait;
 	use FilterTrait;
+	use DBTrait;
 
 	protected static $use_settings_trait = true;
 	protected static $transients         = [];
@@ -20,6 +21,8 @@ abstract class TestCase extends BaseTestCase {
 
 	public static function set_up_before_class() {
 		parent::set_up_before_class();
+
+		self::installFresh();
 
 		CapTrait::hasAdminCapBeforeClass();
 
@@ -36,6 +39,8 @@ abstract class TestCase extends BaseTestCase {
 
 	public static function tear_down_after_class() {
 		parent::tear_down_after_class();
+
+		self::uninstallAll();
 
 		CapTrait::resetAdminCap();
 

--- a/tests/Integration/bootstrap.php
+++ b/tests/Integration/bootstrap.php
@@ -192,15 +192,6 @@ tests_add_filter(
 	}
 );
 
-tests_add_filter(
-	'init',
-	function() {
-		$container             = apply_filters( 'rocket_container', null );
-		$preload_cache_table = $container->get( 'preload_caches_table' );
-		$preload_cache_table->install();
-	}
-);
-
 // install WC.
 tests_add_filter(
 	'setup_theme',

--- a/tests/Integration/bootstrap.php
+++ b/tests/Integration/bootstrap.php
@@ -2,7 +2,6 @@
 
 namespace WP_Rocket\Tests\Integration;
 
-use Automattic\Jetpack\Modules;
 use WC_Install;
 use WP_Rocket\Tests\Fixtures\Kinsta\Kinsta_Cache;
 use WPMedia\PHPUnit\BootstrapManager;
@@ -193,6 +192,14 @@ tests_add_filter(
 	}
 );
 
+tests_add_filter(
+	'init',
+	function() {
+		$container             = apply_filters( 'rocket_container', null );
+		$preload_cache_table = $container->get( 'preload_caches_table' );
+		$preload_cache_table->install();
+	}
+);
 
 // install WC.
 tests_add_filter(

--- a/tests/Integration/inc/Engine/Admin/Settings/Settings/sanitizeCallback.php
+++ b/tests/Integration/inc/Engine/Admin/Settings/Settings/sanitizeCallback.php
@@ -15,6 +15,18 @@ use WP_Rocket\Tests\Integration\DBTrait;
 class Test_SanitizeCallback extends AdminTestCase {
 	use DBTrait;
 
+	public static function set_up_before_class()
+	{
+		parent::set_up_before_class();
+		self::installFresh();
+	}
+
+	public static function tear_down_after_class()
+	{
+		self::uninstallAll();
+		parent::tear_down_after_class();
+	}
+
 	public function set_up() {
 		DBTrait::removeDBHooks();
 		parent::set_up();

--- a/tests/Integration/inc/Engine/CDN/RocketCDN/CDNOptionsManager/TestCase.php
+++ b/tests/Integration/inc/Engine/CDN/RocketCDN/CDNOptionsManager/TestCase.php
@@ -5,9 +5,12 @@ namespace WP_Rocket\Tests\Integration\inc\Engine\CDN\RocketCDN\CDNOptionsManager
 use WP_Rocket\Admin\Options;
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\CDN\RocketCDN\CDNOptionsManager;
+use WP_Rocket\Tests\Integration\DBTrait;
 use WP_Rocket\Tests\Integration\FilesystemTestCase;
 
 abstract class TestCase extends FilesystemTestCase {
+	use DBTrait;
+
 	protected static $rocketcdn_user_token;
 
 	public static function set_up_before_class() {
@@ -17,7 +20,15 @@ abstract class TestCase extends FilesystemTestCase {
 		];
 		parent::set_up_before_class();
 
+		self::installFresh();
+
 		static::$rocketcdn_user_token = get_option( 'rocketcdn_user_token', null );
+	}
+
+	public static function tear_down_after_class()
+	{
+		self::uninstallAll();
+		parent::tear_down_after_class();
 	}
 
 	public function set_up() {

--- a/tests/Integration/inc/Engine/Cache/PurgeActionsSubscriber/maybePurgeCacheOnTermChange.php
+++ b/tests/Integration/inc/Engine/Cache/PurgeActionsSubscriber/maybePurgeCacheOnTermChange.php
@@ -2,6 +2,7 @@
 
 namespace WP_Rocket\Tests\Integration\inc\Engine\Cache\PurgeActionsSubscriber;
 
+use WP_Rocket\Tests\Integration\DBTrait;
 use WP_Rocket\Tests\Integration\FilesystemTestCase;
 
 /**
@@ -13,6 +14,20 @@ use WP_Rocket\Tests\Integration\FilesystemTestCase;
  */
 class Test_MaybePurgeCacheOnTermChange extends FilesystemTestCase {
 	protected $path_to_test_data = '/inc/Engine/Cache/PurgeActionsSubscriber/maybePurgeCacheOnTermChange.php';
+
+	use DBTrait;
+
+	public static function set_up_before_class()
+	{
+		parent::set_up_before_class();
+		self::installFresh();
+	}
+
+	public static function tear_down_after_class()
+	{
+		self::uninstallAll();
+		parent::tear_down_after_class();
+	}
 
 	public function set_up() {
 		parent::set_up();

--- a/tests/Integration/inc/Engine/Cache/PurgeActionsSubscriber/purgeDatesArchives.php
+++ b/tests/Integration/inc/Engine/Cache/PurgeActionsSubscriber/purgeDatesArchives.php
@@ -3,6 +3,7 @@
 namespace WP_Rocket\Tests\Integration\inc\Engine\Cache\PurgeActionsSubscriber;
 
 use Brain\Monkey\Functions;
+use WP_Rocket\Tests\Integration\DBTrait;
 use WP_Rocket\Tests\Integration\FilesystemTestCase;
 
 /**
@@ -15,6 +16,20 @@ use WP_Rocket\Tests\Integration\FilesystemTestCase;
 class Test_PurgeDatesArchives extends FilesystemTestCase {
 	private static $user_id = 0;
 	protected $path_to_test_data = '/inc/Engine/Cache/Purge/purgeDatesArchives.php';
+
+	use DBTrait;
+
+	public static function set_up_before_class()
+	{
+		parent::set_up_before_class();
+		self::installFresh();
+	}
+
+	public static function tear_down_after_class()
+	{
+		self::uninstallAll();
+		parent::tear_down_after_class();
+	}
 
 	public static function wpSetUpBeforeClass( $factory ) {
 		self::$user_id = $factory->user->create(

--- a/tests/Integration/inc/Engine/Cache/PurgeActionsSubscriber/purgePostTermsUrls.php
+++ b/tests/Integration/inc/Engine/Cache/PurgeActionsSubscriber/purgePostTermsUrls.php
@@ -2,6 +2,7 @@
 
 namespace WP_Rocket\Tests\Integration\inc\Engine\Cache\PurgeActionsSubscriber;
 
+use WP_Rocket\Tests\Integration\DBTrait;
 use WP_Rocket\Tests\Integration\FilesystemTestCase;
 
 /**
@@ -14,6 +15,20 @@ use WP_Rocket\Tests\Integration\FilesystemTestCase;
 class Test_GetRocketPostTermsUrls extends FilesystemTestCase {
 	private static $user_id      = 0;
 	protected $path_to_test_data = '/inc/Engine/Cache/Purge/purgePostTermsUrls.php';
+
+	use DBTrait;
+
+	public static function set_up_before_class()
+	{
+		parent::set_up_before_class();
+		self::installFresh();
+	}
+
+	public static function tear_down_after_class()
+	{
+		self::uninstallAll();
+		parent::tear_down_after_class();
+	}
 
 	public static function wpSetUpBeforeClass( $factory ) {
 		self::$user_id = $factory->user->create(

--- a/tests/Integration/inc/Engine/CriticalPath/Admin/Subscriber/setAsyncCssMobileDefaultValue.php
+++ b/tests/Integration/inc/Engine/CriticalPath/Admin/Subscriber/setAsyncCssMobileDefaultValue.php
@@ -22,7 +22,8 @@ class Test_SetAsyncCssMobileDefaultValue extends TestCase {
     }
 
     public function tear_down() {
-        parent::tear_down();
+
+		parent::tear_down();
 
         add_action( 'wp_rocket_upgrade', 'rocket_new_upgrade' );
     }

--- a/tests/Integration/inc/Engine/CriticalPath/CriticalCSS/getCriticalCssContent.php
+++ b/tests/Integration/inc/Engine/CriticalPath/CriticalCSS/getCriticalCssContent.php
@@ -3,6 +3,7 @@
 namespace WP_Rocket\Tests\Integration\inc\Engine\CriticalPath\CriticalCSS;
 
 use WP_Rocket\Tests\Integration\ContentTrait;
+use WP_Rocket\Tests\Integration\DBTrait;
 use WP_Rocket\Tests\Integration\FilesystemTestCase;
 
 /**
@@ -14,7 +15,7 @@ use WP_Rocket\Tests\Integration\FilesystemTestCase;
  * @group  vfs
  */
 class Test_GetCriticalCssContent extends FilesystemTestCase {
-	use ContentTrait;
+	use ContentTrait, DBTrait;
 
 	protected $path_to_test_data = '/inc/Engine/CriticalPath/CriticalCSS/getCriticalCssContent.php';
 
@@ -29,6 +30,7 @@ class Test_GetCriticalCssContent extends FilesystemTestCase {
 
 	public static function set_up_before_class() {
 		parent::set_up_before_class();
+		self::installFresh();
 
 		$container          = apply_filters( 'rocket_container', null );
 		self::$critical_css = $container->get( 'critical_css' );
@@ -39,6 +41,12 @@ class Test_GetCriticalCssContent extends FilesystemTestCase {
 				'user_nicename' => 'rocket_tester',
 			]
 		);
+	}
+
+	public static function tear_down_after_class()
+	{
+		self::uninstallAll();
+		parent::tear_down_after_class();
 	}
 
 	public function set_up() {

--- a/tests/Integration/inc/Engine/CriticalPath/CriticalCSS/processHandler.php
+++ b/tests/Integration/inc/Engine/CriticalPath/CriticalCSS/processHandler.php
@@ -8,6 +8,7 @@ use WP_Rocket\Engine\CriticalPath\CriticalCSS;
 use WP_Rocket\Engine\CriticalPath\CriticalCSSGeneration;
 use WP_Rocket\Engine\CriticalPath\DataManager;
 use WP_Rocket\Engine\CriticalPath\ProcessorService;
+use WP_Rocket\Tests\Integration\DBTrait;
 use WP_Rocket\Tests\Integration\FilesystemTestCase;
 
 /**
@@ -21,6 +22,20 @@ use WP_Rocket\Tests\Integration\FilesystemTestCase;
  * @group  CriticalPath
  */
 class Test_ProcessHandler extends FilesystemTestCase {
+	use DBTrait;
+
+	public static function set_up_before_class()
+	{
+		parent::set_up_before_class();
+		self::installFresh();
+	}
+
+	public static function tear_down_after_class()
+	{
+		self::uninstallAll();
+		parent::tear_down_after_class();
+	}
+
 	protected $path_to_test_data = '/inc/Engine/CriticalPath/CriticalCSS/processHandler.php';
 
 	private $critical_css;

--- a/tests/Integration/inc/Engine/CriticalPath/CriticalCSSSubscriber/insertCriticalCssBuffer.php
+++ b/tests/Integration/inc/Engine/CriticalPath/CriticalCSSSubscriber/insertCriticalCssBuffer.php
@@ -3,6 +3,7 @@
 namespace WP_Rocket\Tests\Integration\inc\Engine\CriticalPath\CriticalCSSSubscriber;
 
 use WP_Rocket\Tests\Integration\ContentTrait;
+use WP_Rocket\Tests\Integration\DBTrait;
 use WP_Rocket\Tests\Integration\FilesystemTestCase;
 
 /**
@@ -16,8 +17,19 @@ use WP_Rocket\Tests\Integration\FilesystemTestCase;
  * @group  vfs
  */
 class Test_InsertCriticalCssBuffer extends FilesystemTestCase {
-	use ContentTrait;
+	use ContentTrait, DBTrait;
 
+	public static function set_up_before_class()
+	{
+		parent::set_up_before_class();
+		self::installFresh();
+	}
+
+	public static function tear_down_after_class()
+	{
+		self::uninstallAll();
+		parent::tear_down_after_class();
+	}
 	protected $path_to_test_data = '/inc/Engine/CriticalPath/CriticalCSSSubscriber/insertCriticalCssBuffer.php';
 
 	protected static $use_settings_trait = true;

--- a/tests/Integration/inc/Engine/CriticalPath/RESTWPPost/delete.php
+++ b/tests/Integration/inc/Engine/CriticalPath/RESTWPPost/delete.php
@@ -2,6 +2,7 @@
 
 namespace WP_Rocket\Tests\Integration\inc\Engine\CriticalPath\RESTWPPost;
 
+use WP_Rocket\Tests\Integration\DBTrait;
 use WP_Rocket\Tests\Integration\RESTVfsTestCase;
 
 /**
@@ -14,6 +15,8 @@ use WP_Rocket\Tests\Integration\RESTVfsTestCase;
  * @group  vfs
  */
 class Test_Delete extends RESTVfsTestCase {
+	use DBTrait;
+
 	protected $path_to_test_data = '/inc/Engine/CriticalPath/RESTWPPost/delete.php';
 
 	protected static $use_settings_trait = true;
@@ -27,6 +30,8 @@ class Test_Delete extends RESTVfsTestCase {
 
 	public static function set_up_before_class() {
 		parent::set_up_before_class();
+		self::installFresh();
+
 		$admin                 = get_role( 'administrator' );
 		static::$had_admin_cap = $admin->has_cap( 'rocket_regenerate_critical_css' );
 	}
@@ -36,6 +41,8 @@ class Test_Delete extends RESTVfsTestCase {
 		if ( ! static::$had_cap ) {
 			$admin->remove_cap( 'rocket_regenerate_critical_css' );
 		}
+		self::uninstallAll();
+
 		parent::tear_down_after_class();
 	}
 

--- a/tests/Integration/inc/Engine/CriticalPath/RESTWPPost/generate.php
+++ b/tests/Integration/inc/Engine/CriticalPath/RESTWPPost/generate.php
@@ -3,6 +3,7 @@
 namespace WP_Rocket\Tests\Integration\inc\Engine\CriticalPath\RESTWPPost;
 
 use Brain\Monkey\Functions;
+use WP_Rocket\Tests\Integration\DBTrait;
 use WP_Rocket\Tests\Integration\RESTVfsTestCase;
 
 /**
@@ -11,6 +12,19 @@ use WP_Rocket\Tests\Integration\RESTVfsTestCase;
  * @group  vfs
  */
 class Test_Generate extends RESTVfsTestCase {
+	use DBTrait;
+
+	public static function set_up_before_class()
+	{
+		parent::set_up_before_class();
+		self::installFresh();
+	}
+
+	public static function tear_down_after_class()
+	{
+		self::uninstallAll();
+		parent::tear_down_after_class();
+	}
 	protected $path_to_test_data = '/inc/Engine/CriticalPath/RESTWPPost/generate.php';
 	private static $post_id;
 

--- a/tests/Integration/inc/Engine/Optimization/DelayJS/Admin/Subscriber/sanitizeOptions.php
+++ b/tests/Integration/inc/Engine/Optimization/DelayJS/Admin/Subscriber/sanitizeOptions.php
@@ -17,6 +17,7 @@ class Test_SanitizeOptions extends TestCase {
         $container = apply_filters( 'rocket_container', null );
 
         self::$admin_settings = $container->get( 'settings' );
+		parent::set_up_before_class();
     }
 
 	public function set_up() {

--- a/tests/Integration/inc/Engine/Optimization/Minify/AdminSubscriber/cleanMinifyAll.php
+++ b/tests/Integration/inc/Engine/Optimization/Minify/AdminSubscriber/cleanMinifyAll.php
@@ -2,6 +2,7 @@
 
 namespace WP_Rocket\Tests\Integration\inc\Engine\Optimization\Minify\AdminSubscriber;
 
+use WP_Rocket\Tests\Integration\DBTrait;
 use WP_Rocket\Tests\Integration\FilesystemTestCase;
 
 /**
@@ -15,10 +16,24 @@ use WP_Rocket\Tests\Integration\FilesystemTestCase;
  * @group  AdminOnly
  */
 class Test_CleanMinifyAll extends FilesystemTestCase {
+	use DBTrait;
+
 	protected $path_to_test_data = '/inc/Engine/Optimization/Minify/AdminSubscriber/cleanMinifyAll.php';
 
 	private $minify_js;
 	private $minify_css;
+
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		self::installFresh();
+	}
+
+	public static function tear_down_after_class() {
+		self::uninstallAll();
+
+		parent::tear_down_after_class();
+	}
 
 	public function tear_down() {
 		remove_filter( 'pre_get_rocket_option_minify_js', [ $this, 'set_minify_js' ] );

--- a/tests/Integration/inc/Engine/Optimization/Minify/CSS/AdminSubscriber/cleanMinify.php
+++ b/tests/Integration/inc/Engine/Optimization/Minify/CSS/AdminSubscriber/cleanMinify.php
@@ -2,6 +2,7 @@
 
 namespace WP_Rocket\Tests\Integration\inc\Engine\Optimization\Minify\CSS\AdminSubscriber;
 
+use WP_Rocket\Tests\Integration\DBTrait;
 use WP_Rocket\Tests\Integration\inc\Engine\Optimization\TestCase;
 
 /**
@@ -15,7 +16,21 @@ use WP_Rocket\Tests\Integration\inc\Engine\Optimization\TestCase;
  * @group  AdminOnly
  */
 class Test_CleanMinify extends TestCase {
+	use DBTrait;
+
 	protected $path_to_test_data = '/inc/Engine/Optimization/Minify/CSS/AdminSubscriber/cleanMinify.php';
+
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		self::installFresh();
+	}
+
+	public static function tear_down_after_class() {
+		self::uninstallAll();
+
+		parent::tear_down_after_class();
+	}
 
 	/**
 	 * @dataProvider providerTestData

--- a/tests/Integration/inc/Engine/Support/Subscriber/registerSupportRoute.php
+++ b/tests/Integration/inc/Engine/Support/Subscriber/registerSupportRoute.php
@@ -2,6 +2,7 @@
 
 namespace WP_Rocket\Tests\Integration\inc\Engine\Support\Subscriber;
 
+use WP_Rocket\Tests\Integration\DBTrait;
 use WPMedia\PHPUnit\Integration\ApiTrait;
 use WPMedia\PHPUnit\Integration\RESTfulTestCase as WPMediaRESTfulTestCase;
 use WP_Rocket\Tests\StubTrait;
@@ -14,6 +15,7 @@ use WP_Rocket\Tests\StubTrait;
 class Test_RegisterSupportRoute extends WPMediaRESTfulTestCase {
 	use ApiTrait;
 	use StubTrait;
+	use DBTrait;
 
 	protected static $api_credentials_config_file = 'license.php';
 	protected $config;
@@ -22,8 +24,15 @@ class Test_RegisterSupportRoute extends WPMediaRESTfulTestCase {
 
 	public static function set_up_before_class() {
 		parent::set_up_before_class();
+		self::installFresh();
 
 		self::pathToApiCredentialsConfigFile( WP_ROCKET_TESTS_DIR . '/../env/local/' );
+	}
+
+	public static function tear_down_after_class() {
+		self::uninstallAll();
+
+		parent::tear_down_after_class();
 	}
 
 	public function set_up() {
@@ -78,7 +87,7 @@ class Test_RegisterSupportRoute extends WPMediaRESTfulTestCase {
 
 		foreach ( $expected as $key => $value ) {
 			$this->assertArrayHasKey( $key, $actual );
-			
+
 			if ( is_array( $value ) ) {
 				foreach ( $value as $sub_key => $sub_value ) {
 					$this->assertArrayHasKey( $sub_key, $actual[ $key ] );

--- a/tests/Integration/inc/ThirdParty/Themes/Avada/cleanDomain.php
+++ b/tests/Integration/inc/ThirdParty/Themes/Avada/cleanDomain.php
@@ -2,6 +2,8 @@
 
 namespace WP_Rocket\Tests\Integration\inc\ThirdParty\Themes\Avada;
 
+use WP_Rocket\Tests\Integration\DBTrait;
+
 /**
  * @covers \WP_Rocket\ThirdParty\Avada::clean_domain
  *
@@ -9,7 +11,21 @@ namespace WP_Rocket\Tests\Integration\inc\ThirdParty\Themes\Avada;
  * @group  ThirdParty
  */
 class Test_CleanDomain extends TestCase {
+	use DBTrait;
+
 	protected      $path_to_test_data = '/inc/ThirdParty/Themes/Avada/cleanDomain.php';
+
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		self::installFresh();
+	}
+
+	public static function tear_down_after_class() {
+		self::uninstallAll();
+
+		parent::tear_down_after_class();
+	}
 
 	public function testShouldCleanCacheWhenAvadaCacheIsCleaned() {
 		$cache_exists = false;

--- a/tests/Integration/inc/ThirdParty/Themes/Bridge/maybeClearCache.php
+++ b/tests/Integration/inc/ThirdParty/Themes/Bridge/maybeClearCache.php
@@ -2,6 +2,7 @@
 
 namespace WP_Rocket\Tests\Integration\inc\ThirdParty\Themes\Bridge;
 
+use WP_Rocket\Tests\Integration\DBTrait;
 use WP_Rocket\Tests\Integration\FilesystemTestCase;
 
 /**
@@ -11,16 +12,21 @@ use WP_Rocket\Tests\Integration\FilesystemTestCase;
  * @group  ThirdParty
  */
 class Test_MaybeClearCache extends FilesystemTestCase {
+	use DBTrait;
+
 	protected      $path_to_test_data = '/inc/ThirdParty/Themes/Bridge/maybeClearCache.php';
 	private static $container;
 
 	public static function set_up_before_class() {
 		parent::set_up_before_class();
+		self::installFresh();
 
 		self::$container = apply_filters( 'rocket_container', '' );
 	}
 
 	public static function tear_down_after_class() {
+		self::uninstallAll();
+
 		parent::tear_down_after_class();
 
 		self::$container->get( 'event_manager' )->remove_subscriber( self::$container->get( 'bridge_subscriber' ) );

--- a/tests/Integration/inc/ThirdParty/Themes/Divi/disableImageDimensionsHeightPercentage.php
+++ b/tests/Integration/inc/ThirdParty/Themes/Divi/disableImageDimensionsHeightPercentage.php
@@ -1,6 +1,7 @@
 <?php
 namespace WP_Rocket\Tests\Integration\inc\ThirdParty\Themes\Divi;
 
+use WP_Rocket\Tests\Integration\DBTrait;
 use WP_Rocket\Tests\Integration\WPThemeTestcase;
 
 /**
@@ -9,17 +10,22 @@ use WP_Rocket\Tests\Integration\WPThemeTestcase;
  * @group  ThirdParty
  */
 class Test_DisableImageDimensionsHeightPercentage extends WPThemeTestcase {
+	use DBTrait;
+
 	protected $path_to_test_data = '/inc/ThirdParty/Themes/Divi/disableImageDimensionsHeightPercentage.php';
 
 	private static $container;
 
 	public static function set_up_before_class() {
 		parent::set_up_before_class();
+		self::installFresh();
 
 		self::$container = apply_filters( 'rocket_container', '' );
 	}
 
 	public static function tear_down_after_class() {
+		self::uninstallAll();
+
 		parent::tear_down_after_class();
 
 		self::$container->get( 'event_manager' )->remove_subscriber( self::$container->get( 'divi' ) );

--- a/tests/Integration/inc/ThirdParty/Themes/Divi/maybeDisableYoutubePreview.php
+++ b/tests/Integration/inc/ThirdParty/Themes/Divi/maybeDisableYoutubePreview.php
@@ -1,6 +1,7 @@
 <?php
 namespace WP_Rocket\Tests\Integration\inc\ThirdParty\Themes\Divi;
 
+use WP_Rocket\Tests\Integration\DBTrait;
 use WP_Rocket\Tests\Integration\WPThemeTestcase;
 use WP_Rocket\ThirdParty\Themes\Divi;
 
@@ -11,16 +12,21 @@ use WP_Rocket\ThirdParty\Themes\Divi;
  * @group  ThirdParty
  */
 class Test_MaybeDisableYoutubePreview extends WPThemeTestcase {
+	use DBTrait;
+
 	protected $path_to_test_data = '/inc/ThirdParty/Themes/Divi/maybeDisableYoutubePreview.php';
 	private static $container;
 
 	public static function set_up_before_class() {
 		parent::set_up_before_class();
+		self::installFresh();
 
 		self::$container = apply_filters( 'rocket_container', '' );
 	}
 
 	public static function tear_down_after_class() {
+		self::uninstallAll();
+
 		parent::tear_down_after_class();
 
 		self::$container->get( 'event_manager' )->remove_subscriber( self::$container->get( 'divi' ) );

--- a/tests/Integration/inc/ThirdParty/Themes/Divi/removeAssetsGenerated.php
+++ b/tests/Integration/inc/ThirdParty/Themes/Divi/removeAssetsGenerated.php
@@ -2,6 +2,7 @@
 
 namespace WP_Rocket\Tests\Integration\inc\ThirdParty\Themes\Divi;
 
+use WP_Rocket\Tests\Integration\DBTrait;
 use WP_Rocket\Tests\Integration\WPThemeTestcase;
 use WP_Rocket\ThirdParty\Themes\Divi;
 
@@ -13,17 +14,22 @@ use WP_Rocket\ThirdParty\Themes\Divi;
  */
 class Test_RemoveAssetsGenerated extends WPThemeTestcase
 {
+	use DBTrait;
+
 	protected $path_to_test_data = '/inc/ThirdParty/Themes/Divi/removeAssetsGenerated.php';
 
 	private static $container;
 
 	public static function set_up_before_class() {
 		parent::set_up_before_class();
+		self::installFresh();
 
 		self::$container = apply_filters( 'rocket_container', '' );
 	}
 
 	public static function tear_down_after_class() {
+		self::uninstallAll();
+
 		parent::tear_down_after_class();
 
 		self::$container->get( 'event_manager' )->remove_subscriber( self::$container->get( 'divi' ) );

--- a/tests/Integration/inc/admin/rocketAfterSaveOptions.php
+++ b/tests/Integration/inc/admin/rocketAfterSaveOptions.php
@@ -5,6 +5,7 @@ namespace WP_Rocket\Tests\Integration\inc\admin;
 use Brain\Monkey\Functions;
 use WP_Rocket\Engine\Cache\AdvancedCache;
 use WP_Rocket\Tests\Fixtures\DIContainer;
+use WP_Rocket\Tests\Integration\DBTrait;
 use WP_Rocket\Tests\Integration\FilesystemTestCase;
 
 /**
@@ -23,6 +24,8 @@ use WP_Rocket\Tests\Integration\FilesystemTestCase;
  * @group SaveOptions
  */
 class Test_RocketAfterSaveOptions extends FilesystemTestCase {
+	use DBTrait;
+
 	protected $path_to_test_data = '/inc/admin/rocketAfterSaveOptions.php';
 
 	protected static $use_settings_trait = true;
@@ -38,6 +41,18 @@ class Test_RocketAfterSaveOptions extends FilesystemTestCase {
 	private $rocketCleanDomainShouldNotClean;
 	private $rocketCleanMinifyShouldNotClean;
 	private $dicontainer;
+
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		self::installFresh();
+	}
+
+	public static function tear_down_after_class() {
+		self::uninstallAll();
+
+		parent::tear_down_after_class();
+	}
 
 	public function set_up() {
 		// Unhook to avoid triggering when storing the configured settings.

--- a/tests/Integration/inc/admin/rocketNewUpgrade.php
+++ b/tests/Integration/inc/admin/rocketNewUpgrade.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WP_Rocket\Tests\Unit\Inc\admin;
+namespace WP_Rocket\Tests\Integration\Inc\admin;
 
 use Brain\Monkey\Functions;
 use WP_Rocket\Tests\Integration\DBTrait;

--- a/tests/Integration/inc/common/rocketCleanCacheThemeUpdate.php
+++ b/tests/Integration/inc/common/rocketCleanCacheThemeUpdate.php
@@ -3,6 +3,7 @@
 namespace WP_Rocket\Tests\Integration\inc\common;
 
 use Brain\Monkey\Functions;
+use WP_Rocket\Tests\Integration\DBTrait;
 use WP_Rocket\Tests\Integration\FilesystemTestCase;
 
 /**
@@ -14,16 +15,21 @@ use WP_Rocket\Tests\Integration\FilesystemTestCase;
  * @group  vfs
  */
 class Test_RocketCleanCacheThemeUpdate extends FilesystemTestCase {
+	use DBTrait;
+
 	protected        $path_to_test_data = '/inc/common/rocketCleanCacheThemeUpdate.php';
 	protected static $hooks;
 
 	public static function set_up_before_class() {
 		parent::set_up_before_class();
+		self::installFresh();
 
 		self::$hooks = $GLOBALS['wp_filter']['upgrader_process_complete']->callbacks;
 	}
 
 	public static function tear_down_after_class() {
+		self::uninstallAll();
+
 		parent::tear_down_after_class();
 
 		$GLOBALS['wp_filter']['upgrader_process_complete']->callbacks = self::$hooks;

--- a/tests/Integration/inc/common/rocketCleanPostCacheOnSlugChange.php
+++ b/tests/Integration/inc/common/rocketCleanPostCacheOnSlugChange.php
@@ -3,6 +3,7 @@
 namespace WP_Rocket\Tests\Integration\inc\common;
 
 use Brain\Monkey\Functions;
+use WP_Rocket\Tests\Integration\DBTrait;
 use WPMedia\PHPUnit\Integration\TestCase;
 
 /**
@@ -11,6 +12,8 @@ use WPMedia\PHPUnit\Integration\TestCase;
  * @group Purge
  */
 class TestRocketCleanPostCacheOnSlugChange extends TestCase {
+	use DBTrait;
+
 	/**
 	 * User's ID.
 	 * @var int
@@ -21,6 +24,18 @@ class TestRocketCleanPostCacheOnSlugChange extends TestCase {
 	 * @var WP_Post
 	 */
 	private $original_post;
+
+	public static function set_up_before_class()
+	{
+		parent::set_up_before_class();
+		self::installFresh();
+	}
+
+	public static function tear_down_after_class()
+	{
+		self::uninstallAll();
+		parent::tear_down_after_class();
+	}
 
 	/**
 	 * Set up the User ID before tests start.

--- a/tests/Integration/inc/common/rocketGetPurgeUrls.php
+++ b/tests/Integration/inc/common/rocketGetPurgeUrls.php
@@ -1,6 +1,7 @@
 <?php
 namespace WP_Rocket\Tests\Integration\inc\common;
 
+use WP_Rocket\Tests\Integration\DBTrait;
 use WP_Rocket\Tests\Integration\FilesystemTestCase;
 use Brain\Monkey\Functions;
 
@@ -12,6 +13,8 @@ use Brain\Monkey\Functions;
  * @group  Purge
  */
 class Test_RocketGetPurgeUrls extends FilesystemTestCase {
+	use DBTrait;
+
 	protected $path_to_test_data = '/inc/common/rocketGetPurgeUrls.php';
 
 	private $site_options = [
@@ -22,6 +25,18 @@ class Test_RocketGetPurgeUrls extends FilesystemTestCase {
 	private $posts_map   = [];
 	private $authors_map = [];
 	private $post_data   = [];
+
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		self::installFresh();
+	}
+
+	public static function tear_down_after_class() {
+		self::uninstallAll();
+
+		parent::tear_down_after_class();
+	}
 
 	public function set_up() {
 		$this->set_permalink_structure( "/%postname%/" );

--- a/tests/Integration/inc/common/rocketWidgetUpdateCallback.php
+++ b/tests/Integration/inc/common/rocketWidgetUpdateCallback.php
@@ -2,6 +2,7 @@
 
 namespace WP_Rocket\Tests\Integration\inc\common;
 
+use WP_Rocket\Tests\Integration\DBTrait;
 use WP_Widget_Text;
 use WP_Rocket\Tests\Integration\FilesystemTestCase;
 
@@ -14,7 +15,21 @@ use WP_Rocket\Tests\Integration\FilesystemTestCase;
  * @group  vfs
  */
 class Test_RocketWidgetUpdateCallback extends FilesystemTestCase {
+	use DBTrait;
+
 	protected $path_to_test_data = '/inc/common/rocketWidgetUpdateCallback.php';
+
+	public static function set_up_before_class()
+	{
+		parent::set_up_before_class();
+		self::installFresh();
+	}
+
+	public static function tear_down_after_class()
+	{
+		self::uninstallAll();
+		parent::tear_down_after_class();
+	}
 
 	public static function wpSetUpBeforeClass( $factory ) {
 		wp_set_current_user( $factory->user->create( [ 'role' => 'administrator' ] ) );

--- a/tests/Integration/inc/functions/getRocketSamplePermalink.php
+++ b/tests/Integration/inc/functions/getRocketSamplePermalink.php
@@ -2,6 +2,7 @@
 
 namespace WP_Rocket\Tests\Integration\inc\functions;
 
+use WP_Rocket\Tests\Integration\DBTrait;
 use WPMedia\PHPUnit\Integration\TestCase;
 
 /**
@@ -10,7 +11,21 @@ use WPMedia\PHPUnit\Integration\TestCase;
  * @group Posts
  */
 class Test_GetRocketSamePermalink extends TestCase {
+	use DBTrait;
+
 	private $did_filter;
+
+	public static function set_up_before_class()
+	{
+		parent::set_up_before_class();
+		self::installFresh();
+	}
+
+	public static function tear_down_after_class()
+	{
+		self::uninstallAll();
+		parent::tear_down_after_class();
+	}
 
 	public function set_up() {
 		parent::set_up();

--- a/tests/Integration/inc/functions/rocketCleanDomain.php
+++ b/tests/Integration/inc/functions/rocketCleanDomain.php
@@ -3,6 +3,7 @@
 namespace WP_Rocket\Tests\Integration\inc\functions;
 
 use WP_Rocket\Tests\Fixtures\i18n\i18nTrait;
+use WP_Rocket\Tests\Integration\DBTrait;
 use WP_Rocket\Tests\Integration\FilesystemTestCase;
 
 /**
@@ -21,8 +22,19 @@ use WP_Rocket\Tests\Integration\FilesystemTestCase;
  * @group Clean
  */
 class Test_RocketCleanDomain extends FilesystemTestCase {
-	use i18nTrait;
+	use i18nTrait, DBTrait;
 
+	public static function set_up_before_class()
+	{
+		parent::set_up_before_class();
+		self::installFresh();
+	}
+
+	public static function tear_down_after_class()
+	{
+		self::uninstallAll();
+		parent::tear_down_after_class();
+	}
 	protected $path_to_test_data = '/inc/functions/rocketCleanDomain.php';
 
 	public function tear_down() {

--- a/tests/Integration/inc/functions/rocketCleanFiles.php
+++ b/tests/Integration/inc/functions/rocketCleanFiles.php
@@ -2,6 +2,7 @@
 
 namespace WP_Rocket\Tests\Integration\inc\functions;
 
+use WP_Rocket\Tests\Integration\DBTrait;
 use WP_Rocket\Tests\Integration\FilesystemTestCase;
 
 /**
@@ -15,7 +16,21 @@ use WP_Rocket\Tests\Integration\FilesystemTestCase;
  * @group Clean
  */
 class Test_RocketCleanFiles extends FilesystemTestCase {
+	use DBTrait;
+
 	protected $path_to_test_data = '/inc/functions/rocketCleanFiles.php';
+
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		self::installFresh();
+	}
+
+	public static function tear_down_after_class() {
+		self::uninstallAll();
+
+		parent::tear_down_after_class();
+	}
 
 	/**
 	 * @dataProvider providerTestData


### PR DESCRIPTION
## Description
Fix warning due to the cache table from the new preload functionality.

For that I added the table in the bootstrap and added it on every tests needing it.
Note: I could fix warnings on the initial load from the bootstrap.php.
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] Automated Test

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
