### PR TITLE
SEOPress xml sitemap preloading replace deprecated functions

### DIFF
--- a/inc/ThirdParty/Plugins/SEO/SEOPress.php
+++ b/inc/ThirdParty/Plugins/SEO/SEOPress.php
@@ -27,9 +27,14 @@ class SEOPress implements Subscriber_Interface {
 	 * Subscribed events.
 	 */
 	public static function get_subscribed_events() {
-		if ( ! function_exists( 'seopress_get_toggle_xml_sitemap_option' ) || 1 !== (int) seopress_get_toggle_xml_sitemap_option() ) {
+		if ( ! function_exists('seopress_get_toggle_option') || '1' !== seopress_get_toggle_option('xml-sitemap')) {
 			return [];
 		}
+
+		if ( ! method_exists(seopress_get_service('SitemapOption'), 'isEnabled')  || '1' !== seopress_get_service('SitemapOption')->isEnabled() ) {
+			return [];
+		}
+
 		return [
 			'rocket_sitemap_preload_list' => [ 'add_seopress_sitemap', 15 ],
 		];

--- a/inc/ThirdParty/Plugins/SEO/SEOPress.php
+++ b/inc/ThirdParty/Plugins/SEO/SEOPress.php
@@ -27,11 +27,11 @@ class SEOPress implements Subscriber_Interface {
 	 * Subscribed events.
 	 */
 	public static function get_subscribed_events() {
-		if ( ! function_exists('seopress_get_toggle_option') || '1' !== seopress_get_toggle_option('xml-sitemap')) {
+		if ( ! function_exists( 'seopress_get_toggle_option' ) || '1' !== seopress_get_toggle_option( 'xml-sitemap' ) ) {
 			return [];
 		}
 
-		if ( ! method_exists(seopress_get_service('SitemapOption'), 'isEnabled')  || '1' !== seopress_get_service('SitemapOption')->isEnabled() ) {
+		if ( ! method_exists( seopress_get_service( 'SitemapOption' ), 'isEnabled' )  || '1' !== seopress_get_service( 'SitemapOption' )->isEnabled() ) {
 			return [];
 		}
 

--- a/inc/ThirdParty/Plugins/SEO/SEOPress.php
+++ b/inc/ThirdParty/Plugins/SEO/SEOPress.php
@@ -31,7 +31,7 @@ class SEOPress implements Subscriber_Interface {
 			return [];
 		}
 
-		if ( ! method_exists( seopress_get_service( 'SitemapOption' ), 'isEnabled' )  || '1' !== seopress_get_service( 'SitemapOption' )->isEnabled() ) {
+		if ( ! method_exists( seopress_get_service( 'SitemapOption' ), 'isEnabled' ) || '1' !== seopress_get_service( 'SitemapOption' )->isEnabled() ) {
 			return [];
 		}
 


### PR DESCRIPTION
Fixes #(issue number)

#5839 

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
