### PR TITLE
Closes #5549 Clear cache table on domain change

### DIFF
--- a/inc/Engine/Media/AboveTheFold/WarmUp/Subscriber.php
+++ b/inc/Engine/Media/AboveTheFold/WarmUp/Subscriber.php
@@ -29,9 +29,10 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events(): array {
 		return [
-			'wp_rocket_upgrade'          => [ 'warm_up_on_update', 10, 2 ],
-			'rocket_after_clear_atf'     => 'warm_up',
-			'rocket_saas_api_queued_url' => 'add_wpr_imagedimensions_query_arg',
+			'wp_rocket_upgrade'             => [ 'warm_up_on_update', 10, 2 ],
+			'rocket_after_clear_atf'        => 'warm_up',
+			'rocket_saas_api_queued_url'    => 'add_wpr_imagedimensions_query_arg',
+			'rocket_domain_options_changed' => 'warm_up',
 		];
 	}
 

--- a/inc/Engine/Media/AboveTheFold/WarmUp/Subscriber.php
+++ b/inc/Engine/Media/AboveTheFold/WarmUp/Subscriber.php
@@ -29,12 +29,11 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events(): array {
 		return [
-			'wp_rocket_upgrade'             => [ 'warm_up_on_update', 10, 2 ],
-			'rocket_after_clear_atf'        => 'warm_up_home',
-			'rocket_saas_api_queued_url'    => 'add_wpr_imagedimensions_query_arg',
-			'rocket_job_warmup'             => 'warm_up',
-			'rocket_job_warmup_url'         => 'send_to_saas',
-			'rocket_domain_options_changed' => 'warm_up_home',
+			'wp_rocket_upgrade'          => [ 'warm_up_on_update', 10, 2 ],
+			'rocket_after_clear_atf'     => 'warm_up_home',
+			'rocket_saas_api_queued_url' => 'add_wpr_imagedimensions_query_arg',
+			'rocket_job_warmup'          => 'warm_up',
+			'rocket_job_warmup_url'      => 'send_to_saas',
 		];
 	}
 

--- a/inc/Engine/Preload/Admin/Settings.php
+++ b/inc/Engine/Preload/Admin/Settings.php
@@ -44,7 +44,7 @@ class Settings {
 	 * @param LoadInitialSitemap $load_initial_sitemap LoadInitialSitemap instance.
 	 * @param CacheTable         $cache_table CacheTable instance.
 	 */
-	public function __construct( Options_Data $options, PreloadUrl $preload_url, $load_initial_sitemap, $cache_table ) {
+	public function __construct( Options_Data $options, PreloadUrl $preload_url, LoadInitialSitemap $load_initial_sitemap, CacheTable $cache_table ) {
 		$this->options              = $options;
 		$this->preload_url          = $preload_url;
 		$this->load_initial_sitemap = $load_initial_sitemap;
@@ -139,7 +139,7 @@ class Settings {
 	 * @return void
 	 */
 	public function clear_and_preload() {
-		$this->cache_table->truncate();
+		$this->cache_table->truncate_cache_table();
 
 		if ( ! $this->is_enabled() ) {
 			return;

--- a/inc/Engine/Preload/Admin/Settings.php
+++ b/inc/Engine/Preload/Admin/Settings.php
@@ -121,6 +121,19 @@ class Settings {
 	}
 
 	/**
+	 * Preload the homepage.
+	 *
+	 * @return void
+	 */
+	public function preload_homepage() {
+		if ( ! $this->is_enabled() ) {
+			return;
+		}
+
+		$this->preload_url->preload_url( home_url() );
+	}
+
+	/**
 	 * Clear cache table and preload.
 	 *
 	 * @return void

--- a/inc/Engine/Preload/Admin/Settings.php
+++ b/inc/Engine/Preload/Admin/Settings.php
@@ -1,18 +1,19 @@
 <?php
+declare(strict_types=1);
 
 namespace WP_Rocket\Engine\Preload\Admin;
 
-use WP_Rocket\Engine\Preload\Controller\PreloadUrl;
 use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Engine\Preload\Controller\{LoadInitialSitemap, PreloadUrl};
+use WP_Rocket\Engine\Preload\Database\Tables\Cache as CacheTable;
 
 class Settings {
-
 	/**
 	 * Instance of options handler.
 	 *
 	 * @var Options_Data
 	 */
-	protected $options;
+	private $options;
 
 	/**
 	 * PreloadUrl instance
@@ -22,14 +23,32 @@ class Settings {
 	private $preload_url;
 
 	/**
+	 * LoadInitialSitemap instance
+	 *
+	 * @var LoadInitialSitemap
+	 */
+	private $load_initial_sitemap;
+
+	/**
+	 * CacheTable instance
+	 *
+	 * @var CacheTable
+	 */
+	private $cache_table;
+
+	/**
 	 * Instantiate the class
 	 *
-	 * @param Options_Data $options Instance of options handler.
-	 * @param PreloadUrl   $preload_url PreloadUrl instance.
+	 * @param Options_Data       $options Instance of options handler.
+	 * @param PreloadUrl         $preload_url PreloadUrl instance.
+	 * @param LoadInitialSitemap $load_initial_sitemap LoadInitialSitemap instance.
+	 * @param CacheTable         $cache_table CacheTable instance.
 	 */
-	public function __construct( Options_Data $options, PreloadUrl $preload_url ) {
-		$this->options     = $options;
-		$this->preload_url = $preload_url;
+	public function __construct( Options_Data $options, PreloadUrl $preload_url, $load_initial_sitemap, $cache_table ) {
+		$this->options              = $options;
+		$this->preload_url          = $preload_url;
+		$this->load_initial_sitemap = $load_initial_sitemap;
+		$this->cache_table          = $cache_table;
 	}
 
 	/**
@@ -102,11 +121,18 @@ class Settings {
 	}
 
 	/**
-	 * Preload the homepage
+	 * Clear cache table and preload.
 	 *
 	 * @return void
 	 */
-	public function preload_homepage() {
+	public function clear_and_preload() {
+		$this->cache_table->truncate();
+
+		if ( ! $this->is_enabled() ) {
+			return;
+		}
+
+		$this->load_initial_sitemap->load_initial_sitemap();
 		$this->preload_url->preload_url( home_url() );
 	}
 }

--- a/inc/Engine/Preload/Admin/Subscriber.php
+++ b/inc/Engine/Preload/Admin/Subscriber.php
@@ -1,24 +1,11 @@
 <?php
+declare(strict_types=1);
 
 namespace WP_Rocket\Engine\Preload\Admin;
 
-use stdClass;
-use WP_Rocket\Admin\Options_Data;
-use WP_Rocket\Engine\Preload\Controller\ClearCache;
-
 use WP_Rocket\Event_Management\Subscriber_Interface;
-use WP_Rocket\Logger\Logger;
-use WP_Rocket\Engine\Admin\Settings\Settings as AdminSettings;
 
 class Subscriber implements Subscriber_Interface {
-
-	/**
-	 * Options instance.
-	 *
-	 * @var Options_Data
-	 */
-	protected $options;
-
 	/**
 	 * Settings instance.
 	 *
@@ -28,12 +15,10 @@ class Subscriber implements Subscriber_Interface {
 
 	/**
 	 * Creates an instance of the class.
-	 *
-	 * @param Options_Data $options Options instance.
-	 * @param Settings     $settings Settings instance.
+
+	 * @param Settings $settings Settings instance.
 	 */
-	public function __construct( Options_Data $options, Settings $settings ) {
-		$this->options  = $options;
+	public function __construct( Settings $settings ) {
 		$this->settings = $settings;
 	}
 
@@ -50,7 +35,7 @@ class Subscriber implements Subscriber_Interface {
 			'rocket_options_changed'        => 'preload_homepage',
 			'switch_theme'                  => 'preload_homepage',
 			'rocket_after_clean_used_css'   => 'preload_homepage',
-			'rocket_domain_options_changed' => 'preload_homepage',
+			'rocket_domain_options_changed' => 'clear_and_preload',
 			'rocket_input_sanitize'         => 'sanitize_options',
 			'wp_rocket_upgrade'             => [ 'maybe_clean_cron', 15, 2 ],
 		];
@@ -66,12 +51,12 @@ class Subscriber implements Subscriber_Interface {
 	}
 
 	/**
-	 * Preload the homepage after changing the settings
+	 * Clear the cache table and preload
 	 *
 	 * @return void
 	 */
-	public function preload_homepage() {
-		$this->settings->preload_homepage();
+	public function clear_and_preload() {
+		$this->settings->clear_and_preload();
 	}
 
 	/**

--- a/inc/Engine/Preload/Admin/Subscriber.php
+++ b/inc/Engine/Preload/Admin/Subscriber.php
@@ -51,6 +51,15 @@ class Subscriber implements Subscriber_Interface {
 	}
 
 	/**
+	 * Preload the homepage
+	 *
+	 * @return void
+	 */
+	public function preload_homepage() {
+		$this->settings->preload_homepage();
+	}
+
+	/**
 	 * Clear the cache table and preload
 	 *
 	 * @return void

--- a/inc/Engine/Preload/Database/Tables/Cache.php
+++ b/inc/Engine/Preload/Database/Tables/Cache.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace WP_Rocket\Engine\Preload\Database\Tables;
 
@@ -95,5 +96,18 @@ class Cache extends Table {
 		}
 
 		return $this->is_success( $created );
+	}
+
+	/**
+	 * Truncate cache table.
+	 *
+	 * @return bool
+	 */
+	public function truncate_cache_table(): bool {
+		if ( ! $this->exists() ) {
+			return false;
+		}
+
+		return $this->truncate();
 	}
 }

--- a/inc/Engine/Preload/ServiceProvider.php
+++ b/inc/Engine/Preload/ServiceProvider.php
@@ -116,7 +116,9 @@ class ServiceProvider extends AbstractServiceProvider {
 
 		$this->getContainer()->add( 'preload_settings', Settings::class )
 			->addArgument( $options )
-			->addArgument( $preload_url_controller );
+			->addArgument( $preload_url_controller )
+			->addArgument( $this->getContainer()->get( 'load_initial_sitemap_controller' ) )
+			->addArgument( $this->getContainer()->get( 'preload_caches_table' ) );
 
 		$preload_settings = $this->getContainer()->get( 'preload_settings' );
 
@@ -161,7 +163,6 @@ class ServiceProvider extends AbstractServiceProvider {
 			->addTag( 'common_subscriber' );
 
 		$this->getContainer()->add( 'preload_admin_subscriber', AdminSubscriber::class )
-			->addArgument( $options )
 			->addArgument( $preload_settings )
 			->addTag( 'common_subscriber' );
 	}

--- a/tests/Fixtures/inc/Engine/Preload/Admin/Settings/clearAndPreload.php
+++ b/tests/Fixtures/inc/Engine/Preload/Admin/Settings/clearAndPreload.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+	'testShouldOnlyTruncateWhenPreloadDisabled' => [
+		'config'   => [
+			'options' => [
+				'manual_preload' => 0,
+			],
+		],
+		'expected' => false,
+	],
+	'testShouldPreloadHomepageAndSitemap' => [
+		'config'   => [
+			'options' => [
+				'manual_preload' => 1,
+			],
+		],
+		'expected' => true,
+	],
+];

--- a/tests/Fixtures/inc/Engine/Preload/Admin/Settings/preloadHomepage.php
+++ b/tests/Fixtures/inc/Engine/Preload/Admin/Settings/preloadHomepage.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+	'testShouldDoNothingWhenPreloadDisabled' => [
+		'config'   => [
+			'options' => [
+				'manual_preload' => 0,
+			],
+		],
+		'expected' => false,
+	],
+	'testShouldPreloadHomepage' => [
+		'config'   => [
+			'options' => [
+				'manual_preload' => 1,
+			],
+		],
+		'expected' => true,
+	],
+];

--- a/tests/Unit/inc/Engine/Preload/Admin/Settings/clearAndPreload.php
+++ b/tests/Unit/inc/Engine/Preload/Admin/Settings/clearAndPreload.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\Preload\Admin\Settings;
+
+use Brain\Monkey\Functions;
+use Mockery;
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Engine\Preload\Admin\Settings;
+use WP_Rocket\Engine\Preload\Controller\{LoadInitialSitemap, PreloadUrl};
+use WP_Rocket\Engine\Preload\Database\Tables\Cache as CacheTable;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * Test class covering \WP_Rocket\Engine\Preload\Admin\Settings::clear_and_preload
+ *
+ * @group Preload
+ */
+class TestClearAndPreload extends TestCase {
+	private $settings;
+	private $options;
+	private $preload_url;
+	private $sitemap;
+	private $cache;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->options     = Mockery::mock( Options_Data::class );
+		$this->preload_url = Mockery::mock( PreloadUrl::class );
+		$this->sitemap     = Mockery::mock( LoadInitialSitemap::class );
+		$this->cache       = $this->createMock( CacheTable::class );
+		$this->settings    = new Settings(
+			$this->options,
+			$this->preload_url,
+			$this->sitemap,
+			$this->cache
+		);
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldDoExpected( $config, $expected ) {
+		Functions\when( 'home_url' )->justReturn( 'http://example.org/' );
+
+		$this->cache->expects( $this->once() )
+			->method( 'truncate' );
+
+		$this->options->shouldReceive( 'get' )
+			->with( 'manual_preload', 0 )
+			->andReturn( $config['options']['manual_preload'] );
+
+		if ( $expected ) {
+			$this->sitemap->shouldReceive( 'load_initial_sitemap' )
+				->once();
+			$this->preload_url->shouldReceive( 'preload_url' )
+				->once();
+		} else {
+			$this->sitemap->shouldReceive( 'load_initial_sitemap' )
+				->never();
+			$this->preload_url->shouldReceive( 'preload_url' )
+				->never();
+		}
+
+		$this->settings->clear_and_preload();
+	}
+}

--- a/tests/Unit/inc/Engine/Preload/Admin/Settings/clearAndPreload.php
+++ b/tests/Unit/inc/Engine/Preload/Admin/Settings/clearAndPreload.php
@@ -45,7 +45,7 @@ class TestClearAndPreload extends TestCase {
 		Functions\when( 'home_url' )->justReturn( 'http://example.org/' );
 
 		$this->cache->expects( $this->once() )
-			->method( 'truncate' );
+			->method( 'truncate_cache_table' );
 
 		$this->options->shouldReceive( 'get' )
 			->with( 'manual_preload', 0 )

--- a/tests/Unit/inc/Engine/Preload/Admin/Settings/maybeDisplayPreloadNotice.php
+++ b/tests/Unit/inc/Engine/Preload/Admin/Settings/maybeDisplayPreloadNotice.php
@@ -1,26 +1,36 @@
 <?php
+declare(strict_types=1);
+
 namespace WP_Rocket\Tests\Unit\inc\Engine\Preload\Admin\Settings;
 
 use Brain\Monkey\Functions;
 use Mockery;
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\Preload\Admin\Settings;
-use WP_Rocket\Engine\Preload\Controller\PreloadUrl;
+use WP_Rocket\Engine\Preload\Controller\{LoadInitialSitemap, PreloadUrl};
+use WP_Rocket\Engine\Preload\Database\Tables\Cache as CacheTable;
 use WP_Rocket\Tests\Unit\TestCase;
 
 /**
  * Test class covering \WP_Rocket\Engine\Preload\Admin\Settings::maybe_display_preload_notice
- * @group  Preload
+ *
+ * @group Preload
  */
 class Test_MaybeDisplayPreloadNotice extends TestCase {
 	protected $settings;
 	protected $options;
 
-	protected function setUp(): void
-	{
+	protected function setUp(): void {
 		parent::setUp();
-		$this->options = Mockery::mock(Options_Data::class);
-		$this->settings = new Settings($this->options, Mockery::mock(PreloadUrl::class));
+
+		$this->options  = Mockery::mock( Options_Data::class );
+		$this->settings = new Settings(
+			$this->options,
+			Mockery::mock( PreloadUrl::class ),
+			Mockery::mock( LoadInitialSitemap::class ),
+			$this->createMock( CacheTable::class )
+		);
+
 		$this->stubTranslationFunctions();
 	}
 
@@ -28,21 +38,21 @@ class Test_MaybeDisplayPreloadNotice extends TestCase {
 	 * @dataProvider configTestData
 	 */
 	public function testShouldReturnAsExpected( $config, $expected ) {
-		Functions\when('get_current_screen')->justReturn( $config['screen'] );
-		Functions\when('current_user_can')->justReturn( $config['has_right'] );
-		Functions\when('get_current_user_id')->justReturn( 1 );
-		Functions\when('get_user_meta')->justReturn([]);
+		Functions\when( 'get_current_screen' )->justReturn( $config['screen'] );
+		Functions\when( 'current_user_can' )->justReturn( $config['has_right'] );
+		Functions\when( 'get_current_user_id' )->justReturn( 1 );
+		Functions\when( 'get_user_meta' )->justReturn( [] );
 
 		Functions\expect( 'rocket_dismiss_box' )
 			->with( 'preload_notice' )
 			->atMost()
 			->once();
 
-		$this->options->allows()->get('manual_preload', 0)->andReturns($config['enabled']);
-		Functions\when('get_transient')->justReturn($config['transient']);
+		$this->options->allows()->get( 'manual_preload', 0 )->andReturns( $config['enabled'] );
+		Functions\when( 'get_transient' )->justReturn( $config['transient'] );
 
 		if ( $expected ) {
-			Functions\expect('rocket_notice_html')->once()->with($expected['notice']);
+			Functions\expect( 'rocket_notice_html' )->once()->with( $expected['notice'] );
 		} else {
 			Functions\expect('rocket_notice_html')->never();
 		}

--- a/tests/Unit/inc/Engine/Preload/Admin/Settings/preloadHomepage.php
+++ b/tests/Unit/inc/Engine/Preload/Admin/Settings/preloadHomepage.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\Preload\Admin\Settings;
+
+use Brain\Monkey\Functions;
+use Mockery;
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Engine\Preload\Admin\Settings;
+use WP_Rocket\Engine\Preload\Controller\{LoadInitialSitemap, PreloadUrl};
+use WP_Rocket\Engine\Preload\Database\Tables\Cache as CacheTable;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * Test class covering \WP_Rocket\Engine\Preload\Admin\Settings::preload_homepage
+ *
+ * @group Preload
+ */
+class TestPreloadHomepage extends TestCase {
+	private $settings;
+	private $options;
+	private $preload_url;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->options     = Mockery::mock( Options_Data::class );
+		$this->preload_url = Mockery::mock( PreloadUrl::class );
+		$this->settings    = new Settings(
+			$this->options,
+			$this->preload_url,
+			Mockery::mock( LoadInitialSitemap::class ),
+			$this->createMock( CacheTable::class )
+		);
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldDoExpected( $config, $expected ) {
+		Functions\when( 'home_url' )->justReturn( 'http://example.org/' );
+
+		$this->options->shouldReceive( 'get' )
+			->with( 'manual_preload', 0 )
+			->andReturn( $config['options']['manual_preload'] );
+
+		if ( $expected ) {
+			$this->preload_url->shouldReceive( 'preload_url' )
+				->once();
+		} else {
+			$this->preload_url->shouldReceive( 'preload_url' )
+				->never();
+		}
+
+		$this->settings->preload_homepage();
+	}
+}


### PR DESCRIPTION
# Description

Fixes #5549

## Documentation

### User documentation

- Clear the cache table on domain change
- Trigger the OCI warmup on domain change
- Trigger the sitemap preload on domain change

### Technical documentation

- Added a new method to truncate the cache table
- Added a new method to truncate the cache table and start the sitemap preload
- Added a new method callback to trigger the OCI warmup on domain change

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I wrote comments to explain why it does it.
- [x] I named variables and functions explicitely.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.