### PR TITLE
Closes #6609 Make the LCP/ATF warmup asynchronous

### DIFF
--- a/inc/Engine/Media/AboveTheFold/Activation/Activation.php
+++ b/inc/Engine/Media/AboveTheFold/Activation/Activation.php
@@ -20,7 +20,7 @@ class Activation implements ActivationInterface {
 	 *
 	 * @var ContextInterface
 	 */
-	protected $context;
+	private $context;
 
 	/**
 	 * Instantiate class.
@@ -50,6 +50,6 @@ class Activation implements ActivationInterface {
 			return;
 		}
 
-		$this->controller->warm_up();
+		$this->controller->warm_up_home();
 	}
 }

--- a/inc/Engine/Media/AboveTheFold/Activation/ServiceProvider.php
+++ b/inc/Engine/Media/AboveTheFold/Activation/ServiceProvider.php
@@ -7,11 +7,11 @@ use WP_Rocket\Dependencies\League\Container\ServiceProvider\AbstractServiceProvi
 use WP_Rocket\Engine\Media\AboveTheFold\Context\Context;
 use WP_Rocket\Engine\Media\AboveTheFold\WarmUp\{
 	APIClient,
-	Controller as WarmUpController
+	Controller as WarmUpController,
+	Queue
 };
 
 class ServiceProvider extends AbstractServiceProvider {
-
 	/**
 	 * The provides array is a way to let the container
 	 * know that a service is provided by this service
@@ -26,6 +26,7 @@ class ServiceProvider extends AbstractServiceProvider {
 		'warmup_apiclient',
 		'warmup_controller',
 		'atf_activation',
+		'warmup_queue',
 	];
 
 	/**
@@ -50,6 +51,8 @@ class ServiceProvider extends AbstractServiceProvider {
 		$this->getContainer()->add( 'warmup_apiclient', APIClient::class )
 			->addArgument( $this->getContainer()->get( 'options' ) );
 
+		$this->getContainer()->add( 'warmup_queue', Queue::class );
+
 		$this->getContainer()->add( 'warmup_controller', WarmUpController::class )
 			->addArguments(
 				[
@@ -57,6 +60,7 @@ class ServiceProvider extends AbstractServiceProvider {
 					$this->getContainer()->get( 'options' ),
 					$this->getContainer()->get( 'warmup_apiclient' ),
 					$this->getContainer()->get( 'user' ),
+					$this->getContainer()->get( 'warmup_queue' ),
 				]
 			);
 

--- a/inc/Engine/Media/AboveTheFold/ServiceProvider.php
+++ b/inc/Engine/Media/AboveTheFold/ServiceProvider.php
@@ -14,7 +14,8 @@ use WP_Rocket\Engine\Media\AboveTheFold\Cron\{Controller as CronController, Subs
 use WP_Rocket\Engine\Media\AboveTheFold\WarmUp\{
 	APIClient,
 	Controller as WarmUpController,
-	Subscriber as WarmUpSubscriber
+	Subscriber as WarmUpSubscriber,
+	Queue
 };
 
 class ServiceProvider extends AbstractServiceProvider {
@@ -42,6 +43,7 @@ class ServiceProvider extends AbstractServiceProvider {
 		'warmup_controller',
 		'warmup_subscriber',
 		'warmup_apiclient',
+		'warmup_queue',
 	];
 
 	/**
@@ -103,6 +105,9 @@ class ServiceProvider extends AbstractServiceProvider {
 
 		$this->getContainer()->add( 'warmup_apiclient', APIClient::class )
 			->addArgument( $this->getContainer()->get( 'options' ) );
+
+		$this->getContainer()->add( 'warmup_queue', Queue::class );
+
 		$this->getContainer()->add( 'warmup_controller', WarmUpController::class )
 			->addArguments(
 				[
@@ -110,6 +115,7 @@ class ServiceProvider extends AbstractServiceProvider {
 					$this->getContainer()->get( 'options' ),
 					$this->getContainer()->get( 'warmup_apiclient' ),
 					$this->getContainer()->get( 'user' ),
+					$this->getContainer()->get( 'warmup_queue' ),
 				]
 			);
 		$this->getContainer()->addShared( 'warmup_subscriber', WarmUpSubscriber::class )

--- a/inc/Engine/Media/AboveTheFold/WarmUp/Controller.php
+++ b/inc/Engine/Media/AboveTheFold/WarmUp/Controller.php
@@ -3,13 +3,12 @@ declare(strict_types=1);
 
 namespace WP_Rocket\Engine\Media\AboveTheFold\WarmUp;
 
-use WP_Rocket\Engine\Common\Context\ContextInterface;
 use WP_Rocket\Admin\Options_Data;
-use WP_Rocket\Engine\License\API\User;
+use WP_Rocket\Engine\Common\Context\ContextInterface;
 use WP_Rocket\Engine\Common\Utils;
+use WP_Rocket\Engine\License\API\User;
 
 class Controller {
-
 	/**
 	 * ATF context.
 	 *
@@ -39,22 +38,49 @@ class Controller {
 	private $user;
 
 	/**
+	 * Queue instance.
+	 *
+	 * @var Queue
+	 */
+	private $queue;
+
+	/**
 	 * Constructor
 	 *
 	 * @param ContextInterface $context ATF Context.
 	 * @param Options_Data     $options Options instance.
 	 * @param APIClient        $api_client APIClient instance.
 	 * @param User             $user User instance.
+	 * @param Queue            $queue Queue instance.
 	 */
-	public function __construct( ContextInterface $context, Options_Data $options, APIClient $api_client, User $user ) {
+	public function __construct( ContextInterface $context, Options_Data $options, APIClient $api_client, User $user, Queue $queue ) {
 		$this->context    = $context;
 		$this->options    = $options;
 		$this->api_client = $api_client;
 		$this->user       = $user;
+		$this->queue      = $queue;
 	}
 
 	/**
-	 * Send links for warm up.
+	 * Send home URL for warm up.
+	 *
+	 * @return void
+	 */
+	public function warm_up_home(): void {
+		if ( (bool) $this->options->get( 'remove_unused_css', 0 ) ) {
+			return;
+		}
+
+		if ( ! $this->context->is_allowed() ) {
+			return;
+		}
+
+		$this->send_to_saas( home_url() );
+		$this->queue->add_job_warmup();
+	}
+
+	/**
+	 * Fetch links and send them to SaaS for warm up.
 	 *
 	 * @return void
 	 */
@@ -67,7 +93,11 @@ class Controller {
 			return;
 		}
 
-		$this->send_to_saas( $this->fetch_links() );
+		$links = $this->fetch_links();
+
+		foreach ( $links as $link ) {
+			$this->queue->add_job_warmup_url( $link );
+		}
 	}
 
 	/**
@@ -88,7 +118,7 @@ class Controller {
 			'timeout'    => 60,
 		];
 
-		$response = wp_remote_get( $home_url, $args );
+		$response = wp_safe_remote_get( $home_url, $args );
 
 		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
 			return [];
@@ -147,7 +177,7 @@ class Controller {
 		// Remove duplicate links.
 		$links = array_unique( $links );
 
-		$default_limit = 5;
+		$default_limit = 10;
 
 		/**
 		 * Filters the number of links to return from the homepage.
@@ -161,51 +191,22 @@ class Controller {
 		}
 
 		$links = array_slice( $links, 0, $links_limit );
-		// Add home url to the list of links.
-		$links[] = home_url();
 
 		return $links;
 	}
 
 	/**
-	 * Send fetched links to SaaS to do the warmup.
+	 * Send link to SaaS to do the warmup.
 	 *
-	 * @param array $links Array of links to be sent.
+	 * @param string $url Url to send.
 	 *
 	 * @return void
 	 */
-	private function send_to_saas( $links ) {
-		if ( empty( $links ) ) {
-			return;
-		}
+	public function send_to_saas( string $url ) {
+		$this->api_client->add_to_atf_queue( $url );
 
-		$default_delay = 5000;
-
-		if ( rocket_get_constant( 'WP_ROCKET_DEBUG' ) ) {
-			$default_delay = 500000;
-		}
-
-		/**
-		 * Filter the delay between each request.
-		 *
-		 * @param int $delay_between the defined delay.
-		 *
-		 * @returns int
-		 */
-		$delay_between = (int) apply_filters( 'rocket_lcp_warmup_delay_between_requests', $default_delay );
-
-		if ( ! is_int( $delay_between ) || $delay_between < 0 ) {
-			$delay_between = $default_delay;
-		}
-
-		foreach ( $links as $link ) {
-			$this->api_client->add_to_atf_queue( $link );
-
-			if ( $this->is_mobile() ) {
-				$this->api_client->add_to_atf_queue( $link, 'mobile' );
-			}
-
-			usleep( $delay_between );
+		if ( $this->is_mobile() ) {
+			$this->api_client->add_to_atf_queue( $url, 'mobile' );
 		}
 	}
 

--- a/inc/Engine/Media/AboveTheFold/WarmUp/Queue.php
+++ b/inc/Engine/Media/AboveTheFold/WarmUp/Queue.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Engine\Media\AboveTheFold\WarmUp;
+
+use WP_Rocket\Engine\Common\Queue\AbstractASQueue;
+
+class Queue extends AbstractASQueue {
+	/**
+	 * ATF queue group
+	 *
+	 * @var string
+	 */
+	protected $group = 'rocket-atf-warmup';
+
+	/**
+	 * Add an async job to warm up home links
+	 *
+	 * @return int
+	 */
+	public function add_job_warmup(): int {
+		return $this->add_async( 'rocket_job_warmup' );
+	}
+
+	/**
+	 * Add an async job to send URL to SaaS for warmup
+	 *
+	 * @param string $url URL to warm up.
+	 *
+	 * @return int
+	 */
+	public function add_job_warmup_url( string $url ): int {
+		return $this->add_async( 'rocket_job_warmup_url', [ $url ] );
+	}
+}

--- a/inc/Engine/Media/AboveTheFold/WarmUp/Subscriber.php
+++ b/inc/Engine/Media/AboveTheFold/WarmUp/Subscriber.php
@@ -30,18 +30,40 @@ class Subscriber implements Subscriber_Interface {
 	public static function get_subscribed_events(): array {
 		return [
 			'wp_rocket_upgrade'          => [ 'warm_up_on_update', 10, 2 ],
-			'rocket_after_clear_atf'     => 'warm_up',
+			'rocket_after_clear_atf'     => 'warm_up_home',
 			'rocket_saas_api_queued_url' => 'add_wpr_imagedimensions_query_arg',
+			'rocket_job_warmup'          => 'warm_up',
+			'rocket_job_warmup_url'      => 'send_to_saas',
 		];
 	}
 
 	/**
-	 * Process links fetched from homepage.
+	 * Send home to warmup and start async fetch links
+	 *
+	 * @return void
+	 */
+	public function warm_up_home(): void {
+		$this->controller->warm_up_home();
+	}
+
+	/**
+	 * Fetch links for warmup and create async tasks
 	 *
 	 * @return void
 	 */
 	public function warm_up(): void {
 		$this->controller->warm_up();
+	}
+
+	/**
+	 * Send url to SaaS for warmup
+	 *
+	 * @param string $url URL to be sent.
+	 *
+	 * @return void
+	 */
+	public function send_to_saas( string $url ): void {
+		$this->controller->send_to_saas( $url );
 	}
 
 	/**

--- a/tests/Fixtures/inc/Engine/Media/AboveTheFold/WarmUp/Controller/fetchLinks.php
+++ b/tests/Fixtures/inc/Engine/Media/AboveTheFold/WarmUp/Controller/fetchLinks.php
@@ -58,7 +58,7 @@ return [
 		],
 		'expected' => [],
 	],
-	'shouldReturnOnlyHomeWithNoValidLinks' => [
+	'shouldReturnEmpyWithNoValidLinks' => [
 		'config' => [
 			'license_expired' => false,
 			'headers' => [
@@ -73,9 +73,7 @@ return [
 				],
 			],
 		],
-		'expected' => [
-			'https://example.org',
-		],
+		'expected' => [],
 	],
 	'shouldReturnValidLinksAmongInvalidLinks' => [
 		'config' => [
@@ -96,10 +94,9 @@ return [
 			'https://example.org/hello-world',
 			'https://example.org/another-day',
 			'https://example.org/rich-dad-poor-dad',
-			'https://example.org',
 		],
 	],
-	'shouldReturnOnlyHomeWithExternalLinks' => [
+	'shouldReturnEmptyWithExternalLinks' => [
 		'config' => [
 			'license_expired' => false,
 			'headers' => [
@@ -114,9 +111,7 @@ return [
 				],
 			],
 		],
-		'expected' => [
-			'https://example.org',
-		],
+		'expected' => [],
 	],
 	'shouldReturnValidLinksAmongExternalLinks' => [
 		'config' => [
@@ -137,7 +132,6 @@ return [
 			'https://example.org/hello-world',
 			'https://example.org/another-day',
 			'https://example.org/rich-dad-poor-dad',
-			'https://example.org',
 		],
 	],
 	'shouldReturnLinksWithoutDuplicate' => [
@@ -160,7 +154,6 @@ return [
 			'https://example.org/another-day',
 			'https://example.org/rich-dad-poor-dad',
 			'https://example.org/rebecca-brown-he-came-to-set-the-captives-free',
-			'https://example.org',
 		],
 	],
 	'shouldReturnLinksWithRelativeUrl' => [
@@ -183,10 +176,9 @@ return [
 			'https://example.org/another-day',
 			'https://example.org/rich-dad-poor-dad',
 			'https://example.org/rebecca-brown-he-came-to-set-the-captives-free',
-			'https://example.org',
 		],
 	],
-	'shouldReturnFiveLinksPlusHome' => [
+	'shouldReturn10Links' => [
 		'config' => [
 			'license_expired' => false,
 			'headers' => [
@@ -207,10 +199,14 @@ return [
 			'https://example.org/hello-world-4',
 			'https://example.org/hello-world-5',
 			'https://example.org/hello-world-6',
-			'https://example.org',
+			'https://example.org/hello-world-7',
+			'https://example.org/hello-world-8',
+			'https://example.org/hello-world-9',
+			'https://example.org/rich-dad-poor-dad',
+			'https://example.org/rebecca-brown-he-came-to-set-the-captives-free',
 		],
 	],
-	'shouldReturnFiveLinksWithExternalLinksBeforeInternal' => [
+	'shouldReturn10LinksWithExternalLinksBeforeInternal' => [
 		'config' => [
 			'license_expired' => false,
 			'headers' => [
@@ -231,7 +227,11 @@ return [
 			'https://example.org/cover-galleries',
 			'https://example.org/countdown-timer',
 			'https://example.org/cover-galleries-2',
-			'https://example.org',
+			'https://example.org/cover-galleries-3',
+			'https://example.org/cover-galleries-4',
+			'https://example.org/cover-galleries-5',
+			'https://example.org/cover-galleries-6',
+			'https://example.org/cover-galleries-7',
 		],
 	],
 	'shouldReturnLinksWithoutRSSAndRestAPILink' => [
@@ -255,7 +255,9 @@ return [
 			'https://example.org/hello-world-6',
 			'https://example.org/hello-world-7',
 			'https://example.org/hello-world-8',
-			'https://example.org',
+			'https://example.org/hello-world-9',
+			'https://example.org/rich-dad-poor-dad',
+			'https://example.org/rebecca-brown-he-came-to-set-the-captives-free',
 		],
 	],
 ];

--- a/tests/Unit/inc/Engine/Media/AboveTheFold/WarmUp/Controller/addWPRImageDimensionQueryArg.php
+++ b/tests/Unit/inc/Engine/Media/AboveTheFold/WarmUp/Controller/addWPRImageDimensionQueryArg.php
@@ -2,14 +2,13 @@
 
 namespace WP_Rocket\Tests\Unit\Inc\Engine\Media\AboveTheFold\WarmUp\Controller;
 
+use Brain\Monkey\Functions;
 use Mockery;
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\Common\Context\ContextInterface;
 use WP_Rocket\Engine\License\API\User;
-use WP_Rocket\Engine\Media\AboveTheFold\WarmUp\APIClient;
-use WP_Rocket\Engine\Media\AboveTheFold\WarmUp\Controller;
+use WP_Rocket\Engine\Media\AboveTheFold\WarmUp\{APIClient, Controller, Queue};
 use WP_Rocket\Tests\Unit\TestCase;
-use Brain\Monkey\Functions;
 
 /**
  * @covers \WP_Rocket\Engine\Media\AboveTheFold\WarmUp\Controller::add_wpr_imagedimensions_query_arg
@@ -21,15 +20,17 @@ class Test_AddWPRImageDimensionQueryArg extends TestCase {
 	private $user;
 	private $controller;
 	private $context;
+	private $queue;
 
 	protected function setUp(): void {
 		parent::setUp();
 
 		$this->context    = Mockery::mock( ContextInterface::class );
-		$options    = Mockery::mock( Options_Data::class );
-		$api_client = Mockery::mock( APIClient::class );
-		$this->user = Mockery::mock( User::class );
-		$this->controller = new Controller( $this->context, $options, $api_client, $this->user );
+		$options          = Mockery::mock( Options_Data::class );
+		$api_client       = Mockery::mock( APIClient::class );
+		$this->user       = Mockery::mock( User::class );
+		$this->queue      = Mockery::mock( Queue::class );
+		$this->controller = new Controller( $this->context, $options, $api_client, $this->user, $this->queue );
 	}
 
 	/**
@@ -41,12 +42,15 @@ class Test_AddWPRImageDimensionQueryArg extends TestCase {
 			->once()
 			->andReturn( $config['filter'] );
 
-		Functions\expect('add_query_arg')->with([ 'wpr_imagedimensions' => 1 ])->andReturn($expected);
+		Functions\expect( 'add_query_arg' )
+			->with(
+				[ 'wpr_imagedimensions' => 1 ]
+			)
+			->andReturn( $expected );
 
 		$this->assertSame(
 			$expected,
 			$this->controller->add_wpr_imagedimensions_query_arg( $config['url'] )
 		);
 	}
-
 }

--- a/tests/Unit/inc/Engine/Media/AboveTheFold/WarmUp/Controller/fetchLinks.php
+++ b/tests/Unit/inc/Engine/Media/AboveTheFold/WarmUp/Controller/fetchLinks.php
@@ -7,7 +7,7 @@ use Mockery;
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\Common\Context\ContextInterface;
 use WP_Rocket\Engine\License\API\User;
-use WP_Rocket\Engine\Media\AboveTheFold\WarmUp\{APIClient, Controller};
+use WP_Rocket\Engine\Media\AboveTheFold\WarmUp\{APIClient, Controller, Queue};
 use WP_Rocket\Tests\Unit\TestCase;
 
 /**
@@ -19,6 +19,7 @@ use WP_Rocket\Tests\Unit\TestCase;
 class Test_FetchLinks extends TestCase {
 	private $user;
 	private $controller;
+	private $queue;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -27,7 +28,8 @@ class Test_FetchLinks extends TestCase {
 		$options          = Mockery::mock( Options_Data::class );
 		$api_client       = Mockery::mock( APIClient::class );
 		$this->user       = Mockery::mock( User::class );
-		$this->controller = new Controller( $context, $options, $api_client, $this->user );
+		$this->queue      = Mockery::mock( Queue::class );
+		$this->controller = new Controller( $context, $options, $api_client, $this->user, $this->queue );
 	}
 
 	/**
@@ -44,7 +46,7 @@ class Test_FetchLinks extends TestCase {
 			}
 		);
 
-		Functions\expect( 'wp_remote_get' )
+		Functions\expect( 'wp_safe_remote_get' )
 			->atMost()
 			->once()
 			->with( 'https://example.org', $config['headers'] )
@@ -74,7 +76,7 @@ class Test_FetchLinks extends TestCase {
 
 			Filters\expectApplied( 'rocket_atf_warmup_links_number' )
 				->once()
-				->with( 5 );
+				->with( 10 );
 		}
 
 		$this->assertSame(


### PR DESCRIPTION
# Description

Fixes #6609

### Technical documentation

- A request to send the homepage to SaaS is triggered directly
- An background task is created to fetch the links on the page at the same time
- A background task is created for each of the 10 links, to send them to the SaaS

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Documentation

- [ ] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [ ] The user documentation covers new/changed entry points (endpoints, WP hooks, configuration files, ...).
- [ ] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I wrote comments to explain why it does it.
- [x] I named variables and functions explicitely.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.