### PR TITLE
Fix failing tests with php 7.4

### DIFF
--- a/tests/Unit/inc/Engine/HealthCheck/HealthCheck/missedCron.php
+++ b/tests/Unit/inc/Engine/HealthCheck/HealthCheck/missedCron.php
@@ -44,7 +44,7 @@ class Test_MissedCron extends TestCase {
 		Functions\expect( 'wp_next_scheduled' )
 			->atMost()
 			->times( 5 )
-			->andReturnValues( $config['events'] );
+			->andReturnValues( array_values( $config['events'] ) );
 
 		Functions\when( 'rocket_notice_html' )->alias(
 			function ( $args ) {
@@ -74,7 +74,7 @@ class Test_MissedCron extends TestCase {
 		$this->options->shouldReceive( 'get' )
 		        ->atMost()
 		        ->times( 4 )
-		        ->andReturnValues( $config['options'] );
+		        ->andReturnValues( array_values( $config['options'] ));
 	}
 
 	private function getActualHtml() {

--- a/tests/Unit/inc/admin/rocketFirstInstall.php
+++ b/tests/Unit/inc/admin/rocketFirstInstall.php
@@ -31,7 +31,7 @@ class Test_RocketFirstInstall extends TestCase {
 
 		Functions\expect( 'create_rocket_uniqid' )
 			->times( 3 )
-			->andReturnValues( $uniqids );
+			->andReturnValues( array_values( $uniqids ) );
 		Functions\expect( 'rocket_get_constant' )
 			->with( 'WP_ROCKET_SLUG' )
 			->andReturn( 'wp_rocket_settings' );


### PR DESCRIPTION
# Description

That's dev initiative to fix the following errors when using php 7.4 to run unit tests.

```
1) WP_Rocket\Tests\Unit\inc\Engine\HealthCheck\HealthCheck\Test_MissedCron::testShouldReturnNullWhenNothingToDisplay with data set "noCap" (array(false, 'options_general', array(), array(0, 0, 0, 0), array(false, false, false, false, false), false), '')
Error: Cannot unpack array with string keys

/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/vendor/mockery/mockery/library/Mockery/Expectation.php:338
/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/vendor/mockery/mockery/library/Mockery/CompositeExpectation.php:37
/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/tests/Unit/inc/Engine/HealthCheck/HealthCheck/missedCron.php:77
/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/tests/Unit/inc/Engine/HealthCheck/HealthCheck/missedCron.php:34
phpvfscomposer:///Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/vendor/phpunit/phpunit/phpunit:106

2) WP_Rocket\Tests\Unit\inc\Engine\HealthCheck\HealthCheck\Test_MissedCron::testShouldReturnNullWhenNothingToDisplay with data set "badScreen" (array(true, 'options_general', array(), array(0, 0, 0, 0), array(false, false, false, false, false), false), '')
Error: Cannot unpack array with string keys

/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/vendor/mockery/mockery/library/Mockery/Expectation.php:338
/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/vendor/mockery/mockery/library/Mockery/CompositeExpectation.php:37
/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/tests/Unit/inc/Engine/HealthCheck/HealthCheck/missedCron.php:77
/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/tests/Unit/inc/Engine/HealthCheck/HealthCheck/missedCron.php:34
phpvfscomposer:///Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/vendor/phpunit/phpunit/phpunit:106

3) WP_Rocket\Tests\Unit\inc\Engine\HealthCheck\HealthCheck\Test_MissedCron::testShouldReturnNullWhenNothingToDisplay with data set "dismissedWarning" (array(true, 'settings_page_wprocket', array('rocket_warning_cron'), array(0, 0, 0, 0), array(false, false, false, false, false), false), '')
Error: Cannot unpack array with string keys

/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/vendor/mockery/mockery/library/Mockery/Expectation.php:338
/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/vendor/mockery/mockery/library/Mockery/CompositeExpectation.php:37
/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/tests/Unit/inc/Engine/HealthCheck/HealthCheck/missedCron.php:77
/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/tests/Unit/inc/Engine/HealthCheck/HealthCheck/missedCron.php:34
phpvfscomposer:///Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/vendor/phpunit/phpunit/phpunit:106

4) WP_Rocket\Tests\Unit\inc\Engine\HealthCheck\HealthCheck\Test_MissedCron::testShouldReturnNullWhenNothingToDisplay with data set "disabledOptions" (array(true, 'settings_page_wprocket', array(), array(0, 0, 0, 0), array(false, false, false, false, false), false), '')
Error: Cannot unpack array with string keys

/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/vendor/mockery/mockery/library/Mockery/Expectation.php:338
/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/vendor/mockery/mockery/library/Mockery/CompositeExpectation.php:37
/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/tests/Unit/inc/Engine/HealthCheck/HealthCheck/missedCron.php:77
/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/tests/Unit/inc/Engine/HealthCheck/HealthCheck/missedCron.php:34
phpvfscomposer:///Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/vendor/phpunit/phpunit/phpunit:106

5) WP_Rocket\Tests\Unit\inc\Engine\HealthCheck\HealthCheck\Test_MissedCron::testShouldReturnNullWhenNothingToDisplay with data set "noScheduledEvents" (array(true, 'settings_page_wprocket', array(), array(1, 1, 1, 1), array(false, false, false, false, false), false), '')
Error: Cannot unpack array with string keys

/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/vendor/mockery/mockery/library/Mockery/Expectation.php:338
/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/vendor/mockery/mockery/library/Mockery/CompositeExpectation.php:37
/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/tests/Unit/inc/Engine/HealthCheck/HealthCheck/missedCron.php:77
/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/tests/Unit/inc/Engine/HealthCheck/HealthCheck/missedCron.php:34
phpvfscomposer:///Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/vendor/phpunit/phpunit/phpunit:106

6) WP_Rocket\Tests\Unit\inc\Engine\HealthCheck\HealthCheck\Test_MissedCron::testShouldReturnNullWhenNothingToDisplay with data set "noMissedEvents" (array(true, 'settings_page_wprocket', array(), array(1, 1, 1, 1), false, array(1721733853, 1721733853, 1721733853, 1721733853, 1721733853)), '')
Error: Cannot unpack array with string keys

/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/vendor/mockery/mockery/library/Mockery/Expectation.php:338
/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/vendor/mockery/mockery/library/Mockery/CompositeExpectation.php:37
/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/tests/Unit/inc/Engine/HealthCheck/HealthCheck/missedCron.php:77
/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/tests/Unit/inc/Engine/HealthCheck/HealthCheck/missedCron.php:34
phpvfscomposer:///Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/vendor/phpunit/phpunit/phpunit:106

7) WP_Rocket\Tests\Unit\inc\Engine\HealthCheck\HealthCheck\Test_MissedCron::testShouldReturnNullWhenNothingToDisplay with data set "PurgeTimeMissedEvent" (array(true, 'settings_page_wprocket', array(), array(1, 1, 1, 1), array(1721730253, 1721733853, 1721733853, 1721733853, 1721733853), false), '<div class="notice notice-war...</div>')
Error: Cannot unpack array with string keys

/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/vendor/mockery/mockery/library/Mockery/Expectation.php:338
/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/vendor/mockery/mockery/library/Mockery/CompositeExpectation.php:37
/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/tests/Unit/inc/Engine/HealthCheck/HealthCheck/missedCron.php:77
/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/tests/Unit/inc/Engine/HealthCheck/HealthCheck/missedCron.php:34
phpvfscomposer:///Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/vendor/phpunit/phpunit/phpunit:106

8) WP_Rocket\Tests\Unit\inc\Engine\HealthCheck\HealthCheck\Test_MissedCron::testShouldReturnNullWhenNothingToDisplay with data set "MultipleMissedEvents" (array(true, 'settings_page_wprocket', array(), array(1, 1, 1, 1), array(1721730253, 1721730253, 1721733853, 1721733853, 1721733853), false), '<div class="notice notice-war...</div>')
Error: Cannot unpack array with string keys

/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/vendor/mockery/mockery/library/Mockery/Expectation.php:338
/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/vendor/mockery/mockery/library/Mockery/CompositeExpectation.php:37
/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/tests/Unit/inc/Engine/HealthCheck/HealthCheck/missedCron.php:77
/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/tests/Unit/inc/Engine/HealthCheck/HealthCheck/missedCron.php:34
phpvfscomposer:///Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/vendor/phpunit/phpunit/phpunit:106

9) WP_Rocket\Tests\Unit\inc\Engine\HealthCheck\HealthCheck\Test_MissedCron::testShouldReturnNullWhenNothingToDisplay with data set "PurgeTimeMissedEventDisabledCron" (array(true, 'settings_page_wprocket', array(), array(1, 1, 1, 1), array(1721726653, 1721733853, 1721733853, 1721733853, 1721733853), true), '<div class="notice notice-war...</div>')
Error: Cannot unpack array with string keys

/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/vendor/mockery/mockery/library/Mockery/Expectation.php:338
/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/vendor/mockery/mockery/library/Mockery/CompositeExpectation.php:37
/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/tests/Unit/inc/Engine/HealthCheck/HealthCheck/missedCron.php:77
/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/tests/Unit/inc/Engine/HealthCheck/HealthCheck/missedCron.php:34
phpvfscomposer:///Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/vendor/phpunit/phpunit/phpunit:106

10) WP_Rocket\Tests\Unit\inc\Engine\HealthCheck\HealthCheck\Test_MissedCron::testShouldReturnNullWhenNothingToDisplay with data set "MultipleMissedEventsDisabledCron" (array(true, 'settings_page_wprocket', array(), array(1, 1, 1, 1), array(1721726653, 1721726653, 1721733853, 1721733853, 1721733853), true), '<div class="notice notice-war...</div>')
Error: Cannot unpack array with string keys

/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/vendor/mockery/mockery/library/Mockery/Expectation.php:338
/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/vendor/mockery/mockery/library/Mockery/CompositeExpectation.php:37
/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/tests/Unit/inc/Engine/HealthCheck/HealthCheck/missedCron.php:77
/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/tests/Unit/inc/Engine/HealthCheck/HealthCheck/missedCron.php:34
phpvfscomposer:///Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/vendor/phpunit/phpunit/phpunit:106

11) WP_Rocket\Tests\Unit\inc\admin\Test_RocketFirstInstall::testShouldAddOption with data set "defaultOptionsArray" (array(array('secret_cache_key_uniqid', 1, 1, 0, 0, 1, 1, array(), array(), array(), array(), array(), 10, 'HOUR_IN_SECONDS', array(), array(), array(), 0, 0, '', 0, 0, 0, 0, 'minify_css_key_uniqid', 0, 'minify_js_key_uniqid', 0, 1, 1, 0, array(), 0, 0, 0, 0, 0, 0, 0, 0, 'daily', 0, array(), array(), array(), 0, '', '', '', 0, 0, 0, '', 1, 'reduce_periodicity', 'reduce_periodicity', 'reduce_periodicity', 0, 0, 0, ''), array('secret_cache_key_uniqid', 1, 1, 0, 0, 1, 1, array(), array(), array(), array(), array(), 10, 'HOUR_IN_SECONDS', array(), array(), array(), 0, 0, '', 0, 0, 0, 0, 'minify_css_key_uniqid', 0, 'minify_js_key_uniqid', 0, 1, 1, 0, array(), 0, 0, 0, 0, 0, 0, 0, 0, 'daily', 0, array(), array(), array(), 0, '', '', '', 0, 0, 0, '', 1, 'reduce_periodicity', 'reduce_periodicity', 'reduce_periodicity', 0, 0, 0, '', 1, array(), 0, array(), array(), array(), 0, array(), 1, 0, array())))
Error: Cannot unpack array with string keys

/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/vendor/mockery/mockery/library/Mockery/Expectation.php:338
/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/vendor/mockery/mockery/library/Mockery/CompositeExpectation.php:37
/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/vendor/brain/monkey/src/Expectation/Expectation.php:156
/Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/tests/Unit/inc/admin/rocketFirstInstall.php:34
phpvfscomposer:///Users/leemichael/local/app/public/wp-content/plugins/wp-rocket/vendor/phpunit/phpunit/phpunit:106
```