### PR TITLE
Fix excluding many private urls from preload

### DIFF
--- a/inc/Engine/Preload/Subscriber.php
+++ b/inc/Engine/Preload/Subscriber.php
@@ -485,6 +485,10 @@ class Subscriber implements Subscriber_Interface {
 	private function get_all_private_urls() {
 		static $private_urls;
 
+		if ( rocket_get_constant( 'WP_ROCKET_IS_TESTING', false ) ) {
+			$private_urls = null;
+		}
+
 		if ( isset( $private_urls ) ) {
 			return $private_urls;
 		}

--- a/inc/Engine/Preload/Subscriber.php
+++ b/inc/Engine/Preload/Subscriber.php
@@ -508,7 +508,7 @@ class Subscriber implements Subscriber_Interface {
 		foreach ( $query->posts as $post ) {
 			// Temporarily cast publish status to get pretty url.
 			$post->post_status = 'publish';
-			$private_post_url  = untrailingslashit( get_permalink( $post ) );
+			$private_post_url  = get_permalink( $post );
 
 			$private_urls[ md5( $private_post_url ) ] = $private_post_url;
 		}
@@ -533,7 +533,6 @@ class Subscriber implements Subscriber_Interface {
 			return $regexes;
 		}
 
-		$url = untrailingslashit( $url );
 		if ( ! isset( $private_urls[ md5( $url ) ] ) ) {
 			return $regexes;
 		}

--- a/inc/Engine/Preload/Subscriber.php
+++ b/inc/Engine/Preload/Subscriber.php
@@ -122,7 +122,7 @@ class Subscriber implements Subscriber_Interface {
 			'rocket_preload_exclude_urls'            => [
 				[ 'add_preload_excluded_uri' ],
 				[ 'add_cache_reject_uri_to_excluded' ],
-				[ 'exclude_private_post_uri' ],
+				[ 'exclude_private_post_uri', 10, 2 ],
 			],
 			'rocket_rucss_after_clearing_failed_url' => [ 'clean_urls', 20 ],
 			'transition_post_status'                 => [ 'remove_private_post', 10, 3 ],
@@ -478,42 +478,66 @@ class Subscriber implements Subscriber_Interface {
 	}
 
 	/**
-	 * Exclude private urls.
+	 * Get all private urls for public post types.
 	 *
-	 * @param array $regexes regexes containing excluded uris.
 	 * @return array
 	 */
-	public function exclude_private_post_uri( $regexes ) : array {
+	private function get_all_private_urls() {
 		static $private_urls;
-
-		if ( ! is_array( $regexes ) ) {
-			$regexes = (array) $regexes;
-		}
 
 		if ( isset( $private_urls ) ) {
 			return $private_urls;
 		}
 
+		$private_urls = [];
+
+		$public_post_types = get_post_types( [ 'public' => true ] );
+		unset( $public_post_types['attachment'] );
+
 		$arg   = [
-			'post_type'      => 'any',
+			'post_type'      => $public_post_types,
 			'post_status'    => 'private',
 			'posts_per_page' => -1,
 		];
 		$query = new \WP_Query( $arg );
 
 		if ( ! $query->have_posts() ) {
+			return [];
+		}
+
+		foreach ( $query->posts as $post ) {
+			// Temporarily cast publish status to get pretty url.
+			$post->post_status = 'publish';
+			$private_post_url  = get_permalink( $post );
+
+			$private_urls[ md5( $private_post_url ) ] = $private_post_url;
+		}
+
+		return $private_urls;
+	}
+
+	/**
+	 * Exclude private urls.
+	 *
+	 * @param array  $regexes regexes containing excluded uris.
+	 * @param string $url Current url to test against.
+	 * @return array
+	 */
+	public function exclude_private_post_uri( $regexes, $url ) : array {
+		if ( ! is_array( $regexes ) ) {
+			$regexes = (array) $regexes;
+		}
+
+		$private_urls = $this->get_all_private_urls();
+		if ( empty( $private_urls ) ) {
 			return $regexes;
 		}
 
-		$private_post_urls = [];
-		foreach ( $query->posts as $post ) {
-			// Temporarily cast publish status to get pretty url.
-			$post->post_status   = 'publish';
-			$private_post_urls[] = get_permalink( $post );
+		if ( ! isset( $private_urls[ md5( $url ) ] ) ) {
+			return $regexes;
 		}
 
-		$private_urls = array_merge( $regexes, $private_post_urls );
-
-		return $private_urls;
+		$regexes[] = $url;
+		return $regexes;
 	}
 }

--- a/inc/Engine/Preload/Subscriber.php
+++ b/inc/Engine/Preload/Subscriber.php
@@ -508,7 +508,7 @@ class Subscriber implements Subscriber_Interface {
 		foreach ( $query->posts as $post ) {
 			// Temporarily cast publish status to get pretty url.
 			$post->post_status = 'publish';
-			$private_post_url  = get_permalink( $post );
+			$private_post_url  = untrailingslashit( get_permalink( $post ) );
 
 			$private_urls[ md5( $private_post_url ) ] = $private_post_url;
 		}
@@ -533,6 +533,7 @@ class Subscriber implements Subscriber_Interface {
 			return $regexes;
 		}
 
+		$url = untrailingslashit( $url );
 		if ( ! isset( $private_urls[ md5( $url ) ] ) ) {
 			return $regexes;
 		}

--- a/tests/Fixtures/inc/Engine/Preload/Subscriber/excludePrivatePostUri.php
+++ b/tests/Fixtures/inc/Engine/Preload/Subscriber/excludePrivatePostUri.php
@@ -8,30 +8,68 @@ return [
             ],
             'have_posts' => false,
             'posts' => [],
+	        'url' => 'http://example.org/test-4/',
+            'post_types' => [
+	            'post',
+	            'page',
+	            'attachment',
+            ],
         ],
         'expected' => [
             '/page/\d+',
         ],
     ],
+    'testShouldNotReturnUrlIfNotPrivate' => [
+	    'config' => [
+		    'regex' => [
+			    '/page/\d+',
+		    ],
+		    'have_posts' => true,
+		    'posts' => [
+			    (object) [
+				    'ID' => 2,
+				    'post_status' => 'private',
+			    ],
+		    ],
+		    'get_permalink' => [
+			    'http://example.org/test-4/',
+		    ],
+		    'url' => 'http://example.org/test-400/',
+		    'post_types' => [
+				'post',
+			    'page',
+			    'attachment',
+		    ],
+	    ],
+	    'expected' => [
+		    '/page/\d+',
+	    ],
+    ],
     'testShouldReturnExpectedRegex' => [
-        'config' => [
-            'regex' => [
-                '/page/\d+',
-            ],
-            'have_posts' => true,
-            'posts' => [
-                (object) [
-                    'ID' => 2,
-                    'post_status' => 'private',
-                ],
-            ],
-            'get_permalink' => [
-                'http://example.org/test-4/',
-            ],
-        ],
-        'expected' => [
-            '/page/\d+',
-            'http://example.org/test-4/',
-        ],
+	    'config' => [
+		    'regex' => [
+			    '/page/\d+',
+		    ],
+		    'have_posts' => true,
+		    'posts' => [
+			    (object) [
+				    'ID' => 2,
+				    'post_status' => 'private',
+			    ],
+		    ],
+		    'get_permalink' => [
+			    'http://example.org/test-4/',
+		    ],
+		    'url' => 'http://example.org/test-4/',
+		    'post_types' => [
+			    'post',
+			    'page',
+			    'attachment',
+		    ],
+	    ],
+	    'expected' => [
+		    '/page/\d+',
+		    'http://example.org/test-4/',
+	    ],
     ],
 ];

--- a/tests/Integration/inc/Engine/Preload/Subscriber/excludePrivatePostUri.php
+++ b/tests/Integration/inc/Engine/Preload/Subscriber/excludePrivatePostUri.php
@@ -3,25 +3,14 @@
 namespace WP_Rocket\Tests\Integration\inc\Engine\Preload\Subscriber;
 
 use WP_Rocket\Tests\Integration\AdminTestCase;
+use WP_Rocket\Tests\Integration\TestCase;
 
 /**
  * @covers \WP_Rocket\Engine\Preload\Subscriber::exclude_private_post_uri
+ *
  * @group  Preload
  */
-class Test_ExcludePrivatePostUri extends AdminTestCase
-{
-	public static function set_up_before_class()
-	{
-		parent::set_up_before_class();
-		self::installFresh();
-	}
-
-	public static function tear_down_after_class()
-	{
-		self::uninstallAll();
-		parent::tear_down_after_class();
-	}
-
+class Test_ExcludePrivatePostUri extends TestCase {
     public function set_up() {
         parent::set_up();
         $this->set_permalink_structure( "/%postname%/" );
@@ -40,7 +29,11 @@ class Test_ExcludePrivatePostUri extends AdminTestCase
 	 */
 	public function testShouldDoAsExpected( $config, $expected ) {
         if ( $config['have_posts'] ) {
-            wp_insert_post( [ 'post_title' => 'test 4', 'post_status' => 'private' ] );
+	        $this->factory->post->create( [
+		        'post_title' => 'test 4',
+		        'post_status' => 'private',
+		        'post_type' => 'post'
+	        ] );
         }
 
         $this->assertSame( $expected, apply_filters( 'rocket_preload_exclude_urls', $config['regex'], $config['url'] ) );

--- a/tests/Integration/inc/Engine/Preload/Subscriber/excludePrivatePostUri.php
+++ b/tests/Integration/inc/Engine/Preload/Subscriber/excludePrivatePostUri.php
@@ -43,6 +43,6 @@ class Test_ExcludePrivatePostUri extends AdminTestCase
             wp_insert_post( [ 'post_title' => 'test 4', 'post_status' => 'private' ] );
         }
 
-        $this->assertSame( $expected, apply_filters( 'rocket_preload_exclude_urls', $config['regex'] ) );
+        $this->assertSame( $expected, apply_filters( 'rocket_preload_exclude_urls', $config['regex'], $config['url'] ) );
 	}
 }

--- a/tests/Unit/inc/Engine/Preload/Subscriber/excludePrivatePostUri.php
+++ b/tests/Unit/inc/Engine/Preload/Subscriber/excludePrivatePostUri.php
@@ -15,7 +15,9 @@ use WP_Rocket_Mobile_Detect;
 use WP_Query;
 
 /**
- * @covers \WP_Rocket\Engine\Preload\Subscriber::exclude_private_post_uri 
+ * @covers \WP_Rocket\Engine\Preload\Subscriber::exclude_private_post_uri
+ *
+ * @runTestsInSeparateProcesses
  *
  * @group  Preload
  */
@@ -58,15 +60,18 @@ class Test_ExcludePrivatePostUri extends TestCase
         WP_Query::$have_posts = $config['have_posts'];
         WP_Query::$set_posts = $config['posts'];
 
+		Functions\expect( 'get_post_types' )
+			->once()
+			->andReturn( $config['post_types'] );
+
         if ( ! $config['have_posts'] ) {
             Functions\expect( 'get_permalink' )->never();
-        }
-        else {
+        } else {
             Functions\expect( 'get_permalink' )
             ->once()
             ->andReturnValues( $config['get_permalink'] );
         }
 
-        $this->assertSame( $expected, $this->subscriber->exclude_private_post_uri( $config['regex'] ) );
+        $this->assertSame( $expected, $this->subscriber->exclude_private_post_uri( $config['regex'], $config['url'] ) );
 	}
 }

--- a/tests/Unit/inc/Engine/Preload/Subscriber/excludePrivatePostUri.php
+++ b/tests/Unit/inc/Engine/Preload/Subscriber/excludePrivatePostUri.php
@@ -17,8 +17,6 @@ use WP_Query;
 /**
  * @covers \WP_Rocket\Engine\Preload\Subscriber::exclude_private_post_uri
  *
- * @runTestsInSeparateProcesses
- *
  * @group  Preload
  */
 class Test_ExcludePrivatePostUri extends TestCase


### PR DESCRIPTION
## Description

In this PR, we are changing two things:

1. The search criteria for private posts to limit it to public post types only and exclude attachment post type.
2. Compare the current url with the list of private url and if this url is private we will exclude this url only so this filter will not keep the whole private urls that consumes memory/CPU.

Fixes #6097

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Is the solution different from the one proposed during the grooming?

Hotfix, not groomed, found during escalated issue investigation.

## How Has This Been Tested?

- [x] Tested on customer's site
- [ ] Automated tests

# Checklist:

Please delete the options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
