### PR TITLE
Closes #6821 Add span to array of target elements for OCI

### DIFF
--- a/inc/Engine/Media/AboveTheFold/Frontend/Controller.php
+++ b/inc/Engine/Media/AboveTheFold/Frontend/Controller.php
@@ -533,6 +533,7 @@ class Controller {
 			'svg',
 			'section',
 			'header',
+			'span',
 		];
 
 		$default_elements = $elements;

--- a/tests/Fixtures/inc/Engine/Media/AboveTheFold/Frontend/Subscriber/HTML/output_w_beacon.html
+++ b/tests/Fixtures/inc/Engine/Media/AboveTheFold/Frontend/Subscriber/HTML/output_w_beacon.html
@@ -3,5 +3,5 @@
 	<title>Test</title>
 </head>
 <body>
-<script>var rocket_lcp_data = {"ajax_url":"http:\/\/example.org\/wp-admin\/admin-ajax.php","nonce":"96ac96b69e","url":"http:\/\/example.org","is_mobile":false,"elements":"img, video, picture, p, main, div, li, svg, section, header","width_threshold":1600,"height_threshold":700,"delay":500,"debug":false}</script><script data-name="wpr-lcp-beacon" src='http://example.org/wp-content/plugins/wp-rocket/assets/js/lcp-beacon.min.js' async></script></body>
+<script>var rocket_lcp_data = {"ajax_url":"http:\/\/example.org\/wp-admin\/admin-ajax.php","nonce":"96ac96b69e","url":"http:\/\/example.org","is_mobile":false,"elements":"img, video, picture, p, main, div, li, svg, section, header, span","width_threshold":1600,"height_threshold":700,"delay":500,"debug":false}</script><script data-name="wpr-lcp-beacon" src='http://example.org/wp-content/plugins/wp-rocket/assets/js/lcp-beacon.min.js' async></script></body>
 </html>


### PR DESCRIPTION
# Description

Fixes #6821

## Documentation

### User documentation

`span` tag is now a target elements for OCI

### Technical documentation

Added `span` to the array of target elements

## Type of change
- [x] Enhancement (non-breaking change which improves an existing functionality).

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Documentation

- [x] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [x] The user documentation covers new/changed entry points (endpoints, WP hooks, configuration files, ...).
- [x] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [x] I named variables and functions explicitely.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.