### PR TITLE
3.16 bug the warm up of lcpatf is not triggered when clicking clear critical images in the admin

### DIFF
--- a/inc/Engine/Media/AboveTheFold/Admin/Controller.php
+++ b/inc/Engine/Media/AboveTheFold/Admin/Controller.php
@@ -53,7 +53,6 @@ class Controller {
 		}
 
 		$this->delete_rows();
-
 	}
 
 	/**
@@ -73,7 +72,6 @@ class Controller {
 		 * Fires after clearing lcp & atf data.
 		 */
 		do_action( 'rocket_after_clear_atf' );
-
 	}
 
 	/**

--- a/inc/Engine/Media/AboveTheFold/Admin/Controller.php
+++ b/inc/Engine/Media/AboveTheFold/Admin/Controller.php
@@ -54,10 +54,6 @@ class Controller {
 
 		$this->delete_rows();
 
-		/**
-		 * Fires after clearing lcp & atf data.
-		 */
-		do_action( 'rocket_after_clear_atf' );
 	}
 
 	/**
@@ -72,6 +68,12 @@ class Controller {
 		}
 
 		$this->table->truncate_atf_table();
+
+		/**
+		 * Fires after clearing lcp & atf data.
+		 */
+		do_action( 'rocket_after_clear_atf' );
+
 	}
 
 	/**
@@ -123,7 +125,7 @@ class Controller {
 	 *
 	 * @return array
 	 */
-	public function truncate( $clean ) {
+	public function truncate_atf_admin( $clean ) {
 		if ( ! $this->context->is_allowed() ) {
 			return $clean;
 		}

--- a/inc/Engine/Media/AboveTheFold/Admin/Subscriber.php
+++ b/inc/Engine/Media/AboveTheFold/Admin/Subscriber.php
@@ -38,7 +38,7 @@ class Subscriber implements Subscriber_Interface {
 			'wp_update_comment_count'       => 'delete_post_atf',
 			'edit_term'                     => 'delete_term_atf',
 			'pre_delete_term'               => 'delete_term_atf',
-			'rocket_saas_clean_all'         => 'truncate',
+			'rocket_saas_clean_all'         => 'truncate_atf_admin',
 			'rocket_saas_clean_url'         => 'clean_url',
 		];
 	}
@@ -81,8 +81,8 @@ class Subscriber implements Subscriber_Interface {
 	 *
 	 * @return array
 	 */
-	public function truncate( $clean ) {
-		return $this->controller->truncate( $clean );
+	public function truncate_atf_admin( $clean ) {
+		return $this->controller->truncate_atf_admin( $clean );
 	}
 
 	/**

--- a/tests/Fixtures/inc/Engine/Media/AboveTheFold/Admin/Controller/truncateAtfAdmin.php
+++ b/tests/Fixtures/inc/Engine/Media/AboveTheFold/Admin/Controller/truncateAtfAdmin.php
@@ -1,0 +1,76 @@
+<?php
+
+return [
+	'testShouldTruncateDb' => [
+		'config' => [
+			'rows' => [
+				[
+					'status' => 'completed',
+					'url' => 'http://example.org',
+					'lcp' => json_encode((object)[
+						'type' => 'img',
+						'src' => 'http://example.org/wp-content/uploads/image.jpg',
+					]),
+					'viewport' => json_encode([
+						0 => (object)[
+							'type' => 'img',
+							'src' => 'http://example.org/wp-content/uploads/image.jpg',
+						],
+					]),
+				],
+				[
+					'status' => 'completed',
+					'url' => 'http://example.org/page-1/',
+					'lcp' => json_encode((object)[
+						'type' => 'img',
+						'src' => 'http://example.org/wp-content/uploads/image.jpg',
+					]),
+					'viewport' => json_encode([
+						0 => (object)[
+							'type' => 'img',
+							'src' => 'http://example.org/wp-content/uploads/image.jpg',
+						],
+					])
+				]
+			],
+			'rocket_manage_options' => true,
+		],
+		'expected' => 0
+	],
+	'testShouldNotTruncateDb' => [
+		'config' => [
+			'rows' => [
+				[
+					'status' => 'completed',
+					'url' => 'http://example.org',
+					'lcp' => json_encode((object)[
+						'type' => 'img',
+						'src' => 'http://example.org/wp-content/uploads/image.jpg',
+					]),
+					'viewport' => json_encode([
+						0 => (object)[
+							'type' => 'img',
+							'src' => 'http://example.org/wp-content/uploads/image.jpg',
+						],
+					]),
+				],
+				[
+					'status' => 'completed',
+					'url' => 'http://example.org/page-1/',
+					'lcp' => json_encode((object)[
+						'type' => 'img',
+						'src' => 'http://example.org/wp-content/uploads/image.jpg',
+					]),
+					'viewport' => json_encode([
+						0 => (object)[
+							'type' => 'img',
+							'src' => 'http://example.org/wp-content/uploads/image.jpg',
+						],
+					])
+				]
+			],
+			'rocket_manage_options' => false,
+		],
+		'expected' => 2
+	],
+];

--- a/tests/Integration/inc/Engine/Media/AboveTheFold/Admin/Controller/truncateAtfAdmin.php
+++ b/tests/Integration/inc/Engine/Media/AboveTheFold/Admin/Controller/truncateAtfAdmin.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\Media\AboveTheFold\Admin\Controller;
+
+use WP_Rocket\Tests\Integration\DBTrait;
+use WP_Rocket\Tests\Integration\TestCase;
+use Brain\Monkey\Functions;
+use Mockery;
+use WP_Rocket\Engine\Media\AboveTheFold\WarmUp\Controller;
+
+/**
+ * @covers \WP_Rocket\Engine\Media\AboveTheFold\Admin\Controller::truncate_atf_admin
+ *
+ * @group AboveTheFold
+ */
+class Test_TruncateAtfAdmin extends TestCase {
+	use DBTrait;
+
+	protected $path_to_test_data = '/inc/Engine/Media/AboveTheFold/Admin/Controller/truncateAtfAdmin.php';
+
+	protected $config;
+	public function set_up() {
+		parent::set_up();
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldDoAsExpected( $config, $expected ) {
+		$this->config = $config;
+		$container    = apply_filters( 'rocket_container', null );
+		$warm_up_controller = Mockery::mock( Controller::class );
+		foreach ( $this->config['rows'] as $row ) {
+			self::addLcp( $row );
+		}
+		Functions\expect( 'current_user_can' )->once()->with('rocket_manage_options')->andReturn($config['rocket_manage_options']);
+		do_action( 'rocket_saas_clean_all' );
+
+		$atf_query              = $container->get( 'atf_query' );
+		$result_atf_after_clean = $atf_query->query();
+
+		$this->assertCount( $expected, $result_atf_after_clean );
+		if ( ! $expected ) {
+			$this->assertSame( 1, did_action( 'rocket_after_clear_atf' ) );
+		}
+
+	}
+}


### PR DESCRIPTION
# Description

Move `rocket_after_clear_atf` firing in `delete_rows` to make sure it fires for all truncate.
Rename truncate method to something a bit more explicit

Fixes #6516 

## Documentation

### User documentation

the "Clear Critical Images" button in the WP Admin will now fire the warm-up process for LCP/ATF

### Technical documentation

NA

## Type of change
*Delete options that are not relevant.*

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).

## New dependencies
*List any new dependencies that are required for this change.*

## Risks
*List possible performance & security issues or risks, and explain how they have been mitigated.*

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Documentation

- [x] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [x] The user documentation covers new/changed entry points (endpoints, WP hooks, configuration files, ...).
- [x] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I wrote comments to explain why it does it.
- [x] I named variables and functions explicitely.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.
- [x] I listed the introduced external dependencies explicitely on the PR.
- [x] I validated the repo-specific guidelines from CONTRIBUTING.md.

## Observability
- [x] I handled errors when needed.
- [x] I wrote user-facing messages that are understandable and provide actionable feedbacks.
- [x] I prepared ways to observe the implemented system (logs, data, etc.).

## Risks
- [x] I explicitely mentioned performance risks in the PR.
- [x] I explicitely mentioned security risks in the PR.
