### PR TITLE
Closes #6518: inject beacon for saas

### DIFF
--- a/inc/Engine/Media/AboveTheFold/Frontend/Controller.php
+++ b/inc/Engine/Media/AboveTheFold/Frontend/Controller.php
@@ -93,6 +93,10 @@ class Controller {
 	 * @return string
 	 */
 	private function preload_lcp( $html, $row ) {
+		if ( rocket_bypass() ) { // Bail out if rocket_bypass() returns true.
+			return $html;
+		}
+
 		if ( ! preg_match( '#</title\s*>#', $html, $matches ) ) {
 			return $html;
 		}

--- a/inc/Engine/Media/AboveTheFold/Frontend/Subscriber.php
+++ b/inc/Engine/Media/AboveTheFold/Frontend/Subscriber.php
@@ -29,8 +29,9 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events() {
 		return [
-			'rocket_buffer'                => [ 'lcp', 17 ],
-			'rocket_lazyload_excluded_src' => 'add_exclusions',
+			'rocket_buffer'                           => [ 'lcp', 17 ],
+			'rocket_lazyload_excluded_src'            => 'add_exclusions',
+			'rocket_critical_image_saas_visit_buffer' => [ 'lcp', 17 ],
 		];
 	}
 

--- a/inc/Engine/Media/ImageDimensions/Subscriber.php
+++ b/inc/Engine/Media/ImageDimensions/Subscriber.php
@@ -44,8 +44,9 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events() {
 		return [
-			'rocket_buffer'     => [ 'specify_image_dimensions', 17 ],
-			'template_redirect' => [ 'start_image_dimensions_buffer', 3 ],
+			'rocket_buffer'                           => [ 'specify_image_dimensions', 17 ],
+			'template_redirect'                       => [ 'start_image_dimensions_buffer', 3 ],
+			'rocket_critical_image_saas_visit_buffer' => 'specify_image_dimensions',
 		];
 	}
 
@@ -76,9 +77,7 @@ class Subscriber implements Subscriber_Interface {
 			return $buffer;
 		}
 
-		do_action( 'rocket_critical_image_saas_visit_buffer', $buffer );
-
-		return $this->dimensions->specify_image_dimensions( $buffer );
+		return apply_filters( 'rocket_critical_image_saas_visit_buffer', $buffer );
 	}
 
 	/**

--- a/inc/Engine/Media/ImageDimensions/Subscriber.php
+++ b/inc/Engine/Media/ImageDimensions/Subscriber.php
@@ -65,6 +65,23 @@ class Subscriber implements Subscriber_Interface {
 	}
 
 	/**
+	 * Update images that have no width/height with real dimentions for the SaaS
+	 *
+	 * @param string $buffer Page HTML content.
+	 *
+	 * @return string Page HTML content after update.
+	 */
+	public function prepare_critical_image_saas_visit( $buffer ) {
+		if ( ! isset( $_GET['wpr_imagedimensions'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return $buffer;
+		}
+
+		do_action( 'rocket_critical_image_saas_visit_buffer', $buffer );
+
+		return $this->dimensions->specify_image_dimensions( $buffer );
+	}
+
+	/**
 	 * Start image dimensions buffer to add
 	 *
 	 * @return void
@@ -80,6 +97,6 @@ class Subscriber implements Subscriber_Interface {
 
 		add_filter( 'rocket_specify_image_dimensions', '__return_true' );
 
-		ob_start( [ $this, 'specify_image_dimensions' ] );
+		ob_start( [ $this, 'prepare_critical_image_saas_visit' ] );
 	}
 }


### PR DESCRIPTION
# Description

Fixes #6518 

This PR addresses an issue where the beacon script was not being injected into certain URLs due to the presence of specific query strings. The changes ensure that the beacon script is correctly injected and that the LCP/ATF front-end optimization is correctly applied based on the query strings present in the URL. 

## Documentation

### User documentation

This change will not directly impact users, as it is a backend optimization. However, it will improve the performance of the website by ensuring that the beacon script and LCP/ATF front-end optimization are correctly applied.

### Technical documentation

The changes involve the creation of a new method `prepare_critical_image_saas_visit` in the `Subscriber` class. This method checks if the `wpr_imagedimensions` query string is set and if so, fires an action `rocket_critical_image_saas_visit_buffer` and then calls the `specify_image_dimensions` method. The `start_image_dimensions_buffer` method has been updated to call this new method instead of `specify_image_dimensions`. 

In the `preload_lcp` method, a bail out condition based on `rocket_bypass()` has been added to ensure that SaaS visits do not receive the LCP/ATF optimizations.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## New dependencies
N/A

## Risks
N/A

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.

## Documentation

- [x] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [x] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I wrote comments to explain why it does it.
- [x] I named variables and functions explicitly.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] I listed the introduced external dependencies explicitly on the PR.
- [x] I validated the repo-specific guidelines from CONTRIBUTING.md.
