### PR TITLE
Closes #6852: 3.17 refactor regression: fatal error when clear critical images while the feature is disabled

### DIFF
--- a/inc/Engine/Common/PerformanceHints/Admin/Controller.php
+++ b/inc/Engine/Common/PerformanceHints/Admin/Controller.php
@@ -104,12 +104,14 @@ class Controller {
 
 	/**
 	 * Deletes rows when triggering clean from admin
+	 * 
+	 * @param array $clean An array containing the status and message.
 	 *
-	 * @return array|void
+	 * @return array
 	 */
-	public function truncate_from_admin() {
+	public function truncate_from_admin( $clean ) {
 		if ( empty( $this->factories ) ) {
-			return;
+			return $clean;
 		}
 
 		if ( ! current_user_can( 'rocket_manage_options' ) ) {

--- a/inc/Engine/Common/PerformanceHints/Admin/Controller.php
+++ b/inc/Engine/Common/PerformanceHints/Admin/Controller.php
@@ -104,7 +104,7 @@ class Controller {
 
 	/**
 	 * Deletes rows when triggering clean from admin
-	 * 
+	 *
 	 * @param array $clean An array containing the status and message.
 	 *
 	 * @return array

--- a/inc/Engine/Common/PerformanceHints/Admin/Subscriber.php
+++ b/inc/Engine/Common/PerformanceHints/Admin/Subscriber.php
@@ -77,7 +77,7 @@ class Subscriber implements Subscriber_Interface {
 
 	/**
 	 * Deletes rows when triggering clean from admin
-	 * 
+	 *
 	 * @param array $clean An array containing the status and message.
 	 *
 	 * @return array

--- a/inc/Engine/Common/PerformanceHints/Admin/Subscriber.php
+++ b/inc/Engine/Common/PerformanceHints/Admin/Subscriber.php
@@ -77,11 +77,13 @@ class Subscriber implements Subscriber_Interface {
 
 	/**
 	 * Deletes rows when triggering clean from admin
+	 * 
+	 * @param array $clean An array containing the status and message.
 	 *
 	 * @return array
 	 */
-	public function truncate_from_admin(): array {
-		return $this->controller->truncate_from_admin();
+	public function truncate_from_admin( $clean ): array {
+		return $this->controller->truncate_from_admin( $clean );
 	}
 
 	/**


### PR DESCRIPTION
# Description

Fixes #6852 

## Documentation

### User documentation

Fatal error is thrown on the admin when atf is disabled through code snippet, this happens because there is no page refresh at the point of snippet activation thereby still leaving the clear critical image link in the WPR admin bar which when clicked throws a fatal error.

### Technical documentation

We return the default value of the filter when the feature is disabled, that way there is no conflict in return expectation.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue).

## New dependencies
None

## Risks
None

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Documentation

- [x] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [x] The user documentation covers new/changed entry points (endpoints, WP hooks, configuration files, ...).
- [x] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I wrote comments to explain why it does it.
- [x] I named variables and functions explicitely.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.

