### PR TITLE
Fix contact form 7 enqueuing scripts issues

### DIFF
--- a/inc/ThirdParty/Plugins/ContactForm7.php
+++ b/inc/ThirdParty/Plugins/ContactForm7.php
@@ -19,7 +19,7 @@ class ContactForm7 implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events() {
 		return [
-			'template_redirect' => [ 'maybe_optimize_contact_form_7', 10 ],
+			'template_redirect' => [ 'maybe_optimize_contact_form_7' ],
 		];
 	}
 
@@ -33,8 +33,8 @@ class ContactForm7 implements Subscriber_Interface {
 		}
 
 		// Force scripts and styles to not load by default.
-		add_filter( 'wpcf7_load_js', '__return_false', PHP_INT_MAX );
-		add_filter( 'wpcf7_load_css', '__return_false', PHP_INT_MAX );
+		add_filter( 'wpcf7_load_js', '__return_false' );
+		add_filter( 'wpcf7_load_css', '__return_false' );
 
 		// Conditionally enqueue scripts.
 		add_action( 'wpcf7_shortcode_callback', [ $this, 'conditionally_enqueue_scripts' ] );
@@ -45,17 +45,19 @@ class ContactForm7 implements Subscriber_Interface {
 	 * Enqueue scripts if not already enqueued.
 	 */
 	public function conditionally_enqueue_scripts() {
-		if ( ! did_action( 'wpcf7_enqueue_scripts' ) ) { // Prevent double-enqueueing when multiple forms present.
-			wpcf7_enqueue_scripts();
+		if ( did_action( 'wpcf7_enqueue_scripts' ) ) { // Prevent double-enqueueing when multiple forms present.
+			return;
 		}
+		add_filter( 'wpcf7_load_js', '__return_true', 11 );
 	}
 
 	/**
 	 * Enqueue styles if not already enqueued.
 	 */
 	public function conditionally_enqueue_styles() {
-		if ( ! did_action( 'wpcf7_enqueue_styles' ) ) { // Prevent double-enqueueing when multiple forms present.
-			wpcf7_enqueue_styles();
+		if ( did_action( 'wpcf7_enqueue_styles' ) ) { // Prevent double-enqueueing when multiple forms present.
+			return;
 		}
+		add_filter( 'wpcf7_load_css', '__return_true' );
 	}
 }

--- a/inc/ThirdParty/Plugins/ContactForm7.php
+++ b/inc/ThirdParty/Plugins/ContactForm7.php
@@ -19,7 +19,7 @@ class ContactForm7 implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events() {
 		return [
-			'template_redirect' => [ 'maybe_optimize_contact_form_7' ],
+			'template_redirect' => 'maybe_optimize_contact_form_7',
 		];
 	}
 
@@ -48,6 +48,10 @@ class ContactForm7 implements Subscriber_Interface {
 		if ( did_action( 'wpcf7_enqueue_scripts' ) ) { // Prevent double-enqueueing when multiple forms present.
 			return;
 		}
+		if ( did_action( 'wp_enqueue_scripts' ) ) {
+			wpcf7_enqueue_scripts();
+			return;
+		}
 		add_filter( 'wpcf7_load_js', '__return_true', 11 );
 	}
 
@@ -58,6 +62,10 @@ class ContactForm7 implements Subscriber_Interface {
 		if ( did_action( 'wpcf7_enqueue_styles' ) ) { // Prevent double-enqueueing when multiple forms present.
 			return;
 		}
-		add_filter( 'wpcf7_load_css', '__return_true' );
+		if ( did_action( 'wp_enqueue_scripts' ) ) {
+			wpcf7_enqueue_styles();
+			return;
+		}
+		add_filter( 'wpcf7_load_css', '__return_true', 11 );
 	}
 }


### PR DESCRIPTION
## Description

Props to @Miraeld 

Gael groomed the issue and did a great job trying to find the root cause.
I can see also that the hook `wpcf7_shortcode_callback` is firing too early before `contact form 7` registers their scripts (they register them with the hook `wp_enqueue_scripts`) this leads to that we try to enqueue the scripts before they are registered by calling the function `wpcf7_enqueue_scripts` this will lead to not loading the inline script needed for the script to run.

So here we are trying to play with the filters `wpcf7_load_js` and `wpcf7_load_css` to control loading styles and scripts.

Fixes #6331

## Type of change

*Please delete options that are not relevant.*

- Bug fix (non-breaking change which fixes an issue).

## Is the solution different from the one proposed during the grooming?

I changed it a bit.

# Checklists

## Generic development checklist

- [x] My code follows the style guidelines of this project, with adapted comments and without new warnings.
- [ ] I have added unit and integration tests that prove my fix is effective or that my feature works.
- [x] The CI passes locally with my changes (including unit tests, integration tests, linter).
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] If applicable, I have made corresponding changes to the documentation. *Provide a link to the documentation.*

## Test summary

- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I validated all Acceptance Criteria of the related issues. (If applicable, provide proof).
- [x] I validated all test plan the QA Review asked me to.

*If not, detail what you could not test.*

*Please describe any additional tests you performed.*
I tested with block based themes and classic themes.