### PR TITLE
Added support for WooCommerce Multilingual Standalone Version

### DIFF
--- a/inc/3rd-party/plugins/ecommerce/woocommerce-multilingual.php
+++ b/inc/3rd-party/plugins/ecommerce/woocommerce-multilingual.php
@@ -8,9 +8,7 @@ defined( 'ABSPATH' ) || exit;
  * @return bool
  */
 function rocket_wcml_has_requirements() {
-	return defined( 'ICL_SITEPRESS_VERSION' )
-		&& version_compare( ICL_SITEPRESS_VERSION, '4.4.11', '>=' )
-		&& defined( 'WCML_VERSION' )
+	return defined( 'WCML_VERSION' )
 		&& version_compare( WCML_VERSION, '4.12.6', '>=' );
 }
 


### PR DESCRIPTION
# Description
[WooCommerce Multilingual ](https://wpml.org/documentation/related-projects/woocommerce-multilingual/multi-currency-support-woocommerce/) comes in two versions: Standalone Version and Full Features with WPML.

In PR #4462, we added support for Full Features with WPML, but Standalone Version was released after these changes. That is currently not working with WP Rocket. You can view the customer report [WCML shows default currency, regardless of location](https://wpml.org/forums/topic/wcml-shows-default-currency-regardless-of-location/)

These changes were suggested by @strategio 

## Documentation

### User documentation
- Added support for WooCommerce Multilingual Standalone Version

### Technical documentation
- Removed the `ICL_SITEPRESS_VERSION` constant that is defined only in WPML, and retained `WCML_VERSION` defined in WooCommerce Multilingual.

## Type of change
- [x] Enhancement (non-breaking change which improves an existing functionality).


# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.

## Documentation

- [x] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [x] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I did not introduce unecessary complexity.
