### PR TITLE
Replace slashes with dot to load correct configuration file if the website loads via reverse proxy

### DIFF
--- a/inc/classes/Buffer/class-config.php
+++ b/inc/classes/Buffer/class-config.php
@@ -170,6 +170,7 @@ class Config {
 
 		$host = $this->get_server_input( 'HTTP_HOST', (string) time() );
 		$host = preg_replace( '/:\d+$/', '', $host );
+		$host = str_replace( '/', '.', untrailingslashit( $host ) );
 		$host = trim( strtolower( $host ), '.' );
 
 		return self::memoize( __FUNCTION__, [], rawurlencode( $host ) );


### PR DESCRIPTION
## Description

Remove trailing forward slashes and backslashes if they exist and then replace slashes with dot.

## Type of change
Bug fix (non-breaking change which fixes an issue)


## Is the solution different from the one proposed during the grooming?

No grooming as it's a very small change.

## How Has This Been Tested?

If the HTTP_HOST is **www.example.com/blog/** then WP Rocket try to load the configuration file from **www.example.com%2Fblog.php** instead of **www.example.com.blog.php**.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
