### PR TITLE
Format Markdown table in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,21 +32,20 @@ To be able to validate your license and use the plugin, you will also have to ma
 
 ## Gulp Tasks
 
-| Command                        |                                                           Description                                                            |
-|--------------------------------|:--------------------------------------------------------------------------------------------------------------------------------:|
-| **CSS Tasks**                  |                                                                                                                                  |
-| `gulp build:saas:unmin`        |                                  Builds Full admin CSS, the unminified version (wpr-admin.css)                                   |
-| `gulp build:saas:min`          |                                 Builds Full admin CSS, the minified version (wpr-admin.min.css)                                  |
-| `gulp build:sass:all`          |             Builds all admin CSS files (wpr-admin.css, wpr-admin.min.css, wpr-admin-rtl.css, wpr-admin-rtl.min.css)              |
-| `gulp sass:watch`              |                        Watches all admin CSS files mentioned above and builds them again with any change.                        |
-| **JS Tasks**                   |                                                                                                                                  |
-| `gulp build:js:app:unmin`      |                                 Builds admin app js file, the unminified version (wpr-admin.js)                                  |
-| `gulp build:js:app:min`        |                                Builds admin app js file, the minified version (wpr-admin.min.js)                                 |
-| `gulp build:js:lazyloadcss:min` |                             Builds lazyload CSS js file, the minified version (lazyload-css.min.js)                              |
-| `gulp build:js:lcp`         |                  Builds lcp beacon script, the minified version (lcp-beacon.min.js, source file, and map file)                   |
-| `gulp build:js:all`            |              Builds all js files mentioned above (wpr-admin.js, wpr-admin.min.js, lazyload-css.min.js, lcp-beacon)               |
-| `gulp js:watch`                |                                Watches all js files changes and build them again with any change.                                |
-
+| Command                         | Description                                                                                             |
+|---------------------------------|:-------------------------------------------------------------------------------------------------------:|
+| **CSS Tasks**                   |                                                                                                         |
+| `gulp build:saas:unmin`         | Builds Full admin CSS, the unminified version (wpr-admin.css)                                           |
+| `gulp build:saas:min`           | Builds Full admin CSS, the minified version (wpr-admin.min.css)                                         |
+| `gulp build:sass:all`           | Builds all admin CSS files (wpr-admin.css, wpr-admin.min.css, wpr-admin-rtl.css, wpr-admin-rtl.min.css) |
+| `gulp sass:watch`               | Watches all admin CSS files mentioned above and builds them again with any change.                      |
+| **JS Tasks**                    |                                                                                                         |
+| `gulp build:js:app:unmin`       | Builds admin app js file, the unminified version (wpr-admin.js)                                         |
+| `gulp build:js:app:min`         | Builds admin app js file, the minified version (wpr-admin.min.js)                                       |
+| `gulp build:js:lazyloadcss:min` | Builds lazyload CSS js file, the minified version (lazyload-css.min.js)                                 |
+| `gulp build:js:lcp`             | Builds lcp beacon script, the minified version (lcp-beacon.min.js, source file, and map file)           |
+| `gulp build:js:all`             | Builds all js files mentioned above (wpr-admin.js, wpr-admin.min.js, lazyload-css.min.js, lcp-beacon)   |
+| `gulp js:watch`                 | Watches all js files changes and build them again with any change.                                      |
 
 ## Support
 


### PR DESCRIPTION
# Description

Markdown tables do not need whitespaces.

Preview: https://github.com/szepeviktor/wp-rocket/blob/patch-1/README.md#gulp-tasks
