### PR TITLE
Prevent flooding AS queue

### DIFF
--- a/inc/Engine/Preload/Controller/Queue.php
+++ b/inc/Engine/Preload/Controller/Queue.php
@@ -125,4 +125,17 @@ class Queue extends AbstractASQueue {
 		$this->cancel_all( '' );
 	}
 
+	/**
+	 * Return pending actions inside AS scheduler queue.
+	 *
+	 * @return array
+	 */
+	public function get_pending_preload_actions(): array {
+		return $this->search(
+			[
+				'hook'   => 'rocket_preload_job_preload_url',
+				'status' => ActionScheduler_Store::STATUS_PENDING,
+			]
+		);
+	}
 }

--- a/inc/Engine/Preload/Controller/Queue.php
+++ b/inc/Engine/Preload/Controller/Queue.php
@@ -133,8 +133,9 @@ class Queue extends AbstractASQueue {
 	public function get_pending_preload_actions(): array {
 		return $this->search(
 			[
-				'hook'   => 'rocket_preload_job_preload_url',
-				'status' => ActionScheduler_Store::STATUS_PENDING,
+				'hook'     => 'rocket_preload_job_preload_url',
+				'status'   => ActionScheduler_Store::STATUS_PENDING,
+				'per_page' => -1,
 			]
 		);
 	}

--- a/inc/Engine/Preload/Database/Queries/Cache.php
+++ b/inc/Engine/Preload/Database/Queries/Cache.php
@@ -339,6 +339,10 @@ class Cache extends Query {
 	 */
 	public function get_pending_jobs( int $total = 45 ) {
 
+		if ( $total <= 0 ) {
+			return [];
+		}
+
 		$orderby = 'modified';
 
 		/**

--- a/inc/Engine/Preload/Database/Queries/Cache.php
+++ b/inc/Engine/Preload/Database/Queries/Cache.php
@@ -338,18 +338,6 @@ class Cache extends Query {
 	 * @return array
 	 */
 	public function get_pending_jobs( int $total = 45 ) {
-		$inprogress_count = $this->query(
-			[
-				'count'     => true,
-				'status'    => 'in-progress',
-				'is_locked' => false,
-			],
-			false
-		);
-
-		if ( $inprogress_count >= $total ) {
-			return [];
-		}
 
 		$orderby = 'modified';
 
@@ -366,7 +354,7 @@ class Cache extends Query {
 
 		return $this->query(
 			[
-				'number'         => ( $total - $inprogress_count ),
+				'number'         => $total,
 				'status'         => 'pending',
 				'fields'         => [
 					'id',

--- a/tests/Fixtures/inc/Engine/Preload/Cron/Subscriber/processPendingUrls.php
+++ b/tests/Fixtures/inc/Engine/Preload/Cron/Subscriber/processPendingUrls.php
@@ -1,0 +1,201 @@
+<?php
+return [
+    'pendingShouldAddToTheQueue' => [
+        'config' => [
+			'rocket_preload_cache_pending_jobs_cron_rows_count' => 10,
+			'manual_preload' => true,
+			'rocket_preload_outdated' => -1,
+			'rows' => [
+				[
+					'url' => 'http://example.org/test',
+					'status' => 'pending'
+				],
+				[
+					'url' => 'http://example.org/test2',
+					'status' => 'pending'
+				],
+			],
+			'actions' => [
+
+			]
+        ],
+		'expected' => [
+			'rows' => [
+				[
+					'url' => 'http://example.org/test',
+					'status' => 'in-progress'
+				],
+				[
+					'url' => 'http://example.org/test2',
+					'status' => 'in-progress'
+				],
+			],
+			'actions' => [
+				[
+					'exists' => true,
+					'args' => [
+						'hook'   => 'rocket_preload_job_preload_url',
+						'args' => ['http://example.org/test']
+					],
+				],
+				[
+					'exists' => true,
+					'args' => [
+						'hook'   => 'rocket_preload_job_preload_url',
+						'args' => ['http://example.org/test2']
+					],
+				],
+			]
+		]
+    ],
+	'InProgressAndInQueueShouldNotFail' => [
+		'config' => [
+			'rocket_preload_cache_pending_jobs_cron_rows_count' => 10,
+			'manual_preload' => true,
+			'rocket_preload_outdated' => -1,
+			'rows' => [
+				[
+					'url' => 'http://example.org/test',
+					'status' => 'in-progress'
+				],
+				[
+					'url' => 'http://example.org/test2',
+					'status' => 'pending'
+				],
+				[
+					'url' => 'http://example.org/test3',
+					'status' => 'in-progress'
+				],
+			],
+			'actions' => [
+				'http://example.org/test'
+			]
+		],
+		'expected' => [
+			'rows' => [
+				[
+					'url' => 'http://example.org/test',
+					'status' => 'in-progress'
+				],
+				[
+					'url' => 'http://example.org/test2',
+					'status' => 'in-progress'
+				],
+				[
+					'url' => 'http://example.org/test3',
+					'status' => 'failed'
+				],
+			],
+			'actions' => [
+				[
+					'exists' => true,
+					'args' => [
+						'hook'   => 'rocket_preload_job_preload_url',
+						'args' => ['http://example.org/test']
+					],
+				],
+				[
+					'exists' => true,
+					'args' => [
+						'hook'   => 'rocket_preload_job_preload_url',
+						'args' => ['http://example.org/test2']
+					],
+				],
+			]
+		]
+	],
+	'InProgressShouldNotExceedMaxQueue' => [
+		'config' => [
+			'rocket_preload_cache_pending_jobs_cron_rows_count' => 3,
+			'manual_preload' => true,
+			'rocket_preload_outdated' => 1000,
+			'rows' => [
+				[
+					'url' => 'http://example.org/test',
+					'status' => 'in-progress'
+				],
+				[
+					'url' => 'http://example.org/test2',
+					'status' => 'pending'
+				],
+				[
+					'url' => 'http://example.org/test3',
+					'status' => 'in-progress'
+				],
+				[
+					'url' => 'http://example.org/test4',
+					'status' => 'pending'
+				],
+				[
+					'url' => 'http://example.org/test5',
+					'status' => 'pending'
+				],
+			],
+			'actions' => [
+				'http://example.org/test'
+			]
+		],
+		'expected' => [
+			'rows' => [
+				[
+					'url' => 'http://example.org/test',
+					'status' => 'in-progress'
+				],
+				[
+					'url' => 'http://example.org/test2',
+					'status' => 'in-progress'
+				],
+				[
+					'url' => 'http://example.org/test3',
+					'status' => 'in-progress'
+				],
+				[
+					'url' => 'http://example.org/test4',
+					'status' => 'in-progress'
+				],
+				[
+					'url' => 'http://example.org/test5',
+					'status' => 'pending'
+				],
+			],
+			'actions' => [
+				[
+					'exists' => true,
+					'args' => [
+						'hook'   => 'rocket_preload_job_preload_url',
+						'args' => ['http://example.org/test']
+					],
+				],
+				[
+					'exists' => true,
+					'args' => [
+						'hook'   => 'rocket_preload_job_preload_url',
+						'args' => ['http://example.org/test2']
+					],
+				],
+				[
+					'exists' => false,
+					'args' => [
+						'hook'   => 'rocket_preload_job_preload_url',
+						'args' => ['http://example.org/test3']
+					],
+				],
+				[
+					'exists' => true,
+					'args' => [
+						'hook'   => 'rocket_preload_job_preload_url',
+						'args' => ['http://example.org/test4']
+					],
+				],
+				[
+					'exists' => false,
+					'args' => [
+						'hook'   => 'rocket_preload_job_preload_url',
+						'args' => ['http://example.org/test5']
+					],
+				],
+			]
+		]
+	],
+
+];

--- a/tests/Fixtures/inc/Engine/Preload/Cron/Subscriber/processPendingUrls.php
+++ b/tests/Fixtures/inc/Engine/Preload/Cron/Subscriber/processPendingUrls.php
@@ -197,5 +197,132 @@ return [
 			]
 		]
 	],
-
+	'BigBatchShouldNotFail' => [
+		'config' => [
+			'rocket_preload_cache_pending_jobs_cron_rows_count' => 3,
+			'manual_preload' => true,
+			'rocket_preload_outdated' => -1,
+			'rows' => [
+				[
+					'url' => 'http://example.org/test',
+					'status' => 'in-progress'
+				],
+				[
+					'url' => 'http://example.org/test2',
+					'status' => 'in-progress'
+				],
+				[
+					'url' => 'http://example.org/test3',
+					'status' => 'in-progress'
+				],
+				[
+					'url' => 'http://example.org/test4',
+					'status' => 'in-progress'
+				],
+				[
+					'url' => 'http://example.org/test5',
+					'status' => 'in-progress'
+				],
+				[
+					'url' => 'http://example.org/test6',
+					'status' => 'in-progress'
+				],
+				[
+					'url' => 'http://example.org/test7',
+					'status' => 'in-progress'
+				],
+			],
+			'actions' => [
+				'http://example.org/test',
+				'http://example.org/test3',
+				'http://example.org/test4',
+				'http://example.org/test5',
+				'http://example.org/test6',
+				'http://example.org/test7',
+			]
+		],
+		'expected' => [
+			'rows' => [
+				[
+					'url' => 'http://example.org/test',
+					'status' => 'in-progress'
+				],
+				[
+					'url' => 'http://example.org/test2',
+					'status' => 'failed'
+				],
+				[
+					'url' => 'http://example.org/test3',
+					'status' => 'in-progress'
+				],
+				[
+					'url' => 'http://example.org/test4',
+					'status' => 'in-progress'
+				],
+				[
+					'url' => 'http://example.org/test5',
+					'status' => 'in-progress'
+				],
+				[
+					'url' => 'http://example.org/test6',
+					'status' => 'in-progress'
+				],
+				[
+					'url' => 'http://example.org/test7',
+					'status' => 'in-progress'
+				],
+			],
+			'actions' => [
+				[
+					'exists' => true,
+					'args' => [
+						'hook'   => 'rocket_preload_job_preload_url',
+						'args' => ['http://example.org/test']
+					],
+				],
+				[
+					'exists' => false,
+					'args' => [
+						'hook'   => 'rocket_preload_job_preload_url',
+						'args' => ['http://example.org/test2']
+					],
+				],
+				[
+					'exists' => true,
+					'args' => [
+						'hook'   => 'rocket_preload_job_preload_url',
+						'args' => ['http://example.org/test3']
+					],
+				],
+				[
+					'exists' => true,
+					'args' => [
+						'hook'   => 'rocket_preload_job_preload_url',
+						'args' => ['http://example.org/test4']
+					],
+				],
+				[
+					'exists' => true,
+					'args' => [
+						'hook'   => 'rocket_preload_job_preload_url',
+						'args' => ['http://example.org/test5']
+					],
+				],
+				[
+					'exists' => true,
+					'args' => [
+						'hook'   => 'rocket_preload_job_preload_url',
+						'args' => ['http://example.org/test6']
+					],
+				],
+				[
+					'exists' => true,
+					'args' => [
+						'hook'   => 'rocket_preload_job_preload_url',
+						'args' => ['http://example.org/test7']
+					],
+				],
+			]
+		]
+	],
 ];

--- a/tests/Fixtures/inc/Engine/Preload/Database/Queries/Cache/getPendingJobs.php
+++ b/tests/Fixtures/inc/Engine/Preload/Database/Queries/Cache/getPendingJobs.php
@@ -8,7 +8,6 @@ return [
 	'shouldReturnPendingRowsWhenInProgressLessThanTotal' => [
 		'config' => [
 			'total' => 45,
-			'in-progress' => 1,
 			'results' => [
 				$cache,
 			]
@@ -16,25 +15,5 @@ return [
 		'expected' => [
 			$cache
 		]
-	],
-	'shouldReturnEmptyPendingRowsWhenInProgressEqualsTotal' => [
-		'config' => [
-			'total' => 45,
-			'in-progress' => 45,
-			'results' => [
-				$cache,
-			],
-		],
-		'expected' => [],
-	],
-	'shouldReturnEmptyPendingRowsWhenInProgressMoreThanTotal' => [
-		'config' => [
-			'total' => 45,
-			'in-progress' => 45,
-			'results' => [
-				$cache,
-			],
-		],
-		'expected' => [],
 	],
 ];

--- a/tests/Fixtures/inc/Engine/Preload/Database/Queries/Cache/getPendingJobs.php
+++ b/tests/Fixtures/inc/Engine/Preload/Database/Queries/Cache/getPendingJobs.php
@@ -16,4 +16,14 @@ return [
 			$cache
 		]
 	],
+	'negativeCountShouldReturnEmpty' => [
+		'config' => [
+			'total' => -10,
+			'results' => [
+				$cache,
+			]
+		],
+		'expected' => [
+		]
+	],
 ];

--- a/tests/Integration/inc/Engine/Preload/Cron/Subscriber/processPendingUrls.php
+++ b/tests/Integration/inc/Engine/Preload/Cron/Subscriber/processPendingUrls.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\Preload\Cron\Subscriber;
+
+use WP_Rocket\Engine\Preload\Controller\Queue;
+use WP_Rocket\Tests\Integration\DBTrait;
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Preload\Cron\Subscriber::process_pending_urls
+ */
+class Test_processPendingUrls extends TestCase {
+
+	use DBTrait;
+
+	protected $config;
+
+	public static function set_up_before_class()
+	{
+		parent::set_up_before_class();
+		self::installFresh();
+	}
+
+	public static function tear_down_after_class()
+	{
+		$container = apply_filters('rocket_container', null);
+		if(! $container) {
+			return;
+		}
+
+		/**
+		 * @var Queue $queue
+		 */
+		$queue = $container->get('preload_queue');
+
+		if(! $queue) {
+			return;
+		}
+
+		$queue->cancel_all('rocket_preload_job_preload_url');
+
+		self::uninstallAll();
+		parent::tear_down_after_class();
+	}
+
+	public function set_up()
+	{
+		add_filter('pre_get_rocket_option_manual_preload', [$this, 'manual_preload']);
+		add_filter('rocket_preload_outdated', [$this, 'rocket_preload_outdated']);
+		add_filter('rocket_preload_cache_pending_jobs_cron_rows_count', [$this, 'rocket_preload_cache_pending_jobs_cron_rows_count']);
+		parent::set_up();
+	}
+
+	public function tear_down()
+	{
+		remove_filter('pre_get_rocket_option_manual_preload', [$this, 'manual_preload']);
+		remove_filter('rocket_preload_outdated', [$this, 'rocket_preload_outdated']);
+		remove_filter('rocket_preload_cache_pending_jobs_cron_rows_count', [$this, 'rocket_preload_cache_pending_jobs_cron_rows_count']);
+		parent::tear_down();
+	}
+
+	/**
+     * @dataProvider configTestData
+     */
+    public function testShouldDoAsExpected( $config, $expected )
+    {
+		$this->config = $config;
+
+		$container = apply_filters('rocket_container', null);
+		if(! $container) {
+			return;
+		}
+
+		/**
+		 * @var Queue $queue
+		 */
+		$queue = $container->get('preload_queue');
+
+		if(! $queue) {
+			return;
+		}
+
+		foreach ($config['rows'] as $row) {
+			self::addCache($row);
+		}
+
+		foreach ($config['actions'] as $action) {
+			$queue->add_job_preload_job_preload_url_async($action);
+		}
+
+        do_action('rocket_preload_process_pending');
+
+
+		foreach ($expected['rows'] as $row) {
+			$this->assertTrue(self::cacheFound($row), json_encode($row) . ' not found');
+		}
+
+		foreach ($expected['actions'] as $action) {
+			$this->assertSame($action['exists'], count($queue->search($action['args'])) > 0, json_encode($action));
+		}
+    }
+
+	public function manual_preload() {
+		return $this->config['manual_preload'];
+	}
+
+	public function rocket_preload_outdated() {
+		return $this->config['rocket_preload_outdated'];
+	}
+
+	public function rocket_preload_cache_pending_jobs_cron_rows_count() {
+		return $this->config['rocket_preload_cache_pending_jobs_cron_rows_count'];
+	}
+}

--- a/tests/Unit/inc/Engine/Preload/Controller/PreloadUrl/processPendingJobs.php
+++ b/tests/Unit/inc/Engine/Preload/Controller/PreloadUrl/processPendingJobs.php
@@ -39,6 +39,7 @@ class Test_processPendingJobs extends TestCase
 	 */
 	public function testShouldDoAsExpected($config, $expected) {
 
+		$this->queue->expects()->get_pending_preload_actions()->andReturn([]);
 		Filters\expectApplied('rocket_preload_cache_pending_jobs_cron_rows_count')->with(100)->andReturn($config['rows']);
 		$this->query->expects(self::once())->method( 'get_outdated_in_progress_jobs' )->with()->willReturn($config['outdated_jobs']);
 		$this->query->expects(self::atLeastOnce())->method('make_status_failed')->withConsecutive(...$expected['outdated_jobs_id']);

--- a/tests/Unit/inc/Engine/Preload/Database/Queries/Cache/getPendingJobs.php
+++ b/tests/Unit/inc/Engine/Preload/Database/Queries/Cache/getPendingJobs.php
@@ -24,28 +24,21 @@ class Test_GetPendingJobs extends TestCase {
 	 * @dataProvider configTestData
 	 */
 	public function testShouldReturnPending($config, $expected) {
-		$this->query->expects($this->at(0))->method('query')->with( [
-			'count'  => true,
-			'status' => 'in-progress',
-			'is_locked' => false,
-		] )->willReturn( $config['in-progress'] );
 
-		if ( $config['total'] > $config['in-progress'] ) {
-			$this->query->expects($this->at(1))->method('query')->with([
-				'number'         => $config['total'] - $config['in-progress'],
-				'status'         => 'pending',
-				'fields'         => [
-					'id',
-					'url',
-				],
-				'job_id__not_in' => [
-					'not_in' => '',
-				],
-				'orderby'        => Filters\applied( 'rocket_preload_order' ) > 0 ? 'id' : 'modified',
-				'order'          => 'asc',
-				'is_locked' => false
-			])->willReturn($config['results']);
-		}
+		$this->query->expects()->method('query')->with([
+			'number'         => $config['total'] - $config['in-progress'],
+			'status'         => 'pending',
+			'fields'         => [
+				'id',
+				'url',
+			],
+			'job_id__not_in' => [
+				'not_in' => '',
+			],
+			'orderby'        => Filters\applied( 'rocket_preload_order' ) > 0 ? 'id' : 'modified',
+			'order'          => 'asc',
+			'is_locked' => false
+		])->willReturn($config['results']);
 
 
 		$this->assertSame($expected, $this->query->get_pending_jobs($config['total']));

--- a/tests/Unit/inc/Engine/Preload/Database/Queries/Cache/getPendingJobs.php
+++ b/tests/Unit/inc/Engine/Preload/Database/Queries/Cache/getPendingJobs.php
@@ -25,21 +25,22 @@ class Test_GetPendingJobs extends TestCase {
 	 */
 	public function testShouldReturnPending($config, $expected) {
 
-		$this->query->expects(self::once())->method('query')->with([
-			'number'         => $config['total'],
-			'status'         => 'pending',
-			'fields'         => [
-				'id',
-				'url',
-			],
-			'job_id__not_in' => [
-				'not_in' => '',
-			],
-			'orderby'        => Filters\applied( 'rocket_preload_order' ) > 0 ? 'id' : 'modified',
-			'order'          => 'asc',
-			'is_locked' => false
-		])->willReturn($config['results']);
-
+		if($config['total'] > 0) {
+			$this->query->expects(self::once())->method('query')->with([
+				'number'         => $config['total'],
+				'status'         => 'pending',
+				'fields'         => [
+					'id',
+					'url',
+				],
+				'job_id__not_in' => [
+					'not_in' => '',
+				],
+				'orderby'        => Filters\applied( 'rocket_preload_order' ) > 0 ? 'id' : 'modified',
+				'order'          => 'asc',
+				'is_locked' => false
+			])->willReturn($config['results']);
+		}
 
 		$this->assertSame($expected, $this->query->get_pending_jobs($config['total']));
 	}

--- a/tests/Unit/inc/Engine/Preload/Database/Queries/Cache/getPendingJobs.php
+++ b/tests/Unit/inc/Engine/Preload/Database/Queries/Cache/getPendingJobs.php
@@ -25,8 +25,8 @@ class Test_GetPendingJobs extends TestCase {
 	 */
 	public function testShouldReturnPending($config, $expected) {
 
-		$this->query->expects()->method('query')->with([
-			'number'         => $config['total'] - $config['in-progress'],
+		$this->query->expects(self::once())->method('query')->with([
+			'number'         => $config['total'],
 			'status'         => 'pending',
 			'fields'         => [
 				'id',


### PR DESCRIPTION
## Description

Prevent the AS queue to be flooded with preload actions.
For that we now check number of actions in the queue instead of checking actions inside the cache table.
We do the same for the failed actions and now check if they exists inside AS queue first.

Fixes #6058

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## Is the solution different from the one proposed during the grooming?

No.

## How Has This Been Tested

- [ ] Integration Test

# Checklist:


- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
