### PR TITLE
Closes #5520 Perfmatters local google fonts preloaded with RUCSS

### DIFF
--- a/inc/ThirdParty/Plugins/Optimization/Perfmatters.php
+++ b/inc/ThirdParty/Plugins/Optimization/Perfmatters.php
@@ -19,6 +19,7 @@ class Perfmatters implements Subscriber_Interface {
 		return [
 			'rocket_disable_rucss_setting'            => 'disable_rucss_setting',
 			'pre_get_rocket_option_remove_unused_css' => 'maybe_disable_rucss',
+			'rocket_enable_rucss_fonts_preload'       => 'maybe_disable_fonts_preload',
 		];
 	}
 
@@ -46,6 +47,17 @@ class Perfmatters implements Subscriber_Interface {
 	 */
 	public function maybe_disable_rucss() {
 		return $this->is_perfmatters_rucss_active() ? false : null;
+	}
+
+	/**
+	 * Disable fonts preloading.
+	 *
+	 * @return boolean
+	 */
+	public function maybe_disable_fonts_preload(): bool {
+		$perfmatters_options = get_option( 'perfmatters_options' );
+
+		return empty( $perfmatters_options['fonts']['local_google_fonts'] );
 	}
 
 	/**

--- a/tests/Fixtures/inc/ThirdParty/Plugins/Optimization/Perfmatters/maybeDisableFontsPreload.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/Optimization/Perfmatters/maybeDisableFontsPreload.php
@@ -1,0 +1,23 @@
+<?php
+return [
+    'shouldDisableFontsPreloadWhenPerfmattersLocalGoogleFontsisEnabled' => [
+        'config' => [
+            'perfmatters_options' => [
+                'fonts' => [
+                    'local_google_fonts' => 1,
+                ],
+            ],
+        ],
+        'expected' => false,
+    ],
+    'shouldNotDisableFontsPreloadWhenPerfmattersLocalGoogleFontsisDisabled' => [
+        'config' => [
+            'perfmatters_options' => [
+                'fonts' => [
+                    'local_google_fonts' => '',
+                ],
+            ],
+        ],
+        'expected' => true,
+    ],
+];

--- a/tests/Integration/inc/ThirdParty/Plugins/Optimization/Perfmatters/maybeDisableFontsPreload.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Optimization/Perfmatters/maybeDisableFontsPreload.php
@@ -1,0 +1,25 @@
+<?php
+namespace WP_Rocket\Tests\Integration\inc\ThirdParty\Plugins\Optimization;
+
+use Brain\Monkey\Functions;
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * @covers WP_Rocket\ThirdParty\Plugins\Optimization\Perfmatters::maybe_disable_fonts_preload
+ * 
+ * @group Perfmatters
+ */
+class Test_MaybeDisableFontsPreload extends TestCase {
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnAsExpected( $config, $expected ) {
+        Functions\expect( 'get_option' )
+			->once()
+			->with( 'perfmatters_options' )
+			->andReturn( $config['perfmatters_options'] );
+            
+		$this->assertSame( $expected, apply_filters( 'rocket_enable_rucss_fonts_preload', true ) );
+	}
+}

--- a/tests/Unit/inc/ThirdParty/Plugins/Optimization/Perfmatters/maybeDisableFontsPreload.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/Optimization/Perfmatters/maybeDisableFontsPreload.php
@@ -1,0 +1,31 @@
+<?php
+namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\Optimization;
+
+use Brain\Monkey\Functions;
+use WP_Rocket\Tests\Unit\TestCase;
+use WP_Rocket\ThirdParty\Plugins\Optimization\Perfmatters;
+
+/**
+ * @covers WP_Rocket\ThirdParty\Plugins\Optimization\Perfmatters::maybe_disable_fonts_preload
+ */
+class Test_MaybeDisableFontsPreload extends TestCase {
+	protected $subscriber;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->subscriber = new Perfmatters();
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnAsExpected( $config, $expected ) {
+        Functions\expect( 'get_option' )
+			->once()
+			->with( 'perfmatters_options' )
+			->andReturn( $config['perfmatters_options'] );
+
+		$this->assertSame( $expected, $this->subscriber->maybe_disable_fonts_preload() );
+	}
+}


### PR DESCRIPTION
## Description
Stop font preload when local google fonts option is enabled in perfmatters.

Fixes #5520 

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?
No

## How Has This Been Tested?
Automated tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
