### PR TITLE
Fix risky tests and tests generating PHP warnings

### DIFF
--- a/tests/Fixtures/inc/Engine/Saas/Admin/Notices/displayProcessingNotice.php
+++ b/tests/Fixtures/inc/Engine/Saas/Admin/Notices/displayProcessingNotice.php
@@ -1,8 +1,6 @@
 <?php
 
 return [
-	'vfs_dir' => 'wp-content/',
-
 	'test_data' => [
 		'shouldDoNothingWhenNotWPRSettingsPage' => [
 			'config' => [

--- a/tests/Fixtures/inc/Engine/Saas/Admin/Notices/displaySuccessNotice.php
+++ b/tests/Fixtures/inc/Engine/Saas/Admin/Notices/displaySuccessNotice.php
@@ -1,8 +1,6 @@
 <?php
 
 return [
-	'vfs_dir' => 'wp-content/',
-
 	'test_data' => [
 		'shouldDoNothingWhenNotWPRSettingsPage' => [
 			'config' => [

--- a/tests/Integration/inc/Engine/Admin/Settings/Subscriber/enableSeparateCacheFilesMobile.php
+++ b/tests/Integration/inc/Engine/Admin/Settings/Subscriber/enableSeparateCacheFilesMobile.php
@@ -1,27 +1,33 @@
 <?php
+declare(strict_types=1);
+
 namespace WP_Rocket\Tests\Integration\inc\Engine\Admin\Settings\Subscriber;
 
 use WP_Rocket\Tests\Integration\TestCase;
 
 /**
  * @covers \WP_Rocket\Engine\Admin\Settings\Subscriber::enable_separate_cache_files_mobile
+ *
+ * @group Settings
  */
-class Test_EnableSeparateCAcheFilesMobile extends TestCase {
-
+class Test_EnableSeparateCacheFilesMobile extends TestCase {
 	public function set_up() {
 		parent::set_up();
 
 		$this->unregisterAllCallbacksExcept( 'wp_rocket_upgrade', 'enable_separate_cache_files_mobile', 10 );
+		// Disable ATF optimization to prevent DB request (unrelated to the test).
+		add_filter( 'rocket_above_the_fold_optimization', '__return_false' );
 	}
 
 	public function tear_down() {
 		parent::tear_down();
 
+		remove_filter( 'rocket_above_the_fold_optimization', '__return_false' );
 		$this->restoreWpHook( 'wp_rocket_upgrade' );
 	}
 
 	/**
-	 * @dataProvider provideTestData
+	 * @dataProvider configTestData
 	 */
 	public function testShouldEnableSeparateCacheFilesMobile( $config ) {
 		$options = get_option( 'wp_rocket_settings', [] );
@@ -39,9 +45,5 @@ class Test_EnableSeparateCAcheFilesMobile extends TestCase {
 		} else {
 			$this->assertEquals( 0, $do_caching_mobile_files );
 		}
-	}
-
-	public function provideTestData() {
-		return $this->getTestData( __DIR__, 'enableSeparateCacheFilesMobile' );
 	}
 }

--- a/tests/Integration/inc/Engine/Optimization/Minify/CSS/AdminSubscriber/onUpdate.php
+++ b/tests/Integration/inc/Engine/Optimization/Minify/CSS/AdminSubscriber/onUpdate.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace WP_Rocket\Tests\Integration\inc\Engine\Optimization\Minify\CSS\AdminSubscriber;
 
@@ -16,10 +17,13 @@ class TestOnUpdate extends TestCase {
 		parent::set_up();
 
 		remove_filter( 'wp_rocket_upgrade', 'rocket_new_upgrade' );
+		// Disable ATF optimization to prevent DB request (unrelated to the test).
+		add_filter( 'rocket_above_the_fold_optimization', '__return_false' );
 	}
 
 	public function tear_down() {
 		add_filter( 'wp_rocket_upgrade', 'rocket_new_upgrade', 10, 2 );
+		remove_filter( 'rocket_above_the_fold_optimization', '__return_false' );
 
 		parent::tear_down();
 	}

--- a/tests/Integration/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/onUpdate.php
+++ b/tests/Integration/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/onUpdate.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace WP_Rocket\Tests\Integration\inc\Engine\Optimization\RUCSS\Frontend\Subscriber;
 
@@ -6,34 +7,40 @@ use WP_Rocket\Tests\Integration\TestCase;
 
 /**
  * Test class covering \WP_Rocket\Engine\Optimization\RUCSS\Frontend\Subscriber::on_update
- * 
+ *
  * @group RUCSS
  */
-class Test_onUpdate extends TestCase {
-
-	public function set_up()
-	{
+class Test_OnUpdate extends TestCase {
+	public function set_up() {
 		parent::set_up();
+
 		delete_option('wp_rocket_no_licence');
 		delete_transient('wp_rocket_no_licence');
+
+		// Disable ATF optimization to prevent DB request (unrelated to the test).
+		add_filter( 'rocket_above_the_fold_optimization', '__return_false' );
 	}
 
-	public function tear_down()
-	{
+	public function tear_down() {
 		delete_option('wp_rocket_no_licence');
 		delete_transient('wp_rocket_no_licence');
+		remove_filter( 'rocket_above_the_fold_optimization', '__return_false' );
+
 		parent::tear_down();
 	}
     /**
      * @dataProvider configTestData
      */
-    public function testShouldDoAsExpected( $config, $expected )
-    {
-		if($config['has_transient']) {
+    public function testShouldDoAsExpected( $config, $expected ) {
+		if ( $config['has_transient'] ) {
 			set_transient('wp_rocket_no_licence', $config['has_transient']);
 		}
-        do_action('wp_rocket_upgrade', $config['new_version'], $config['old_version']);
 
-    	$this->assertSame($expected['has_transient'], get_option('wp_rocket_no_licence'));
+        do_action( 'wp_rocket_upgrade', $config['new_version'], $config['old_version'] );
+
+    	$this->assertSame(
+			$expected['has_transient'],
+			get_option( 'wp_rocket_no_licence' )
+		);
 	}
 }

--- a/tests/StubTrait.php
+++ b/tests/StubTrait.php
@@ -110,6 +110,9 @@ trait StubTrait {
 			case 'WP_ROCKET_CRITICAL_CSS_PATH':
 				return "{$this->wp_content_dir}/cache/critical-css/";
 
+			case 'WP_ROCKET_USED_CSS_PATH':
+				return "{$this->wp_content_dir}/cache/used-css/";
+
 			case 'WP_ROCKET_DEBUG':
 				return $this->wp_rocket_debug;
 

--- a/tests/Unit/inc/Engine/Saas/Admin/Notices/displayProcessingNotice.php
+++ b/tests/Unit/inc/Engine/Saas/Admin/Notices/displayProcessingNotice.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace WP_Rocket\Tests\Unit\inc\Engine\Saas\Admin\Notices;
 
@@ -8,16 +9,14 @@ use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\Admin\Beacon\Beacon;
 use WP_Rocket\Engine\Common\Context\ContextInterface;
 use WP_Rocket\Engine\Saas\Admin\Notices;
-use WP_Rocket\Tests\Unit\FilesystemTestCase;
+use WP_Rocket\Tests\Unit\TestCase;
 
 /**
  * Test class covering \WP_Rocket\Engine\Saas\Admin\Notices::display_processing_notice
  *
- * @group  SaaS
+ * @group SaaS
  */
-class Test_DisplayProcessingNotice extends FilesystemTestCase {
-	protected $path_to_test_data = '/inc/Engine/Saas/Admin/Notices/displayProcessingNotice.php';
-
+class Test_DisplayProcessingNotice extends TestCase {
 	private $options;
 	protected $atf_context;
 	private $notices;
@@ -26,25 +25,23 @@ class Test_DisplayProcessingNotice extends FilesystemTestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->options  = Mockery::mock( Options_Data::class );
-		$this->atf_context  = Mockery::mock( ContextInterface::class );
-		$this->notices = new Notices( $this->options, Mockery::mock( Beacon::class ), $this->atf_context );
+		$this->options     = Mockery::mock( Options_Data::class );
+		$this->atf_context = Mockery::mock( ContextInterface::class );
+		$this->notices     = new Notices( $this->options, Mockery::mock( Beacon::class ), $this->atf_context );
 
 		$this->stubTranslationFunctions();
 	}
 
 	/**
-	 * @dataProvider providerTestData
+	 * @dataProvider configTestData
 	 */
 	public function testShouldDoExpected( $config, $expected ) {
-
 		Functions\when( 'get_current_screen' )->justReturn( $config['current_screen'] );
 		Functions\when( 'current_user_can' )->justReturn( $config['capability'] );
 
 		$this->options->shouldReceive( 'get' )
 				->with( 'remove_unused_css', 0 )
 				->andReturn( $config['remove_unused_css'] );
-
 
 		Functions\when('get_transient')->alias(function ($name) use ($config) {
 			if('wp_rocket_rucss_errors_count' === $name) {
@@ -59,8 +56,6 @@ class Test_DisplayProcessingNotice extends FilesystemTestCase {
 		} else {
 			Functions\expect( 'rocket_notice_html' )->never();
 		}
-
-		$this->assertTrue( $this->filesystem->is_writable( rocket_get_constant( 'WP_ROCKET_USED_CSS_PATH' ) ) );
 
 		$this->notices->display_processing_notice();
 	}

--- a/tests/Unit/inc/Engine/Saas/Admin/Notices/displaySuccessNotice.php
+++ b/tests/Unit/inc/Engine/Saas/Admin/Notices/displaySuccessNotice.php
@@ -1,6 +1,7 @@
 <?php
+declare(strict_types=1);
 
-namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\RUCSS\Admin\Settings;
+namespace WP_Rocket\Tests\Unit\inc\Engine\Saas\Admin\Notices;
 
 use Brain\Monkey\Functions;
 use Mockery;
@@ -8,16 +9,14 @@ use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\Admin\Beacon\Beacon;
 use WP_Rocket\Engine\Common\Context\ContextInterface;
 use WP_Rocket\Engine\Saas\Admin\Notices;
-use WP_Rocket\Tests\Unit\FilesystemTestCase;
+use WP_Rocket\Tests\Unit\TestCase;
 
 /**
  * Test class covering \WP_Rocket\Engine\Saas\Admin\Notices::display_success_notice
  *
- * @group  RUCSS
+ * @group SaaS
  */
-class Test_DisplaySuccessNotice extends FilesystemTestCase {
-	protected $path_to_test_data = '/inc/Engine/Saas/Admin/Notices/displaySuccessNotice.php';
-
+class Test_DisplaySuccessNotice extends TestCase {
 	private $options;
 	private $beacon;
 	private $notices;
@@ -26,17 +25,17 @@ class Test_DisplaySuccessNotice extends FilesystemTestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->options = Mockery::mock( Options_Data::class );
-		$this->beacon =  Mockery::mock( Beacon::class );
-		$this->atf_context  = Mockery::mock( ContextInterface::class );
-		$this->notices = new Notices( $this->options, $this->beacon, $this->atf_context );
+		$this->options     = Mockery::mock( Options_Data::class );
+		$this->beacon      = Mockery::mock( Beacon::class );
+		$this->atf_context = Mockery::mock( ContextInterface::class );
+		$this->notices     = new Notices( $this->options, $this->beacon, $this->atf_context );
 
 		$this->stubTranslationFunctions();
 		$this->stubEscapeFunctions();
 	}
 
 	/**
-	 * @dataProvider providerTestData
+	 * @dataProvider configTestData
 	 */
 	public function testShouldDoExpected( $config, $expected ) {
 		Functions\when( 'get_current_screen' )->justReturn( $config['current_screen'] );
@@ -60,8 +59,6 @@ class Test_DisplaySuccessNotice extends FilesystemTestCase {
 		} else {
 			Functions\expect( 'rocket_notice_html' )->never();
 		}
-
-		$this->assertTrue( $this->filesystem->is_writable( rocket_get_constant( 'WP_ROCKET_USED_CSS_PATH' ) ) );
 
 		$this->notices->display_success_notice();
 	}


### PR DESCRIPTION
# Description

## Documentation

### User documentation

No impact

### Technical documentation

- Disable OCI on some tests that are unrelated to the feature and were generating risky tests
- Update tests that were generating PHP warnings on PHP 8.2/8.3 because of incorrect type passed

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue).

# Checklists

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I wrote comments to explain why it does it.
- [x] I named variables and functions explicitely.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.

## Observability
- [x] I handled errors when needed.
