### PR TITLE
Fixes #5374: webp problem on preload

### DIFF
--- a/inc/Engine/Preload/Controller/PreloadUrl.php
+++ b/inc/Engine/Preload/Controller/PreloadUrl.php
@@ -213,6 +213,13 @@ class PreloadUrl {
 
 		$file_cache_path = rocket_get_constant( 'WP_ROCKET_CACHE_PATH' ) . $url['host'] . strtolower( $url['path'] . $url['query'] ) . 'index' . $mobile . $https . '.html';
 
-		return $this->filesystem->exists( $file_cache_path );
+		if ( ! $this->options->get( 'cache_webp', false ) ) {
+			return $this->filesystem->exists( $file_cache_path );
+		}
+
+		$webp_path    = rocket_get_constant( 'WP_ROCKET_CACHE_PATH' ) . $url['host'] . strtolower( $url['path'] . $url['query'] ) . 'index' . $mobile . $https . '-webp.html';
+		$no_webp_path = rocket_get_constant( 'WP_ROCKET_CACHE_PATH' ) . $url['host'] . strtolower( $url['path'] . $url['query'] ) . '.no-webp';
+
+		return $this->filesystem->exists( $webp_path ) || ( $this->filesystem->exists( $no_webp_path ) && $this->filesystem->exists( $file_cache_path ) );
 	}
 }

--- a/tests/Fixtures/inc/Engine/Preload/Controller/PreloadUrl/isAlreadyCached.php
+++ b/tests/Fixtures/inc/Engine/Preload/Controller/PreloadUrl/isAlreadyCached.php
@@ -1,0 +1,103 @@
+<?php
+return [
+	'noWebpAndNotExistingShouldReturnFalse' => [
+		'config' => [
+			'ssl' => true,
+			'url' => 'url',
+			'parsed_url' => [
+				'host' => 'host',
+				'path' => 'path',
+				'query' => 'query',
+			],
+			'cache_ssl' => true,
+			'cache_webp' => false,
+			'cache_path' => 'WP_ROCKET_CACHE_PATHhostpath/#query/index-https.html',
+			'cache_path_exists' => false,
+			'webp_path' => 'WP_ROCKET_CACHE_PATHhostpath/#query/index-https-webp.html',
+			'webp_path_exists' => true,
+			'nowebp_path' => 'WP_ROCKET_CACHE_PATHhost/path/#query/.no-webp',
+			'nowebp_path_exists' => true
+		],
+		'expected' => false,
+	],
+	'noWebpAndExistingShouldReturnTrue' => [
+		'config' => [
+			'ssl' => true,
+			'url' => 'url',
+			'parsed_url' => [
+				'host' => 'host',
+				'path' => 'path',
+				'query' => 'query',
+			],
+			'cache_ssl' => true,
+			'cache_webp' => false,
+			'cache_path' => 'WP_ROCKET_CACHE_PATHhostpath/#query/index-https.html',
+			'cache_path_exists' => true,
+			'webp_path' => 'WP_ROCKET_CACHE_PATHhostpath/#query/index-https-webp.html',
+			'webp_path_exists' => false,
+			'nowebp_path' => 'WP_ROCKET_CACHE_PATHhost/path/#query/.no-webp',
+			'nowebp_path_exists' => false
+		],
+		'expected' => true
+	],
+	'webpAndNotExistingShouldReturnFalse' => [
+		'config' => [
+			'ssl' => true,
+			'url' => 'url',
+			'parsed_url' => [
+				'host' => 'host',
+				'path' => 'path',
+				'query' => 'query',
+			],
+			'cache_ssl' => true,
+			'cache_webp' => true,
+			'cache_path' => 'WP_ROCKET_CACHE_PATHhostpath/#query/index-https.html',
+			'cache_path_exists' => true,
+			'webp_path' => 'WP_ROCKET_CACHE_PATHhostpath/#query/index-https-webp.html',
+			'webp_path_exists' => false,
+			'nowebp_path' => 'WP_ROCKET_CACHE_PATHhostpath/#query/.no-webp',
+			'nowebp_path_exists' => false
+		],
+		'expected' => false
+	],
+	'webpAndExistingWebpShouldReturnTrue' => [
+		'config' => [
+			'ssl' => true,
+			'url' => 'url',
+			'parsed_url' => [
+				'host' => 'host',
+				'path' => 'path',
+				'query' => 'query',
+			],
+			'cache_ssl' => true,
+			'cache_webp' => true,
+			'cache_path' => 'WP_ROCKET_CACHE_PATHhostpath/#query/index-https.html',
+			'cache_path_exists' => true,
+			'webp_path' => 'WP_ROCKET_CACHE_PATHhostpath/#query/index-https-webp.html',
+			'webp_path_exists' => true,
+			'nowebp_path' => 'WP_ROCKET_CACHE_PATHhostpath/#query/.no-webp',
+			'nowebp_path_exists' => false
+		],
+		'expected' => true
+	],
+	'webpAndExistingNoWebpShouldReturnTrue' => [
+		'config' => [
+			'ssl' => true,
+			'url' => 'url',
+			'parsed_url' => [
+				'host' => 'host',
+				'path' => 'path',
+				'query' => 'query',
+			],
+			'cache_ssl' => true,
+			'cache_webp' => true,
+			'cache_path' => 'WP_ROCKET_CACHE_PATHhostpath/#query/index-https.html',
+			'cache_path_exists' => false,
+			'webp_path' => 'WP_ROCKET_CACHE_PATHhostpath/#query/index-https-webp.html',
+			'webp_path_exists' => true,
+			'nowebp_path' => 'WP_ROCKET_CACHE_PATHhostpath/#query/.no-webp',
+			'nowebp_path_exists' => true
+		],
+		'expected' => true
+	],
+];

--- a/tests/Unit/inc/Engine/Preload/Controller/PreloadUrl/isAlreadyCached.php
+++ b/tests/Unit/inc/Engine/Preload/Controller/PreloadUrl/isAlreadyCached.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\Preload\Controller\PreloadUrl;
+
+use Mockery;
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Engine\Preload\Controller\PreloadUrl;
+use WP_Rocket\Engine\Preload\Controller\Queue;
+use WP_Rocket\Engine\Preload\Database\Queries\Cache;
+use WP_Filesystem_Direct;
+use WP_Rocket\Tests\Unit\TestCase;
+use Brain\Monkey\Functions;
+
+/**
+ * @covers \WP_Rocket\Engine\Preload\Controller\PreloadUrl::is_already_cached
+ * @group  Preload
+ */
+class Test_IsAlreadyCached extends TestCase
+{
+	protected $queue;
+	protected $query;
+	protected $options;
+	protected $controller;
+	protected $file_system;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->options = Mockery::mock(Options_Data::class);
+		$this->query = $this->createMock(Cache::class);
+		$this->queue = Mockery::mock(Queue::class);
+		$this->file_system = Mockery::mock(WP_Filesystem_Direct::class);
+		$this->controller = Mockery::mock(PreloadUrl::class . '[get_mobile_user_agent_prefix]', [$this->options, $this->queue, $this->query, $this->file_system])->shouldAllowMockingProtectedMethods();
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldDoAsExpected($config, $expected) {
+		Functions\when('is_ssl')->justReturn($config['ssl']);
+		Functions\when('get_rocket_parse_url')->justReturn($config['parsed_url']);
+		Functions\when('path')->justReturn($config['parsed_url']['path']);
+		Functions\when('rocket_get_constant')->alias(function ($name) {
+			return $name;
+		});
+
+		if($config['ssl']) {
+			$this->options->shouldReceive('get')->with('cache_ssl')->zeroOrMoreTimes()->andReturn($config['cache_ssl']);
+		}
+
+		if($config['cache_webp']) {
+			$this->file_system->shouldReceive('exists')->with($config['nowebp_path'])->zeroOrMoreTimes()->andReturn($config['nowebp_path_exists']);
+			$this->file_system->expects()->exists($config['webp_path'])->andReturn($config['webp_path_exists']);
+			$this->file_system->shouldReceive('exists')->with($config['cache_path'])->zeroOrMoreTimes()->andReturn($config['cache_path_exists']);
+
+		} else {
+			$this->file_system->expects()->exists($config['cache_path'])->andReturn($config['cache_path_exists']);
+		}
+
+		$this->options->expects()->get('cache_webp', false)->andReturn($config['cache_webp']);
+
+		$this->assertSame($expected, $this->controller->is_already_cached($config['url']));
+	}
+}


### PR DESCRIPTION
## Description

Fixed a problem where preload didn't handled well webp.
For that we changed the is_already_cached method to make it handle webp.

Fixes #5374

## Type of change

Please delete options that are not relevant.

- [ ] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

No.

## How Has This Been Tested?

- [ ] Automated Tests


# Checklist:

Please delete the options that are not relevant.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
