### PR TITLE
Guard against older versions of action scheduler

### DIFF
--- a/inc/Engine/Common/Queue/RUCSSQueueRunner.php
+++ b/inc/Engine/Common/Queue/RUCSSQueueRunner.php
@@ -213,13 +213,25 @@ class RUCSSQueueRunner extends ActionScheduler_Abstract_QueueRunner {
 			$this->store->release_claim( $claim );
 			$this->monitor->detach();
 			$this->clear_caches();
-			$this->store->set_claim_filter( 'group', '' );
+			$this->reset_group();
 			return $processed_actions;
 		} catch ( \Exception $exception ) {
 			Logger::debug( $exception->getMessage() );
-			$this->store->set_claim_filter( 'group', '' );
+			$this->reset_group();
 			return 0;
 		}
+	}
+
+	/**
+	 * Reset group in store's claim filter.
+	 *
+	 * @return void
+	 */
+	private function reset_group() {
+		if ( ! method_exists( $this->store, 'set_claim_filter' ) ) {
+			return;
+		}
+		$this->store->set_claim_filter( 'group', '' );
 	}
 
 	/**

--- a/inc/ThirdParty/Plugins/CDN/Cloudflare.php
+++ b/inc/ThirdParty/Plugins/CDN/Cloudflare.php
@@ -458,8 +458,8 @@ class Cloudflare implements Subscriber_Interface, DeactivationInterface {
 	 */
 	public function deactivate() {
 		$this->purge_cloudflare();
-  }
-  
+	}
+
 	/**
 	 * Unregister Call on clean posts.
 	 *


### PR DESCRIPTION
## Description

In the previous PR: https://github.com/wp-media/wp-rocket/pull/6156 we called the method `set_claim_filter` from inside the store instance without making sure that it's there or not (this method is there from version 3.6.0) and inside WP Rocket we still use version 3.5.4 so this method isn't there at all and will produce a fatal error if called directly.

Fixes #6119

## Type of change

*Please delete options that are not relevant.*

- Bug fix (non-breaking change which fixes an issue).

## Is the solution different from the one proposed during the grooming?

Not groomed, the customer discovered it and I created this PR to fix it before going live with the other PR.

# Checklists

## Generic development checklist

- [x] My code follows the style guidelines of this project, with adapted comments and without new warnings.
- [ ] I have added unit and integration tests that prove my fix is effective or that my feature works.
- [x] The CI passes locally with my changes (including unit tests, integration tests, linter).
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] If applicable, I have made corresponding changes to the documentation. *Provide a link to the documentation.*

## Test summary

- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I validated all Acceptance Criteria of the related issues. (If applicable, provide proof).
- [ ] I validated all test plan the QA Review asked me to.

