### PR TITLE
Reconfigure plugin deployment

### DIFF
--- a/.github/workflows/deploy_plugin.yml
+++ b/.github/workflows/deploy_plugin.yml
@@ -55,31 +55,10 @@ jobs:
         run: zip -r __wp-rocket_${GITHUB_REF##*v}.zip wp-rocket
         working-directory: /tmp
 
-      - name: Install Swift
-        run: |
-          sudo apt update
-          sudo apt install python3-swiftclient -y
-      # Use Openstack Swift to upload the zip to OVH block storage
-      # We post a header to instruct the file to be deleted after 10 minutes
       - name: Upload Zip
-        env:
-          OS_AUTH_URL: ${{ secrets.OBJECT_STORAGE_URL }}
-          OS_PASSWORD: ${{ secrets.OBJECT_STORAGE_PASSWORD }}
-          OS_PROJECT_NAME: ${{ secrets.OBJECT_STORAGE_PROJECT }}
-          OS_PROJECT_ID: ${{ secrets.OBJECT_STORAGE_PROJECT_ID }}
-          OS_REGION_NAME: ${{ secrets.OBJECT_STORAGE_REGION }}
-          OS_USERNAME: ${{ secrets.OBJECT_STORAGE_USERNAME }}
-          OS_USER_DOMAIN_NAME: "Default"
-        working-directory: /tmp
         run: |
-          /usr/bin/swift upload rocket-plugin __wp-rocket_${GITHUB_REF##*v}.zip
-          /usr/bin/swift post --header "X-Delete-After: 600" rocket-plugin __wp-rocket_${GITHUB_REF##*v}.zip
-
-
-      # Call the webhook on AWX to fetch and deploy the zip
-      - name: Invoke deployment hook
-        uses: distributhor/workflow-webhook@v1
-        env:
-          webhook_type: 'json-extended'
-          webhook_url: ${{ secrets.WEBHOOK_URL_PLUGIN }}
-          webhook_secret: ${{ secrets.WEBHOOK_KEY_PLUGIN }}
+          curl -v -X POST \
+            -H "Content-Type: multipart/form-data" \
+            -F "file=@/tmp/__wp-rocket_${GITHUB_REF##*v}.zip;type=application/zip" \
+            -H "Authorization: Bearer ${{ secrets.UPLOAD_ZIP_TOKEN }}" \
+            ${{ secrets.UPLOAD_ZIP_URL }}


### PR DESCRIPTION
Depends on these new secrets being setup in the repo:

- UPLOAD_ZIP_URL
- UPLOAD_ZIP_TOKEN

The following secrets can be removed from the repository after merging

- OBJECT_STORAGE_URL
- OBJECT_STORAGE_PASSWORD
- OBJECT_STORAGE_PROJECT
- OBJECT_STORAGE_PROJECT_ID
- OBJECT_STORAGE_REGION
- OBJECT_STORAGE_USERNAME
- WEBHOOK_URL_PLUGIN
- WEBHOOK_KEY_PLUGIN
