### PR TITLE
pass true to purge_url function to clear pagination

### DIFF
--- a/inc/Engine/Cache/Purge.php
+++ b/inc/Engine/Cache/Purge.php
@@ -166,7 +166,7 @@ class Purge {
 	public function purge_post_terms_urls( WP_Post $post ) {
 		$urls = $this->get_post_terms_urls( $post );
 		foreach ( $urls as $url ) {
-			$this->purge_url( $url );
+			$this->purge_url( $url, true );
 		}
 		/**
 		 * Action to preload urls after cleaning cache.

--- a/tests/Unit/inc/Engine/Cache/Purge/purgePostTermsUrls.php
+++ b/tests/Unit/inc/Engine/Cache/Purge/purgePostTermsUrls.php
@@ -121,6 +121,8 @@ class Test_PurgePostTermsUrls extends FilesystemTestCase {
 			return parse_url( $url, $component );
 		} );
 
+		$GLOBALS['wp_rewrite'] = (object) [ 'pagination_base' => 'page' ];
+
 		$this->purge->purge_post_terms_urls( $post_mocked );
 
 		$this->checkEntriesDeleted( $expected );


### PR DESCRIPTION
## Description
clear cahce for taxonomies pagination pages 
Fix #4035  


- [x] Bug fix (non-breaking change which fixes an issue)


## Is the solution different from the one proposed during the grooming?

No
## How Has This Been Tested?

- [x] local setup

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
