### PR TITLE
Fixes #6758 Use array_filter to remove empty values from excluded values

### DIFF
--- a/inc/Dependencies/RocketLazyload/Image.php
+++ b/inc/Dependencies/RocketLazyload/Image.php
@@ -373,6 +373,8 @@ class Image {
 			$excluded_values = (array) $excluded_values;
 		}
 
+		$excluded_values = array_filter( $excluded_values );
+
 		if ( empty( $excluded_values ) ) {
 			return false;
 		}

--- a/inc/Engine/Media/Lazyload/CSS/Subscriber.php
+++ b/inc/Engine/Media/Lazyload/CSS/Subscriber.php
@@ -543,6 +543,8 @@ class Subscriber implements Subscriber_Interface, LoggerAwareInterface {
 			$excluded_values = (array) $excluded_values;
 		}
 
+		$excluded_values = array_filter( $excluded_values );
+
 		if ( empty( $excluded_values ) ) {
 			return false;
 		}
@@ -586,6 +588,8 @@ class Subscriber implements Subscriber_Interface, LoggerAwareInterface {
 		if ( ! is_array( $excluded_values ) ) {
 			$excluded_values = (array) $excluded_values;
 		}
+
+		$excluded_values = array_filter( $excluded_values );
 
 		if ( empty( $excluded_values ) ) {
 			return $excluded;


### PR DESCRIPTION
# Description

Fixes #6758

## Documentation

### User documentation

Prevent PHP warning when using `strpos()` with empty value

### Technical documentation

Use `array_filter()` to remove empty values from the excluded values array

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I wrote comments to explain why it does it.
- [x] I named variables and functions explicitely.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.