### PR TITLE
This line is not needed since #3483

### DIFF
--- a/inc/ThirdParty/Plugins/I18n/WPML.php
+++ b/inc/ThirdParty/Plugins/I18n/WPML.php
@@ -22,7 +22,7 @@ class WPML implements Subscriber_Interface {
 		}
 
 		$events = [
-			'rocket_rucss_is_home_url'                          => [ 'is_secondary_home', 10, 2 ],
+			'rocket_rucss_is_home_url'                => [ 'is_secondary_home', 10, 2 ],
 			'rocket_preload_all_to_pending_condition' => 'clean_only_right_domain',
 			'rocket_preload_sitemap_before_queue'     => 'add_languages_sitemaps',
 		];

--- a/inc/ThirdParty/Plugins/I18n/WPML.php
+++ b/inc/ThirdParty/Plugins/I18n/WPML.php
@@ -22,9 +22,9 @@ class WPML implements Subscriber_Interface {
 		}
 
 		$events = [
-			'rocket_rucss_is_home_url'                     => [ 'is_secondary_home', 10, 2 ],
-			'rocket_preload_all_to_pending_condition'      => 'clean_only_right_domain',
-			'rocket_preload_sitemap_before_queue'          => 'add_languages_sitemaps',
+			'rocket_rucss_is_home_url'                          => [ 'is_secondary_home', 10, 2 ],
+			'rocket_preload_all_to_pending_condition' => 'clean_only_right_domain',
+			'rocket_preload_sitemap_before_queue'     => 'add_languages_sitemaps',
 		];
 
 		return $events;

--- a/inc/ThirdParty/Plugins/I18n/WPML.php
+++ b/inc/ThirdParty/Plugins/I18n/WPML.php
@@ -22,7 +22,6 @@ class WPML implements Subscriber_Interface {
 		}
 
 		$events = [
-			'wcml_is_cache_enabled_for_switching_currency' => 'return_true',
 			'rocket_rucss_is_home_url'                     => [ 'is_secondary_home', 10, 2 ],
 			'rocket_preload_all_to_pending_condition'      => 'clean_only_right_domain',
 			'rocket_preload_sitemap_before_queue'          => 'add_languages_sitemaps',


### PR DESCRIPTION
This PR is specifically for 'WooCommerce Multilingual' compatibility, the WPML add-on for WooCommerce. 

## Description

Since #3483, where we added multicurrency support, we no longer need to add the currency URL argument.

- [x] Enhancement (non-breaking change which improves an existing functionality)

## How Has This Been Tested?

- Setup WooCommerce, WooCommerce Multilingual & wp-rocket
- Use a theme like storefront that has a mini-cart
- Setup Multicurrency with at least one more currency
- Create a product
- In an incognito window, visit the product page
- add to the cart
- Switch to secondary currency
- There shouldn't be an argument in the URL - e.g. ?wcmlc=USD
- Both the product price and the minicart should have switched currency
- Switch back to the default currency
- Both the product price and the minicart should have switched currency
