### PR TITLE
Disable webp option when any webp plugin serves webp generation

### DIFF
--- a/inc/Addon/WebP/Subscriber.php
+++ b/inc/Addon/WebP/Subscriber.php
@@ -172,7 +172,7 @@ class Subscriber extends AbstractWebp implements Subscriber_Interface {
 	 * @return bool
 	 */
 	public function maybe_disable_webp_cache( $disable_webp_cache ): bool {
-		return $disable_webp_cache && ! empty( $this->get_plugins_serving_webp() ) ? true : (bool) $disable_webp_cache;
+		return $disable_webp_cache || ! empty( $this->get_plugins_serving_webp() );
 	}
 
 	/**


### PR DESCRIPTION
## Description

This is a regression found by @Mai-Saad so we need to make sure that we disable webp option when any supported webp plugin is serving webp images like Imagify.

@wp-media/productrocket I don't know if we need to handle the following case also here or not:
1. Deactivate Imagify
2. Enable Webp option in WPR
3. Enable Imagify
4. The option is disabled but in ON mode

I think this should be in OFF mode, what do u think?

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Locally

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
