### PR TITLE
Fixes #6314 Pass the error code instead of the retries count in the RUCSS strategy

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Strategy/Strategies/DefaultProcess.php
+++ b/inc/Engine/Optimization/RUCSS/Strategy/Strategies/DefaultProcess.php
@@ -88,7 +88,7 @@ class DefaultProcess implements StrategyInterface {
 			return;
 		}
 
-		$this->used_css_query->increment_retries( $row_details->id, (int) $row_details->retries, $job_details['message'] );
+		$this->used_css_query->increment_retries( $row_details->id, (int) $job_details['code'], $job_details['message'] );
 
 		$rucss_retry_duration = $this->time_table_retry[ $row_details->retries ] ?? $this->default_waiting_retry; // Default to 30 minutes.
 

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Strategy/Strategies/DefaultProcess/execute.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Strategy/Strategies/DefaultProcess/execute.php
@@ -1,33 +1,26 @@
 <?php
 
-use WP_Rocket\Tests\Unit\TestCase;
-use Brain\Monkey\Functions;
-use Brain\Monkey\Filters;
-use Brain\Monkey\Actions;
+use Brain\Monkey\{Actions, Filters};
+use WP_Rocket\Engine\Common\Clock\WPRClock;
 use WP_Rocket\Engine\Optimization\RUCSS\Database\Queries\UsedCSS as UsedCSS_Query;
 use WP_Rocket\Engine\Optimization\RUCSS\Strategy\Strategies\DefaultProcess;
-use WP_Rocket\Engine\Common\Clock\WPRClock;
-
+use WP_Rocket\Tests\Unit\TestCase;
 
 /**
  * @covers \WP_Rocket\Engine\Optimization\RUCSS\Strategy\Strategies\DefaultProcess::execute
  *
- * @group  RUCSS
+ * @group RUCSS
  */
-class Test_DefaultProcess_Execute extends TestCase {
+class Test_Execute extends TestCase {
 	protected $used_css_query;
 	protected $wpr_clock;
-
 	protected $strategy;
 
-	public function setUp():void {
+	public function setUp(): void {
 		parent::setUp();
 		$this->used_css_query = $this->createMock( UsedCSS_Query::class );
-		$this->wpr_clock = Mockery::mock(WPRClock::class);
-
-		$this->strategy = new DefaultProcess($this->used_css_query, $this->wpr_clock);
-
-
+		$this->wpr_clock      = Mockery::mock( WPRClock::class );
+		$this->strategy       = new DefaultProcess( $this->used_css_query, $this->wpr_clock );
 	}
 
 	public function tearDown(): void {
@@ -37,28 +30,34 @@ class Test_DefaultProcess_Execute extends TestCase {
 	/**
 	 * @dataProvider configTestData
 	 */
-	public function testShouldBehaveAsExpected( $config, $expected )
-	{
+	public function testShouldBehaveAsExpected( $config, $expected ) {
 		if ( $config['row_details']->retries >= count( $config['time_table'] ) ) {
-			Actions\expectDone('rocket_preload_unlock_url')->with($config['row_details']->url);
+			Actions\expectDone( 'rocket_preload_unlock_url' )->with( $config['row_details']->url );
 
+			$this->used_css_query->expects( self::once() )
+				->method( 'make_status_failed' )
+				->with( $config['row_details']->id, strval( $config['job_details']['code'] ), $config['job_details']['message'] );
+			$this->strategy->execute( $config['row_details'], $config['job_details'] );
 
-			$this->used_css_query->expects(self::once())->method('make_status_failed')->with($config['row_details']->id, strval($config['job_details']['code']), $config['job_details']['message']);
-			$this->strategy->execute($config['row_details'], $config['job_details']);
 			return;
 		}
 
-		$this->used_css_query->expects(self::once())->method('increment_retries')->with( $config['row_details']->id, (int) $config['row_details']->retries);
+		$this->used_css_query->expects( self::once() )
+		->method( 'increment_retries' )
+		->with( $config['row_details']->id, (int) $config['job_details']['code'] );
 
-		Filters\expectApplied('rocket_rucss_retry_duration')->andReturn($config['duration_retry']);
+		Filters\expectApplied( 'rocket_rucss_retry_duration' )->andReturn( $config['duration_retry'] );
 
-		$this->wpr_clock->expects('current_time')->with('timestamp', true)->andReturn(0);
+		$this->wpr_clock->expects( 'current_time' )->with( 'timestamp', true )->andReturn( 0 );
 		// update the `next_retry_time` column.
 
-		$this->used_css_query->expects(self::once())->method('update_message')->with($config['row_details']->id, $config['job_details']['code'], $config['job_details']['message'], $config['row_details']->error_message);
-		$this->used_css_query->expects(self::once())->method('update_next_retry_time')->with($config['job_id'], $config['duration_retry']);
+		$this->used_css_query->expects( self::once() )
+			->method( 'update_message' )
+			->with( $config['row_details']->id, $config['job_details']['code'], $config['job_details']['message'], $config['row_details']->error_message );
+		$this->used_css_query->expects( self::once() )
+		->method( 'update_next_retry_time' )
+		->with( $config['job_id'], $config['duration_retry'] );
 
-		$this->strategy->execute($config['row_details'], $config['job_details']);
-		return;
+		$this->strategy->execute( $config['row_details'], $config['job_details'] );
 	}
 }


### PR DESCRIPTION
## Description

Pass the error code instead of the retries count, as the expected second parameter of `increment_retries()` is the error code value.

Fixes #6314

## Type of change

- Bug fix (non-breaking change which fixes an issue).

## Is the solution different from the one proposed during the grooming?

No grooming for XS

# Checklists

## Generic development checklist

- [x] My code follows the style guidelines of this project, with adapted comments and without new warnings.
- [x] I have added unit and integration tests that prove my fix is effective or that my feature works.
- [x] The CI passes locally with my changes (including unit tests, integration tests, linter).

## Test summary

- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I validated all Acceptance Criteria of the related issues. (If applicable, provide proof).