### PR TITLE
Guard against exceeding in-progress items in the cache table

### DIFF
--- a/inc/Engine/Preload/Database/Queries/Cache.php
+++ b/inc/Engine/Preload/Database/Queries/Cache.php
@@ -300,7 +300,7 @@ class Cache extends Query {
 	 * @param int $total total of jobs to fetch.
 	 * @return array
 	 */
-	public function get_pending_jobs( int $total ) {
+	public function get_pending_jobs( int $total = 45 ) {
 		$inprogress_count = $this->query(
 			[
 				'count'  => true,

--- a/inc/Engine/Preload/Database/Queries/Cache.php
+++ b/inc/Engine/Preload/Database/Queries/Cache.php
@@ -301,10 +301,20 @@ class Cache extends Query {
 	 * @return array
 	 */
 	public function get_pending_jobs( int $total ) {
+		$inprogress_count = $this->query(
+			[
+				'count'  => true,
+				'status' => 'in-progress',
+			]
+		);
+
+		if ( $inprogress_count >= $total ) {
+			return [];
+		}
 
 		return $this->query(
 			[
-				'number'         => $total,
+				'number'         => ( $total - $inprogress_count ),
 				'status'         => 'pending',
 				'fields'         => [
 					'id',

--- a/tests/Fixtures/inc/Engine/Preload/Database/Queries/Cache/getPendingJobs.php
+++ b/tests/Fixtures/inc/Engine/Preload/Database/Queries/Cache/getPendingJobs.php
@@ -5,9 +5,11 @@ use WP_Rocket\Engine\Preload\Database\Rows\CacheRow;
 $cache = new CacheRow((object)[]);
 
 return [
-	'shouldReturnElements' => [
+	'shouldReturnPendingRowsWhenInProgressLessThanTotal' => [
 		'config' => [
-			'total' => 1,
+			'total' => 45,
+			'pending' => 1,
+			'in-progress' => 1,
 			'results' => [
 				$cache,
 			]
@@ -15,5 +17,27 @@ return [
 		'expected' => [
 			$cache
 		]
+	],
+	'shouldReturnEmptyPendingRowsWhenInProgressEqualsTotal' => [
+		'config' => [
+			'total' => 45,
+			'pending' => 100,
+			'in-progress' => 45,
+			'results' => [
+				$cache,
+			],
+		],
+		'expected' => [],
+	],
+	'shouldReturnEmptyPendingRowsWhenInProgressMoreThanTotal' => [
+		'config' => [
+			'total' => 45,
+			'pending' => 100,
+			'in-progress' => 45,
+			'results' => [
+				$cache,
+			],
+		],
+		'expected' => [],
 	],
 ];

--- a/tests/Unit/inc/Engine/Preload/Database/Queries/Cache/getPendingJobs.php
+++ b/tests/Unit/inc/Engine/Preload/Database/Queries/Cache/getPendingJobs.php
@@ -23,19 +23,27 @@ class Test_GetPendingJobs extends TestCase {
 	 * @dataProvider configTestData
 	 */
 	public function testShouldReturnPending($config, $expected) {
-		$this->query->expects(self::atLeastOnce())->method('query')->with([
-			'number'         => $config['total'],
-			'status'         => 'pending',
-			'fields'         => [
-				'id',
-				'url',
-			],
-			'job_id__not_in' => [
-				'not_in' => '',
-			],
-			'orderby'        => 'modified',
-			'order'          => 'asc',
-		])->willReturn($config['results']);
+		$this->query->expects($this->at(0))->method('query')->with( [
+			'count'  => true,
+			'status' => 'in-progress',
+		] )->willReturn( $config['in-progress'] );
+
+		if ( $config['total'] > $config['in-progress'] ) {
+			$this->query->expects($this->at(1))->method('query')->with([
+				'number'         => $config['total'] - $config['in-progress'],
+				'status'         => 'pending',
+				'fields'         => [
+					'id',
+					'url',
+				],
+				'job_id__not_in' => [
+					'not_in' => '',
+				],
+				'orderby'        => 'modified',
+				'order'          => 'asc',
+			])->willReturn($config['results']);
+		}
+
 		$this->assertSame($expected, $this->query->get_pending_jobs($config['total']));
 	}
 


### PR DESCRIPTION
## Description

Sometimes we may have in-progress items in the preload cache database more than the maximum number of items should be processed, this PR will make sure that we will not exceed this max. number.

Fixes #5373

## Type of change

Please delete options that are not relevant.

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

[XS] effort, not groomed

## How Has This Been Tested?

- [x] Locally

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
