### PR TITLE
Closes #6206: Conflict with Advanced Ads plugin causes fatal error when viewing Popular tab in the Ad New plugins page

### DIFF
--- a/inc/Engine/Plugin/InformationSubscriber.php
+++ b/inc/Engine/Plugin/InformationSubscriber.php
@@ -177,6 +177,9 @@ class InformationSubscriber implements Subscriber_Interface {
 
 			if ( in_array( $slug, $result_slugs, true ) ) {
 				foreach ( $result->plugins as $index => $plugin ) {
+					if ( is_object( $plugin ) ) {
+						$plugin = (array) $plugin;
+					}
 					if ( $slug === $plugin['slug'] ) {
 						$move = $plugin;
 						unset( $result->plugins[ $index ] );


### PR DESCRIPTION
## Description
As explained in the first message of the issue, some plugins are retrieved as an object and some other as an array. 
As we were only focusing on array structure, it could happen to have errors.

Fixes #6206 

## Type of change

- Bug fix (non-breaking change which fixes an issue).

## Is the solution different from the one proposed during the grooming?

No

# Checklists

## Generic development checklist

- [x] My code follows the style guidelines of this project, with adapted comments and without new warnings.
- [x] I have added unit and integration tests that prove my fix is effective or that my feature works.
- [x] The CI passes locally with my changes (including unit tests, integration tests, linter).
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] If applicable, I have made corresponding changes to the documentation. *Provide a link to the documentation.*

## Test summary

- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I validated all Acceptance Criteria of the related issues. (If applicable, provide proof).
- [ ] I validated all test plan the QA Review asked me to.
