### PR TITLE
Make RUCSS DB table migration runs with init

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Database/Tables/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Database/Tables/UsedCSS.php
@@ -49,6 +49,7 @@ class UsedCSS extends Table {
 	public function __construct() {
 		parent::__construct();
 		add_action( 'admin_init', [ $this, 'maybe_trigger_recreate_table' ], 9 );
+		add_action( 'init',  array( $this, 'maybe_upgrade' ) );
 	}
 
 	/**

--- a/inc/Engine/Optimization/RUCSS/Database/Tables/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Database/Tables/UsedCSS.php
@@ -49,7 +49,7 @@ class UsedCSS extends Table {
 	public function __construct() {
 		parent::__construct();
 		add_action( 'admin_init', [ $this, 'maybe_trigger_recreate_table' ], 9 );
-		add_action( 'init',  array( $this, 'maybe_upgrade' ) );
+		add_action( 'init',  [ $this, 'maybe_upgrade' ] );
 	}
 
 	/**


### PR DESCRIPTION
## Description

Like what we did with preload, here we are triggering the database migration check with init event.

This is to guard against the following error in log:

```
WordPress database error Unknown column 'error_code' in 'field list' for query INSERT INTO `wp_wpr_rucss_used_css` (`url`, `css`, `hash`, `error_code`, `error_message`, `retries`, `is_mobile`, `job_id`, `queue_name`, `status`, `modified`, `last_accessed`) VALUES ('https://new.rocketlabsqa.ovh/test4', '', '', '', '', '0', '0', '6433360', 'EU', 'pending', '2022-11-24T17:20:34Z', '2022-11-24 17:20:34')
```
