### PR TITLE
Closes 2441: Fixed warning when temporary file can't be created

### DIFF
--- a/inc/classes/Buffer/class-cache.php
+++ b/inc/classes/Buffer/class-cache.php
@@ -332,7 +332,7 @@ class Cache extends Abstract_Buffer {
 		}
 
 		// Save the cache file.
-		if ( rocket_put_content( $temp_filepath, $content ) ) {
+		if ( ! rocket_put_content( $temp_filepath, $content ) ) {
 			return;
 		}
 

--- a/inc/classes/Buffer/class-cache.php
+++ b/inc/classes/Buffer/class-cache.php
@@ -332,7 +332,7 @@ class Cache extends Abstract_Buffer {
 		}
 
 		// Save the cache file.
-		if( rocket_put_content( $temp_filepath, $content ) ) {
+		if ( rocket_put_content( $temp_filepath, $content ) ) {
 			return;
 		}
 
@@ -346,7 +346,7 @@ class Cache extends Abstract_Buffer {
 			 */
 			$compression_level = apply_filters( 'rocket_gzencode_level_compression', 6 );
 
-			if( rocket_put_content( $temp_gzip_filepath, gzencode( $content, $compression_level ) ) ) {
+			if ( rocket_put_content( $temp_gzip_filepath, gzencode( $content, $compression_level ) ) ) {
 				return;
 			}
 

--- a/inc/classes/Buffer/class-cache.php
+++ b/inc/classes/Buffer/class-cache.php
@@ -332,7 +332,10 @@ class Cache extends Abstract_Buffer {
 		}
 
 		// Save the cache file.
-		rocket_put_content( $temp_filepath, $content );
+		if( rocket_put_content( $temp_filepath, $content ) ) {
+			return;
+		}
+
 		rocket_direct_filesystem()->move( $temp_filepath, $cache_filepath, true );
 
 		if ( function_exists( 'gzencode' ) ) {
@@ -343,7 +346,10 @@ class Cache extends Abstract_Buffer {
 			 */
 			$compression_level = apply_filters( 'rocket_gzencode_level_compression', 6 );
 
-			rocket_put_content( $temp_gzip_filepath, gzencode( $content, $compression_level ) );
+			if( rocket_put_content( $temp_gzip_filepath, gzencode( $content, $compression_level ) ) ) {
+				return;
+			}
+
 			rocket_direct_filesystem()->move( $temp_gzip_filepath, $gzip_filepath, true );
 		}
 	}

--- a/inc/classes/Buffer/class-cache.php
+++ b/inc/classes/Buffer/class-cache.php
@@ -346,7 +346,7 @@ class Cache extends Abstract_Buffer {
 			 */
 			$compression_level = apply_filters( 'rocket_gzencode_level_compression', 6 );
 
-			if ( rocket_put_content( $temp_gzip_filepath, gzencode( $content, $compression_level ) ) ) {
+			if ( ! rocket_put_content( $temp_gzip_filepath, gzencode( $content, $compression_level ) ) ) {
 				return;
 			}
 


### PR DESCRIPTION
## Description
Fixed a problem due to a warning happening when we are moving the temporary file to its final position.
For that we added a check to verify if the file was created before moving it.

Fixes #2441

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

No.

## How Has This Been Tested?

- [ ] Manual Test

# Checklist:

Please delete the options that are not relevant.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
