### PR TITLE
Remove not used delay JS hidden field

### DIFF
--- a/inc/Engine/Optimization/DelayJS/Admin/Subscriber.php
+++ b/inc/Engine/Optimization/DelayJS/Admin/Subscriber.php
@@ -49,7 +49,6 @@ class Subscriber implements Subscriber_Interface {
 				[ 'sanitize_selected_exclusions', 14 ],
 			],
 			'pre_update_option_wp_rocket_settings' => [ 'maybe_disable_combine_js', 11, 2 ],
-			'rocket_hidden_settings_fields'        => 'add_exclusions_hidden_field',
 			'rocket_after_save_dynamic_lists'      => 'refresh_exclusions_option',
 		];
 	}
@@ -143,18 +142,6 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	public function maybe_disable_combine_js( $value, $old_value ): array {
 		return $this->settings->maybe_disable_combine_js( $value, $old_value );
-	}
-
-	/**
-	 * Add exclusions hidden field.
-	 *
-	 * @param array $fields Hidden fields.
-	 *
-	 * @return array
-	 */
-	public function add_exclusions_hidden_field( array $fields ) {
-		$fields[] = 'delay_js_exclusion_selected_exclusions';
-		return $fields;
 	}
 
 	/**


### PR DESCRIPTION
## Description

We need to remove not used hidden field called `delay_js_exclusion_selected_exclusions` because we don't use it at all and it'll be in the exported json file.

Props to @Mai-Saad 