### PR TITLE
Fixes #5471 Prevent fatal error if sitemaps value is not an array

### DIFF
--- a/inc/Engine/Preload/Controller/LoadInitialSitemap.php
+++ b/inc/Engine/Preload/Controller/LoadInitialSitemap.php
@@ -71,7 +71,8 @@ class LoadInitialSitemap {
 		 *
 		 * @param array Array of sitemaps URL
 		 */
-		$sitemaps = apply_filters( 'rocket_sitemap_preload_list', [] );
+		$sitemaps = (array) apply_filters( 'rocket_sitemap_preload_list', [] );
+
 		if ( count( $sitemaps ) > 0 ) {
 			/**
 			 * Filter sitemaps URL that will be preloaded.

--- a/inc/ThirdParty/Plugins/SEO/Yoast.php
+++ b/inc/ThirdParty/Plugins/SEO/Yoast.php
@@ -44,6 +44,10 @@ class Yoast implements Subscriber_Interface {
 	 * @return array
 	 */
 	public function add_sitemap( $sitemaps ): array {
+		if ( ! is_array( $sitemaps ) ) {
+			$sitemaps = (array) $sitemaps;
+		}
+
 		if ( ! $this->is_sitemap_enabled() ) {
 			return $sitemaps;
 		}


### PR DESCRIPTION
## Description

Prevent a fatal error if the sitemaps value is not an array when passed to the Yoast SEO preload sitemaps method.

Fixes #5471

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
