### PR TITLE
Add compatibility with Members

### DIFF
--- a/inc/Engine/Capabilities/Manager.php
+++ b/inc/Engine/Capabilities/Manager.php
@@ -141,6 +141,29 @@ class Manager implements ActivationInterface, DeactivationInterface {
 	}
 
 	/**
+	 * Add WP Rocket as a cap group in Members
+	 */
+	public function add_cap_group_to_members() {
+		\members_register_cap_group(
+			'wp_rocket',
+			[
+				'label'    => esc_html( 'WP Rocket' ),
+				'priority' => 42,
+				'caps'     => $this->get_capabilities(),
+			]
+		);
+	}
+
+	/**
+	 * Add WP Rocket capabilities to Members
+	 */
+	public function add_caps_to_members() {
+		foreach ( $this->get_capabilities() as $cap ) {
+			\members_register_cap( $cap, [ 'label' => $cap ] );
+		}
+	}
+
+	/**
 	 * Adds WP Rocket capabilities on plugin upgrade
 	 *
 	 * @since 3.6.3

--- a/inc/Engine/Capabilities/Subscriber.php
+++ b/inc/Engine/Capabilities/Subscriber.php
@@ -39,6 +39,8 @@ class Subscriber implements Subscriber_Interface {
 			"option_page_capability_{$slug}" => 'required_capability',
 			'ure_built_in_wp_caps'           => 'add_caps_to_ure',
 			'ure_capabilities_groups_tree'   => 'add_group_to_ure',
+			'members_register_cap_groups'    => 'add_cap_group_to_members',
+			'members_register_caps'          => 'add_caps_to_members',
 			'wp_rocket_upgrade'              => [ 'add_capabilities_on_upgrade', 12, 2 ],
 		];
 	}
@@ -78,6 +80,21 @@ class Subscriber implements Subscriber_Interface {
 	public function add_group_to_ure( $groups ) {
 		return $this->capabilities->add_group_to_ure( $groups );
 	}
+
+	/**
+	 * Add WP Rocket as a cap group in Members
+	 */
+	public function add_cap_group_to_members() {
+		$this->capabilities->add_cap_group_to_members();
+	}
+
+	/**
+	 * Add WP Rocket capabilities to Members
+	 */
+	public function add_caps_to_members() {
+		$this->capabilities->add_caps_to_members();
+	}
+
 
 	/**
 	 * Adds WP Rocket capabilities on plugin upgrade


### PR DESCRIPTION
## Description

This PR adds compatibility with the Members plugin (https://github.com/caseproof/members)
It adds a specific group for WP Rocket capabilities in the role editor page of Members

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
Install Members plugin and check the following 
- [x] Check that the WP Rocket group has been added to the role editor page
- [x] Check that the new group contains all capabilities listed on https://docs.wp-rocket.me/article/1280-customize-access-to-options-for-user-roles
- [x] Check that the WP Rocket capabilities no longer appear in the Custom group

# Checklist:

Please delete the options that are not relevant.

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings

