### PR TITLE
fix typo

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Cron/Subscriber.php
+++ b/inc/Engine/Optimization/RUCSS/Cron/Subscriber.php
@@ -194,7 +194,7 @@ class Subscriber implements Subscriber_Interface {
 
 		$schedules['rocket_rucss_on_submit_jobs'] = [
 			'interval' => $interval,
-			'display'  => esc_html__( 'WP Rocket procees on submit jobs', 'rocket' ),
+			'display'  => esc_html__( 'WP Rocket process on submit jobs', 'rocket' ),
 		];
 
 		return $schedules;


### PR DESCRIPTION
assuming 'procees' is meant to be 'process'