### PR TITLE
Closes #6851: 3.17 refactor regression: {wpr_imagedimensions=1} query string isnot added to home page while warmup after fresh install

### DIFF
--- a/inc/Engine/Activation/Activation.php
+++ b/inc/Engine/Activation/Activation.php
@@ -11,6 +11,7 @@ use WP_Rocket\Logger\ServiceProvider as LoggerServiceProvider;
 use WP_Rocket\ServiceProvider\Options as OptionsServiceProvider;
 use WP_Rocket\ThirdParty\Hostings\HostResolver;
 use WP_Rocket\ThirdParty\Hostings\ServiceProvider as HostingsServiceProvider;
+use WP_Rocket\Event_Management\Event_Manager;
 
 /**
  * Plugin activation controller
@@ -41,6 +42,7 @@ class Activation {
 	 */
 	public static function activate_plugin() {
 		$container = new Container();
+		$event_manager = new Event_Manager();
 
 		$container->add( 'template_path', WP_ROCKET_PATH . 'views' );
 		$options_api = new Options( 'wp_rocket_' );
@@ -53,6 +55,7 @@ class Activation {
 		$container->addServiceProvider( new LoggerServiceProvider() );
 		$container->get( 'logger' );
 		$container->addServiceProvider( new PerformanceHintsActivationServiceProvider() );
+		$event_manager->add_subscriber( $container->get( 'performance_hints_warmup_subscriber' ) );
 
 		$host_type = HostResolver::get_host_service();
 

--- a/inc/Engine/Activation/Activation.php
+++ b/inc/Engine/Activation/Activation.php
@@ -41,7 +41,7 @@ class Activation {
 	 * @return void
 	 */
 	public static function activate_plugin() {
-		$container = new Container();
+		$container     = new Container();
 		$event_manager = new Event_Manager();
 
 		$container->add( 'template_path', WP_ROCKET_PATH . 'views' );

--- a/inc/Engine/Common/PerformanceHints/Activation/ServiceProvider.php
+++ b/inc/Engine/Common/PerformanceHints/Activation/ServiceProvider.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace WP_Rocket\Engine\Common\PerformanceHints\Activation;
 
 use WP_Rocket\Dependencies\League\Container\ServiceProvider\AbstractServiceProvider;
-use WP_Rocket\Engine\Common\PerformanceHints\WarmUp\{APIClient, Controller as WarmUpController, Queue};
+use WP_Rocket\Engine\Common\PerformanceHints\WarmUp\{APIClient, Controller as WarmUpController, Subscriber as WarmUpSubscriber, Queue};
 use WP_Rocket\Engine\Media\AboveTheFold\Context\Context as ATFContext;
 use WP_Rocket\Engine\Media\AboveTheFold\Activation\ActivationFactory as ATFActivationFactory;
 
@@ -23,6 +23,7 @@ class ServiceProvider extends AbstractServiceProvider {
 		'performance_hints_warmup_queue',
 		'performance_hints_warmup_controller',
 		'performance_hints_activation',
+		'performance_hints_warmup_subscriber',
 		'atf_context',
 		'atf_activation_factory',
 	];
@@ -77,6 +78,9 @@ class ServiceProvider extends AbstractServiceProvider {
 					$this->getContainer()->get( 'performance_hints_warmup_queue' ),
 				]
 			);
+
+		$this->getContainer()->add( 'performance_hints_warmup_subscriber', WarmUpSubscriber::class )
+			->addArgument( $this->getContainer()->get( 'performance_hints_warmup_controller' ) );
 
 		$this->getContainer()->add( 'performance_hints_activation', Activation::class )
 			->addArguments(

--- a/inc/Engine/Common/PerformanceHints/Activation/ServiceProvider.php
+++ b/inc/Engine/Common/PerformanceHints/Activation/ServiceProvider.php
@@ -79,7 +79,7 @@ class ServiceProvider extends AbstractServiceProvider {
 				]
 			);
 
-		$this->getContainer()->add( 'performance_hints_warmup_subscriber', WarmUpSubscriber::class )
+		$this->getContainer()->addShared( 'performance_hints_warmup_subscriber', WarmUpSubscriber::class )
 			->addArgument( $this->getContainer()->get( 'performance_hints_warmup_controller' ) );
 
 		$this->getContainer()->add( 'performance_hints_activation', Activation::class )


### PR DESCRIPTION
# Description

Fixes #6851 

## Documentation

### User documentation

Imagedimension query argument is now added for home during activation, this initially prevent the home from having entries in DB

### Technical documentation
In the 3.17 refactor we removed these [lines](https://github.com/wp-media/wp-rocket/blob/961f78501527775c9cc22b6f284cdcf31f9048f6/inc/Engine/Media/AboveTheFold/WarmUp/APIClient.php#L22-L27) and depended on the filter to apply this query arg [here](https://github.com/wp-media/wp-rocket/blob/961f78501527775c9cc22b6f284cdcf31f9048f6/inc/Engine/Media/AboveTheFold/WarmUp/Subscriber.php#L91) but the issue was that the warmup subscriber will not be loaded early enough for this callback to be fired, so in this PR we loaded the subscriber early enough to trigger the callback.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue).

## New dependencies
None

## Risks
None

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.

## Documentation

- [x] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [x] The user documentation covers new/changed entry points (endpoints, WP hooks, configuration files, ...).
- [x] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I named variables and functions explicitely.
- [x] I did not introduce unecessary complexity.
