### PR TITLE
Fixes #6509 Don't display clear critical images for this URL on admin view

### DIFF
--- a/inc/Engine/Saas/Admin/AdminBar.php
+++ b/inc/Engine/Saas/Admin/AdminBar.php
@@ -106,23 +106,13 @@ class AdminBar extends Abstract_Render {
 	 * @return void
 	 */
 	public function add_clean_url_menu_item( WP_Admin_Bar $wp_admin_bar ) {
-		global $pagenow, $post;
+		global $post;
 
 		if ( 'local' === wp_get_environment_type() ) {
 			return;
 		}
 
-		if (
-			is_admin()
-			&&
-			(
-				! $post
-				||
-				'post.php' !== $pagenow
-				||
-				! isset( $_GET['action'], $_GET['post'] )  // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			)
-		) {
+		if ( is_admin() ) {
 			return;
 		}
 

--- a/inc/Engine/Saas/Admin/AdminBar.php
+++ b/inc/Engine/Saas/Admin/AdminBar.php
@@ -166,7 +166,7 @@ class AdminBar extends Abstract_Render {
 		$wp_admin_bar->add_menu(
 			[
 				'parent' => 'wp-rocket',
-				'id'     => 'clear-saaas-url',
+				'id'     => 'clear-saas-url',
 				'title'  => $title,
 				'href'   => wp_nonce_url( admin_url( 'admin-post.php?action=' . $action . $referer ), $action ),
 			]

--- a/tests/Fixtures/inc/Engine/Saas/Admin/AdminBar/addCleanSaasMenuItem.php
+++ b/tests/Fixtures/inc/Engine/Saas/Admin/AdminBar/addCleanSaasMenuItem.php
@@ -1,0 +1,50 @@
+<?php
+
+return [
+	'testShouldReturnNullWhenLocalEnvironment' => [
+		'config'   => [
+			'environment'       => 'local',
+			'is_admin'          => false,
+			'atf_context'       => false,
+			'remove_unused_css' => 0,
+			'current_user_can'  => true,
+		],
+		'expected' => null,
+	],
+	'testShouldReturnNullWhenNotAdmin' => [
+		'config'   => [
+			'environment'       => 'production',
+			'is_admin'          => false,
+			'atf_context'       => false,
+			'remove_unused_css' => 0,
+			'current_user_can'  => true,
+		],
+		'expected' => null,
+	],
+	'testShouldAddItemWithDefaultTitle' => [
+		'config'   => [
+			'environment'       => 'production',
+			'is_admin'          => true,
+			'atf_context'       => true,
+			'remove_unused_css' => 0,
+			'current_user_can'  => true,
+		],
+		'expected' => [
+			'id'    => 'clean-saas',
+			'title' => 'Clear Critical Images',
+		],
+	],
+	'testShouldAddItemWithRUCSSTitle' => [
+		'config'   => [
+			'environment'       => 'production',
+			'is_admin'          => true,
+			'atf_context'       => true,
+			'remove_unused_css' => 1,
+			'current_user_can'  => true,
+		],
+		'expected' => [
+			'id'    => 'clean-saas',
+			'title' => 'Clear Used CSS',
+		],
+	],
+];

--- a/tests/Fixtures/inc/Engine/Saas/Admin/AdminBar/addCleanUrlMenuItem.php
+++ b/tests/Fixtures/inc/Engine/Saas/Admin/AdminBar/addCleanUrlMenuItem.php
@@ -1,0 +1,94 @@
+<?php
+
+return [
+	'testShouldReturnNullWhenLocalEnvironment' => [
+		'config'   => [
+			'environment'       => 'local',
+			'is_admin'          => false,
+			'post'              => (object) [
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+			],
+			'can_display_options' => true,
+			'atf_context'       => true,
+			'rucss_context' => true,
+		],
+		'expected' => null,
+	],
+	'testShouldReturnNullWhenAdmin' => [
+		'config'   => [
+			'environment'       => 'production',
+			'is_admin'          => true,
+			'post'              => (object) [
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+			],
+			'can_display_options' => true,
+			'atf_context'       => true,
+			'rucss_context' => true,
+		],
+		'expected' => null,
+	],
+	'testShouldReturnNullWhenOptionsNotDisplayed' => [
+		'config'   => [
+			'environment'       => 'production',
+			'is_admin'          => false,
+			'post'              => (object) [
+				'post_type'   => 'post',
+				'post_status' => 'draft',
+			],
+			'can_display_options' => false,
+			'atf_context'       => true,
+			'rucss_context' => true,
+		],
+		'expected' => null,
+	],
+	'testShouldReturnNullWhenNotAllowed' => [
+		'config'   => [
+			'environment'       => 'production',
+			'is_admin'          => false,
+			'post'              => (object) [
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+			],
+			'can_display_options' => true,
+			'atf_context'       => false,
+			'rucss_context' => false,
+		],
+		'expected' => null,
+	],
+	'testShouldAddItemWithDefaultTitle' => [
+		'config'   => [
+			'environment'       => 'production',
+			'is_admin'          => false,
+			'post'              => (object) [
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+			],
+			'can_display_options' => true,
+			'atf_context'       => true,
+			'rucss_context' => false,
+		],
+		'expected' => [
+			'id'    => 'clear-saas-url',
+			'title' => 'Clear Critical Images of this URL',
+		],
+	],
+	'testShouldAddItemWithRUCSSTitle' => [
+		'config'   => [
+			'environment'       => 'production',
+			'is_admin'          => false,
+			'post'              => (object) [
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+			],
+			'can_display_options' => true,
+			'atf_context'       => true,
+			'rucss_context' => true,
+		],
+		'expected' => [
+			'id'    => 'clear-saas-url',
+			'title' => 'Clear Used CSS of this URL',
+		],
+	],
+];

--- a/tests/Unit/inc/Engine/Saas/Admin/AdminBar/addCleanSaasMenuItem.php
+++ b/tests/Unit/inc/Engine/Saas/Admin/AdminBar/addCleanSaasMenuItem.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\Saas\Admin\AdminBar;
+
+use Mockery;
+use Brain\Monkey\Functions;
+use WP_Admin_Bar;
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Engine\Common\Context\ContextInterface;
+use WP_Rocket\Engine\Saas\Admin\AdminBar;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Saas\Admin\AdminBar::add_clean_saas_menu_item
+ * @group  Saas
+ */
+class Test_AddCleanSaasMenuItem extends TestCase {
+	private $admin_bar;
+	private $options;
+	private $atf_context;
+	private $rucss_url_context;
+	private $wp_admin_bar;
+
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
+		require_once WP_ROCKET_TESTS_FIXTURES_DIR . '/WP_Admin_Bar.php';
+	}
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->options           = Mockery::mock( Options_Data::class );
+		$this->atf_context       = Mockery::mock( ContextInterface::class );
+		$this->rucss_url_context = Mockery::mock( ContextInterface::class );
+		$this->admin_bar         = new AdminBar( $this->options, $this->atf_context, $this->rucss_url_context, '' );
+		$this->wp_admin_bar      = new WP_Admin_Bar();
+
+		$this->stubTranslationFunctions();
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldDoExpected( $config, $expected ) {
+		Functions\when( 'wp_get_environment_type' )
+			->justReturn( $config['environment'] );
+		Functions\when( 'is_admin' )
+			->justReturn( $config['is_admin'] );
+
+		$this->atf_context->shouldReceive( 'is_allowed' )
+			->andReturn( $config['atf_context'] );
+
+		$this->options->shouldReceive( 'get' )
+			->with( 'remove_unused_css', 0 )
+			->andReturn( $config['remove_unused_css'] );
+
+		Functions\when( 'current_user_can' )
+			->justReturn( $config['current_user_can'] );
+
+		Functions\when( 'wp_nonce_url' )->alias(
+			function ( $url ) {
+				return str_replace( '&', '&amp;', "{$url}&_wpnonce=123456" );
+			}
+		);
+
+		Functions\when( 'admin_url' )->alias(
+			function ( $path ) {
+				return "http://example.org/wp-admin/{$path}";
+			}
+		);
+
+		$this->admin_bar->add_clean_saas_menu_item( $this->wp_admin_bar );
+
+		$node = $this->wp_admin_bar->get_node( 'clean-saas' );
+
+		if ( null === $expected ) {
+			$this->assertNull( $node );
+			return;
+		}
+
+		$this->assertSame(
+			$expected['id'],
+			$node->id
+		);
+
+		$this->assertSame(
+			$expected['title'],
+			$node->title
+		);
+	}
+}

--- a/tests/Unit/inc/Engine/Saas/Admin/AdminBar/addCleanUrlMenuItem.php
+++ b/tests/Unit/inc/Engine/Saas/Admin/AdminBar/addCleanUrlMenuItem.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\Saas\Admin\AdminBar;
+
+use Mockery;
+use Brain\Monkey\Functions;
+use WP_Admin_Bar;
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Engine\Common\Context\ContextInterface;
+use WP_Rocket\Engine\Saas\Admin\AdminBar;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Saas\Admin\AdminBar::add_clean_url_menu_item
+ * @group  Saas
+ */
+class Test_AddCleanUrlMenuItem extends TestCase {
+	private $admin_bar;
+	private $options;
+	private $atf_context;
+	private $rucss_url_context;
+	private $wp_admin_bar;
+
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
+		require_once WP_ROCKET_TESTS_FIXTURES_DIR . '/WP_Admin_Bar.php';
+	}
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->options           = Mockery::mock( Options_Data::class );
+		$this->atf_context       = Mockery::mock( ContextInterface::class );
+		$this->rucss_url_context = Mockery::mock( ContextInterface::class );
+		$this->admin_bar         = new AdminBar( $this->options, $this->atf_context, $this->rucss_url_context, '' );
+		$this->wp_admin_bar      = new WP_Admin_Bar();
+
+		$this->stubTranslationFunctions();
+	}
+
+	protected function tearDown(): void {
+		unset( $GLOBALS['post'] );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldDoExpected( $config, $expected ) {
+		Functions\when( 'wp_get_environment_type' )
+			->justReturn( $config['environment'] );
+		Functions\when( 'is_admin' )
+			->justReturn( $config['is_admin'] );
+
+		$GLOBALS['post'] = $config['post'];
+
+		Functions\when( 'rocket_can_display_options' )
+			->justReturn( $config['can_display_options'] );
+
+		$this->atf_context->shouldReceive( 'is_allowed' )
+			->andReturn( $config['atf_context'] );
+
+		$this->rucss_url_context->shouldReceive( 'is_allowed' )
+			->andReturn( $config['rucss_context'] );
+
+		Functions\when( 'wp_nonce_url' )->alias(
+			function ( $url ) {
+				return str_replace( '&', '&amp;', "{$url}&_wpnonce=123456" );
+			}
+		);
+
+		Functions\when( 'admin_url' )->alias(
+			function ( $path ) {
+				return "http://example.org/wp-admin/{$path}";
+			}
+		);
+
+		$this->admin_bar->add_clean_url_menu_item( $this->wp_admin_bar );
+
+		$node = $this->wp_admin_bar->get_node( 'clear-saas-url' );
+
+		if ( null === $expected ) {
+			$this->assertNull( $node );
+			return;
+		}
+
+		$this->assertSame(
+			$expected['id'],
+			$node->id
+		);
+
+		$this->assertSame(
+			$expected['title'],
+			$node->title
+		);
+	}
+}


### PR DESCRIPTION
# Description

The admin menu item only needs to be displayed on frontend view

Fixes #6509 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I wrote comments to explain why it does it.
- [x] I named variables and functions explicitely.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.
