### PR TITLE
Fixes #5893: Escape quotes in permalink structure

### DIFF
--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -155,7 +155,7 @@ function get_rocket_config_file() { // phpcs:ignore WordPress.NamingConventions.
 
 	$buffer .= '$rocket_cache_dynamic_cookies = ' . call_user_func( 'var_export', get_rocket_cache_dynamic_cookies(), true ) . ";\n";
 
-	$buffer .= '$rocket_permalink_structure = \'' . get_option( 'permalink_structure' ) . "';\n";
+	$buffer .= '$rocket_permalink_structure = \'' . wp_slash( get_option( 'permalink_structure' ) ) . "';\n";
 
 	/** This filter is documented in inc/front/htaccess.php */
 	if ( apply_filters( 'rocket_url_no_dots', false ) ) {


### PR DESCRIPTION
## Description

Escapes quotes in permalink structure before adding to config file.

Fixes #5893 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?
No

## How Has This Been Tested?

Manual Test.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
