### PR TITLE
Changed url for export on safemode

### DIFF
--- a/assets/js/wpr-admin-common.js
+++ b/assets/js/wpr-admin-common.js
@@ -1,4 +1,5 @@
 jQuery( document ).ready( function( $ ){
+var sent = false;
 	$( '.rocket-dismiss' ).on( 'click', function( e ) {
 		e.preventDefault();
 		var url = $( this ).attr( 'href' ).replace( 'admin-post', 'admin-ajax' );
@@ -19,12 +20,11 @@ jQuery( document ).ready( function( $ ){
 
 	$( '#wpr-deactivation-intent-form' ).submit(function (e) {
 		const checked = $( '#export_settings' ).prop('checked');
-		if(! checked) {
+		if(! checked || sent) {
 			return true;
 		}
 
 		e.preventDefault();
-
 		$.ajax( {
 			url: rocket_option_export.rest_url_option_export,
 			method: 'GET',
@@ -55,7 +55,7 @@ jQuery( document ).ready( function( $ ){
 				window.URL.revokeObjectURL(url);
 			},
 			complete: function () {
-				$( '#export_settings' ).prop('checked', false);
+				sent = true;
 				$( '#wpr-deactivation-intent-form' ).submit();
 			}
 		} );

--- a/assets/js/wpr-admin-common.js
+++ b/assets/js/wpr-admin-common.js
@@ -28,9 +28,6 @@ jQuery( document ).ready( function( $ ){
 		$.ajax( {
 			url: rocket_option_export.rest_url_option_export,
 			method: 'GET',
-			beforeSend: function ( xhr ) {
-				xhr.setRequestHeader( 'X-WP-Nonce', jQuery('#wpr-deactivation-intent-form input[name="rest_auth_nonce"]').val() );
-			},
 			success: function( data, textStatus, xhr ) {
 				const disposition = xhr.getResponseHeader('content-disposition');
 

--- a/inc/Engine/Admin/API/Subscriber.php
+++ b/inc/Engine/Admin/API/Subscriber.php
@@ -31,7 +31,7 @@ class Subscriber implements Subscriber_Interface {
 			'wpr-admin-common',
 			'rocket_option_export',
 			[
-				'rest_url_option_export' => rest_url( 'wp-rocket/v1/options/export/' ),
+				'rest_url_option_export' => wp_nonce_url( admin_url( 'admin-post.php?action=rocket_export' ), 'rocket_export' ),
 			]
 		);
 	}


### PR DESCRIPTION
## Description

This pull request addresses issue #5684 where exporting settings before applying Safe Mode might not work reliably in some scenarios. The problem is caused by the plugin using the WordPress REST API to export settings, but this API is not working correctly in some cases. This can lead to the Safe Mode being applied but the export not starting.

The solution proposed is to use an admin post action to export settings instead of relying on the WordPress REST API. This change is made by replacing the line `'rest_url_option_export' => rest_url( 'wp-rocket/v1/options/export/' )` with `'rest_url_option_export' => wp_nonce_url( admin_url( 'admin-post.php?action=rocket_export' ), 'rocket_export' )`.

Fixes #5684

## Type of change

Please delete options that are not relevant.


- [ ] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

No.

## How Has This Been Tested?

- [ ] Tested locally.

# Checklist:

Please delete the options that are not relevant.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
