### PR TITLE
Closes #4226: Importing data should not clear cache

### DIFF
--- a/inc/Engine/Cache/Purge.php
+++ b/inc/Engine/Cache/Purge.php
@@ -180,15 +180,6 @@ class Purge {
 	 * @param WP_Post $post Post object.
 	 */
 	public function purge_post_terms_urls( WP_Post $post ) {
-		/**
-		 * Filter use to determine if we are currently importing data into the WordPress.
-		 * Bails out if this filter returns true.
-		 *
-		 * @param boolean Tells if we are importing or not.
-		 */
-		if ( (bool) apply_filters( 'rocket_importing_mode', false ) || defined( 'WP_IMPORTING' ) ) {
-			return;
-		}
 		$urls = $this->get_post_terms_urls( $post );
 		foreach ( $urls as $url ) {
 			$this->purge_url( $url, true );

--- a/inc/Engine/Cache/Purge.php
+++ b/inc/Engine/Cache/Purge.php
@@ -180,6 +180,15 @@ class Purge {
 	 * @param WP_Post $post Post object.
 	 */
 	public function purge_post_terms_urls( WP_Post $post ) {
+		/**
+		 * Filter use to determine if we are currently importing data into the WordPress.
+		 * Bails out if this filter returns true.
+		 *
+		 * @param boolean Tells if we are importing or not.
+		 */
+		if ( (bool) apply_filters( 'rocket_importing_mode', false ) || defined( 'WP_IMPORTING' ) ) {
+			return;
+		}
 		$urls = $this->get_post_terms_urls( $post );
 		foreach ( $urls as $url ) {
 			$this->purge_url( $url, true );

--- a/inc/Engine/Cache/PurgeActionsSubscriber.php
+++ b/inc/Engine/Cache/PurgeActionsSubscriber.php
@@ -89,13 +89,7 @@ class PurgeActionsSubscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function maybe_purge_cache_on_term_change( $term_id, $tt_id, $taxonomy ) {
-		/**
-		 * Filter use to determine if we are currently importing data into the WordPress.
-		 * Bails out if this filter returns true.
-		 *
-		 * @param boolean Tells if we are importing or not.
-		 */
-		if ( (bool) apply_filters( 'rocket_importing_mode', false ) || defined( 'WP_IMPORTING' ) ) {
+		if ( rocket_is_importing() ) {
 			return;
 		}
 

--- a/inc/Engine/Cache/PurgeActionsSubscriber.php
+++ b/inc/Engine/Cache/PurgeActionsSubscriber.php
@@ -1,6 +1,7 @@
 <?php
 namespace WP_Rocket\Engine\Cache;
 
+use WP_Post;
 use WP_Rocket\Event_Management\Subscriber_Interface;
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Logger\Logger;
@@ -88,6 +89,16 @@ class PurgeActionsSubscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function maybe_purge_cache_on_term_change( $term_id, $tt_id, $taxonomy ) {
+		/**
+		 * Filter use to determine if we are currently importing data into the WordPress.
+		 * Bails out if this filter returns true.
+		 *
+		 * @param boolean Tells if we are importing or not.
+		 */
+		if ( (bool) apply_filters( 'rocket_importing_mode', false ) || defined( 'WP_IMPORTING' ) ) {
+			return;
+		}
+
 		if ( ! $this->is_taxonomy_public( $taxonomy ) ) {
 			return;
 		}

--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -172,6 +172,16 @@ if ( ! function_exists( 'rocket_get_purge_urls' ) ) {
  * @param WP_Post $post    WP_Post object.
  */
 function rocket_clean_post( $post_id, $post = null ) {
+	/**
+	 * Filter use to determine if we are currently importing data into the Wordpress.
+	 * Bails out if this filter returns true.
+	 *
+	 * @param boolean Tells if we are importing or not.
+	 */
+	if ( (bool) apply_filters( 'rocket_importing_mode', false ) ) {
+		return;
+	}
+
 	static $done = [];
 
 	if ( isset( $done[ $post_id ] ) ) {
@@ -288,6 +298,16 @@ add_action( 'wp_update_comment_count', 'rocket_clean_post' );
  * @param array $post_data Array of unslashed post data.
  */
 function rocket_clean_post_cache_on_status_change( $post_id, $post_data ) {
+	/**
+	 * Filter use to determine if we are currently importing data into the Wordpress.
+	 * Bails out if this filter returns true.
+	 *
+	 * @param boolean Tells if we are importing or not.
+	 */
+	if ( (bool) apply_filters( 'rocket_importing_mode', false ) ) {
+		return;
+	}
+
 	if ( 'publish' !== get_post_field( 'post_status', $post_id ) || 'draft' !== $post_data['post_status'] ) {
 		return;
 	}
@@ -575,6 +595,16 @@ add_action( 'admin_post_purge_cache', 'do_admin_post_rocket_purge_cache' );
  * @param array       $hook_extra  Array of bulk item update data.
  */
 function rocket_clean_cache_theme_update( $wp_upgrader, $hook_extra ) {
+	/**
+	 * Filter use to determine if we are currently importing data into the Wordpress.
+	 * Bails out if this filter returns true.
+	 *
+	 * @param boolean Tells if we are importing or not.
+	 */
+	if ( (bool) apply_filters( 'rocket_importing_mode', false ) ) {
+		return;
+	}
+
 	if ( ! isset( $hook_extra['action'] ) || 'update' !== $hook_extra['action'] ) {
 		return;
 	}
@@ -611,6 +641,16 @@ add_action( 'upgrader_process_complete', 'rocket_clean_cache_theme_update', 10, 
  * @param array $post_data Array of unslashed post data.
  */
 function rocket_clean_post_cache_on_slug_change( $post_id, $post_data ) {
+	/**
+	 * Filter use to determine if we are currently importing data into the Wordpress.
+	 * Bails out if this filter returns true.
+	 *
+	 * @param boolean Tells if we are importing or not.
+	 */
+	if ( (bool) apply_filters( 'rocket_importing_mode', false ) ) {
+		return;
+	}
+
 	// Bail out if the post status is draft, pending or auto-draft.
 	if ( in_array( get_post_field( 'post_status', $post_id ), [ 'draft', 'pending', 'auto-draft', 'trash' ], true ) ) {
 		return;

--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -172,13 +172,7 @@ if ( ! function_exists( 'rocket_get_purge_urls' ) ) {
  * @param WP_Post $post    WP_Post object.
  */
 function rocket_clean_post( $post_id, $post = null ) {
-	/**
-	 * Filter use to determine if we are currently importing data into the WordPress.
-	 * Bails out if this filter returns true.
-	 *
-	 * @param boolean Tells if we are importing or not.
-	 */
-	if ( (bool) apply_filters( 'rocket_importing_mode', false ) || defined( 'WP_IMPORTING' ) ) {
+	if ( rocket_is_importing() ) {
 		return;
 	}
 
@@ -298,13 +292,7 @@ add_action( 'wp_update_comment_count', 'rocket_clean_post' );
  * @param array $post_data Array of unslashed post data.
  */
 function rocket_clean_post_cache_on_status_change( $post_id, $post_data ) {
-	/**
-	 * Filter use to determine if we are currently importing data into the WordPress.
-	 * Bails out if this filter returns true.
-	 *
-	 * @param boolean Tells if we are importing or not.
-	 */
-	if ( (bool) apply_filters( 'rocket_importing_mode', false ) || defined( 'WP_IMPORTING' ) ) {
+	if ( rocket_is_importing() ) {
 		return;
 	}
 
@@ -595,13 +583,7 @@ add_action( 'admin_post_purge_cache', 'do_admin_post_rocket_purge_cache' );
  * @param array       $hook_extra  Array of bulk item update data.
  */
 function rocket_clean_cache_theme_update( $wp_upgrader, $hook_extra ) {
-	/**
-	 * Filter use to determine if we are currently importing data into the WordPress.
-	 * Bails out if this filter returns true.
-	 *
-	 * @param boolean Tells if we are importing or not.
-	 */
-	if ( (bool) apply_filters( 'rocket_importing_mode', false ) || defined( 'WP_IMPORTING' ) ) {
+	if ( rocket_is_importing() ) {
 		return;
 	}
 
@@ -641,13 +623,7 @@ add_action( 'upgrader_process_complete', 'rocket_clean_cache_theme_update', 10, 
  * @param array $post_data Array of unslashed post data.
  */
 function rocket_clean_post_cache_on_slug_change( $post_id, $post_data ) {
-	/**
-	 * Filter use to determine if we are currently importing data into the WordPress.
-	 * Bails out if this filter returns true.
-	 *
-	 * @param boolean Tells if we are importing or not.
-	 */
-	if ( (bool) apply_filters( 'rocket_importing_mode', false ) || defined( 'WP_IMPORTING' ) ) {
+	if ( rocket_is_importing() ) {
 		return;
 	}
 

--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -178,7 +178,7 @@ function rocket_clean_post( $post_id, $post = null ) {
 	 *
 	 * @param boolean Tells if we are importing or not.
 	 */
-	if ( (bool) apply_filters( 'rocket_importing_mode', false ) ) {
+	if ( (bool) apply_filters( 'rocket_importing_mode', false ) || defined( 'WP_IMPORTING' ) ) {
 		return;
 	}
 
@@ -304,7 +304,7 @@ function rocket_clean_post_cache_on_status_change( $post_id, $post_data ) {
 	 *
 	 * @param boolean Tells if we are importing or not.
 	 */
-	if ( (bool) apply_filters( 'rocket_importing_mode', false ) ) {
+	if ( (bool) apply_filters( 'rocket_importing_mode', false ) || defined( 'WP_IMPORTING' ) ) {
 		return;
 	}
 
@@ -601,7 +601,7 @@ function rocket_clean_cache_theme_update( $wp_upgrader, $hook_extra ) {
 	 *
 	 * @param boolean Tells if we are importing or not.
 	 */
-	if ( (bool) apply_filters( 'rocket_importing_mode', false ) ) {
+	if ( (bool) apply_filters( 'rocket_importing_mode', false ) || defined( 'WP_IMPORTING' ) ) {
 		return;
 	}
 
@@ -647,7 +647,7 @@ function rocket_clean_post_cache_on_slug_change( $post_id, $post_data ) {
 	 *
 	 * @param boolean Tells if we are importing or not.
 	 */
-	if ( (bool) apply_filters( 'rocket_importing_mode', false ) ) {
+	if ( (bool) apply_filters( 'rocket_importing_mode', false ) || defined( 'WP_IMPORTING' ) ) {
 		return;
 	}
 

--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -173,7 +173,7 @@ if ( ! function_exists( 'rocket_get_purge_urls' ) ) {
  */
 function rocket_clean_post( $post_id, $post = null ) {
 	/**
-	 * Filter use to determine if we are currently importing data into the Wordpress.
+	 * Filter use to determine if we are currently importing data into the WordPress.
 	 * Bails out if this filter returns true.
 	 *
 	 * @param boolean Tells if we are importing or not.
@@ -299,7 +299,7 @@ add_action( 'wp_update_comment_count', 'rocket_clean_post' );
  */
 function rocket_clean_post_cache_on_status_change( $post_id, $post_data ) {
 	/**
-	 * Filter use to determine if we are currently importing data into the Wordpress.
+	 * Filter use to determine if we are currently importing data into the WordPress.
 	 * Bails out if this filter returns true.
 	 *
 	 * @param boolean Tells if we are importing or not.
@@ -596,7 +596,7 @@ add_action( 'admin_post_purge_cache', 'do_admin_post_rocket_purge_cache' );
  */
 function rocket_clean_cache_theme_update( $wp_upgrader, $hook_extra ) {
 	/**
-	 * Filter use to determine if we are currently importing data into the Wordpress.
+	 * Filter use to determine if we are currently importing data into the WordPress.
 	 * Bails out if this filter returns true.
 	 *
 	 * @param boolean Tells if we are importing or not.
@@ -642,7 +642,7 @@ add_action( 'upgrader_process_complete', 'rocket_clean_cache_theme_update', 10, 
  */
 function rocket_clean_post_cache_on_slug_change( $post_id, $post_data ) {
 	/**
-	 * Filter use to determine if we are currently importing data into the Wordpress.
+	 * Filter use to determine if we are currently importing data into the WordPress.
 	 * Bails out if this filter returns true.
 	 *
 	 * @param boolean Tells if we are importing or not.

--- a/inc/functions/api.php
+++ b/inc/functions/api.php
@@ -148,3 +148,18 @@ function rocket_is_live_site() {
 
 	return true;
 }
+
+/**
+ * Checks if importing
+ *
+ * @return bool
+ */
+function rocket_is_importing() {
+	/**
+	* Filter use to determine if we are currently importing data into the WordPress.
+	* Bails out if this filter returns true.
+	*
+	* @param boolean Tells if we are importing or not.
+	*/
+	return ( (bool) apply_filters( 'rocket_importing_mode', false ) || defined( 'WP_IMPORTING' ) );
+}

--- a/inc/functions/api.php
+++ b/inc/functions/api.php
@@ -161,5 +161,5 @@ function rocket_is_importing() {
 	*
 	* @param boolean Tells if we are importing or not.
 	*/
-	return ( (bool) apply_filters( 'rocket_importing_mode', false ) || defined( 'WP_IMPORTING' ) );
+	return (bool) apply_filters( 'rocket_is_importing', rocket_get_constant( 'WP_IMPORTING' ) );
 }

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -803,14 +803,7 @@ function rocket_clean_home_feeds() {
  * @param WP_Filesystem_Direct|null $filesystem Optional. Instance of filesystem handler.
  */
 function rocket_clean_domain( $lang = '', $filesystem = null ) {
-
-	/**
-	 * Filter use to determine if we are currently importing data into the WordPress.
-	 * Bails out if this filter returns true.
-	 *
-	 * @param boolean Tells if we are importing or not.
-	 */
-	if ( (bool) apply_filters( 'rocket_importing_mode', false ) || defined( 'WP_IMPORTING' ) ) {
+	if ( rocket_is_importing() ) {
 		return;
 	}
 

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -810,7 +810,7 @@ function rocket_clean_domain( $lang = '', $filesystem = null ) {
 	 *
 	 * @param boolean Tells if we are importing or not.
 	 */
-	if ( (bool) apply_filters( 'rocket_importing_mode', false ) ) {
+	if ( (bool) apply_filters( 'rocket_importing_mode', false ) || defined( 'WP_IMPORTING' ) ) {
 		return;
 	}
 

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -805,7 +805,7 @@ function rocket_clean_home_feeds() {
 function rocket_clean_domain( $lang = '', $filesystem = null ) {
 
 	/**
-	 * Filter use to determine if we are currently importing data into the Wordpress.
+	 * Filter use to determine if we are currently importing data into the WordPress.
 	 * Bails out if this filter returns true.
 	 *
 	 * @param boolean Tells if we are importing or not.

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -803,10 +803,20 @@ function rocket_clean_home_feeds() {
  * @param WP_Filesystem_Direct|null $filesystem Optional. Instance of filesystem handler.
  */
 function rocket_clean_domain( $lang = '', $filesystem = null ) {
+
+	/**
+	 * Filter use to determine if we are currently importing data into the Wordpress.
+	 * Bails out if this filter returns true.
+	 *
+	 * @param boolean Tells if we are importing or not.
+	 */
+	if ( (bool) apply_filters( 'rocket_importing_mode', false ) ) {
+		return;
+	}
+
 	$urls = ( ! $lang || is_object( $lang ) || is_array( $lang ) || is_int( $lang ) )
 		? (array) get_rocket_i18n_uri()
 		: (array) get_rocket_i18n_home_url( $lang );
-
 	/**
 	 * Filter URLs to delete all caching files from a domain.
 	 *

--- a/tests/Fixtures/inc/common/rocketCleanCacheThemeUpdate.php
+++ b/tests/Fixtures/inc/common/rocketCleanCacheThemeUpdate.php
@@ -36,6 +36,18 @@ return [
 				'wp_get_theme' => null,
 			],
 		],
+		'shouldBailOutWhenImporting'  => [
+			'hook_extra' => [
+				'action' => 'update',
+				'type'   => 'plugin',
+				'themes' => [ 'default' ],
+				'importing' => true,
+			],
+			'expected'   => [
+				'cleaned'      => [],
+				'wp_get_theme' => null,
+			],
+		],
 		'shouldCleanDomain'                => [
 			'hook_extra' => [
 				'action' => 'update',


### PR DESCRIPTION
## Description
When a user is importing data to Wordpress or WooCommerce, WP Rocket is clearing cache for each new content which make the process very slow. 
Here we are offering our user a new filter `rocket_importing_mode` which will disable cache clearing. 

Fixes #4226 
## Type of change

- New feature (non-breaking change which adds functionality).


## Is the solution different from the one proposed during the grooming?

Yes, we have created a new filter `rocket_importing_mode` to let our user or thirdparties enable it to avoid cache clearing. 

# Checklists

## Generic development checklist

- [x] My code follows the style guidelines of this project, with adapted comments and without new warnings.
- [x] I have added unit and integration tests that prove my fix is effective or that my feature works.
- [x] The CI passes locally with my changes (including unit tests, integration tests, linter).
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] If applicable, I have made corresponding changes to the documentation. *Provide a link to the documentation.*

## Test summary

- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I validated all Acceptance Criteria of the related issues. (If applicable, provide proof).
- [ ] I validated all test plan the QA Review asked me to.

