### PR TITLE
Remove Not operator

### DIFF
--- a/inc/Engine/Optimization/LazyRenderContent/Frontend/Controller.php
+++ b/inc/Engine/Optimization/LazyRenderContent/Frontend/Controller.php
@@ -69,7 +69,7 @@ class Controller {
 		$url       = untrailingslashit( home_url( add_query_arg( [], $wp->request ) ) );
 		$is_mobile = $this->is_mobile();
 
-		if ( ! $this->query->get_row( $url, $is_mobile ) ) {
+		if ( $this->query->get_row( $url, $is_mobile ) ) {
 			return $html;
 		}
 


### PR DESCRIPTION
# Description

Fixes the issue of hash not generated

## Documentation

### User documentation

WPR can identify elements to lazy render.

### Technical documentation

We are checking if LRC data is not in DB and bailing which will always be true the first time and always thereby making the hash generation code to never run.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## New dependencies
N/A

## Risks
N/A

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Documentation

- [x] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [x] The user documentation covers new/changed entry points (endpoints, WP hooks, configuration files, ...).
- [x] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I wrote comments to explain why it does it.
- [x] I named variables and functions explicitely.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.
