### PR TITLE
Update Image.php to prevent Fatal error when preg_split fails.

### DIFF
--- a/inc/Dependencies/RocketLazyload/Image.php
+++ b/inc/Dependencies/RocketLazyload/Image.php
@@ -551,6 +551,10 @@ class Image {
 		$output = '';
 		// HTML loop taken from texturize function, could possible be consolidated.
 		$textarr = preg_split( '/(<.*>)/U', $text, -1, PREG_SPLIT_DELIM_CAPTURE ); // capture the tags as well as in between.
+		if ( ! is_countable( $textarr ) ) {
+			// For unknown reasons, preg_split failed, return the content unaltered.
+			return $text;
+		}
 		$stop    = count( $textarr );// loop stuff.
 
 		// Ignore processing of specific tags.


### PR DESCRIPTION
Prevent fatal error when `preg_split` does not return a countable result.

WHY `preg_split` fails is unkown, but we've seen it in numerous occasions, especially with very large HTML.
