### PR TITLE
LCP Warmup requests always blocking and default limit to 5

### DIFF
--- a/inc/Engine/Common/JobManager/APIHandler/APIClient.php
+++ b/inc/Engine/Common/JobManager/APIHandler/APIClient.php
@@ -48,12 +48,11 @@ class APIClient extends AbstractAPIClient implements LoggerAwareInterface {
 		$url = apply_filters( 'rocket_saas_api_queued_url', $url );
 
 		$args = [
-			'body'     => [
+			'body'    => [
 				'url'    => $url,
 				'config' => $options,
 			],
-			'timeout'  => 5,
-			'blocking' => true,
+			'timeout' => 5,
 		];
 
 		$this->logger::debug(

--- a/inc/Engine/Common/JobManager/APIHandler/APIClient.php
+++ b/inc/Engine/Common/JobManager/APIHandler/APIClient.php
@@ -47,14 +47,6 @@ class APIClient extends AbstractAPIClient implements LoggerAwareInterface {
 		 */
 		$url = apply_filters( 'rocket_saas_api_queued_url', $url );
 
-		$blocking = true;
-
-		if ( isset( $options['blocking'] ) ) {
-			$blocking = $options['blocking'];
-
-			unset( $options['blocking'] );
-		}
-
 		$args = [
 			'body'     => [
 				'url'    => $url,
@@ -63,11 +55,6 @@ class APIClient extends AbstractAPIClient implements LoggerAwareInterface {
 			'timeout'  => 5,
 			'blocking' => true,
 		];
-
-		if ( ! $blocking ) {
-			$args['blocking'] = false;
-			$args['timeout']  = 0.01;
-		}
 
 		$this->logger::debug(
 			'Add to queue request arguments',

--- a/inc/Engine/Media/AboveTheFold/WarmUp/APIClient.php
+++ b/inc/Engine/Media/AboveTheFold/WarmUp/APIClient.php
@@ -30,7 +30,6 @@ class APIClient extends BaseAPIClient {
 			'optimization_list' => '',
 			'is_home'           => $is_home,
 			'is_mobile'         => 'mobile' === $device,
-			'blocking'          => rocket_get_constant( 'WP_ROCKET_DEBUG', false ),
 		];
 
 		return $this->add_to_queue( $url, $config );

--- a/inc/Engine/Media/AboveTheFold/WarmUp/Controller.php
+++ b/inc/Engine/Media/AboveTheFold/WarmUp/Controller.php
@@ -147,7 +147,7 @@ class Controller {
 		// Remove duplicate links.
 		$links = array_unique( $links );
 
-		$default_limit = 10;
+		$default_limit = 5;
 
 		/**
 		 * Filters the number of links to return from the homepage.

--- a/tests/Fixtures/inc/Engine/Media/AboveTheFold/WarmUp/Controller/fetchLinks.php
+++ b/tests/Fixtures/inc/Engine/Media/AboveTheFold/WarmUp/Controller/fetchLinks.php
@@ -186,7 +186,7 @@ return [
 			'https://example.org',
 		],
 	],
-	'shouldReturnTenLinksPlusHome' => [
+	'shouldReturnFiveLinksPlusHome' => [
 		'config' => [
 			'license_expired' => false,
 			'headers' => [
@@ -207,15 +207,10 @@ return [
 			'https://example.org/hello-world-4',
 			'https://example.org/hello-world-5',
 			'https://example.org/hello-world-6',
-			'https://example.org/hello-world-7',
-			'https://example.org/hello-world-8',
-			'https://example.org/hello-world-9',
-			'https://example.org/rich-dad-poor-dad',
-			'https://example.org/rebecca-brown-he-came-to-set-the-captives-free',
 			'https://example.org',
 		],
 	],
-	'shouldReturnTenLinksWithExternalLinksBeforeInternal' => [
+	'shouldReturnFiveLinksWithExternalLinksBeforeInternal' => [
 		'config' => [
 			'license_expired' => false,
 			'headers' => [
@@ -236,11 +231,6 @@ return [
 			'https://example.org/cover-galleries',
 			'https://example.org/countdown-timer',
 			'https://example.org/cover-galleries-2',
-			'https://example.org/cover-galleries-3',
-			'https://example.org/cover-galleries-4',
-			'https://example.org/cover-galleries-5',
-			'https://example.org/cover-galleries-6',
-			'https://example.org/cover-galleries-7',
 			'https://example.org',
 		],
 	],
@@ -265,9 +255,6 @@ return [
 			'https://example.org/hello-world-6',
 			'https://example.org/hello-world-7',
 			'https://example.org/hello-world-8',
-			'https://example.org/hello-world-9',
-			'https://example.org/rich-dad-poor-dad',
-			'https://example.org/rebecca-brown-he-came-to-set-the-captives-free',
 			'https://example.org',
 		],
 	],

--- a/tests/Unit/inc/Engine/Media/AboveTheFold/WarmUp/Controller/fetchLinks.php
+++ b/tests/Unit/inc/Engine/Media/AboveTheFold/WarmUp/Controller/fetchLinks.php
@@ -30,10 +30,6 @@ class Test_FetchLinks extends TestCase {
 		$this->controller = new Controller( $context, $options, $api_client, $this->user );
 	}
 
-	protected function tearDown(): void {
-		parent::tearDown();
-	}
-
 	/**
 	 * @dataProvider configTestData
 	 */
@@ -78,7 +74,7 @@ class Test_FetchLinks extends TestCase {
 
 			Filters\expectApplied( 'rocket_atf_warmup_links_number' )
 				->once()
-				->with( 10 );
+				->with( 5 );
 		}
 
 		$this->assertSame(


### PR DESCRIPTION
# Description

Changes the LCP warmup requests to be always blocking, and reduce the default limit from 10 to 5.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I wrote comments to explain why it does it.
- [x] I named variables and functions explicitely.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.
