### PR TITLE
Closes #6301: Purging cache from post/page editor redirects to posts/pages list when using Classic

### DIFF
--- a/inc/common/admin-bar.php
+++ b/inc/common/admin-bar.php
@@ -22,7 +22,7 @@ function rocket_admin_bar( $wp_admin_bar ) {
 		 *
 		 * @param string $uri Current uri
 		 */
-		$referer = (string) apply_filters( 'rocket_admin_bar_referer', sanitize_url( $uri ) );
+		$referer = (string) apply_filters( 'rocket_admin_bar_referer', sanitize_url( $uri ) ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 		$referer = '&_wp_http_referer=' . rawurlencode( remove_query_arg( 'fl_builder', $referer ) );
 	} else {
 		$referer = '';

--- a/inc/common/admin-bar.php
+++ b/inc/common/admin-bar.php
@@ -22,7 +22,8 @@ function rocket_admin_bar( $wp_admin_bar ) {
 		 *
 		 * @param string $uri Current uri
 		 */
-		$referer = (string) esc_url_raw( apply_filters( 'rocket_admin_bar_referer', $uri ) );
+		$referer = (string) apply_filters( 'rocket_admin_bar_referer', $uri );
+		$referer = esc_url_raw( $referer );
 		$referer = '&_wp_http_referer=' . rawurlencode( remove_query_arg( 'fl_builder', $referer ) );
 	} else {
 		$referer = '';

--- a/inc/common/admin-bar.php
+++ b/inc/common/admin-bar.php
@@ -22,7 +22,7 @@ function rocket_admin_bar( $wp_admin_bar ) {
 		 *
 		 * @param string $uri Current uri
 		 */
-		$referer = (string) apply_filters( 'rocket_admin_bar_referer', sanitize_url( $uri ) ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		$referer = (string) apply_filters( 'rocket_admin_bar_referer', esc_url_raw( $uri ) );
 		$referer = '&_wp_http_referer=' . rawurlencode( remove_query_arg( 'fl_builder', $referer ) );
 	} else {
 		$referer = '';

--- a/inc/common/admin-bar.php
+++ b/inc/common/admin-bar.php
@@ -22,7 +22,7 @@ function rocket_admin_bar( $wp_admin_bar ) {
 		 *
 		 * @param string $uri Current uri
 		 */
-		$referer = (string) apply_filters( 'rocket_admin_bar_referer', esc_url( $uri ) );
+		$referer = (string) apply_filters( 'rocket_admin_bar_referer', sanitize_url( $uri ) );
 		$referer = '&_wp_http_referer=' . rawurlencode( remove_query_arg( 'fl_builder', $referer ) );
 	} else {
 		$referer = '';

--- a/inc/common/admin-bar.php
+++ b/inc/common/admin-bar.php
@@ -22,7 +22,7 @@ function rocket_admin_bar( $wp_admin_bar ) {
 		 *
 		 * @param string $uri Current uri
 		 */
-		$referer = (string) apply_filters( 'rocket_admin_bar_referer', esc_url_raw( $uri ) );
+		$referer = (string) esc_url_raw( apply_filters( 'rocket_admin_bar_referer', $uri ) );
 		$referer = '&_wp_http_referer=' . rawurlencode( remove_query_arg( 'fl_builder', $referer ) );
 	} else {
 		$referer = '';


### PR DESCRIPTION
## Description

When you click on Clear cache in the admin bar, they get redirected to the list of posts.

Fixes #6301 

## Type of change

- Bug fix (non-breaking change which fixes an issue).

## Is the solution different from the one proposed during the grooming?

No

# Checklists

## Generic development checklist

- [x] My code follows the style guidelines of this project, with adapted comments and without new warnings.
- [ ] I have added unit and integration tests that prove my fix is effective or that my feature works.
- [x] The CI passes locally with my changes (including unit tests, integration tests, linter).
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] If applicable, I have made corresponding changes to the documentation. *Provide a link to the documentation.*

## Test summary

- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I validated all Acceptance Criteria of the related issues. (If applicable, provide proof).
- [ ] I validated all test plan the QA Review asked me to.
