### PR TITLE
Closes #4966 Remove warnings on minify CSS/JS options

### DIFF
--- a/inc/Engine/Admin/Settings/Page.php
+++ b/inc/Engine/Admin/Settings/Page.php
@@ -472,9 +472,8 @@ class Page extends Abstract_Render {
 		$offline_beacon             = $this->beacon->get_suggest( 'offline' );
 		$fallback_css_beacon        = $this->beacon->get_suggest( 'fallback_css' );
 
-		$disable_combine_js  = $this->disable_combine_js();
-		$disable_combine_css = $this->disable_combine_css();
-		$disable_ocd         = 'local' === wp_get_environment_type();
+		$disable_combine_js = $this->disable_combine_js();
+		$disable_ocd        = 'local' === wp_get_environment_type();
 
 		/**
 		 * Filters the status of the RUCSS option.
@@ -559,7 +558,6 @@ class Page extends Abstract_Render {
 					'description'       => __( 'Minify CSS removes whitespace and comments to reduce the file size.', 'rocket' ),
 					'container_class'   => [
 						rocket_maybe_disable_minify_css() ? 'wpr-isDisabled' : '',
-						'wpr-field--parent',
 					],
 					'section'           => 'css',
 					'page'              => 'file_optimization',
@@ -567,11 +565,6 @@ class Page extends Abstract_Render {
 					'sanitize_callback' => 'sanitize_checkbox',
 					'input_attr'        => [
 						'disabled' => rocket_maybe_disable_minify_css() ? 1 : 0,
-					],
-					'warning'           => [
-						'title'        => __( 'This could break things!', 'rocket' ),
-						'description'  => __( 'If you notice any errors on your website after having activated this setting, just deactivate it again, and your site will be back to normal.', 'rocket' ),
-						'button_label' => __( 'Activate minify CSS', 'rocket' ),
 					],
 				],
 				'exclude_css'                  => [
@@ -689,7 +682,6 @@ class Page extends Abstract_Render {
 					'description'       => __( 'Minify JavaScript removes whitespace and comments to reduce the file size.', 'rocket' ),
 					'container_class'   => [
 						rocket_maybe_disable_minify_js() ? 'wpr-isDisabled' : '',
-						'wpr-field--parent',
 					],
 					'section'           => 'js',
 					'page'              => 'file_optimization',
@@ -698,11 +690,6 @@ class Page extends Abstract_Render {
 						'disabled' => rocket_maybe_disable_minify_js() ? 1 : 0,
 					],
 					'sanitize_callback' => 'sanitize_checkbox',
-					'warning'           => [
-						'title'        => __( 'This could break things!', 'rocket' ),
-						'description'  => __( 'If you notice any errors on your website after having activated this setting, just deactivate it again, and your site will be back to normal.', 'rocket' ),
-						'button_label' => __( 'Activate minify JavaScript', 'rocket' ),
-					],
 				],
 				'minify_concatenate_js'        => [
 					'type'              => 'checkbox',
@@ -2176,21 +2163,6 @@ class Page extends Abstract_Render {
 		}
 
 		return ! (bool) get_rocket_option( 'minify_js', 0 );
-	}
-
-	/**
-	 * Checks if combine CSS option should be disabled
-	 *
-	 * @since 3.11
-	 *
-	 * @return bool
-	 */
-	private function disable_combine_css(): bool {
-		if ( (bool) get_rocket_option( 'remove_unused_css', 0 ) ) {
-			return true;
-		}
-
-		return ! (bool) get_rocket_option( 'minify_css', 0 );
 	}
 
 	/**


### PR DESCRIPTION
# Description

Fixes #4966

## Documentation

### User documentation

Remove the warnings displayed when checking the minify CSS/JS options

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I wrote comments to explain why it does it.
- [x] I named variables and functions explicitely.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.
