### PR TITLE
Fix issue with buffer modification with more than one factory parsed

### DIFF
--- a/inc/Engine/Common/PerformanceHints/Frontend/Processor.php
+++ b/inc/Engine/Common/PerformanceHints/Frontend/Processor.php
@@ -59,17 +59,27 @@ class Processor {
 		$is_mobile = $this->is_mobile();
 
 		$html_optimized = null;
+		// Flag to check if any optimization has been applied.
+		$optimization_applied = false;
+
 		foreach ( $this->factories as $factory ) {
 			$row = $factory->queries()->get_row( $url, $is_mobile );
-			if ( empty( $row ) ) {
-				return $this->inject_beacon( $html, $url, $is_mobile );
-			}
 
-			$html           = $html_optimized ?? $html;
-			$html_optimized = $factory->get_frontend_controller()->optimize( $html, $row );
+			if ( ! empty( $row ) ) {
+				$html_optimized = $factory->get_frontend_controller()->optimize( $html, $row );
+				// Update html for the next iteration.
+				$html = $html_optimized;
+				// Set flag as true since optimization has been applied.
+				$optimization_applied = true;
+			}
 		}
 
-		return $html_optimized;
+		// Check if any optimizations were applied, if not, inject beacon.
+		if ( ! $optimization_applied ) {
+			$html = $this->inject_beacon( $html, $url, $is_mobile );
+		}
+
+		return $html_optimized ?? $html;
 	}
 
 	/**

--- a/inc/Engine/Common/PerformanceHints/Frontend/Processor.php
+++ b/inc/Engine/Common/PerformanceHints/Frontend/Processor.php
@@ -65,13 +65,15 @@ class Processor {
 		foreach ( $this->factories as $factory ) {
 			$row = $factory->queries()->get_row( $url, $is_mobile );
 
-			if ( ! empty( $row ) ) {
-				$html_optimized = $factory->get_frontend_controller()->optimize( $html, $row );
-				// Update html for the next iteration.
-				$html = $html_optimized;
-				// Set flag as true since optimization has been applied.
-				$optimization_applied = true;
+			if ( empty( $row ) ) {
+				continue;
 			}
+
+			$html_optimized = $factory->get_frontend_controller()->optimize( $html, $row );
+			// Update html for the next iteration.
+			$html = $html_optimized;
+			// Set flag as true since optimization has been applied.
+			$optimization_applied = true;
 		}
 
 		// Check if any optimizations were applied, if not, inject beacon.


### PR DESCRIPTION
# Description

While proactively testing the lrc factory being parsed in the performance hints, I noticed that the html buffer was not correctly modified. If there was an existing atf optimization applied on the html buffer, the lrc factory will reset it to the original html buffer. This PR fixes that.

## Documentation

### User documentation

Both ATF & LRC Optimization should now be correctly applied on the page with LRC enabled.

### Technical documentation
We were previously returning in the loop the inject_beacon content which accepts the original html buffer, so when a 2nd factory (LRC) is added to the factory array, we will run the first loop ok but return on the 2nd the original html buffer with the beacon inserted. This now fixed and we only return once but no longer in the factory loop

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).

## New dependencies
N/A

## Risks
N/A

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Documentation

- [x] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [x] The user documentation covers new/changed entry points (endpoints, WP hooks, configuration files, ...).
- [x] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I wrote comments to explain why it does it.
- [x] I named variables and functions explicitely.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.