### PR TITLE
Improve instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ You can use composer to install the plugin as a dependency:
 composer require wp-media/wp-rocket
 ```
 
+Then, in the plugin's folder, install the dependencies:
+```
+cd wp-content/plugins/wp-rocket/
+composer install --no-dev --no-scripts
+```
+
 To be able to validate your license and use the plugin, you will also have to manually define 2 constants in your wp-config.php file:
 
 - `WP_ROCKET_EMAIL` which is the email for your WP Rocket account


### PR DESCRIPTION
## Description

The README currently doesn't explain that composer install needs to be executed in the plugin's folder. The official documentation [suggests it](https://docs.wp-rocket.me/article/1301-wp-rocket-installation-from-github-using-composer#:~:text=composer%20install%20%2D%2Dno%2Ddev%20%2D%2Dno%2Dscripts), but it is deep and hard to find.

## Type of change

Please delete options that are not relevant.

- [X] This change requires a documentation update
