### PR TITLE
Fixes fatal error on activation using feature/lrc branch

### DIFF
--- a/inc/Engine/Common/PerformanceHints/Activation/ServiceProvider.php
+++ b/inc/Engine/Common/PerformanceHints/Activation/ServiceProvider.php
@@ -7,7 +7,7 @@ use WP_Rocket\Dependencies\League\Container\ServiceProvider\AbstractServiceProvi
 use WP_Rocket\Engine\Common\PerformanceHints\WarmUp\{APIClient, Controller as WarmUpController, Subscriber as WarmUpSubscriber, Queue};
 use WP_Rocket\Engine\Media\AboveTheFold\Context\Context as ATFContext;
 use WP_Rocket\Engine\Media\AboveTheFold\Activation\ActivationFactory as ATFActivationFactory;
-use WP_Rocket\Engine\Optimization\LazyRenderContent\Activation\ActivationFactory as LCRActivationFactory;
+use WP_Rocket\Engine\Optimization\LazyRenderContent\Activation\ActivationFactory as LRCActivationFactory;
 use WP_Rocket\Engine\Optimization\LazyRenderContent\Context\Context as LRCContext;
 
 class ServiceProvider extends AbstractServiceProvider {
@@ -29,7 +29,7 @@ class ServiceProvider extends AbstractServiceProvider {
 		'atf_context',
 		'atf_activation_factory',
 		'lrc_context',
-		'lcr_activation_factory',
+		'lrc_activation_factory',
 	];
 
 	/**
@@ -61,7 +61,7 @@ class ServiceProvider extends AbstractServiceProvider {
 
 		$this->getContainer()->add( 'lrc_context', LRCContext::class );
 
-		$this->getContainer()->addShared( 'lcr_activation_factory', LCRActivationFactory::class )
+		$this->getContainer()->addShared( 'lrc_activation_factory', LRCActivationFactory::class )
 			->addArguments(
 				[
 					$this->getContainer()->get( 'lrc_context' ),
@@ -76,10 +76,10 @@ class ServiceProvider extends AbstractServiceProvider {
 			$factories[] = $atf_activation_factory;
 		}
 
-		$lcr_activation_factory = $this->getContainer()->get( 'lcr_activation_factory' );
+		$lrc_activation_factory = $this->getContainer()->get( 'lrc_activation_factory' );
 
-		if ( $lcr_activation_factory->get_context()->is_allowed() ) {
-			$factories[] = $lcr_activation_factory;
+		if ( $lrc_activation_factory->get_context()->is_allowed() ) {
+			$factories[] = $lrc_activation_factory;
 		}
 
 		$this->getContainer()->add( 'performance_hints_warmup_apiclient', APIClient::class )

--- a/inc/Engine/Common/PerformanceHints/Activation/ServiceProvider.php
+++ b/inc/Engine/Common/PerformanceHints/Activation/ServiceProvider.php
@@ -60,7 +60,7 @@ class ServiceProvider extends AbstractServiceProvider {
 			);
 
 		$this->getContainer()->add( 'lrc_context', LRCContext::class );
-		
+
 		$this->getContainer()->addShared( 'lcr_activation_factory', LCRActivationFactory::class )
 			->addArguments(
 				[

--- a/inc/Engine/Common/PerformanceHints/Activation/ServiceProvider.php
+++ b/inc/Engine/Common/PerformanceHints/Activation/ServiceProvider.php
@@ -8,6 +8,7 @@ use WP_Rocket\Engine\Common\PerformanceHints\WarmUp\{APIClient, Controller as Wa
 use WP_Rocket\Engine\Media\AboveTheFold\Context\Context as ATFContext;
 use WP_Rocket\Engine\Media\AboveTheFold\Activation\ActivationFactory as ATFActivationFactory;
 use WP_Rocket\Engine\Optimization\LazyRenderContent\Activation\ActivationFactory as LCRActivationFactory;
+use WP_Rocket\Engine\Optimization\LazyRenderContent\Context\Context as LRCContext;
 
 class ServiceProvider extends AbstractServiceProvider {
 	/**
@@ -27,6 +28,7 @@ class ServiceProvider extends AbstractServiceProvider {
 		'performance_hints_warmup_subscriber',
 		'atf_context',
 		'atf_activation_factory',
+		'lrc_context',
 		'lcr_activation_factory',
 	];
 
@@ -56,10 +58,13 @@ class ServiceProvider extends AbstractServiceProvider {
 					$this->getContainer()->get( 'atf_context' ),
 				]
 			);
+
+		$this->getContainer()->add( 'lrc_context', LRCContext::class );
+		
 		$this->getContainer()->addShared( 'lcr_activation_factory', LCRActivationFactory::class )
 			->addArguments(
 				[
-					$this->getContainer()->get( 'lcr_context' ),
+					$this->getContainer()->get( 'lrc_context' ),
 				]
 			);
 


### PR DESCRIPTION
# Description

Fixes error on activation of plugin on feature/lrc branch

## Documentation

### User documentation

Fixes issue with user unable to activate plugin after install.

### Technical documentation

lrc_context was not registered in the Activation ServiceProvider which triggered a fatal error on activation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## New dependencies
None

## Risks
None

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Documentation

- [x] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [x] The user documentation covers new/changed entry points (endpoints, WP hooks, configuration files, ...).
- [x] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I named variables and functions explicitely.
- [x] I did not introduce unecessary complexity.
