### PR TITLE
Fixes #6690 Prevent type error if preg_replace() returns null

### DIFF
--- a/inc/Engine/Media/AboveTheFold/Frontend/Controller.php
+++ b/inc/Engine/Media/AboveTheFold/Frontend/Controller.php
@@ -111,6 +111,11 @@ class Controller {
 		$preload .= $this->preload_tag( $lcp );
 
 		$replace = preg_replace( '#' . $title . '#', $preload, $html, 1 );
+
+		if ( null === $replace ) {
+			return $html;
+		}
+
 		$replace = $this->set_fetchpriority( $lcp, $replace );
 
 		return $replace;
@@ -168,7 +173,13 @@ class Controller {
 				}
 
 				// If it doesn't exist, add the fetchpriority attribute.
-				return preg_replace( '/<img/', '<img fetchpriority="high"', $matches[0] );
+				$replace = preg_replace( '/<img/', '<img fetchpriority="high"', $matches[0] );
+
+				if ( null === $replace ) {
+					return $matches[0];
+				}
+
+				return $replace;
 			},
 			$html,
 			1


### PR DESCRIPTION
# Description

Fixes #6690

## Documentation

### Technical documentation

`preg_replace can return `null` when there is an error, and if we use the value after, it will cause a fatal error due to passing an incorrect type.

Adding a guard clause prevents the issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklists

## Feature validation

- [ ] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [ ] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style
- [ ] I wrote self-explanatory code about what it does.
- [ ] I wrote comments to explain why it does it.
- [ ] I named variables and functions explicitely.
- [ ] I protected entry points against unexpected inputs.
- [ ] I did not introduce unecessary complexity.
