### PR TITLE
add wp-asset-clean-up in plugins to deactivate

### DIFF
--- a/inc/admin/ui/notices.php
+++ b/inc/admin/ui/notices.php
@@ -148,6 +148,7 @@ function rocket_plugins_to_deactivate() {
 		'add-expires-headers'                        => 'add-expires-headers/add-expires-headers.php',
 		'page-optimize'                              => 'page-optimize/page-optimize.php',
 		'psn-pagespeed-ninja'                        => 'psn-pagespeed-ninja/pagespeedninja.php',
+		'wp-asset-clean-up'                          => 'wp-asset-clean-up/wpacu.php',
 	];
 
 	if ( get_rocket_option( 'lazyload' ) ) {

--- a/inc/admin/ui/notices.php
+++ b/inc/admin/ui/notices.php
@@ -149,6 +149,7 @@ function rocket_plugins_to_deactivate() {
 		'page-optimize'                              => 'page-optimize/page-optimize.php',
 		'psn-pagespeed-ninja'                        => 'psn-pagespeed-ninja/pagespeedninja.php',
 		'wp-asset-clean-up'                          => 'wp-asset-clean-up/wpacu.php',
+		'wp-asset-clean-up-pro'                      => 'wp-asset-clean-up-pro/wpacu.php',
 	];
 
 	if ( get_rocket_option( 'lazyload' ) ) {


### PR DESCRIPTION
## Description

add wp-asset-clean-up  and wp-asset-clean-up-pro plugins in not compatible plugins

Fixes #5268

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Is the solution different from the one proposed during the grooming?
No, I just added the pro part
## How Has This Been Tested?

- [ ] locally

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
