### PR TITLE
Fixes #6323: Get the actual title tag of the document and use as regex directly

### DIFF
--- a/inc/Engine/Media/AboveTheFold/Frontend/Controller.php
+++ b/inc/Engine/Media/AboveTheFold/Frontend/Controller.php
@@ -85,13 +85,18 @@ class Controller {
 	 * @return string
 	 */
 	private function preload_lcp( $html, $row ) {
-		$preload = '</title>';
+		if ( ! preg_match('#</title\s*>#', $html, $matches) ) {
+			return $html;
+		}
+
+		$title = $matches[0];
+		$preload = $title;
 
 		$lcp = json_decode( $row->lcp );
 
 		$preload .= $this->preload_tag( $lcp );
 
-		$replace = preg_replace( '#</title>#', $preload, $html, 1 );
+		$replace = preg_replace( '#' . $title . '#', $preload, $html, 1 );
 		$replace = $this->set_fetchpriority( $lcp, $replace );
 
 		return $replace;

--- a/inc/Engine/Media/AboveTheFold/Frontend/Controller.php
+++ b/inc/Engine/Media/AboveTheFold/Frontend/Controller.php
@@ -85,11 +85,11 @@ class Controller {
 	 * @return string
 	 */
 	private function preload_lcp( $html, $row ) {
-		if ( ! preg_match('#</title\s*>#', $html, $matches) ) {
+		if ( ! preg_match( '#</title\s*>#', $html, $matches ) ) {
 			return $html;
 		}
 
-		$title = $matches[0];
+		$title   = $matches[0];
 		$preload = $title;
 
 		$lcp = json_decode( $row->lcp );


### PR DESCRIPTION
## Description

Fix an issue where lcp preload is not added because of a space in the closing title tag.

Fixes #6323 

## Type of change

- Bug fix (non-breaking change which fixes an issue).
