### PR TITLE
Fises #5753 rocket_clean_home_feeds() to not clear feed cache when cache feed is disabled

### DIFF
--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -662,7 +662,7 @@ function rocket_clean_home( $lang = '' ) {
  */
 function rocket_clean_home_feeds() {
 
-	if ( ! get_rocket_option( 'cache_feed', false ) ) {
+	if ( ! has_filter( 'rocket_cache_reject_uri', 'wp_rocket_cache_feed' ) ) {
 		return;
 	}
 

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -662,6 +662,10 @@ function rocket_clean_home( $lang = '' ) {
  */
 function rocket_clean_home_feeds() {
 
+	if ( ! get_rocket_option( 'cache_feed', false ) ) {
+		return;
+	}
+
 	$urls   = [];
 	$urls[] = get_feed_link();
 	$urls[] = get_feed_link( 'comments_' );

--- a/tests/Fixtures/inc/functions/rocketCleanHomeFeeds.php
+++ b/tests/Fixtures/inc/functions/rocketCleanHomeFeeds.php
@@ -1,0 +1,33 @@
+<?php
+
+return [
+	// Use in tests when the test data starts in this directory.
+	'vfs_dir'   => 'wp-content/cache/',
+
+	// Test data.
+	'test_data' => [
+		'shouldDeleteFeeds'    => [
+			'config'   => [
+				'cache_feed' => true,
+				'urls'    => [
+					'http://example.org/feed',
+					'http://example.org/comments/feed',
+				],
+			],
+			'expected' => [
+				'cleaned' => [
+					'vfs://public/wp-content/cache/wp-rocket/example.org/feed'          => null,
+					'vfs://public/wp-content/cache/wp-rocket/example.org/comments/feed' => null,
+				],
+			],
+		],
+		'shouldNotDeleteFeeds' => [
+			'config'   => [
+				'cache_feed' => false,
+			],
+			'expected' => [
+				'cleaned'  => [],
+			],
+		],
+	],
+];

--- a/tests/Unit/inc/functions/rocketCleanHomeFeeds.php
+++ b/tests/Unit/inc/functions/rocketCleanHomeFeeds.php
@@ -17,17 +17,21 @@ use WP_Rocket\Tests\Unit\FilesystemTestCase;
 class Test_RocketCleanHomeFeeds extends FilesystemTestCase {
 	protected $path_to_test_data = '/inc/functions/rocketCleanHomeFeeds.php';
 
+	protected function tearDown(): void {
+		// Reset after each test.
+		remove_filter( 'rocket_cache_reject_uri', 'wp_rocket_cache_feed' );
+
+		parent::tearDown();
+	}
+
 	/**
 	 * @dataProvider providerTestData
 	 */
 	public function testShouldExpected( $config, $expected ) {
 		$this->generateEntriesShouldExistAfter( $expected['cleaned'] );
 
-		// Run it.
-		Functions\expect( 'get_rocket_option' )
-			->with( 'cache_feed' )
-			->andReturn( $config['cache_feed'] );
 		if($config['cache_feed']){
+			add_filter( 'rocket_cache_reject_uri', 'wp_rocket_cache_feed' );
 			Functions\expect( 'get_feed_link' )
 				->andReturn( $config['urls'][0] );
 			Functions\expect( 'get_feed_link' )
@@ -37,9 +41,9 @@ class Test_RocketCleanHomeFeeds extends FilesystemTestCase {
 			Functions\when( 'wp_parse_url' )->justReturn( null );
 
 			Actions\expectDone( 'before_rocket_clean_home_feeds' )
-				->once()->with( $config['cache_feed'] );
+				->once()->with( true );
 			Actions\expectDone( 'after_rocket_clean_home_feeds' )
-				->once()->with( $config['cache_feed'] );
+				->once()->with( true );
 		}
 		rocket_clean_home_feeds();
 

--- a/tests/Unit/inc/functions/rocketCleanHomeFeeds.php
+++ b/tests/Unit/inc/functions/rocketCleanHomeFeeds.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\functions;
+
+use Brain\Monkey\Actions;
+use Brain\Monkey\Functions;
+use WP_Rocket\Tests\Unit\FilesystemTestCase;
+
+/**
+ * @covers ::rocket_clean_home_feeds
+ * @uses  ::rocket_direct_filesystem
+ *
+ * @group Functions
+ * @group Files
+ * @group vfs
+ */
+class Test_RocketCleanHomeFeeds extends FilesystemTestCase {
+	protected $path_to_test_data = '/inc/functions/rocketCleanHomeFeeds.php';
+
+	/**
+	 * @dataProvider providerTestData
+	 */
+	public function testShouldExpected( $config, $expected ) {
+		$this->generateEntriesShouldExistAfter( $expected['cleaned'] );
+
+		// Run it.
+		Functions\expect( 'get_rocket_option' )
+			->with( 'cache_feed' )
+			->andReturn( $config['cache_feed'] );
+		if($config['cache_feed']){
+			Functions\expect( 'get_feed_link' )
+				->andReturn( $config['urls'][0] );
+			Functions\expect( 'get_feed_link' )
+				->with( 'comments_' )
+				->andReturn( $config['urls'][1] );
+
+			Functions\when( 'wp_parse_url' )->justReturn( null );
+
+			Actions\expectDone( 'before_rocket_clean_home_feeds' )
+				->once()->with( $config['cache_feed'] );
+			Actions\expectDone( 'after_rocket_clean_home_feeds' )
+				->once()->with( $config['cache_feed'] );
+		}
+		rocket_clean_home_feeds();
+
+		$this->checkEntriesDeleted( $expected['cleaned'] );
+		$this->checkShouldNotDeleteEntries();
+	}
+}


### PR DESCRIPTION
## Description

check if cache_feed enabled before cleaning the home feed cache

Fixes #5753 

## Type of change
- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

No
## How Has This Been Tested?

- [ ] unit test
- [ ] local env same steps in the issue

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
