### PR TITLE
Closes #6760: E_ERROR in 3.16.2: Argument #1 ($microseconds) must be of type int. In line 164 of PreloadUrl.php

### DIFF
--- a/inc/Engine/Preload/Controller/PreloadUrl.php
+++ b/inc/Engine/Preload/Controller/PreloadUrl.php
@@ -161,7 +161,8 @@ class PreloadUrl {
 			 *
 			 * @param int $delay_between the defined delay.
 			 */
-			$delay_between = (int) apply_filters( 'rocket_preload_delay_between_requests', $default_delay_between );
+			$delay_between = apply_filters( 'rocket_preload_delay_between_requests', $default_delay_between );
+			$delay_between = absint( $delay_between );
 
 			if ( empty( $delay_between ) ) {
 				$delay_between = $default_delay_between;

--- a/inc/Engine/Preload/Controller/PreloadUrl.php
+++ b/inc/Engine/Preload/Controller/PreloadUrl.php
@@ -161,9 +161,9 @@ class PreloadUrl {
 			 *
 			 * @param int $delay_between the defined delay.
 			 */
-			$delay_between = apply_filters( 'rocket_preload_delay_between_requests', $default_delay_between );
+			$delay_between = (int) apply_filters( 'rocket_preload_delay_between_requests', $default_delay_between );
 
-			if ( ! is_int( $delay_between ) ) {
+			if ( empty( $delay_between ) ) {
 				$delay_between = $default_delay_between;
 			}
 

--- a/inc/Engine/Preload/Controller/PreloadUrl.php
+++ b/inc/Engine/Preload/Controller/PreloadUrl.php
@@ -154,12 +154,18 @@ class PreloadUrl {
 				$duration = ( microtime( true ) - $start ); // Duration of the request.
 			}
 
+			$default_delay_between = 500000;
+
 			/**
 			 * Filter the delay between each preload request.
 			 *
-			 * @param float $delay_between the defined delay.
+			 * @param int $delay_between the defined delay.
 			 */
-			$delay_between = apply_filters( 'rocket_preload_delay_between_requests', 500000 );
+			$delay_between = apply_filters( 'rocket_preload_delay_between_requests', $default_delay_between );
+			
+			if ( ! is_int( $delay_between ) ) {
+				$delay_between = $default_delay_between;
+			}
 
 			usleep( $delay_between );
 

--- a/inc/Engine/Preload/Controller/PreloadUrl.php
+++ b/inc/Engine/Preload/Controller/PreloadUrl.php
@@ -162,7 +162,7 @@ class PreloadUrl {
 			 * @param int $delay_between the defined delay.
 			 */
 			$delay_between = apply_filters( 'rocket_preload_delay_between_requests', $default_delay_between );
-			
+
 			if ( ! is_int( $delay_between ) ) {
 				$delay_between = $default_delay_between;
 			}

--- a/tests/Fixtures/inc/Engine/Preload/Controller/PreloadUrl/preloadUrl.php
+++ b/tests/Fixtures/inc/Engine/Preload/Controller/PreloadUrl/preloadUrl.php
@@ -76,7 +76,25 @@ return [
 			],
 		],
 	],
-	'shouldStillPreloadOnlyOnceWhenRocketPreloadDelayBetweenRequestsIsNotIntAndMobileCacheDisabledAndCheckDuration' => [
+	'shouldStillPreloadOnlyOnceWhenRocketPreloadDelayBetweenRequestsIsAStringAndMobileCacheDisabledAndCheckDuration' => [
+		'config' => [
+			'transient_check_duration' => false,
+			'url' => 'url',
+			'cache_exists' => false,
+			'cache_mobile' => false,
+			'user_agent' => 'user_agent',
+			'rocket_preload_delay_between_requests' => "hello",
+			'request' => [
+				'config' => [
+					'blocking' => true,
+					'timeout'  => 20,
+					'user-agent' => 'WP Rocket/Preload',
+					'sslverify' => false,
+				],
+			],
+		],
+	],
+	'shouldStillPreloadOnlyOnceWhenRocketPreloadDelayBetweenRequestsIsAFloatAndMobileCacheDisabledAndCheckDuration' => [
 		'config' => [
 			'transient_check_duration' => false,
 			'url' => 'url',

--- a/tests/Fixtures/inc/Engine/Preload/Controller/PreloadUrl/preloadUrl.php
+++ b/tests/Fixtures/inc/Engine/Preload/Controller/PreloadUrl/preloadUrl.php
@@ -76,4 +76,22 @@ return [
 			],
 		],
 	],
+	'shouldStillPreloadOnlyOnceWhenRocketPreloadDelayBetweenRequestsIsNotIntAndMobileCacheDisabledAndCheckDuration' => [
+		'config' => [
+			'transient_check_duration' => false,
+			'url' => 'url',
+			'cache_exists' => false,
+			'cache_mobile' => false,
+			'user_agent' => 'user_agent',
+			'rocket_preload_delay_between_requests' => 5.2,
+			'request' => [
+				'config' => [
+					'blocking' => true,
+					'timeout'  => 20,
+					'user-agent' => 'WP Rocket/Preload',
+					'sslverify' => false,
+				],
+			],
+		],
+	],
 ];

--- a/tests/Unit/inc/Engine/Preload/Controller/PreloadUrl/preloadUrl.php
+++ b/tests/Unit/inc/Engine/Preload/Controller/PreloadUrl/preloadUrl.php
@@ -44,6 +44,7 @@ class Test_PreloadUrl extends TestCase {
 	 * @dataProvider configTestData
 	 */
 	public function testShouldDoAsExpected( $config ) {
+
 		Functions\expect( 'get_transient' )
 			->atMost()
 			->once()
@@ -81,6 +82,14 @@ class Test_PreloadUrl extends TestCase {
 
 	protected function expectDesktopRequest( $config ) {
 		if ( $config['cache_exists'] ) {
+			$delay_value = 500000;
+
+			if ( isset( $config['rocket_preload_delay_between_requests'] ) ) {
+				$delay_value = $config['rocket_preload_delay_between_requests'];
+			}
+
+			Functions\expect('apply_filters')->with( 'rocket_preload_delay_between_requests', $delay_value )->andReturn( $delay_value );
+
 			Functions\expect( 'wp_safe_remote_get' )
 			->with( $config['url'] . '/', $config['request']['config'] )
 			->never();

--- a/tests/Unit/inc/Engine/Preload/Controller/PreloadUrl/preloadUrl.php
+++ b/tests/Unit/inc/Engine/Preload/Controller/PreloadUrl/preloadUrl.php
@@ -83,13 +83,6 @@ class Test_PreloadUrl extends TestCase {
 
 	protected function expectDesktopRequest( $config ) {
 		if ( $config['cache_exists'] ) {
-			$delay_value = 500000;
-
-			if ( isset( $config['rocket_preload_delay_between_requests'] ) ) {
-				$delay_value = $config['rocket_preload_delay_between_requests'];
-			}
-
-			Functions\expect('apply_filters')->with( 'rocket_preload_delay_between_requests', 500000 )->andReturn( $delay_value );
 
 			Functions\expect( 'wp_safe_remote_get' )
 			->with( $config['url'] . '/', $config['request']['config'] )
@@ -100,6 +93,14 @@ class Test_PreloadUrl extends TestCase {
 
 		Functions\expect( 'wp_safe_remote_get' )
 			->with( $config['url'] . '/', $config['request']['config'] );
+
+		$delay_value = 500000;
+
+		if ( isset( $config['rocket_preload_delay_between_requests'] ) ) {
+			$delay_value = $config['rocket_preload_delay_between_requests'];
+		}
+
+		Filters\expectApplied( 'rocket_preload_delay_between_requests' )->with( 500000 )->andReturn( $delay_value );
 	}
 
 	protected function expectMobileRequest( $config ) {

--- a/tests/Unit/inc/Engine/Preload/Controller/PreloadUrl/preloadUrl.php
+++ b/tests/Unit/inc/Engine/Preload/Controller/PreloadUrl/preloadUrl.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace WP_Rocket\Tests\Unit\inc\Engine\Preload\Controller\PreloadUrl;
 
 use Brain\Monkey\Functions;
+use Brain\Monkey\Filters;
 use Mockery;
 use WP_Filesystem_Direct;
 use WP_Rocket\Admin\Options_Data;
@@ -88,7 +89,7 @@ class Test_PreloadUrl extends TestCase {
 				$delay_value = $config['rocket_preload_delay_between_requests'];
 			}
 
-			Functions\expect('apply_filters')->with( 'rocket_preload_delay_between_requests', $delay_value )->andReturn( $delay_value );
+			Functions\expect('apply_filters')->with( 'rocket_preload_delay_between_requests', 500000 )->andReturn( $delay_value );
 
 			Functions\expect( 'wp_safe_remote_get' )
 			->with( $config['url'] . '/', $config['request']['config'] )


### PR DESCRIPTION
# Description

Fixes #6760 

## Documentation

### User documentation

Fixes error thrown about unexpected argument type parsed.

### Technical documentation

Guards the filter value from unexpected type other than `int`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## New dependencies
None

## Risks
None

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [ ] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Documentation

- [ ] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [ ] The user documentation covers new/changed entry points (endpoints, WP hooks, configuration files, ...).
- [ ] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [ ] I wrote comments to explain why it does it.
- [x] I named variables and functions explicitely.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.
- [ ] I listed the introduced external dependencies explicitely on the PR.
- [ ] I validated the repo-specific guidelines from CONTRIBUTING.md.

## Observability
- [ ] I handled errors when needed.
- [ ] I wrote user-facing messages that are understandable and provide actionable feedbacks.
- [ ] I prepared ways to observe the implemented system (logs, data, etc.).

## Risks
- [ ] I explicitely mentioned performance risks in the PR.
- [ ] I explicitely mentioned security risks in the PR.
