### PR TITLE
Fix PHP warnings in tests on PHP 8.1/8.2

### DIFF
--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Cron/Subscriber/cronCleanRows.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Cron/Subscriber/cronCleanRows.php
@@ -15,6 +15,8 @@ use WP_Rocket\Tests\Integration\TestCase;
 class Test_CronCleanRows extends TestCase {
 	use DBTrait;
 
+	private $input;
+
 	protected function loadTestDataConfig() {
 		$obj      = new ReflectionObject( $this );
 		$filename = $obj->getFileName();
@@ -34,7 +36,7 @@ class Test_CronCleanRows extends TestCase {
 		self::uninstallAll();
 	}
 
-	public function tear_down() : void {
+	public function tear_down() {
 		remove_filter( 'rocket_rucss_delete_interval', [ $this, 'set_rucss_delay' ] );
 
 		parent::tear_down();
@@ -43,11 +45,11 @@ class Test_CronCleanRows extends TestCase {
 	/**
 	 * @dataProvider configTestData
 	 */
-	public function testShouldDoExpected( $input ){
+	public function testShouldDoExpected( $input ) {
 		$container           = apply_filters( 'rocket_container', null );
 		$rucss_usedcss_query = $container->get( 'rucss_used_css_query' );
 		$current_date        = current_time( 'mysql', true );
-		$old_date            = strtotime( $current_date. ' - 32 days' );
+		$old_date            = strtotime( $current_date . ' - 32 days' );
 
 		$this->input = $input;
 
@@ -55,9 +57,10 @@ class Test_CronCleanRows extends TestCase {
 		$this->set_permalink_structure( "/%postname%/" );
 
 		$count_remain_used_css = 0;
+
 		foreach ( $input['used_css'] as $used_css ) {
-			if ( $old_date <  strtotime( $used_css['last_accessed']) ) {
-				$count_remain_used_css ++;
+			if ( $old_date <  strtotime( $used_css['last_accessed'] ) ) {
+				++$count_remain_used_css;
 			}
 			$rucss_usedcss_query->add_item( $used_css );
 		}
@@ -72,7 +75,7 @@ class Test_CronCleanRows extends TestCase {
 
 
 		if ( $this->input['delay'] ) {
-			$this->assertCount( $count_remain_used_css,$resultUsedCssAfterClean );
+			$this->assertCount( $count_remain_used_css, $resultUsedCssAfterClean );
 		} else {
 			$this->assertCount( count( $input['used_css'] ), $resultUsedCssAfterClean );
 		}

--- a/tests/Integration/inc/ThirdParty/Plugins/CDN/Cloudflare/addCdnHelperMessage.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/CDN/Cloudflare/addCdnHelperMessage.php
@@ -11,38 +11,45 @@ class Test_addCdnHelperMessage extends TestCase {
 
 	protected $config;
 
-	public function set_up()
-	{
+	public function set_up() {
 		parent::set_up();
-		add_filter('pre_option_active_plugins', [$this, 'plugin_enabled']);
-		add_filter('pre_option_cloudflare_api_email', [$this, 'cloudflare_api_email']);
-		add_filter('pre_option_cloudflare_api_key', [$this, 'cloudflare_api_key']);
-		add_filter('pre_option_cloudflare_cached_domain_name', [$this, 'cloudflare_cached_domain_name']);
+
+		add_filter( 'pre_option_active_plugins', [ $this, 'plugin_enabled' ] );
+		add_filter( 'pre_option_cloudflare_api_email', [ $this, 'cloudflare_api_email' ] );
+		add_filter( 'pre_option_cloudflare_api_key', [ $this, 'cloudflare_api_key' ] );
+		add_filter( 'pre_option_cloudflare_cached_domain_name', [ $this, 'cloudflare_cached_domain_name' ] );
 	}
 
-	public function tear_down()
-	{
-		remove_filter('pre_option_active_plugins', [$this, 'plugin_enabled']);
-		remove_filter('pre_option_cloudflare_api_email', [$this, 'cloudflare_api_email']);
-		remove_filter('pre_option_cloudflare_api_key', [$this, 'cloudflare_api_key']);
-		remove_filter('pre_option_cloudflare_cached_domain_name', [$this, 'cloudflare_cached_domain_name']);
+	public function tear_down() {
+		remove_filter( 'pre_option_active_plugins', [ $this, 'plugin_enabled' ] );
+		remove_filter( 'pre_option_cloudflare_api_email', [ $this, 'cloudflare_api_email' ] );
+		remove_filter( 'pre_option_cloudflare_api_key', [ $this, 'cloudflare_api_key' ] );
+		remove_filter( 'pre_option_cloudflare_cached_domain_name', [ $this, 'cloudflare_cached_domain_name' ] );
+
 		parent::tear_down();
 	}
 
 	/**
-     * @dataProvider configTestData
-     */
-    public function testShouldReturnAsExpected( $config, $expected )
-    {
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnAsExpected( $config, $expected ) {
 		$this->config = $config;
-        $this->assertSame($expected, apply_filters('rocket_cdn_helper_addons', $config['addons']));
-    }
+		$this->assertSame(
+			$expected,
+			apply_filters( 'rocket_cdn_helper_addons', $config['addons'] )
+		);
+	}
 
-	public function plugin_enabled($plugins) {
-		if(! $this->config['plugin_enabled']) {
+	public function plugin_enabled( $plugins ) {
+		if ( ! $this->config['plugin_enabled'] ) {
 			return $plugins;
 		}
-		$plugins []= 'cloudflare/cloudflare.php';
+
+		if ( ! is_array( $plugins ) ) {
+			$plugins = (array) $plugins;
+		}
+
+		$plugins[] = 'cloudflare/cloudflare.php';
 
 		return $plugins;
 	}


### PR DESCRIPTION
## Description

I noticed a couple of warnings poping-up in our test suite:

- PHP 8.1 warning on line 45 in tests/Integration/inc/ThirdParty/Plugins/CDN/Cloudflare/addCdnHelperMessage.php 
> Automatic conversion of false to array is deprecated

- PHP 8.2 warning on line 52 in tests/Integration/inc/Engine/Optimization/RUCSS/Cron/Subscriber/cronCleanRows.php
> Creation of dynamic property WP_Rocket\Tests\Integration\inc\Engine\Optimization\RUCSS\Cron\Subscriber\Test_CronCleanRows::$input is deprecated

This PR updates the tests concerned to fix those.

## Type of change

- Bug fix (non-breaking change which fixes an issue).

## Is the solution different from the one proposed during the grooming?

No grooming necessary, this doesn't impact the production code.

# Checklists

## Generic development checklist

- [x] My code follows the style guidelines of this project, with adapted comments and without new warnings.
- [x] The CI passes locally with my changes (including unit tests, integration tests, linter).