### PR TITLE
Closes 5624 wp-json is cached for language slugs that use TranslatePress

### DIFF
--- a/inc/3rd-party/plugins/wp-rest-api.php
+++ b/inc/3rd-party/plugins/wp-rest-api.php
@@ -41,7 +41,7 @@ function rocket_exclude_wp_rest_api( $uri ) {
 	 * - Single site:        (/index\.php)?/wp\-json(/.*|$)
 	 * - Multisite: (/[^/]+)?(/index\.php)?/wp\-json(/.*|$)
 	 */
-	$uri[] = $prefix . '/(' . $index . '/)?' . $suffix . '(/.*|$)';
+	$uri[] = $prefix . '/(' . $index . '/)?(.*)' . $suffix . '(/.*|$)';
 
 	return $uri;
 }


### PR DESCRIPTION
## Description
Fixes the issue when /wp-json/ is cached.

Fixes #5624 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?
No

## How Has This Been Tested?
Manual Tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
