### PR TITLE
Close #3444 Added code to delete params files

### DIFF
--- a/inc/Engine/Cache/Purge.php
+++ b/inc/Engine/Cache/Purge.php
@@ -74,7 +74,7 @@ class Purge {
 
 			foreach ( $this->get_iterator( $path ) as $item ) {
 
-				if ( $item->isFile() || str_contains($item->getPathname(), '#' ) ) {
+				if ( $item->isFile() || str_contains( $item->getPathname(), '#' ) ) {
 					$this->filesystem->delete( $item->getPathname(), true );
 				}
 			}

--- a/inc/Engine/Cache/Purge.php
+++ b/inc/Engine/Cache/Purge.php
@@ -74,7 +74,12 @@ class Purge {
 
 			foreach ( $this->get_iterator( $path ) as $item ) {
 
-				if ( $item->isFile() || str_contains( $item->getPathname(), '#' ) ) {
+				if ( $item->isFile() ) {
+					$this->filesystem->delete( $item->getPathname() );
+					continue;
+				}
+
+				if ( str_contains( $item->getPathname(), '#' ) ) {
 					$this->filesystem->delete( $item->getPathname(), true );
 				}
 			}

--- a/inc/Engine/Cache/Purge.php
+++ b/inc/Engine/Cache/Purge.php
@@ -73,8 +73,9 @@ class Purge {
 			}
 
 			foreach ( $this->get_iterator( $path ) as $item ) {
-				if ( $item->isFile() ) {
-					$this->filesystem->delete( $item->getPathname() );
+
+				if ( $item->isFile() || str_contains($item->getPathname(), '#' ) ) {
+					$this->filesystem->delete( $item->getPathname(), true );
 				}
 			}
 

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -709,6 +709,14 @@ function rocket_clean_home( $lang = '' ) {
 		}
 	}
 
+	$param_dirs = glob( $root . '/#*', GLOB_NOSORT );
+
+	if ( $param_dirs ) {
+		foreach ( $param_dirs as $dir ) {
+			rocket_rrmdir( $dir );
+		}
+	}
+
 	// Remove the hidden empty file for mobile detection on NGINX with the Rocket NGINX configuration.
 	$nginx_mobile_detect_files = glob( $root . '/.mobile-active', GLOB_NOSORT );
 	if ( $nginx_mobile_detect_files ) {


### PR DESCRIPTION
## Description

In this PR we fix a problem in the cache cleaning where params cache from homepage are not cleared when a post is updated.
This has been fixed by adding a check on folders starting with # and if some exist we delete them.

Fixes #3444

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Is the solution different from the one proposed during the grooming?

No.

## How Has This Been Tested?

- [ ] Manual Test

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
