### PR TITLE
Added callback `exclude_pages` to `rocket_preload_exclude_urls`

### DIFF
--- a/inc/Engine/Preload/Controller/CheckExcludedTrait.php
+++ b/inc/Engine/Preload/Controller/CheckExcludedTrait.php
@@ -48,6 +48,7 @@ trait CheckExcludedTrait {
 		}
 
 		$regexes = array_unique( $regexes );
+		$url     = strtok( $url, '?' );
 		$url     = user_trailingslashit( $url );
 
 		foreach ( $regexes as $regex ) {

--- a/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber.php
+++ b/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber.php
@@ -202,10 +202,9 @@ class WooCommerceSubscriber implements Event_Manager_Aware_Subscriber_Interface 
 		if ( ! function_exists( 'wc_get_page_id' ) ) {
 			return $urls;
 		}
-		$checkout_urls = $this->exclude_page( wc_get_page_id( 'checkout' ), 'page', '(.*)' );
+		$checkout_urls = $this->exclude_page( wc_get_page_id( 'checkout' ), 'page', '?(.*)' );
 		$cart_urls     = $this->exclude_page( wc_get_page_id( 'cart' ) );
-		$account_urls  = $this->exclude_page( wc_get_page_id( 'myaccount' ), 'page', '(.*)' );
-
+		$account_urls  = $this->exclude_page( wc_get_page_id( 'myaccount' ), 'page', '?(.*)' );
 		return array_merge( $urls, $checkout_urls, $cart_urls, $account_urls );
 	}
 
@@ -221,6 +220,7 @@ class WooCommerceSubscriber implements Event_Manager_Aware_Subscriber_Interface 
 	 * @return array
 	 */
 	private function exclude_page( $page_id, $post_type = 'page', $pattern = '' ) {
+		global $wp_rewrite;
 		$urls = [];
 
 		if ( $page_id <= 0 || (int) get_option( 'page_on_front' ) === $page_id ) {
@@ -229,6 +229,10 @@ class WooCommerceSubscriber implements Event_Manager_Aware_Subscriber_Interface 
 
 		if ( 'publish' !== get_post_status( $page_id ) ) {
 			return $urls;
+		}
+
+		if ( $wp_rewrite->use_trailing_slashes ) {
+			$pattern = "?$pattern";
 		}
 
 		$urls = get_rocket_i18n_translated_post_urls( $page_id, $post_type, $pattern );

--- a/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber.php
+++ b/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber.php
@@ -67,6 +67,9 @@ class WooCommerceSubscriber implements Event_Manager_Aware_Subscriber_Interface 
 			$events['rocket_cache_reject_uri']            = [
 				[ 'exclude_pages' ],
 			];
+			$events['rocket_preload_exclude_urls']        = [
+				[ 'exclude_pages' ],
+			];
 			$events['rocket_cache_query_strings']         = 'cache_geolocation_query_string';
 			$events['rocket_cpcss_excluded_taxonomies']   = 'exclude_product_attributes_cpcss';
 			$events['rocket_exclude_post_taxonomy']       = 'exclude_product_shipping_taxonomy';

--- a/tests/Fixtures/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/excludePages.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/excludePages.php
@@ -1,7 +1,8 @@
 <?php
 return [
-    '' => [
+    'ExcludeShouldExcludePages' => [
         'config' => [
+			'use_trailing_slashes' => false,
             'urls' => [],
 			'checkout_id' => 10,
 			'cart_id' => 18,

--- a/tests/Fixtures/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/excludePages.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/excludePages.php
@@ -1,0 +1,27 @@
+<?php
+return [
+    '' => [
+        'config' => [
+            'urls' => [],
+			'checkout_id' => 10,
+			'cart_id' => 18,
+			'myaccount_id' => 21,
+			'i18n_urls' => [
+				'url',
+			],
+        ],
+        'expected' => [
+			'urls' => [
+				'url',
+				'url',
+				'url',
+			],
+			'checkout_id' => 10,
+			'cart_id' => 18,
+			'myaccount_id' => 21,
+			'type' => 'page',
+			'pattern' => '(.*)',
+        ]
+    ],
+
+];

--- a/tests/Unit/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/excludePages.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/excludePages.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber;
+
+use WP_Rocket\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber;
+use Mockery;
+use WP_Rocket\Engine\Optimization\DelayJS\HTML;
+use Brain\Monkey\Functions;
+
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @covers \WP_Rocket\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber::exclude_pages
+ */
+class Test_excludePages extends TestCase {
+
+    /**
+     * @var HTML
+     */
+    protected $delayjs_html;
+
+    /**
+     * @var WooCommerceSubscriber
+     */
+    protected $woocommercesubscriber;
+
+    public function set_up() {
+        parent::set_up();
+        $this->delayjs_html = Mockery::mock(HTML::class);
+
+        $this->woocommercesubscriber = new WooCommerceSubscriber($this->delayjs_html);
+    }
+
+    /**
+     * @dataProvider configTestData
+     */
+    public function testShouldReturnAsExpected( $config, $expected )
+    {
+		Functions\when('get_option')->justReturn(false);
+		Functions\when('get_post_status')->justReturn('publish');
+		Functions\expect('wc_get_page_id')->with('checkout')->andReturn($config['checkout_id']);
+		Functions\expect('wc_get_page_id')->with('cart')->andReturn($config['cart_id']);
+		Functions\expect('wc_get_page_id')->with('myaccount')->andReturn($config['myaccount_id']);
+		Functions\expect('get_rocket_i18n_translated_post_urls')->with($expected['checkout_id'], $expected['type'], $expected['pattern'])->andReturn($config['i18n_urls']);
+		Functions\expect('get_rocket_i18n_translated_post_urls')->with($expected['cart_id'])->andReturn($config['i18n_urls']);
+		Functions\expect('get_rocket_i18n_translated_post_urls')->with($expected['myaccount_id'], $expected['type'], $expected['pattern'])->andReturn($config['i18n_urls']);
+        $this->assertSame($expected['urls'], $this->woocommercesubscriber->exclude_pages($config['urls']));
+    }
+}

--- a/tests/Unit/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/excludePages.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber/excludePages.php
@@ -2,6 +2,7 @@
 
 namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber;
 
+use WP_Rewrite;
 use WP_Rocket\ThirdParty\Plugins\Ecommerce\WooCommerceSubscriber;
 use Mockery;
 use WP_Rocket\Engine\Optimization\DelayJS\HTML;
@@ -24,18 +25,35 @@ class Test_excludePages extends TestCase {
      */
     protected $woocommercesubscriber;
 
+	/**
+	 * @var WP_Rewrite
+	 */
+	protected $rewrite;
+
     public function set_up() {
         parent::set_up();
+
         $this->delayjs_html = Mockery::mock(HTML::class);
+
+		$this->rewrite = Mockery::mock(WP_Rewrite::class);
+
+		$GLOBALS['wp_rewrite'] = $this->rewrite;
 
         $this->woocommercesubscriber = new WooCommerceSubscriber($this->delayjs_html);
     }
 
-    /**
+	protected function tear_down()
+	{
+		unset($GLOBALS['wp_rewrite']);
+		parent::tear_down();
+	}
+
+	/**
      * @dataProvider configTestData
      */
     public function testShouldReturnAsExpected( $config, $expected )
     {
+		$this->rewrite->use_trailing_slashes = $config['use_trailing_slashes'];
 		Functions\when('get_option')->justReturn(false);
 		Functions\when('get_post_status')->justReturn('publish');
 		Functions\expect('wc_get_page_id')->with('checkout')->andReturn($config['checkout_id']);


### PR DESCRIPTION
## Description
Fix an issue where the preload was loading Woocommerce excluded pages. That was due to the wrong hook being used in Woocommerce thirdparty class.

Fixes #5805

## Type of change

Please delete options that are not relevant.


- [ ] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

No.

## How Has This Been Tested?

- [ ] Tested locally
- [ ] Automated Test

# Checklist:

Please delete the options that are not relevant.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
