### PR TITLE
Overwrite .htaccess file after deleting rules even if there is no content

### DIFF
--- a/inc/functions/htaccess.php
+++ b/inc/functions/htaccess.php
@@ -150,7 +150,7 @@ function flush_rocket_htaccess( $remove_rules = false ) { // phpcs:ignore WordPr
 	fseek( $pointer, 0 );
 	$bytes = fwrite( $pointer, $new_file_data ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
 
-	if ( $bytes !== false ) {
+	if ( false !== $bytes ) {
 		ftruncate( $pointer, ftell( $pointer ) );
 	}
 

--- a/inc/functions/htaccess.php
+++ b/inc/functions/htaccess.php
@@ -150,7 +150,7 @@ function flush_rocket_htaccess( $remove_rules = false ) { // phpcs:ignore WordPr
 	fseek( $pointer, 0 );
 	$bytes = fwrite( $pointer, $new_file_data ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
 
-	if ( $bytes ) {
+	if ( $bytes !== false ) {
 		ftruncate( $pointer, ftell( $pointer ) );
 	}
 


### PR DESCRIPTION
# Description

Fixed the process of clearing the .htaccess file in cases where the .htaccess file was empty.

## Documentation

### User documentation

If during deactivation of the plugin there are no other rules that relate to WordPress, then the WP Rocket rules will not be deleted.

### Technical documentation

The `fwrite` function will not write changes to a file if the `$new_file_data` variable is empty.
Even though fwrite returns 0, which is not an error, the following condition will not work:
```
if ( $bytes ) {
 ftruncate( $pointer, ftell( $pointer ) );
}
```

It is necessary to clearly determine that no error occurred when trying to work with the file, and only in this case do not try to truncate the file:
```
if ( $bytes !== false ) {
 ftruncate( $pointer, ftell( $pointer ) );
}
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).

# Checklists

## Code style
- [+] I wrote self-explanatory code about what it does.
- [+] I did not introduce unecessary complexity.
