### PR TITLE
Closes 5510: Thirdparty class for the events calendar

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -117,7 +117,7 @@
 	},
 	"scripts": {
 		"test-unit": "\"vendor/bin/phpunit\" --testsuite unit --colors=always --configuration tests/Unit/phpunit.xml.dist",
-		"test-integration": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --exclude-group AdminOnly,BeaverBuilder,Elementor,Hummingbird,WithSmush,WithWoo,WithAmp,WithAmpAndCloudflare,WithSCCSS,Cloudways,Dreampress,DoCloudflare,Multisite,WPEngine,SpinUpWP,WordPressCom,O2Switch,PDFEmbedder,PDFEmbedderPremium,PDFEmbedderSecure,Godaddy,LiteSpeed,RevolutionSlider,WordFence,ConvertPlug,Kinsta,Jetpack,RankMathSEO,AllInOneSeoPack,SEOPress,TheSEOFramework,RocketLazyLoad",
+		"test-integration": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --exclude-group AdminOnly,BeaverBuilder,Elementor,Hummingbird,WithSmush,WithWoo,WithAmp,WithAmpAndCloudflare,WithSCCSS,Cloudways,Dreampress,DoCloudflare,Multisite,WPEngine,SpinUpWP,WordPressCom,O2Switch,PDFEmbedder,PDFEmbedderPremium,PDFEmbedderSecure,Godaddy,LiteSpeed,RevolutionSlider,WordFence,ConvertPlug,Kinsta,Jetpack,RankMathSEO,AllInOneSeoPack,SEOPress,TheSEOFramework,RocketLazyLoad,TheEventsCalendar",
 		"test-integration-adminonly": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group AdminOnly",
 		"test-integration-bb": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group BeaverBuilder",
 		"test-integration-cloudflare": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group DoCloudflare",
@@ -150,6 +150,7 @@
 	    "test-integration-seopress": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group SEOPress",
 	    "test-integration-the-seo-framework": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group TheSEOFramework",
 	    "test-integration-rocket-lazy-load": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group RocketLazyLoad",
+	    "test-integration-the-events-calendar": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group TheEventsCalendar",
 		"run-tests": [
 			"@test-unit",
 			"@test-integration",
@@ -182,7 +183,8 @@
 		    "@test-integration-jetpack",
 		    "@test-integration-rank-math-seo",
 		    "@test-integration-all-in-seo-pack",
-		    "@test-integration-seopress"
+		    "@test-integration-seopress",
+		    "@test-integration-the-events-calendar"
 		],
 		"run-stan": "vendor/bin/phpstan analyze --memory-limit=2G --no-progress",
 		"install-codestandards": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -343,6 +343,7 @@ class Plugin {
 			'xstore',
 			'cloudflare_plugin_subscriber',
 			'rocket_lazy_load',
+			'the_events_calendar',
 		];
 
 		$host_type = HostResolver::get_host_service();

--- a/inc/ThirdParty/Plugins/TheEventsCalendar.php
+++ b/inc/ThirdParty/Plugins/TheEventsCalendar.php
@@ -30,7 +30,15 @@ class TheEventsCalendar implements Subscriber_Interface {
 	 * @return array
 	 */
 	public function exclude_from_preload_calendars( $excluded ) {
-		$excluded[] = '/calendar/20(.*)';
+
+		if ( ! function_exists( 'tribe_get_option' ) ) {
+			return $excluded;
+		}
+
+		$uri = tribe_get_option( 'singleEventSlug', 'event' );
+
+		$excluded[] = "/$uri/20(.*)";
+
 		return $excluded;
 	}
 }

--- a/inc/ThirdParty/Plugins/TheEventsCalendar.php
+++ b/inc/ThirdParty/Plugins/TheEventsCalendar.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace WP_Rocket\ThirdParty\Plugins;
+
+use WP_Rocket\Event_Management\Subscriber_Interface;
+
+/**
+ * Subscriber for compatibility with the Events Calendar.
+ */
+class TheEventsCalendar implements Subscriber_Interface {
+
+
+	/**
+	 * Subscribed events for The Events Calendar.
+	 */
+	public static function get_subscribed_events() {
+		if ( ! rocket_get_constant( 'TRIBE_EVENTS_FILE', false ) ) {
+			return [];
+		}
+
+		return [
+			'rocket_preload_exclude_urls' => 'exclude_from_preload_calendars',
+		];
+	}
+
+	/**
+	 * Exclude calendars from the preload.
+	 *
+	 * @param array $excluded excluded urls.
+	 * @return array
+	 */
+	public function exclude_from_preload_calendars( $excluded ) {
+		$excluded[] = '/calendar/20(.*)';
+		return $excluded;
+	}
+}

--- a/inc/ThirdParty/Plugins/TheEventsCalendar.php
+++ b/inc/ThirdParty/Plugins/TheEventsCalendar.php
@@ -35,7 +35,7 @@ class TheEventsCalendar implements Subscriber_Interface {
 			return $excluded;
 		}
 
-		$uri = tribe_get_option( 'singleEventSlug', 'event' );
+		$uri = tribe_get_option( 'eventsSlug', 'event' );
 
 		$excluded[] = "/$uri/20(.*)";
 

--- a/inc/ThirdParty/ServiceProvider.php
+++ b/inc/ThirdParty/ServiceProvider.php
@@ -29,6 +29,7 @@ use WP_Rocket\ThirdParty\Plugins\Security\WordFenceCompatibility;
 use WP_Rocket\ThirdParty\Plugins\SEO\Yoast;
 use WP_Rocket\ThirdParty\Plugins\SimpleCustomCss;
 use WP_Rocket\ThirdParty\Plugins\Smush;
+use WP_Rocket\ThirdParty\Plugins\TheEventsCalendar;
 use WP_Rocket\ThirdParty\Plugins\ThirstyAffiliates;
 use WP_Rocket\ThirdParty\Plugins\UnlimitedElements;
 use WP_Rocket\ThirdParty\Themes\Avada;
@@ -106,6 +107,7 @@ class ServiceProvider extends AbstractServiceProvider {
 		'xstore',
 		'cloudflare_plugin_subscriber',
 		'rocket_lazy_load',
+		'the_events_calendar',
 	];
 
 	/**
@@ -276,6 +278,9 @@ class ServiceProvider extends AbstractServiceProvider {
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
 			->share( 'rocket_lazy_load', RocketLazyLoad::class )
+			->addTag( 'common_subscriber' );
+		$this->getContainer()
+			->share( 'the_events_calendar', TheEventsCalendar::class )
 			->addTag( 'common_subscriber' );
 	}
 }

--- a/tests/Fixtures/inc/ThirdParty/Plugins/TheEventsCalendar/excludeFromPreloadCalendars.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/TheEventsCalendar/excludeFromPreloadCalendars.php
@@ -1,7 +1,19 @@
 <?php
 return [
+	'testDoesnTExistsShouldReturnSame' => [
+		'config' => [
+			'params' => [],
+			'exists' => false,
+			'slug' => 'calendar'
+		],
+		'expected' => [],
+	],
 	'testShouldReturnAsExpected' => [
-		'config' => [],
+		'config' => [
+			'params' => [],
+			'exists' => true,
+			'slug' => 'calendar'
+		],
 		'expected' => ['/calendar/20(.*)'],
 	]
 ];

--- a/tests/Fixtures/inc/ThirdParty/Plugins/TheEventsCalendar/excludeFromPreloadCalendars.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/TheEventsCalendar/excludeFromPreloadCalendars.php
@@ -1,0 +1,7 @@
+<?php
+return [
+	'testShouldReturnAsExpected' => [
+		'config' => [],
+		'expected' => ['/calendar/20(.*)'],
+	]
+];

--- a/tests/Integration/bootstrap.php
+++ b/tests/Integration/bootstrap.php
@@ -78,6 +78,10 @@ tests_add_filter(
 			define( 'CP_VERSION', '1.0' );
 		}
 
+		if ( BootstrapManager::isGroup( 'TheEventsCalendar' ) ) {
+			define( 'TRIBE_EVENTS_FILE', true );
+		}
+
 		if ( BootstrapManager::isGroup( 'Hummingbird' ) ) {
 			define( 'WP_ADMIN', true );
 			require WP_ROCKET_PLUGIN_ROOT . '/vendor/wpackagist-plugin/hummingbird-performance/wp-hummingbird.php';

--- a/tests/Integration/inc/ThirdParty/Plugins/TheEventsCalendar/excludeFromPreloadCalendars.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/TheEventsCalendar/excludeFromPreloadCalendars.php
@@ -4,6 +4,7 @@ namespace WP_Rocket\Tests\Integration\inc\ThirdParty\Plugins\TheEventsCalendar;
 
 use WP_Rocket\Tests\Integration\FilterTrait;
 use WP_Rocket\Tests\Integration\TestCase;
+use Brain\Monkey\Functions;
 
 /**
  * @covers \WP_Rocket\ThirdParty\Plugins\TheEventsCalendar::exclude_from_preload_calendars
@@ -30,6 +31,9 @@ class Test_ExcludeFromPreloadCalendars extends TestCase
 	 * @dataProvider configTestData
 	 */
 	public function testShouldDoAsExpected($config, $expected) {
-		$this->assertSame($expected, apply_filters('rocket_preload_exclude_urls', $config));
+		if($config['exists']) {
+			Functions\expect('tribe_get_option')->andReturn($config['slug']);
+		}
+		$this->assertSame($expected, apply_filters('rocket_preload_exclude_urls', $config['params']));
 	}
 }

--- a/tests/Integration/inc/ThirdParty/Plugins/TheEventsCalendar/excludeFromPreloadCalendars.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/TheEventsCalendar/excludeFromPreloadCalendars.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\ThirdParty\Plugins\TheEventsCalendar;
+
+use WP_Rocket\Tests\Integration\FilterTrait;
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * @covers \WP_Rocket\ThirdParty\Plugins\TheEventsCalendar::exclude_from_preload_calendars
+ * @group ThirdParty
+ * @group TheEventsCalendar
+ */
+class Test_ExcludeFromPreloadCalendars extends TestCase
+{
+	use FilterTrait;
+
+	public function set_up()
+	{
+		parent::set_up();
+		$this->unregisterAllCallbacksExcept( 'rocket_preload_exclude_urls', 'exclude_from_preload_calendars', 10 );
+	}
+
+	public function tear_down() {
+		$this->restoreWpFilter( 'rocket_preload_exclude_urls' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldDoAsExpected($config, $expected) {
+		$this->assertSame($expected, apply_filters('rocket_preload_exclude_urls', $config));
+	}
+}

--- a/tests/Unit/inc/ThirdParty/Plugins/TheEventsCalendar/excludeFromPreloadCalendars.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/TheEventsCalendar/excludeFromPreloadCalendars.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\TheEventsCalendar;
+
+use WP_Rocket\Tests\Unit\TestCase;
+use WP_Rocket\ThirdParty\Plugins\TheEventsCalendar;
+
+class Test_ExcludeFromPreloadCalendars extends TestCase
+{
+	protected $subscriber;
+
+	protected function set_up()
+	{
+		parent::set_up();
+		$this->subscriber = new TheEventsCalendar();
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnAsExpected($config, $expected) {
+		$this->assertSame($expected, $this->subscriber->exclude_from_preload_calendars($config));
+	}
+}

--- a/tests/Unit/inc/ThirdParty/Plugins/TheEventsCalendar/excludeFromPreloadCalendars.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/TheEventsCalendar/excludeFromPreloadCalendars.php
@@ -4,7 +4,7 @@ namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\TheEventsCalendar;
 
 use WP_Rocket\Tests\Unit\TestCase;
 use WP_Rocket\ThirdParty\Plugins\TheEventsCalendar;
-
+use Brain\Monkey\Functions;
 class Test_ExcludeFromPreloadCalendars extends TestCase
 {
 	protected $subscriber;
@@ -19,6 +19,9 @@ class Test_ExcludeFromPreloadCalendars extends TestCase
 	 * @dataProvider configTestData
 	 */
 	public function testShouldReturnAsExpected($config, $expected) {
-		$this->assertSame($expected, $this->subscriber->exclude_from_preload_calendars($config));
+		if($config['exists']) {
+			Functions\expect('tribe_get_option')->andReturn($config['slug']);
+		}
+		$this->assertSame($expected, $this->subscriber->exclude_from_preload_calendars($config['params']));
 	}
 }


### PR DESCRIPTION
## Description

Fix a problem where the db was flooded with calendar rows.
For that we excluded urls from the calendar from the preload.

Fixes #5510 

## Type of change

Please delete options that are not relevant.
- [ ] Enhancement (non-breaking change which improves an existing functionality)


## Is the solution different from the one proposed during the grooming?

Yes, I added code to work with an option value instead of a constant.

## How Has This Been Tested?
- [ ] Automated Tests

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
