### PR TITLE
Fixes #6040 Preload mobile homepage on activation & RUCSS clean

### DIFF
--- a/inc/Engine/Activation/Activation.php
+++ b/inc/Engine/Activation/Activation.php
@@ -91,14 +91,9 @@ class Activation {
 			]
 		);
 
-		wp_remote_get(
-			home_url(),
-			[
-				'timeout'    => 0.01,
-				'blocking'   => false,
-				'user-agent' => 'WP Rocket/Homepage Preload',
-				'sslverify'  => apply_filters( 'https_local_ssl_verify', false ), // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
-			]
-		);
+		/**
+		 * Fires after WP Rocket is activated
+		 */
+		do_action( 'rocket_after_activation' );
 	}
 }

--- a/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
@@ -211,16 +211,6 @@ class Subscriber implements Subscriber_Interface {
 
 		$this->delete_used_css_rows();
 		$this->set_notice_transient();
-
-		wp_safe_remote_get(
-			home_url(),
-			[
-				'timeout'    => 0.01,
-				'blocking'   => false,
-				'user-agent' => 'WP Rocket/Homepage Preload',
-				'sslverify'  => apply_filters( 'https_local_ssl_verify', false ), // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
-			]
-		);
 	}
 
 	/**
@@ -331,9 +321,10 @@ class Subscriber implements Subscriber_Interface {
 			rocket_get_constant( 'WP_ROCKET_IS_TESTING', false ) ? wp_die() : exit;
 		}
 
+		rocket_clean_domain();
+
 		$this->delete_used_css_rows();
 
-		rocket_clean_domain();
 		rocket_dismiss_box( 'rocket_warning_plugin_modification' );
 
 		set_transient(
@@ -349,16 +340,6 @@ class Subscriber implements Subscriber_Interface {
 		);
 
 		$this->set_notice_transient();
-
-		wp_remote_get(
-			home_url(),
-			[
-				'timeout'    => 0.01,
-				'blocking'   => false,
-				'user-agent' => 'WP Rocket/Homepage Preload',
-				'sslverify'  => apply_filters( 'https_local_ssl_verify', false ), // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
-			]
-		);
 
 		wp_safe_redirect( esc_url_raw( wp_get_referer() ) );
 		rocket_get_constant( 'WP_ROCKET_IS_TESTING', false ) ? wp_die() : exit;
@@ -579,16 +560,6 @@ class Subscriber implements Subscriber_Interface {
 		$this->database->truncate_used_css_table();
 		rocket_clean_domain();
 		$this->set_notice_transient();
-
-		wp_safe_remote_get(
-			home_url(),
-			[
-				'timeout'    => 0.01,
-				'blocking'   => false,
-				'user-agent' => 'WP Rocket/Homepage Preload',
-				'sslverify'  => apply_filters( 'https_local_ssl_verify', false ), // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
-			]
-		);
 	}
 
 	/**

--- a/inc/Engine/Preload/Activation/Activation.php
+++ b/inc/Engine/Preload/Activation/Activation.php
@@ -1,13 +1,20 @@
 <?php
+declare(strict_types=1);
 
 namespace WP_Rocket\Engine\Preload\Activation;
 
-use WP_Rocket\Admin\Options_Data;
-use WP_Rocket\Engine\Preload\Controller\Queue;
-use WP_Rocket\Engine\Preload\Database\Queries\Cache;
 use WP_Rocket\Engine\Activation\ActivationInterface;
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Engine\Preload\Controller\{PreloadUrl,Queue};
+use WP_Rocket\Engine\Preload\Database\Queries\Cache;
 
 class Activation implements ActivationInterface {
+	/**
+	 * Preload controller
+	 *
+	 * @var PreloadUrl
+	 */
+	private $preload_url;
 
 	/**
 	 * Preload queue.
@@ -33,14 +40,16 @@ class Activation implements ActivationInterface {
 	/**
 	 * Instantiate class.
 	 *
+	 * @param PreloadUrl   $preload_url PreloadUrl instance.
 	 * @param Queue        $queue Preload queue.
 	 * @param Cache        $query DB query.
 	 * @param Options_Data $options Options.
 	 */
-	public function __construct( Queue $queue, Cache $query, Options_Data $options ) {
-		$this->queue   = $queue;
-		$this->query   = $query;
-		$this->options = $options;
+	public function __construct( PreloadUrl $preload_url, Queue $queue, Cache $query, Options_Data $options ) {
+		$this->preload_url = $preload_url;
+		$this->queue       = $queue;
+		$this->query       = $query;
+		$this->options     = $options;
 	}
 
 	/**
@@ -48,6 +57,7 @@ class Activation implements ActivationInterface {
 	 */
 	public function activate() {
 		add_action( 'rocket_activation', [ $this, 'preload_activation' ], 15 );
+		add_action( 'rocket_after_activation', [ $this, 'preload_homepage' ] );
 	}
 
 	/**
@@ -66,6 +76,15 @@ class Activation implements ActivationInterface {
 		do_action( 'rocket_preload_activation' );
 
 		$this->queue->add_job_preload_job_load_initial_sitemap_async();
+	}
+
+	/**
+	 * Preloads the homepage on activation
+	 *
+	 * @return void
+	 */
+	public function preload_homepage() {
+		$this->preload_url->preload_url( home_url() );
 	}
 
 	/**

--- a/inc/Engine/Preload/Activation/ServiceProvider.php
+++ b/inc/Engine/Preload/Activation/ServiceProvider.php
@@ -1,9 +1,11 @@
 <?php
+declare(strict_types=1);
 
 namespace WP_Rocket\Engine\Preload\Activation;
 
+use WP_Filesystem_Direct;
 use WP_Rocket\Dependencies\League\Container\ServiceProvider\AbstractServiceProvider;
-use WP_Rocket\Engine\Preload\Controller\Queue;
+use WP_Rocket\Engine\Preload\Controller\{PreloadUrl, Queue};
 use WP_Rocket\Engine\Preload\Database\Queries\Cache as CacheQuery;
 use WP_Rocket\Engine\Preload\Database\Tables\Cache as CacheTable;
 use WP_Rocket\Logger\Logger;
@@ -20,7 +22,9 @@ class ServiceProvider extends AbstractServiceProvider {
 	 * @var array
 	 */
 	protected $provides = [
+		'preload_cache_table',
 		'preload_caches_query',
+		'preload_url_controller',
 		'preload_queue',
 		'preload_activation',
 	];
@@ -33,19 +37,27 @@ class ServiceProvider extends AbstractServiceProvider {
 	 * @return void
 	 */
 	public function register() {
-		$options = $this->getContainer()->get( 'options' );
+		$options = $this->getLeagueContainer()->get( 'options' );
 
-		$this->getContainer()->add( 'preload_caches_table', CacheTable::class );
-		$this->getContainer()->get( 'preload_caches_table' );
-
-		$this->getContainer()->add( 'preload_caches_query', CacheQuery::class )
+		$this->getLeagueContainer()->add( 'preload_cache_table', CacheTable::class );
+		$this->getLeagueContainer()->get( 'preload_cache_table' );
+		$this->getLeagueContainer()->add( 'wp_direct_filesystem', WP_Filesystem_Direct::class )
+			->addArgument( [] );
+		$this->getLeagueContainer()->add( 'preload_cache_query', CacheQuery::class )
 			->addArgument( new Logger() );
-		$cache_query = $this->getContainer()->get( 'preload_caches_query' );
+		$this->getLeagueContainer()->add( 'preload_queue', Queue::class );
 
-		$this->getContainer()->add( 'preload_queue', Queue::class );
-		$queue = $this->getContainer()->get( 'preload_queue' );
+		$cache_query = $this->getLeagueContainer()->get( 'preload_cache_query' );
+		$queue       = $this->getLeagueContainer()->get( 'preload_queue' );
 
-		$this->getContainer()->add( 'preload_activation', Activation::class )
+		$this->getLeagueContainer()->add( 'preload_url_controller', PreloadUrl::class )
+			->addArgument( $options )
+			->addArgument( $queue )
+			->addArgument( $cache_query )
+			->addArgument( $this->getLeagueContainer()->get( 'wp_direct_filesystem' ) );
+
+		$this->getLeagueContainer()->add( 'preload_activation', Activation::class )
+			->addArgument( $this->getLeagueContainer()->get( 'preload_url_controller' ) )
 			->addArgument( $queue )
 			->addArgument( $cache_query )
 			->addArgument( $options );

--- a/inc/Engine/Preload/Activation/ServiceProvider.php
+++ b/inc/Engine/Preload/Activation/ServiceProvider.php
@@ -37,27 +37,27 @@ class ServiceProvider extends AbstractServiceProvider {
 	 * @return void
 	 */
 	public function register() {
-		$options = $this->getLeagueContainer()->get( 'options' );
+		$options = $this->getContainer()->get( 'options' );
 
-		$this->getLeagueContainer()->add( 'preload_cache_table', CacheTable::class );
-		$this->getLeagueContainer()->get( 'preload_cache_table' );
-		$this->getLeagueContainer()->add( 'wp_direct_filesystem', WP_Filesystem_Direct::class )
+		$this->getContainer()->add( 'preload_cache_table', CacheTable::class );
+		$this->getContainer()->get( 'preload_cache_table' );
+		$this->getContainer()->add( 'wp_direct_filesystem', WP_Filesystem_Direct::class )
 			->addArgument( [] );
-		$this->getLeagueContainer()->add( 'preload_cache_query', CacheQuery::class )
+		$this->getContainer()->add( 'preload_cache_query', CacheQuery::class )
 			->addArgument( new Logger() );
-		$this->getLeagueContainer()->add( 'preload_queue', Queue::class );
+		$this->getContainer()->add( 'preload_queue', Queue::class );
 
-		$cache_query = $this->getLeagueContainer()->get( 'preload_cache_query' );
-		$queue       = $this->getLeagueContainer()->get( 'preload_queue' );
+		$cache_query = $this->getContainer()->get( 'preload_cache_query' );
+		$queue       = $this->getContainer()->get( 'preload_queue' );
 
-		$this->getLeagueContainer()->add( 'preload_url_controller', PreloadUrl::class )
+		$this->getContainer()->add( 'preload_url_controller', PreloadUrl::class )
 			->addArgument( $options )
 			->addArgument( $queue )
 			->addArgument( $cache_query )
-			->addArgument( $this->getLeagueContainer()->get( 'wp_direct_filesystem' ) );
+			->addArgument( $this->getContainer()->get( 'wp_direct_filesystem' ) );
 
-		$this->getLeagueContainer()->add( 'preload_activation', Activation::class )
-			->addArgument( $this->getLeagueContainer()->get( 'preload_url_controller' ) )
+		$this->getContainer()->add( 'preload_activation', Activation::class )
+			->addArgument( $this->getContainer()->get( 'preload_url_controller' ) )
 			->addArgument( $queue )
 			->addArgument( $cache_query )
 			->addArgument( $options );

--- a/inc/Engine/Preload/ServiceProvider.php
+++ b/inc/Engine/Preload/ServiceProvider.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace WP_Rocket\Engine\Preload;
 
 use WP_Filesystem_Direct;
@@ -6,12 +8,7 @@ use WP_Rocket\Dependencies\League\Container\ServiceProvider\AbstractServiceProvi
 use WP_Rocket\Engine\Preload\Activation\Activation;
 use WP_Rocket\Engine\Preload\Admin\Settings;
 use WP_Rocket\Engine\Preload\Admin\Subscriber as AdminSubscriber;
-use WP_Rocket\Engine\Preload\Controller\CheckFinished;
-use WP_Rocket\Engine\Preload\Controller\ClearCache;
-use WP_Rocket\Engine\Preload\Controller\CrawlHomepage;
-use WP_Rocket\Engine\Preload\Controller\LoadInitialSitemap;
-use WP_Rocket\Engine\Preload\Controller\PreloadUrl;
-use WP_Rocket\Engine\Preload\Controller\Queue;
+use WP_Rocket\Engine\Preload\Controller\{CheckFinished,ClearCache,CrawlHomepage,LoadInitialSitemap,PreloadUrl,Queue};
 use WP_Rocket\Engine\Preload\Cron\Subscriber as CronSubscriber;
 use WP_Rocket\Engine\Preload\Database\Queries\Cache as CacheQuery;
 use WP_Rocket\Engine\Preload\Database\Tables\Cache as CacheTable;
@@ -63,102 +60,103 @@ class ServiceProvider extends AbstractServiceProvider {
 	 * @return void
 	 */
 	public function register() {
-		$options = $this->getContainer()->get( 'options' );
+		$options = $this->getLeagueContainer()->get( 'options' );
 
-		$this->getContainer()->add( 'preload_mobile_detect', WP_Rocket_Mobile_Detect::class );
+		$this->getLeagueContainer()->add( 'preload_mobile_detect', WP_Rocket_Mobile_Detect::class );
 
-		$this->getContainer()->add( 'wp_direct_filesystem', WP_Filesystem_Direct::class )
+		$this->getLeagueContainer()->add( 'wp_direct_filesystem', WP_Filesystem_Direct::class )
 			->addArgument( [] );
-		$wp_file_system = $this->getContainer()->get( 'wp_direct_filesystem' );
+		$wp_file_system = $this->getLeagueContainer()->get( 'wp_direct_filesystem' );
 
-		$this->getContainer()->add( 'preload_caches_table', CacheTable::class );
-		$this->getContainer()->add( 'preload_caches_query', CacheQuery::class )
+		$this->getLeagueContainer()->add( 'preload_caches_table', CacheTable::class );
+		$this->getLeagueContainer()->add( 'preload_caches_query', CacheQuery::class )
 			->addArgument( new Logger() );
-		$this->getContainer()->get( 'preload_caches_table' );
+		$this->getLeagueContainer()->get( 'preload_caches_table' );
 
-		$cache_query = $this->getContainer()->get( 'preload_caches_query' );
+		$cache_query = $this->getLeagueContainer()->get( 'preload_caches_query' );
 
-		$this->getContainer()->add( 'preload_queue', Queue::class );
-		$queue = $this->getContainer()->get( 'preload_queue' );
+		$this->getLeagueContainer()->add( 'preload_queue', Queue::class );
+		$queue = $this->getLeagueContainer()->get( 'preload_queue' );
 
-		$this->getContainer()->add( 'preload_url_controller', PreloadUrl::class )
+		$this->getLeagueContainer()->add( 'preload_url_controller', PreloadUrl::class )
 			->addArgument( $options )
 			->addArgument( $queue )
 			->addArgument( $cache_query )
 			->addArgument( $wp_file_system );
 
-		$preload_url_controller = $this->getContainer()->get( 'preload_url_controller' );
+		$preload_url_controller = $this->getLeagueContainer()->get( 'preload_url_controller' );
 
-		$this->getContainer()->add( 'homepage_crawler', CrawlHomepage::class );
-		$crawl_homepage = $this->getContainer()->get( 'homepage_crawler' );
+		$this->getLeagueContainer()->add( 'homepage_crawler', CrawlHomepage::class );
+		$crawl_homepage = $this->getLeagueContainer()->get( 'homepage_crawler' );
 
-		$this->getContainer()->add( 'sitemap_parser', SitemapParser::class );
-		$sitemap_parser = $this->getContainer()->get( 'sitemap_parser' );
+		$this->getLeagueContainer()->add( 'sitemap_parser', SitemapParser::class );
+		$sitemap_parser = $this->getLeagueContainer()->get( 'sitemap_parser' );
 
-		$this->getContainer()->add( 'fetch_sitemap_controller', FetchSitemap::class )
+		$this->getLeagueContainer()->add( 'fetch_sitemap_controller', FetchSitemap::class )
 			->addArgument( $sitemap_parser )
 			->addArgument( $queue )
 			->addArgument( $cache_query );
 
-		$fetch_sitemap_controller = $this->getContainer()->get( 'fetch_sitemap_controller' );
+		$fetch_sitemap_controller = $this->getLeagueContainer()->get( 'fetch_sitemap_controller' );
 
-		$this->getContainer()->add( 'load_initial_sitemap_controller', LoadInitialSitemap::class )
+		$this->getLeagueContainer()->add( 'load_initial_sitemap_controller', LoadInitialSitemap::class )
 			->addArgument( $queue )
 			->addArgument( $cache_query )
 			->addArgument( $crawl_homepage );
 
-		$this->getContainer()->add( 'preload_activation', Activation::class )
+		$this->getLeagueContainer()->add( 'preload_activation', Activation::class )
+			->addArgument( $preload_url_controller )
 			->addArgument( $queue )
 			->addArgument( $cache_query )
 			->addArgument( $options );
 
-		$this->getContainer()->add( 'preload_settings', Settings::class )
+		$this->getLeagueContainer()->add( 'preload_settings', Settings::class )
 			->addArgument( $options )
 			->addArgument( $preload_url_controller );
 
-		$preload_settings = $this->getContainer()->get( 'preload_settings' );
+		$preload_settings = $this->getLeagueContainer()->get( 'preload_settings' );
 
-		$this->getContainer()->add( 'check_finished_controller', CheckFinished::class )
+		$this->getLeagueContainer()->add( 'check_finished_controller', CheckFinished::class )
 			->addArgument( $preload_settings )
 			->addArgument( $cache_query )
 			->addArgument( $queue );
 
-		$check_finished_controller = $this->getContainer()->get( 'check_finished_controller' );
+		$check_finished_controller = $this->getLeagueContainer()->get( 'check_finished_controller' );
 
-		$this->getContainer()->share( 'preload_front_subscriber', FrontEndSubscriber::class )
+		$this->getLeagueContainer()->share( 'preload_front_subscriber', FrontEndSubscriber::class )
 			->addArgument( $fetch_sitemap_controller )
 			->addArgument( $preload_url_controller )
 			->addArgument( $check_finished_controller )
-			->addArgument( $this->getContainer()->get( 'load_initial_sitemap_controller' ) )
+			->addArgument( $this->getLeagueContainer()->get( 'load_initial_sitemap_controller' ) )
 			->addTag( 'common_subscriber' );
 
-		$this->getContainer()->add( 'preload_clean_controller', ClearCache::class )
+		$this->getLeagueContainer()->add( 'preload_clean_controller', ClearCache::class )
 			->addArgument( $cache_query );
 
-		$clean_controller = $this->getContainer()->get( 'preload_clean_controller' );
+		$clean_controller = $this->getLeagueContainer()->get( 'preload_clean_controller' );
 
-		$this->getContainer()->share( 'preload_subscriber', Subscriber::class )
+		$this->getLeagueContainer()->share( 'preload_subscriber', Subscriber::class )
 			->addArgument( $options )
-			->addArgument( $this->getContainer()->get( 'load_initial_sitemap_controller' ) )
+			->addArgument( $this->getLeagueContainer()->get( 'load_initial_sitemap_controller' ) )
 			->addArgument( $cache_query )
-			->addArgument( $this->getContainer()->get( 'preload_activation' ) )
-			->addArgument( $this->getContainer()->get( 'preload_mobile_detect' ) )
+			->addArgument( $this->getLeagueContainer()->get( 'preload_activation' ) )
+			->addArgument( $this->getLeagueContainer()->get( 'preload_mobile_detect' ) )
 			->addArgument( $clean_controller )
 			->addArgument( $queue )
 			->addTag( 'common_subscriber' );
 
-		$this->getContainer()->share( 'preload_cron_subscriber', CronSubscriber::class )
+		$this->getLeagueContainer()->share( 'preload_cron_subscriber', CronSubscriber::class )
 			->addArgument( $preload_settings )
 			->addArgument( $cache_query )
 			->addArgument( $preload_url_controller )
 			->addTag( 'common_subscriber' );
 
-		$this->getContainer()->share( 'fonts_preload_subscriber', Fonts::class )
+		$this->getLeagueContainer()->share( 'fonts_preload_subscriber', Fonts::class )
 			->addArgument( $options )
-			->addArgument( $this->getContainer()->get( 'cdn' ) )
+			->addArgument( $this->getLeagueContainer()->get( 'cdn' ) )
 			->addTag( 'common_subscriber' );
 
-		$this->getContainer()->add( 'preload_admin_subscriber', AdminSubscriber::class )
+		$this->getLeagueContainer()->add( 'preload_admin_subscriber', AdminSubscriber::class )
 			->addArgument( $options )
 			->addArgument( $preload_settings )
 			->addTag( 'common_subscriber' );

--- a/inc/Engine/Preload/ServiceProvider.php
+++ b/inc/Engine/Preload/ServiceProvider.php
@@ -60,103 +60,103 @@ class ServiceProvider extends AbstractServiceProvider {
 	 * @return void
 	 */
 	public function register() {
-		$options = $this->getLeagueContainer()->get( 'options' );
+		$options = $this->getContainer()->get( 'options' );
 
-		$this->getLeagueContainer()->add( 'preload_mobile_detect', WP_Rocket_Mobile_Detect::class );
+		$this->getContainer()->add( 'preload_mobile_detect', WP_Rocket_Mobile_Detect::class );
 
-		$this->getLeagueContainer()->add( 'wp_direct_filesystem', WP_Filesystem_Direct::class )
+		$this->getContainer()->add( 'wp_direct_filesystem', WP_Filesystem_Direct::class )
 			->addArgument( [] );
-		$wp_file_system = $this->getLeagueContainer()->get( 'wp_direct_filesystem' );
+		$wp_file_system = $this->getContainer()->get( 'wp_direct_filesystem' );
 
-		$this->getLeagueContainer()->add( 'preload_caches_table', CacheTable::class );
-		$this->getLeagueContainer()->add( 'preload_caches_query', CacheQuery::class )
+		$this->getContainer()->add( 'preload_caches_table', CacheTable::class );
+		$this->getContainer()->add( 'preload_caches_query', CacheQuery::class )
 			->addArgument( new Logger() );
-		$this->getLeagueContainer()->get( 'preload_caches_table' );
+		$this->getContainer()->get( 'preload_caches_table' );
 
-		$cache_query = $this->getLeagueContainer()->get( 'preload_caches_query' );
+		$cache_query = $this->getContainer()->get( 'preload_caches_query' );
 
-		$this->getLeagueContainer()->add( 'preload_queue', Queue::class );
-		$queue = $this->getLeagueContainer()->get( 'preload_queue' );
+		$this->getContainer()->add( 'preload_queue', Queue::class );
+		$queue = $this->getContainer()->get( 'preload_queue' );
 
-		$this->getLeagueContainer()->add( 'preload_url_controller', PreloadUrl::class )
+		$this->getContainer()->add( 'preload_url_controller', PreloadUrl::class )
 			->addArgument( $options )
 			->addArgument( $queue )
 			->addArgument( $cache_query )
 			->addArgument( $wp_file_system );
 
-		$preload_url_controller = $this->getLeagueContainer()->get( 'preload_url_controller' );
+		$preload_url_controller = $this->getContainer()->get( 'preload_url_controller' );
 
-		$this->getLeagueContainer()->add( 'homepage_crawler', CrawlHomepage::class );
-		$crawl_homepage = $this->getLeagueContainer()->get( 'homepage_crawler' );
+		$this->getContainer()->add( 'homepage_crawler', CrawlHomepage::class );
+		$crawl_homepage = $this->getContainer()->get( 'homepage_crawler' );
 
-		$this->getLeagueContainer()->add( 'sitemap_parser', SitemapParser::class );
-		$sitemap_parser = $this->getLeagueContainer()->get( 'sitemap_parser' );
+		$this->getContainer()->add( 'sitemap_parser', SitemapParser::class );
+		$sitemap_parser = $this->getContainer()->get( 'sitemap_parser' );
 
-		$this->getLeagueContainer()->add( 'fetch_sitemap_controller', FetchSitemap::class )
+		$this->getContainer()->add( 'fetch_sitemap_controller', FetchSitemap::class )
 			->addArgument( $sitemap_parser )
 			->addArgument( $queue )
 			->addArgument( $cache_query );
 
-		$fetch_sitemap_controller = $this->getLeagueContainer()->get( 'fetch_sitemap_controller' );
+		$fetch_sitemap_controller = $this->getContainer()->get( 'fetch_sitemap_controller' );
 
-		$this->getLeagueContainer()->add( 'load_initial_sitemap_controller', LoadInitialSitemap::class )
+		$this->getContainer()->add( 'load_initial_sitemap_controller', LoadInitialSitemap::class )
 			->addArgument( $queue )
 			->addArgument( $cache_query )
 			->addArgument( $crawl_homepage );
 
-		$this->getLeagueContainer()->add( 'preload_activation', Activation::class )
+		$this->getContainer()->add( 'preload_activation', Activation::class )
 			->addArgument( $preload_url_controller )
 			->addArgument( $queue )
 			->addArgument( $cache_query )
 			->addArgument( $options );
 
-		$this->getLeagueContainer()->add( 'preload_settings', Settings::class )
+		$this->getContainer()->add( 'preload_settings', Settings::class )
 			->addArgument( $options )
 			->addArgument( $preload_url_controller );
 
-		$preload_settings = $this->getLeagueContainer()->get( 'preload_settings' );
+		$preload_settings = $this->getContainer()->get( 'preload_settings' );
 
-		$this->getLeagueContainer()->add( 'check_finished_controller', CheckFinished::class )
+		$this->getContainer()->add( 'check_finished_controller', CheckFinished::class )
 			->addArgument( $preload_settings )
 			->addArgument( $cache_query )
 			->addArgument( $queue );
 
-		$check_finished_controller = $this->getLeagueContainer()->get( 'check_finished_controller' );
+		$check_finished_controller = $this->getContainer()->get( 'check_finished_controller' );
 
-		$this->getLeagueContainer()->share( 'preload_front_subscriber', FrontEndSubscriber::class )
+		$this->getContainer()->share( 'preload_front_subscriber', FrontEndSubscriber::class )
 			->addArgument( $fetch_sitemap_controller )
 			->addArgument( $preload_url_controller )
 			->addArgument( $check_finished_controller )
-			->addArgument( $this->getLeagueContainer()->get( 'load_initial_sitemap_controller' ) )
+			->addArgument( $this->getContainer()->get( 'load_initial_sitemap_controller' ) )
 			->addTag( 'common_subscriber' );
 
-		$this->getLeagueContainer()->add( 'preload_clean_controller', ClearCache::class )
+		$this->getContainer()->add( 'preload_clean_controller', ClearCache::class )
 			->addArgument( $cache_query );
 
-		$clean_controller = $this->getLeagueContainer()->get( 'preload_clean_controller' );
+		$clean_controller = $this->getContainer()->get( 'preload_clean_controller' );
 
-		$this->getLeagueContainer()->share( 'preload_subscriber', Subscriber::class )
+		$this->getContainer()->share( 'preload_subscriber', Subscriber::class )
 			->addArgument( $options )
-			->addArgument( $this->getLeagueContainer()->get( 'load_initial_sitemap_controller' ) )
+			->addArgument( $this->getContainer()->get( 'load_initial_sitemap_controller' ) )
 			->addArgument( $cache_query )
-			->addArgument( $this->getLeagueContainer()->get( 'preload_activation' ) )
-			->addArgument( $this->getLeagueContainer()->get( 'preload_mobile_detect' ) )
+			->addArgument( $this->getContainer()->get( 'preload_activation' ) )
+			->addArgument( $this->getContainer()->get( 'preload_mobile_detect' ) )
 			->addArgument( $clean_controller )
 			->addArgument( $queue )
 			->addTag( 'common_subscriber' );
 
-		$this->getLeagueContainer()->share( 'preload_cron_subscriber', CronSubscriber::class )
+		$this->getContainer()->share( 'preload_cron_subscriber', CronSubscriber::class )
 			->addArgument( $preload_settings )
 			->addArgument( $cache_query )
 			->addArgument( $preload_url_controller )
 			->addTag( 'common_subscriber' );
 
-		$this->getLeagueContainer()->share( 'fonts_preload_subscriber', Fonts::class )
+		$this->getContainer()->share( 'fonts_preload_subscriber', Fonts::class )
 			->addArgument( $options )
-			->addArgument( $this->getLeagueContainer()->get( 'cdn' ) )
+			->addArgument( $this->getContainer()->get( 'cdn' ) )
 			->addTag( 'common_subscriber' );
 
-		$this->getLeagueContainer()->add( 'preload_admin_subscriber', AdminSubscriber::class )
+		$this->getContainer()->add( 'preload_admin_subscriber', AdminSubscriber::class )
 			->addArgument( $options )
 			->addArgument( $preload_settings )
 			->addTag( 'common_subscriber' );

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/truncateUsedCSSHandler.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/truncateUsedCSSHandler.php
@@ -5,21 +5,18 @@ namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\RUCSS\Admin\Subscriber;
 
 use Mockery;
 use Brain\Monkey\Functions;
-use WP_Rocket\Engine\Optimization\RUCSS\Controller\Queue;
-use WP_Rocket\Tests\Unit\TestCase;
-use WP_Rocket\Engine\Optimization\RUCSS\Admin\Database;
-use WP_Rocket\Engine\Optimization\RUCSS\Admin\Settings;
-use WP_Rocket\Engine\Optimization\RUCSS\Admin\Subscriber;
-use WP_Rocket\Engine\Optimization\RUCSS\Controller\UsedCSS;
 use WPDieException;
+use WP_Rocket\Engine\Optimization\RUCSS\Controller\Queue;
+use WP_Rocket\Engine\Optimization\RUCSS\Admin\{Database,Settings,Subscriber};
+use WP_Rocket\Engine\Optimization\RUCSS\Controller\UsedCSS;
+use WP_Rocket\Tests\Unit\TestCase;
 
 /**
  * @covers \WP_Rocket\Engine\Optimization\RUCSS\Admin\Subscriber::truncate_used_css_handler
  *
- * @group  RUCSS
+ * @group RUCSS
  */
 class Test_TruncateUsedCSSHandler extends TestCase {
-
 	private $settings;
 	private $database;
 	private $used_css;
@@ -27,16 +24,16 @@ class Test_TruncateUsedCSSHandler extends TestCase {
 
 	protected $path_to_test_data = '/inc/Engine/Optimization/RUCSS/Admin/Subscriber/truncateUsedCSSHandler.php';
 
-	public function setUp() : void {
+	protected function setUp(): void {
 		parent::setUp();
 
 		$this->settings   = Mockery::mock( Settings::class );
 		$this->database   = Mockery::mock( Database::class );
-		$this->used_css    = Mockery::mock( UsedCSS::class );
+		$this->used_css   = Mockery::mock( UsedCSS::class );
 		$this->subscriber = new Subscriber( $this->settings, $this->database, $this->used_css, Mockery::mock( Queue::class ) );
 	}
 
-	public function tearDown() : void {
+	protected function tearDown(): void {
 		parent::tearDown();
 
 		unset( $_GET['_wpnonce'] );
@@ -53,7 +50,7 @@ class Test_TruncateUsedCSSHandler extends TestCase {
 		if ( ! isset( $input['nonce'] ) ) {
 			Functions\expect( 'wp_verify_nonce' )->never();
 			Functions\expect( 'sanitize_key' )->never();
-		} else{
+		} else {
 			Functions\expect( 'wp_verify_nonce' )->once()->with( $input['nonce'], 'rocket_clear_usedcss' )->andReturn( 'rocket_clear_usedcss' === $input['nonce'] );
 			Functions\expect( 'sanitize_key' )->once()->andReturnFirstArg();
 		}
@@ -68,7 +65,7 @@ class Test_TruncateUsedCSSHandler extends TestCase {
 
 		if ( ! isset( $input['cap'] ) ) {
 			Functions\expect( 'current_user_can' )->never();
-		}else{
+		}else {
 			Functions\expect( 'current_user_can' )
 				->once()
 				->with( 'rocket_remove_unused_css' )
@@ -129,12 +126,6 @@ class Test_TruncateUsedCSSHandler extends TestCase {
 				);
 
 			Functions\when('home_url')->justReturn($input['home_url']);
-
-			Functions\expect('wp_remote_get')->once()->with(
-				$input['home_url'],
-				$input['home_request_configs']
-			);
-
 			Functions\expect( 'rocket_renew_box' )
 				->once()
 				->with( 'rucss_success_notice' );

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/truncateUsedCss.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Admin/Subscriber/truncateUsedCss.php
@@ -1,30 +1,24 @@
 <?php
 namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\RUCSS\Admin\Subscriber;
 
+use Brain\Monkey\{Actions,Functions};
 use Mockery;
-use WP_Rocket\Engine\Optimization\RUCSS\Admin\Database;
-use WP_Rocket\Engine\Optimization\RUCSS\Admin\Settings;
-use WP_Rocket\Engine\Optimization\RUCSS\Admin\Subscriber;
-use WP_Rocket\Engine\Optimization\RUCSS\Controller\Queue;
-use WP_Rocket\Engine\Optimization\RUCSS\Controller\UsedCSS;
+use WP_Rocket\Engine\Optimization\RUCSS\Admin\{Database,Settings,Subscriber};
+use WP_Rocket\Engine\Optimization\RUCSS\Controller\{Queue,UsedCSS};
 use WP_Rocket\Tests\Unit\TestCase;
-use Brain\Monkey\Functions;
-use Brain\Monkey\Actions;
 
 /**
  * @covers \WP_Rocket\Engine\Optimization\RUCSS\Admin\Subscriber::truncate_used_css
  *
- * @group  RUCSS
+ * @group RUCSS
  */
 class Test_TruncateUsedCss extends TestCase {
-
 	private $settings;
 	private $database;
 	private $usedCSS;
 	private $subscriber;
 
-	protected function setUp(): void
-	{
+	protected function setUp(): void {
 		parent::setUp();
 
 		$this->settings   = Mockery::mock( Settings::class );
@@ -72,16 +66,5 @@ class Test_TruncateUsedCss extends TestCase {
 		Functions\expect('set_transient')->with('rocket_rucss_processing', time() + 90, 1.5 * MINUTE_IN_SECONDS);
 
 		Functions\expect('rocket_renew_box')->with('rucss_success_notice');
-
-		Functions\expect('wp_safe_remote_get')->with(
-			$config['home'],
-			[
-				'timeout'    => 0.01,
-				'blocking'   => false,
-				'user-agent' => 'WP Rocket/Homepage Preload',
-				'sslverify'  => true,
-			]
-		);
-
 	}
 }

--- a/tests/Unit/inc/Engine/Preload/Activation/cleanOnUpdate.php
+++ b/tests/Unit/inc/Engine/Preload/Activation/cleanOnUpdate.php
@@ -2,31 +2,29 @@
 
 namespace WP_Rocket\Tests\Unit\inc\Engine\Preload\Activation;
 
+use Brain\Monkey\Functions;
 use Mockery;
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\Preload\Activation\Activation;
-use WP_Rocket\Engine\Preload\Controller\LoadInitialSitemap;
-use WP_Rocket\Engine\Preload\Controller\Queue;
+use WP_Rocket\Engine\Preload\Controller\{PreloadUrl,Queue};
 use WP_Rocket\Engine\Preload\Database\Queries\Cache;
 use WP_Rocket\Tests\Unit\TestCase;
-use Brain\Monkey\Functions;
 
-class Test_CleanOnUpdate extends TestCase
-{
-	protected $controller;
+class Test_CleanOnUpdate extends TestCase {
+	protected $preload_url;
 	protected $activation;
 	protected $queue;
 	protected $query;
 	private $options;
 
-	protected function setUp(): void
-	{
+	protected function setUp(): void {
 		parent::setUp();
-		$this->controller = Mockery::mock(LoadInitialSitemap::class);
-		$this->queue = Mockery::mock(Queue::class);
-		$this->query = $this->createMock(Cache::class);
-		$this->options = $this->createMock( Options_Data::class );
-		$this->activation = new Activation($this->queue, $this->query, $this->options);
+
+		$this->preload_url = Mockery::mock( PreloadUrl::class );
+		$this->queue      = Mockery::mock(Queue::class);
+		$this->query      = $this->createMock(Cache::class);
+		$this->options    = $this->createMock( Options_Data::class );
+		$this->activation = new Activation( $this->preload_url, $this->queue, $this->query, $this->options );
 	}
 
 	/**

--- a/tests/Unit/inc/Engine/Preload/Activation/refreshOnUpdate.php
+++ b/tests/Unit/inc/Engine/Preload/Activation/refreshOnUpdate.php
@@ -5,28 +5,24 @@ namespace WP_Rocket\Tests\Unit\inc\Engine\Preload\Activation;
 use Mockery;
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\Preload\Activation\Activation;
-use WP_Rocket\Engine\Preload\Controller\LoadInitialSitemap;
-use WP_Rocket\Engine\Preload\Controller\Queue;
+use WP_Rocket\Engine\Preload\Controller\{PreloadUrl,Queue};
 use WP_Rocket\Engine\Preload\Database\Queries\Cache;
 use WP_Rocket\Tests\Unit\TestCase;
-use Brain\Monkey\Functions;
 
-class Test_RefreshOnUpdate extends TestCase
-{
+class Test_RefreshOnUpdate extends TestCase {
 	protected $activation;
-	protected $controller;
+	protected $preload_url;
 	protected $queue;
 	protected $query;
 	private $options;
 
-	protected function setUp(): void
-	{
+	protected function setUp(): void {
 		parent::setUp();
-		$this->controller = Mockery::mock(LoadInitialSitemap::class);
-		$this->queue = Mockery::mock(Queue::class);
-		$this->query = $this->createMock(Cache::class);
-		$this->options = $this->createMock( Options_Data::class );
-		$this->activation = new Activation($this->queue, $this->query, $this->options);
+		$this->preload_url = Mockery::mock(PreloadUrl::class);
+		$this->queue       = Mockery::mock(Queue::class);
+		$this->query       = $this->createMock(Cache::class);
+		$this->options     = $this->createMock( Options_Data::class );
+		$this->activation  = new Activation( $this->preload_url, $this->queue, $this->query, $this->options );
 	}
 
 	/**


### PR DESCRIPTION
## Description

Preload mobile homepage on activation, and fix bug where preload happened before cache clean when doing a RUCSS clean.

Fixes #6040

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

No

## How Has This Been Tested?

- [x] Automated tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
