### PR TITLE
Closes #5723 Add a filter to enable/disable the noscript tag of lazyloaded images

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
 	"require": {
 		"php": ">=7.3",
 		"cloudflare/cf-ip-rewrite": "^1.0",
-		"composer/installers": "^1.0 || ^2.0"
+		"composer/installers": "^1.0 || ^2.0",
+		"wp-media/apply-filters-typed": "^1.0"
 	},
 	"require-dev": {
 		"php": "^7 || ^8",

--- a/inc/Dependencies/RocketLazyload/Assets.php
+++ b/inc/Dependencies/RocketLazyload/Assets.php
@@ -17,7 +17,7 @@ class Assets {
 	/**
 	 * Inserts the lazyload script in the HTML
 	 *
-	 * @param array $args Array of arguments to populate the lazyload script tag.
+	 * @param array<string> $args Array of arguments to populate the lazyload script tag.
 	 * @return void
 	 */
 	public function insertLazyloadScript( $args = [] ) {
@@ -27,7 +27,7 @@ class Assets {
 	/**
 	 * Gets the inline lazyload script configuration
 	 *
-	 * @param array $args Array of arguments to populate the lazyload script options.
+	 * @param array<string, int> $args Array of arguments to populate the lazyload script options.
 	 * @return string
 	 */
 	public function getInlineLazyloadScript( $args = [] ) {
@@ -177,7 +177,7 @@ class Assets {
 	/**
 	 * Returns the lazyload inline script
 	 *
-	 * @param array $args Array of arguments to populate the lazyload script options.
+	 * @param array<string> $args Array of arguments to populate the lazyload script options.
 	 * @return string
 	 */
 	public function getLazyloadScript( $args = [] ) {
@@ -194,7 +194,7 @@ class Assets {
 		 *
 		 * @since 2.2.6
 		 *
-		 * @param $script_tag HTML tag for the lazyload script.
+		 * @param string $script_tag HTML tag for the lazyload script.
 		 */
 		return apply_filters( 'rocket_lazyload_script_tag', '<script data-no-minify="1" async src="' . $args['base_url'] . $args['version'] . '/lazyload' . $min . '.js"></script>' ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 	}
@@ -202,7 +202,7 @@ class Assets {
 	/**
 	 * Inserts in the HTML the script to replace the Youtube thumbnail by the iframe.
 	 *
-	 * @param array $args Array of arguments to populate the script options.
+	 * @param array<string, bool> $args Array of arguments to populate the script options.
 	 * @return void
 	 */
 	public function insertYoutubeThumbnailScript( $args = [] ) {
@@ -212,7 +212,7 @@ class Assets {
 	/**
 	 * Returns the Youtube Thumbnail inline script
 	 *
-	 * @param array $args Array of arguments to populate the script options.
+	 * @param array<string, bool> $args Array of arguments to populate the script options.
 	 * @return string
 	 */
 	public function getYoutubeThumbnailScript( $args = [] ) {
@@ -286,7 +286,7 @@ class Assets {
 	/**
 	 * Inserts the CSS to style the Youtube thumbnail container
 	 *
-	 * @param array $args Array of arguments to populate the CSS.
+	 * @param array<string, bool> $args Array of arguments to populate the CSS.
 	 * @return void
 	 */
 	public function insertYoutubeThumbnailCSS( $args = [] ) {
@@ -298,7 +298,7 @@ class Assets {
 	/**
 	 * Returns the CSS for the Youtube Thumbnail
 	 *
-	 * @param array $args Array of arguments to populate the CSS.
+	 * @param array<string, bool> $args Array of arguments to populate the CSS.
 	 * @return string
 	 */
 	public function getYoutubeThumbnailCSS( $args = [] ) {
@@ -320,6 +320,8 @@ class Assets {
 
 	/**
 	 * Inserts the CSS needed when Javascript is not enabled to keep the display correct
+	 *
+	 * @return void
 	 */
 	public function insertNoJSCSS() {
 		echo $this->getNoJSCSS(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/inc/Dependencies/RocketLazyload/Iframe.php
+++ b/inc/Dependencies/RocketLazyload/Iframe.php
@@ -15,9 +15,10 @@ class Iframe {
 	/**
 	 * Finds iframes in the HTML provided and call the methods to lazyload them
 	 *
-	 * @param string $html   Original HTML.
-	 * @param string $buffer Content to parse.
-	 * @param array  $args   Array of arguments to use.
+	 * @param string      $html   Original HTML.
+	 * @param string      $buffer Content to parse.
+	 * @param array<bool> $args   Array of arguments to use.
+	 *
 	 * @return string
 	 */
 	public function lazyloadIframes( $html, $buffer, $args = [] ) {
@@ -49,6 +50,8 @@ class Iframe {
 				continue;
 			}
 
+			$iframe_lazyload = '';
+
 			if ( $args['youtube'] ) {
 				$iframe_lazyload = $this->replaceYoutubeThumbnail( $iframe );
 			}
@@ -68,7 +71,7 @@ class Iframe {
 	/**
 	 * Checks if the provided iframe is excluded from lazyload
 	 *
-	 * @param array $iframe Array of matched patterns.
+	 * @param array<string> $iframe Array of matched patterns.
 	 * @return boolean
 	 */
 	public function isIframeExcluded( $iframe ) {
@@ -87,7 +90,7 @@ class Iframe {
 	 *
 	 * @since 2.1.1
 	 *
-	 * @return array
+	 * @return array<string>
 	 */
 	private function getExcludedPatterns() {
 		/**
@@ -114,7 +117,8 @@ class Iframe {
 	/**
 	 * Applies lazyload on the iframe provided
 	 *
-	 * @param array $iframe Array of matched elements.
+	 * @param array<string> $iframe Array of matched elements.
+	 *
 	 * @return string
 	 */
 	private function replaceIframe( $iframe ) {
@@ -139,7 +143,7 @@ class Iframe {
 		 *
 		 * @since 1.0
 		 *
-		 * @param array $html Output that will be printed.
+		 * @param string $html Output that will be printed.
 		 */
 		$iframe_lazyload  = apply_filters( 'rocket_lazyload_iframe_html', $iframe_lazyload );
 		$iframe_lazyload .= '<noscript>' . $iframe[0] . '</noscript>';
@@ -150,17 +154,22 @@ class Iframe {
 	/**
 	 * Replaces the iframe provided by the Youtube thumbnail
 	 *
-	 * @param array $iframe Array of matched elements.
-	 * @return bool|string
+	 * @param array<string> $iframe Array of matched elements.
+	 *
+	 * @return string
 	 */
 	private function replaceYoutubeThumbnail( $iframe ) {
 		$youtube_id = $this->getYoutubeIDFromURL( $iframe['src'] );
 
-		if ( ! $youtube_id ) {
-			return false;
+		if ( '' === $youtube_id ) {
+			return '';
 		}
 
 		$query = wp_parse_url( htmlspecialchars_decode( $iframe['src'] ), PHP_URL_QUERY );
+
+		if ( ! is_string( $query ) ) {
+			$query = '';
+		}
 
 		$youtube_url = $this->changeYoutubeUrlForYoutuDotBe( $iframe['src'] );
 		$youtube_url = $this->cleanYoutubeUrl( $iframe['src'] );
@@ -173,7 +182,7 @@ class Iframe {
 		 *
 		 * @since 2.11
 		 *
-		 * @param array $html Output that will be printed.
+		 * @param string $html Output that will be printed.
 		 */
 		$youtube_lazyload  = apply_filters( 'rocket_lazyload_youtube_html', '<div class="rll-youtube-player" data-src="' . esc_attr( $youtube_url ) . '" data-id="' . esc_attr( $youtube_id ) . '" data-query="' . esc_attr( $query ) . '" data-alt="' . esc_attr( $title ) . '"></div>' );
 		$youtube_lazyload .= '<noscript>' . $iframe[0] . '</noscript>';
@@ -185,19 +194,20 @@ class Iframe {
 	 * Gets the Youtube ID from the URL provided
 	 *
 	 * @param string $url URL to search.
-	 * @return bool|string
+	 *
+	 * @return string
 	 */
 	public function getYoutubeIDFromURL( $url ) {
 		$pattern = '#^(?:https?:)?(?://)?(?:www\.)?(?:youtu\.be|youtube\.com|youtube-nocookie\.com)/(?:embed/|v/|watch/?\?v=)?([\w-]{11})#iU';
 		$result  = preg_match( $pattern, $url, $matches );
 
 		if ( ! $result ) {
-			return false;
+			return '';
 		}
 
 		// exclude playlist.
 		if ( 'videoseries' === $matches[1] ) {
-			return false;
+			return '';
 		}
 
 		return $matches[1];

--- a/inc/Dependencies/RocketLazyload/Image.php
+++ b/inc/Dependencies/RocketLazyload/Image.php
@@ -542,15 +542,15 @@ class Image {
 	/**
 	 * Checks if the noscript tag is enabled
 	 *
-	 * @return bool
+	 * @return mixed
 	 */
-	private function noscriptEnabled(): bool {
+	private function noscriptEnabled() {
 		/**
 		 * Filter to enable or disable noscript tag
 		 *
 		 * @param bool $enable_noscript Enable or disable noscript tag.
 		 */
-		return apply_filters( 'rocket_lazyload_noscript', true );
+		return wpm_apply_filters_typed( 'boolean', 'rocket_lazyload_noscript', true );
 	}
 
 	/**
@@ -614,7 +614,7 @@ class Image {
 
 		$stop = count( $textarr );// loop stuff.
 
-		// Ignore proessing of specific tags.
+		// Ignore processing of specific tags.
 		$tags_to_ignore       = 'code|pre|style|script|textarea';
 		$ignore_block_element = '';
 

--- a/inc/Dependencies/RocketLazyload/Image.php
+++ b/inc/Dependencies/RocketLazyload/Image.php
@@ -38,7 +38,7 @@ class Image {
 
 			$image_lazyload = $this->replaceImage( $image, $use_native );
 
-			if ( ! $use_native ) {
+			if ( ! $use_native && $this->noscriptEnabled() ) {
 				$image_lazyload .= $this->noscript( $image[0] );
 			}
 
@@ -121,8 +121,15 @@ class Image {
 	 */
 	private function addLazyClass( $element ) {
 		$class = $this->getClasses( $element );
-		if ( empty( $class ) ) {
-			return preg_replace( '#<(img|div|figure|section|li|span|a)([^>]*)>#is', '<\1 class="rocket-lazyload"\2>', $element );
+
+		if ( ! $class ) {
+			$result = preg_replace( '#<(img|div|figure|section|li|span|a)([^>]*)>#is', '<\1 class="rocket-lazyload"\2>', $element );
+
+			if ( ! $result ) {
+				return $element;
+			}
+
+			return $result;
 		}
 
 		if ( empty( $class['attribute'] ) || empty( $class['classes'] ) ) {
@@ -150,7 +157,7 @@ class Image {
 	 *
 	 * @param string $attribute_value The target attribute's value.
 	 *
-	 * @return bool|string quotation character; else false when no quotation mark.
+	 * @return false|string quotation character; else false when no quotation mark.
 	 */
 	private function getAttributeQuotes( $attribute_value ) {
 		$attribute_value = trim( $attribute_value );
@@ -168,7 +175,7 @@ class Image {
 	 *
 	 * @param string $element Given HTML element to extract classes from.
 	 *
-	 * @return bool|string[] {
+	 * @return false|string[] {
 	 *      @type string $attribute Class attribute and value, e.g. class="value"
 	 *      @type string $classes   String of class attribute's value(s)
 	 * }; else, false when no class attribute exists.
@@ -178,11 +185,7 @@ class Image {
 			return false;
 		}
 
-		if ( empty( $class ) ) {
-			return false;
-		}
-
-		if ( ! isset( $class['classes'] ) ) {
+		if ( empty( $class['classes'] ) ) {
 			return false;
 		}
 
@@ -195,13 +198,14 @@ class Image {
 	/**
 	 * Removes outer single or double quotations.
 	 *
-	 * @param string $string String to strip quotes from.
-	 * @param string $quotes The outer quotes to remove.
+	 * @param string       $string String to strip quotes from.
+	 * @param false|string $quotes The outer quotes to remove.
 	 *
 	 * @return string string without quotes.
 	 */
 	private function trimOuterQuotes( $string, $quotes ) {
 		$string = trim( $string );
+
 		if ( empty( $string ) ) {
 			return '';
 		}
@@ -241,10 +245,10 @@ class Image {
 	 *  1. Removes empties.
 	 *  2. Trims each string.
 	 *
-	 * @param string $string    The target string to convert.
-	 * @param string $delimiter Optional. Default: ' ' empty string.
+	 * @param string           $string    The target string to convert.
+	 * @param non-empty-string $delimiter Optional. Default: ' ' (one space).
 	 *
-	 * @return array An array of trimmed strings.
+	 * @return array<string> An array of trimmed strings.
 	 */
 	private function stringToArray( $string, $delimiter = ' ' ) {
 		if ( empty( $string ) ) {
@@ -252,6 +256,11 @@ class Image {
 		}
 
 		$array = explode( $delimiter, $string );
+
+		if ( ! $array ) {
+			return [];
+		}
+
 		$array = array_map( 'trim', $array );
 
 		// Remove empties.
@@ -298,7 +307,12 @@ class Image {
 
 				foreach ( $sources as $source ) {
 					$lazyload_srcset = preg_replace( '/([\s"\'])srcset/i', '\1data-lazy-srcset', $source[0] );
-					$lazy_picture    = str_replace( $source[0], $lazyload_srcset, $lazy_picture );
+
+					if ( ! $lazyload_srcset ) {
+						continue;
+					}
+
+					$lazy_picture = str_replace( $source[0], $lazyload_srcset, $lazy_picture );
 
 					unset( $lazyload_srcset );
 					$lazy_sources++;
@@ -321,10 +335,21 @@ class Image {
 				continue;
 			}
 
-			$img_lazy  = $this->replaceImage( $img, false );
-			$img_lazy .= $this->noscript( $img[0] );
-			$safe_img  = str_replace( '/', '\/', preg_quote( $img[0], '#' ) );
-			$html      = preg_replace( '#<noscript[^>]*>.*' . $safe_img . '.*<\/noscript>(*SKIP)(*FAIL)|' . $safe_img . '#i', $img_lazy, $html );
+			$img_lazy = $this->replaceImage( $img, false );
+
+			if ( $this->noscriptEnabled() ) {
+				$img_lazy .= $this->noscript( $img[0] );
+			}
+
+			$safe_img = str_replace( '/', '\/', preg_quote( $img[0], '#' ) );
+
+			$new_html = preg_replace( '#<noscript[^>]*>.*' . $safe_img . '.*<\/noscript>(*SKIP)(*FAIL)|' . $safe_img . '#i', $img_lazy, $html );
+
+			if ( ! $new_html ) {
+				continue;
+			}
+
+			$html = $new_html;
 
 			unset( $img_lazy );
 		}
@@ -335,8 +360,9 @@ class Image {
 	/**
 	 * Checks if the image can be lazyloaded
 	 *
-	 * @param Array $image Array of image data coming from Regex.
-	 * @return bool|Array
+	 * @param array<string> $image Array of image data coming from Regex.
+	 *
+	 * @return false|array<string>
 	 */
 	private function canLazyload( $image ) {
 		if ( $this->isExcluded( $image['atts'], $this->getExcludedAttributes() ) ) {
@@ -364,9 +390,10 @@ class Image {
 	/**
 	 * Checks if the provided string matches with the provided excluded patterns
 	 *
-	 * @param string $string          String to check.
-	 * @param array  $excluded_values Patterns to match against.
-	 * @return boolean
+	 * @param string        $string          String to check.
+	 * @param array<string> $excluded_values Patterns to match against.
+	 *
+	 * @return bool
 	 */
 	public function isExcluded( $string, $excluded_values ) {
 		if ( ! is_array( $excluded_values ) ) {
@@ -391,7 +418,7 @@ class Image {
 	/**
 	 * Returns the list of excluded attributes
 	 *
-	 * @return array
+	 * @return array<string>
 	 */
 	public function getExcludedAttributes() {
 		/**
@@ -433,7 +460,7 @@ class Image {
 	/**
 	 * Returns the list of excluded src
 	 *
-	 * @return array
+	 * @return array<string>
 	 */
 	public function getExcludedSrc() {
 		/**
@@ -456,8 +483,8 @@ class Image {
 	/**
 	 * Replaces the original image by the lazyload one
 	 *
-	 * @param array $image Array of matches elements.
-	 * @param bool  $use_native Use native lazyload.
+	 * @param array<string> $image      Array of matches elements.
+	 * @param bool          $use_native Use native lazyload.
 	 *
 	 * @return string
 	 */
@@ -492,7 +519,11 @@ class Image {
 			$image_lazyload = str_replace( $image['atts'], $placeholder_atts . ' data-lazy-src="' . $image['src'] . '"', $image_lazyload );
 
 			if ( preg_match( $native_pattern, $image_lazyload ) ) {
-				$image_lazyload = preg_replace( $native_pattern, '', $image_lazyload );
+				$result = preg_replace( $native_pattern, '', $image_lazyload );
+
+				if ( is_string( $result ) ) {
+					$image_lazyload = $result;
+				}
 			}
 		}
 
@@ -506,6 +537,20 @@ class Image {
 		$image_lazyload = apply_filters( 'rocket_lazyload_html', $image_lazyload );
 
 		return $image_lazyload;
+	}
+
+	/**
+	 * Checks if the noscript tag is enabled
+	 *
+	 * @return bool
+	 */
+	private function noscriptEnabled(): bool {
+		/**
+		 * Filter to enable or disable noscript tag
+		 *
+		 * @param bool $enable_noscript Enable or disable noscript tag.
+		 */
+		return apply_filters( 'rocket_lazyload_noscript', true );
 	}
 
 	/**
@@ -525,10 +570,21 @@ class Image {
 	 * @return string
 	 */
 	public function lazyloadResponsiveAttributes( $html ) {
-		$html = preg_replace( '/[\s|"|\'](srcset)\s*=\s*("|\')([^"|\']+)\2/i', ' data-lazy-$1=$2$3$2', $html );
-		$html = preg_replace( '/[\s|"|\'](sizes)\s*=\s*("|\')([^"|\']+)\2/i', ' data-lazy-$1=$2$3$2', $html );
+		$data_srcset = preg_replace( '/[\s|"|\'](srcset)\s*=\s*("|\')([^"|\']+)\2/i', ' data-lazy-$1=$2$3$2', $html );
 
-		return $html;
+		if ( ! $data_srcset ) {
+			return $html;
+		}
+
+		$html = $data_srcset;
+
+		$lazy_responsive = preg_replace( '/[\s|"|\'](sizes)\s*=\s*("|\')([^"|\']+)\2/i', ' data-lazy-$1=$2$3$2', $html );
+
+		if ( ! $lazy_responsive ) {
+			return $html;
+		}
+
+		return $lazy_responsive;
 	}
 
 	/**
@@ -551,9 +607,14 @@ class Image {
 		$output = '';
 		// HTML loop taken from texturize function, could possible be consolidated.
 		$textarr = preg_split( '/(<.*>)/U', $text, -1, PREG_SPLIT_DELIM_CAPTURE ); // capture the tags as well as in between.
-		$stop    = count( $textarr );// loop stuff.
 
-		// Ignore processing of specific tags.
+		if ( ! $textarr ) {
+			return $text;
+		}
+
+		$stop = count( $textarr );// loop stuff.
+
+		// Ignore proessing of specific tags.
 		$tags_to_ignore       = 'code|pre|style|script|textarea';
 		$ignore_block_element = '';
 
@@ -584,7 +645,8 @@ class Image {
 	/**
 	 * Replace matches by smiley image, lazyloaded
 	 *
-	 * @param array $matches Array of matches.
+	 * @param array<string> $matches Array of matches.
+	 *
 	 * @return string
 	 */
 	private function translateSmiley( $matches ) {


### PR DESCRIPTION
# Description

Closes #5723 

Also includes changes to pass PHPStan level 9.

## Documentation

### User documentation

Add a new filter `rocket_lazyload_noscript` with a boolean value, that can be used to enable/disable the `noscript` tag added to lazyloaded images.

### Technical documentation

Add a new method `noscriptEnabled()`, and use it in the `lazyloadImages` and `lazyloadPictures` methods.

## Type of change
- [x] Enhancement (non-breaking change which improves an existing functionality).

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Documentation

- [x] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [x] The user documentation covers new/changed entry points (endpoints, WP hooks, configuration files, ...).
- [x] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I wrote comments to explain why it does it.
- [x] I named variables and functions explicitely.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.
