### PR TITLE
Close #5918: PHP Fatal error debugging

### DIFF
--- a/tests/Fixtures/content/endingContent.php
+++ b/tests/Fixtures/content/endingContent.php
@@ -20,6 +20,14 @@ spl_autoload_register(
 				$rocket_path . 'inc/classes/logger/class-stream-handler.php',
 			],
 			'WP_Rocket\\Traits\\Memoize'         => [ $rocket_path . 'inc/classes/traits/trait-memoize.php' ],
+			'WP_Rocket\\Dependencies\\Psr\\Log'  => [
+				$rocket_path . 'inc/Dependencies/Psr/Log/' . str_replace( '\\', '/', $class ) . '.php',
+				$rocket_path . 'vendor/psr/log/src/' . str_replace( '\\', '/', $class ) . '.php',
+			],
+			'WP_Rocket\\Dependencies\\Monolog'   => [
+				$rocket_path . 'inc/Dependencies/Monolog/' . str_replace( '\\', '/', $class ) . '.php',
+				$rocket_path . 'vendor/monolog/monolog/src/' . str_replace( '\\', '/', $class ) . '.php',
+			],
 		];
 
 		if ( isset( $rocket_classes[ $class ] ) ) {
@@ -31,20 +39,6 @@ spl_autoload_register(
 					$file = $file_option;
 					break;
 				}
-			}
-		} elseif ( strpos( $class, 'WP_Rocket\\Dependencies\\Monolog\\' ) === 0 ) {
-			$class = str_replace( 'WP_Rocket\\Dependencies\\Monolog\\', '', $class );
-
-			$file = $rocket_path . 'inc/Dependencies/Monolog/' . str_replace( '\\', '/', $class ) . '.php';
-			if ( ! file_exists( $file ) ) {
-				$file = $rocket_path . 'vendor/monolog/monolog/src/' . str_replace( '\\', '/', $class ) . '.php';
-			}
-		} elseif ( strpos( $class, 'WP_Rocket\\Dependencies\\Psr\\Log\\' ) === 0 ) {
-			$class = str_replace( 'WP_Rocket\\Dependencies\\Psr\\Log\\', '', $class );
-
-			$file = $rocket_path . 'inc/Dependencies/Psr/Log/' . str_replace( '\\', '/', $class ) . '.php';
-			if ( ! file_exists( $file ) ) {
-				$file = $rocket_path . 'vendor/psr/log/' . str_replace( '\\', '/', $class ) . '.php';
 			}
 		} else {
 			return;

--- a/views/cache/advanced-cache.php
+++ b/views/cache/advanced-cache.php
@@ -48,11 +48,11 @@ spl_autoload_register(
 				$rocket_path . 'inc/classes/logger/class-stream-handler.php',
 			],
 			'WP_Rocket\\Traits\\Memoize'         => [ $rocket_path . 'inc/classes/traits/trait-memoize.php' ],
-			'WP_Rocket\\Dependencies\\Psr\\Log' => [
+			'WP_Rocket\\Dependencies\\Psr\\Log'  => [
 				$rocket_path . 'inc/Dependencies/Psr/Log/' . str_replace( '\\', '/', $class ) . '.php',
-				$rocket_path . 'vendor/psr/log/src/' . str_replace('\\', '/', $class) . '.php',
+				$rocket_path . 'vendor/psr/log/src/' . str_replace( '\\', '/', $class ) . '.php',
 			],
-			'WP_Rocket\\Dependencies\\Monolog' => [
+			'WP_Rocket\\Dependencies\\Monolog'   => [
 				$rocket_path . 'inc/Dependencies/Monolog/' . str_replace( '\\', '/', $class ) . '.php',
 				$rocket_path . 'vendor/monolog/monolog/src/' . str_replace( '\\', '/', $class ) . '.php',
 			],

--- a/views/cache/advanced-cache.php
+++ b/views/cache/advanced-cache.php
@@ -48,6 +48,14 @@ spl_autoload_register(
 				$rocket_path . 'inc/classes/logger/class-stream-handler.php',
 			],
 			'WP_Rocket\\Traits\\Memoize'         => [ $rocket_path . 'inc/classes/traits/trait-memoize.php' ],
+			'WP_Rocket\\Dependencies\\Psr\\Log' => [
+				$rocket_path . 'inc/Dependencies/Psr/Log/' . str_replace( '\\', '/', $class ) . '.php',
+				$rocket_path . 'vendor/psr/log/src/' . str_replace('\\', '/', $class) . '.php',
+			],
+			'WP_Rocket\\Dependencies\\Monolog' => [
+				$rocket_path . 'inc/Dependencies/Monolog/' . str_replace( '\\', '/', $class ) . '.php',
+				$rocket_path . 'vendor/monolog/monolog/src/' . str_replace( '\\', '/', $class ) . '.php',
+			],
 		];
 
 		if ( isset( $rocket_classes[ $class ] ) ) {
@@ -59,20 +67,6 @@ spl_autoload_register(
 					$file = $file_option;
 					break;
 				}
-			}
-		} elseif ( strpos( $class, 'WP_Rocket\\Dependencies\\Monolog\\' ) === 0 ) {
-			$class = str_replace( 'WP_Rocket\\Dependencies\\Monolog\\', '', $class );
-
-			$file = $rocket_path . 'inc/Dependencies/Monolog/' . str_replace( '\\', '/', $class ) . '.php';
-			if ( ! file_exists( $file ) ) {
-				$file = $rocket_path . 'vendor/monolog/monolog/src/' . str_replace( '\\', '/', $class ) . '.php';
-			}
-		} elseif ( strpos( $class, 'WP_Rocket\\Dependencies\\Psr\\Log\\' ) === 0 ) {
-			$class = str_replace( 'WP_Rocket\\Dependencies\\Psr\\Log\\', '', $class );
-
-			$file = $rocket_path . 'inc/Dependencies/Psr/Log/' . str_replace( '\\', '/', $class ) . '.php';
-			if ( ! file_exists( $file ) ) {
-				$file = $rocket_path . 'vendor/psr/log/' . str_replace( '\\', '/', $class ) . '.php';
 			}
 		} else {
 			return;


### PR DESCRIPTION
## Description

Depending on the Log librairie version, the path is different. As within WP Rocket we were loading it from one path, it could result into a fatal error. 

Fixes #5918 

## Type of change

*Please delete options that are not relevant.*

- Bug fix (non-breaking change which fixes an issue).

## Is the solution different from the one proposed during the grooming?

No

# Checklists

## Generic development checklist

- [x] My code follows the style guidelines of this project, with adapted comments and without new warnings.
- [ ] I have added unit and integration tests that prove my fix is effective or that my feature works.
- [x] The CI passes locally with my changes (including unit tests, integration tests, linter).
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] If applicable, I have made corresponding changes to the documentation. *Provide a link to the documentation.*

## Test summary

- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I validated all Acceptance Criteria of the related issues. (If applicable, provide proof).
- [ ] I validated all test plan the QA Review asked me to.