### PR TITLE
disable preload for pagination URLs

### DIFF
--- a/inc/Engine/Preload/Controller/CheckExcludedTrait.php
+++ b/inc/Engine/Preload/Controller/CheckExcludedTrait.php
@@ -28,7 +28,9 @@ trait CheckExcludedTrait {
 		 *
 		 * @param string[] regexes to check
 		 */
-		$regexes = (array) apply_filters( 'rocket_preload_exclude_urls', [] );
+		global $wp_rewrite;
+		$pagination_regex = "/$wp_rewrite->pagination_base/\d+";
+		$regexes          = (array) apply_filters( 'rocket_preload_exclude_urls', [ $pagination_regex ] );
 
 		if ( empty( $regexes ) ) {
 			return false;

--- a/inc/Engine/Preload/Controller/CheckExcludedTrait.php
+++ b/inc/Engine/Preload/Controller/CheckExcludedTrait.php
@@ -23,14 +23,14 @@ trait CheckExcludedTrait {
 	 * @return bool
 	 */
 	protected function is_excluded_by_filter( string $url ): bool {
+		global $wp_rewrite;
+		$pagination_regex = "/$wp_rewrite->pagination_base/\d+";
 		/**
 		 * Regex to exclude URI from preload.
 		 *
 		 * @param string[] regexes to check
 		 */
-		global $wp_rewrite;
-		$pagination_regex = "/$wp_rewrite->pagination_base/\d+";
-		$regexes          = (array) apply_filters( 'rocket_preload_exclude_urls', [ $pagination_regex ] );
+		$regexes = (array) apply_filters( 'rocket_preload_exclude_urls', [ $pagination_regex ] );
 
 		if ( empty( $regexes ) ) {
 			return false;

--- a/tests/Fixtures/inc/Engine/Preload/Controller/CheckExcludedTrait/isExcludedByFilter.php
+++ b/tests/Fixtures/inc/Engine/Preload/Controller/CheckExcludedTrait/isExcludedByFilter.php
@@ -24,5 +24,12 @@ return [
 			'url' => 'http://example.org/test'
 		],
 		'expected' => true
+	],
+	'matchingPaginationShouldReturnTrue' => [
+		'config' => [
+			'regexes' => [],
+			'url' => 'http://example.org/page/22'
+		],
+		'expected' => true
 	]
 ];

--- a/tests/Unit/inc/Engine/Preload/Controller/CheckExcludedTrait/isExcludedByFilter.php
+++ b/tests/Unit/inc/Engine/Preload/Controller/CheckExcludedTrait/isExcludedByFilter.php
@@ -29,6 +29,7 @@ class Test_IsExcludedByFilter extends TestCase
 	public function testShouldReturnAsExpected($config, $expected) {
 		global $wp_rewrite;
 		$pagination_regex = "/$wp_rewrite->pagination_base/\d+";
+		$config['regexes'][]= $pagination_regex;
 		Filters\expectApplied('rocket_preload_exclude_urls')->with([$pagination_regex])->andReturn($config['regexes']);
 		$method = $this->get_reflective_method('is_excluded_by_filter',  get_class($this->trait));
 		$this->assertSame($expected, $method->invokeArgs($this->trait,[$config['url']]));

--- a/tests/Unit/inc/Engine/Preload/Controller/CheckExcludedTrait/isExcludedByFilter.php
+++ b/tests/Unit/inc/Engine/Preload/Controller/CheckExcludedTrait/isExcludedByFilter.php
@@ -15,13 +15,21 @@ class Test_IsExcludedByFilter extends TestCase
 	{
 		parent::setUp();
 		$this->trait = Mockery::mock(CheckExcludedTrait::class)->makePartial();
+		$GLOBALS['wp_rewrite'] = (object) [ 'pagination_base' => 'page' ];
 	}
 
+	public function tearDown(): void {
+		parent::tearDown();
+
+		unset( $GLOBALS['wp_rewrite'] );
+	}
 	/**
 	 * @dataProvider configTestData
 	 */
 	public function testShouldReturnAsExpected($config, $expected) {
-		Filters\expectApplied('rocket_preload_exclude_urls')->with([])->andReturn($config['regexes']);
+		global $wp_rewrite;
+		$pagination_regex = "/$wp_rewrite->pagination_base/\d+";
+		Filters\expectApplied('rocket_preload_exclude_urls')->with([$pagination_regex])->andReturn($config['regexes']);
 		$method = $this->get_reflective_method('is_excluded_by_filter',  get_class($this->trait));
 		$this->assertSame($expected, $method->invokeArgs($this->trait,[$config['url']]));
 	}


### PR DESCRIPTION
## Description

disable add pagination URLs in `wpr_rocket_cache` table
Fixes #5544 

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

No
## How Has This Been Tested?
- [x] local envoinment
- [x] unit and integration tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
