### PR TITLE
Closes #5423 Adjust preload notice

### DIFF
--- a/inc/Engine/Deactivation/Deactivation.php
+++ b/inc/Engine/Deactivation/Deactivation.php
@@ -90,6 +90,9 @@ class Deactivation {
 		delete_site_transient( 'update_wprocket_response' );
 		delete_site_transient( 'wp_rocket_update_data' );
 
+		// Delete user metadata.
+		delete_user_meta( get_current_user_id(), 'rocket_boxes' );
+
 		// Unschedule WP Cron events.
 		wp_clear_scheduled_hook( 'rocket_cache_dir_size_check' );
 

--- a/inc/Engine/Preload/Admin/Settings.php
+++ b/inc/Engine/Preload/Admin/Settings.php
@@ -36,11 +36,19 @@ class Settings {
 			return;
 		}
 
+		$boxes = get_user_meta( get_current_user_id(), 'rocket_boxes', true );
+
+		if ( in_array( 'preload_notice', (array) $boxes, true ) ) {
+			return;
+		}
+
 		$message = sprintf(
 			// translators: %1$s = plugin name.
 			__( '%1$s: The preload service is now active. After the initial preload it will continue to cache all your pages whenever they are purged. No further action is needed.', 'rocket' ),
 			'<strong>WP Rocket</strong>'
 		);
+
+		rocket_dismiss_box( 'preload_notice' );
 
 		rocket_notice_html(
 			[

--- a/inc/Engine/Preload/Subscriber.php
+++ b/inc/Engine/Preload/Subscriber.php
@@ -133,6 +133,8 @@ class Subscriber implements Subscriber_Interface {
 			return;
 		}
 
+		rocket_renew_box( 'preload_notice' );
+
 		$this->controller->load_initial_sitemap();
 	}
 

--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -485,6 +485,7 @@ function do_admin_post_rocket_purge_cache() { // phpcs:ignore WordPress.NamingCo
 				}
 
 				rocket_dismiss_box( 'rocket_warning_plugin_modification' );
+				rocket_renew_box( 'preload_notice' );
 				break;
 
 			// Clear terms, homepage and other files associated at current post in back-end.

--- a/tests/Fixtures/inc/Engine/Preload/Admin/Settings/maybeDisplayPreloadNotice.php
+++ b/tests/Fixtures/inc/Engine/Preload/Admin/Settings/maybeDisplayPreloadNotice.php
@@ -42,6 +42,26 @@ return [
 			]
 		]
 	],
+	'alreadyDisplayedShouldBailOut' => [
+		'config' => [
+			'screen' => 'settings_page_wprocket',
+			'has_right' => true,
+			'load_transient' => true,
+			'enabled' => true,
+			'transient' => true,
+			'rocket_boxes' => [
+				'rocket_warning_plugin_modification',
+				'preload_notice',
+			],
+		],
+		'expected' => [
+			'notice' => [
+				'status'  => 'info',
+				'message' => '<strong>WP Rocket</strong>: The preload service is now active. After the initial preload it will continue to cache all your pages whenever they are purged. No further action is needed.',
+				'id'      => 'rocket-notice-preload-processing',
+			]
+		]
+	],
 	'shouldDisplayNotice' => [
 		'config' => [
 			'screen' => 'settings_page_wprocket',
@@ -50,6 +70,9 @@ return [
 			'enabled' => true,
 			'transient' => true,
 			'show_display_notice' => true,
+			'rocket_boxes' => [
+				'rocket_warning_plugin_modification',
+			],
 		],
 		'expected' => [
 			'notice' => [

--- a/tests/Unit/inc/Engine/Preload/Admin/Settings/maybeDisplayPreloadNotice.php
+++ b/tests/Unit/inc/Engine/Preload/Admin/Settings/maybeDisplayPreloadNotice.php
@@ -29,6 +29,8 @@ class Test_MaybeDisplayPreloadNotice extends TestCase {
 	public function testShouldReturnAsExpected($config, $expected) {
 		Functions\expect('get_current_screen')->with()->andReturn($config['screen']);
 		Functions\expect('current_user_can')->with('rocket_manage_options')->andReturn($config['has_right']);
+		Functions\expect( 'rocket_dismiss_box' )->with( 'preload_notice' )->andReturnNull();
+		$this->configureRocketBoxes( $config );
 		$this->configureEnabled($config);
 		$this->configureTransient($config);
 		$this->configureNotice($config, $expected);
@@ -48,6 +50,15 @@ class Test_MaybeDisplayPreloadNotice extends TestCase {
 		}
 
 		Functions\expect('get_transient')->with('rocket_preload_processing')->andReturn($config['transient']);
+	}
+
+	protected function configureRocketBoxes( $config ) {
+		if(! key_exists('rocket_boxes', $config)) {
+			return;
+		}
+
+		Functions\expect('get_current_user_id')->andReturn( 1 );
+		Functions\when('get_user_meta')->justReturn( $config['rocket_boxes'] );
 	}
 
 	protected function configureNotice($config, $expected) {

--- a/tests/Unit/inc/common/doAdminPostRocketPurgeCache.php
+++ b/tests/Unit/inc/common/doAdminPostRocketPurgeCache.php
@@ -67,6 +67,7 @@ class Test_DoAdminPostRocketPurgeCache extends FilesystemTestCase {
 				Functions\expect( 'set_transient' )->once()->with( 'rocket_clear_cache', 'all', HOUR_IN_SECONDS )->andReturnNull();
 				Functions\expect( 'rocket_clean_domain' )->once()->with( $config['lang'] )->andReturnNull();
 				Functions\expect( 'rocket_dismiss_box' )->once()->with( 'rocket_warning_plugin_modification' )->andReturnNull();
+				Functions\expect( 'rocket_renew_box' )->once()->with( 'preload_notice' )->andReturnNull();
 				break;
 			case 'post':
 				Functions\expect( 'set_transient' )->once()->with( 'rocket_clear_cache', 'post', HOUR_IN_SECONDS )->andReturnNull();


### PR DESCRIPTION
## Description

Closes reappearing preload notice on WPR settings.

Fixes #5423 

## Type of change
- [x] Enhancement (non-breaking change which improves an existing functionality)

## How Has This Been Tested?

Automated and Manual tests.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
