### PR TITLE
Closes #5519 Never cache this page is not applied immediately after saving a post

### DIFF
--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -123,7 +123,7 @@ function get_rocket_config_file() { // phpcs:ignore WordPress.NamingConventions.
 		}
 
 		if ( 'cache_reject_uri' === $option ) {
-			$buffer .= '$rocket_' . $option . ' = \'' . get_rocket_cache_reject_uri() . "';\n";
+			$buffer .= '$rocket_' . $option . ' = \'' . get_rocket_cache_reject_uri( true ) . "';\n";
 		}
 
 		if ( 'cache_query_strings' === $option ) {


### PR DESCRIPTION
## Description
Fixes the issue where posts added to never cache uri from the metabox was not applied immediately.

Fixes #5519 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?
No

## How Has This Been Tested?
Manual Test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
