### PR TITLE
Fixes #6392 Optimize WP Query in `rocket_url_to_postid()`

### DIFF
--- a/inc/functions/posts.php
+++ b/inc/functions/posts.php
@@ -250,7 +250,15 @@ if ( ! function_exists( 'rocket_url_to_postid' ) ) {
 				$query = (array) apply_filters( 'rocket_url_to_postid_query_args', $query, $url );
 
 				// Do the query.
-				$query = new WP_Query( $query );
+				$query = new WP_Query(
+					$query,
+					[
+						'no_found_rows'          => true,
+						'update_post_term_cache' => false,
+						'update_post_meta_cache' => false,
+					]
+				);
+
 				if ( ! empty( $query->posts ) && $query->is_singular ) {
 					return $query->post->ID;
 				} else {

--- a/inc/functions/posts.php
+++ b/inc/functions/posts.php
@@ -249,15 +249,12 @@ if ( ! function_exists( 'rocket_url_to_postid' ) ) {
 				 */
 				$query = (array) apply_filters( 'rocket_url_to_postid_query_args', $query, $url );
 
+				$query['no_found_rows']          = true;
+				$query['update_post_term_cache'] = false;
+				$query['update_post_meta_cache'] = false;
+
 				// Do the query.
-				$query = new WP_Query(
-					$query,
-					[
-						'no_found_rows'          => true,
-						'update_post_term_cache' => false,
-						'update_post_meta_cache' => false,
-					]
-				);
+				$query = new WP_Query( $query );
 
 				if ( ! empty( $query->posts ) && $query->is_singular ) {
 					return $query->post->ID;


### PR DESCRIPTION
## Description

Optimize the query by passing the args to prevent caching and found rows calculation.

Fixes #6392

## Type of change

- Enhancement (non-breaking change which improves an existing functionality).

## Is the solution different from the one proposed during the grooming?

No grooming, small change.

# Checklists

## Generic development checklist

- [x] My code follows the style guidelines of this project, with adapted comments and without new warnings.
- [x] The CI passes locally with my changes (including unit tests, integration tests, linter).

## Test summary

- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I validated all Acceptance Criteria of the related issues. (If applicable, provide proof).
- [ ] I validated all test plan the QA Review asked me to.