### PR TITLE
Exclude prism.js from JavaScript minification

### DIFF
--- a/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
+++ b/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
@@ -269,6 +269,7 @@ abstract class AbstractJSOptimization extends AbstractOptimization {
 			'm2d.m2.ai',
 			'pubguru.net',
 			'trustindex.io',
+			'cdnjs.cloudflare.com/ajax/libs/prism/',
 		];
 
 		$excluded_external = array_merge( $defaults, $this->options->get( 'exclude_js', [] ) );


### PR DESCRIPTION
## Description

Excludes `cdnjs.cloudflare.com/ajax/libs/prism/` from JavaScript minification.

Fixes #5484.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

N/A.

## How Has This Been Tested?

- [x] Locally using a template from the customer's site.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

