### PR TITLE
Fixes #6576 Add safe guard for links limit filter value in warmup

### DIFF
--- a/inc/Engine/Media/AboveTheFold/WarmUp/Controller.php
+++ b/inc/Engine/Media/AboveTheFold/WarmUp/Controller.php
@@ -142,13 +142,20 @@ class Controller {
 		// Remove duplicate links.
 		$links = array_unique( $links );
 
+		$default_limit = 10;
+
 		/**
 		 * Filters the number of links to return from the homepage.
 		 *
-		 * @param int number of links to return.
+		 * @param int $links_limit number of links to return.
 		 */
-		$link_number = apply_filters( 'rocket_atf_warmup_links_number', 10 );
-		$links       = array_slice( $links, 0, $link_number );
+		$links_limit = apply_filters( 'rocket_atf_warmup_links_number', $default_limit );
+
+		if ( ! is_int( $links_limit ) || $links_limit < 1 ) {
+			$links_limit = $default_limit;
+		}
+
+		$links = array_slice( $links, 0, $links_limit );
 		// Add home url to the list of links.
 		$links[] = home_url();
 


### PR DESCRIPTION
# Description

Add a default value used as safe guard for the links limit filter value in warmup, if the returned value is not a int or is inferior to 1

Fixes #6576

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklists

## Feature validation

- [ ] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [ ] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style
- [ ] I wrote self-explanatory code about what it does.
- [ ] I wrote comments to explain why it does it.
- [ ] I named variables and functions explicitely.
- [ ] I protected entry points against unexpected inputs.
- [ ] I did not introduce unecessary complexity.
- [ ] I listed the introduced external dependencies explicitely on the PR.
- [ ] I validated the repo-specific guidelines from CONTRIBUTING.md.

## Observability
- [ ] I handled errors when needed.
- [ ] I wrote user-facing messages that are understandable and provide actionable feedbacks.
- [ ] I prepared ways to observe the implemented system (logs, data, etc.).
