### PR TITLE
Closes #6721 Move rocket analytics field to my account section

### DIFF
--- a/inc/Engine/Admin/Settings/Page.php
+++ b/inc/Engine/Admin/Settings/Page.php
@@ -426,30 +426,6 @@ class Page extends Abstract_Render {
 				'customer_data'    => $this->customer_data(),
 			]
 		);
-
-		$this->settings->add_settings_sections(
-			[
-				'status' => [
-					'title' => __( 'My Status', 'rocket' ),
-					'page'  => 'dashboard',
-				],
-			]
-		);
-
-		$this->settings->add_settings_fields(
-			[
-				'analytics_enabled' => [
-					'type'              => 'sliding_checkbox',
-					'label'             => __( 'Rocket Analytics', 'rocket' ),
-					// translators: %1$s = opening <a> tag, %2$s = closing </a> tag.
-					'description'       => sprintf( __( 'I agree to share anonymous data with the development team to help improve WP Rocket. %1$sWhat info will we collect?%2$s', 'rocket' ), '<button class="wpr-js-popin">', '</button>' ),
-					'section'           => 'status',
-					'page'              => 'dashboard',
-					'default'           => 0,
-					'sanitize_callback' => 'sanitize_checkbox',
-				],
-			]
-		);
 	}
 
 	/**

--- a/views/settings/page-sections/dashboard.php
+++ b/views/settings/page-sections/dashboard.php
@@ -119,6 +119,26 @@ defined( 'ABSPATH' ) || exit;
 				</div>
 			</div>
 			<?php endif; ?>
+			<div class="wpr-fieldsContainer">
+				<fieldset class="wpr-fieldsContainer-fieldset">
+					<div class="wpr-field wpr-field--radio">
+						<div class="wpr-radio">
+							<input type="checkbox" id="analytics_enabled" class="" name="wp_rocket_settings[analytics_enabled]" value="1" <?php checked( get_rocket_option( 'analytics_enabled', 0 ), 1 ); ?>>
+							<label for="analytics_enabled" class="">
+								<span data-l10n-active="On"
+									data-l10n-inactive="Off" class="wpr-radio-ui"></span>
+								<?php esc_html_e( 'Rocket Analytics', 'rocket' ); ?>
+							</label>
+						</div>
+						<div class="wpr-field-description">
+							<?php
+							// translators: %1$s = opening <a> tag, %2$s = closing </a> tag.
+							printf( esc_html__( 'I agree to share anonymous data with the development team to help improve WP Rocket. %1$sWhat info will we collect?%2$s', 'rocket' ), '<button class="wpr-js-popin">', '</button>' );
+							?>
+						</div>
+					</div>
+				</fieldset>
+			</div>
 			<?php
 			/**
 			 * Fires after the account data section on the WP Rocket settings dashboard
@@ -126,9 +146,6 @@ defined( 'ABSPATH' ) || exit;
 			 * @since 3.5
 			 */
 			do_action( 'rocket_dashboard_after_account_data' );
-			?>
-			<?php
-				$this->render_settings_sections( $data['id'] );
 			?>
 		</div>
 


### PR DESCRIPTION
# Description

Fixes #6721

## Documentation

### User documentation

Remove the `My status` section from the dashboard, move the `Rocket analytics` field to `My account`

### Technical documentation

Remove the field from the settings fields loop, hardcode it into the my account section in the dashboard view instead, to be able to display it as needed.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

# Checklists

## Feature validation

- [ ] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [ ] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style
- [ ] I wrote self-explanatory code about what it does.
- [ ] I wrote comments to explain why it does it.
- [ ] I named variables and functions explicitely.
- [ ] I protected entry points against unexpected inputs.
- [ ] I did not introduce unecessary complexity.

