### PR TITLE
Mock dynamiclists in integration tests

### DIFF
--- a/tests/Fixtures/inc/Engine/Optimization/DeferJS/Subscriber/excludeJqueryCombine.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DeferJS/Subscriber/excludeJqueryCombine.php
@@ -1,13 +1,5 @@
 <?php
-$default_list = [
-	'/wp-includes/js/dist/i18n.min.js',
-	'/interactive-3d-flipbook-powered-physics-engine/assets/js/html2canvas.min.js',
-	'/interactive-3d-flipbook-powered-physics-engine/assets/js/pdf.min.js',
-	'/interactive-3d-flipbook-powered-physics-engine/assets/js/three.min.js',
-	'/interactive-3d-flipbook-powered-physics-engine/assets/js/3d-flip-book.min.js',
-	'/google-site-kit/dist/assets/js/(.*).js',
-	'/wp-live-chat-support/public/js/callus(.*).js',
-];
+$default_list = [];
 
 return [
 	'testShouldReturnOriginalWhenConstantSet' => [

--- a/tests/Integration/DynamicListsTrait.php
+++ b/tests/Integration/DynamicListsTrait.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration;
+
+trait DynamicListsTrait {
+
+	public function setup_lists() {
+		add_filter( 'pre_transient_wpr_dynamic_lists', '__return_empty_array' );
+		add_filter( 'pre_transient_wpr_dynamic_lists_delayjs', '__return_empty_array' );
+		add_filter( 'pre_transient_wpr_dynamic_lists_incompatible_plugins', '__return_empty_array' );
+	}
+
+	public function teardown_lists() {
+		remove_filter( 'pre_transient_wpr_dynamic_lists', '__return_empty_array' );
+		remove_filter( 'pre_transient_wpr_dynamic_lists_delayjs', '__return_empty_array' );
+		remove_filter( 'pre_transient_wpr_dynamic_lists_incompatible_plugins', '__return_empty_array' );
+	}
+
+}

--- a/tests/Integration/inc/Engine/Optimization/DeferJS/Subscriber/excludeJqueryCombine.php
+++ b/tests/Integration/inc/Engine/Optimization/DeferJS/Subscriber/excludeJqueryCombine.php
@@ -20,12 +20,15 @@ class Test_ExcludeJqueryCombine extends TestCase {
 		parent::set_up();
 
 		set_current_screen( 'front' );
+		add_filter( 'pre_transient_wpr_dynamic_lists', '__return_empty_array' );
+
 	}
 
 	public function tear_down() {
 		remove_filter( 'pre_get_rocket_option_defer_all_js', [ $this, 'set_defer_js' ] );
 		remove_filter( 'pre_get_rocket_option_minify_concatenate_js', [ $this, 'set_minify_concatenate_js' ] );
 		delete_post_meta( 100, '_rocket_exclude_defer_all_js' );
+		remove_filter( 'pre_transient_wpr_dynamic_lists', '__return_empty_array' );
 
 		parent::tear_down();
 	}

--- a/tests/Integration/inc/Engine/Optimization/DeferJS/Subscriber/excludeJqueryCombine.php
+++ b/tests/Integration/inc/Engine/Optimization/DeferJS/Subscriber/excludeJqueryCombine.php
@@ -3,6 +3,7 @@
 namespace WP_Rocket\Tests\Integration\inc\Engine\Optimization\DeferJS\Subscriber;
 
 use WP_Rocket\Tests\Integration\ContentTrait;
+use WP_Rocket\Tests\Integration\DynamicListsTrait;
 use WP_Rocket\Tests\Integration\TestCase;
 
 /**
@@ -11,7 +12,7 @@ use WP_Rocket\Tests\Integration\TestCase;
  * @group  DeferJS
  */
 class Test_ExcludeJqueryCombine extends TestCase {
-	use ContentTrait;
+	use ContentTrait, DynamicListsTrait;
 
 	private $defer_js;
 	private $combine_js;
@@ -20,15 +21,14 @@ class Test_ExcludeJqueryCombine extends TestCase {
 		parent::set_up();
 
 		set_current_screen( 'front' );
-		add_filter( 'pre_transient_wpr_dynamic_lists', '__return_empty_array' );
-
+		$this->setup_lists();
 	}
 
 	public function tear_down() {
 		remove_filter( 'pre_get_rocket_option_defer_all_js', [ $this, 'set_defer_js' ] );
 		remove_filter( 'pre_get_rocket_option_minify_concatenate_js', [ $this, 'set_minify_concatenate_js' ] );
 		delete_post_meta( 100, '_rocket_exclude_defer_all_js' );
-		remove_filter( 'pre_transient_wpr_dynamic_lists', '__return_empty_array' );
+		$this->teardown_lists();
 
 		parent::tear_down();
 	}


### PR DESCRIPTION
## Description

This is a dev initiative, to mock dynamic lists return in integration tests so our tests will not depend on the backend values and only depend on the values added by the plugin's code.

Fixes #6056

## Type of change

*Please delete options that are not relevant.*

- Enhancement (non-breaking change which improves an existing functionality).

## Is the solution different from the one proposed during the grooming?

No

# Checklists

## Generic development checklist

- [x] My code follows the style guidelines of this project, with adapted comments and without new warnings.
- [x] I have added unit and integration tests that prove my fix is effective or that my feature works.
- [x] The CI passes locally with my changes (including unit tests, integration tests, linter).
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] If applicable, I have made corresponding changes to the documentation. *Provide a link to the documentation.*

## Test summary

- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I validated all Acceptance Criteria of the related issues. (If applicable, provide proof).
- [ ] I validated all test plan the QA Review asked me to.

*If not, detail what you could not test.*

*Please describe any additional tests you performed.*
