### PR TITLE
Closes 5382: Excluded url with extensions

### DIFF
--- a/inc/Engine/Preload/Database/Queries/Cache.php
+++ b/inc/Engine/Preload/Database/Queries/Cache.php
@@ -516,7 +516,7 @@ class Cache extends Query {
 	 * @param string $url url to check.
 	 * @return bool
 	 */
-	protected function is_rejected( string $url ) {
+	protected function is_rejected( string $url ): bool {
 		$extensions = [
 			'php' => 1,
 			'xml' => 1,

--- a/inc/Engine/Preload/Database/Queries/Cache.php
+++ b/inc/Engine/Preload/Database/Queries/Cache.php
@@ -124,6 +124,10 @@ class Cache extends Query {
 	public function create_or_update( array $resource ) {
 		$url = untrailingslashit( strtok( $resource['url'], '?' ) );
 
+		if ( $this->is_rejected( $resource['url'] ) ) {
+			return false;
+		}
+
 		// check the database if those resources added before.
 		$rows = $this->query(
 			[
@@ -182,6 +186,11 @@ class Cache extends Query {
 	 * @return bool
 	 */
 	public function create_or_nothing( array $resource ) {
+
+		if ( $this->is_rejected( $resource['url'] ) ) {
+			return false;
+		}
+
 		$url = strtok( $resource['url'], '?' );
 
 		// check the database if those resources added before.
@@ -499,5 +508,17 @@ class Cache extends Query {
 		$prefixed_table_name = $db->prefix . $this->table_name;
 
 		$db->query( "DELETE FROM `$prefixed_table_name` WHERE 1 = 1" );
+	}
+
+	protected function is_rejected( string $url ) {
+		$extensions = [
+			'php' => 1,
+			'xml' => 1,
+			'xsl' => 1,
+		];
+
+		$extension = pathinfo( $url, PATHINFO_EXTENSION );
+
+		return $extension && isset( $extensions[ $extension ] );
 	}
 }

--- a/inc/Engine/Preload/Database/Queries/Cache.php
+++ b/inc/Engine/Preload/Database/Queries/Cache.php
@@ -510,6 +510,12 @@ class Cache extends Query {
 		$db->query( "DELETE FROM `$prefixed_table_name` WHERE 1 = 1" );
 	}
 
+	/**
+	 * Check if the url is rejected.
+	 *
+	 * @param string $url url to check.
+	 * @return bool
+	 */
 	protected function is_rejected( string $url ) {
 		$extensions = [
 			'php' => 1,

--- a/inc/Engine/Preload/Database/Queries/Cache.php
+++ b/inc/Engine/Preload/Database/Queries/Cache.php
@@ -521,6 +521,7 @@ class Cache extends Query {
 			'php' => 1,
 			'xml' => 1,
 			'xsl' => 1,
+			'kml' => 1,
 		];
 
 		$extension = pathinfo( $url, PATHINFO_EXTENSION );

--- a/tests/Fixtures/inc/Engine/Preload/Database/Queries/Cache/createOrNothing.php
+++ b/tests/Fixtures/inc/Engine/Preload/Database/Queries/Cache/createOrNothing.php
@@ -1,7 +1,26 @@
 <?php
 return [
+	'phpShouldReturnFalse' => [
+		'config' => [
+			'rejected' => true,
+			'resource' => [
+				'url' => 'http://example.com/test.php',
+				'status' => 'pending',
+			],
+			'save' => [
+				'url' => 'http://example.com',
+				'status' => 'pending',
+				'last_accessed' => '838:59:59.000000'
+			],
+			'id' => 10,
+			'time' => '838:59:59.000000',
+			'rows' => [],
+		],
+		'expected' => false
+	],
 	'notExistingShouldCreate' => [
 		'config' => [
+			'rejected' => false,
 			'resource' => [
 				'url' => 'http://example.com',
 				'status' => 'pending',
@@ -19,6 +38,7 @@ return [
 	],
 	'notExistingAndErrorShouldCreateAndReturnFalse' => [
 		'config' => [
+			'rejected' => false,
 			'resource' => [
 				'url' => 'http://example.com',
 				'status' => 'pending',
@@ -36,6 +56,7 @@ return [
 	],
 	'existingShouldDoNothing' => [
 		'config' => [
+			'rejected' => false,
 			'resource' => [
 				'url' => 'http://example.com',
 				'status' => 'pending',

--- a/tests/Fixtures/inc/Engine/Preload/Database/Queries/Cache/createOrUpdate.php
+++ b/tests/Fixtures/inc/Engine/Preload/Database/Queries/Cache/createOrUpdate.php
@@ -1,7 +1,26 @@
 <?php
 return [
+	'phpShouldReturnFalse' => [
+		'config' => [
+			'rejected' => true,
+			'resource' => [
+				'url' => 'http://example.com/test.php',
+				'status' => 'pending',
+			],
+			'save' => [
+				'url' => 'http://example.com',
+				'status' => 'pending',
+				'last_accessed' => '838:59:59.000000'
+			],
+			'id' => 10,
+			'time' => '838:59:59.000000',
+			'rows' => [],
+		],
+		'expected' => false
+	],
 	'notExistingShouldCreate' => [
 		'config' => [
+			'rejected' => false,
 			'resource' => [
 				'url' => 'http://example.com',
 				'status' => 'pending',
@@ -19,6 +38,7 @@ return [
 	],
 	'notExistingAndErrorShouldCreateAndReturnFalse' => [
 		'config' => [
+			'rejected' => false,
 			'resource' => [
 				'url' => 'http://example.com',
 				'status' => 'pending',
@@ -36,6 +56,7 @@ return [
 	],
 	'existingShouldUpdate' => [
 		'config' => [
+			'rejected' => false,
 			'resource' => [
 				'url' => 'http://example.com',
 				'status' => 'pending',

--- a/tests/Unit/inc/Engine/Preload/Database/Queries/Cache/createOrNothing.php
+++ b/tests/Unit/inc/Engine/Preload/Database/Queries/Cache/createOrNothing.php
@@ -32,11 +32,14 @@ class Test_CreateOrNothing extends TestCase {
 	 */
 	public function testShouldReturnAsExpected($config, $expected) {
 		Functions\when('current_time')->justReturn($config['time']);
-		$this->query->expects(self::once())->method('query')->with([
-			'url' => $config['resource']['url'],
-		])->willReturn($config['rows']);
 
-		$this->configureCreate($config);
+		if(! $config['rejected']) {
+			$this->query->expects(self::once())->method('query')->with([
+				'url' => $config['resource']['url'],
+			])->willReturn($config['rows']);
+
+			$this->configureCreate($config);
+		}
 
 		$this->assertSame($expected, $this->query->create_or_nothing($config['resource']));
 	}

--- a/tests/Unit/inc/Engine/Preload/Database/Queries/Cache/createOrUpdate.php
+++ b/tests/Unit/inc/Engine/Preload/Database/Queries/Cache/createOrUpdate.php
@@ -32,12 +32,16 @@ class Test_CreateOrUpdate extends TestCase {
 	 */
 	public function testShouldReturnAsExpected($config, $expected) {
 		Functions\when('current_time')->justReturn($config['time']);
-		$this->query->expects(self::once())->method('query')->with([
-			'url' => $config['resource']['url'],
-		])->willReturn($config['rows']);
 
-		$this->configureCreate($config);
-		$this->configureUpdate($config);
+
+		if(! $config['rejected']) {
+			$this->query->expects(self::once())->method('query')->with([
+				'url' => $config['resource']['url'],
+			])->willReturn($config['rows']);
+
+			$this->configureCreate($config);
+			$this->configureUpdate($config);
+		}
 
 		$this->assertSame($expected, $this->query->create_or_update($config['resource']));
 	}


### PR DESCRIPTION
## Description
Fix a problem due to extensions URLs blocked in `in-progress` when they are added to the preload table.

For that we guarded the `create_or_nothing` and the `create_or_update` from [`Cache`](https://github.com/wp-media/wp-rocket/blob/develop/inc/Engine/Preload/Database/Queries/Cache.php) class against urls with file extensions.

Fixes #5382

## Type of change

- [ ] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

Please describe in this section if there is any change to the solution, and why.

## How Has This Been Tested?

- [ ] Automated Tests

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
