### PR TITLE
Add the url as a second parameter to the filter `rocket_preload_exclude_urls`

### DIFF
--- a/inc/Engine/Preload/Controller/CheckExcludedTrait.php
+++ b/inc/Engine/Preload/Controller/CheckExcludedTrait.php
@@ -35,21 +35,24 @@ trait CheckExcludedTrait {
 	 */
 	protected function is_excluded_by_filter( string $url ): bool {
 		global $wp_rewrite;
+
 		$pagination_regex = "/$wp_rewrite->pagination_base/\d+";
+		$url              = strtok( $url, '?' );
+		$url              = user_trailingslashit( $url );
+
 		/**
 		 * Regex to exclude URI from preload.
 		 *
-		 * @param string[] regexes to check
+		 * @param string[] $regexes Regexes to check.
+		 * @param string   $url Current preloading url.
 		 */
-		$regexes = (array) apply_filters( 'rocket_preload_exclude_urls', [ $pagination_regex ] );
+		$regexes = (array) apply_filters( 'rocket_preload_exclude_urls', [ $pagination_regex ], $url );
 
 		if ( empty( $regexes ) ) {
 			return false;
 		}
 
 		$regexes = array_unique( $regexes );
-		$url     = strtok( $url, '?' );
-		$url     = user_trailingslashit( $url );
 
 		foreach ( $regexes as $regex ) {
 			if ( ! is_string( $regex ) ) {


### PR DESCRIPTION
## Description

Add a second argument to the filter `rocket_preload_exclude_urls` to allow having a helper plugin to allow specific list of urls only to be preloaded and other than them will be excluded from preload process.

Filter can be used like:

```
add_filter( 'rocket_preload_exclude_urls', function( $regexes, $url ) {
    $inclusion_list = [ 'https://example.org/url1', 'https://example.org/url1', ];
    if ( ! in_array( $url, $inclusion_list, true ) ) {
        $regexes[] = $url;
    }
    return $regexes;
}, 10, 2 );
```

Fixes #6001

## Type of change

Please delete options that are not relevant.

- [x] Enhancement (non-breaking change which improves an existing functionality)

## Is the solution different from the one proposed during the grooming?

It's XS effort.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Locally

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
