### PR TITLE
fix Background-image lazy-loading with WPML

### DIFF
--- a/inc/Engine/Media/Lazyload/CSS/Front/Extractor.php
+++ b/inc/Engine/Media/Lazyload/CSS/Front/Extractor.php
@@ -197,7 +197,7 @@ class Extractor {
 			return $url;
 		}
 
-		return home_url() . '/' . trim( $url, '/ ' );
+		return rocket_get_home_url() . '/' . trim( $url, '/ ' );
 	}
 
 	/**
@@ -213,7 +213,7 @@ class Extractor {
 			return false;
 		}
 
-		$home_host = wp_parse_url( home_url(), PHP_URL_HOST );
+		$home_host = wp_parse_url( rocket_get_home_url(), PHP_URL_HOST );
 
 		return $host !== $home_host;
 	}

--- a/inc/Engine/Media/Lazyload/CSS/Subscriber.php
+++ b/inc/Engine/Media/Lazyload/CSS/Subscriber.php
@@ -530,7 +530,7 @@ class Subscriber implements Subscriber_Interface, LoggerAwareInterface {
 		$parsed_url_host = wp_parse_url( $string, PHP_URL_HOST );
 
 		if ( ! $parsed_url_host ) {
-			$values [] = home_url() . $string;
+			$values [] = rocket_get_home_url() . $string;
 		}
 
 		/**


### PR DESCRIPTION
## Description

Fix background-image lazy-loading with WPML by using the correct URL without the translation

Fixes #6178

## Type of change
- Bug fix (non-breaking change which fixes an issue).


## Is the solution different from the one proposed during the grooming?

No
# Checklists

## Generic development checklist

- [x] My code follows the style guidelines of this project, with adapted comments and without new warnings.
- [x] The CI passes locally with my changes (including unit tests, integration tests, linter).

## Test summary

- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I validated all Acceptance Criteria of the related issues. (If applicable, provide proof).
- [ ] I validated all test plan the QA Review asked me to.

I couldn't test WPML domain base setup locally but it should work
