### PR TITLE
Closes #5687 Remove multiple config files on deactivation

### DIFF
--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -233,8 +233,8 @@ function rocket_delete_config_file() {
 		rocket_direct_filesystem()->delete( $config_file );
 	}
 
-	// Bail out if WP Rocket is not network active.
-	if ( is_multisite() && ! is_plugin_active_for_network( plugin_basename( WP_ROCKET_FILE ) ) ) {
+	// Bail out if WP Rocket is multisite.
+	if ( is_multisite() ) {
 		return;
 	}
 

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -232,6 +232,24 @@ function rocket_delete_config_file() {
 	foreach ( $config_files_path as $config_file ) {
 		rocket_direct_filesystem()->delete( $config_file );
 	}
+
+	// Bail out if WP Rocket is not network active.
+	if ( is_multisite() && ! is_plugin_active_for_network( plugin_basename( WP_ROCKET_FILE ) ) ) {
+		return;
+	}
+
+	try {
+		$config_dir = new FilesystemIterator( (string) rocket_get_constant( 'WP_ROCKET_CONFIG_PATH' ) );
+	} catch ( Exception $e ) {
+		return;
+	}
+
+	// Remove all files with php extension in the config folder.
+	foreach ( $config_dir as $file ) {
+		if ( $file->isFile() && 'php' === $file->getExtension() ) {
+			rocket_direct_filesystem()->delete( $file->getPathname() );
+		}
+	}
 }
 
 /**

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -246,7 +246,7 @@ function rocket_delete_config_file() {
 
 	// Remove all files with php extension in the config folder.
 	foreach ( $config_dir as $file ) {
-		if ( ! $file->isFile() || 'php' !== $file->getExtension() ) {
+		if ( ! $file->isFile() || 'php' !== strtolower( $file->getExtension() ) ) {
 			continue;
 		}
 		rocket_direct_filesystem()->delete( $file->getPathname() );

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -246,9 +246,10 @@ function rocket_delete_config_file() {
 
 	// Remove all files with php extension in the config folder.
 	foreach ( $config_dir as $file ) {
-		if ( $file->isFile() && 'php' === $file->getExtension() ) {
-			rocket_direct_filesystem()->delete( $file->getPathname() );
+		if ( ! $file->isFile() || 'php' !== $file->getExtension() ) {
+			continue;
 		}
+		rocket_direct_filesystem()->delete( $file->getPathname() );
 	}
 }
 


### PR DESCRIPTION
## Description
This PR solves the issue where we do not clear out irrelevant config files when WP Rocket is deactivated.

Fixes #5687 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?
Slightly different with a helpful addition from @engahmeds3ed 

## How Has This Been Tested?
Manual Tests

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
