### PR TITLE
Update phpdoc for get_rocket_option to match Options_Data.get

### DIFF
--- a/inc/functions/options.php
+++ b/inc/functions/options.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 1.3.0
  *
  * @param string $option  The option name.
- * @param bool   $default (default: false) The default value of option.
+ * @param mixed   $default (default: false) The default value of option.
  * @return mixed The option value
  */
 function get_rocket_option( $option, $default = false ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals

--- a/inc/functions/options.php
+++ b/inc/functions/options.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 1.3.0
  *
  * @param string $option  The option name.
- * @param mixed   $default (default: false) The default value of option.
+ * @param mixed  $default (default: false) The default value of option.
  * @return mixed The option value
  */
 function get_rocket_option( $option, $default = false ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals


### PR DESCRIPTION
Hi :wave: 

## Description

https://github.com/wp-media/wp-rocket/blob/6ca9b29e29d71bd0a783f8b797cb54b18357549f/inc/classes/admin/class-options-data.php#L40-L50

The signature for  `Options_Data.get` define `mixed` as type for $default. 
get_rocket_option should use the same type to avoid warnings by static code analysis.

For example: ` get_rocket_option( 'lazyload', 0 )`

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Is the solution different from the one proposed during the grooming?

Not applicable

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

Please delete the options that are not relevant.

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
