### PR TITLE
Temporarily Hide action scheduler past due

### DIFF
--- a/inc/Engine/Admin/ActionSchedulerSubscriber.php
+++ b/inc/Engine/Admin/ActionSchedulerSubscriber.php
@@ -21,7 +21,14 @@ class ActionSchedulerSubscriber implements Subscriber_Interface {
 		];
 	}
 
-	public function hide_pastdue_status_filter( $extra_actions ) {
+	/**
+	 * Hide past-due from status filter in Action Scheduler tools page.
+	 *
+	 * @param array $extra_actions Array with format action_count_identifier => action count.
+	 *
+	 * @return array
+	 */
+	public function hide_pastdue_status_filter( array $extra_actions ) {
 		if ( ! isset( $extra_actions['past-due'] ) ) {
 			return $extra_actions;
 		}

--- a/inc/Engine/Admin/ActionSchedulerSubscriber.php
+++ b/inc/Engine/Admin/ActionSchedulerSubscriber.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace WP_Rocket\Engine\Admin;
+
+use WP_Rocket\Event_Management\Subscriber_Interface;
+use WP_Rocket\ThirdParty\ReturnTypesTrait;
+
+class ActionSchedulerSubscriber implements Subscriber_Interface {
+
+	use ReturnTypesTrait;
+
+	/**
+	 * Return an array of events that this subscriber wants to listen to.
+	 *
+	 * @return array
+	 */
+	public static function get_subscribed_events() {
+		return [
+			'action_scheduler_check_pastdue_actions' => 'return_false',
+			'action_scheduler_extra_action_counts'   => 'hide_pastdue_status_filter',
+		];
+	}
+
+	public function hide_pastdue_status_filter( $extra_actions ) {
+		if ( ! isset( $extra_actions['past-due'] ) ) {
+			return $extra_actions;
+		}
+
+		unset( $extra_actions['past-due'] );
+		return $extra_actions;
+	}
+}

--- a/inc/Engine/Admin/ServiceProvider.php
+++ b/inc/Engine/Admin/ServiceProvider.php
@@ -28,6 +28,7 @@ class ServiceProvider extends AbstractServiceProvider {
 		'hummingbird_subscriber',
 		'notices',
 		'notices_admin_subscriber',
+		'actionscheduler_admin_subscriber',
 	];
 
 	/**
@@ -52,5 +53,6 @@ class ServiceProvider extends AbstractServiceProvider {
 		$this->getContainer()->share( 'notices_admin_subscriber', NoticesSubscriber::class )
 			->addArgument( $this->getContainer()->get( 'notices' ) )
 			->addTag( 'admin_subscriber' );
+		$this->getContainer()->share( 'actionscheduler_admin_subscriber', ActionSchedulerSubscriber::class );
 	}
 }

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -210,6 +210,7 @@ class Plugin {
 			'preload_admin_subscriber',
 			'minify_admin_subscriber',
 			'notices_admin_subscriber',
+			'actionscheduler_admin_subscriber',
 		];
 	}
 

--- a/tests/Fixtures/inc/Engine/Admin/ActionSchedulerSubscriber/hidePastdueStatusFilter.php
+++ b/tests/Fixtures/inc/Engine/Admin/ActionSchedulerSubscriber/hidePastdueStatusFilter.php
@@ -1,0 +1,24 @@
+<?php
+return [
+	'DoNothingWhenPastdueIsNotThere' => [
+		'input' => [
+			'test' => 'value',
+		],
+		'expected' => [
+			'test' => 'value',
+		],
+	],
+	'DoNothingWhenArrayIsEmpty' => [
+		'input' => [],
+		'expected' => [],
+	],
+	'HideWhenPastdueIsThere' => [
+		'input' => [
+			'test' => 'value',
+			'past-due' => 'value',
+		],
+		'expected' => [
+			'test' => 'value',
+		],
+	],
+];

--- a/tests/Unit/inc/Engine/Admin/ActionSchedulerSubscriber/hidePastdueStatusFilter.php
+++ b/tests/Unit/inc/Engine/Admin/ActionSchedulerSubscriber/hidePastdueStatusFilter.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\Admin\Beacon\Beacon;
+
+use WP_Rocket\Engine\Admin\ActionSchedulerSubscriber;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Admin\ActionSchedulerSubscriber::hide_pastdue_status_filter
+ * @group  Beacon
+ */
+class Test_HidePastdueStatusFilter extends TestCase {
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldHidePastDue( $input, $expected ) {
+		$subscriber = new ActionSchedulerSubscriber();
+		$this->assertSame( $expected, $subscriber->hide_pastdue_status_filter( $input ) );
+	}
+
+}


### PR DESCRIPTION
## Description

We need to hide the past due admin notice from Action Scheduler in case the users has the latest version of Action Scheduler used at any other plugin not to confuse them.

The main problem is inside Action Scheduler itself, because Async tasks don't have schedule date and just have zeros/null value so the following query which gets the past due actions:
https://github.com/woocommerce/action-scheduler/blob/trunk/classes/ActionScheduler_AdminView.php#L154-L158
needs some adjustment to only get the rows that have real dates there.

We need to keep our eyes on action scheduler code base to see if this issue is solved there to revert this PR's changes.

Also we will try contributing there to help getting this fix as soon as possible.

Fixes #5450

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which improves an existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Is the solution different from the one proposed during the grooming?

Not groomed.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit tests
- [x] Manual testing

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
