### PR TITLE
Closes #6606 Display notice for 3.16 changes

### DIFF
--- a/inc/Engine/Admin/Beacon/Beacon.php
+++ b/inc/Engine/Admin/Beacon/Beacon.php
@@ -791,6 +791,18 @@ class Beacon extends Abstract_Render implements Subscriber_Interface {
 					'url' => 'https://fr.docs.wp-rocket.me/article/1577-supprimer-les-ressources-css-inutilisees?utm_source=wp_plugin&utm_medium=wp_rocket#basic-requirements',
 				],
 			],
+			'optimize_critical_images'   => [
+				'en' => [
+					'id'  => '',
+					'url' => 'https://docs.wp-rocket.me/article/1816-optimize-critical-images?utm_source=wp_plugin&utm_medium=wp_rocket',
+				],
+			],
+			'remove_cache_tab'           => [
+				'en' => [
+					'id'  => '',
+					'url' => 'https://docs.wp-rocket.me/article/1817-removal-of-the-cache-tab?utm_source=wp_plugin&utm_medium=wp_rocket',
+				],
+			],
 		];
 
 		return isset( $suggest[ $doc_id ][ $this->get_user_locale() ] )

--- a/inc/Engine/Admin/Beacon/Beacon.php
+++ b/inc/Engine/Admin/Beacon/Beacon.php
@@ -793,14 +793,22 @@ class Beacon extends Abstract_Render implements Subscriber_Interface {
 			],
 			'optimize_critical_images'   => [
 				'en' => [
-					'id'  => '',
+					'id'  => '662c1a144c3ddc1d4e7a1d25',
 					'url' => 'https://docs.wp-rocket.me/article/1816-optimize-critical-images?utm_source=wp_plugin&utm_medium=wp_rocket',
+				],
+				'fr' => [
+					'id'  => '6634e9fe0cfcb4508af6b290',
+					'url' => 'https://fr.docs.wp-rocket.me/article/1819-optimiser-images-essentielle?utm_source=wp_plugin&utm_medium=wp_rocket',
 				],
 			],
 			'remove_cache_tab'           => [
 				'en' => [
-					'id'  => '',
+					'id'  => '6633b5df1009cb439ac6a432',
 					'url' => 'https://docs.wp-rocket.me/article/1817-removal-of-the-cache-tab?utm_source=wp_plugin&utm_medium=wp_rocket',
+				],
+				'fr' => [
+					'id'  => '6634e9b21009cb439ac6a6fb',
+					'url' => 'https://fr.docs.wp-rocket.me/article/1818-suppression-onglet-cache?utm_source=wp_plugin&utm_medium=wp_rocket',
 				],
 			],
 		];

--- a/inc/Engine/Admin/Settings/Page.php
+++ b/inc/Engine/Admin/Settings/Page.php
@@ -2249,4 +2249,45 @@ class Page extends Abstract_Render {
 		$this->options->set( 'do_caching_mobile_files', 1 );
 		update_option( rocket_get_constant( 'WP_ROCKET_SLUG', 'wp_rocket_settings' ), $this->options->get_options() );
 	}
+
+	/**
+	 * Display an update notice when the plugin is updated.
+	 *
+	 * @return void
+	 */
+	public function display_update_notice() {
+		if ( ! current_user_can( 'rocket_manage_options' ) ) {
+			return;
+		}
+
+		if ( 'settings_page_wprocket' !== get_current_screen()->id ) {
+			return false;
+		}
+
+		$boxes = get_user_meta( get_current_user_id(), 'rocket_boxes', true );
+
+		if ( in_array( 'rocket_update_notice', (array) $boxes, true ) ) {
+			return;
+		}
+
+		$critical_images_beacon = $this->beacon->get_suggest( 'optimize_critical_images' );
+		$remove_cache_tab       = $this->beacon->get_suggest( 'remove_cache_tab' );
+
+		rocket_notice_html(
+			[
+				'status'         => 'info',
+				'dismissible'    => '',
+				'message'        => sprintf(
+					// translators: %1$s: opening strong tag, %2$s: closing strong tag.
+					__( '%1$sWP Rocket:%2$s the plugin has been updated to the 3.16 version. Our brand new feature %3$sOptimize critical images%5$s is automatically activated now! Also, the Cache tab was removed but the existing features will remain working, %4$ssee more here%5$s.', 'rocket' ),
+					'<strong>',
+					'</strong>',
+					'<a href="' . esc_url( $critical_images_beacon['url'] ) . '" data-beacon-article="' . esc_attr( $critical_images_beacon['id'] ) . '" target="_blank" rel="noopener noreferrer">',
+					'<a href="' . esc_url( $remove_cache_tab['url'] ) . '" data-beacon-article="' . esc_attr( $remove_cache_tab['id'] ) . '" target="_blank" rel="noopener noreferrer">',
+					'</a>'
+				),
+				'dismiss_button' => 'rocket_update_notice',
+			]
+		);
+	}
 }

--- a/inc/Engine/Admin/Settings/Page.php
+++ b/inc/Engine/Admin/Settings/Page.php
@@ -2096,6 +2096,7 @@ class Page extends Abstract_Render {
 			'minify_css_key',
 			'minify_js_key',
 			'version',
+			'previous_version',
 			'cloudflare_old_settings',
 			'cache_ssl',
 			'minify_google_fonts',
@@ -2267,6 +2268,18 @@ class Page extends Abstract_Render {
 		$boxes = get_user_meta( get_current_user_id(), 'rocket_boxes', true );
 
 		if ( in_array( 'rocket_update_notice', (array) $boxes, true ) ) {
+			return;
+		}
+
+		$previous_version = $this->options->get( 'previous_version' );
+
+		// Bail-out for fresh install.
+		if ( empty( $previous_version ) ) {
+			return;
+		}
+
+		// Bail-out if previous version is greater than 3.16.
+		if ( $previous_version > '3.16' ) {
 			return;
 		}
 

--- a/inc/Engine/Admin/Settings/Page.php
+++ b/inc/Engine/Admin/Settings/Page.php
@@ -2278,7 +2278,7 @@ class Page extends Abstract_Render {
 				'status'         => 'info',
 				'dismissible'    => '',
 				'message'        => sprintf(
-					// translators: %1$s: opening strong tag, %2$s: closing strong tag.
+					// translators: %1$s: opening strong tag, %2$s: closing strong tag, %3$s: opening a tag, %4$s: option a tag, %5$s: opening a tag.
 					__( '%1$sWP Rocket:%2$s the plugin has been updated to the 3.16 version. Our brand new feature %3$sOptimize critical images%5$s is automatically activated now! Also, the Cache tab was removed but the existing features will remain working, %4$ssee more here%5$s.', 'rocket' ),
 					'<strong>',
 					'</strong>',

--- a/inc/Engine/Admin/Settings/Subscriber.php
+++ b/inc/Engine/Admin/Settings/Subscriber.php
@@ -54,6 +54,7 @@ class Subscriber implements Subscriber_Interface {
 			'rocket_settings_tools_content'        => 'display_mobile_cache_option',
 			'wp_ajax_rocket_enable_mobile_cache'   => 'enable_mobile_cache',
 			'wp_rocket_upgrade'                    => [ 'enable_separate_cache_files_mobile', 9, 2 ],
+			'admin_notices'                        => 'display_update_notice',
 		];
 	}
 
@@ -265,5 +266,14 @@ class Subscriber implements Subscriber_Interface {
 		}
 
 		$this->page->enable_separate_cache_files_mobile();
+	}
+
+	/**
+	 * Display the update notice.
+	 *
+	 * @return void
+	 */
+	public function display_update_notice() {
+		$this->page->display_update_notice();
 	}
 }

--- a/inc/admin/upgrader.php
+++ b/inc/admin/upgrader.php
@@ -10,7 +10,7 @@ defined( 'ABSPATH' ) || exit;
  */
 function rocket_upgrader() {
 	// Grab some infos.
-	$actual_version = (string) get_rocket_option( 'version' );
+	$actual_version = (string) get_rocket_option( 'version', '' );
 	// You can hook the upgrader to trigger any action when WP Rocket is upgraded.
 	// first install.
 	if ( ! $actual_version ) {
@@ -25,8 +25,10 @@ function rocket_upgrader() {
 	if ( did_action( 'wp_rocket_first_install' ) || did_action( 'wp_rocket_upgrade' ) ) {
 		flush_rocket_htaccess();
 
-		$options            = get_option( WP_ROCKET_SLUG ); // do not use get_rocket_option() here.
-		$options['version'] = WP_ROCKET_VERSION;
+		$options = get_option( WP_ROCKET_SLUG ); // do not use get_rocket_option() here.
+
+		$options['version']          = WP_ROCKET_VERSION;
+		$options['previous_version'] = $actual_version;
 
 		$keys = rocket_check_key();
 		if ( is_array( $keys ) ) {

--- a/tests/Fixtures/inc/Engine/Admin/Settings/Page/displayUpdateNotice.php
+++ b/tests/Fixtures/inc/Engine/Admin/Settings/Page/displayUpdateNotice.php
@@ -1,0 +1,98 @@
+<?php
+
+return [
+	'testShouldDoNothingWhenNoCapability' => [
+		'config' => [
+			'capability' => false,
+			'screen'     => (object) [
+				'id' => 'settings_page_wprocket',
+			],
+			'boxes'            => [],
+			'previous_version' => '3.15',
+			'beacon'           => [
+				'id'  => '123',
+				'url' => 'http://example.org',
+			],
+		],
+		'expected' => null,
+	],
+	'testShouldDoNothingWhenNotSettingsPage' => [
+		'config' => [
+			'capability' => true,
+			'screen'     => (object) [
+				'id' => 'dashboard',
+			],
+			'boxes'            => [],
+			'previous_version' => '3.15',
+			'beacon'           => [
+				'id'  => '123',
+				'url' => 'http://example.org',
+			],
+		],
+		'expected' => null,
+	],
+	'testShouldDoNothingWhenDismissed' => [
+		'config' => [
+			'capability' => true,
+			'screen'     => (object) [
+				'id' => 'settings_page_wprocket',
+			],
+			'boxes'            => [
+				'rocket_update_notice',
+			],
+			'previous_version' => '3.15',
+			'beacon'           => [
+				'id'  => '123',
+				'url' => 'http://example.org',
+			],
+		],
+		'expected' => null,
+	],
+	'testShouldDoNothingWhenFirstInstall' => [
+		'config' => [
+			'capability' => true,
+			'screen'     => (object) [
+				'id' => 'settings_page_wprocket',
+			],
+			'boxes'            => [],
+			'previous_version' => '',
+			'beacon'           => [
+				'id'  => '123',
+				'url' => 'http://example.org',
+			],
+		],
+		'expected' => null,
+	],
+	'testShouldDoNothingWhenVersionGT316' => [
+		'config' => [
+			'capability' => true,
+			'screen'     => (object) [
+				'id' => 'settings_page_wprocket',
+			],
+			'boxes'            => [],
+			'previous_version' => '3.16.1',
+			'beacon'           => null,
+		],
+		'expected' => null,
+	],
+	'testShouldDisplayNotice' => [
+		'config' => [
+			'capability' => true,
+			'screen'     => (object) [
+				'id' => 'settings_page_wprocket',
+			],
+			'boxes'            => [],
+			'previous_version' => '3.15',
+			'beacon'           => [
+				'id'  => '123',
+				'url' => 'http://example.org',
+			],
+		],
+		'expected' => [
+			'status'         => 'info',
+			'dismissible'    => '',
+			'message'        => '<strong>WP Rocket:</strong> the plugin has been updated to the 3.16 version. Our brand new feature <a href="http://example.org" data-beacon-article="123" target="_blank" rel="noopener noreferrer">Optimize critical images</a> is automatically activated now! Also, the Cache tab was removed but the existing features will remain working, <a href="http://example.org" data-beacon-article="123" target="_blank" rel="noopener noreferrer">see more here</a>.',
+			'dismiss_button' => 'rocket_update_notice',
+		],
+	],
+];

--- a/tests/Unit/inc/Engine/Admin/Settings/Page/displayUpdateNotice.php
+++ b/tests/Unit/inc/Engine/Admin/Settings/Page/displayUpdateNotice.php
@@ -1,0 +1,82 @@
+<?php
+namespace WP_Rocket\Tests\Unit\inc\Engine\Admin\Settings\Page;
+
+use Mockery;
+use Brain\Monkey\Functions;
+use WP_Rocket\Engine\Admin\Database\Optimization;
+use WP_Rocket\Engine\Admin\Beacon\Beacon;
+use WP_Rocket\Engine\Admin\Settings\Page;
+use WP_Rocket\Engine\Admin\Settings\Settings;
+use WP_Rocket\Engine\License\API\UserClient;
+use WP_Rocket\Engine\Optimization\DelayJS\Admin\SiteList;
+use WP_Rocket\Tests\Unit\TestCase;
+use WP_Rocket\Admin\Options_Data;
+
+/**
+ * Test class covering \WP_Rocket\Engine\Admin\Settings\Page::display_update_notice
+ *
+ * @group Admin
+ * @group SettingsPage
+ */
+class Test_DisplayUpdateNotice extends TestCase {
+	private $page;
+	private $beacon;
+	private $options;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->beacon       = Mockery::mock( Beacon::class );
+		$this->options      = Mockery::mock( Options_Data::class );
+		$config = [
+			'slug'       => 'wprocket',
+			'title'      => 'WP Rocket',
+			'capability' => 'rocket_manage_options',
+		];
+
+		$template_path = 'vfs://public/wp-content/plugins/wp-rocket/views';
+
+		$this->page = new Page(
+			$config,
+			Mockery::mock( Settings::class ),
+			Mockery::mock( 'WP_Rocket\Interfaces\Render_Interface' ),
+			$this->beacon,
+			Mockery::mock( Optimization::class ),
+			Mockery::mock( UserClient::class ),
+			Mockery::mock( SiteList::class ),
+			$template_path,
+			$this->options
+		);
+
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShoulDoExpected( $config, $expected ) {
+		Functions\when( 'current_user_can' )->justReturn( $config['capability'] );
+
+		Functions\when( 'get_current_screen' )->justReturn( $config['screen'] );
+
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_user_meta' )->justReturn( $config['boxes'] );
+
+		$this->options->shouldReceive( 'get' )
+			->andReturn( $config['previous_version'] );
+
+		$this->beacon->shouldReceive( 'get_suggest' )
+			->andReturn( $config['beacon'] );
+
+		if ( ! $expected ) {
+			Functions\expect( 'rocket_notice_html' )->never();
+		} else {
+			Functions\expect( 'rocket_notice_html' )
+				->once()
+				->with( $expected );
+		}
+
+		$this->page->display_update_notice();
+	}
+}


### PR DESCRIPTION
# Description

Display a notice about 3.16 changes on the WPR settings page.

To be able to handle the display of the notice depending on the previous version, We now store the previous version value with the plugin settings.

Fixes #6606

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I wrote comments to explain why it does it.
- [x] I named variables and functions explicitely.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.

## Observability
- [x] I handled errors when needed.
- [x] I wrote user-facing messages that are understandable and provide actionable feedbacks.
- [x] I prepared ways to observe the implemented system (logs, data, etc.).
