### PR TITLE
Fix admin slowness after 3.12.5

### DIFF
--- a/inc/Engine/Admin/Settings/Subscriber.php
+++ b/inc/Engine/Admin/Settings/Subscriber.php
@@ -46,8 +46,8 @@ class Subscriber implements Subscriber_Interface {
 				[ 'add_tutorials_page', 11 ],
 			],
 			'admin_enqueue_scripts'                => [
-				'enqueue_rocket_scripts',
-				'enqueue_url',
+				[ 'enqueue_rocket_scripts' ],
+				[ 'enqueue_url' ],
 			],
 			'script_loader_tag'                    => [ 'async_wistia_script', 10, 2 ],
 			'rocket_after_settings_radio_options'  => [ 'display_radio_options_sub_fields', 11 ],


### PR DESCRIPTION
## Description

After updating to 3.12.5, we got notified from few customers that admin became very slow and in some cases it leads to maximum memory consumption.

After checking a customer's site, I found there is an admin callback that is added in a wrong syntax.

**Note: I validated the fix in one of our customers' site.**

Fixes #5685 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

In customer's site as I still can't reproduce it locally.

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
