### PR TITLE
Closes #6202: Stop preloading fonts when it's excluded

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
 		"wpackagist-plugin/amp": "^1.1.4",
 		"wpackagist-plugin/hummingbird-performance": "2.0.1",
 		"wpackagist-plugin/jetpack": "9.3.2",
-		"wpackagist-plugin/pdf-embedder": "^4.6",
+		"wpackagist-plugin/pdf-embedder": "4.6.*",
 		"wpackagist-plugin/simple-custom-css": "^4.0.3",
 		"wpackagist-plugin/spinupwp": "^1.1",
 		"wpackagist-plugin/woocommerce": "^8",

--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -785,6 +785,14 @@ class UsedCSS implements LoggerAwareInterface {
 			return $html;
 		}
 
+        /**
+         * Filters the list of fonts to exclude from preload
+         *
+         * @since 3.15.10
+         *
+         * @param array $excluded_fonts_preload List of fonts to exclude from preload
+         */
+        $exclude_fonts_preload = apply_filters( 'rocket_exclude_rucss_fonts_preload', [] );
 		$urls = [];
 
 		foreach ( $font_faces as $font_face ) {
@@ -793,6 +801,7 @@ class UsedCSS implements LoggerAwareInterface {
 			}
 
 			$font_url = $this->extract_first_font( $font_face['content'] );
+
 
 			/**
 			 * Filters font URL with CDN hostname
@@ -806,6 +815,11 @@ class UsedCSS implements LoggerAwareInterface {
 			if ( empty( $font_url ) ) {
 				continue;
 			}
+
+            // Check if the font URL is in the exclude_fonts_preload array
+            if (in_array($font_url, $exclude_fonts_preload)) {
+                continue; // Skip this iteration as the font URL is in the exclusion list
+            }
 
 			$urls[] = $font_url;
 		}

--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -785,14 +785,15 @@ class UsedCSS implements LoggerAwareInterface {
 			return $html;
 		}
 
-        /**
-         * Filters the list of fonts to exclude from preload
-         *
-         * @since 3.15.10
-         *
-         * @param array $excluded_fonts_preload List of fonts to exclude from preload
-         */
-        $exclude_fonts_preload = apply_filters( 'rocket_exclude_rucss_fonts_preload', [] );
+		/**
+		 * Filters the list of fonts to exclude from preload
+		 *
+		 * @since 3.15.10
+		 *
+		 * @param array $excluded_fonts_preload List of fonts to exclude from preload
+		 */
+		$exclude_fonts_preload = apply_filters( 'rocket_exclude_rucss_fonts_preload', [] );
+
 		$urls = [];
 
 		foreach ( $font_faces as $font_face ) {
@@ -801,7 +802,6 @@ class UsedCSS implements LoggerAwareInterface {
 			}
 
 			$font_url = $this->extract_first_font( $font_face['content'] );
-
 
 			/**
 			 * Filters font URL with CDN hostname
@@ -816,10 +816,10 @@ class UsedCSS implements LoggerAwareInterface {
 				continue;
 			}
 
-            // Check if the font URL is in the exclude_fonts_preload array
-            if (in_array($font_url, $exclude_fonts_preload)) {
-                continue; // Skip this iteration as the font URL is in the exclusion list
-            }
+			// Check if the font URL is in the exclude_fonts_preload array.
+			if ( in_array( $font_url, $exclude_fonts_preload, true ) ) {
+				continue; // Skip this iteration as the font URL is in the exclusion list.
+			}
 
 			$urls[] = $font_url;
 		}

--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -793,6 +793,9 @@ class UsedCSS implements LoggerAwareInterface {
 		 * @param array $excluded_fonts_preload List of fonts to exclude from preload
 		 */
 		$exclude_fonts_preload = apply_filters( 'rocket_exclude_rucss_fonts_preload', [] );
+		if ( ! is_array( $exclude_fonts_preload ) ) {
+			$exclude_fonts_preload = [];
+		}
 
 		$urls = [];
 
@@ -816,8 +819,11 @@ class UsedCSS implements LoggerAwareInterface {
 				continue;
 			}
 
-			// Check if the font URL is in the exclude_fonts_preload array.
-			if ( in_array( $font_url, $exclude_fonts_preload, true ) ) {
+			// Combine the array elements into a single string with | as a separator.
+			$exclude_fonts_preload_pattern = implode( '|', array_map( 'preg_quote', $exclude_fonts_preload ) );
+
+			// Check if the font URL matches any part of the exclude_fonts_preload array.
+			if ( preg_match( '/' . $exclude_fonts_preload_pattern . '/i', $font_url ) ) {
 				continue; // Skip this iteration as the font URL is in the exclusion list.
 			}
 

--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -819,20 +819,23 @@ class UsedCSS implements LoggerAwareInterface {
 				continue;
 			}
 
-			// Combine the array elements into a single string with | as a separator and returning a pattern.
-			$exclude_fonts_preload_pattern = implode(
-				'|',
-				array_map(
-					function ( $item ) {
-						return preg_quote( $item, '/' );
-					},
-					$exclude_fonts_preload
-				)
-			);
+			// Making sure the excluded fonts array isn't empty to avoid excluding all fonts.
+			if ( ! empty( $exclude_fonts_preload ) ) {
+				// Combine the array elements into a single string with | as a separator and returning a pattern.
+				$exclude_fonts_preload_pattern = implode(
+					'|',
+					array_map(
+						function ( $item ) {
+							return preg_quote( $item, '/' );
+						},
+						$exclude_fonts_preload
+					)
+				);
 
-			// Check if the font URL matches any part of the exclude_fonts_preload array.
-			if ( preg_match( '/' . $exclude_fonts_preload_pattern . '/i', $font_url ) ) {
-				continue; // Skip this iteration as the font URL is in the exclusion list.
+				// Check if the font URL matches any part of the exclude_fonts_preload array.
+				if ( ! empty( $exclude_fonts_preload_pattern ) && preg_match( '/' . $exclude_fonts_preload_pattern . '/i', $font_url ) ) {
+					continue; // Skip this iteration as the font URL is in the exclusion list.
+				}
 			}
 
 			$urls[] = $font_url;

--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -826,7 +826,7 @@ class UsedCSS implements LoggerAwareInterface {
 					'|',
 					array_map(
 						function ( $item ) {
-							return preg_quote( $item, '/' );
+							return is_string( $item ) ? preg_quote( $item, '/' ) : '';
 						},
 						$exclude_fonts_preload
 					)

--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -819,8 +819,16 @@ class UsedCSS implements LoggerAwareInterface {
 				continue;
 			}
 
-			// Combine the array elements into a single string with | as a separator.
-			$exclude_fonts_preload_pattern = implode( '|', array_map( 'preg_quote', $exclude_fonts_preload ) );
+			// Combine the array elements into a single string with | as a separator and returning a pattern.
+			$exclude_fonts_preload_pattern = implode(
+				'|',
+				array_map(
+					function ( $item ) {
+						return preg_quote( $item, '/' );
+					},
+					$exclude_fonts_preload
+				)
+			);
 
 			// Check if the font URL matches any part of the exclude_fonts_preload array.
 			if ( preg_match( '/' . $exclude_fonts_preload_pattern . '/i', $font_url ) ) {

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/CSS/FontPreloaded.css
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/CSS/FontPreloaded.css
@@ -1,0 +1,8 @@
+@font-face {
+	font-family: 'MyFont';
+	src: url('https://domain.com/fonts/MyFont.woff') format('woff');
+}
+
+body {
+	font-family: 'MyFont';
+}

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/CSS/test.css
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/CSS/test.css
@@ -1,0 +1,17 @@
+@font-face {
+	font-family: 'MyFontExcluded';
+	src: url('https://domaina.com/fonts/MyFontExcluded.woff') format('woff');
+}
+
+@font-face {
+	font-family: 'MyFont';
+	src: url('https://domain.com/fonts/MyFont.woff') format('woff');
+}
+
+body {
+	font-family: 'MyFont';
+}
+
+p {
+	font-family: 'MyFontExcluded';
+}

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/HTML/outputFontExcluded.html
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/HTML/outputFontExcluded.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>Title</title><link rel="preload" as="font" href="https://domain.com/fonts/MyFont.woff" crossorigin><style id="wpr-usedcss">@font-face {
+	font-family: 'MyFontExcluded';
+	src: url('https://domaina.com/fonts/MyFontExcluded.woff') format('woff');
+}
+
+@font-face {
+	font-family: 'MyFont';
+	src: url('https://domain.com/fonts/MyFont.woff') format('woff');
+}
+
+body {
+	font-family: 'MyFont';
+}
+
+p {
+	font-family: 'MyFontExcluded';
+}
+</style>
+</head>
+<body>
+
+</body>
+</html>

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/HTML/outputFontPreloaded.html
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/HTML/outputFontPreloaded.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>Title</title><link rel="preload" as="font" href="https://domain.com/fonts/MyFont.woff" crossorigin><style id="wpr-usedcss">@font-face {
+	font-family: 'MyFont';
+	src: url('https://domain.com/fonts/MyFont.woff') format('woff');
+}
+
+body {
+	font-family: 'MyFont';
+}
+</style>
+</head>
+<body>
+
+</body>
+</html>

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/treeshake.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/treeshake.php
@@ -2,6 +2,7 @@
 
 $html_input = file_get_contents(__DIR__ . '/HTML/input.html');
 $html_output = file_get_contents(__DIR__ . '/HTML/output.html');
+$html_output_font_excluded = file_get_contents(__DIR__ . '/HTML/outputFontExcluded.html');
 
 
 return [
@@ -15,8 +16,8 @@ return [
 				],
 				'files' => [
 
-				]
-
+				],
+				'font_excluded' => [],
 			],
 			'expected' => [
 				'html' => $html_output,
@@ -51,7 +52,8 @@ return [
 				],
 				'files' => [
 
-				]
+				],
+				'font_excluded' => [],
 
 			],
 			'expected' => [
@@ -71,5 +73,43 @@ return [
 				]
 			]
 		],
+		'shouldNotPreloadFontExcluded' => [
+			'config' => [
+				'rucss' => true,
+				'html' => $html_input,
+				'rows' => [
+					[
+						'url' => 'http://example.org',
+						'job_id' => '1234',
+						'queue_name' => 'eu',
+						'is_mobile' => false,
+						'status'        => 'completed',
+						'retries'       => 0,
+						'hash'          => '1234abcd',
+					]
+				],
+				'font_excluded' => ['https://domaina.com'],
+				'files' => [
+					'wp-content/cache/used-css/1/1/2/3/4abcd.css.gz' => gzencode( file_get_contents(__DIR__ . '/CSS/test.css') )
+				],
+			],
+			'expected' => [
+				'html' => $html_output_font_excluded,
+				'rows' => [
+					[
+						'url' => 'http://example.org',
+						'job_id' => '1234',
+						'queue_name' => 'eu',
+						'is_mobile' => false,
+						'status'        => 'completed',
+						'retries'       => 0,
+						'hash'          => '1234abcd',
+					]
+				],
+				'files' => [
+
+				]
+			]
+		]
 	]
 ];

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/treeshake.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/treeshake.php
@@ -3,6 +3,7 @@
 $html_input = file_get_contents(__DIR__ . '/HTML/input.html');
 $html_output = file_get_contents(__DIR__ . '/HTML/output.html');
 $html_output_font_excluded = file_get_contents(__DIR__ . '/HTML/outputFontExcluded.html');
+$html_output_font_preloaded = file_get_contents(__DIR__ . '/HTML/outputFontPreloaded.html');
 
 
 return [
@@ -110,6 +111,82 @@ return [
 
 				]
 			]
-		]
+		],
+		'shouldPreloadFont' => [
+			'config' => [
+				'rucss' => true,
+				'html' => $html_input,
+				'rows' => [
+					[
+						'url' => 'http://example.org',
+						'job_id' => '1234',
+						'queue_name' => 'eu',
+						'is_mobile' => false,
+						'status'        => 'completed',
+						'retries'       => 0,
+						'hash'          => '1234abcd',
+					]
+				],
+				'font_excluded' => [],
+				'files' => [
+					'wp-content/cache/used-css/1/1/2/3/4abcd.css.gz' => gzencode( file_get_contents(__DIR__ . '/CSS/FontPreloaded.css') )
+				],
+			],
+			'expected' => [
+				'html' => $html_output_font_preloaded,
+				'rows' => [
+					[
+						'url' => 'http://example.org',
+						'job_id' => '1234',
+						'queue_name' => 'eu',
+						'is_mobile' => false,
+						'status'        => 'completed',
+						'retries'       => 0,
+						'hash'          => '1234abcd',
+					]
+				],
+				'files' => [
+
+				]
+			]
+		],
+		'shouldPreloadFontEvenWithEmptyExcludeArray' => [
+			'config' => [
+				'rucss' => true,
+				'html' => $html_input,
+				'rows' => [
+					[
+						'url' => 'http://example.org',
+						'job_id' => '1234',
+						'queue_name' => 'eu',
+						'is_mobile' => false,
+						'status'        => 'completed',
+						'retries'       => 0,
+						'hash'          => '1234abcd',
+					]
+				],
+				'font_excluded' => [''],
+				'files' => [
+					'wp-content/cache/used-css/1/1/2/3/4abcd.css.gz' => gzencode( file_get_contents(__DIR__ . '/CSS/FontPreloaded.css') )
+				],
+			],
+			'expected' => [
+				'html' => $html_output_font_preloaded,
+				'rows' => [
+					[
+						'url' => 'http://example.org',
+						'job_id' => '1234',
+						'queue_name' => 'eu',
+						'is_mobile' => false,
+						'status'        => 'completed',
+						'retries'       => 0,
+						'hash'          => '1234abcd',
+					]
+				],
+				'files' => [
+
+				]
+			]
+		],
 	]
 ];

--- a/tests/Integration/DBTrait.php
+++ b/tests/Integration/DBTrait.php
@@ -19,6 +19,9 @@ trait DBTrait {
 		if(key_exists('status', $resource) && 'pending' === $resource['status']) {
 			$resource_query->make_status_pending($job_id);
 		}
+		if(key_exists('status', $resource) && 'completed' === $resource['status']) {
+			$resource_query->make_status_completed($job_id, $resource['hash']);
+		}
 		return $job_id;
 	}
 

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/treeshake.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/treeshake.php
@@ -7,9 +7,11 @@ use WP_Rocket\Tests\Integration\FilesystemTestCase;
 use WP_Rocket\Tests\Integration\TestCase;
 
 /**
+ * @group RUCSS
  * @covers \WP_Rocket\Engine\Optimization\RUCSS\Frontend\Subscriber::treeshake
  */
-class Test_treeshake extends FilesystemTestCase {
+class Test_treeshake extends FilesystemTestCase
+{
 
 	use DBTrait;
 
@@ -33,21 +35,29 @@ class Test_treeshake extends FilesystemTestCase {
 	{
 		parent::set_up();
 		add_filter('pre_get_rocket_option_remove_unused_css', [$this, 'rucss']);
+		add_filter('rocket_exclude_rucss_fonts_preload', [$this, 'exclude_fonts_preload']);
+		add_filter('rocket_used_css_dir_level', [$this, 'used_css_dir_level']);
 	}
 
 	public function tear_down()
 	{
 		remove_filter('pre_get_rocket_option_remove_unused_css', [$this, 'rucss']);
+		remove_filter('rocket_exclude_rucss_fonts_preload', [$this, 'exclude_fonts_preload']);
+		remove_filter('rocket_used_css_dir_level', [$this, 'used_css_dir_level']);
+
 		parent::tear_down();
 	}
 
-    /**
-     * @dataProvider providerTestData
-     */
-    public function testShouldReturnAsExpected( $config, $expected )
-    {
+	/**
+	 * @dataProvider providerTestData
+	 */
+	public function testShouldReturnAsExpected($config, $expected)
+	{
 		$this->config = $config;
-
+		foreach ($config['files'] as $path => $file) {
+			rocket_mkdir_p(dirname($path), $this->filesystem);
+			$this->filesystem->put_contents($path, $file);
+		}
 		foreach ($config['rows'] as $row) {
 			self::addResource($row);
 		}
@@ -57,9 +67,19 @@ class Test_treeshake extends FilesystemTestCase {
 		foreach ($expected['rows'] as $row) {
 			$this->assertTrue(self::resourceFound($row), json_encode($row) . ' not found');
 		}
-    }
+	}
 
-	public function rucss() {
+	public function rucss()
+	{
 		return $this->config['rucss'];
+	}
+
+	public function exclude_fonts_preload()
+	{
+		return $this->config['font_excluded'];
+	}
+
+	public function used_css_dir_level() {
+		return 3;
 	}
 }


### PR DESCRIPTION
# Description
This PR gives users a filter to be able to exclude fonts urls to be preloaded.

Fixes #6202 

## Documentation

### User documentation
With this PR, you now have the ability to control which fonts get preloaded on your website. This is done using the `rocket_exclude_rucss_fonts_preload` filter.  
Let's say your website uses two fonts: one from `https://domainA.com/fonts/myFontA.woff` and another from `https://domainB.com/fonts/myFontsB.woff`. If you want to **prevent** the font from `domainA.com` from being preloaded, you can use the filter and return `['https://domainA.com']`.  This means that `myFontA.woff` **won't be preloaded**, but `myFontB.woff` **will be**. 
This gives you more control over the performance of your website.

### Technical documentation

We apply a filter to get the excluded fonts urls, and in the loop we check if the current url is within the excluded array. If that's the case we bail-out.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I added tests 

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I wrote comments to explain why it does it.
- [x] I named variables and functions explicitely.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.
- [x] I listed the introduced external dependencies explicitely on the PR.
- [x] I validated the repo-specific guidelines from CONTRIBUTING.md.
