### PR TITLE
fix truncate rucss on wp-rocket options changes

### DIFF
--- a/inc/Engine/Admin/DomainChange/Subscriber.php
+++ b/inc/Engine/Admin/DomainChange/Subscriber.php
@@ -112,7 +112,7 @@ class Subscriber implements Subscriber_Interface {
 		 *
 		 * @param array $value An array of submitted values for the settings.
 		 */
-		do_action( 'rocket_options_changed', $options );
+		do_action( 'rocket_domain_options_changed', $options );
 	}
 
 	/**

--- a/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Subscriber.php
@@ -73,7 +73,7 @@ class Subscriber implements Subscriber_Interface {
 			],
 			'switch_theme'                            => 'truncate_used_css',
 			'permalink_structure_changed'             => 'truncate_used_css',
-			'rocket_options_changed'                  => 'truncate_used_css',
+			'rocket_domain_options_changed'           => 'truncate_used_css',
 			'wp_trash_post'                           => 'delete_used_css_on_update_or_delete',
 			'delete_post'                             => 'delete_used_css_on_update_or_delete',
 			'clean_post_cache'                        => 'delete_used_css_on_update_or_delete',

--- a/inc/Engine/Preload/Admin/Subscriber.php
+++ b/inc/Engine/Preload/Admin/Subscriber.php
@@ -44,14 +44,15 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events() {
 		return [
-			'admin_notices'               => [
+			'admin_notices'                 => [
 				[ 'maybe_display_preload_notice' ],
 			],
-			'rocket_options_changed'      => 'preload_homepage',
-			'switch_theme'                => 'preload_homepage',
-			'rocket_after_clean_used_css' => 'preload_homepage',
-			'rocket_input_sanitize'       => 'sanitize_options',
-			'wp_rocket_upgrade'           => [ 'maybe_clean_cron', 15, 2 ],
+			'rocket_options_changed'        => 'preload_homepage',
+			'switch_theme'                  => 'preload_homepage',
+			'rocket_after_clean_used_css'   => 'preload_homepage',
+			'rocket_domain_options_changed' => 'preload_homepage',
+			'rocket_input_sanitize'         => 'sanitize_options',
+			'wp_rocket_upgrade'             => [ 'maybe_clean_cron', 15, 2 ],
 		];
 	}
 

--- a/tests/Unit/inc/Engine/Admin/DomainChange/Subscriber/maybeCleanCacheDomainChange.php
+++ b/tests/Unit/inc/Engine/Admin/DomainChange/Subscriber/maybeCleanCacheDomainChange.php
@@ -54,7 +54,7 @@ class Test_maybeCleanCacheDomainChange extends TestCase {
 		Filters\expectApplied('rocket_configurations_changed')->andReturn($config['rocket_configurations_changed']);
 
 		if($config['options'] && ! $config['rocket_configurations_changed']) {
-			Actions\expectDone('rocket_options_changed');
+			Actions\expectDone('rocket_domain_options_changed');
 		}
 
         $this->subscriber->maybe_clean_cache_domain_change();


### PR DESCRIPTION
## Description

change action name `rocket_options_changed` => `rocket_domain_options_changed` to avoid truncating rucss on options changes because this action `rocket_options_changed` is already used when we change options


Fixes #5667 

## Type of change

- Bug fix (non-breaking change which fixes an issue).


## Is the solution different from the one proposed during the grooming?
No gromming

# Checklists

## Generic development checklist

- [x] My code follows the style guidelines of this project, with adapted comments and without new warnings.
- [x] The CI passes locally with my changes (including unit tests, integration tests, linter).
- [x] Any dependent changes have been merged and published in downstream modules.
- [ ] If applicable, I have made corresponding changes to the documentation. *Provide a link to the documentation.*

## Test summary

- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I validated all Acceptance Criteria of the related issues. (If applicable, provide proof).
- [ ] I validated all test plan the QA Review asked me to.

- activate rucss and generate rucss fro some pages
- change any wp-rocket option except the rucss safelist or deactivate rucss
- rucss table (results) should not be truncated 
