### PR TITLE
Closes #5412 - exclude rocket lazyload script from delayjs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -117,7 +117,7 @@
 	},
 	"scripts": {
 		"test-unit": "\"vendor/bin/phpunit\" --testsuite unit --colors=always --configuration tests/Unit/phpunit.xml.dist",
-		"test-integration": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --exclude-group AdminOnly,BeaverBuilder,Elementor,Hummingbird,WithSmush,WithWoo,WithAmp,WithAmpAndCloudflare,WithSCCSS,Cloudways,Dreampress,DoCloudflare,Multisite,WPEngine,SpinUpWP,WordPressCom,O2Switch,PDFEmbedder,PDFEmbedderPremium,PDFEmbedderSecure,Godaddy,LiteSpeed,RevolutionSlider,WordFence,ConvertPlug,Kinsta,Jetpack,RankMathSEO,AllInOneSeoPack,SEOPress,TheSEOFramework",
+		"test-integration": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --exclude-group AdminOnly,BeaverBuilder,Elementor,Hummingbird,WithSmush,WithWoo,WithAmp,WithAmpAndCloudflare,WithSCCSS,Cloudways,Dreampress,DoCloudflare,Multisite,WPEngine,SpinUpWP,WordPressCom,O2Switch,PDFEmbedder,PDFEmbedderPremium,PDFEmbedderSecure,Godaddy,LiteSpeed,RevolutionSlider,WordFence,ConvertPlug,Kinsta,Jetpack,RankMathSEO,AllInOneSeoPack,SEOPress,TheSEOFramework,RocketLazyLoad",
 		"test-integration-adminonly": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group AdminOnly",
 		"test-integration-bb": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group BeaverBuilder",
 		"test-integration-cloudflare": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group DoCloudflare",
@@ -149,6 +149,7 @@
 	    "test-integration-all-in-seo-pack": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group AllInOneSeoPack",
 	    "test-integration-seopress": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group SEOPress",
 	    "test-integration-the-seo-framework": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group TheSEOFramework",
+	    "test-integration-rocket-lazy-load": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group RocketLazyLoad",
 		"run-tests": [
 			"@test-unit",
 			"@test-integration",

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -342,6 +342,7 @@ class Plugin {
 			'wpml',
 			'xstore',
 			'cloudflare_plugin_subscriber',
+			'rocket_lazy_load',
 		];
 
 		$host_type = HostResolver::get_host_service();

--- a/inc/ThirdParty/Plugins/Optimization/RocketLazyLoad.php
+++ b/inc/ThirdParty/Plugins/Optimization/RocketLazyLoad.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace WP_Rocket\ThirdParty\Plugins\Optimization;
+
+use WP_Rocket\Event_Management\Subscriber_Interface;
+
+class RocketLazyLoad implements Subscriber_Interface {
+	/**
+	 * Return an array of events that this subscriber wants to listen to.
+	 *
+	 * @return array
+	 */
+	public static function get_subscribed_events(): array {
+		if ( ! defined( 'ROCKET_LL_VERSION' ) ) {
+			return [];
+		}
+
+		return [
+			'rocket_delay_js_exclusions' => 'exclude_rocket_lazyload_script',
+		];
+	}
+
+	/**
+	 * Excludes rocket lazyload script from delay js.
+	 *
+	 * @param array $excluded List of excluded files.
+	 *
+	 * @return array
+	 */
+	public function exclude_rocket_lazyload_script( $excluded ): array {
+		$excluded[] = 'rocket-lazy-load/assets/js/\d\d\.\d/lazyload.min.js';
+		return $excluded;
+	}
+}

--- a/inc/ThirdParty/ServiceProvider.php
+++ b/inc/ThirdParty/ServiceProvider.php
@@ -39,6 +39,13 @@ use WP_Rocket\ThirdParty\Themes\Polygon;
 use WP_Rocket\ThirdParty\Themes\Jevelin;
 use WP_Rocket\ThirdParty\Themes\Xstore;
 use WP_Rocket\ThirdParty\Plugins\CDN\Cloudflare;
+use WP_Rocket\ThirdParty\Plugins\Jetpack;
+use WP_Rocket\ThirdParty\Themes\MinimalistBlogger;
+use WP_Rocket\ThirdParty\Plugins\SEO\RankMathSEO;
+use WP_Rocket\ThirdParty\Plugins\SEO\AllInOneSEOPack;
+use WP_Rocket\ThirdParty\Plugins\SEO\SEOPress;
+use WP_Rocket\ThirdParty\Plugins\SEO\TheSEOFramework;
+use WP_Rocket\ThirdParty\Plugins\Optimization\RocketLazyLoad;
 
 /**
  * Service provider for WP Rocket third party compatibility
@@ -98,6 +105,7 @@ class ServiceProvider extends AbstractServiceProvider {
 		'wpml',
 		'xstore',
 		'cloudflare_plugin_subscriber',
+		'rocket_lazy_load',
 	];
 
 	/**
@@ -241,30 +249,33 @@ class ServiceProvider extends AbstractServiceProvider {
 			->addArgument( $options )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'jetpack', 'WP_Rocket\ThirdParty\Plugins\Jetpack' )
+			->share( 'jetpack', Jetpack::class )
 			->addArgument( $options )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'minimalist_blogger', 'WP_Rocket\ThirdParty\Themes\MinimalistBlogger' )
+			->share( 'minimalist_blogger', MinimalistBlogger::class )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'convertplug', 'WP_Rocket\ThirdParty\Plugins\ConvertPlug' )
+			->share( 'convertplug', ConvertPlug::class )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'rank_math_seo', 'WP_Rocket\ThirdParty\Plugins\SEO\RankMathSEO' )
+			->share( 'rank_math_seo', RankMathSEO::class )
 			->addArgument( $options )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'all_in_one_seo_pack', 'WP_Rocket\ThirdParty\Plugins\SEO\AllInOneSEOPack' )
+			->share( 'all_in_one_seo_pack', AllInOneSEOPack::class )
 			->addArgument( $options )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'seopress', 'WP_Rocket\ThirdParty\Plugins\SEO\SEOPress' )
+			->share( 'seopress', SEOPress::class )
 			->addArgument( $options )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'the_seo_framework', 'WP_Rocket\ThirdParty\Plugins\SEO\TheSEOFramework' )
+			->share( 'the_seo_framework', TheSEOFramework::class )
 			->addArgument( $options )
+			->addTag( 'common_subscriber' );
+		$this->getContainer()
+			->share( 'rocket_lazy_load', RocketLazyLoad::class )
 			->addTag( 'common_subscriber' );
 	}
 }

--- a/tests/Fixtures/inc/ThirdParty/Plugins/Optimization/RocketLazyLoad/excludeRocketLazyLoadScript.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/Optimization/RocketLazyLoad/excludeRocketLazyLoadScript.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'shouldExcludeFromDelayJs' => [
+        'excluded' => [],
+        'expected' => [
+            'rocket-lazy-load/assets/js/\d\d\.\d/lazyload.min.js',
+        ],
+    ],
+];

--- a/tests/Integration/bootstrap.php
+++ b/tests/Integration/bootstrap.php
@@ -188,6 +188,10 @@ tests_add_filter(
 			require WP_ROCKET_TESTS_FIXTURES_DIR . '/inc/ThirdParty/Plugins/Jetpack/functions.php';
 		}
 
+		if ( BootstrapManager::isGroup( 'RocketLazyLoad' ) ) {
+			define( 'ROCKET_LL_VERSION', '2.3.6' );
+		}
+
 		// Load the plugin.
 		require WP_ROCKET_PLUGIN_ROOT . '/wp-rocket.php';
 	}

--- a/tests/Integration/inc/ThirdParty/Plugins/Optimization/RocketLazyLoad/excludeRocketLazyLoadScript.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Optimization/RocketLazyLoad/excludeRocketLazyLoadScript.php
@@ -1,0 +1,19 @@
+<?php
+namespace WP_Rocket\Tests\Integration\inc\ThirdParty\Plugins\Optimization;
+
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * @covers WP_Rocket\ThirdParty\Plugins\Optimization\RocketLazyLoad::exclude_rocket_lazyload_script
+ * 
+ * @group RocketLazyLoad
+ */
+class Test_ExcludeRocketLazyLoadScript extends TestCase {
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnAsExpected( $excluded, $expected ) {
+		$this->assertSame( $expected, apply_filters( 'rocket_delay_js_exclusions', $excluded ) );
+	}
+}

--- a/tests/Unit/inc/ThirdParty/Plugins/Optimization/RocketLazyLoad/excludeRocketLazyLoadScript.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/Optimization/RocketLazyLoad/excludeRocketLazyLoadScript.php
@@ -1,0 +1,25 @@
+<?php
+namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\Optimization;
+
+use WP_Rocket\Tests\Unit\TestCase;
+use WP_Rocket\ThirdParty\Plugins\Optimization\RocketLazyLoad;
+
+/**
+ * @covers WP_Rocket\ThirdParty\Plugins\Optimization\RocketLazyLoad::exclude_rocket_lazyload_script
+ */
+class Test_ExcludeRocketLazyLoadScript extends TestCase {
+	protected $subscriber;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->subscriber = new RocketLazyLoad();
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnAsExpected( $excluded, $expected ) {
+		$this->assertSame( $expected, $this->subscriber->exclude_rocket_lazyload_script( $excluded ) );
+	}
+}


### PR DESCRIPTION
## Description
This PR excludes rocket lazyload script from being delayed when delay js execution is enabled on WPR.

Fixes #5412 

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## How Has This Been Tested?

Automated tests and Manual Tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
