### PR TITLE
Closes #5927: Fatal Error UsedCSS::revert_to_pending()

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -836,11 +836,13 @@ class UsedCSS {
 		foreach ( $rows as  $row ) {
 			$failed_urls[] = $row->url;
 
-			if ( empty( $row->id ) || ! is_int( $row->id ) ) {
+			$id = (int) $row->id;
+
+			if ( empty( $id ) ) {
 				continue;
 			}
 
-			$this->used_css_query->revert_to_pending( (int) $row->id );
+			$this->used_css_query->revert_to_pending( $id );
 		}
 
 		/**

--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -835,7 +835,12 @@ class UsedCSS {
 
 		foreach ( $rows as  $row ) {
 			$failed_urls[] = $row->url;
-			$this->used_css_query->revert_to_pending( $row->id );
+
+			if ( empty( $row->id ) || ! is_int( $row->id ) ) {
+				continue;
+			}
+
+			$this->used_css_query->revert_to_pending( (int) $row->id );
 		}
 
 		/**

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Controller/UsedCSS/clearFailedUrls.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Controller/UsedCSS/clearFailedUrls.php
@@ -1,0 +1,90 @@
+<?php
+
+return [
+	'testShouldBailOutWithEmptyRows' => [
+		'config' => [
+			'rows' => [],
+		],
+        'expected' => [
+            'failed_urls' => [],
+        ],
+	],
+    'testShouldBailOutWithAlphabeticStringAsId' => [
+		'config' => [
+			'rows' => [
+                (object) [
+                    'id' => 'two',
+                    'url' => 'http://example.org/test-2',
+                ],
+                (object) [
+                    'id' => 'three',
+                    'url' => 'http://example.org/test-3',
+                ],
+                (object) [
+                    'id' => 'four',
+                    'url' => 'http://example.org/test-4',
+                ],
+            ],
+            'is_int' => false,
+		],
+        'expected' => [
+            'failed_urls' => [
+                'http://example.org/test-2',
+                'http://example.org/test-3',
+                'http://example.org/test-4',
+            ],
+        ],
+	],
+    'testShouldClearFailedUrlsWithNumericStringAsId' => [
+		'config' => [
+			'rows' => [
+                (object) [
+                    'id' => '2',
+                    'url' => 'http://example.org/test-2',
+                ],
+                (object) [
+                    'id' => '3',
+                    'url' => 'http://example.org/test-3',
+                ],
+                (object) [
+                    'id' => '4',
+                    'url' => 'http://example.org/test-4',
+                ],
+            ],
+            'is_int' => true,
+		],
+        'expected' => [
+            'failed_urls' => [
+                'http://example.org/test-2',
+                'http://example.org/test-3',
+                'http://example.org/test-4',
+            ],
+        ],
+	],
+    'testShouldClearFailedUrlsWithIntegergAsId' => [
+		'config' => [
+			'rows' => [
+                (object) [
+                    'id' => 2,
+                    'url' => 'http://example.org/test-2',
+                ],
+                (object) [
+                    'id' => 3,
+                    'url' => 'http://example.org/test-3',
+                ],
+                (object) [
+                    'id' => 4,
+                    'url' => 'http://example.org/test-4',
+                ],
+            ],
+            'is_int' => true,
+		],
+        'expected' => [
+            'failed_urls' => [
+                'http://example.org/test-2',
+                'http://example.org/test-3',
+                'http://example.org/test-4',
+            ],
+        ],
+	],
+];

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Controller/UsedCSS/clearFailedUrls.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Controller/UsedCSS/clearFailedUrls.php
@@ -1,0 +1,90 @@
+<?php
+
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Engine\Common\Queue\QueueInterface;
+use WP_Rocket\Engine\Optimization\RUCSS\Controller\Filesystem;
+use WP_Rocket\Engine\Optimization\RUCSS\Controller\UsedCSS;
+use WP_Rocket\Engine\Optimization\RUCSS\Database\Queries\UsedCSS as UsedCSS_Query;
+use WP_Rocket\Engine\Optimization\RUCSS\Database\Row\UsedCSS as UsedCSS_Row;
+use WP_Rocket\Engine\Optimization\RUCSS\Frontend\APIClient;
+use WP_Rocket\Logger\Logger;
+use WP_Rocket\Tests\Unit\TestCase;
+use WP_Rocket\Engine\Optimization\DynamicLists\DefaultLists\DataManager;
+use Brain\Monkey\Functions;
+use Brain\Monkey\Actions;
+
+
+/**
+ * @covers \WP_Rocket\Engine\Optimization\RUCSS\Controller\UsedCSS::clear_failed_urls
+ *
+ * @group  RUCSS
+ */
+class Test_ClearFailedUrls extends TestCase {
+	protected $options;
+	protected $usedCssQuery;
+	protected $api;
+	protected $queue;
+	protected $usedCss;
+	protected $data_manager;
+	protected $filesystem;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->options      = Mockery::mock( Options_Data::class );
+		$this->usedCssQuery = $this->createMock( UsedCSS_Query::class );
+		$this->api          = Mockery::mock( APIClient::class );
+		$this->queue        = Mockery::mock( QueueInterface::class );
+		$this->data_manager = Mockery::mock( DataManager::class );
+		$this->filesystem   = Mockery::mock( Filesystem::class );
+		$this->usedCss      = Mockery::mock(
+			UsedCSS::class . '[is_allowed,update_last_accessed]',
+			[
+				$this->options,
+				$this->usedCssQuery,
+				$this->api,
+				$this->queue,
+				$this->data_manager,
+				$this->filesystem
+			]
+		);
+	}
+
+	protected function tearDown(): void {
+		parent::tearDown();
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnAsExpected( $config, $expected ) {
+        $this->usedCssQuery->expects( self::once() )
+			                   ->method( 'get_failed_rows' )
+                               ->willReturn( $config['rows'] );
+
+        if ( isset( $config['is_int'] ) ) {
+            if ( ! $config['is_int'] ) {
+                $this->usedCssQuery->expects( self::never() )
+                                ->method( 'revert_to_pending' );
+            }
+            else {
+                foreach ( $config['rows'] as $row ) {
+                    $this->usedCssQuery->expects( self::any() )
+                                ->method( 'revert_to_pending' )
+                                ->with($this->anything())
+                                ->will($this->returnCallback( 
+                                    function ( $value ) use ($row) {
+                                        return $value === $row->id;
+                                    }
+                                 ) );
+                }
+            }
+
+            Actions\expectDone( 'rocket_rucss_after_clearing_failed_url' )->with( $expected['failed_urls'] );
+        }
+        else {
+            Actions\expectDone( 'rocket_rucss_after_clearing_failed_url' )->never();
+        }
+
+        $this->usedCss->clear_failed_urls();
+	}
+}


### PR DESCRIPTION
## Description

Guards against parsing string to `UsedCSS::revert_to_pending()`

Fixes #5927 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?
No

## How Has This Been Tested?

Automated tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
