### PR TITLE
Add a log for test/QA when private URL is excluded from preload

### DIFF
--- a/inc/Engine/Preload/Subscriber.php
+++ b/inc/Engine/Preload/Subscriber.php
@@ -558,7 +558,7 @@ class Subscriber implements Subscriber_Interface, LoggerAwareInterface {
 			$this->logger::debug(
 				"Private URL excluded from preload: {$url}",
 				[
-					'method' => __METHOD__
+					'method' => __METHOD__,
 				]
 			);
 		}

--- a/inc/Engine/Preload/Subscriber.php
+++ b/inc/Engine/Preload/Subscriber.php
@@ -12,9 +12,12 @@ use WP_Rocket\Engine\Preload\Controller\Queue;
 use WP_Rocket\Engine\Preload\Database\Queries\Cache;
 use WP_Rocket\Event_Management\Subscriber_Interface;
 use WP_Rocket_Mobile_Detect;
+use WP_Rocket\Logger\LoggerAware;
+use WP_Rocket\Logger\LoggerAwareInterface;
 
-class Subscriber implements Subscriber_Interface {
+class Subscriber implements Subscriber_Interface, LoggerAwareInterface {
 
+	use LoggerAware;
 	use CheckExcludedTrait;
 
 	/**
@@ -549,6 +552,17 @@ class Subscriber implements Subscriber_Interface {
 			return true;
 		}
 
-		return ! empty( rocket_url_to_postid( $url, [ 'private' ] ) );
+		$is_private = ! empty( rocket_url_to_postid( $url, [ 'private' ] ) );
+
+		if ( $is_private ) {
+			$this->logger::debug(
+				"Private URL excluded from preload: {$url}",
+				[
+					'method' => __METHOD__
+				]
+			);
+		}
+
+		return $is_private;
 	}
 }


### PR DESCRIPTION
# Description

Add a log, as per request of the QA team to ease testing of the exclusion of private URL from the preload.

Fixes #5971

## Documentation

### User documentation

The log is printed in `wp-content/wp-rocket-debug.log.html` when a URL candidate for the preload is excluded by the exclude_private_url method.
To find the log, you can search for:
- exclude_private_url
- Private URL excluded from preload:

### Technical documentation

NA

## Type of change
*Delete options that are not relevant.*

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).

## New dependencies
*List any new dependencies that are required for this change.*

## Risks
*List possible performance & security issues or risks, and explain how they have been mitigated.*

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Documentation

- [x] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [x] The user documentation covers new/changed entry points (endpoints, WP hooks, configuration files, ...).
- [x] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I wrote comments to explain why it does it.
- [x] I named variables and functions explicitely.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.
- [x] I listed the introduced external dependencies explicitely on the PR.
- [x] I validated the repo-specific guidelines from CONTRIBUTING.md.

## Observability
- [x] I handled errors when needed.
- [x] I wrote user-facing messages that are understandable and provide actionable feedbacks.
- [x] I prepared ways to observe the implemented system (logs, data, etc.).

## Risks
- [x] I explicitely mentioned performance risks in the PR.
- [x] I explicitely mentioned security risks in the PR.
