### PR TITLE
Check if preload is enabled before applying preload callbacks

### DIFF
--- a/inc/Engine/Preload/Subscriber.php
+++ b/inc/Engine/Preload/Subscriber.php
@@ -274,6 +274,10 @@ class Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function clean_full_cache() {
+		if ( ! $this->options->get( 'manual_preload', 0 ) ) {
+			return;
+		}
+
 		set_transient( 'wpr_preload_running', true );
 		$this->queue->add_job_preload_job_check_finished_async();
 		$this->clear_cache->full_clean();


### PR DESCRIPTION
## Description

Check if preload is enabled with common actions like clearing cache, this may solve also the following issue:

https://github.com/wp-media/wp-rocket/issues/5539