### PR TITLE
Closes #6667: Add header to lcp candidates elements

### DIFF
--- a/inc/Engine/Media/AboveTheFold/Frontend/Controller.php
+++ b/inc/Engine/Media/AboveTheFold/Frontend/Controller.php
@@ -485,6 +485,7 @@ class Controller {
 			'li',
 			'svg',
 			'section',
+			'header',
 		];
 
 		$default_elements = $elements;

--- a/tests/Fixtures/inc/Engine/Media/AboveTheFold/Frontend/Subscriber/HTML/output_w_beacon.html
+++ b/tests/Fixtures/inc/Engine/Media/AboveTheFold/Frontend/Subscriber/HTML/output_w_beacon.html
@@ -3,5 +3,5 @@
 	<title>Test</title>
 </head>
 <body>
-<script>var rocket_lcp_data = {"ajax_url":"http:\/\/example.org\/wp-admin\/admin-ajax.php","nonce":"96ac96b69e","url":"http:\/\/example.org","is_mobile":false,"elements":"img, video, picture, p, main, div, li, svg, section","width_threshold":1600,"height_threshold":700,"debug":false}</script><script data-name="wpr-lcp-beacon" src='http://example.org/wp-content/plugins/wp-rocket/assets/js/lcp-beacon.min.js' async></script></body>
+<script>var rocket_lcp_data = {"ajax_url":"http:\/\/example.org\/wp-admin\/admin-ajax.php","nonce":"96ac96b69e","url":"http:\/\/example.org","is_mobile":false,"elements":"img, video, picture, p, main, div, li, svg, section, header","width_threshold":1600,"height_threshold":700,"debug":false}</script><script data-name="wpr-lcp-beacon" src='http://example.org/wp-content/plugins/wp-rocket/assets/js/lcp-beacon.min.js' async></script></body>
 </html>


### PR DESCRIPTION
# Description

Fixes #6667 

## Documentation

### User documentation

Adds the `<header></header>` to be considered as a lcp candidate. 

### Technical documentation


## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## New dependencies

## Risks


# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.

## Documentation

- [ ] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [ ] The user documentation covers new/changed entry points (endpoints, WP hooks, configuration files, ...).
- [ ] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [ ] I wrote self-explanatory code about what it does.
- [ ] I wrote comments to explain why it does it.
- [ ] I named variables and functions explicitely.
- [ ] I protected entry points against unexpected inputs.
- [ ] I did not introduce unecessary complexity.
- [ ] I listed the introduced external dependencies explicitely on the PR.
- [ ] I validated the repo-specific guidelines from CONTRIBUTING.md.

## Observability
- [ ] I handled errors when needed.
- [ ] I wrote user-facing messages that are understandable and provide actionable feedbacks.
- [ ] I prepared ways to observe the implemented system (logs, data, etc.).

## Risks
- [ ] I explicitely mentioned performance risks in the PR.
- [ ] I explicitely mentioned security risks in the PR.
