### PR TITLE
Closes #5742: HTML Shown in Sucuri add-on section

### DIFF
--- a/inc/Engine/Admin/Settings/Page.php
+++ b/inc/Engine/Admin/Settings/Page.php
@@ -2078,7 +2078,7 @@ class Page {
 		$this->settings->add_settings_fields(
 			[
 				'sucury_waf_api_key' => [
-					'label'       => _x( 'Firewall API key (for plugin), must be in format <code>{32 characters}/{32 characters}</code>:', 'Sucuri', 'rocket' ),
+					'label'       => _x( 'Firewall API key (for plugin), must be in format {32 characters}/{32 characters}:', 'Sucuri', 'rocket' ),
 					'description' => sprintf( '<a href="%1$s" target="_blank">%2$s</a>', 'https://kb.sucuri.net/firewall/Performance/clearing-cache', _x( 'Find your API key', 'Sucuri', 'rocket' ) ),
 					'default'     => '',
 					'section'     => 'sucuri_credentials',

--- a/views/settings/fields/text.php
+++ b/views/settings/fields/text.php
@@ -25,7 +25,7 @@ defined( 'ABSPATH' ) || exit;
 	<div class="wpr-text">
 		<?php if ( ! empty( $data['description'] ) ) : ?>
 		<div class="wpr-flex">
-			<label for="<?php echo esc_attr( $data['id'] ); ?>"><?php echo 'sucury_waf_api_key' === $data['id'] ? $data['label'] : esc_html( $data['label'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Dynamic content is properly escaped in the view. ?></label>
+			<label for="<?php echo esc_attr( $data['id'] ); ?>"><?php echo esc_html( $data['label'] ); ?></label>
 			<div class="wpr-field-description">
 				<?php echo $data['description']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Dynamic content is properly escaped in the view. ?>
 			</div>

--- a/views/settings/fields/text.php
+++ b/views/settings/fields/text.php
@@ -25,7 +25,7 @@ defined( 'ABSPATH' ) || exit;
 	<div class="wpr-text">
 		<?php if ( ! empty( $data['description'] ) ) : ?>
 		<div class="wpr-flex">
-			<label for="<?php echo esc_attr( $data['id'] ); ?>"><?php echo esc_html( $data['label'] ); ?></label>
+			<label for="<?php echo esc_attr( $data['id'] ); ?>"><?php echo 'sucury_waf_api_key' === $data['id'] ? $data['label'] : esc_html( $data['label'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Dynamic content is properly escaped in the view. ?></label>
 			<div class="wpr-field-description">
 				<?php echo $data['description']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Dynamic content is properly escaped in the view. ?>
 			</div>


### PR DESCRIPTION
## Description
Bypass html escaping for sucuri api key label.

Fixes #5742 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manual Test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
