### PR TITLE
Fixes: #6322: Guard LCP filter from wrong value

### DIFF
--- a/inc/Engine/Media/AboveTheFold/Context/Context.php
+++ b/inc/Engine/Media/AboveTheFold/Context/Context.php
@@ -18,6 +18,12 @@ class Context implements ContextInterface {
 		 *
 		 * @param bool $allow True to allow, false otherwise.
 		 */
-		return apply_filters( 'rocket_above_the_fold_optimization', true );
+		$is_atf_enabled = apply_filters( 'rocket_above_the_fold_optimization', true );
+
+		if ( ! is_bool( $is_atf_enabled ) ) {
+			return true;
+		}
+
+		return $is_atf_enabled;
 	}
 }


### PR DESCRIPTION
## Description
Guards the LCP filter from wrong value

Fixes #6322 

## Type of change

- Bug fix (non-breaking change which fixes an issue).

