### PR TITLE
Fix Contact Form 7 compatibility issues

### DIFF
--- a/inc/ThirdParty/Plugins/ContactForm7.php
+++ b/inc/ThirdParty/Plugins/ContactForm7.php
@@ -25,16 +25,6 @@ class ContactForm7 implements Subscriber_Interface {
 	 * Subscribed events.
 	 */
 	public static function get_subscribed_events() {
-		/**
-		 * Filters register this compatibility events or not.
-		 *
-		 * @param bool $status Load the compatibility file or not, default is True.
-		 * @param string $thirdparty Thirdparty id.
-		 */
-		if ( ! apply_filters( 'rocket_thirdparty_load', true, 'contact-form-7' ) ) {
-			return [];
-		}
-
 		return [
 			'template_redirect' => 'maybe_optimize_contact_form_7',
 		];
@@ -44,6 +34,16 @@ class ContactForm7 implements Subscriber_Interface {
 	 * Optimize ContactForm7 scripts.
 	 */
 	public function maybe_optimize_contact_form_7() {
+		/**
+		 * Filters register this compatibility events or not.
+		 *
+		 * @param bool $status Load the compatibility file or not, default is True.
+		 * @param string $thirdparty Thirdparty id.
+		 */
+		if ( ! apply_filters( 'rocket_thirdparty_load', true, 'contact-form-7' ) ) {
+			return;
+		}
+
 		// The wpcf7_shortcode_callback action was added in CF7 version 5.8.1.
 		if ( ! defined( 'WPCF7_VERSION' ) || version_compare( WPCF7_VERSION, self::REQUIRED_CF7_VERSION, '<' ) ) {
 			return;


### PR DESCRIPTION
## Description

This is a working prototype to detect if CF7 main script is added as a dependency then force loading all JS in this case not to fire console error.

I tried many ways like using the `script_loader_src` filter to detect if CF7 main script is being loaded but at this point I won't be able to load the localized script because the main script is already loaded in frontend.

Fixes #6384

## Type of change

*Please delete options that are not relevant.*

- Bug fix (non-breaking change which fixes an issue).

## Is the solution different from the one proposed during the grooming?

Not groomed, I did R&D and directly created this PR so we all can validate the idea.

# Checklists

## Generic development checklist

- [x] My code follows the style guidelines of this project, with adapted comments and without new warnings.
- [ ] I have added unit and integration tests that prove my fix is effective or that my feature works.
- [x] The CI passes locally with my changes (including unit tests, integration tests, linter).
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] If applicable, I have made corresponding changes to the documentation. *Provide a link to the documentation.*

## Test summary

- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I validated all Acceptance Criteria of the related issues. (If applicable, provide proof).
- [ ] I validated all test plan the QA Review asked me to.

*If not, detail what you could not test.*

*Please describe any additional tests you performed.*
