### PR TITLE
Fixes new PHPCS error RequireExplicitBooleanOperatorPrecedence.MissingParentheses

### DIFF
--- a/inc/Engine/Common/ExtractCSS/Subscriber.php
+++ b/inc/Engine/Common/ExtractCSS/Subscriber.php
@@ -72,11 +72,13 @@ class Subscriber implements Subscriber_Interface, LoggerAwareInterface {
 
 		foreach ( $link_styles as $style ) {
 			if (
-				! (bool) preg_match( '/rel=[\'"]?stylesheet[\'"]?/is', $style[0] )
-				&&
-				! ( (bool) preg_match( '/rel=[\'"]?preload[\'"]?/is', $style[0] ) && (bool) preg_match( '/as=[\'"]?style[\'"]?/is', $style[0] ) )
+				(
+					! (bool) preg_match( '/rel=[\'"]?stylesheet[\'"]?/is', $style[0] )
+					&&
+					! ( (bool) preg_match( '/rel=[\'"]?preload[\'"]?/is', $style[0] ) && (bool) preg_match( '/as=[\'"]?style[\'"]?/is', $style[0] ) )
+				)
 				||
-				( strstr( $style['url'], '//fonts.googleapis.com/css' ) )
+				strstr( $style['url'], '//fonts.googleapis.com/css' )
 			) {
 				$this->logger::notice(
 					"Skipped URL: {$style['url']}",

--- a/inc/Engine/Media/Lazyload/CSS/Front/Extractor.php
+++ b/inc/Engine/Media/Lazyload/CSS/Front/Extractor.php
@@ -268,7 +268,11 @@ class Extractor {
 	protected function make_url_complete( string $url, string $file_url ): string {
 		$host = wp_parse_url( $url, PHP_URL_HOST );
 
-		if ( $host || $this->is_relative( $url ) && ! empty( $file_url ) ) {
+		if (
+			$host
+			||
+			( $this->is_relative( $url ) && ! empty( $file_url ) )
+		) {
 			return $this->transform_relative_to_absolute( $url, $file_url );
 		}
 

--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -317,9 +317,11 @@ class UsedCSS implements LoggerAwareInterface {
 
 		foreach ( $link_styles as $style ) {
 			if (
-				! (bool) preg_match( '/rel=[\'"]?stylesheet[\'"]?/is', $style[0] )
-				&&
-				! ( (bool) preg_match( '/rel=[\'"]?preload[\'"]?/is', $style[0] ) && (bool) preg_match( '/as=[\'"]?style[\'"]?/is', $style[0] ) )
+				(
+					! (bool) preg_match( '/rel=[\'"]?stylesheet[\'"]?/is', $style[0] )
+					&&
+					! ( (bool) preg_match( '/rel=[\'"]?preload[\'"]?/is', $style[0] ) && (bool) preg_match( '/as=[\'"]?style[\'"]?/is', $style[0] ) )
+				)
 				||
 				( $preserve_google_font && strstr( $style['url'], '//fonts.googleapis.com/css' ) )
 			) {

--- a/inc/admin/options.php
+++ b/inc/admin/options.php
@@ -33,8 +33,24 @@ function rocket_after_save_options( $oldvalue, $value ) {
 	}
 
 	// Regenerate advanced-cache.php file.
-	// phpcs:ignore WordPress.Security.NonceVerification.Missing
-	if ( ! empty( $_POST ) && ( ( isset( $oldvalue['do_caching_mobile_files'] ) && ! isset( $value['do_caching_mobile_files'] ) ) || ( ! isset( $oldvalue['do_caching_mobile_files'] ) && isset( $value['do_caching_mobile_files'] ) ) || ( isset( $oldvalue['do_caching_mobile_files'], $value['do_caching_mobile_files'] ) ) && $oldvalue['do_caching_mobile_files'] !== $value['do_caching_mobile_files'] ) ) {
+	if (
+		! empty( $_POST ) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		&&
+		(
+			(
+				isset( $oldvalue['do_caching_mobile_files'] ) && ! isset( $value['do_caching_mobile_files'] )
+			)
+			||
+			(
+				! isset( $oldvalue['do_caching_mobile_files'] ) && isset( $value['do_caching_mobile_files'] )
+			)
+			||
+			(
+				isset( $oldvalue['do_caching_mobile_files'], $value['do_caching_mobile_files'] )
+				&&
+				$oldvalue['do_caching_mobile_files'] !== $value['do_caching_mobile_files']
+			)
+		) ) {
 		rocket_generate_advanced_cache_file();
 	}
 
@@ -157,10 +173,16 @@ function rocket_pre_main_option( $newvalue, $oldvalue ) {
 	}
 
 	// Regenerate the minify key if JS files have been modified.
-	// phpcs:ignore Universal.Operators.StrictComparisons.LooseNotEqual
-	if ( ( isset( $newvalue['minify_js'], $oldvalue['minify_js'] ) && $newvalue['minify_js'] != $oldvalue['minify_js'] )
-		|| ( isset( $newvalue['exclude_js'], $oldvalue['exclude_js'] ) && $newvalue['exclude_js'] !== $oldvalue['exclude_js'] )
-		|| ( isset( $oldvalue['cdn'] ) && ! isset( $newvalue['cdn'] ) || ! isset( $oldvalue['cdn'] ) && isset( $newvalue['cdn'] ) )
+	if (
+		( isset( $newvalue['minify_js'], $oldvalue['minify_js'] ) && $newvalue['minify_js'] != $oldvalue['minify_js'] ) // phpcs:ignore Universal.Operators.StrictComparisons.LooseNotEqual
+		||
+		( isset( $newvalue['exclude_js'], $oldvalue['exclude_js'] ) && $newvalue['exclude_js'] !== $oldvalue['exclude_js'] )
+		||
+		(
+			( isset( $oldvalue['cdn'] ) && ! isset( $newvalue['cdn'] ) )
+			||
+			( ! isset( $oldvalue['cdn'] ) && isset( $newvalue['cdn'] ) )
+		)
 	) {
 		$newvalue['minify_js_key'] = create_rocket_uniqid();
 	}

--- a/inc/classes/Buffer/class-cache.php
+++ b/inc/classes/Buffer/class-cache.php
@@ -584,7 +584,15 @@ class Cache extends Abstract_Buffer {
 
 		$detect = new \WP_Rocket_Mobile_Detect();
 
-		if ( $detect->isMobile() && ! $detect->isTablet() && 'desktop' === $cache_mobile_files_tablet || ( $detect->isMobile() || $detect->isTablet() ) && 'mobile' === $cache_mobile_files_tablet ) {
+		if (
+			( $detect->isMobile() && ! $detect->isTablet() && 'desktop' === $cache_mobile_files_tablet )
+			||
+			(
+				( $detect->isMobile() || $detect->isTablet() )
+				&&
+				'mobile' === $cache_mobile_files_tablet
+			)
+		) {
 				return $filename .= '-mobile';
 		}
 

--- a/inc/functions/htaccess.php
+++ b/inc/functions/htaccess.php
@@ -172,7 +172,11 @@ function get_rocket_htaccess_mod_rewrite() { // phpcs:ignore WordPress.NamingCon
 	}
 
 	// No rewrite rules for Korean.
-	if ( defined( 'WPLANG' ) && 'ko_KR' === WPLANG || 'ko_KR' === get_locale() ) {
+	if (
+		( defined( 'WPLANG' ) && 'ko_KR' === WPLANG )
+		||
+		'ko_KR' === get_locale()
+		) {
 		return;
 	}
 


### PR DESCRIPTION
# Description

Fixes new error now included in WPCS 3.1

### Technical documentation

Error description: 
> Mixing different binary boolean operators within an expression without using parentheses to clarify precedence is not allowed.

To fix, I added parentheses where needed to make the mixed conditions more explicit.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklists

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I named variables and functions explicitely.
- [x] I did not introduce unecessary complexity.
