### PR TITLE
Prevent the abstract query from returning an array

### DIFF
--- a/inc/Engine/Common/Database/Queries/AbstractQuery.php
+++ b/inc/Engine/Common/Database/Queries/AbstractQuery.php
@@ -58,6 +58,10 @@ class AbstractQuery extends Query {
 			]
 		);
 
+		if( is_array( $query ) ) {
+			$query = array_pop( $query );
+		}
+
 		if ( empty( $query ) ) {
 			return false;
 		}

--- a/inc/Engine/Common/Database/Queries/AbstractQuery.php
+++ b/inc/Engine/Common/Database/Queries/AbstractQuery.php
@@ -58,7 +58,7 @@ class AbstractQuery extends Query {
 			]
 		);
 
-		if( is_array( $query ) ) {
+		if ( is_array( $query ) ) {
 			$query = array_pop( $query );
 		}
 


### PR DESCRIPTION
# Description

Fixes an issue that prevent PSI tests from passing.

When a single element is returned, the method `query` returns an array with one value instead of the direct value itself.

This PR fixes the issue described above.

Fixes [#36](https://github.com/wp-media/wp-rocket-lighthouse-simulator/issues/36)

## Documentation

### User documentation

*Explain how this code impacts users.*

### Technical documentation

*Explain how this code works. Diagram & drawings are welcomed.*

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).

## New dependencies
*List any new dependencies that are required for this change.*

## Risks
*List possible performance & security issues or risks, and explain how they have been mitigated.*

# Checklists

## Feature validation

- [ ] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [ ] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Documentation

- [ ] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [ ] The user documentation covers new/changed entry points (endpoints, WP hooks, configuration files, ...).
- [ ] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [ ] I wrote self-explanatory code about what it does.
- [ ] I wrote comments to explain why it does it.
- [ ] I named variables and functions explicitely.
- [ ] I protected entry points against unexpected inputs.
- [ ] I did not introduce unecessary complexity.
- [ ] I listed the introduced external dependencies explicitely on the PR.
- [ ] I validated the repo-specific guidelines from CONTRIBUTING.md.

## Observability
- [ ] I handled errors when needed.
- [ ] I wrote user-facing messages that are understandable and provide actionable feedbacks.
- [ ] I prepared ways to observe the implemented system (logs, data, etc.).

## Risks
- [ ] I explicitely mentioned performance risks in the PR.
- [ ] I explicitely mentioned security risks in the PR.
