### PR TITLE
Fix preloading mobile cache version when a Mandatory cookie is set

### DIFF
--- a/inc/Engine/Preload/Controller/PreloadUrl.php
+++ b/inc/Engine/Preload/Controller/PreloadUrl.php
@@ -158,7 +158,7 @@ class PreloadUrl {
 	 * @return string
 	 */
 	protected function get_mobile_user_agent_prefix() {
-		$prefix = 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1';
+		$prefix = 'WP Rocket Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1';
 
 		/**
 		 * Filter the prefix to prepend to the user agent used for preload to make a HTTP request detected as a mobile device.

--- a/inc/Engine/Preload/Controller/PreloadUrl.php
+++ b/inc/Engine/Preload/Controller/PreloadUrl.php
@@ -171,7 +171,7 @@ class PreloadUrl {
 			return $prefix;
 		}
 
-		return 'WP Rocket ' . $new_prefix;
+		return 'WP Rocket/Preload ' . $new_prefix;
 	}
 
 	/**

--- a/inc/Engine/Preload/Controller/PreloadUrl.php
+++ b/inc/Engine/Preload/Controller/PreloadUrl.php
@@ -158,7 +158,7 @@ class PreloadUrl {
 	 * @return string
 	 */
 	protected function get_mobile_user_agent_prefix() {
-		$prefix = 'WP Rocket Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1';
+		$prefix = 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1';
 
 		/**
 		 * Filter the prefix to prepend to the user agent used for preload to make a HTTP request detected as a mobile device.
@@ -171,7 +171,7 @@ class PreloadUrl {
 			return $prefix;
 		}
 
-		return $new_prefix;
+		return 'WP Rocket ' . $new_prefix;
 	}
 
 	/**

--- a/tests/Fixtures/inc/Engine/Preload/Controller/PreloadUrl/getMobileUserAgentPrefix.php
+++ b/tests/Fixtures/inc/Engine/Preload/Controller/PreloadUrl/getMobileUserAgentPrefix.php
@@ -2,15 +2,15 @@
 return [
 	'shouldUsePrefixOnInvalidFilterPrefix' => [
 		'config' => [
-			'prefix' => 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1',
+			'prefix' => 'WP Rocket Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1',
 			'filter' => '',
 
 		],
-		'expected' => 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1'
+		'expected' => 'WP Rocket Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1'
 	],
 	'shouldUseFilterPrefixOnFilterPrefix' => [
 		'config' => [
-			'prefix' => 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1',
+			'prefix' => 'WP Rocket Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1',
 			'filter' => 'new_prefix',
 
 		],

--- a/tests/Fixtures/inc/Engine/Preload/Controller/PreloadUrl/getMobileUserAgentPrefix.php
+++ b/tests/Fixtures/inc/Engine/Preload/Controller/PreloadUrl/getMobileUserAgentPrefix.php
@@ -2,18 +2,18 @@
 return [
 	'shouldUsePrefixOnInvalidFilterPrefix' => [
 		'config' => [
-			'prefix' => 'WP Rocket Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1',
+			'prefix' => 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1',
 			'filter' => '',
 
 		],
-		'expected' => 'WP Rocket Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1'
+		'expected' => 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1'
 	],
 	'shouldUseFilterPrefixOnFilterPrefix' => [
 		'config' => [
-			'prefix' => 'WP Rocket Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1',
+			'prefix' => 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1',
 			'filter' => 'new_prefix',
 
 		],
-		'expected' => 'new_prefix'
+		'expected' => 'WP Rocket new_prefix'
 	]
 ];

--- a/tests/Fixtures/inc/Engine/Preload/Controller/PreloadUrl/getMobileUserAgentPrefix.php
+++ b/tests/Fixtures/inc/Engine/Preload/Controller/PreloadUrl/getMobileUserAgentPrefix.php
@@ -14,6 +14,6 @@ return [
 			'filter' => 'new_prefix',
 
 		],
-		'expected' => 'WP Rocket new_prefix'
+		'expected' => 'WP Rocket/Preload new_prefix'
 	]
 ];

--- a/tests/Fixtures/inc/Engine/Preload/Frontend/Subscriber/preloadUrl.php
+++ b/tests/Fixtures/inc/Engine/Preload/Frontend/Subscriber/preloadUrl.php
@@ -15,10 +15,10 @@ return [
 			'config_mobile' => [
 				'blocking' => false,
 				'timeout'  => 0.01,
-				'user-agent' => 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1'
+				'user-agent' => 'WP Rocket Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1'
 			],
 			'mobile_cache' => true,
-			'user_agent' => 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1',
+			'user_agent' => 'WP Rocket Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1',
 			'process_generate' => [
 				'is_wp_error' => true,
 				'response' => 'content'
@@ -48,10 +48,10 @@ return [
 			'config_mobile' => [
 				'blocking' => false,
 				'timeout'  => 0.01,
-				'user-agent' => 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1'
+				'user-agent' => 'WP Rocket Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1'
 			],
 			'mobile_cache' => true,
-			'user_agent' => 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1',
+			'user_agent' => 'WP Rocket Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1',
 			'process_generate' => [
 				'is_wp_error' => true,
 				'response' => 'content'

--- a/tests/Fixtures/inc/Engine/Preload/Frontend/Subscriber/preloadUrl.php
+++ b/tests/Fixtures/inc/Engine/Preload/Frontend/Subscriber/preloadUrl.php
@@ -15,10 +15,10 @@ return [
 			'config_mobile' => [
 				'blocking' => false,
 				'timeout'  => 0.01,
-				'user-agent' => 'WP Rocket Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1'
+				'user-agent' => 'WP Rocket/Preload Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1'
 			],
 			'mobile_cache' => true,
-			'user_agent' => 'WP Rocket Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1',
+			'user_agent' => 'WP Rocket/Preload Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1',
 			'process_generate' => [
 				'is_wp_error' => true,
 				'response' => 'content'
@@ -48,10 +48,10 @@ return [
 			'config_mobile' => [
 				'blocking' => false,
 				'timeout'  => 0.01,
-				'user-agent' => 'WP Rocket Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1'
+				'user-agent' => 'WP Rocket/Preload Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1'
 			],
 			'mobile_cache' => true,
-			'user_agent' => 'WP Rocket Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1',
+			'user_agent' => 'WP Rocket/Preload Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1',
 			'process_generate' => [
 				'is_wp_error' => true,
 				'response' => 'content'


### PR DESCRIPTION
## Description

Here we are changing the user agent being used to simulate the mobile visit and add a prefix of `WP Rocket` to it so `is_speed_tool` method should return true when mandatory cookies are set.

Fixes #6027

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Is the solution different from the one proposed during the grooming?

No

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test the normal behavior of preload mobile cache without mandatory cookies
- [x] Test having mandatory cookies and enable separate mobile cache.

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
