### PR TITLE
Closes #5969: Update link ezoic plugin conflict notice

### DIFF
--- a/inc/ThirdParty/Plugins/Optimization/Ezoic.php
+++ b/inc/ThirdParty/Plugins/Optimization/Ezoic.php
@@ -43,7 +43,7 @@ class Ezoic implements Subscriber_Interface {
 		$plugins_explanations['ezoic'] = sprintf(
 			// translators: %1$s = opening <a> tag, %2$s = closing </a> tag.
 			__( 'This plugin blocks WP Rocket\'s caching and optimizations. Deactivate it and use %1$sEzoic\'s nameserver integration%2$s instead.', 'rocket' ),
-			'<a href="https://support.ezoic.com/support/solutions/articles/48000453926-name-server-integration" target="_blank" rel="noopener noreferrer">',
+			'<a href="https://support.ezoic.com/kb/article/how-can-i-integrate-my-site-with-ezoic" target="_blank" rel="noopener noreferrer">',
 			'</a>'
 		);
 

--- a/tests/Integration/inc/ThirdParty/Plugins/Optimization/Ezoic/addExplanations.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Optimization/Ezoic/addExplanations.php
@@ -14,7 +14,7 @@ class Test_Explanations extends TestCase {
 	public function testShouldReturnExpected() {
 		$plugins_explanations = [];
 		$expected             = [
-			'ezoic' => 'This plugin blocks WP Rocket\'s caching and optimizations. Deactivate it and use <a href="https://support.ezoic.com/support/solutions/articles/48000453926-name-server-integration" target="_blank" rel="noopener noreferrer">Ezoic\'s nameserver integration</a> instead.',
+			'ezoic' => 'This plugin blocks WP Rocket\'s caching and optimizations. Deactivate it and use <a href="https://support.ezoic.com/kb/article/how-can-i-integrate-my-site-with-ezoic" target="_blank" rel="noopener noreferrer">Ezoic\'s nameserver integration</a> instead.',
 		];
 
 		$this->assertSame(


### PR DESCRIPTION
## Description

Updated link in notice for ezoic plugin.

Fixes #5969 

## Type of change
- [x] Enhancement (non-breaking change which improves an existing functionality)

## How Has This Been Tested?
Automated Test.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
