### PR TITLE
Closes #6807 Changed link for rucss display notice

### DIFF
--- a/inc/Engine/Admin/Beacon/Beacon.php
+++ b/inc/Engine/Admin/Beacon/Beacon.php
@@ -814,7 +814,7 @@ class Beacon extends Abstract_Render implements Subscriber_Interface {
 			'rucss_database'             => [
 				'en' => [
 					'id'  => '668f1284f0fdf93e4cf10825',
-					'url' => 'https://docs.wp-rocket.me/article/1828-could-not-create-the-rucss-usedcss-table?utm_source=wp_plugin&utm_medium=wp_rocket',
+					'url' => 'https://docs.wp-rocket.me/article/1828-could-not-create-the-rucss-usedcss-table/?utm_source=wp_plugin&utm_medium=wp_rocket',
 				],
 			],
 		];

--- a/inc/Engine/Admin/Beacon/Beacon.php
+++ b/inc/Engine/Admin/Beacon/Beacon.php
@@ -816,6 +816,10 @@ class Beacon extends Abstract_Render implements Subscriber_Interface {
 					'id'  => '668f1284f0fdf93e4cf10825',
 					'url' => 'https://docs.wp-rocket.me/article/1828-could-not-create-the-rucss-usedcss-table/?utm_source=wp_plugin&utm_medium=wp_rocket',
 				],
+				'fr' => [
+					'id'  => '66a32d970d7d86166241eff1',
+					'url' => 'https://fr.docs.wp-rocket.me/article/1833-impossible-creer-table-rucssusedcss/?utm_source=wp_plugin&utm_medium=wp_rocket',
+				],
 			],
 		];
 

--- a/inc/Engine/Admin/Beacon/Beacon.php
+++ b/inc/Engine/Admin/Beacon/Beacon.php
@@ -811,6 +811,12 @@ class Beacon extends Abstract_Render implements Subscriber_Interface {
 					'url' => 'https://fr.docs.wp-rocket.me/article/1818-suppression-onglet-cache?utm_source=wp_plugin&utm_medium=wp_rocket',
 				],
 			],
+			'rucss_database'             => [
+				'en' => [
+					'id'  => '668f1284f0fdf93e4cf10825',
+					'url' => 'https://docs.wp-rocket.me/article/1828-could-not-create-the-rucss-usedcss-table?utm_source=wp_plugin&utm_medium=wp_rocket',
+				],
+			],
 		];
 
 		return isset( $suggest[ $doc_id ][ $this->get_user_locale() ] )

--- a/inc/Engine/Optimization/RUCSS/Admin/Settings.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Settings.php
@@ -257,7 +257,7 @@ class Settings {
 			$main_message,
 			'<strong>WP Rocket</strong>',
 			$this->used_css->get_name(),
-			'<a href="' . $this->get_support_url() . '" target="_blank" rel="noopener">',
+			'<a href="' . esc_url( __( 'https://docs.wp-rocket.me/article/1828-could-not-create-the-rucss-usedcss-table/?utm_source=wp_plugin&utm_medium=wp_rocket', 'rocket' ) ) . '" target="_blank" rel="noopener">',
 			'</a>'
 		);
 
@@ -267,21 +267,6 @@ class Settings {
 				'dismissible' => '',
 				'message'     => $message,
 				'id'          => 'rocket-notice-rucss-missing-table',
-			]
-		);
-	}
-
-	/**
-	 * Get support URL.
-	 *
-	 * @return string
-	 */
-	protected function get_support_url() {
-		return rocket_get_external_url(
-			'support',
-			[
-				'utm_source' => 'wp_plugin',
-				'utm_medium' => 'wp_rocket',
 			]
 		);
 	}

--- a/inc/Engine/Optimization/RUCSS/Admin/Settings.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Settings.php
@@ -250,14 +250,15 @@ class Settings {
 		}
 
 		// translators: %1$s = plugin name, %2$s = table name, %3$s = <a> open tag, %4$s = </a> closing tag.
-		$main_message = esc_html__( '%1$s: Could not create the %2$s table in the database which is necessary for the Remove Unused CSS feature to work. Please reach out to %3$sour support%4$s.', 'rocket' );
+		$main_message   = esc_html__( '%1$s: Could not create the %2$s table in the database which is necessary for the Remove Unused CSS feature to work. Please reach out to %3$sour support%4$s.', 'rocket' );
+		$rucss_database = $this->beacon->get_suggest( 'rucss_database' );
 
 		$message = sprintf(
 		// translators: %1$s = plugin name, %2$s = table name, %3$s = <a> open tag, %4$s = </a> closing tag.
 			$main_message,
 			'<strong>WP Rocket</strong>',
 			$this->used_css->get_name(),
-			'<a href="' . esc_url( __( 'https://docs.wp-rocket.me/article/1828-could-not-create-the-rucss-usedcss-table/?utm_source=wp_plugin&utm_medium=wp_rocket', 'rocket' ) ) . '" target="_blank" rel="noopener">',
+			'<a href="' . esc_url( $rucss_database['url'] ) . '" data-beacon-article="' . esc_attr( $rucss_database['id'] ) . '" target="_blank" rel="noopener">',
 			'</a>'
 		);
 

--- a/inc/Engine/Optimization/RUCSS/Admin/Settings.php
+++ b/inc/Engine/Optimization/RUCSS/Admin/Settings.php
@@ -250,7 +250,7 @@ class Settings {
 		}
 
 		// translators: %1$s = plugin name, %2$s = table name, %3$s = <a> open tag, %4$s = </a> closing tag.
-		$main_message   = esc_html__( '%1$s: Could not create the %2$s table in the database which is necessary for the Remove Unused CSS feature to work. Please reach out to %3$sour support%4$s.', 'rocket' );
+		$main_message   = esc_html__( '%1$s: Could not create the %2$s table in the database which is necessary for the Remove Unused CSS feature to work. Please check our %3$sdocumentation%4$s.', 'rocket' );
 		$rucss_database = $this->beacon->get_suggest( 'rucss_database' );
 
 		$message = sprintf(

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/displayNoTableNotice.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/displayNoTableNotice.php
@@ -4,7 +4,7 @@ $content = <<<Notice
 <p>
 <strong>
 WP Rocket</strong>
-: Could not create the wpr_table table in the database which is necessary for the Remove Unused CSS feature to work. Please reach out to <a href="https://wp-rocket.me/support/?utm_source=wp_plugin&utm_medium=wp_rocket" target="_blank" rel="noopener">our support</a>.</p>
+: Could not create the wpr_table table in the database which is necessary for the Remove Unused CSS feature to work. Please reach out to <a href="https://docs.wp-rocket.me/article/1828-could-not-create-the-rucss-usedcss-table/?utm_source=wp_plugin&utm_medium=wp_rocket" target="_blank" rel="noopener">our support</a>.</p>
 </div>
 Notice;
 

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/displayNoTableNotice.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/displayNoTableNotice.php
@@ -4,7 +4,7 @@ $content = <<<Notice
 <p>
 <strong>
 WP Rocket</strong>
-: Could not create the wpr_table table in the database which is necessary for the Remove Unused CSS feature to work. Please reach out to <a href="https://docs.wp-rocket.me/article/1828-could-not-create-the-rucss-usedcss-table/?utm_source=wp_plugin&utm_medium=wp_rocket" target="_blank" rel="noopener">our support</a>.</p>
+: Could not create the wpr_table table in the database which is necessary for the Remove Unused CSS feature to work. Please reach out to <a href="https://docs.wp-rocket.me/article/1828-could-not-create-the-rucss-usedcss-table/?utm_source=wp_plugin&#038;utm_medium=wp_rocket" target="_blank" rel="noopener">our support</a>.</p>
 </div>
 Notice;
 

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/displayNoTableNotice.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/displayNoTableNotice.php
@@ -4,7 +4,7 @@ $content = <<<Notice
 <p>
 <strong>
 WP Rocket</strong>
-: Could not create the wpr_table table in the database which is necessary for the Remove Unused CSS feature to work. Please reach out to <a href="https://docs.wp-rocket.me/article/1828-could-not-create-the-rucss-usedcss-table/?utm_source=wp_plugin&#038;utm_medium=wp_rocket" target="_blank" rel="noopener">our support</a>.</p>
+: Could not create the wpr_table table in the database which is necessary for the Remove Unused CSS feature to work. Please reach out to <a href="https://docs.wp-rocket.me/article/1828-could-not-create-the-rucss-usedcss-table/?utm_source=wp_plugin&#038;utm_medium=wp_rocket" data-beacon-article="668f1284f0fdf93e4cf10825" target="_blank" rel="noopener">our support</a>.</p>
 </div>
 Notice;
 

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/displayNoTableNotice.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Admin/Subscriber/displayNoTableNotice.php
@@ -4,7 +4,7 @@ $content = <<<Notice
 <p>
 <strong>
 WP Rocket</strong>
-: Could not create the wpr_table table in the database which is necessary for the Remove Unused CSS feature to work. Please reach out to <a href="https://docs.wp-rocket.me/article/1828-could-not-create-the-rucss-usedcss-table/?utm_source=wp_plugin&#038;utm_medium=wp_rocket" data-beacon-article="668f1284f0fdf93e4cf10825" target="_blank" rel="noopener">our support</a>.</p>
+: Could not create the wpr_table table in the database which is necessary for the Remove Unused CSS feature to work. Please check our <a href="https://docs.wp-rocket.me/article/1828-could-not-create-the-rucss-usedcss-table/?utm_source=wp_plugin&#038;utm_medium=wp_rocket" data-beacon-article="668f1284f0fdf93e4cf10825" target="_blank" rel="noopener">documentation</a>.</p>
 </div>
 Notice;
 


### PR DESCRIPTION
# Description

Fixes #6807 

## Documentation
Update the support link for when RUCSS db is not created.

### User documentation

*Explain how this code impacts users.*

### Technical documentation

*Explain how this code works. Diagram & drawings are welcomed.*

## Type of change
- [x] Enhancement (non-breaking change which improves an existing functionality).

## New dependencies
*List any new dependencies that are required for this change.*

## Risks
*List possible performance & security issues or risks, and explain how they have been mitigated.*

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Documentation

- [ ] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [ ] The user documentation covers new/changed entry points (endpoints, WP hooks, configuration files, ...).
- [ ] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [ ] I wrote self-explanatory code about what it does.
- [ ] I wrote comments to explain why it does it.
- [ ] I named variables and functions explicitely.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.
- [ ] I listed the introduced external dependencies explicitely on the PR.
- [ ] I validated the repo-specific guidelines from CONTRIBUTING.md.

## Observability
- [ ] I handled errors when needed.
- [ ] I wrote user-facing messages that are understandable and provide actionable feedbacks.
- [ ] I prepared ways to observe the implemented system (logs, data, etc.).

## Risks
- [ ] I explicitely mentioned performance risks in the PR.
- [ ] I explicitely mentioned security risks in the PR.
