### PR TITLE
Find another way to prevent clearing the whole cache with trash restore without using url_to_postid function

### DIFF
--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -612,7 +612,7 @@ add_action( 'upgrader_process_complete', 'rocket_clean_cache_theme_update', 10, 
  */
 function rocket_clean_post_cache_on_slug_change( $post_id, $post_data ) {
 	// Bail out if the post status is draft, pending or auto-draft.
-	if ( in_array( get_post_field( 'post_status', $post_id ), [ 'draft', 'pending', 'auto-draft' ], true ) ) {
+	if ( in_array( get_post_field( 'post_status', $post_id ), [ 'draft', 'pending', 'auto-draft', 'trash' ], true ) ) {
 		return;
 	}
 	$post_name = get_post_field( 'post_name', $post_id );

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -587,12 +587,6 @@ function rocket_clean_files( $urls, $filesystem = null ) {
 
 		$parsed_url = get_rocket_parse_url( $url );
 
-		$post_id = url_to_postid( $url );
-
-		if ( $post_id ) {
-			$parsed_url = rocket_maybe_find_right_trash_url( $parsed_url, $post_id );
-		}
-
 		if ( ! empty( $parsed_url['host'] ) ) {
 			foreach ( _rocket_get_cache_dirs( $parsed_url['host'], $cache_path ) as $dir ) {
 				// Decode url path.

--- a/tests/Unit/inc/functions/rocketCleanFiles.php
+++ b/tests/Unit/inc/functions/rocketCleanFiles.php
@@ -72,7 +72,6 @@ class Test_RocketCleanFiles extends FilesystemTestCase {
 	}
 
 	private function doCleanFilesTest( $urls, $config, $expected ) {
-		Functions\when('url_to_postid')->justReturn($config['post_id']);
 		Filters\expectApplied( 'rocket_url_no_dots' )
 			->once()
 			->with( false )


### PR DESCRIPTION
## Description

We get rid of `url_to_postid` function from the cache clearing and find another way to prevent the whole cache clearing with restore as groomed.

Fixes #5971

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

Exactly as groomed.

## How Has This Been Tested?

Locally and in customers' sites.

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
