### PR TITLE
Don't define WP_ROCKET_CACHE_PATH if already set

### DIFF
--- a/wp-rocket.php
+++ b/wp-rocket.php
@@ -60,7 +60,10 @@ define( 'WP_ROCKET_ASSETS_IMG_URL',        WP_ROCKET_ASSETS_URL . 'img/' );
 if ( ! defined( 'WP_ROCKET_CACHE_ROOT_PATH' ) ) {
 	define( 'WP_ROCKET_CACHE_ROOT_PATH', WP_CONTENT_DIR . '/cache/' );
 }
-define( 'WP_ROCKET_CACHE_PATH',         WP_ROCKET_CACHE_ROOT_PATH . 'wp-rocket/' );
+
+if ( ! defined( 'WP_ROCKET_CACHE_PATH' ) ) {
+	define( 'WP_ROCKET_CACHE_PATH',         WP_ROCKET_CACHE_ROOT_PATH . 'wp-rocket/' );
+}
 define( 'WP_ROCKET_MINIFY_CACHE_PATH',  WP_ROCKET_CACHE_ROOT_PATH . 'min/' );
 define( 'WP_ROCKET_CACHE_BUSTING_PATH', WP_ROCKET_CACHE_ROOT_PATH . 'busting/' );
 define( 'WP_ROCKET_CRITICAL_CSS_PATH',  WP_ROCKET_CACHE_ROOT_PATH . 'critical-css/' );


### PR DESCRIPTION
## Description

We are using WP Rocket with our Bedrock sites. One Problem we encountered, is that we have to set WP_ROCKET_CACHE_PATH early in our configurations, because else the constant is not ready when advanced-cache.php  is executed. 

Since we already defined WP_ROCKET_CACHE_PATH, we always get a Warning:
Constant WP_ROCKET_CACHE_PATH already defined
app/plugins/wp-rocket/wp-rocket.php:63


## Type of change

- Bug fix (non-breaking change which fixes an issue).

## Is the solution different from the one proposed during the grooming?

*Please describe in this section if there is any change to the groomed solution, and why.*

# Checklists

## Generic development checklist

- [x] My code follows the style guidelines of this project, with adapted comments and without new warnings.
- [ ] I have added unit and integration tests that prove my fix is effective or that my feature works.
- [ ] The CI passes locally with my changes (including unit tests, integration tests, linter).
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] If applicable, I have made corresponding changes to the documentation. *Provide a link to the documentation.*

## Test summary

- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I validated all Acceptance Criteria of the related issues. (If applicable, provide proof).
- [ ] I validated all test plan the QA Review asked me to.

*If not, detail what you could not test.*

*Please describe any additional tests you performed.*
