### PR TITLE
Closes #6468: Imagify 3rd Compatibility

### DIFF
--- a/inc/classes/subscriber/third-party/plugins/Images/Webp/class-imagify-subscriber.php
+++ b/inc/classes/subscriber/third-party/plugins/Images/Webp/class-imagify-subscriber.php
@@ -321,8 +321,7 @@ class Imagify_Subscriber implements Webp_Interface, Subscriber_Interface {
 			// No Imagify, no webp.
 			return false;
 		}
-
-		return (bool) get_imagify_option( 'display_webp' );
+		return (bool) ( get_imagify_option( 'display_webp' ) || get_imagify_option( 'display_nextgen' ) );
 	}
 
 	/**

--- a/inc/classes/subscriber/third-party/plugins/Images/Webp/class-imagify-subscriber.php
+++ b/inc/classes/subscriber/third-party/plugins/Images/Webp/class-imagify-subscriber.php
@@ -221,10 +221,10 @@ class Imagify_Subscriber implements Webp_Interface, Subscriber_Interface {
 	 * @param mixed $value     The new option value.
 	 */
 	public function sync_on_option_update( $old_value, $value ) {
-		$old_display = ! empty( $old_value['display_webp'] );
-		$display     = ! empty( $value['display_webp'] );
+		$old_display = ! empty( $old_value['display_nextgen'] );
+		$display     = ! empty( $value['display_nextgen'] );
 
-		if ( $old_display !== $display || $old_value['display_webp_method'] !== $value['display_webp_method'] ) {
+		if ( $old_display !== $display || $old_value['display_nextgen_method'] !== $value['display_nextgen_method'] ) {
 			$this->trigger_webp_change();
 		}
 	}

--- a/inc/classes/subscriber/third-party/plugins/Images/Webp/class-imagify-subscriber.php
+++ b/inc/classes/subscriber/third-party/plugins/Images/Webp/class-imagify-subscriber.php
@@ -338,7 +338,7 @@ class Imagify_Subscriber implements Webp_Interface, Subscriber_Interface {
 			return false;
 		}
 
-		return 'rewrite' !== get_imagify_option( 'display_webp_method' );
+		return 'rewrite' !== get_imagify_option( 'display_webp_method' ) || 'rewrite' !== get_imagify_option( 'display_nextgen_method' );
 	}
 
 	/**

--- a/inc/classes/subscriber/third-party/plugins/Images/Webp/class-imagify-subscriber.php
+++ b/inc/classes/subscriber/third-party/plugins/Images/Webp/class-imagify-subscriber.php
@@ -304,7 +304,7 @@ class Imagify_Subscriber implements Webp_Interface, Subscriber_Interface {
 			return false;
 		}
 
-		return (bool) get_imagify_option( 'convert_to_webp' );
+		return (bool) ! get_imagify_option( 'convert_to_avif' ) || get_imagify_option( 'convert_to_webp' );
 	}
 
 	/**

--- a/tests/Unit/inc/classes/third-party/plugins/Images/Webp/Imagify_Subscriber/isConvertingToWebp.php
+++ b/tests/Unit/inc/classes/third-party/plugins/Images/Webp/Imagify_Subscriber/isConvertingToWebp.php
@@ -22,8 +22,8 @@ class Test_IsConvertingToWebp extends TestCase {
 		$this->assertFalse( $subscriber->is_converting_to_webp() );
 
 		Functions\expect( 'get_imagify_option' )
-			->once()
-			->andReturn( false );
+			->twice()
+			->andReturnValues( [ true, false ] );
 
 		$this->assertFalse( $subscriber->is_converting_to_webp() );
 	}
@@ -33,7 +33,7 @@ class Test_IsConvertingToWebp extends TestCase {
 		$subscriber  = new Imagify_Subscriber( $optionsData );
 
 		Functions\expect( 'get_imagify_option' )
-			->once()
+			->twice()
 			->andReturn( true );
 
 		$this->assertTrue( $subscriber->is_converting_to_webp() );

--- a/tests/Unit/inc/classes/third-party/plugins/Images/Webp/Imagify_Subscriber/isServingWebp.php
+++ b/tests/Unit/inc/classes/third-party/plugins/Images/Webp/Imagify_Subscriber/isServingWebp.php
@@ -20,7 +20,7 @@ class Test_IsServingWebp extends TestCase {
 		$subscriber  = new Imagify_Subscriber( $optionsData );
 
 		Functions\expect( 'get_imagify_option' )
-			->once()
+			->twice()
 			->andReturn( false );
 
 		$this->assertFalse( $subscriber->is_serving_webp() );

--- a/tests/Unit/inc/classes/third-party/plugins/Images/Webp/Imagify_Subscriber/isServingWebpCompatibleWithCdn.php
+++ b/tests/Unit/inc/classes/third-party/plugins/Images/Webp/Imagify_Subscriber/isServingWebpCompatibleWithCdn.php
@@ -17,7 +17,7 @@ class Test_IsServingWebpCompatibleWithCdn extends TestCase {
 
 	public function testShouldReturnFalseWhenImagifyNotEnabled() {
 		Functions\expect( 'get_imagify_option' )
-			->once()
+			->twice()
 			->andReturn( false );
 
 		$optionsData = Mockery::mock( Options_Data::class );
@@ -31,7 +31,7 @@ class Test_IsServingWebpCompatibleWithCdn extends TestCase {
 		$subscriber  = new Imagify_Subscriber( $optionsData );
 
 		Functions\expect( 'get_imagify_option' )
-			->once()
+			->twice()
 			->andReturnUsing(
 				function( $option_name ) {
 					if ( 'display_webp' === $option_name ) {

--- a/tests/Unit/inc/classes/third-party/plugins/Images/Webp/Imagify_Subscriber/isServingWebpCompatibleWithCdn.php
+++ b/tests/Unit/inc/classes/third-party/plugins/Images/Webp/Imagify_Subscriber/isServingWebpCompatibleWithCdn.php
@@ -53,13 +53,13 @@ class Test_IsServingWebpCompatibleWithCdn extends TestCase {
 		$subscriber  = new Imagify_Subscriber( $optionsData );
 
 		Functions\expect( 'get_imagify_option' )
-			->twice()
+			->times(3)
 			->andReturnUsing(
 				function( $option_name ) {
-					if ( 'display_webp' === $option_name ) {
+					if ( 'display_webp' === $option_name || 'display_nextgen' === $option_name ) {
 						return 1;
 					}
-					if ( 'display_webp_method' === $option_name ) {
+					if ( 'display_webp_method' === $option_name || 'display_nextgen_method' === $option_name ) {
 						return 'rewrite';
 					}
 


### PR DESCRIPTION
# Description

Fixes #6468

## Documentation

### Technical documentation

Since Imagify 2.2 update, an option has been renamed so we need to take it into account within WP Rocket to ensure the compatibility.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue).

# Checklists

## Feature validation

- [ ] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I wrote comments to explain why it does it.
- [x] I named variables and functions explicitely.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.
- [x] I listed the introduced external dependencies explicitely on the PR.
- [x] I validated the repo-specific guidelines from CONTRIBUTING.md.
