### PR TITLE
Closes #6321: LCP/ATF relative images not excluded from LL

### DIFF
--- a/inc/Engine/Media/AboveTheFold/Frontend/Controller.php
+++ b/inc/Engine/Media/AboveTheFold/Frontend/Controller.php
@@ -213,10 +213,13 @@ class Controller {
 	 * @return array
 	 */
 	private function get_path_for_exclusion( array $exclusions ): array {
-		$exclusions = array_map( function ( $exclusion ) {
-			$exclusion = wp_parse_url( $exclusion );
-		    return $exclusion['path'];
-		}, $exclusions );
+		$exclusions = array_map(
+				function ( $exclusion ) {
+					$exclusion = wp_parse_url( $exclusion );
+					return $exclusion['path'];
+				},
+			$exclusions
+			);
 
 		return $exclusions;
 	}

--- a/inc/Engine/Media/AboveTheFold/Frontend/Controller.php
+++ b/inc/Engine/Media/AboveTheFold/Frontend/Controller.php
@@ -190,16 +190,33 @@ class Controller {
 		if ( $row->lcp && 'not found' !== $row->lcp ) {
 			$lcp = $this->generate_lcp_link_tag_with_sources( json_decode( $row->lcp ) );
 			$lcp = $lcp['sources'];
+			$lcp = $this->get_path_for_exclusion( $lcp );
 		}
 
 		if ( $row->viewport && 'not found' !== $row->viewport ) {
 			$atf = $this->get_atf_sources( json_decode( $row->viewport ) );
+			$atf = $this->get_path_for_exclusion( $atf );
 		}
 
 		$exclusions = array_merge( $exclusions, $lcp, $atf );
 
 		// Remove lcp candidate from the atf array.
 		$exclusions = array_unique( $exclusions );
+
+		return $exclusions;
+	}
+
+	/**
+	 * Get only the url path to exclude.
+	 *
+	 * @param array $exclusions Array of exclusions.
+	 * @return array
+	 */
+	private function get_path_for_exclusion( array $exclusions ): array {
+		$exclusions = array_map( function ( $exclusion ) {
+			$exclusion = wp_parse_url( $exclusion );
+		    return $exclusion['path'];
+		}, $exclusions );
 
 		return $exclusions;
 	}


### PR DESCRIPTION
## Description
This PR fixes the issue where LCP/ATF are not excluded from LazyLoad.

Fixes #6321 

## Type of change

- Bug fix (non-breaking change which fixes an issue).

# Checklists

## Generic development checklist

- [x] My code follows the style guidelines of this project, with adapted comments and without new warnings.
- [ ] I have added unit and integration tests that prove my fix is effective or that my feature works.
- [ ] The CI passes locally with my changes (including unit tests, integration tests, linter).
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] If applicable, I have made corresponding changes to the documentation. *Provide a link to the documentation.*
