### PR TITLE
Closes #6175 Fatal error related to Logger

### DIFF
--- a/inc/Engine/Cache/PurgeActionsSubscriber.php
+++ b/inc/Engine/Cache/PurgeActionsSubscriber.php
@@ -57,6 +57,7 @@ class PurgeActionsSubscriber implements Subscriber_Interface {
 			'rocket_after_save_dynamic_lists'     => 'purge_cache_after_saving_dynamic_lists',
 			'update_option_' . $slug              => [ 'purge_cache_reject_uri_partially', 10, 2 ],
 			'update_option_blog_public'           => 'purge_cache',
+			'wp_rocket_upgrade'                   => [ 'on_update', 10, 2 ],
 		];
 	}
 
@@ -192,5 +193,20 @@ class PurgeActionsSubscriber implements Subscriber_Interface {
 			return;
 		}
 		$this->purge_cache();
+	}
+
+	/**
+	 * Regenerate the advanced cache file on update
+	 *
+	 * @param string $new_version New plugin version.
+	 * @param string $old_version Previous plugin version.
+	 *
+	 * @return void
+	 */
+	public function on_update( $new_version, $old_version ) {
+		if ( version_compare( $old_version, '3.15.3', '>=' ) ) {
+			return;
+		}
+		rocket_generate_advanced_cache_file();
 	}
 }

--- a/tests/Fixtures/content/endingContent.php
+++ b/tests/Fixtures/content/endingContent.php
@@ -33,11 +33,15 @@ spl_autoload_register(
 				}
 			}
 		} elseif ( strpos( $class, 'WP_Rocket\\Dependencies\\Monolog\\' ) === 0 ) {
+			$class = str_replace( 'WP_Rocket\\Dependencies\\Monolog\\', '', $class );
+
 			$file = $rocket_path . 'inc/Dependencies/Monolog/' . str_replace( '\\', '/', $class ) . '.php';
 			if ( ! file_exists( $file ) ) {
 				$file = $rocket_path . 'vendor/monolog/monolog/src/' . str_replace( '\\', '/', $class ) . '.php';
 			}
 		} elseif ( strpos( $class, 'WP_Rocket\\Dependencies\\Psr\\Log\\' ) === 0 ) {
+			$class = str_replace( 'WP_Rocket\\Dependencies\\Psr\\Log\\', '', $class );
+
 			$file = $rocket_path . 'inc/Dependencies/Psr/Log/' . str_replace( '\\', '/', $class ) . '.php';
 			if ( ! file_exists( $file ) ) {
 				$file = $rocket_path . 'vendor/psr/log/' . str_replace( '\\', '/', $class ) . '.php';

--- a/tests/Fixtures/inc/Engine/Cache/PurgeActionsSubscriber/onUpdate.php
+++ b/tests/Fixtures/inc/Engine/Cache/PurgeActionsSubscriber/onUpdate.php
@@ -1,0 +1,17 @@
+<?php
+return [
+	'NotSuperiorShouldGenerate' => [
+		'config' => [
+			'new_version' => '3.15',
+			'old_version' => '3.14',
+			'is_superior' => false
+		],
+	],
+	'SuperiorShouldNotGenerate' => [
+		'config' => [
+			'new_version' => '3.17',
+			'old_version' => '3.16',
+			'is_superior' => true
+		],
+	],
+];

--- a/tests/Unit/inc/Engine/Cache/PurgeActionsSubscriber/onUpdate.php
+++ b/tests/Unit/inc/Engine/Cache/PurgeActionsSubscriber/onUpdate.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\Cache\PurgeActionsSubscriber;
+
+use Brain\Monkey\Functions;
+use Mockery;
+use WP_Rocket\Engine\Cache\{PurgeActionsSubscriber,Purge};
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @covers WP_Rocket\Engine\Cache\PurgeActionsSubscriber::on_update
+ */
+class Test_onUpdate extends TestCase {
+	private $subscriber;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		Functions\stubTranslationFunctions();
+
+		$this->subscriber = new PurgeActionsSubscriber(
+			Mockery::mock( Options_Data::class ),
+			Mockery::mock( Purge::class )
+		);
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldDoAsExpected( $config )
+	{
+		if ( $config['is_superior'] ) {
+			Functions\expect( 'rocket_generate_advanced_cache_file' )->never();
+		} else {
+			Functions\expect( 'rocket_generate_advanced_cache_file' )->once();
+		}
+
+		$this->subscriber->on_update( $config['new_version'], $config['old_version'] );
+	}
+}

--- a/views/cache/advanced-cache.php
+++ b/views/cache/advanced-cache.php
@@ -61,11 +61,15 @@ spl_autoload_register(
 				}
 			}
 		} elseif ( strpos( $class, 'WP_Rocket\\Dependencies\\Monolog\\' ) === 0 ) {
+			$class = str_replace( 'WP_Rocket\\Dependencies\\Monolog\\', '', $class );
+
 			$file = $rocket_path . 'inc/Dependencies/Monolog/' . str_replace( '\\', '/', $class ) . '.php';
 			if ( ! file_exists( $file ) ) {
 				$file = $rocket_path . 'vendor/monolog/monolog/src/' . str_replace( '\\', '/', $class ) . '.php';
 			}
 		} elseif ( strpos( $class, 'WP_Rocket\\Dependencies\\Psr\\Log\\' ) === 0 ) {
+			$class = str_replace( 'WP_Rocket\\Dependencies\\Psr\\Log\\', '', $class );
+
 			$file = $rocket_path . 'inc/Dependencies/Psr/Log/' . str_replace( '\\', '/', $class ) . '.php';
 			if ( ! file_exists( $file ) ) {
 				$file = $rocket_path . 'vendor/psr/log/' . str_replace( '\\', '/', $class ) . '.php';


### PR DESCRIPTION
## Description

When enabling the debug mode of WP Rocket, we get a fatal error related to Monolog.
As explained in the grooming this is due to Mozart. 

Fixes #6175

## Type of change

*Please delete options that are not relevant.*

- Bug fix (non-breaking change which fixes an issue).

## Is the solution different from the one proposed during the grooming?

No

# Checklists

## Generic development checklist

- [x] My code follows the style guidelines of this project, with adapted comments and without new warnings.
- [x] I have added unit and integration tests that prove my fix is effective or that my feature works.
- [x] The CI passes locally with my changes (including unit tests, integration tests, linter).
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] If applicable, I have made corresponding changes to the documentation. *Provide a link to the documentation.*

## Test summary

- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I validated all Acceptance Criteria of the related issues. (If applicable, provide proof).
- [ ] I validated all test plan the QA Review asked me to.
