### PR TITLE
Make sure to send mobile visit to saas warmup for OCI with a fresh install

### DIFF
--- a/inc/Engine/Media/AboveTheFold/WarmUp/Controller.php
+++ b/inc/Engine/Media/AboveTheFold/WarmUp/Controller.php
@@ -240,11 +240,6 @@ class Controller {
 	 * @return bool
 	 */
 	private function is_mobile(): bool {
-		$plugin_version = (string) get_rocket_option( 'version', '' );
-		if ( ! $plugin_version ) { // We are warming up a fresh installation. Options are not set yet.
-			return true;
-		}
-
-		return $this->options->get( 'cache_mobile', 0 ) && $this->options->get( 'do_caching_mobile_files', 0 );
+		return $this->options->get( 'cache_mobile', 1 ) && $this->options->get( 'do_caching_mobile_files', 1 );
 	}
 }

--- a/tests/Unit/inc/Engine/Media/AboveTheFold/WarmUp/Controller/sendToSass.php
+++ b/tests/Unit/inc/Engine/Media/AboveTheFold/WarmUp/Controller/sendToSass.php
@@ -37,15 +37,12 @@ class sendToSass extends TestCase {
 	 */
 	public function testShouldReturnExpected( $config, $expected ) {
 		$this->options->shouldReceive('get')
-			->with('cache_mobile', 0)
-			->andReturn(0);
+			->with( 'cache_mobile', 1 )
+			->andReturn( 1 );
 
-		if('desktop' === $config['device']) {
-			Functions\expect( 'get_rocket_option' )
-				->once()
-				->with( 'version', '' )
-				->andReturn( true );
-		}
+		$this->options->shouldReceive('get')
+			->with( 'do_caching_mobile_files', 1 )
+			->andReturn( 1 );
 
 		$this->api_client->shouldReceive('add_to_atf_queue')
 			->with('http://example.com')
@@ -53,15 +50,12 @@ class sendToSass extends TestCase {
 			->andReturn([$config['url'], []]);
 
 		if('mobile' === $config['device']) {
-			Functions\expect( 'get_rocket_option' )
-				->once()
-				->with( 'version', '' )
-				->andReturn( '' );
+
 
 			$this->api_client->shouldReceive('add_to_atf_queue')
-				->with('http://example.com', $config['device'])
+				->with( 'http://example.com', $config['device'] )
 				->once()
-				->andReturn([$config['url'], []]);
+				->andReturn( [$config['url'], []] );
 		}
 
 		$this->controller->send_to_saas($config['url']);

--- a/tests/Unit/inc/Engine/Media/AboveTheFold/WarmUp/Controller/sendToSass.php
+++ b/tests/Unit/inc/Engine/Media/AboveTheFold/WarmUp/Controller/sendToSass.php
@@ -36,13 +36,15 @@ class sendToSass extends TestCase {
 	 * @dataProvider configTestData
 	 */
 	public function testShouldReturnExpected( $config, $expected ) {
+		$mobile_cache = 'mobile' === $config['device'] ? 1 : 0;
+
 		$this->options->shouldReceive('get')
 			->with( 'cache_mobile', 1 )
-			->andReturn( 1 );
+			->andReturn( $mobile_cache );
 
 		$this->options->shouldReceive('get')
 			->with( 'do_caching_mobile_files', 1 )
-			->andReturn( 1 );
+			->andReturn( $mobile_cache );
 
 		$this->api_client->shouldReceive('add_to_atf_queue')
 			->with('http://example.com')
@@ -50,8 +52,6 @@ class sendToSass extends TestCase {
 			->andReturn([$config['url'], []]);
 
 		if('mobile' === $config['device']) {
-
-
 			$this->api_client->shouldReceive('add_to_atf_queue')
 				->with( 'http://example.com', $config['device'] )
 				->once()


### PR DESCRIPTION
# Description

Fixes #6752

## Documentation

### User documentation

For fresh installation or when the mobile cache settings are not set, we will consider it active by default.

### Technical documentation

Here we set the default value sent to `$this->options->get` to be 1.

## Type of change
*Delete options that are not relevant.*

- [x] Bug fix (non-breaking change which fixes an issue).

## New dependencies
*List any new dependencies that are required for this change.*

## Risks

Can't think of any risk here.

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Documentation

- [x] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [ ] The user documentation covers new/changed entry points (endpoints, WP hooks, configuration files, ...).
- [x] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I wrote comments to explain why it does it.
- [x] I named variables and functions explicitely.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.
- [ ] I listed the introduced external dependencies explicitely on the PR.
- [x] I validated the repo-specific guidelines from CONTRIBUTING.md.

## Observability
- [x] I handled errors when needed.
- [ ] I wrote user-facing messages that are understandable and provide actionable feedbacks.
- [ ] I prepared ways to observe the implemented system (logs, data, etc.).

## Risks
- [ ] I explicitely mentioned performance risks in the PR.
- [ ] I explicitely mentioned security risks in the PR.
