### PR TITLE
Closes #6589:  LCP/ATF Warm up process not blocked on local env

### DIFF
--- a/inc/Engine/Media/AboveTheFold/WarmUp/Controller.php
+++ b/inc/Engine/Media/AboveTheFold/WarmUp/Controller.php
@@ -59,6 +59,10 @@ class Controller {
 	 * @return void
 	 */
 	public function warm_up(): void {
+		if ( 'local' === wp_get_environment_type() ) {
+			return;
+		}
+
 		if ( (bool) $this->options->get( 'remove_unused_css', 0 ) ) {
 			return;
 		}

--- a/tests/Fixtures/inc/Engine/Media/AboveTheFold/WarmUp/Subscriber/warmUp.php
+++ b/tests/Fixtures/inc/Engine/Media/AboveTheFold/WarmUp/Subscriber/warmUp.php
@@ -1,0 +1,45 @@
+<?php
+return [
+	'testShouldCallSendToSaas' => [
+		'config'   => [
+			'wp_env' => 'production',
+			'remove_unused_css' => 0,
+			'is_allowed' => true,
+			'links' => [
+				'http://example.com/link1',
+				'http://example.com/link2',
+			],
+		],
+		'expected' => 2,
+	],
+	'testShouldNotCallSendToSaasWhenLocalEnv' => [
+		'config'   => [
+			'wp_env' => 'local',
+			'remove_unused_css' => 0,
+			'is_allowed' => true,
+			'links' => [
+			],
+		],
+		'expected' => 0,
+	],
+	'testShouldNotCallSendToSaasWhenRemoveUnusedCssEnabled' => [
+		'config'   => [
+			'wp_env' => 'production',
+			'remove_unused_css' => 1,
+			'is_allowed' => true,
+			'links' => [
+			],
+		],
+		'expected' => 0,
+	],
+	'testShouldNotCallSendToSaasWhenNotAllowed' => [
+		'config'   => [
+			'wp_env' => 'production',
+			'remove_unused_css' => 0,
+			'is_allowed' => false,
+			'links' => [
+			],
+		],
+		'expected' => 0,
+	],
+];

--- a/tests/Integration/inc/Engine/Media/AboveTheFold/WarmUp/Subscriber/warmUp.php
+++ b/tests/Integration/inc/Engine/Media/AboveTheFold/WarmUp/Subscriber/warmUp.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\Media\AboveTheFold\WarmUp\Subscriber;
+
+use WP_Rocket\Tests\Integration\TestCase;
+use Brain\Monkey\Functions;
+use WP_Rocket\Engine\License\API\User;
+use WP_Rocket\Engine\Media\AboveTheFold\WarmUp\APIClient;
+use WP_Rocket\Engine\Common\Context\ContextInterface;
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Engine\Media\AboveTheFold\WarmUp\Controller;
+
+use Mockery;
+
+
+
+/**
+ * Test class covering \WP_Rocket\Engine\Media\AboveTheFold\WarmUp\Subscriber::warm_up
+ *
+ * @group AboveTheFold
+ */
+class Test_WarmUp extends TestCase {
+	protected $path_to_test_data = '/inc/Engine/Media/AboveTheFold/WarmUp/Subscriber/warmUp.php';
+
+	/**
+	 * @var array
+	 */
+	protected $config;
+
+	/**
+	 * Test should do expected.
+	 *
+	 * @dataProvider configTestData
+	 */
+	public function testShouldDoExpected( $config, $expected ) {
+		$this->config = $config;
+		$context = Mockery::mock(ContextInterface::class);
+		$options = Mockery::mock(Options_Data::class);
+		$api_client = Mockery::mock(APIClient::class);
+		$user = Mockery::mock(User::class);
+		$controller = Mockery::mock(Controller::class, [$context, $options, $api_client, $user])->makePartial();
+
+		$options->shouldReceive('get')
+			->with('cache_mobile', 0)
+			->andReturn(0);
+
+		$context->shouldReceive('is_allowed')
+			->andReturn($config['is_allowed']);
+
+		$controller->shouldReceive('fetch_links')
+			->andReturn($config['links']);
+
+
+		Functions\expect( 'wp_get_environment_type' )->once()->andReturn($config['wp_env']);
+
+		if ( 'local' !== $config['wp_env'] ) {
+			$options->shouldReceive('get')
+				->with('remove_unused_css', 0)
+				->andReturn($config['remove_unused_css']);
+		}
+
+		$api_client->shouldReceive('add_to_atf_queue')
+			->times($expected);
+
+		$controller->warm_up();
+	}
+}


### PR DESCRIPTION
# Description

Fixes #6589 

## Documentation

### User documentation

Warm up process introduced by 3.16 won't be running on local environment. 

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## New dependencies
N/a

## Risks
N/a

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I wrote comments to explain why it does it.
- [x] I named variables and functions explicitely.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.
- [x] I listed the introduced external dependencies explicitely on the PR.
- [x] I validated the repo-specific guidelines from CONTRIBUTING.md.

## Observability
- [x] I handled errors when needed.
- [x] I wrote user-facing messages that are understandable and provide actionable feedbacks.
- [x] I prepared ways to observe the implemented system (logs, data, etc.).
