### PR TITLE
Update RUCSSQueueRunner.php fixes #6119

### DIFF
--- a/inc/Engine/Common/Queue/RUCSSQueueRunner.php
+++ b/inc/Engine/Common/Queue/RUCSSQueueRunner.php
@@ -213,11 +213,11 @@ class RUCSSQueueRunner extends ActionScheduler_Abstract_QueueRunner {
 			$this->store->release_claim( $claim );
 			$this->monitor->detach();
 			$this->clear_caches();
-                        $this->store->set_claim_filter( 'group', '' );
+			$this->store->set_claim_filter( 'group', '' );
 			return $processed_actions;
 		} catch ( \Exception $exception ) {
 			Logger::debug( $exception->getMessage() );
-                        $this->store->set_claim_filter( 'group', '' );
+			$this->store->set_claim_filter( 'group', '' );
 			return 0;
 		}
 	}

--- a/inc/Engine/Common/Queue/RUCSSQueueRunner.php
+++ b/inc/Engine/Common/Queue/RUCSSQueueRunner.php
@@ -213,11 +213,11 @@ class RUCSSQueueRunner extends ActionScheduler_Abstract_QueueRunner {
 			$this->store->release_claim( $claim );
 			$this->monitor->detach();
 			$this->clear_caches();
-
+                        $this->store->set_claim_filter( 'group', '' );
 			return $processed_actions;
 		} catch ( \Exception $exception ) {
 			Logger::debug( $exception->getMessage() );
-
+                        $this->store->set_claim_filter( 'group', '' );
 			return 0;
 		}
 	}


### PR DESCRIPTION
## Description
Fixes #6119
```
PHP Fatal error: Uncaught InvalidArgumentException: The group "rocket-rucss" does not exist. in /srv/users/stgleather/apps/stgleather/public/wp-content/plugins/woocommerce/packages/action-scheduler/classes/data-stores/ActionScheduler_DBStore.php:907
```  

## Type of change

- Bug fix (non-breaking change which fixes an issue).

## Test summary

- [x] I triggered all changed lines of code at least once without new errors/warnings/notices. (on a live system.)