### PR TITLE
Closes #6657 Remove loading lazy attribute on images excluded from lazyload

### DIFF
--- a/inc/Dependencies/RocketLazyload/Image.php
+++ b/inc/Dependencies/RocketLazyload/Image.php
@@ -30,9 +30,18 @@ class Image {
 		$images = array_unique( $images, SORT_REGULAR );
 
 		foreach ( $images as $image ) {
-			$image = $this->canLazyload( $image );
+			$original_image = $image;
+			$image          = $this->canLazyload( $image );
 
 			if ( ! $image ) {
+				$image_no_lazy = preg_replace( '/loading=["\']lazy["\']/i', '', $original_image );
+
+				if ( null === $image_no_lazy ) {
+					continue;
+				}
+
+				$html = str_replace( $original_image, $image_no_lazy, $html );
+
 				continue;
 			}
 


### PR DESCRIPTION
# Description

Closes #6657

## Documentation

### User documentation

Remove `loading="lazy"` attribute from images that are excluded from lazyload in WP Rocket (from UI, SaaS or filters).

### Technical documentation

When an image is excluded, perform a `preg_replace()` to remove the attribute from the image element.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Documentation

- [x] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [x] The user documentation covers new/changed entry points (endpoints, WP hooks, configuration files, ...).
- [x] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I named variables and functions explicitely.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.