### PR TITLE
Fix PHP fatal error when the HTML is null

### DIFF
--- a/inc/Engine/Optimization/DelayJS/HTML.php
+++ b/inc/Engine/Optimization/DelayJS/HTML.php
@@ -133,6 +133,11 @@ class HTML {
 	 * @return string
 	 */
 	private function parse( $html ): string {
+
+		if ( empty( $html ) ) {
+			return $html;
+		}
+
 		$result = $this->replace_xmp_tags( $html );
 
 		$replaced_html = preg_replace_callback(


### PR DESCRIPTION
## Description
return before  perg_replace NULL

Fixes #5555 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)


## Is the solution different from the one proposed during the grooming?

no
## How Has This Been Tested?

- [ ] local test

# Checklist:

Please delete the options that are not relevant.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
