### PR TITLE
Add htaccess redirect rules for WebP images

### DIFF
--- a/inc/functions/htaccess.php
+++ b/inc/functions/htaccess.php
@@ -356,6 +356,12 @@ function rocket_get_webp_rewritecond( $cache_dir_path ) {
 	$rules  = 'RewriteCond %{HTTP_ACCEPT} image/webp' . PHP_EOL;
 	$rules .= 'RewriteCond "' . $cache_dir_path . '/.no-webp" !-f' . PHP_EOL;
 	$rules .= 'RewriteRule .* - [E=WPR_WEBP:-webp]' . PHP_EOL;
+	// Check if an image was requested.
+	$rules .='RewriteCond %{REQUEST_FILENAME} (.*)\.(jpe?g|png|gif|bmp)$';
+	// Check if WebP replacement image exists.
+	$rules .= 'RewriteCond %{REQUEST_FILENAME}.webp -f';
+	// Serve WebP image instead.
+	$rules .= 'RewriteRule (.+)\.(jpe?g|png|gif)$ $1.$2.webp [T=image/webp,E=accept:1]';
 
 	/**
 	 * Filter rules for webp.


### PR DESCRIPTION
## Description

If the [WebP Compatibility](https://docs.wp-rocket.me/article/1282-webp) is enabled, the website serves only WebP images that are directly linked from the HTML source of the page. It doesn’t serve WebP equivalents of images:
- linked from CSS files
- linked from JS files
- linked from encoded JS data inside HTML source
- with URLs dynamically loaded via API call or other means

This pull request adds extra redirect rules that will be placed in the `.htaccess` file. These rules will results in loading WebP equivalents of JPG, PNG and BMP images if they exists on the filesystem.

## Request for feedback
- Is there a reason why this wasn’t already part of the plugin?
- Were there some concerns regarding this solution?

## Type of change
- Enhancement (non-breaking change which improves an existing functionality).

# Checklists

## Generic development checklist

- [x] My code follows the style guidelines of this project, with adapted comments and without new warnings.
- [x] The CI passes locally with my changes (including unit tests, integration tests, linter).

## Test summary

- [x] I have performed a self-review of my own code
- [x] Existing unit tests pass locally with my changes
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
