### PR TITLE
Call callback outside preload

### DIFF
--- a/inc/Engine/Preload/Subscriber.php
+++ b/inc/Engine/Preload/Subscriber.php
@@ -173,7 +173,7 @@ class Subscriber implements Subscriber_Interface {
 
 		$url = home_url( add_query_arg( [], $wp->request ) );
 
-		if ( $this->query->is_preloaded( $url ) ) {
+		if ( ! $this->query->is_preloaded( $url ) ) {
 			$detected = $this->mobile_detect->isMobile() && ! $this->mobile_detect->isTablet() ? 'mobile' : 'desktop';
 
 			/**

--- a/tests/Fixtures/inc/Engine/Preload/Subscriber/updateCacheRow.php
+++ b/tests/Fixtures/inc/Engine/Preload/Subscriber/updateCacheRow.php
@@ -1,6 +1,6 @@
 <?php
 return [
-	'testCallActionWhenPreloaded' => [
+	'testNoCallActionWhenPreloaded' => [
 		'config' => [
 			'links' => [
 				[
@@ -20,13 +20,9 @@ return [
 			]
 		]
 	],
-	'testNoCallActionWhenNotPreloaded' => [
+	'testCallActionWhenNotPreloaded' => [
 		'config' => [
 			'links' => [
-				[
-					'url' => 'http://example.org',
-					'status' => 'in-progress',
-				],
 			],
 			'is_preloaded' => false,
 		],

--- a/tests/Integration/inc/Engine/Preload/Subscriber/updateCacheRow.php
+++ b/tests/Integration/inc/Engine/Preload/Subscriber/updateCacheRow.php
@@ -30,9 +30,11 @@ class Test_UpdateCacheRow extends AdminTestCase
 			self::addCache($link);
 		}
 
+
+
 		do_action('rocket_after_process_buffer');
 
-		if($config['is_preloaded']) {
+		if(! $config['is_preloaded']) {
 			$this->assertGreaterThan( 0, did_action('rocket_preload_completed') );
 		}
 


### PR DESCRIPTION
## Description
For the lighthouse  plugin we use the cache to generation to launch the test for the page.

Due to that we need to run cache generation outside preload to make the loading faster and so we need to activate the callback outside of preload.

For that we inverted the condition on [this line](https://github.com/wp-media/wp-rocket/blob/9cac116c41d1a3ed68a41ab1ef89c370edb42a2f/inc/Engine/Preload/Subscriber.php#L176) .

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] Manual Test

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
