### PR TITLE
Closes #5617 Update Minify dependency with latest changes

### DIFF
--- a/inc/Dependencies/Minify/CSS.php
+++ b/inc/Dependencies/Minify/CSS.php
@@ -740,7 +740,7 @@ class CSS extends Minify
 		// PHP only supports $this inside anonymous functions since 5.4
 		$minifier = $this;
 		$this->registerPattern(
-			'/(?<=^|[;}])\s*(--[^:;{}"\'\s]+)\s*:([^;{}]+)/m',
+			'/(?<=^|[;}{])\s*(--[^:;{}"\'\s]+)\s*:([^;{}]+)/m',
 			function ($match) use ($minifier) {
 				$placeholder = '--custom-'. count($minifier->extracted) . ':0';
 				$minifier->extracted[$placeholder] = $match[1] .':'. trim($match[2]);


### PR DESCRIPTION
## Description
Pulls [change](https://github.com/matthiasmullie/minify/commit/d8993df3953c2db59c12a713e9e5c927fe4c5426) from the minify lib that will fix the `px` unit that is removed. This usually happened with styles on a single line like `:root {--test-margin-offset: 0px}`

Fixes #2083
Fixes #5617 

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?
NO

## How Has This Been Tested?
Manual Test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
