### PR TITLE
3.12.6 Release

### DIFF
--- a/inc/Addon/WebP/Subscriber.php
+++ b/inc/Addon/WebP/Subscriber.php
@@ -172,7 +172,7 @@ class Subscriber extends AbstractWebp implements Subscriber_Interface {
 	 * @return bool
 	 */
 	public function maybe_disable_webp_cache( $disable_webp_cache ): bool {
-		return $disable_webp_cache && ! empty( $this->get_plugins_serving_webp() ) ? true : (bool) $disable_webp_cache;
+		return $disable_webp_cache || ! empty( $this->get_plugins_serving_webp() );
 	}
 
 	/**


### PR DESCRIPTION
This is the second version of the 3.12.6 release.

## Changelog

- **BugFix:** Partial URL added to Never Cache URLs is excluded from preloading #5588
- **3rd-party compatibility:** Add compatibility with Members #5668
- **Enhancement:** Clear cache partially instead of globally when Never cache This Page is changed in the Edit screen metabox #4773
- **BugFix:** Used CSS isnot generated automatically for home page in certain cases #5631
- **Enhancement:** Update Minify dependency with latest changes #5617
- **BugFix:** Lazyload compatibility with the new Avada background markup #5649
- **BugFix:** Preload can get stuck when disabling Remove Unused CSS while there are pending jobs #5671
- **Enhancement:** Remove Unused CSS - Detect usage of Perfmatters' Used CSS #5533
- **Enhancement:** Detect usage of Autoptimize's RapidLoad Used CSS  #5424
- **BugFix:** Improve the logic of adding URLs to the preload queue #5619
- **Enhancement:** ONE - RocketCDN's CTA banner is displayed in the CDN tab #5682
- **Enhancement:** Update action scheduler to v3.5.4 #5714
- **Enhancement:** Preload - disable preload for pagination pages by default #5544
- **Enhancement:** Missing column on wp_wpr_rocket_cache during updates #5645
- **Enhancement:** Improve webp detection on apple devices #5654
- **BugFix:** Update Delay JS script to the latest version #5756