### PR TITLE
Fix WP Rocket deactivation modal style applied to the checkboxes in the plugins page in WordPress 6.3

### DIFF
--- a/assets/css/wpr-modal.css
+++ b/assets/css/wpr-modal.css
@@ -16,6 +16,7 @@
 	display: flex;
 	justify-content: center;
 	align-items: center;
+	z-index: 100;
 }
 
 .wpr-modal-container {


### PR DESCRIPTION
## Description

WP Rocket deactivation modal styles are applied to the checkboxes in the plugins page from WordPress 6.3, causing possible UI interference. The boxes from the plugin list (in background) are clickable when the modal is opened (in foreground). 

The issue can be fixed by modifying the `z-index` of the modal element. 

Fixes #6110

## Type of change

- Enhancement (non-breaking change which improves an existing functionality).

## Is the solution different from the one proposed during the grooming?

No. 

# Checklists

## Generic development checklist

- [x] My code follows the style guidelines of this project, with adapted comments and without new warnings.
- [ ] I have added unit and integration tests that prove my fix is effective or that my feature works.
- [ ] The CI passes locally with my changes (including unit tests, integration tests, linter).
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] If applicable, I have made corresponding changes to the documentation. *Provide a link to the documentation.*

## Test summary

- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I validated all Acceptance Criteria of the related issues. (If applicable, provide proof).
- [ ] I validated all test plan the QA Review asked me to.

*If not, detail what you could not test.*

*Please describe any additional tests you performed.*
