### PR TITLE
Closes #6289: Error Code when RUCSS can't be reached

### DIFF
--- a/inc/Engine/Optimization/RUCSS/AbstractAPIClient.php
+++ b/inc/Engine/Optimization/RUCSS/AbstractAPIClient.php
@@ -125,6 +125,12 @@ abstract class AbstractAPIClient {
 		if ( 200 !== $this->response_code ) {
 			$previous_errors = (int) get_transient( 'wp_rocket_rucss_errors_count' );
 			set_transient( 'wp_rocket_rucss_errors_count', $previous_errors + 1, 5 * MINUTE_IN_SECONDS );
+
+			if ( empty( $response ) ) {
+				$this->error_message = 'API Client Error';
+				return false;
+			}
+
 			$this->error_message = is_array( $response )
 				? wp_remote_retrieve_response_message( $response )
 				: $response->get_error_message();


### PR DESCRIPTION
## Description

This PR adds a default message when API response returns empty.

Fixes #6289

## Type of change

- Enhancement (non-breaking change which improves an existing functionality).

## Is the solution different from the one proposed during the grooming?

No

# Checklists

## Generic development checklist

- [x] My code follows the style guidelines of this project, with adapted comments and without new warnings.
- [x] The CI passes locally with my changes (including unit tests, integration tests, linter).

## Test summary

- [ ] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I validated all Acceptance Criteria of the related issues. (If applicable, provide proof).
- [ ] I validated all test plan the QA Review asked me to.

*If not, detail what you could not test.*

*Please describe any additional tests you performed.*
