### PR TITLE
Fixes #6545 error in integration test with WP 6.5

### DIFF
--- a/tests/Fixtures/inc/Engine/Optimization/Minify/JS/Subscriber/process.php
+++ b/tests/Fixtures/inc/Engine/Optimization/Minify/JS/Subscriber/process.php
@@ -1,8 +1,9 @@
 <?php
 
-global $wp_scripts;
+$scripts = new WP_Scripts();
+wp_default_scripts( $scripts );
 
-$jquery_path = $wp_scripts->registered['jquery-core']->src;
+$jquery_path = $scripts->registered['jquery-core']->src;
 $timenow = time();
 
 return [

--- a/tests/Integration/inc/Engine/CriticalPath/CriticalCSSSubscriber/deleteCpcss.php
+++ b/tests/Integration/inc/Engine/CriticalPath/CriticalCSSSubscriber/deleteCpcss.php
@@ -61,7 +61,7 @@ class Test_DeleteCpcss extends FilesystemTestCase {
 			$this->assertTrue( $this->filesystem->exists( $mobile_item_path ) );
 		}
 
-		do_action( 'before_delete_post', self::$post_id );
+		do_action( 'before_delete_post', self::$post_id, self::factory()->post->get_object_by_id( self::$post_id ) );
 
 		if ( ! $config['current_user_can'] || ! $config['async_css'] ) {
 			// should bail out & files will exist.


### PR DESCRIPTION
# Description

Fixes #6545 

### Technical documentation

The original `do_action()` for `before_delete_post` does have 2 parameters, so we need to match with that.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Code style

- [x] I named variables and functions explicitely.
- [x] I did not introduce unecessary complexity.
