### PR TITLE
Fixes #5550 Fix method name in BigCommerce compatibility class

### DIFF
--- a/inc/ThirdParty/Plugins/Ecommerce/BigCommerce.php
+++ b/inc/ThirdParty/Plugins/Ecommerce/BigCommerce.php
@@ -10,7 +10,7 @@ use WP_Rocket\Traits\Config_Updater;
  *
  * @since 3.3.7
  */
-class BigCommercer implements Event_Manager_Aware_Subscriber_Interface {
+class BigCommerce implements Event_Manager_Aware_Subscriber_Interface {
 	use Config_Updater;
 
 	/**

--- a/inc/ThirdParty/Plugins/Ecommerce/BigCommerce.php
+++ b/inc/ThirdParty/Plugins/Ecommerce/BigCommerce.php
@@ -1,17 +1,17 @@
 <?php
-namespace WP_Rocket\Subscriber\Third_Party\Plugins\Ecommerce;
+namespace WP_Rocket\ThirdParty\Plugins\Ecommerce;
 
 use WP_Rocket\Event_Management\Event_Manager;
 use WP_Rocket\Event_Management\Event_Manager_Aware_Subscriber_Interface;
+use WP_Rocket\Traits\Config_Updater;
 
 /**
  * BigCommerce compatibility subscriber
  *
  * @since 3.3.7
- * @author Remy Perona
  */
-class BigCommerce_Subscriber implements Event_Manager_Aware_Subscriber_Interface {
-	use \WP_Rocket\Traits\Config_Updater;
+class BigCommercer implements Event_Manager_Aware_Subscriber_Interface {
+	use Config_Updater;
 
 	/**
 	 * The WordPress Event Manager
@@ -60,7 +60,6 @@ class BigCommerce_Subscriber implements Event_Manager_Aware_Subscriber_Interface
 	 * Add exclusions when activating the BigCommerce plugin
 	 *
 	 * @since 3.3.7
-	 * @author Rémy Perona
 	 */
 	public function activate_bigcommerce() {
 		$this->event_manager->add_callback( 'rocket_cache_reject_uri', [ $this, 'exclude_pages' ] );
@@ -76,9 +75,8 @@ class BigCommerce_Subscriber implements Event_Manager_Aware_Subscriber_Interface
 	 * Remove exclusions when deactivating the BigCommerce plugin
 	 *
 	 * @since 3.3.7
-	 * @author Rémy Perona
 	 */
-	public function deactivate_woocommerce() {
+	public function deactivate_bigcommerce() {
 		$this->event_manager->remove_callback( 'rocket_cache_reject_uri', [ $this, 'exclude_pages' ] );
 
 		// Update .htaccess file rules.
@@ -92,7 +90,6 @@ class BigCommerce_Subscriber implements Event_Manager_Aware_Subscriber_Interface
 	 * Maybe regenerate the htaccess & config file if a BigCommerce page is published
 	 *
 	 * @since 3.3.7
-	 * @author Remy Perona
 	 *
 	 * @param string  $new_status New post status.
 	 * @param string  $old_status Old post status.
@@ -140,7 +137,6 @@ class BigCommerce_Subscriber implements Event_Manager_Aware_Subscriber_Interface
 	 * Excludes BigCommerce checkout page from cache
 	 *
 	 * @since 3.3.7
-	 * @author Remy Perona
 	 *
 	 * @param int    $page_id   ID of page to exclude.
 	 * @param string $post_type Post type of the page.

--- a/inc/ThirdParty/ServiceProvider.php
+++ b/inc/ThirdParty/ServiceProvider.php
@@ -2,7 +2,6 @@
 namespace WP_Rocket\ThirdParty;
 
 use WP_Rocket\Dependencies\League\Container\ServiceProvider\AbstractServiceProvider;
-use WP_Rocket\Subscriber\Third_Party\Plugins\Ecommerce\BigCommerce_Subscriber;
 use WP_Rocket\Subscriber\Third_Party\Plugins\Images\Webp\EWWW_Subscriber;
 use WP_Rocket\Subscriber\Third_Party\Plugins\Images\Webp\Imagify_Subscriber;
 use WP_Rocket\Subscriber\Third_Party\Plugins\Images\Webp\Optimus_Subscriber;
@@ -12,6 +11,7 @@ use WP_Rocket\Subscriber\Third_Party\Plugins\NGG_Subscriber;
 use WP_Rocket\Subscriber\Third_Party\Plugins\SyntaxHighlighter_Subscriber;
 use WP_Rocket\ThirdParty\Plugins\Ads\Adthrive;
 use WP_Rocket\ThirdParty\Plugins\ConvertPlug;
+use WP_Rocket\ThirdParty\Plugins\Ecommerce\BigCommerce;
 use WP_Rocket\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber;
 use WP_Rocket\ThirdParty\Plugins\I18n\WPML;
 use WP_Rocket\ThirdParty\Plugins\InlineRelatedPosts;
@@ -143,7 +143,7 @@ class ServiceProvider extends AbstractServiceProvider {
 			->share( 'optimus_webp_subscriber', Optimus_Subscriber::class )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
-			->share( 'bigcommerce_subscriber', BigCommerce_Subscriber::class )
+			->share( 'bigcommerce_subscriber', BigCommerce::class )
 			->addTag( 'common_subscriber' );
 		$this->getContainer()
 			->share( 'beaverbuilder_subscriber', BeaverBuilder::class )


### PR DESCRIPTION
## Description

Fix method name in BigCommerce compatibility class, causing PHP fatal error. Also moved the class to the new architecture.

Fixes #5550

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
