### PR TITLE
Closes #6536: ATF image in root not excluded from root with specific markup

### DIFF
--- a/inc/Engine/Media/AboveTheFold/Frontend/Controller.php
+++ b/inc/Engine/Media/AboveTheFold/Frontend/Controller.php
@@ -213,7 +213,7 @@ class Controller {
 		$exclusions = array_map(
 				function ( $exclusion ) {
 					$exclusion = wp_parse_url( $exclusion );
-					return $exclusion['path'];
+					return ltrim( $exclusion['path'], '/' );
 				},
 			$exclusions
 			);

--- a/tests/Fixtures/inc/Engine/Media/AboveTheFold/Frontend/Controller/addExclusions.php
+++ b/tests/Fixtures/inc/Engine/Media/AboveTheFold/Frontend/Controller/addExclusions.php
@@ -55,12 +55,12 @@ return [
 			'row'                     => (object) [
 				'lcp'      => json_encode( (object) [
 					'type' => 'img',
-					'src'  => 'bar',
+					'src'  => 'https://example.com/bar.jpg',
 				] ),
 				'viewport' => json_encode( [
 					0 => (object) [
 						'type' => 'img',
-						'src'  => 'foobar',
+						'src'  => 'https://example.com/foobar.jpg',
 					],
 				] ),
 			],
@@ -73,8 +73,8 @@ return [
 		],
 		'expected'   => [
 			'foo',
-			'bar',
-			'foobar',
+			'bar.jpg',
+			'foobar.jpg',
 		],
 	],
 ];


### PR DESCRIPTION
# Description
Fixes issue of images in root not being excluded from LL

Fixes #6536 

## Documentation

### User documentation

*Explain how this code impacts users.*

### Technical documentation
`wp_parse_url` adds a forward slash to the path of a relative url, This PR trims off the forward slash using `ltrim`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## New dependencies
None

## Risks
None

# Checklists

## Feature validation

- [ ] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [ ] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Documentation

- [ ] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [ ] The user documentation covers new/changed entry points (endpoints, WP hooks, configuration files, ...).
- [ ] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [ ] I wrote comments to explain why it does it.
- [ ] I named variables and functions explicitely.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.
- [ ] I listed the introduced external dependencies explicitely on the PR.
- [x] I validated the repo-specific guidelines from CONTRIBUTING.md.

## Observability
- [x] I handled errors when needed.
- [ ] I wrote user-facing messages that are understandable and provide actionable feedbacks.
- [ ] I prepared ways to observe the implemented system (logs, data, etc.).

## Risks
- [ ] I explicitely mentioned performance risks in the PR.
- [ ] I explicitely mentioned security risks in the PR.
