### PR TITLE
Closes #6533: Inconsistency between Clear used CSS / Critical Images vs. Clean […] buttons

### DIFF
--- a/inc/Engine/Saas/Admin/AdminBar.php
+++ b/inc/Engine/Saas/Admin/AdminBar.php
@@ -170,7 +170,7 @@ class AdminBar extends Abstract_Render {
 		$title = __( 'Clear Critical Images of this URL', 'rocket' );
 
 		if ( $this->rucss_url_context->is_allowed() ) {
-			$title = __( 'Clean Used CSS of this URL', 'rocket' );
+			$title = __( 'Clear Used CSS of this URL', 'rocket' );
 		}
 
 		$wp_admin_bar->add_menu(
@@ -201,7 +201,7 @@ class AdminBar extends Abstract_Render {
 		}
 
 		$title = __( 'Critical Images Cache', 'rocket' );
-		$label = esc_html__( 'Clean Critical Images', 'rocket' );
+		$label = esc_html__( 'Clear Critical Images', 'rocket' );
 
 		if ( $this->rucss_url_context->is_allowed() ) {
 			$title = __( 'Remove Used CSS Cache', 'rocket' );


### PR DESCRIPTION
# Description
Fixes the inconsistency in text between Clear & Clean.

Fixes #6533 

## Documentation

### User documentation

*Explain how this code impacts users.*

### Technical documentation

*Explain how this code works. Diagram & drawings are welcomed.*

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## New dependencies
*List any new dependencies that are required for this change.*

## Risks
*List possible performance & security issues or risks, and explain how they have been mitigated.*

# Checklists

## Feature validation

- [ ] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [ ] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Documentation

- [ ] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [ ] The user documentation covers new/changed entry points (endpoints, WP hooks, configuration files, ...).
- [ ] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [ ] I wrote self-explanatory code about what it does.
- [ ] I wrote comments to explain why it does it.
- [ ] I named variables and functions explicitely.
- [ ] I protected entry points against unexpected inputs.
- [ ] I did not introduce unecessary complexity.
- [ ] I listed the introduced external dependencies explicitely on the PR.
- [ ] I validated the repo-specific guidelines from CONTRIBUTING.md.

## Observability
- [ ] I handled errors when needed.
- [ ] I wrote user-facing messages that are understandable and provide actionable feedbacks.
- [ ] I prepared ways to observe the implemented system (logs, data, etc.).

## Risks
- [ ] I explicitely mentioned performance risks in the PR.
- [ ] I explicitely mentioned security risks in the PR.
