### PR TITLE
Fix CPCSS for mobile isn't regenerated when switching theme

### DIFF
--- a/inc/Engine/CriticalPath/CriticalCSS.php
+++ b/inc/Engine/CriticalPath/CriticalCSS.php
@@ -85,6 +85,7 @@ class CriticalCSS {
 	/**
 	 * Performs the critical CSS generation.
 	 *
+	 * @since 3.13.2 Always clear all CPCSS files.
 	 * @since 3.6 Added the $version parameter.
 	 * @since 2.11
 	 *
@@ -108,7 +109,7 @@ class CriticalCSS {
 			return;
 		}
 
-		$this->clean_critical_css( $version );
+		$this->clean_critical_css( 'all' );
 
 		$this->stop_generation();
 

--- a/inc/Engine/CriticalPath/CriticalCSS.php
+++ b/inc/Engine/CriticalPath/CriticalCSS.php
@@ -90,8 +90,9 @@ class CriticalCSS {
 	 * @since 2.11
 	 *
 	 * @param string $version Optional. Version of the CPCSS files to generate. Possible values: default, mobile, all.
+	 * @param string $clean_version Optional: Version of the CPCSS files to clean. Possible values: default, mobile, all.
 	 */
-	public function process_handler( $version = 'default' ) {
+	public function process_handler( $version = 'default', $clean_version = '' ) {
 		/**
 		 * Filters the critical CSS generation process.
 		 *
@@ -109,7 +110,11 @@ class CriticalCSS {
 			return;
 		}
 
-		$this->clean_critical_css( 'all' );
+		if ( empty( $clean_version ) ) {
+			$clean_version = $version;
+		}
+
+		$this->clean_critical_css( $clean_version );
 
 		$this->stop_generation();
 

--- a/inc/Engine/CriticalPath/CriticalCSSSubscriber.php
+++ b/inc/Engine/CriticalPath/CriticalCSSSubscriber.php
@@ -698,10 +698,20 @@ JS;
 	/**
 	 * Regenerates the CPCSS when switching theme if the option is active.
 	 *
-	 * @since  3.3
+	 * @since 3.3
+	 * @since 3.12.6 we added a check on mobile option.
 	 */
 	public function maybe_regenerate_cpcss() {
 		if ( ! $this->options->get( 'async_css' ) ) {
+			return;
+		}
+
+		if (
+			$this->options->get( 'cache_mobile', 0 )
+			&&
+			$this->options->get( 'do_caching_mobile_files', 0 )
+		) {
+			$this->critical_css->process_handler( 'all' );
 			return;
 		}
 

--- a/inc/Engine/CriticalPath/CriticalCSSSubscriber.php
+++ b/inc/Engine/CriticalPath/CriticalCSSSubscriber.php
@@ -699,7 +699,7 @@ JS;
 	 * Regenerates the CPCSS when switching theme if the option is active.
 	 *
 	 * @since 3.3
-	 * @since 3.12.6 Force clearing all CPCSS files (default and mobile).
+	 * @since 3.12.7 Force clearing all CPCSS files (default and mobile).
 	 */
 	public function maybe_regenerate_cpcss() {
 		if ( ! $this->options->get( 'async_css' ) ) {

--- a/inc/Engine/CriticalPath/CriticalCSSSubscriber.php
+++ b/inc/Engine/CriticalPath/CriticalCSSSubscriber.php
@@ -699,10 +699,14 @@ JS;
 	 * Regenerates the CPCSS when switching theme if the option is active.
 	 *
 	 * @since 3.3
-	 * @since 3.13.2 Force clearing all CPCSS files (default and mobile).
 	 */
 	public function maybe_regenerate_cpcss() {
 		if ( ! $this->options->get( 'async_css' ) ) {
+			return;
+		}
+
+		if ( ! $this->is_mobile_cpcss_active() ) {
+			$this->critical_css->process_handler();
 			return;
 		}
 

--- a/inc/Engine/CriticalPath/CriticalCSSSubscriber.php
+++ b/inc/Engine/CriticalPath/CriticalCSSSubscriber.php
@@ -699,23 +699,14 @@ JS;
 	 * Regenerates the CPCSS when switching theme if the option is active.
 	 *
 	 * @since 3.3
-	 * @since 3.12.6 we added a check on mobile option.
+	 * @since 3.12.6 Force clearing all CPCSS files (default and mobile).
 	 */
 	public function maybe_regenerate_cpcss() {
 		if ( ! $this->options->get( 'async_css' ) ) {
 			return;
 		}
 
-		if (
-			$this->options->get( 'cache_mobile', 0 )
-			&&
-			$this->options->get( 'do_caching_mobile_files', 0 )
-		) {
-			$this->critical_css->process_handler( 'all' );
-			return;
-		}
-
-		$this->critical_css->process_handler();
+		$this->critical_css->process_handler( 'all' );
 	}
 
 	/**

--- a/inc/Engine/CriticalPath/CriticalCSSSubscriber.php
+++ b/inc/Engine/CriticalPath/CriticalCSSSubscriber.php
@@ -706,7 +706,7 @@ JS;
 		}
 
 		if ( ! $this->is_mobile_cpcss_active() ) {
-			$this->critical_css->process_handler();
+			$this->critical_css->process_handler( 'default', 'all' );
 			return;
 		}
 

--- a/inc/Engine/CriticalPath/CriticalCSSSubscriber.php
+++ b/inc/Engine/CriticalPath/CriticalCSSSubscriber.php
@@ -699,7 +699,7 @@ JS;
 	 * Regenerates the CPCSS when switching theme if the option is active.
 	 *
 	 * @since 3.3
-	 * @since 3.12.7 Force clearing all CPCSS files (default and mobile).
+	 * @since 3.13.2 Force clearing all CPCSS files (default and mobile).
 	 */
 	public function maybe_regenerate_cpcss() {
 		if ( ! $this->options->get( 'async_css' ) ) {


### PR DESCRIPTION
## Description

<strike>Here we are checking if separate cache for mobile is enabled so we can regenerate also mobile files.</strike>

After thinking again I found it'd be better to remove all files and no need to check if the mobile option is enabled or not, because when switching theme we need to clear/clean the whole directory.

Fixes #5751

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

Yes as mentioned above, now we remove the whole files inside CPCSS directory with switching theme.

## How Has This Been Tested?

I tested that on my test site.

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
