### PR TITLE
[Preload] Fix action Scheduler search database error with Elementor and some third parties

### DIFF
--- a/inc/Engine/Preload/Controller/Queue.php
+++ b/inc/Engine/Preload/Controller/Queue.php
@@ -77,6 +77,10 @@ class Queue extends AbstractASQueue {
 	 * @return bool
 	 */
 	public function job_preload_job_check_finished_async_exists() {
+		if ( ! did_action( 'init' ) ) {
+			return false;
+		}
+
 		$row_found = $this->search(
 			[
 				'hook'   => 'rocket_preload_job_check_finished',

--- a/inc/Engine/Preload/Controller/Queue.php
+++ b/inc/Engine/Preload/Controller/Queue.php
@@ -77,8 +77,8 @@ class Queue extends AbstractASQueue {
 	 * @return bool
 	 */
 	public function job_preload_job_check_finished_async_exists() {
-		if ( ! did_action( 'init' ) ) {
-			return false;
+		if ( ! did_action( 'init' ) || doing_action( 'init' ) ) {
+			return true;
 		}
 
 		$row_found = $this->search(


### PR DESCRIPTION
## Description

When Preload is active we need to guard searching in Action Scheduler's actions before `init` hook is fired not to see the error mentioned in the issue itself, check this comment to get more context about the issue itself:

https://github.com/wp-media/wp-rocket/issues/5582#issuecomment-1321168244

Fixes #5582

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

No

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Locally and in our rocketlabs

# Steps to reproduce the issue

You can install an older version of Elementor like [v3.7.8](https://downloads.wordpress.org/plugin/elementor.3.7.8.zip) then update manually to [v3.8.0](https://downloads.wordpress.org/plugin/elementor.3.8.0.zip) or update to the latest release.
In my test I updated manually so I replaced the files using ftp or locally by copy/paste not from the UI.

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
