### PR TITLE
Fixes #5577 saving CDN CNAMEs with protocol

### DIFF
--- a/inc/Engine/Admin/Settings/Settings.php
+++ b/inc/Engine/Admin/Settings/Settings.php
@@ -693,10 +693,22 @@ class Settings {
 	private function sanitize_cdn_cnames( array $cnames ) {
 		$cnames = array_map(
 			function( $cname ) {
-				return filter_var( $cname, FILTER_VALIDATE_DOMAIN );
+				if ( empty( $cname ) ) {
+					return false;
+				}
+
+				$cname_parts = get_rocket_parse_url( rocket_add_url_protocol( $cname ) );
+
+				if( false === filter_var( $cname_parts['host'], FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME ) ) {
+					return false;
+				}
+
+				return $cname_parts['scheme'] . '://' . $cname_parts['host'];
 			},
 			$cnames
 		);
+
+		error_log(var_export(compact('cnames'), true));
 
 		return array_unique( array_filter( $cnames ) );
 	}

--- a/inc/Engine/Admin/Settings/Settings.php
+++ b/inc/Engine/Admin/Settings/Settings.php
@@ -693,7 +693,7 @@ class Settings {
 	private function sanitize_cdn_cnames( array $cnames ) {
 		$cnames = array_map(
 			function( $cname ) {
-				return filter_var( $cname, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME );
+				return filter_var( $cname, FILTER_VALIDATE_DOMAIN );
 			},
 			$cnames
 		);

--- a/inc/Engine/Admin/Settings/Settings.php
+++ b/inc/Engine/Admin/Settings/Settings.php
@@ -703,7 +703,7 @@ class Settings {
 					return false;
 				}
 
-				return $cname_parts['scheme'] . '://' . $cname_parts['host'];
+				return $cname_parts['scheme'] . '://' . $cname_parts['host'] . $cname_parts['path'];
 			},
 			$cnames
 		);

--- a/inc/Engine/Admin/Settings/Settings.php
+++ b/inc/Engine/Admin/Settings/Settings.php
@@ -708,8 +708,6 @@ class Settings {
 			$cnames
 		);
 
-		error_log(var_export(compact('cnames'), true));
-
 		return array_unique( array_filter( $cnames ) );
 	}
 }

--- a/inc/Engine/Admin/Settings/Settings.php
+++ b/inc/Engine/Admin/Settings/Settings.php
@@ -699,7 +699,7 @@ class Settings {
 
 				$cname_parts = get_rocket_parse_url( rocket_add_url_protocol( $cname ) );
 
-				if( false === filter_var( $cname_parts['host'], FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME ) ) {
+				if ( false === filter_var( $cname_parts['host'], FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME ) ) {
 					return false;
 				}
 

--- a/inc/Engine/Admin/Settings/Settings.php
+++ b/inc/Engine/Admin/Settings/Settings.php
@@ -693,6 +693,8 @@ class Settings {
 	private function sanitize_cdn_cnames( array $cnames ) {
 		$cnames = array_map(
 			function( $cname ) {
+				$cname = trim( $cname );
+
 				if ( empty( $cname ) ) {
 					return false;
 				}


### PR DESCRIPTION
## Description

When saving CDN CNAMEs, we remove the ones with http protocol from the options, we need to keep them.
Thanks @vmanthos , u did the hard part.

Fixes #5577

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

No

## How Has This Been Tested?

- [x] Locally

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
