### PR TITLE
Added call to make homepage generation on clean RUCSS

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
@@ -184,6 +184,16 @@ class Subscriber implements Subscriber_Interface {
 
 		$this->delete_used_css_rows();
 		$this->set_notice_transient();
+
+		wp_safe_remote_get(
+			home_url(),
+			[
+				'timeout'    => 0.01,
+				'blocking'   => false,
+				'user-agent' => 'WP Rocket/Homepage Preload',
+				'sslverify'  => apply_filters( 'https_local_ssl_verify', false ), // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+			]
+		);
 	}
 
 	/**

--- a/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
@@ -313,6 +313,16 @@ class Subscriber implements Subscriber_Interface {
 
 		$this->set_notice_transient();
 
+		wp_remote_get(
+			home_url(),
+			[
+				'timeout'    => 0.01,
+				'blocking'   => false,
+				'user-agent' => 'WP Rocket/Homepage Preload',
+				'sslverify'  => apply_filters( 'https_local_ssl_verify', false ), // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+			]
+		);
+
 		wp_safe_redirect( esc_url_raw( wp_get_referer() ) );
 		rocket_get_constant( 'WP_ROCKET_IS_TESTING', false ) ? wp_die() : exit;
 	}

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/truncateUsedCSSHandler.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/truncateUsedCSSHandler.php
@@ -57,6 +57,13 @@ return [
 				'nonce' => null,
 				'db_items' => $items,
 				'cache_files' => $cache_files,
+				'home_url' => 'http://example.org',
+				'home_request_configs' => [
+					'timeout'    => 0.01,
+					'blocking'   => false,
+					'user-agent' => 'WP Rocket/Homepage Preload',
+					'sslverify'  => false,
+				]
 			],
 			'expected' => [
 				'truncated' => false,
@@ -70,6 +77,13 @@ return [
 				'nonce' => 'invalid',
 				'db_items' => $items,
 				'cache_files' => $cache_files,
+				'home_url' => 'http://example.org',
+				'home_request_configs' => [
+					'timeout'    => 0.01,
+					'blocking'   => false,
+					'user-agent' => 'WP Rocket/Homepage Preload',
+					'sslverify'  => false,
+				]
 			],
 			'expected' => [
 				'truncated' => false,
@@ -84,6 +98,13 @@ return [
 				'cap'     => false,
 				'db_items' => $items,
 				'cache_files' => $cache_files,
+				'home_url' => 'http://example.org',
+				'home_request_configs' => [
+					'timeout'    => 0.01,
+					'blocking'   => false,
+					'user-agent' => 'WP Rocket/Homepage Preload',
+					'sslverify'  => false,
+				]
 			],
 			'expected' => [
 				'truncated' => false,
@@ -99,6 +120,13 @@ return [
 				'option_enabled' => false,
 				'db_items' => $items,
 				'cache_files' => $cache_files,
+				'home_url' => 'http://example.org',
+				'home_request_configs' => [
+					'timeout'    => 0.01,
+					'blocking'   => false,
+					'user-agent' => 'WP Rocket/Homepage Preload',
+					'sslverify'  => false,
+				]
 			],
 			'expected' => [
 				'truncated' => false,
@@ -119,6 +147,13 @@ return [
 				'db_items' => $items,
 				'cache_files' => $cache_files,
 				'not_completed_count' => 0,
+				'home_url' => 'http://example.org',
+				'home_request_configs' => [
+					'timeout'    => 0.01,
+					'blocking'   => false,
+					'user-agent' => 'WP Rocket/Homepage Preload',
+					'sslverify'  => false,
+				]
 			],
 			'expected' => [
 				'truncated' => true,
@@ -138,6 +173,13 @@ return [
 				'db_items' => $items,
 				'cache_files' => $cache_files,
 				'not_completed_count' => 10,
+				'home_url' => 'http://example.org',
+				'home_request_configs' => [
+					'timeout'    => 0.01,
+					'blocking'   => false,
+					'user-agent' => 'WP Rocket/Homepage Preload',
+					'sslverify'  => false,
+				]
 			],
 			'expected' => [
 				'truncated' => true,

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/truncateUsedCss.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/truncateUsedCss.php
@@ -23,6 +23,7 @@ return [
 		'input' => [
 			'items'             => $items,
 			'remove_unused_css' => false,
+			'home' => 'https://example.org',
 		],
 	],
 	'shouldTruncateUnusedCSS' => [
@@ -32,6 +33,7 @@ return [
 			'is_disabled' => true,
 			'delete_used_css_row' => true,
 			'used_css_count' => 0,
+			'home' => 'https://example.org',
 		],
 	],
 	'shouldNoTruncateOnHookDisabled' =>  [
@@ -40,6 +42,7 @@ return [
 			'items'             => $items,
 			'is_disabled' => false,
 			'used_css_count' => 10,
+			'home' => 'https://example.org',
 		]
 	]
 ];

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/truncateUsedCSSHandler.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/truncateUsedCSSHandler.php
@@ -128,6 +128,13 @@ class Test_TruncateUsedCSSHandler extends TestCase {
 					90
 				);
 
+			Functions\when('home_url')->justReturn($input['home_url']);
+
+			Functions\expect('wp_remote_get')->once()->with(
+				$input['home_url'],
+				$input['home_request_configs']
+			);
+
 			Functions\expect( 'rocket_renew_box' )
 				->once()
 				->with( 'rucss_success_notice' );


### PR DESCRIPTION
## Description
Regenerate homepage even when the preload is disabled and the RUCSS is cleared.
For that we added a fetch from homepage before redirecting the page.

Fixes #5631

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

No.

## How Has This Been Tested?
- [ ] Tested on local website

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
