### PR TITLE
Fixes #6276 Prevent running the function `rocket_clean_domain()` multiple times

### DIFF
--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -803,6 +803,10 @@ function rocket_clean_home_feeds() {
  * @param WP_Filesystem_Direct|null $filesystem Optional. Instance of filesystem handler.
  */
 function rocket_clean_domain( $lang = '', $filesystem = null ) {
+	if ( did_action( 'rocket_after_clean_domain' ) ) {
+		return;
+	}
+
 	if ( rocket_is_importing() ) {
 		return;
 	}


### PR DESCRIPTION
## Description

Check if `rocket_clean_domain()` already ran by using `did_action()`, and returning early if it did.

Fixes #6276 

## Type of change

- Enhancement (non-breaking change which improves an existing functionality).

# Checklists

## Generic development checklist

- [x] My code follows the style guidelines of this project, with adapted comments and without new warnings.
- [x] The CI passes locally with my changes (including unit tests, integration tests, linter).

## Test summary

- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I validated all Acceptance Criteria of the related issues. (If applicable, provide proof).
- [ ] I validated all test plan the QA Review asked me to.