### PR TITLE
Closes #5506 Clean used CSS on permalink structure change

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
@@ -70,6 +70,7 @@ class Subscriber implements Subscriber_Interface {
 				[ 'maybe_set_processing_transient', 50, 2 ],
 			],
 			'switch_theme'                            => 'truncate_used_css',
+			'permalink_structure_changed'             => 'truncate_used_css',
 			'wp_trash_post'                           => 'delete_used_css_on_update_or_delete',
 			'delete_post'                             => 'delete_used_css_on_update_or_delete',
 			'clean_post_cache'                        => 'delete_used_css_on_update_or_delete',

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/deleteUsedCssOnUpdateOrDelete.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/deleteUsedCssOnUpdateOrDelete.php
@@ -44,6 +44,10 @@ class Test_DeleteUsedCssOnUpdateOrDelete extends FilesystemTestCase{
 	public function testShouldTruncateTableWhenOptionIsEnabled( $input ){
 		$container           = apply_filters( 'rocket_container', null );
 		$rucss_usedcss_query = $container->get( 'rucss_used_css_query' );
+		$subscriber          = $container->get( 'rucss_admin_subscriber' );
+		$event_manager       = $container->get( 'event_manager' );
+
+		$event_manager->remove_subscriber_callback( $subscriber, 'permalink_structure_changed', 'truncate_used_css' );
 
 		$this->input = $input;
 		add_filter( 'pre_get_rocket_option_remove_unused_css', [ $this, 'set_rucss_option' ] );

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/deleteUsedCssOnUpdateOrDelete.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/deleteUsedCssOnUpdateOrDelete.php
@@ -47,7 +47,7 @@ class Test_DeleteUsedCssOnUpdateOrDelete extends FilesystemTestCase{
 		$subscriber          = $container->get( 'rucss_admin_subscriber' );
 		$event_manager       = $container->get( 'event_manager' );
 
-		$event_manager->remove_subscriber_callback( $subscriber, 'permalink_structure_changed', 'truncate_used_css' );
+		$event_manager->remove_callback( 'permalink_structure_changed', [ $subscriber, 'truncate_used_css' ] );
 
 		$this->input = $input;
 		add_filter( 'pre_get_rocket_option_remove_unused_css', [ $this, 'set_rucss_option' ] );


### PR DESCRIPTION
## Description

Clean the used CSS when the permalink structure is changed

Fixes #5506

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

No grooming for a small task

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes