### PR TITLE
Inject beacon for other factories without optimization data in db

### DIFF
--- a/inc/Engine/Common/PerformanceHints/Frontend/Processor.php
+++ b/inc/Engine/Common/PerformanceHints/Frontend/Processor.php
@@ -58,20 +58,16 @@ class Processor {
 		$url       = untrailingslashit( home_url( add_query_arg( [], $wp->request ) ) );
 		$is_mobile = $this->is_mobile();
 
-		$html_optimized = null;
-		// Flag to check if any optimization has been applied.
-		$optimization_applied = false;
-
 		foreach ( $this->factories as $factory ) {
 			$row = $factory->queries()->get_row( $url, $is_mobile );
 
 			if ( empty( $row ) ) {
+				// Flag false if optimization has not been applied.
+   				$optimization_applied = false;
 				continue;
 			}
 
-			$html_optimized = $factory->get_frontend_controller()->optimize( $html, $row );
-			// Update html for the next iteration.
-			$html = $html_optimized;
+			$html = $factory->get_frontend_controller()->optimize( $html, $row );
 			// Set flag as true since optimization has been applied.
 			$optimization_applied = true;
 		}
@@ -81,7 +77,7 @@ class Processor {
 			$html = $this->inject_beacon( $html, $url, $is_mobile );
 		}
 
-		return $html_optimized ?? $html;
+		return $html;
 	}
 
 	/**

--- a/inc/Engine/Common/PerformanceHints/Frontend/Processor.php
+++ b/inc/Engine/Common/PerformanceHints/Frontend/Processor.php
@@ -63,7 +63,7 @@ class Processor {
 
 			if ( empty( $row ) ) {
 				// Flag false if optimization has not been applied.
-   				$optimization_applied = false;
+				$optimization_applied = false;
 				continue;
 			}
 


### PR DESCRIPTION
# Description

Fixes an issue where beacon is not injected if one feature optimization data is already generated and the other isn't.

## Documentation

### User documentation

Beacon is injected for all features as long as they don't have generated optimization data in DB.

### Technical documentation

When one the first factory has optimization data in DB and the other doesn't, we continue to return the optimized data from the first factory DB instead of the updated which will have the optimized html buffer with the beacon also injected for the other factory.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).

## New dependencies
N/A

## Risks
N/A

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Documentation

- [x] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [x] The user documentation covers new/changed entry points (endpoints, WP hooks, configuration files, ...).
- [x] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I wrote comments to explain why it does it.
- [x] I named variables and functions explicitely.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.
