### PR TITLE
Fix WPML subdomain languages false notice

### DIFF
--- a/inc/Engine/Admin/DomainChange/Subscriber.php
+++ b/inc/Engine/Admin/DomainChange/Subscriber.php
@@ -66,21 +66,20 @@ class Subscriber implements Subscriber_Interface {
 			return;
 		}
 
-		$base_url         = trailingslashit( get_option( 'home' ) );
-		$base_url_encoded = base64_encode( $base_url ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+		$base_url              = trailingslashit( get_option( 'home' ) );
+		$base_url_encoded      = base64_encode( $base_url ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+		$last_base_url_encoded = get_option( self::LAST_BASE_URL_OPTION );
 
-		if ( ! get_option( self::LAST_BASE_URL_OPTION ) ) {
-			update_option( self::LAST_BASE_URL_OPTION, $base_url_encoded );
+		if ( ! $last_base_url_encoded ) {
+			update_option( self::LAST_BASE_URL_OPTION, $base_url_encoded, true );
 			return;
 		}
-
-		$last_base_url_encoded = get_option( self::LAST_BASE_URL_OPTION );
 
 		if ( $base_url_encoded === $last_base_url_encoded ) {
 			return;
 		}
 
-		update_option( self::LAST_BASE_URL_OPTION, $base_url_encoded );
+		update_option( self::LAST_BASE_URL_OPTION, $base_url_encoded, true );
 
 		$last_base_url = base64_decode( $last_base_url_encoded ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
 

--- a/inc/Engine/Admin/DomainChange/Subscriber.php
+++ b/inc/Engine/Admin/DomainChange/Subscriber.php
@@ -66,7 +66,7 @@ class Subscriber implements Subscriber_Interface {
 			return;
 		}
 
-		$base_url         = trailingslashit( home_url() );
+		$base_url         = trailingslashit( get_option( 'home' ) );
 		$base_url_encoded = base64_encode( $base_url ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 
 		if ( ! get_option( self::LAST_BASE_URL_OPTION ) ) {
@@ -194,7 +194,7 @@ class Subscriber implements Subscriber_Interface {
 		}
 
 		$last_base_url = base64_decode( $last_base_url_encoded ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
-		$base_url      = trailingslashit( home_url() );
+		$base_url      = trailingslashit( get_option( 'home' ) );
 
 		/**
 		 * Fires when the domain of the website has been changed and user clicked on notice.

--- a/tests/Unit/inc/Engine/Admin/DomainChange/Subscriber/maybeLaunchDomainChanged.php
+++ b/tests/Unit/inc/Engine/Admin/DomainChange/Subscriber/maybeLaunchDomainChanged.php
@@ -38,11 +38,18 @@ class Test_MaybeLaunchDomainChanged extends TestCase
 	public function testShouldDoAsExpected($config, $expected) {
 		Functions\when('trailingslashit')->returnArg();
 		Functions\when('rocket_get_constant')->returnArg(2);
-		Functions\expect('home_url')->andReturn($config['base_url']);
-		Functions\expect('get_option')->with(Subscriber::LAST_BASE_URL_OPTION)->andReturn($config['last_base_url']);
+		Functions\expect('get_option')->andReturnUsing(function( $option ) use ( $config ) {
+			switch ( $option ) {
+				case Subscriber::LAST_BASE_URL_OPTION:
+					return $config['last_base_url'];
+
+				case 'home':
+					return $config['base_url'];
+			}
+		});
 
 		if(!$config['ajax_request'] && ($config['is_base_url_different'] || ! $config['base_url_exist'])) {
-			Functions\expect('update_option')->with(Subscriber::LAST_BASE_URL_OPTION, $expected['encrypted_old_url']);
+			Functions\expect('update_option')->with(Subscriber::LAST_BASE_URL_OPTION, $expected['encrypted_old_url'], true);
 		}
 
 		Functions\expect('wp_doing_ajax')->once()->andReturn( $config['ajax_request'] );

--- a/tests/Unit/inc/Engine/Admin/DomainChange/Subscriber/regenerateConfiguration.php
+++ b/tests/Unit/inc/Engine/Admin/DomainChange/Subscriber/regenerateConfiguration.php
@@ -43,7 +43,7 @@ class Test_regenerateConfiguration extends TestCase {
      */
     public function testShouldDoAsExpected( $config, $expected )
     {
-		Functions\when('home_url')->justReturn($config['home_url']);
+	    Functions\expect('get_option')->with('home')->andReturn($config['home_url']);
 		Functions\when('trailingslashit')->returnArg();
 
 		$this->ajax_handler->expects()->validate_referer('rocket_regenerate_configuration', 'rocket_manage_options')->andReturn($config['is_validated']);


### PR DESCRIPTION
## Description

Here we stop using `home_url()` and use `get_option( 'home' )` instead because all Multilingual plugins are changing the filter `home_url` so we need a not changing value to depend on.

Also here we added the autoload to the used option to make it faster to load as it's loading with `admin_init` which runs with every admin UI page.

**Steps to reproduce the issue:**

1. Setup different domain per language
2. Go to the WP Admin
3. Change the language from default to different one in the top menu

## Type of change

*Please delete options that are not relevant.*

- Bug fix (non-breaking change which fixes an issue).

## Is the solution different from the one proposed during the grooming?

*Please describe in this section if there is any change to the groomed solution, and why.*

# Checklists

## Generic development checklist

- [x] My code follows the style guidelines of this project, with adapted comments and without new warnings.
- [x] I have added unit and integration tests that prove my fix is effective or that my feature works.
- [ ] The CI passes locally with my changes (including unit tests, integration tests, linter).
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] If applicable, I have made corresponding changes to the documentation. *Provide a link to the documentation.*

## Test summary

- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I validated all Acceptance Criteria of the related issues. (If applicable, provide proof).
- [x] I validated all test plan the QA Review asked me to.

*If not, detail what you could not test.*

*Please describe any additional tests you performed.*
