### PR TITLE
Closes #6846: Regression on 3.17 Pilot Refactor where LCP is not excluded from LL

### DIFF
--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -391,6 +391,7 @@ class Plugin {
 			'debug_subscriber',
 			'rucss_cron_subscriber',
 			'saas_admin_subscriber',
+			'atf_subscriber',
 			'performance_hints_ajax_subscriber',
 			'performance_hints_frontend_subscriber',
 			'performance_hints_cron_subscriber',


### PR DESCRIPTION
# Description

Fixes #6846 

## Documentation

### User documentation

Fixes regression: Excludes LCP candidates from LL.

### Technical documentation

`atf_subscriber` was not registered in the common subscriber.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## New dependencies
None

## Risks
None

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Documentation

- [x] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [x] The user documentation covers new/changed entry points (endpoints, WP hooks, configuration files, ...).
- [x] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [x] I did not introduce unecessary complexity.

