### PR TITLE
Closes #6278: Do not add URLs to the wpr_rocket_cache table if Preload is disabled

### DIFF
--- a/inc/Engine/Preload/Subscriber.php
+++ b/inc/Engine/Preload/Subscriber.php
@@ -449,13 +449,8 @@ class Subscriber implements Subscriber_Interface {
 	public function add_preload_excluded_uri( $regexes ): array {
 		$preload_excluded_uri = (array) $this->options->get( 'preload_excluded_uri', [] );
 
-		if ( ! empty( $_SERVER['REQUEST_URI'] ) ) {
-			$request_uri = filter_var( wp_unslash( $_SERVER['REQUEST_URI'] ), FILTER_SANITIZE_URL );
-
-			if ( (bool) ! get_rocket_option( 'manual_preload', true ) ) {
-				// add the currently visited URL to the exclusions array.
-				$regexes[] = $request_uri;
-			}
+		if ( ! empty( $_SERVER['REQUEST_URI'] ) && (bool) ! $this->options->get( 'manual_preload', true ) ) {
+			$regexes[] = filter_var( wp_unslash( $_SERVER['REQUEST_URI'] ), FILTER_SANITIZE_URL );
 		}
 
 		if ( empty( $preload_excluded_uri ) ) {

--- a/inc/Engine/Preload/Subscriber.php
+++ b/inc/Engine/Preload/Subscriber.php
@@ -189,6 +189,10 @@ class Subscriber implements Subscriber_Interface {
 			return;
 		}
 
+		if ( (bool) ! $this->options->get( 'manual_preload', true ) ) {
+			return; // Bail out if preload is disabled.
+		}
+
 		$url = home_url( add_query_arg( [], $wp->request ) );
 
 		$detected = $this->mobile_detect->isMobile() && ! $this->mobile_detect->isTablet() ? 'mobile' : 'desktop';
@@ -448,10 +452,6 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	public function add_preload_excluded_uri( $regexes ): array {
 		$preload_excluded_uri = (array) $this->options->get( 'preload_excluded_uri', [] );
-
-		if ( ! empty( $_SERVER['REQUEST_URI'] ) && (bool) ! $this->options->get( 'manual_preload', true ) ) {
-			$regexes[] = filter_var( wp_unslash( $_SERVER['REQUEST_URI'] ), FILTER_SANITIZE_URL );
-		}
 
 		if ( empty( $preload_excluded_uri ) ) {
 			return $regexes;

--- a/inc/Engine/Preload/Subscriber.php
+++ b/inc/Engine/Preload/Subscriber.php
@@ -242,6 +242,10 @@ class Subscriber implements Subscriber_Interface {
 	public function on_permalink_changed() {
 		$this->query->remove_all();
 		$this->queue->cancel_pending_jobs();
+		if ( ! $this->options->get( 'manual_preload', false ) ) {
+			return;
+		}
+
 		$this->queue->add_job_preload_job_load_initial_sitemap_async();
 	}
 

--- a/inc/Engine/Preload/Subscriber.php
+++ b/inc/Engine/Preload/Subscriber.php
@@ -276,7 +276,9 @@ class Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function clean_url( string $url ) {
-
+		if ( ! $this->options->get( 'manual_preload', 0 ) ) {
+			return;
+		}
 		$this->clear_cache->partial_clean( [ $url ] );
 	}
 
@@ -300,6 +302,10 @@ class Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function clean_partial_cache( $object, array $urls, $lang ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.objectFound
+		if ( ! $this->options->get( 'manual_preload', false ) ) {
+			return;
+		}
+
 		// Add Homepage URL to $purge_urls for preload.
 		$urls[] = get_rocket_i18n_home_url( $lang );
 
@@ -314,6 +320,9 @@ class Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function clean_urls( array $urls ) {
+		if ( ! $this->options->get( 'manual_preload', 0 ) ) {
+			return;
+		}
 
 		$this->clear_cache->partial_clean( $urls );
 	}
@@ -469,7 +478,6 @@ class Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function remove_private_post( string $new_status, string $old_status, $post ) {
-
 		if ( $new_status === $old_status ) {
 			return;
 		}

--- a/inc/Engine/Preload/Subscriber.php
+++ b/inc/Engine/Preload/Subscriber.php
@@ -449,11 +449,13 @@ class Subscriber implements Subscriber_Interface {
 	public function add_preload_excluded_uri( $regexes ): array {
 		$preload_excluded_uri = (array) $this->options->get( 'preload_excluded_uri', [] );
 
-		$request_uri = filter_var( wp_unslash( $_SERVER['REQUEST_URI'] ), FILTER_SANITIZE_URL );
+		if ( ! empty( $_SERVER['REQUEST_URI'] ) ) {
+			$request_uri = filter_var( wp_unslash( $_SERVER['REQUEST_URI'] ), FILTER_SANITIZE_URL );
 
-		if( (bool) !get_rocket_option( 'manual_preload', true ) ) {
-			// add the currently visited URL to the exclusions array
-			$regexes[] = $request_uri;
+			if ( (bool) ! get_rocket_option( 'manual_preload', true ) ) {
+				// add the currently visited URL to the exclusions array.
+				$regexes[] = $request_uri;
+			}
 		}
 
 		if ( empty( $preload_excluded_uri ) ) {

--- a/inc/Engine/Preload/Subscriber.php
+++ b/inc/Engine/Preload/Subscriber.php
@@ -449,6 +449,13 @@ class Subscriber implements Subscriber_Interface {
 	public function add_preload_excluded_uri( $regexes ): array {
 		$preload_excluded_uri = (array) $this->options->get( 'preload_excluded_uri', [] );
 
+		$request_uri = filter_var( wp_unslash( $_SERVER['REQUEST_URI'] ), FILTER_SANITIZE_URL );
+
+		if( (bool) !get_rocket_option( 'manual_preload', true ) ) {
+			// add the currently visited URL to the exclusions array
+			$regexes[] = $request_uri;
+		}
+
 		if ( empty( $preload_excluded_uri ) ) {
 			return $regexes;
 		}

--- a/tests/Fixtures/inc/Engine/Preload/Subscriber/updateCacheRow.php
+++ b/tests/Fixtures/inc/Engine/Preload/Subscriber/updateCacheRow.php
@@ -70,7 +70,7 @@ return [
 			]
 		]
 	],
-	'testShouldBailOut' => [
+	'testShouldBailOutWHenPreloadDisabled' => [
 		'config' => [
 			'regexes' => [],
 			'manual_preload' => false,

--- a/tests/Fixtures/inc/Engine/Preload/Subscriber/updateCacheRow.php
+++ b/tests/Fixtures/inc/Engine/Preload/Subscriber/updateCacheRow.php
@@ -3,6 +3,7 @@ return [
 	'testCallActionWhenPreloaded' => [
 		'config' => [
 			'regexes' => [],
+			'manual_preload' => true,
 			'links' => [
 				[
 					'url' => 'http://example.org',
@@ -25,6 +26,7 @@ return [
 	'testNoCallActionWhenNotPreloaded' => [
 		'config' => [
 			'regexes' => [],
+			'manual_preload' => true,
 			'links' => [
 				[
 					'url' => 'http://example.org',
@@ -49,6 +51,7 @@ return [
 			'regexes' => [
 				'(.*)example.org(.*)'
 			],
+			'manual_preload' => true,
 			'links' => [
 				[
 					'url' => 'http://example.org',
@@ -66,5 +69,23 @@ return [
 				],
 			]
 		]
-	]
+	],
+	'testShouldBailOut' => [
+		'config' => [
+			'regexes' => [],
+			'manual_preload' => false,
+			'links' => [
+			],
+			'is_preloaded' => false,
+		],
+		'expected' => [
+			'url' => 'http://example.org',
+			'exists' => false,
+			'links' => [
+				[
+					'url' => 'http://example.org',
+				],
+			],
+		],
+	],
 ];

--- a/tests/Integration/inc/Engine/Preload/Subscriber/updateCacheRow.php
+++ b/tests/Integration/inc/Engine/Preload/Subscriber/updateCacheRow.php
@@ -22,6 +22,7 @@ class Test_UpdateCacheRow extends AdminTestCase
 	{
 		parent::set_up();
 		add_filter('rocket_preload_exclude_urls', [$this, 'excluded']);
+		add_filter('pre_get_rocket_option_manual_preload', [$this, 'manual_preload']);
 	}
 
 	public static function tear_down_after_class()
@@ -33,6 +34,7 @@ class Test_UpdateCacheRow extends AdminTestCase
 	public function tear_down()
 	{
 		remove_filter('rocket_preload_exclude_urls', [$this, 'excluded']);
+		remove_filter('pre_get_rocket_option_manual_preload', [$this, 'rucss']);
 		parent::tear_down();
 	}
 
@@ -47,6 +49,7 @@ class Test_UpdateCacheRow extends AdminTestCase
 		}
 
 		do_action('rocket_after_process_buffer');
+
 
 		if($config['is_preloaded']) {
 			$this->assertGreaterThan( 0, did_action('rocket_preload_completed') );
@@ -63,5 +66,9 @@ class Test_UpdateCacheRow extends AdminTestCase
 
 	public function excluded($regexes): array {
 		return array_merge($regexes, $this->config['regexes']);
+	}
+
+	public function manual_preload() {
+		return $this->config['manual_preload'];
 	}
 }

--- a/tests/Integration/inc/ThirdParty/Plugins/Smush/isSmushIframesLazyloadActive.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Smush/isSmushIframesLazyloadActive.php
@@ -7,6 +7,7 @@ namespace WP_Rocket\Tests\Integration\inc\ThirdParty\Plugins\Smush;
  * @group ThirdParty
  * @group Smush
  * @group WithSmush
+ * @requires PHP >= 7.4
  */
 class Test_IsSmushIframesLazyloadActive extends SmushSubscriberTestCase {
 	/**

--- a/tests/Integration/inc/ThirdParty/Plugins/Smush/isSmushLazyloadActive.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Smush/isSmushLazyloadActive.php
@@ -7,6 +7,7 @@ namespace WP_Rocket\Tests\Integration\inc\ThirdParty\Plugins\Smush;
  * @group ThirdParty
  * @group Smush
  * @group WithSmush
+ * @requires PHP >= 7.4
  */
 class Test_IsSmushLazyloadActive extends SmushSubscriberTestCase {
 	/**

--- a/tests/Integration/inc/ThirdParty/Plugins/Smush/maybeDeactivateRocketLazyload.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Smush/maybeDeactivateRocketLazyload.php
@@ -7,6 +7,7 @@ namespace WP_Rocket\Tests\Integration\inc\ThirdParty\Plugins\Smush;
  * @group ThirdParty
  * @group Smush
  * @group WithSmush
+ * @requires PHP >= 7.4
  */
 class Test_MaybeDeactivateRocketLazyload extends SmushSubscriberTestCase {
 	private $option_hook_prefix = 'pre_get_rocket_option_';

--- a/tests/Unit/inc/Engine/Preload/Subscriber/onPermalinkChanged.php
+++ b/tests/Unit/inc/Engine/Preload/Subscriber/onPermalinkChanged.php
@@ -38,7 +38,7 @@ class Test_OnPermalinkChanged extends TestCase
 	}
 
 	public function testShouldDoAsExpected() {
-		$this->queue->expects()->add_job_preload_job_load_initial_sitemap_async();
+		$this->options->expects()->get('manual_preload', false)->andReturn(false);
 		$this->query->expects(self::once())->method('remove_all');
 		$this->queue->expects()->cancel_pending_jobs();
 		$this->subscriber->on_permalink_changed();


### PR DESCRIPTION
## Description

Currently, any URL that is visited by a real user is added to the `wpr_rocket_cache` table and automatically assigned a “Complete” status even when the Preload is disabled. This causes the DB to grow too large in some cases.


Fixes #6278 

## Type of change

- Enhancement (non-breaking change which improves an existing functionality).

## Is the solution different from the one proposed during the grooming?

No

# Checklists

## Generic development checklist

- [x] My code follows the style guidelines of this project, with adapted comments and without new warnings.
- [x] I have added unit and integration tests that prove my fix is effective or that my feature works.
- [x] The CI passes locally with my changes (including unit tests, integration tests, linter).
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] If applicable, I have made corresponding changes to the documentation. *Provide a link to the documentation.*

## Test summary

- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I validated all Acceptance Criteria of the related issues. (If applicable, provide proof).
- [ ] I validated all test plan the QA Review asked me to.

