### PR TITLE
Delay JS skip scripts inside xmp 

### DIFF
--- a/inc/Engine/Optimization/DelayJS/HTML.php
+++ b/inc/Engine/Optimization/DelayJS/HTML.php
@@ -5,8 +5,10 @@ namespace WP_Rocket\Engine\Optimization\DelayJS;
 
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\Optimization\DynamicLists\DataManager;
+use WP_Rocket\Engine\Optimization\RegexTrait;
 
 class HTML {
+	use RegexTrait;
 	/**
 	 * Plugin options instance.
 	 *
@@ -29,6 +31,7 @@ class HTML {
 	 * @var array
 	 */
 	protected $excluded = [];
+	protected $scripts  = [];
 
 	/**
 	 * Creates an instance of HTML.
@@ -127,20 +130,21 @@ class HTML {
 	 * @return string
 	 */
 	private function parse( $html ): string {
-		$replaced_html = preg_replace_callback(
-			'/<\s*script\s*(?<attr>[^>]*?)?>(?<content>.*?)?<\s*\/\s*script\s*>/ims',
-			[
-				$this,
-				'replace_scripts',
-			],
-			$html
+		$clean_html           = $this->hide_xmp_tags( $html );
+		$script_regex_pattern = '<\s*script\s*(?<attr>[^>]*?)?>(?<content>.*?)?<\s*\/\s*script\s*>';
+		$scripts              = $this->find(
+			$script_regex_pattern,
+			$clean_html,
+			'ims'
 		);
-
-		if ( empty( $replaced_html ) ) {
-			return $html;
+		foreach ( $scripts as $script ) {
+			$lazy_script = $this->replace_scripts( $script );
+			if ( $lazy_script ) {
+				$search = '#' . preg_quote( $script[0], '#' ) . '#ims';
+				$html   = preg_replace( $search, $lazy_script, $html, 1 );
+			}
 		}
-
-		return $replaced_html;
+		return $html;
 	}
 
 	/**
@@ -154,6 +158,7 @@ class HTML {
 	 * @return string
 	 */
 	public function replace_scripts( $matches ): string {
+
 		foreach ( $this->excluded as $pattern ) {
 			if ( preg_match( "#{$pattern}#i", $matches[0] ) ) {
 				return $matches[0];

--- a/inc/Engine/Optimization/DelayJS/HTML.php
+++ b/inc/Engine/Optimization/DelayJS/HTML.php
@@ -31,7 +31,6 @@ class HTML {
 	 * @var array
 	 */
 	protected $excluded = [];
-	protected $scripts  = [];
 
 	/**
 	 * Creates an instance of HTML.

--- a/inc/Engine/Optimization/RegexTrait.php
+++ b/inc/Engine/Optimization/RegexTrait.php
@@ -83,4 +83,22 @@ trait RegexTrait {
 
 		return $replace;
 	}
+
+	/**
+	 * Hides <xmp> tags from the HTML to be parsed for optimization
+	 *
+	 * @since 3.1.4
+	 *
+	 * @param string $html HTML content.
+	 * @return string
+	 */
+	protected function hide_xmp_tags( $html ) {
+		$replace = preg_replace( '/<xmp(.*)<\/xmp>/mis', '', $html );
+
+		if ( null === $replace ) {
+			return $html;
+		}
+
+		return $replace;
+	}
 }

--- a/tests/Fixtures/inc/Engine/Optimization/DelayJS/HTML/delayJs.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DelayJS/HTML/delayJs.php
@@ -223,6 +223,7 @@ if ( window.addEventListener ) {
 window.wsf_form_json_config = {};
 var FuseboxPlayerAPIKey = "";
 </script>
+<xmp><script>alert("test")</script></xmp>
 </body>
 </html>';
 
@@ -449,6 +450,7 @@ if ( window.addEventListener ) {
 window.wsf_form_json_config = {};
 var FuseboxPlayerAPIKey = "";
 </script>
+<xmp><script>alert("test")</script></xmp>
 </body>
 </html>';
 
@@ -675,6 +677,7 @@ if ( window.addEventListener ) {
 window.wsf_form_json_config = {};
 var FuseboxPlayerAPIKey = "";
 </script>
+<xmp><script>alert("test")</script></xmp>
 </body>
 </html>';
 


### PR DESCRIPTION
## Description
Delay JS skip scripts inside xmp  to avoid adding `type="rocketlazyloadscript"` to scripts inside elementor code highlight 
Fixes #5496 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)


## Is the solution different from the one proposed during the grooming?

No
## How Has This Been Tested?

- [x] locally
- [x] Unit test

# Checklist:


- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

