### PR TITLE
Change the way we detect One.com CDN option

### DIFF
--- a/inc/ThirdParty/Hostings/OneCom.php
+++ b/inc/ThirdParty/Hostings/OneCom.php
@@ -142,7 +142,7 @@ class OneCom implements Subscriber_Interface {
 	 * @return boolean
 	 */
 	public function is_varnish_active() {
-		return rest_sanitize_boolean( get_option( 'varnish_caching_enable' ) );
+		return rocket_get_constant( 'vcaching', false ) && rest_sanitize_boolean( get_option( 'varnish_caching_enable' ) );
 	}
 
 	/**

--- a/inc/ThirdParty/Hostings/OneCom.php
+++ b/inc/ThirdParty/Hostings/OneCom.php
@@ -38,7 +38,7 @@ class OneCom implements Subscriber_Interface {
 	 * @return boolean
 	 */
 	public function is_oc_cdn_enabled(): bool {
-		return rest_sanitize_boolean( get_option( 'oc_cdn_enabled' ) );
+		return class_exists( 'VCachingOC' ) && rest_sanitize_boolean( get_option( 'oc_cdn_enabled' ) );
 	}
 
 	/**
@@ -48,11 +48,7 @@ class OneCom implements Subscriber_Interface {
 	 * @return bool|null
 	 */
 	public function maybe_enable_cdn_option( ?string $cdn ) {
-		if ( ! $this->is_oc_cdn_enabled() ) {
-			return $cdn;
-		}
-
-		return ! $this->is_content_dir_changed();
+		return $this->is_oc_cdn_enabled() ? true : $cdn;
 	}
 
 	/**
@@ -90,16 +86,6 @@ class OneCom implements Subscriber_Interface {
 		$files[] = '/wp-includes/(.*)';
 
 		return $files;
-	}
-
-	/**
-	 * Does wp-content directory changed?
-	 *
-	 * @return bool
-	 */
-	private function is_content_dir_changed() {
-		$wp_content_path = rocket_get_constant( 'WP_CONTENT_DIR' );
-		return 'wp-content' !== str_replace( rocket_get_constant( 'ABSPATH' ), '', $wp_content_path );
 	}
 
 	/**

--- a/inc/ThirdParty/Hostings/OneCom.php
+++ b/inc/ThirdParty/Hostings/OneCom.php
@@ -38,7 +38,7 @@ class OneCom implements Subscriber_Interface {
 	 * @return boolean
 	 */
 	public function is_oc_cdn_enabled(): bool {
-		return class_exists( 'VCachingOC' ) && rest_sanitize_boolean( get_option( 'oc_cdn_enabled' ) );
+		return rocket_get_constant( 'vcaching', false ) && rest_sanitize_boolean( get_option( 'oc_cdn_enabled' ) );
 	}
 
 	/**

--- a/inc/ThirdParty/Hostings/OneCom.php
+++ b/inc/ThirdParty/Hostings/OneCom.php
@@ -48,7 +48,11 @@ class OneCom implements Subscriber_Interface {
 	 * @return bool|null
 	 */
 	public function maybe_enable_cdn_option( ?string $cdn ) {
-		return $this->is_oc_cdn_enabled() ? true : $cdn;
+		if ( ! $this->is_oc_cdn_enabled() ) {
+			return $cdn;
+		}
+
+		return ! $this->is_content_dir_changed();
 	}
 
 	/**
@@ -73,12 +77,12 @@ class OneCom implements Subscriber_Interface {
 
 	/**
 	 * Exclude files from being rewritten.
+	 * From 3.12.5.2 we are excluding new wp-content directory paths if it's not the normal one.
 	 *
 	 * @param array $files Array of files to be excluded.
 	 * @return array
 	 */
 	public function exclude_from_cdn( array $files ): array {
-
 		if ( ! $this->is_oc_cdn_enabled() ) {
 			return $files;
 		}
@@ -86,6 +90,16 @@ class OneCom implements Subscriber_Interface {
 		$files[] = '/wp-includes/(.*)';
 
 		return $files;
+	}
+
+	/**
+	 * Does wp-content directory changed?
+	 *
+	 * @return bool
+	 */
+	private function is_content_dir_changed() {
+		$wp_content_path = rocket_get_constant( 'WP_CONTENT_DIR' );
+		return 'wp-content' !== str_replace( rocket_get_constant( 'ABSPATH' ), '', $wp_content_path );
 	}
 
 	/**

--- a/tests/Fixtures/inc/ThirdParty/Hostings/OneCom/disableCDNChange.php
+++ b/tests/Fixtures/inc/ThirdParty/Hostings/OneCom/disableCDNChange.php
@@ -31,41 +31,71 @@ return [
             ],
         ],
 	],
+	'testShouldNotUpdateFieldSettingsWhenOnePluginIsDisabled' => [
+		'config'      => [
+			'onecom_performance_plugin_enabled' => false,
+			'oc_cdn_enabled' => true,
+			'field_settings' => [
+				'cdn' => [
+					'type'              => 'checkbox',
+					'label'             => 'Some text',
+					'helper'            => '',
+					'section'           => 'cdn_section',
+					'page'              => 'page_cdn',
+					'default'           => 0,
+					'sanitize_callback' => 'sanitize_checkbox',
+				],
+			]
+		],
+		'expected' => [
+			'field_settings' => [
+				'cdn' => [
+					'type'              => 'checkbox',
+					'label'             => 'Some text',
+					'helper'            => '',
+					'section'           => 'cdn_section',
+					'page'              => 'page_cdn',
+					'default'           => 0,
+					'sanitize_callback' => 'sanitize_checkbox',
+				],
+			],
+		],
+	],
 	'testShouldUpdateFieldSettings' => [
 		'config'      => [
 			'onecom_performance_plugin_enabled' => true,
-            'oc_cdn_enabled' => true,
-            'field_settings' => [
-                'cdn' => [
-                    'type'              => 'checkbox',
-                    'label'             => 'Some text',
-                    'helper'            => '',
-                    'section'           => 'cdn_section',
-                    'page'              => 'page_cdn',
-                    'default'           => 0,
-                    'sanitize_callback' => 'sanitize_checkbox',
-                ],
-            ]
-        ],
+			'oc_cdn_enabled' => true,
+			'field_settings' => [
+				'cdn' => [
+					'type'              => 'checkbox',
+					'label'             => 'Some text',
+					'helper'            => '',
+					'section'           => 'cdn_section',
+					'page'              => 'page_cdn',
+					'default'           => 0,
+					'sanitize_callback' => 'sanitize_checkbox',
+				],
+			]
+		],
 		'expected' => [
-            'field_settings' => [
-                'cdn' => [
-                    'type'              => 'checkbox',
-                    'label'             => 'Some text',
-                    'helper'            => '',
-                    'section'           => 'cdn_section',
-                    'page'              => 'page_cdn',
-                    'default'           => 0,
-                    'sanitize_callback' => 'sanitize_checkbox',
-                    'container_class'   => [
-                        'wpr-isDisabled'
-                    ],
-                    'input_attr'        => [
-                        'disabled' => 1,
-                    ]
-                ],
-            ],
-        ],
+			'field_settings' => [
+				'cdn' => [
+					'type'              => 'checkbox',
+					'label'             => 'Some text',
+					'helper'            => '',
+					'section'           => 'cdn_section',
+					'page'              => 'page_cdn',
+					'default'           => 0,
+					'sanitize_callback' => 'sanitize_checkbox',
+					'container_class'   => [
+						'wpr-isDisabled'
+					],
+					'input_attr'        => [
+						'disabled' => 1,
+					]
+				],
+			],
+		],
 	],
 ];
 

--- a/tests/Fixtures/inc/ThirdParty/Hostings/OneCom/disableCDNChange.php
+++ b/tests/Fixtures/inc/ThirdParty/Hostings/OneCom/disableCDNChange.php
@@ -3,6 +3,7 @@
 return [
 	'testShouldReturnDefaultFieldSettings' => [
 		'config'      => [
+			'onecom_performance_plugin_enabled' => true,
             'oc_cdn_enabled' => false,
             'field_settings' => [
                 'cdn' => [
@@ -32,6 +33,7 @@ return [
 	],
 	'testShouldUpdateFieldSettings' => [
 		'config'      => [
+			'onecom_performance_plugin_enabled' => true,
             'oc_cdn_enabled' => true,
             'field_settings' => [
                 'cdn' => [

--- a/tests/Fixtures/inc/ThirdParty/Hostings/OneCom/excludeFromCDN.php
+++ b/tests/Fixtures/inc/ThirdParty/Hostings/OneCom/excludeFromCDN.php
@@ -3,6 +3,7 @@
 return [
 	'testShouldBailOutWithDisabledOneDotComCDN' => [
 		'config'      => [
+			'onecom_performance_plugin_enabled' => true,
             'oc_cdn_enabled' => false,
             'excluded' => [],
         ],
@@ -10,6 +11,7 @@ return [
 	],
 	'testShouldExcludeFromCDN' => [
 		'config'      => [
+			'onecom_performance_plugin_enabled' => true,
             'oc_cdn_enabled' => true,
             'excluded' => [],
         ],

--- a/tests/Fixtures/inc/ThirdParty/Hostings/OneCom/excludeFromCDN.php
+++ b/tests/Fixtures/inc/ThirdParty/Hostings/OneCom/excludeFromCDN.php
@@ -4,9 +4,17 @@ return [
 	'testShouldBailOutWithDisabledOneDotComCDN' => [
 		'config'      => [
 			'onecom_performance_plugin_enabled' => true,
-            'oc_cdn_enabled' => false,
-            'excluded' => [],
-        ],
+			'oc_cdn_enabled' => false,
+			'excluded' => [],
+		],
+		'expected' => [],
+	],
+	'testShouldBailOutWithEnabledOneDotComCDNAndPluginDisabled' => [
+		'config'      => [
+			'onecom_performance_plugin_enabled' => false,
+			'oc_cdn_enabled' => true,
+			'excluded' => [],
+		],
 		'expected' => [],
 	],
 	'testShouldExcludeFromCDN' => [

--- a/tests/Fixtures/inc/ThirdParty/Hostings/OneCom/maybeEnableCDNOption.php
+++ b/tests/Fixtures/inc/ThirdParty/Hostings/OneCom/maybeEnableCDNOption.php
@@ -19,4 +19,24 @@ return [
             'return' => null,
         ],
     ],
+    'testShouldReturnFalseWithOneDotComCDNEnabledAndWPContentDirChanged' => [
+	    'config' => [
+		    'cdn' => null,
+		    'oc_cdn_enabled' => true,
+		    'wp_content_dir' => 'vfs://public/wp-content-changed',
+	    ],
+	    'expected' => [
+		    'return' => false,
+	    ],
+    ],
+    'testShouldReturntrueWithOneDotComCDNEnabledAndWPContentDirNotChanged' => [
+	    'config' => [
+		    'cdn' => null,
+		    'oc_cdn_enabled' => true,
+		    'wp_content_dir' => 'vfs://public/wp-content',
+	    ],
+	    'expected' => [
+		    'return' => true,
+	    ],
+    ],
 ];

--- a/tests/Fixtures/inc/ThirdParty/Hostings/OneCom/maybeEnableCDNOption.php
+++ b/tests/Fixtures/inc/ThirdParty/Hostings/OneCom/maybeEnableCDNOption.php
@@ -3,6 +3,7 @@
 return [
     'testShouldReturnTrueWithOneDotComCDNEnabled' => [
         'config' => [
+			'onecom_performance_plugin_enabled' => true,
             'cdn' => null,
             'oc_cdn_enabled' => true,
         ],
@@ -12,31 +13,12 @@ return [
     ],
     'testShouldReturnNullWithOneDotComCDNDisabled' => [
         'config' => [
+	        'onecom_performance_plugin_enabled' => true,
             'cdn' => null,
             'oc_cdn_enabled' => false,
         ],
         'expected' => [
             'return' => null,
         ],
-    ],
-    'testShouldReturnFalseWithOneDotComCDNEnabledAndWPContentDirChanged' => [
-	    'config' => [
-		    'cdn' => null,
-		    'oc_cdn_enabled' => true,
-		    'wp_content_dir' => 'vfs://public/wp-content-changed',
-	    ],
-	    'expected' => [
-		    'return' => false,
-	    ],
-    ],
-    'testShouldReturntrueWithOneDotComCDNEnabledAndWPContentDirNotChanged' => [
-	    'config' => [
-		    'cdn' => null,
-		    'oc_cdn_enabled' => true,
-		    'wp_content_dir' => 'vfs://public/wp-content',
-	    ],
-	    'expected' => [
-		    'return' => true,
-	    ],
     ],
 ];

--- a/tests/Fixtures/inc/ThirdParty/Hostings/OneCom/maybeEnableCDNOption.php
+++ b/tests/Fixtures/inc/ThirdParty/Hostings/OneCom/maybeEnableCDNOption.php
@@ -12,13 +12,23 @@ return [
         ],
     ],
     'testShouldReturnNullWithOneDotComCDNDisabled' => [
-        'config' => [
-	        'onecom_performance_plugin_enabled' => true,
-            'cdn' => null,
-            'oc_cdn_enabled' => false,
-        ],
-        'expected' => [
-            'return' => null,
-        ],
+	    'config' => [
+		    'onecom_performance_plugin_enabled' => true,
+		    'cdn' => null,
+		    'oc_cdn_enabled' => false,
+	    ],
+	    'expected' => [
+		    'return' => null,
+	    ],
+    ],
+    'testShouldReturnNullWithOneDotComCDNEnabledAndPluginDisabled' => [
+	    'config' => [
+		    'onecom_performance_plugin_enabled' => false,
+		    'cdn' => null,
+		    'oc_cdn_enabled' => false,
+	    ],
+	    'expected' => [
+		    'return' => null,
+	    ],
     ],
 ];

--- a/tests/Fixtures/inc/ThirdParty/Hostings/OneCom/maybeSetVarnishAddonTitle.php
+++ b/tests/Fixtures/inc/ThirdParty/Hostings/OneCom/maybeSetVarnishAddonTitle.php
@@ -28,6 +28,33 @@ return [
             'title' => 'If Varnish runs on your server, you must activate this add-on.'
         ],
     ],
+    'testShouldReturnDefaultVarnishSettingWhenPluginIsDisabled' =>[
+	    'config' => [
+		    'onecom_performance_plugin_enabled' => false,
+		    'is_varnish_active' => true,
+		    'varnish_field_settings' => [
+			    'varnish_auto_purge' => [
+				    'type'              => 'one_click_addon',
+				    'label'             => 'Varnish',
+				    'logo'              => [
+					    'url'    => '/path-to/home/wp-content/plugins/wp-rocket/assets/img/logo-varnish.svg',
+					    'width'  => 152,
+					    'height' => 135,
+				    ],
+				    'title'             => 'If Varnish runs on your server, you must activate this add-on.',
+				    'description'       => 'Varnish cache will be purged each time WP Rocket clears its cache to ensure content is always up-to-date.',
+				    'section'           => 'one_click',
+				    'page'              => 'addons',
+				    'settings_page'     => 'varnish',
+				    'default'           => 0,
+				    'sanitize_callback' => 'sanitize_checkbox',
+			    ],
+		    ],
+	    ],
+	    'expected' => [
+		    'title' => 'If Varnish runs on your server, you must activate this add-on.'
+	    ],
+    ],
     'testShouldReturnUpdatedVarnishSetting' =>[
         'config' => [
 	        'onecom_performance_plugin_enabled' => true,

--- a/tests/Fixtures/inc/ThirdParty/Hostings/OneCom/maybeSetVarnishAddonTitle.php
+++ b/tests/Fixtures/inc/ThirdParty/Hostings/OneCom/maybeSetVarnishAddonTitle.php
@@ -3,6 +3,7 @@
 return [
     'testShouldReturnDefaultVarnishSetting' =>[
         'config' => [
+	        'onecom_performance_plugin_enabled' => true,
             'is_varnish_active' => false,
             'varnish_field_settings' => [
                 'varnish_auto_purge' => [
@@ -29,6 +30,7 @@ return [
     ],
     'testShouldReturnUpdatedVarnishSetting' =>[
         'config' => [
+	        'onecom_performance_plugin_enabled' => true,
             'is_varnish_active' => true,
             'varnish_field_settings' => [
                 'varnish_auto_purge' => [

--- a/tests/Fixtures/inc/ThirdParty/Hostings/OneCom/maybeUpdateCDNCname.php
+++ b/tests/Fixtures/inc/ThirdParty/Hostings/OneCom/maybeUpdateCDNCname.php
@@ -3,6 +3,7 @@
 return [
     'testShouldReturnNewArrayWithOneDotComCDNEnabled' => [
         'config' => [
+	        'onecom_performance_plugin_enabled' => true,
             'cname' => null,
             'oc_cdn_enabled' => true,
             'domain' => 'example.com',
@@ -15,6 +16,7 @@ return [
     ],
     'testShouldReturnNullWithOneDotComCDNDisabled' => [
         'config' => [
+	        'onecom_performance_plugin_enabled' => true,
             'cname' => null,
             'oc_cdn_enabled' => false,
             'domain' => 'example.com',

--- a/tests/Fixtures/inc/ThirdParty/Hostings/OneCom/maybeUpdateCDNCname.php
+++ b/tests/Fixtures/inc/ThirdParty/Hostings/OneCom/maybeUpdateCDNCname.php
@@ -15,14 +15,25 @@ return [
         ],
     ],
     'testShouldReturnNullWithOneDotComCDNDisabled' => [
-        'config' => [
-	        'onecom_performance_plugin_enabled' => true,
-            'cname' => null,
-            'oc_cdn_enabled' => false,
-            'domain' => 'example.com',
-        ],
-        'expected' => [
-            'return' => null,
-        ],
+	    'config' => [
+		    'onecom_performance_plugin_enabled' => true,
+		    'cname' => null,
+		    'oc_cdn_enabled' => false,
+		    'domain' => 'example.com',
+	    ],
+	    'expected' => [
+		    'return' => null,
+	    ],
+    ],
+    'testShouldReturnNullWithOneDotComCDNEnabledAndPluginDisabled' => [
+	    'config' => [
+		    'onecom_performance_plugin_enabled' => false,
+		    'cname' => null,
+		    'oc_cdn_enabled' => true,
+		    'domain' => 'example.com',
+	    ],
+	    'expected' => [
+		    'return' => null,
+	    ],
     ],
 ];

--- a/tests/Fixtures/inc/ThirdParty/Hostings/OneCom/maybeUpdateCDNZone.php
+++ b/tests/Fixtures/inc/ThirdParty/Hostings/OneCom/maybeUpdateCDNZone.php
@@ -3,6 +3,7 @@
 return [
     'testShouldReturnNewArrayWithOneDotComCDNEnabled' => [
         'config' => [
+	        'onecom_performance_plugin_enabled' => true,
             'zone' => null,
             'oc_cdn_enabled' => true,
         ],
@@ -14,6 +15,7 @@ return [
     ],
     'testShouldReturnNullWithOneDotComCDNDisabled' => [
         'config' => [
+	        'onecom_performance_plugin_enabled' => true,
             'zone' => null,
             'oc_cdn_enabled' => false,
         ],

--- a/tests/Fixtures/inc/ThirdParty/Hostings/OneCom/maybeUpdateCDNZone.php
+++ b/tests/Fixtures/inc/ThirdParty/Hostings/OneCom/maybeUpdateCDNZone.php
@@ -14,13 +14,23 @@ return [
         ],
     ],
     'testShouldReturnNullWithOneDotComCDNDisabled' => [
-        'config' => [
-	        'onecom_performance_plugin_enabled' => true,
-            'zone' => null,
-            'oc_cdn_enabled' => false,
-        ],
-        'expected' => [
-            'return' => null,
-        ],
+	    'config' => [
+		    'onecom_performance_plugin_enabled' => true,
+		    'zone' => null,
+		    'oc_cdn_enabled' => false,
+	    ],
+	    'expected' => [
+		    'return' => null,
+	    ],
+    ],
+    'testShouldReturnNullWithOneDotComCDNEnabledAndPluginDisabled' => [
+	    'config' => [
+		    'onecom_performance_plugin_enabled' => false,
+		    'zone' => null,
+		    'oc_cdn_enabled' => true,
+	    ],
+	    'expected' => [
+		    'return' => null,
+	    ],
     ],
 ];

--- a/tests/Unit/inc/ThirdParty/Hostings/OneCom/disableCDNChange.php
+++ b/tests/Unit/inc/ThirdParty/Hostings/OneCom/disableCDNChange.php
@@ -2,7 +2,7 @@
 namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Hostings\OneCom;
 
 use WP_Rocket\ThirdParty\Hostings\OneCom;
-use WPMedia\PHPUnit\Unit\TestCase;
+use WP_Rocket\Tests\Unit\TestCase;
 use Brain\Monkey\Functions;
 
 /**
@@ -15,34 +15,33 @@ class Test_DisableCDNChange extends TestCase {
 
 	public function setUp() : void {
 		parent::setUp();
-        
+
         $this->onecom = new OneCom();
 	}
 
 	/**
-	 * @dataProvider providerTestData
+	 * @dataProvider configTestData
 	 */
 	public function testShouldReturnExpected( $config, $expected ) {
+		$this->constants['vcaching'] = $config['onecom_performance_plugin_enabled'];
 
-        Functions\expect( 'rest_sanitize_boolean' )
+		if ( $config['onecom_performance_plugin_enabled'] ) {
+			Functions\expect( 'rest_sanitize_boolean' )
 				->once()
 				->andReturn( $config['oc_cdn_enabled'] );
 
-        Functions\when( 'get_option' )
-			->alias( function( $value ) use( $config ) {
-				if ( 'oc_cdn_enabled' === $value ) {
-                    return $config['oc_cdn_enabled'];
-                }
-			}
-		);
+			Functions\when( 'get_option' )
+				->alias( function( $value ) use( $config ) {
+					if ( 'oc_cdn_enabled' === $value ) {
+						return $config['oc_cdn_enabled'];
+					}
+				}
+				);
+		}
 
 		$this->assertSame(
 			$expected['field_settings'],
 			$this->onecom->disable_cdn_change( $config['field_settings'] )
 		);
-	}
-
-	public function providerTestData() {
-		return $this->getTestData( __DIR__, 'disableCDNChange' );
 	}
 }

--- a/tests/Unit/inc/ThirdParty/Hostings/OneCom/excludeFromCDN.php
+++ b/tests/Unit/inc/ThirdParty/Hostings/OneCom/excludeFromCDN.php
@@ -2,7 +2,7 @@
 namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Hostings\OneCom;
 
 use WP_Rocket\ThirdParty\Hostings\OneCom;
-use WPMedia\PHPUnit\Unit\TestCase;
+use WP_Rocket\Tests\Unit\TestCase;
 use Brain\Monkey\Functions;
 
 /**
@@ -15,34 +15,33 @@ class Test_ExcludeFromCDN extends TestCase {
 
 	public function setUp() : void {
 		parent::setUp();
-        
+
         $this->onecom = new OneCom();
 	}
 
 	/**
-	 * @dataProvider providerTestData
+	 * @dataProvider configTestData
 	 */
 	public function testShouldReturnExpected( $config, $expected ) {
+		$this->constants['vcaching'] = $config['onecom_performance_plugin_enabled'];
 
-        Functions\expect( 'rest_sanitize_boolean' )
+		if ( $config['onecom_performance_plugin_enabled'] ) {
+			Functions\expect( 'rest_sanitize_boolean' )
 				->once()
 				->andReturn( $config['oc_cdn_enabled'] );
 
-        Functions\when( 'get_option' )
-			->alias( function( $value ) use( $config ) {
-				if ( 'oc_cdn_enabled' === $value ) {
-                    return $config['oc_cdn_enabled'];
-                }
-			}
-		);
+			Functions\when( 'get_option' )
+				->alias( function( $value ) use( $config ) {
+					if ( 'oc_cdn_enabled' === $value ) {
+						return $config['oc_cdn_enabled'];
+					}
+				}
+				);
+		}
 
 		$this->assertSame(
 			$expected,
 			$this->onecom->exclude_from_cdn( $config['excluded'] )
 		);
-	}
-
-	public function providerTestData() {
-		return $this->getTestData( __DIR__, 'excludeFromCDN' );
 	}
 }

--- a/tests/Unit/inc/ThirdParty/Hostings/OneCom/maybeEnableCDNOption.php
+++ b/tests/Unit/inc/ThirdParty/Hostings/OneCom/maybeEnableCDNOption.php
@@ -2,7 +2,7 @@
 namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Hostings\OneCom;
 
 use WP_Rocket\ThirdParty\Hostings\OneCom;
-use WPMedia\PHPUnit\Unit\TestCase;
+use WP_Rocket\Tests\Unit\TestCase;
 use Brain\Monkey\Functions;
 
 /**
@@ -20,7 +20,7 @@ class Test_MaybeEnableCDNOption extends TestCase {
 	}
 
 	/**
-	 * @dataProvider providerTestData
+	 * @dataProvider configTestData
 	 */
 	public function testShouldReturnExpected( $config, $expected ) {
 
@@ -36,10 +36,16 @@ class Test_MaybeEnableCDNOption extends TestCase {
 			}
 		);
 
+		if ( isset( $config['wp_content_dir'] ) ) {
+			$this->wp_content_dir = $config['wp_content_dir'];
+		}
+
         $this->assertSame( $expected['return'], $this->onecom->maybe_enable_cdn_option( $config['cdn'] ) );
 	}
 
-	public function providerTestData() {
-		return $this->getTestData( __DIR__, 'maybeEnableCDNOption' );
+	public function tearDown(): void {
+		parent::tearDown();
+
+		$this->wp_content_dir = 'vfs://public/wp-content';
 	}
 }

--- a/tests/Unit/inc/ThirdParty/Hostings/OneCom/maybeEnableCDNOption.php
+++ b/tests/Unit/inc/ThirdParty/Hostings/OneCom/maybeEnableCDNOption.php
@@ -23,29 +23,22 @@ class Test_MaybeEnableCDNOption extends TestCase {
 	 * @dataProvider configTestData
 	 */
 	public function testShouldReturnExpected( $config, $expected ) {
+		$this->constants['vcaching'] = $config['onecom_performance_plugin_enabled'];
 
-        Functions\expect( 'rest_sanitize_boolean' )
+		if ( $config['onecom_performance_plugin_enabled'] ) {
+			Functions\expect( 'rest_sanitize_boolean' )
 				->once()
 				->andReturn( $config['oc_cdn_enabled'] );
 
-        Functions\when( 'get_option' )
-			->alias( function( $value ) use( $config ) {
-				if ( 'oc_cdn_enabled' === $value ) {
-                    return $config['oc_cdn_enabled'];
-                }
-			}
-		);
-
-		if ( isset( $config['wp_content_dir'] ) ) {
-			$this->wp_content_dir = $config['wp_content_dir'];
+			Functions\when( 'get_option' )
+				->alias( function( $value ) use( $config ) {
+					if ( 'oc_cdn_enabled' === $value ) {
+						return $config['oc_cdn_enabled'];
+					}
+				}
+				);
 		}
 
         $this->assertSame( $expected['return'], $this->onecom->maybe_enable_cdn_option( $config['cdn'] ) );
-	}
-
-	public function tearDown(): void {
-		parent::tearDown();
-
-		$this->wp_content_dir = 'vfs://public/wp-content';
 	}
 }

--- a/tests/Unit/inc/ThirdParty/Hostings/OneCom/maybeSetVarnishAddonTitle.php
+++ b/tests/Unit/inc/ThirdParty/Hostings/OneCom/maybeSetVarnishAddonTitle.php
@@ -2,7 +2,7 @@
 namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Hostings\OneCom;
 
 use WP_Rocket\ThirdParty\Hostings\OneCom;
-use WPMedia\PHPUnit\Unit\TestCase;
+use WP_Rocket\Tests\Unit\TestCase;
 use Brain\Monkey\Functions;
 
 /**
@@ -15,35 +15,34 @@ class Test_MaybeSetVarnishAddonTitle extends TestCase {
 
 	public function setUp() : void {
 		parent::setUp();
-        
+
         $this->onecom = new OneCom();
 
         Functions\stubTranslationFunctions();
 	}
 
 	/**
-	 * @dataProvider providerTestData
+	 * @dataProvider configTestData
 	 */
 	public function testShouldReturnExpected( $config, $expected ) {
+		$this->constants['vcaching'] = $config['onecom_performance_plugin_enabled'];
 
-        Functions\expect( 'rest_sanitize_boolean' )
+		if ( $config['onecom_performance_plugin_enabled'] ) {
+			Functions\expect( 'rest_sanitize_boolean' )
 				->once()
 				->andReturn( $config['is_varnish_active'] );
 
-        Functions\when( 'get_option' )
-			->alias( function( $value ) use( $config ) {
-				if ( 'varnish_caching_enable' === $value ) {
-                    return $config['is_varnish_active'];
-                }
-			}
-		);
+			Functions\when( 'get_option' )
+				->alias( function( $value ) use( $config ) {
+					if ( 'varnish_caching_enable' === $value ) {
+						return $config['is_varnish_active'];
+					}
+				}
+				);
+		}
 
         $settings = $this->onecom->maybe_set_varnish_addon_title( $config['varnish_field_settings'] );
 
 		$this->assertSame( $expected['title'], $settings['varnish_auto_purge']['title'] );
-	}
-
-	public function providerTestData() {
-		return $this->getTestData( __DIR__, 'maybeSetVarnishAddonTitle' );
 	}
 }

--- a/tests/Unit/inc/ThirdParty/Hostings/OneCom/maybeUpdateCDNCname.php
+++ b/tests/Unit/inc/ThirdParty/Hostings/OneCom/maybeUpdateCDNCname.php
@@ -47,7 +47,7 @@ class Test_MaybeUpdateCDNCname extends TestCase {
 				);
 		}
 
-        if ( $config['oc_cdn_enabled'] ) {
+        if ( $config['oc_cdn_enabled'] && $config['onecom_performance_plugin_enabled'] ) {
             $domain_name = $_SERVER['ONECOM_DOMAIN_NAME'] = $config['domain'];
             $http_host = $_SERVER['HTTP_HOST'] = $config['domain'];
 

--- a/tests/Unit/inc/ThirdParty/Hostings/OneCom/maybeUpdateCDNCname.php
+++ b/tests/Unit/inc/ThirdParty/Hostings/OneCom/maybeUpdateCDNCname.php
@@ -2,7 +2,7 @@
 namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Hostings\OneCom;
 
 use WP_Rocket\ThirdParty\Hostings\OneCom;
-use WPMedia\PHPUnit\Unit\TestCase;
+use WP_Rocket\Tests\Unit\TestCase;
 use Brain\Monkey\Functions;
 
 /**
@@ -28,21 +28,24 @@ class Test_MaybeUpdateCDNCname extends TestCase {
 	}
 
 	/**
-	 * @dataProvider providerTestData
+	 * @dataProvider configTestData
 	 */
 	public function testShouldReturnExpected( $config, $expected ) {
+		$this->constants['vcaching'] = $config['onecom_performance_plugin_enabled'];
 
-        Functions\expect( 'rest_sanitize_boolean' )
+		if ( $config['onecom_performance_plugin_enabled'] ) {
+			Functions\expect( 'rest_sanitize_boolean' )
 				->once()
 				->andReturn( $config['oc_cdn_enabled'] );
 
-        Functions\when( 'get_option' )
-			->alias( function( $value ) use( $config ) {
-				if ( 'oc_cdn_enabled' === $value ) {
-                    return $config['oc_cdn_enabled'];
-                }
-			}
-		);
+			Functions\when( 'get_option' )
+				->alias( function( $value ) use( $config ) {
+					if ( 'oc_cdn_enabled' === $value ) {
+						return $config['oc_cdn_enabled'];
+					}
+				}
+				);
+		}
 
         if ( $config['oc_cdn_enabled'] ) {
             $domain_name = $_SERVER['ONECOM_DOMAIN_NAME'] = $config['domain'];
@@ -58,9 +61,5 @@ class Test_MaybeUpdateCDNCname extends TestCase {
         }
 
         $this->assertSame( $expected['return'], $this->onecom->maybe_update_cdn_cname( $config['cname'] ) );
-	}
-
-	public function providerTestData() {
-		return $this->getTestData( __DIR__, 'maybeUpdateCDNCname' );
 	}
 }

--- a/tests/Unit/inc/ThirdParty/Hostings/OneCom/maybeUpdateCDNZone.php
+++ b/tests/Unit/inc/ThirdParty/Hostings/OneCom/maybeUpdateCDNZone.php
@@ -2,7 +2,7 @@
 namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Hostings\OneCom;
 
 use WP_Rocket\ThirdParty\Hostings\OneCom;
-use WPMedia\PHPUnit\Unit\TestCase;
+use WP_Rocket\Tests\Unit\TestCase;
 use Brain\Monkey\Functions;
 
 /**
@@ -20,26 +20,25 @@ class Test_MaybeUpdateCDNZone extends TestCase {
 	}
 
 	/**
-	 * @dataProvider providerTestData
+	 * @dataProvider configTestData
 	 */
 	public function testShouldReturnExpected( $config, $expected ) {
+		$this->constants['vcaching'] = $config['onecom_performance_plugin_enabled'];
 
-        Functions\expect( 'rest_sanitize_boolean' )
+		if ( $config['onecom_performance_plugin_enabled'] ) {
+			Functions\expect( 'rest_sanitize_boolean' )
 				->once()
 				->andReturn( $config['oc_cdn_enabled'] );
 
-        Functions\when( 'get_option' )
-			->alias( function( $value ) use( $config ) {
-				if ( 'oc_cdn_enabled' === $value ) {
-                    return $config['oc_cdn_enabled'];
-                }
-			}
-		);
+			Functions\when( 'get_option' )
+				->alias( function( $value ) use( $config ) {
+					if ( 'oc_cdn_enabled' === $value ) {
+						return $config['oc_cdn_enabled'];
+					}
+				}
+				);
+		}
 
         $this->assertSame( $expected['return'], $this->onecom->maybe_update_cdn_zone( $config['zone'] ) );
-	}
-
-	public function providerTestData() {
-		return $this->getTestData( __DIR__, 'maybeUpdateCDNZone' );
 	}
 }


### PR DESCRIPTION
## Description

Here we changed the way we detect one.com CDN option and added a condition to get the CDN option value from the database only when their performance plugin is enabled by checking if the value of constant `vcaching` which is defined there like this:

![image](https://user-images.githubusercontent.com/15707971/214143536-8e6b2a1b-1c45-483f-80af-c1d972ac74e4.png)


Fixes #5708

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## Is the solution different from the one proposed during the grooming?

[XS] effort, not groomed.

## How Has This Been Tested?

Checked it with @piotrbak 

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
