### PR TITLE
Fixes #5762 warning undefined array key on theme rollback

### DIFF
--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -552,15 +552,15 @@ add_action( 'admin_post_purge_cache', 'do_admin_post_rocket_purge_cache' );
  * @param array       $hook_extra  Array of bulk item update data.
  */
 function rocket_clean_cache_theme_update( $wp_upgrader, $hook_extra ) {
-	if ( 'update' !== $hook_extra['action'] ) {
+	if ( ! isset( $hook_extra['action'] ) || 'update' !== $hook_extra['action'] ) {
 		return;
 	}
 
-	if ( 'theme' !== $hook_extra['type'] ) {
+	if ( ! isset( $hook_extra['type'] ) || 'theme' !== $hook_extra['type'] ) {
 		return;
 	}
 
-	if ( ! is_array( $hook_extra['themes'] ) ) {
+	if ( ! isset( $hook_extra['themes'] ) || ! is_array( $hook_extra['themes'] ) ) {
 		return;
 	}
 


### PR DESCRIPTION
## Description
guard against Undefined array keys on theme rollback

Fixes #5762 

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)


## Is the solution different from the one proposed during the grooming?

No, but i did the check for action and type too

## How Has This Been Tested?

- [ ] unit test
- [ ] local environment same steps on the issue

# Checklist:


- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
