### PR TITLE
Exclude podigee-podcast-player.js from Minify JS

### DIFF
--- a/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
+++ b/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
@@ -269,6 +269,7 @@ abstract class AbstractJSOptimization extends AbstractOptimization {
 			'm2d.m2.ai',
 			'pubguru.net',
 			'trustindex.io',
+			'podigee-podcast-player.js',
 		];
 
 		$excluded_external = array_merge( $defaults, $this->options->get( 'exclude_js', [] ) );


### PR DESCRIPTION
## Description

Resolves issue with Podigee Podcast player iframe.

Fixes #5459 

## Type of change

- [ ] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

n/a

## How Has This Been Tested?

Tested on a customer site by adding `podigee-podcast-player.js` to the exclusions box for Minify/Combine JavaScript.
Ticket: https://secure.helpscout.net/conversation/2015676355/369955/

The automatic exclusion within the plugin was tested on my testing site. The `podigee-podcast-player.js` scripts was successfully excluded and this caused no relevant console errors.
No errors in debug.

# Checklist:

Please delete the options that are not relevant.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
