### PR TITLE
Fixes #5410 Preload homepage on options change

### DIFF
--- a/inc/Engine/Preload/Admin/Settings.php
+++ b/inc/Engine/Preload/Admin/Settings.php
@@ -2,6 +2,7 @@
 
 namespace WP_Rocket\Engine\Preload\Admin;
 
+use WP_Rocket\Engine\Preload\Controller\PreloadUrl;
 use WP_Rocket\Admin\Options_Data;
 
 class Settings {
@@ -14,12 +15,21 @@ class Settings {
 	protected $options;
 
 	/**
+	 * PreloadUrl instance
+	 *
+	 * @var PreloadUrl
+	 */
+	private $preload_url;
+
+	/**
 	 * Instantiate the class
 	 *
 	 * @param Options_Data $options Instance of options handler.
+	 * @param PreloadUrl   $preload_url PreloadUrl instance.
 	 */
-	public function __construct( Options_Data $options ) {
-		$this->options = $options;
+	public function __construct( Options_Data $options, PreloadUrl $preload_url ) {
+		$this->options     = $options;
+		$this->preload_url = $preload_url;
 	}
 
 	/**
@@ -112,5 +122,14 @@ class Settings {
 	 */
 	public function is_enabled() : bool {
 		return (bool) $this->options->get( 'manual_preload', 0 );
+	}
+
+	/**
+	 * Preload the homepage
+	 *
+	 * @return void
+	 */
+	public function preload_homepage() {
+		$this->preload_url->preload_url( home_url() );
 	}
 }

--- a/inc/Engine/Preload/Admin/Subscriber.php
+++ b/inc/Engine/Preload/Admin/Subscriber.php
@@ -43,9 +43,10 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events() {
 		return [
-			'admin_notices' => [
+			'admin_notices'          => [
 				[ 'maybe_display_preload_notice' ],
 			],
+			'rocket_options_changed' => 'preload_homepage',
 		];
 	}
 
@@ -56,5 +57,14 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	public function maybe_display_preload_notice() {
 		$this->settings->maybe_display_preload_notice();
+	}
+
+	/**
+	 * Preload the homepage after changing the settings
+	 *
+	 * @return void
+	 */
+	public function preload_homepage() {
+		$this->settings->preload_homepage();
 	}
 }

--- a/inc/Engine/Preload/Admin/Subscriber.php
+++ b/inc/Engine/Preload/Admin/Subscriber.php
@@ -43,10 +43,12 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events() {
 		return [
-			'admin_notices'          => [
+			'admin_notices'               => [
 				[ 'maybe_display_preload_notice' ],
 			],
-			'rocket_options_changed' => 'preload_homepage',
+			'rocket_options_changed'      => 'preload_homepage',
+			'switch_theme'                => 'preload_homepage',
+			'rocket_after_clean_used_css' => 'preload_homepage',
 		];
 	}
 

--- a/inc/Engine/Preload/ServiceProvider.php
+++ b/inc/Engine/Preload/ServiceProvider.php
@@ -43,6 +43,7 @@ class ServiceProvider extends AbstractServiceProvider {
 		'fetch_sitemap_controller',
 		'check_finished_controller',
 		'load_initial_sitemap_controller',
+		'preload_url_controller',
 		'preload_caches_table',
 		'preload_caches_query',
 		'preload_admin_subscriber',
@@ -62,14 +63,9 @@ class ServiceProvider extends AbstractServiceProvider {
 	 * @return void
 	 */
 	public function register() {
-		// Subscribers.
 		$options = $this->getContainer()->get( 'options' );
 
 		$this->getContainer()->add( 'preload_mobile_detect', WP_Rocket_Mobile_Detect::class );
-
-		$this->getContainer()->add( 'preload_settings', Settings::class )
-			->addArgument( $options );
-		$preload_settings = $this->getContainer()->get( 'preload_settings' );
 
 		$this->getContainer()->add( 'wp_direct_filesystem', WP_Filesystem_Direct::class )
 			->addArgument( [] );
@@ -85,17 +81,19 @@ class ServiceProvider extends AbstractServiceProvider {
 		$this->getContainer()->add( 'preload_queue', Queue::class );
 		$queue = $this->getContainer()->get( 'preload_queue' );
 
-		$this->getContainer()->add( 'homepage_crawler', CrawlHomepage::class );
-		$crawl_homepage = $this->getContainer()->get( 'homepage_crawler' );
-
-		$this->getContainer()->add( 'sitemap_parser', SitemapParser::class );
-		$sitemap_parser = $this->getContainer()->get( 'sitemap_parser' );
-
 		$this->getContainer()->add( 'preload_url_controller', PreloadUrl::class )
 			->addArgument( $options )
 			->addArgument( $queue )
 			->addArgument( $cache_query )
 			->addArgument( $wp_file_system );
+
+		$preload_url_controller = $this->getContainer()->get( 'preload_url_controller' );
+
+		$this->getContainer()->add( 'homepage_crawler', CrawlHomepage::class );
+		$crawl_homepage = $this->getContainer()->get( 'homepage_crawler' );
+
+		$this->getContainer()->add( 'sitemap_parser', SitemapParser::class );
+		$sitemap_parser = $this->getContainer()->get( 'sitemap_parser' );
 
 		$this->getContainer()->add( 'fetch_sitemap_controller', FetchSitemap::class )
 			->addArgument( $sitemap_parser )
@@ -103,7 +101,6 @@ class ServiceProvider extends AbstractServiceProvider {
 			->addArgument( $cache_query );
 
 		$fetch_sitemap_controller = $this->getContainer()->get( 'fetch_sitemap_controller' );
-		$preload_url_controller   = $this->getContainer()->get( 'preload_url_controller' );
 
 		$this->getContainer()->add( 'load_initial_sitemap_controller', LoadInitialSitemap::class )
 			->addArgument( $queue )
@@ -113,6 +110,12 @@ class ServiceProvider extends AbstractServiceProvider {
 		$this->getContainer()->add( 'preload_activation', Activation::class )
 			->addArgument( $queue )
 			->addArgument( $cache_query );
+
+		$this->getContainer()->add( 'preload_settings', Settings::class )
+			->addArgument( $options )
+			->addArgument( $preload_url_controller );
+
+		$preload_settings = $this->getContainer()->get( 'preload_settings' );
 
 		$this->getContainer()->add( 'check_finished_controller', CheckFinished::class )
 			->addArgument( $preload_settings )

--- a/tests/Unit/inc/Engine/Preload/Admin/Settings/maybeDisplayPreloadNotice.php
+++ b/tests/Unit/inc/Engine/Preload/Admin/Settings/maybeDisplayPreloadNotice.php
@@ -4,6 +4,7 @@ namespace WP_Rocket\Tests\Unit\inc\Engine\Preload\Admin\Settings;
 use Mockery;
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\Preload\Admin\Settings;
+use WP_Rocket\Engine\Preload\Controller\PreloadUrl;
 use WP_Rocket\Tests\Unit\TestCase;
 use Brain\Monkey\Functions;
 
@@ -19,7 +20,7 @@ class Test_MaybeDisplayPreloadNotice extends TestCase {
 	{
 		parent::setUp();
 		$this->options = Mockery::mock(Options_Data::class);
-		$this->settings = new Settings($this->options);
+		$this->settings = new Settings($this->options, Mockery::mock(PreloadUrl::class));
 		$this->stubTranslationFunctions();
 	}
 


### PR DESCRIPTION
## Description

Preload the homepage when changing the options

Fixes #5410 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

No

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
