### PR TITLE
Fixed the warning when the plugin param is not defined

### DIFF
--- a/inc/Engine/Plugin/UpdaterSubscriber.php
+++ b/inc/Engine/Plugin/UpdaterSubscriber.php
@@ -520,9 +520,9 @@ class UpdaterSubscriber implements Event_Manager_Aware_Subscriber_Interface {
 	 *
 	 * @return mixed|WP_Error
 	 */
-	public function upgrade_pre_install_option( $return, $plugin ) {
+	public function upgrade_pre_install_option( $return, $plugin = null ) {
 
-		if ( is_wp_error( $return ) ) {
+		if ( is_wp_error( $return ) || ! $plugin ) {
 			return $return;
 		}
 
@@ -545,8 +545,8 @@ class UpdaterSubscriber implements Event_Manager_Aware_Subscriber_Interface {
 	 *
 	 * @return mixed|string|WP_Error
 	 */
-	public function upgrade_post_install_option( $return, $plugin ) {
-		if ( is_wp_error( $return ) ) {
+	public function upgrade_post_install_option( $return, $plugin = null ) {
+		if ( is_wp_error( $return ) || ! $plugin ) {
 			return $return;
 		}
 

--- a/inc/Engine/Plugin/UpdaterSubscriber.php
+++ b/inc/Engine/Plugin/UpdaterSubscriber.php
@@ -114,8 +114,8 @@ class UpdaterSubscriber implements Event_Manager_Aware_Subscriber_Interface {
 			'wp_rocket_loaded'                      => 'maybe_force_check',
 			'auto_update_plugin'                    => [ 'disable_auto_updates', 10, 2 ],
 			'admin_post_rocket_rollback'            => 'rollback',
-			'upgrader_pre_install'                  => 'upgrade_pre_install_option',
-			'upgrader_post_install'                 => 'upgrade_post_install_option',
+			'upgrader_pre_install'                  => [ 'upgrade_pre_install_option', 10, 2 ],
+			'upgrader_post_install'                 => [ 'upgrade_post_install_option', 10, 2 ],
 		];
 	}
 
@@ -520,7 +520,7 @@ class UpdaterSubscriber implements Event_Manager_Aware_Subscriber_Interface {
 	 *
 	 * @return mixed|WP_Error
 	 */
-	public function upgrade_pre_install_option( $return, $plugin = null ) {
+	public function upgrade_pre_install_option( $return, $plugin = [] ) {
 
 		if ( is_wp_error( $return ) || ! $plugin ) {
 			return $return;
@@ -545,7 +545,7 @@ class UpdaterSubscriber implements Event_Manager_Aware_Subscriber_Interface {
 	 *
 	 * @return mixed|string|WP_Error
 	 */
-	public function upgrade_post_install_option( $return, $plugin = null ) {
+	public function upgrade_post_install_option( $return, $plugin = [] ) {
 		if ( is_wp_error( $return ) || ! $plugin ) {
 			return $return;
 		}


### PR DESCRIPTION
## Description

Fix an issue with a warning when the plugin parameter is not defined in the update

Fixes #5645

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [ ] Test locally

# Checklist:

Please delete the options that are not relevant.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
