### PR TITLE
Closes #6199: Lazyload CSS Background Images triggers DOMException errors because of incorrect selector

### DIFF
--- a/inc/Engine/Media/Lazyload/CSS/Front/Extractor.php
+++ b/inc/Engine/Media/Lazyload/CSS/Front/Extractor.php
@@ -39,7 +39,7 @@ class Extractor {
 
 		$background_regex = '(?<selector>(?:[ \-,:\w.()\n\r^>[*"\'=\]#]|(?:\[[^\]]+\]))+)\s?{[^{}]*background\s*:(?<property>[^;}]*)[^}]*}';
 
-		$background_image_regex = '(?<selector>[ \-,:\w.()\n\r>^[*"\'=\]#]+)\s?{[^{}]*background-image\s*:(?<property>[^;}]*)[^}]*}';
+		$background_image_regex = '(?<selector>(?:[ \-,:\w.()\n\r^>[*"\'=\]#]|(?:\[[^\]]+\]))+)\s?{[^{}]*background-image\s*:(?<property>[^;}]*)[^}]*}';
 
 		/**
 		 * Lazyload background property regex.

--- a/inc/Engine/Media/Lazyload/CSS/Front/Extractor.php
+++ b/inc/Engine/Media/Lazyload/CSS/Front/Extractor.php
@@ -37,7 +37,7 @@ class Extractor {
 			$content
 			);
 
-		$background_regex = '(?<selector>[ \-,:\w.()\n\r^>[*"\'=\]#]+)\s?{[^{}]*background\s*:(?<property>[^;}]*)[^}]*}';
+		$background_regex = '(?<selector>(?:[ \-,:\w.()\n\r^>[*"\'=\]#]|(?:\[[^\]]+\]))+)\s?{[^{}]*background\s*:(?<property>[^;}]*)[^}]*}';
 
 		$background_image_regex = '(?<selector>[ \-,:\w.()\n\r>^[*"\'=\]#]+)\s?{[^{}]*background-image\s*:(?<property>[^;}]*)[^}]*}';
 

--- a/tests/Fixtures/inc/Engine/Media/Lazyload/CSS/Front/Extractor/CSS/content_with_url.php
+++ b/tests/Fixtures/inc/Engine/Media/Lazyload/CSS/Front/Extractor/CSS/content_with_url.php
@@ -146,3 +146,7 @@ background-color: #c63dd8;
  [title~="wp-rocket"] {
  background: url("/wp-content/rocket-test-data/images/wp-rocket.svg") no-repeat;
  }
+
+ [title~="wp-rocket-image"] {
+ background-image: url("/wp-content/rocket-test-data/images/wp-rocket.svg") no-repeat;
+ }

--- a/tests/Fixtures/inc/Engine/Media/Lazyload/CSS/Front/Extractor/CSS/content_with_url.php
+++ b/tests/Fixtures/inc/Engine/Media/Lazyload/CSS/Front/Extractor/CSS/content_with_url.php
@@ -142,3 +142,7 @@ background-color: #c63dd8;
  background-image: url(https://www.villmarksbua.no/wp-content/uploads/2022/03/nordic-pocket-saw-foldbar-tursag-for-tre-og-metall.jpg);
  }
  }
+
+ [title~="wp-rocket"] {
+ background: url("/wp-content/rocket-test-data/images/wp-rocket.svg") no-repeat;
+ }

--- a/tests/Fixtures/inc/Engine/Media/Lazyload/CSS/Front/Extractor/extract.php
+++ b/tests/Fixtures/inc/Engine/Media/Lazyload/CSS/Front/Extractor/extract.php
@@ -167,6 +167,16 @@ padding: 15px;
  }'
 				]
 			],
+			'[title~="wp-rocket-image"]' => [
+				[
+					'selector' => '[title~="wp-rocket-image"]',
+					'url' => "url('/wp-content/rocket-test-data/images/wp-rocket.svg')",
+					'original' => 'url("/wp-content/rocket-test-data/images/wp-rocket.svg")',
+					'block' => '[title~="wp-rocket-image"] {
+ background-image: url("/wp-content/rocket-test-data/images/wp-rocket.svg") no-repeat;
+ }'
+				]
+			],
 			'.external-css-background-image' => [
 				[
 					'selector' => '.external-css-background-image',

--- a/tests/Fixtures/inc/Engine/Media/Lazyload/CSS/Front/Extractor/extract.php
+++ b/tests/Fixtures/inc/Engine/Media/Lazyload/CSS/Front/Extractor/extract.php
@@ -157,6 +157,16 @@ padding: 15px;
  }'
 				]
 			],
+			'[title~="wp-rocket"]' => [
+				[
+					'selector' => '[title~="wp-rocket"]',
+					'url' => "url('/wp-content/rocket-test-data/images/wp-rocket.svg')",
+					'original' => 'url("/wp-content/rocket-test-data/images/wp-rocket.svg")',
+					'block' => '[title~="wp-rocket"] {
+ background: url("/wp-content/rocket-test-data/images/wp-rocket.svg") no-repeat;
+ }'
+				]
+			],
 			'.external-css-background-image' => [
 				[
 					'selector' => '.external-css-background-image',

--- a/tests/Fixtures/inc/Engine/Media/Lazyload/CSS/Front/TagGenerator/generate.php
+++ b/tests/Fixtures/inc/Engine/Media/Lazyload/CSS/Front/TagGenerator/generate.php
@@ -3,9 +3,9 @@
 $tags = <<<TAG
 <style id="wpr-lazyload-bg"></style><style id="wpr-lazyload-bg-exclusion">:root{--wpr-bg-15ef8: url(https://domain.ext/path/to/background.ext); }</style>
 <noscript>
-<style id="wpr-lazyload-bg-nostyle">:root{--wpr-bg-16ef9: url(https://domain.ext/path/to/background2.ext); }:root{--wpr-bg-17ef6: url(https://domain.ext/path/to/background3.ext); }</style>
+<style id="wpr-lazyload-bg-nostyle">:root{--wpr-bg-16ef9: url(https://domain.ext/path/to/background2.ext); }:root{--wpr-bg-17ef6: url(https://domain.ext/path/to/background3.ext); }:root{--wpr-bg-18ef6: url(https://domain.ext/path/to/background3.ext); }</style>
 </noscript>
-<script type="application/javascript">const rocket_pairs = [{"selector":"#section_2_hash","style":":root{--wpr-bg-16ef9: url(https:\/\/domain.ext\/path\/to\/background2.ext); }"},{"selector":"title~=\"wp-rocket\"","style":":root{--wpr-bg-17ef6: url(https:\/\/domain.ext\/path\/to\/background3.ext); }"}]; const rocket_excluded_pairs = [{"selector":".internal-css-background-image","style":":root{--wpr-bg-15ef8: url(https:\/\/domain.ext\/path\/to\/background.ext); }"}];</script>
+<script type="application/javascript">const rocket_pairs = [{"selector":"#section_2_hash","style":":root{--wpr-bg-16ef9: url(https:\/\/domain.ext\/path\/to\/background2.ext); }"},{"selector":"title~=\"wp-rocket\"","style":":root{--wpr-bg-17ef6: url(https:\/\/domain.ext\/path\/to\/background3.ext); }"},{"selector":"title~=\"wp-rocket-image\"","style":":root{--wpr-bg-18ef6: url(https:\/\/domain.ext\/path\/to\/background3.ext); }"}]; const rocket_excluded_pairs = [{"selector":".internal-css-background-image","style":":root{--wpr-bg-15ef8: url(https:\/\/domain.ext\/path\/to\/background.ext); }"}];</script>
 TAG;
 
 
@@ -24,6 +24,10 @@ return [
 				  [
 					  'selector' => 'title~="wp-rocket"',
 					  'style' => ':root{--wpr-bg-17ef6: url(https://domain.ext/path/to/background3.ext); }'
+				  ],
+				  [
+					  'selector' => 'title~="wp-rocket-image"',
+					  'style' => ':root{--wpr-bg-18ef6: url(https://domain.ext/path/to/background3.ext); }'
 				  ]
 			  ],
               'loaded' => [

--- a/tests/Fixtures/inc/Engine/Media/Lazyload/CSS/Front/TagGenerator/generate.php
+++ b/tests/Fixtures/inc/Engine/Media/Lazyload/CSS/Front/TagGenerator/generate.php
@@ -3,9 +3,9 @@
 $tags = <<<TAG
 <style id="wpr-lazyload-bg"></style><style id="wpr-lazyload-bg-exclusion">:root{--wpr-bg-15ef8: url(https://domain.ext/path/to/background.ext); }</style>
 <noscript>
-<style id="wpr-lazyload-bg-nostyle">:root{--wpr-bg-16ef9: url(https://domain.ext/path/to/background2.ext); }</style>
+<style id="wpr-lazyload-bg-nostyle">:root{--wpr-bg-16ef9: url(https://domain.ext/path/to/background2.ext); }:root{--wpr-bg-17ef6: url(https://domain.ext/path/to/background3.ext); }</style>
 </noscript>
-<script type="application/javascript">const rocket_pairs = [{"selector":"#section_2_hash","style":":root{--wpr-bg-16ef9: url(https:\/\/domain.ext\/path\/to\/background2.ext); }"}]; const rocket_excluded_pairs = [{"selector":".internal-css-background-image","style":":root{--wpr-bg-15ef8: url(https:\/\/domain.ext\/path\/to\/background.ext); }"}];</script>
+<script type="application/javascript">const rocket_pairs = [{"selector":"#section_2_hash","style":":root{--wpr-bg-16ef9: url(https:\/\/domain.ext\/path\/to\/background2.ext); }"},{"selector":"title~=\"wp-rocket\"","style":":root{--wpr-bg-17ef6: url(https:\/\/domain.ext\/path\/to\/background3.ext); }"}]; const rocket_excluded_pairs = [{"selector":".internal-css-background-image","style":":root{--wpr-bg-15ef8: url(https:\/\/domain.ext\/path\/to\/background.ext); }"}];</script>
 TAG;
 
 
@@ -21,6 +21,10 @@ return [
 					  'selector' => '#section_2_hash',
 					  'style' => ":root{--wpr-bg-16ef9: url(https://domain.ext/path/to/background2.ext); }"
 				  ],
+				  [
+					  'selector' => 'title~="wp-rocket"',
+					  'style' => ':root{--wpr-bg-17ef6: url(https://domain.ext/path/to/background3.ext); }'
+				  ]
 			  ],
               'loaded' => [
 				  [


### PR DESCRIPTION
## Description
As explain in the issue first message.

Fixes #6199 

## Type of change

- Bug fix (non-breaking change which fixes an issue).

## Is the solution different from the one proposed during the grooming?

No

# Checklists

## Generic development checklist

- [x] My code follows the style guidelines of this project, with adapted comments and without new warnings.
- [x] I have added unit and integration tests that prove my fix is effective or that my feature works.
- [x] The CI passes locally with my changes (including unit tests, integration tests, linter).
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] If applicable, I have made corresponding changes to the documentation. *Provide a link to the documentation.*

## Test summary

- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I validated all Acceptance Criteria of the related issues. (If applicable, provide proof).
- [ ] I validated all test plan the QA Review asked me to.
