### PR TITLE
Closes #6561: Clear critical images should not be in admin bar with invalid license

### DIFF
--- a/inc/Engine/Saas/Admin/AdminBar.php
+++ b/inc/Engine/Saas/Admin/AdminBar.php
@@ -54,6 +54,10 @@ class AdminBar extends Abstract_Render {
 	 * @return void
 	 */
 	public function add_clean_saas_menu_item( $wp_admin_bar ) {
+		if ( ! rocket_valid_key() ) {
+			return;
+		}
+
 		if ( 'local' === wp_get_environment_type() ) {
 			return;
 		}

--- a/tests/Fixtures/inc/Engine/Saas/Admin/AdminBar/addCleanSaasMenuItem.php
+++ b/tests/Fixtures/inc/Engine/Saas/Admin/AdminBar/addCleanSaasMenuItem.php
@@ -1,8 +1,20 @@
 <?php
 
 return [
+	'testShouldReturnNullWithInvalidLicense' => [
+		'config'   => [
+			'rocket_valid_key' 	=> false,
+			'environment'       => 'production',
+			'is_admin'          => true,
+			'atf_context'       => true,
+			'remove_unused_css' => 1,
+			'current_user_can'  => true,
+		],
+		'expected' => null,
+	],
 	'testShouldReturnNullWhenLocalEnvironment' => [
 		'config'   => [
+			'rocket_valid_key' 	=> true,
 			'environment'       => 'local',
 			'is_admin'          => false,
 			'atf_context'       => false,
@@ -13,6 +25,7 @@ return [
 	],
 	'testShouldReturnNullWhenNotAdmin' => [
 		'config'   => [
+			'rocket_valid_key' 	=> true,
 			'environment'       => 'production',
 			'is_admin'          => false,
 			'atf_context'       => false,
@@ -23,6 +36,7 @@ return [
 	],
 	'testShouldAddItemWithDefaultTitle' => [
 		'config'   => [
+			'rocket_valid_key' 	=> true,
 			'environment'       => 'production',
 			'is_admin'          => true,
 			'atf_context'       => true,
@@ -36,6 +50,7 @@ return [
 	],
 	'testShouldAddItemWithRUCSSTitle' => [
 		'config'   => [
+			'rocket_valid_key' 	=> true,
 			'environment'       => 'production',
 			'is_admin'          => true,
 			'atf_context'       => true,

--- a/tests/Unit/inc/Engine/Saas/Admin/AdminBar/addCleanSaasMenuItem.php
+++ b/tests/Unit/inc/Engine/Saas/Admin/AdminBar/addCleanSaasMenuItem.php
@@ -43,6 +43,8 @@ class Test_AddCleanSaasMenuItem extends TestCase {
 	 * @dataProvider configTestData
 	 */
 	public function testShouldDoExpected( $config, $expected ) {
+		Functions\when( 'rocket_valid_key' )
+			->justReturn( $config['rocket_valid_key'] );
 		Functions\when( 'wp_get_environment_type' )
 			->justReturn( $config['environment'] );
 		Functions\when( 'is_admin' )


### PR DESCRIPTION
# Description
This PR fixes the bug in a scenario where `Clear Critical Images` was displayed in the admin bar when license is invalid.

Fixes #6561 

## Documentation

### User documentation

*Explain how this code impacts users.*

### Technical documentation

*Explain how this code works. Diagram & drawings are welcomed.*

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## New dependencies
None

## Risks
None

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Documentation

- [ ] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [ ] The user documentation covers new/changed entry points (endpoints, WP hooks, configuration files, ...).
- [ ] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [ ] I wrote comments to explain why it does it.
- [ ] I named variables and functions explicitely.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.
- [ ] I listed the introduced external dependencies explicitely on the PR.
- [ ] I validated the repo-specific guidelines from CONTRIBUTING.md.

## Observability
- [x] I handled errors when needed.
- [ ] I wrote user-facing messages that are understandable and provide actionable feedbacks.
- [ ] I prepared ways to observe the implemented system (logs, data, etc.).

## Risks
- [ ] I explicitely mentioned performance risks in the PR.
- [ ] I explicitely mentioned security risks in the PR.
