### PR TITLE
Inline css safelist for Remove Unused CSS

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -91,6 +91,7 @@ class UsedCSS {
 		'.adsslot_', // For Advanced Ads plugin ads.
 		'.jnews_', // For JNews theme.
 		'.cp-info-bar.content-', // For Convert Plus plugin.
+		'#thb-', // For Revolution theme.
 	];
 
 	/**


### PR DESCRIPTION
## Description

adding `#thb-` at `$inline_content_exclusions` to fix dinamyc inline selectors used by Revolution Theme

Fixes #5229

## Type of change

Please delete options that are not relevant.

- [ ] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

No, is the solution discussed in the GH issue


# Checklist:

Please delete the options that are not relevant.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
