### PR TITLE
Easily compile the plugin and generate zip file

### DIFF
--- a/bin/compile.sh
+++ b/bin/compile.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+root_dir=$PWD
+
+rm -f wp-rocket.zip
+
+echo "Copy wp-rocket to temp"
+mkdir -p ../wp-rocket-tmp/wp-rocket/
+rsync -av . ../wp-rocket-tmp/wp-rocket --exclude node_modules --exclude vendor --exclude bin --exclude src --exclude tests --exclude .git --exclude .github --exclude .tx --quiet
+
+echo "Move working directory to temp one"
+cd ../wp-rocket-tmp/wp-rocket
+echo "Start composer"
+composer install --no-dev --no-scripts --no-interaction --quiet
+
+echo "Build compressed file"
+cd ../
+zip -r $root_dir/wp-rocket.zip wp-rocket -x "*/.*" "*/composer*" "*/gulpfile.js" "*/package*" "*/php*" --quiet
+
+cd ../
+rm -rf wp-rocket-tmp


### PR DESCRIPTION
## Description

This is to help creating zip file from the plugin, this will help QA team mainly when they need to upload the zip file from a specific branch to multiple test sites.

## Steps
1. Open the terminal and move to `wp-rocket` plugin directory.
2. Run the following command `bin/compile.sh`
3. You will find the file `wp-rocket.zip` generated in wp-rocket directory.

## ToDo
- Check if composer installed and show a message.
- Make sure of current PHP version that matches our minimum supported version.

I'll keep it in draft till validated by @wp-media/php @wp-media/qa if it'll help or not.