### PR TITLE
Fix DB not found columns error in cache table with upgrade

### DIFF
--- a/inc/Engine/Cache/PurgeExpired/Subscriber.php
+++ b/inc/Engine/Cache/PurgeExpired/Subscriber.php
@@ -54,11 +54,12 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events() {
 		return [
-			'init'                => 'schedule_event',
-			'rocket_deactivation' => 'unschedule_event',
-			static::EVENT_NAME    => 'purge_expired_files',
-			'cron_schedules'      => 'custom_cron_schedule',
-			'wp_rocket_upgrade'   => [ 'update_lifespan_option_on_update', 13, 2 ],
+			'init'                                   => 'schedule_event',
+			'rocket_deactivation'                    => 'unschedule_event',
+			static::EVENT_NAME                       => 'purge_expired_files',
+			'cron_schedules'                         => 'custom_cron_schedule',
+			'wp_rocket_upgrade'                      => [ 'update_lifespan_option_on_update', 13, 2 ],
+			'rocket_after_automatic_cache_purge_dir' => 'run_upgrade_routine',
 		];
 	}
 
@@ -180,5 +181,14 @@ class Subscriber implements Subscriber_Interface {
 			$this->options->get( 'purge_cron_interval' ),
 			$this->options->get( 'purge_cron_unit' )
 		);
+	}
+
+	/**
+	 * With automatic cache purge we need to run the upgrade routine.
+	 *
+	 * @return void
+	 */
+	public function run_upgrade_routine() {
+		rocket_upgrader();
 	}
 }

--- a/inc/Engine/Cache/PurgeExpired/Subscriber.php
+++ b/inc/Engine/Cache/PurgeExpired/Subscriber.php
@@ -54,12 +54,11 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events() {
 		return [
-			'init'                                   => 'schedule_event',
-			'rocket_deactivation'                    => 'unschedule_event',
-			static::EVENT_NAME                       => 'purge_expired_files',
-			'cron_schedules'                         => 'custom_cron_schedule',
-			'wp_rocket_upgrade'                      => [ 'update_lifespan_option_on_update', 13, 2 ],
-			'rocket_after_automatic_cache_purge_dir' => 'run_upgrade_routine',
+			'init'                => 'schedule_event',
+			'rocket_deactivation' => 'unschedule_event',
+			static::EVENT_NAME    => 'purge_expired_files',
+			'cron_schedules'      => 'custom_cron_schedule',
+			'wp_rocket_upgrade'   => [ 'update_lifespan_option_on_update', 13, 2 ],
 		];
 	}
 
@@ -181,14 +180,5 @@ class Subscriber implements Subscriber_Interface {
 			$this->options->get( 'purge_cron_interval' ),
 			$this->options->get( 'purge_cron_unit' )
 		);
-	}
-
-	/**
-	 * With automatic cache purge we need to run the upgrade routine.
-	 *
-	 * @return void
-	 */
-	public function run_upgrade_routine() {
-		rocket_upgrader();
 	}
 }

--- a/inc/Engine/Preload/Database/Tables/Cache.php
+++ b/inc/Engine/Preload/Database/Tables/Cache.php
@@ -14,7 +14,7 @@ class Cache extends Table {
 	public function __construct() {
 		parent::__construct();
 		add_action( 'rocket_preload_activation', [ $this, 'maybe_upgrade' ] );
-		add_action( 'wp_rocket_upgrade', [ $this, 'maybe_upgrade' ] );
+		add_action( 'init', [ $this, 'maybe_upgrade' ] );
 		add_action( 'admin_init',  [ $this, 'maybe_trigger_recreate_table' ], 9 );
 	}
 

--- a/inc/Engine/Preload/Database/Tables/Cache.php
+++ b/inc/Engine/Preload/Database/Tables/Cache.php
@@ -14,6 +14,7 @@ class Cache extends Table {
 	public function __construct() {
 		parent::__construct();
 		add_action( 'rocket_preload_activation', [ $this, 'maybe_upgrade' ] );
+		add_action( 'wp_rocket_upgrade', [ $this, 'maybe_upgrade' ] );
 		add_action( 'admin_init',  [ $this, 'maybe_trigger_recreate_table' ], 9 );
 	}
 


### PR DESCRIPTION
## Description

When the user upgrades and before he refreshes any admin page, and the preload is triggered (automatically or by a frontend visit), so the new code after upgrade will be working with preload but the database still old because we trigger the database changes with `admin_init` hook, so here we will trigger this again with upgrade, so no need to refresh the admin or visit any admin page.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
