### PR TITLE
Closes #6413 performance optimizations for DefinitionAggregate

### DIFF
--- a/inc/Dependencies/League/Container/Definition/Definition.php
+++ b/inc/Dependencies/League/Container/Definition/Definition.php
@@ -81,6 +81,11 @@ class Definition implements ArgumentResolverInterface, DefinitionInterface
         return isset($this->tags[$tag]);
     }
 
+     public function getTags() : array
+     {
+          return array_keys($this->tags);
+     }
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
## Description

Includes performance optimization suggestions for the DefinitionAggregate::has(), DefinitionAggregate::hasTag() and DefinitionAggregate::getDefinition() methods.

Suggested fix for #6413 

## Note

Please review the comment in __contruct() in line 32 and following.
I am not familiar enough with the inner workings of the plugin to know if this can break any of the core functionality.