### PR TITLE
Fixes 5332: Fixed warning on delete completely post.

### DIFF
--- a/inc/Engine/Preload/Database/Queries/Cache.php
+++ b/inc/Engine/Preload/Database/Queries/Cache.php
@@ -254,7 +254,9 @@ class Cache extends Query {
 
 		$deleted = true;
 		foreach ( $items as $item ) {
-			$deleted = $deleted && $this->delete_item( $item->id );
+			if ( ! is_bool( $item ) ) {
+				$deleted = $deleted && $this->delete_item( $item->id );
+			}
 		}
 
 		return $deleted;

--- a/inc/Engine/Preload/Database/Queries/Cache.php
+++ b/inc/Engine/Preload/Database/Queries/Cache.php
@@ -290,7 +290,9 @@ class Cache extends Query {
 		$rows = $this->get_old_cache();
 
 		foreach ( $rows as $row ) {
-			$this->delete_item( $row->id );
+			if ( ! is_bool( $row ) ) {
+				$this->delete_item( $row->id );
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description

Fixed a problem on preload that generates a warning when deleting a post.

For that we guarded the value against booleans.

Fixes #5332

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

No.

## How Has This Been Tested?

- [ ] Manual

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
