### PR TITLE
Fixes Logger::error() must be of the type array in AbstractASQueue

### DIFF
--- a/inc/Engine/Common/Queue/AbstractASQueue.php
+++ b/inc/Engine/Common/Queue/AbstractASQueue.php
@@ -27,7 +27,7 @@ abstract class AbstractASQueue implements QueueInterface {
 		try {
 			return as_enqueue_async_action( $hook, $args, $this->group );
 		} catch ( Exception $exception ) {
-			Logger::error( $exception->getMessage(), 'Action Scheduler Queue' );
+			Logger::error( $exception->getMessage(), [ 'Action Scheduler Queue' ] );
 
 			return 0;
 		}

--- a/inc/Engine/Common/Queue/AbstractASQueue.php
+++ b/inc/Engine/Common/Queue/AbstractASQueue.php
@@ -45,7 +45,7 @@ abstract class AbstractASQueue implements QueueInterface {
 		try {
 			return as_schedule_single_action( $timestamp, $hook, $args, $this->group );
 		} catch ( Exception $exception ) {
-			Logger::error( $exception->getMessage(), 'Action Scheduler Queue' );
+			Logger::error( $exception->getMessage(), [ 'Action Scheduler Queue' ] );
 
 			return 0;
 		}
@@ -94,7 +94,7 @@ abstract class AbstractASQueue implements QueueInterface {
 		try {
 			return as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args, $this->group );
 		} catch ( Exception $exception ) {
-			Logger::error( $exception->getMessage(), 'Action Scheduler Queue' );
+			Logger::error( $exception->getMessage(), [ 'Action Scheduler Queue' ] );
 
 			return 0;
 		}
@@ -116,7 +116,7 @@ abstract class AbstractASQueue implements QueueInterface {
 		try {
 			return as_has_scheduled_action( $hook, $args, $this->group );
 		} catch ( Exception $exception ) {
-			Logger::error( $exception->getMessage(), 'Action Scheduler Queue' );
+			Logger::error( $exception->getMessage(), [ 'Action Scheduler Queue' ] );
 
 			return false;
 		}
@@ -149,7 +149,7 @@ abstract class AbstractASQueue implements QueueInterface {
 		try {
 			return as_schedule_cron_action( $timestamp, $cron_schedule, $hook, $args, $this->group );
 		} catch ( Exception $exception ) {
-			Logger::error( $exception->getMessage(), 'Action Scheduler Queue' );
+			Logger::error( $exception->getMessage(), [ 'Action Scheduler Queue' ] );
 
 			return 0;
 		}
@@ -174,7 +174,7 @@ abstract class AbstractASQueue implements QueueInterface {
 		try {
 			as_unschedule_action( $hook, $args, $this->group );
 		} catch ( Exception $exception ) {
-			Logger::error( $exception->getMessage(), 'Action Scheduler Queue' );
+			Logger::error( $exception->getMessage(), [ 'Action Scheduler Queue' ] );
 		}
 	}
 
@@ -188,7 +188,7 @@ abstract class AbstractASQueue implements QueueInterface {
 		try {
 			as_unschedule_all_actions( $hook, $args, $this->group );
 		} catch ( Exception $exception ) {
-			Logger::error( $exception->getMessage(), 'Action Scheduler Queue' );
+			Logger::error( $exception->getMessage(), [ 'Action Scheduler Queue' ] );
 		}
 	}
 
@@ -210,7 +210,7 @@ abstract class AbstractASQueue implements QueueInterface {
 
 			return null;
 		} catch ( Exception $exception ) {
-			Logger::error( $exception->getMessage(), 'Action Scheduler Queue' );
+			Logger::error( $exception->getMessage(), [ 'Action Scheduler Queue' ] );
 
 			return null;
 		}
@@ -241,7 +241,7 @@ abstract class AbstractASQueue implements QueueInterface {
 		try {
 			return as_get_scheduled_actions( $args, $return_format );
 		} catch ( Exception $exception ) {
-			Logger::error( $exception->getMessage(), 'Action Scheduler Queue' );
+			Logger::error( $exception->getMessage(), [ 'Action Scheduler Queue' ] );
 
 			return [];
 		}


### PR DESCRIPTION
## Description

change the second parameter from string to array
to avoid the error `Fatal error: Uncaught TypeError: Argument 2 passed to WP_Rocket\Logger\Logger::error() ` in
https://github.com/wp-media/wp-rocket/blob/7249d2ea66c41e7b6905ea42bd64f0657ed0ffc1/inc/Engine/Common/Queue/AbstractASQueue.php#L30

Fixes #5567 

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)


## Is the solution different from the one proposed during the grooming?

No
## How Has This Been Tested?

- [x] Unit and integration tests

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
