### PR TITLE
Fixes #6511 - 3.16 - In some cases DOMContentLoaded is already fired before loading our beacon script

### DIFF
--- a/assets/js/lcp-beacon.js
+++ b/assets/js/lcp-beacon.js
@@ -145,8 +145,14 @@ async function main() {
 	});
 }
 
-document.addEventListener("DOMContentLoaded", async function () {
-    console.time("extract");
-    setTimeout(main, 500);
-    console.timeEnd("extract");
-});
+if (document.readyState !== 'loading') {
+	console.time("extract");
+	setTimeout(main, 500);
+	console.timeEnd("extract");
+} else {
+	document.addEventListener("DOMContentLoaded", async function () {
+		console.time("extract");
+		setTimeout(main, 500);
+		console.timeEnd("extract");
+	});
+}


### PR DESCRIPTION
# Description

Fixes #6511

## Documentation

### User documentation

Everything is mentioned in the issue itself.

### Technical documentation

Everything is mentioned in the issue itself.

## Type of change
*Delete options that are not relevant.*

- [x] Bug fix (non-breaking change which fixes an issue).

## New dependencies
*List any new dependencies that are required for this change.*

## Risks
*List possible performance & security issues or risks, and explain how they have been mitigated.*

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Documentation

- [x] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [ ] The user documentation covers new/changed entry points (endpoints, WP hooks, configuration files, ...).
- [ ] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I wrote comments to explain why it does it.
- [x] I named variables and functions explicitely.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.
- [ ] I listed the introduced external dependencies explicitely on the PR.
- [x] I validated the repo-specific guidelines from CONTRIBUTING.md.

## Observability
- [x] I handled errors when needed.
- [ ] I wrote user-facing messages that are understandable and provide actionable feedbacks.
- [ ] I prepared ways to observe the implemented system (logs, data, etc.).

## Risks
- [ ] I explicitely mentioned performance risks in the PR.
- [ ] I explicitely mentioned security risks in the PR.
