### PR TITLE
Added a way to change delete old cache interval from preload

### DIFF
--- a/inc/Engine/Preload/Cron/Subscriber.php
+++ b/inc/Engine/Preload/Cron/Subscriber.php
@@ -234,7 +234,6 @@ class Subscriber implements Subscriber_Interface {
 		 * Delay before the not accessed row is deleted.
 		 *
 		 * @param string $delay delay before the not accessed row is deleted.
-		 * @returns string
 		 */
 		$delay = (string) apply_filters( 'rocket_preload_delay_delete_non_accessed', '1 month' );
 

--- a/inc/Engine/Preload/Cron/Subscriber.php
+++ b/inc/Engine/Preload/Cron/Subscriber.php
@@ -79,7 +79,6 @@ class Subscriber implements Subscriber_Interface {
 		 * Delay before the not accessed row is deleted.
 		 *
 		 * @param string $delay delay before the not accessed row is deleted.
-		 * @returns string
 		 */
 		$delay = (string) apply_filters( 'rocket_preload_delay_delete_non_accessed', '1 month' );
 

--- a/inc/Engine/Preload/Cron/Subscriber.php
+++ b/inc/Engine/Preload/Cron/Subscriber.php
@@ -251,7 +251,7 @@ class Subscriber implements Subscriber_Interface {
 			$unit   = $parts[1];
 		}
 
-		$this->query->remove_all_not_accessed_rows( $delay, $unit );
+		$this->query->remove_all_not_accessed_rows( $value, $unit );
 	}
 
 	/**

--- a/inc/Engine/Preload/Cron/Subscriber.php
+++ b/inc/Engine/Preload/Cron/Subscriber.php
@@ -246,7 +246,7 @@ class Subscriber implements Subscriber_Interface {
 		$value = 1;
 		$unit  = 'month';
 
-		if ( count( $parts ) === 2 ) {
+		if ( count( $parts ) === 2 || $parts[0] >= 0 ) {
 			$value = $parts[0];
 			$unit  = $parts[1];
 		}

--- a/inc/Engine/Preload/Cron/Subscriber.php
+++ b/inc/Engine/Preload/Cron/Subscriber.php
@@ -83,7 +83,7 @@ class Subscriber implements Subscriber_Interface {
 		 */
 		$delay = (string) apply_filters( 'rocket_preload_delay_delete_non_accessed', '1 month' );
 
-		if ( $delay === "" || wp_next_scheduled( 'rocket_preload_clean_rows_time_event' ) ) {
+		if ( '' === $delay || wp_next_scheduled( 'rocket_preload_clean_rows_time_event' ) ) {
 			return;
 		}
 

--- a/inc/Engine/Preload/Cron/Subscriber.php
+++ b/inc/Engine/Preload/Cron/Subscriber.php
@@ -246,7 +246,7 @@ class Subscriber implements Subscriber_Interface {
 		$value = 1;
 		$unit  = 'month';
 
-		if ( count( $parts ) === 2 || $parts[0] >= 0 ) {
+		if ( count( $parts ) === 2 && $parts[0] >= 0 ) {
 			$value = $parts[0];
 			$unit  = $parts[1];
 		}

--- a/inc/Engine/Preload/Cron/Subscriber.php
+++ b/inc/Engine/Preload/Cron/Subscriber.php
@@ -244,11 +244,11 @@ class Subscriber implements Subscriber_Interface {
 		}
 
 		$value = 1;
-		$unit   = 'month';
+		$unit  = 'month';
 
 		if ( count( $parts ) !== 2 ) {
 			$value = $parts[0];
-			$unit   = $parts[1];
+			$unit  = $parts[1];
 		}
 
 		$this->query->remove_all_not_accessed_rows( $value, $unit );

--- a/inc/Engine/Preload/Cron/Subscriber.php
+++ b/inc/Engine/Preload/Cron/Subscriber.php
@@ -237,11 +237,22 @@ class Subscriber implements Subscriber_Interface {
 		 */
 		$delay = (string) apply_filters( 'rocket_preload_delay_delete_non_accessed', '1 month' );
 
-		if ( '' === $delay ) {
+		$parts = explode(' ', $delay);
+
+		if ( '' === $delay) {
 			return;
 		}
 
-		$this->query->remove_all_not_accessed_rows( $delay );
+
+		if( count($parts) !== 2 ) {
+			$delay = $parts[0];
+			$unit = $parts[1];
+		} else {
+			$delay = 1;
+			$unit = 'month';
+		}
+
+		$this->query->remove_all_not_accessed_rows( $delay, $unit );
 	}
 
 	/**

--- a/inc/Engine/Preload/Cron/Subscriber.php
+++ b/inc/Engine/Preload/Cron/Subscriber.php
@@ -246,7 +246,7 @@ class Subscriber implements Subscriber_Interface {
 		$value = 1;
 		$unit  = 'month';
 
-		if ( count( $parts ) !== 2 ) {
+		if ( count( $parts ) === 2 ) {
 			$value = $parts[0];
 			$unit  = $parts[1];
 		}

--- a/inc/Engine/Preload/Cron/Subscriber.php
+++ b/inc/Engine/Preload/Cron/Subscriber.php
@@ -75,8 +75,15 @@ class Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function schedule_clean_not_commonly_used_rows() {
+		/**
+		 * Delay before the not accessed row is deleted.
+		 *
+		 * @param string $delay delay before the not accessed row is deleted.
+		 * @returns string
+		 */
+		$delay = (string) apply_filters( 'rocket_preload_delay_delete_non_accessed', '1 month' );
 
-		if ( wp_next_scheduled( 'rocket_preload_clean_rows_time_event' ) ) {
+		if ( $delay === "" || wp_next_scheduled( 'rocket_preload_clean_rows_time_event' ) ) {
 			return;
 		}
 

--- a/inc/Engine/Preload/Cron/Subscriber.php
+++ b/inc/Engine/Preload/Cron/Subscriber.php
@@ -243,12 +243,12 @@ class Subscriber implements Subscriber_Interface {
 			return;
 		}
 
+		$value = 1;
+		$unit   = 'month';
+
 		if ( count( $parts ) !== 2 ) {
-			$delay = $parts[0];
-			$unit  = $parts[1];
-		} else {
-			$delay = 1;
-			$unit  = 'month';
+			$value = $parts[0];
+			$unit   = $parts[1];
 		}
 
 		$this->query->remove_all_not_accessed_rows( $delay, $unit );

--- a/inc/Engine/Preload/Cron/Subscriber.php
+++ b/inc/Engine/Preload/Cron/Subscriber.php
@@ -237,19 +237,18 @@ class Subscriber implements Subscriber_Interface {
 		 */
 		$delay = (string) apply_filters( 'rocket_preload_delay_delete_non_accessed', '1 month' );
 
-		$parts = explode(' ', $delay);
+		$parts = explode( ' ', $delay );
 
-		if ( '' === $delay) {
+		if ( '' === $delay ) {
 			return;
 		}
 
-
-		if( count($parts) !== 2 ) {
+		if ( count( $parts ) !== 2 ) {
 			$delay = $parts[0];
-			$unit = $parts[1];
+			$unit  = $parts[1];
 		} else {
 			$delay = 1;
-			$unit = 'month';
+			$unit  = 'month';
 		}
 
 		$this->query->remove_all_not_accessed_rows( $delay, $unit );

--- a/inc/Engine/Preload/Cron/Subscriber.php
+++ b/inc/Engine/Preload/Cron/Subscriber.php
@@ -224,7 +224,19 @@ class Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function remove_old_rows() {
-		$this->query->remove_all_not_accessed_rows();
+		/**
+		 * Delay before the not accessed row is deleted.
+		 *
+		 * @param string $delay delay before the not accessed row is deleted.
+		 * @returns string
+		 */
+		$delay = (string) apply_filters( 'rocket_preload_delay_delete_non_accessed', '1 month' );
+
+		if ( '' === $delay ) {
+			return;
+		}
+
+		$this->query->remove_all_not_accessed_rows( $delay );
 	}
 
 	/**

--- a/inc/Engine/Preload/Cron/Subscriber.php
+++ b/inc/Engine/Preload/Cron/Subscriber.php
@@ -239,7 +239,7 @@ class Subscriber implements Subscriber_Interface {
 
 		$parts = explode( ' ', $delay );
 
-		if ( '' === $delay ) {
+		if ( '' === $delay || '0' === $delay ) {
 			return;
 		}
 

--- a/inc/Engine/Preload/Database/Queries/Cache.php
+++ b/inc/Engine/Preload/Database/Queries/Cache.php
@@ -277,11 +277,11 @@ class Cache extends Query {
 	/**
 	 * Get all preload caches which were not accessed in the last month.
 	 *
-	 * @param int    $delay delay before the not accessed row is deleted.
+	 * @param float  $delay delay before the not accessed row is deleted.
 	 * @param string $unit unit from the delay.
 	 * @return array
 	 */
-	public function get_old_cache( int $delay = 1, string $unit = 'month' ) : array {
+	public function get_old_cache( float $delay = 1, string $unit = 'month' ) : array {
 		// Get the database interface.
 		$db = $this->get_db();
 
@@ -300,11 +300,11 @@ class Cache extends Query {
 	/**
 	 * Remove all completed rows one by one.
 	 *
-	 * @param int    $delay delay before the not accessed row is deleted.
+	 * @param float  $delay delay before the not accessed row is deleted.
 	 * @param string $unit unit from the delay.
 	 * @return void
 	 */
-	public function remove_all_not_accessed_rows( int $delay = 1, string $unit = 'month' ) {
+	public function remove_all_not_accessed_rows( float $delay = 1, string $unit = 'month' ) {
 		$rows = $this->get_old_cache( $delay, $unit );
 
 		foreach ( $rows as $row ) {

--- a/inc/Engine/Preload/Database/Queries/Cache.php
+++ b/inc/Engine/Preload/Database/Queries/Cache.php
@@ -277,11 +277,11 @@ class Cache extends Query {
 	/**
 	 * Get all preload caches which were not accessed in the last month.
 	 *
-	 * @param int $delay delay before the not accessed row is deleted.
+	 * @param int    $delay delay before the not accessed row is deleted.
 	 * @param string $unit unit from the delay.
 	 * @return array
 	 */
-	public function get_old_cache( int $delay = 1, string $unit = 'month') : array {
+	public function get_old_cache( int $delay = 1, string $unit = 'month' ) : array {
 		// Get the database interface.
 		$db = $this->get_db();
 
@@ -300,7 +300,7 @@ class Cache extends Query {
 	/**
 	 * Remove all completed rows one by one.
 	 *
-	 * @param int $delay delay before the not accessed row is deleted.
+	 * @param int    $delay delay before the not accessed row is deleted.
 	 * @param string $unit unit from the delay.
 	 * @return void
 	 */

--- a/inc/Engine/Preload/Database/Queries/Cache.php
+++ b/inc/Engine/Preload/Database/Queries/Cache.php
@@ -277,11 +277,11 @@ class Cache extends Query {
 	/**
 	 * Get all preload caches which were not accessed in the last month.
 	 *
-	 * @param string $delay delay before the not accessed row is deleted.
-	 *
+	 * @param int $delay delay before the not accessed row is deleted.
+	 * @param string $unit unit from the delay.
 	 * @return array
 	 */
-	public function get_old_cache( string $delay = '1 month' ) : array {
+	public function get_old_cache( int $delay = 1, string $unit = 'month') : array {
 		// Get the database interface.
 		$db = $this->get_db();
 
@@ -291,7 +291,7 @@ class Cache extends Query {
 		}
 
 		$prefixed_table_name = $db->prefix . $this->table_name;
-		$query               = "SELECT id FROM `$prefixed_table_name` WHERE `last_accessed` <= date_sub(now(), interval $delay)";
+		$query               = "SELECT id FROM `$prefixed_table_name` WHERE `last_accessed` <= date_sub(now(), interval $delay $unit)";
 		$rows_affected       = $db->get_results( $query );
 
 		return $rows_affected;
@@ -300,11 +300,11 @@ class Cache extends Query {
 	/**
 	 * Remove all completed rows one by one.
 	 *
-	 * @param string $delay delay before the not accessed row is deleted.
-	 *
+	 * @param int $delay delay before the not accessed row is deleted.
+	 * @param string $unit unit from the delay.
 	 * @return void
 	 */
-	public function remove_all_not_accessed_rows( string $delay = '1 month' ) {
+	public function remove_all_not_accessed_rows( int $delay = 1, string $unit = 'month' ) {
 		$rows = $this->get_old_cache( $delay );
 
 		foreach ( $rows as $row ) {

--- a/inc/Engine/Preload/Database/Queries/Cache.php
+++ b/inc/Engine/Preload/Database/Queries/Cache.php
@@ -277,9 +277,11 @@ class Cache extends Query {
 	/**
 	 * Get all preload caches which were not accessed in the last month.
 	 *
+	 * @param string $delay delay before the not accessed row is deleted.
+	 *
 	 * @return array
 	 */
-	public function get_old_cache() : array {
+	public function get_old_cache( string $delay = '1 month' ) : array {
 		// Get the database interface.
 		$db = $this->get_db();
 
@@ -289,7 +291,7 @@ class Cache extends Query {
 		}
 
 		$prefixed_table_name = $db->prefix . $this->table_name;
-		$query               = "SELECT id FROM `$prefixed_table_name` WHERE `last_accessed` <= date_sub(now(), interval 1 month)";
+		$query               = "SELECT id FROM `$prefixed_table_name` WHERE `last_accessed` <= date_sub(now(), interval $delay)";
 		$rows_affected       = $db->get_results( $query );
 
 		return $rows_affected;
@@ -298,10 +300,12 @@ class Cache extends Query {
 	/**
 	 * Remove all completed rows one by one.
 	 *
+	 * @param string $delay delay before the not accessed row is deleted.
+	 *
 	 * @return void
 	 */
-	public function remove_all_not_accessed_rows() {
-		$rows = $this->get_old_cache();
+	public function remove_all_not_accessed_rows( string $delay = '1 month' ) {
+		$rows = $this->get_old_cache( $delay );
 
 		foreach ( $rows as $row ) {
 			if ( ! is_bool( $row ) ) {

--- a/inc/Engine/Preload/Database/Queries/Cache.php
+++ b/inc/Engine/Preload/Database/Queries/Cache.php
@@ -305,7 +305,7 @@ class Cache extends Query {
 	 * @return void
 	 */
 	public function remove_all_not_accessed_rows( int $delay = 1, string $unit = 'month' ) {
-		$rows = $this->get_old_cache( $delay );
+		$rows = $this->get_old_cache( $delay, $unit );
 
 		foreach ( $rows as $row ) {
 			if ( ! is_bool( $row ) ) {


### PR DESCRIPTION
## Description
Gives the opportunity to change the delay before deletion of old not accessed row in the preload or totally disable it.

Fixes #5657

## Type of change

- [ ] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

No.

## How Has This Been Tested?

- [ ] Automated test

# Checklist:

Please delete the options that are not relevant.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
