### PR TITLE
Closes #6389: LL for CSS BG Images coming from PHP file

### DIFF
--- a/inc/Engine/Media/Lazyload/CSS/Front/ContentFetcher.php
+++ b/inc/Engine/Media/Lazyload/CSS/Front/ContentFetcher.php
@@ -57,7 +57,11 @@ class ContentFetcher {
 	 */
 	protected function fetch_content( string $path ) {
 		if ( ! wp_http_validate_url( $path ) ) {
-			return $this->filesystem->get_contents( $path );
+			$file_extension = pathinfo( $path, PATHINFO_EXTENSION );
+
+			if ( strtolower( $file_extension ) !== 'php' ) {
+				return $this->filesystem->get_contents( $path );
+			}
 		}
 		return wp_remote_retrieve_body( wp_remote_get( $path ) );
 	}


### PR DESCRIPTION
## Description

This comes to fix the issue relating to loading a CSS script from a PHP file which use `echo`/`print` etc. 
Until now we were getting the content of the file itself, and while the selector extraction was performing, we were also using the php command inside of it. 

Fixes #6389 

## Type of change

- Bug fix (non-breaking change which fixes an issue).

## Is the solution different from the one proposed during the grooming?
No

# Checklists

## Generic development checklist

- [x] My code follows the style guidelines of this project, with adapted comments and without new warnings.
- [ ] I have added unit and integration tests that prove my fix is effective or that my feature works.
- [x] The CI passes locally with my changes (including unit tests, integration tests, linter).
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] If applicable, I have made corresponding changes to the documentation. *Provide a link to the documentation.*

## Test summary

- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I validated all Acceptance Criteria of the related issues. (If applicable, provide proof).
- [ ] I validated all test plan the QA Review asked me to.
