### PR TITLE
Fixes #6883 Clear performance hints data of current URL

### DIFF
--- a/inc/Engine/Cache/PurgeActionsSubscriber.php
+++ b/inc/Engine/Cache/PurgeActionsSubscriber.php
@@ -44,21 +44,22 @@ class PurgeActionsSubscriber implements Subscriber_Interface {
 		$slug = rocket_get_constant( 'WP_ROCKET_SLUG' );
 
 		return [
-			'profile_update'                      => 'purge_user_cache',
-			'delete_user'                         => 'purge_user_cache',
-			'create_term'                         => [ 'maybe_purge_cache_on_term_change', 10, 3 ],
-			'edit_term'                           => [ 'maybe_purge_cache_on_term_change', 10, 3 ],
-			'delete_term'                         => [ 'maybe_purge_cache_on_term_change', 10, 3 ],
-			'after_rocket_clean_post'             => [
+			'profile_update'                               => 'purge_user_cache',
+			'delete_user'                                  => 'purge_user_cache',
+			'create_term'                                  => [ 'maybe_purge_cache_on_term_change', 10, 3 ],
+			'edit_term'                                    => [ 'maybe_purge_cache_on_term_change', 10, 3 ],
+			'delete_term'                                  => [ 'maybe_purge_cache_on_term_change', 10, 3 ],
+			'after_rocket_clean_post'                      => [
 				[ 'purge_dates_archives' ],
 				[ 'purge_post_terms_urls' ],
 			],
-			'rocket_saas_complete_job_status'     => [ 'purge_url_cache', 100 ],
-			'rocket_rucss_after_clearing_usedcss' => 'purge_url_cache',
-			'rocket_after_save_dynamic_lists'     => 'purge_cache_after_saving_dynamic_lists',
-			'update_option_' . $slug              => [ 'purge_cache_reject_uri_partially', 10, 2 ],
-			'update_option_blog_public'           => 'purge_cache',
-			'wp_rocket_upgrade'                   => [ 'on_update', 10, 2 ],
+			'rocket_saas_complete_job_status'              => [ 'purge_url_cache', 100 ],
+			'rocket_rucss_after_clearing_usedcss'          => 'purge_url_cache',
+			'rocket_performance_hints_data_after_clearing' => 'purge_url_cache',
+			'rocket_after_save_dynamic_lists'              => 'purge_cache_after_saving_dynamic_lists',
+			'update_option_' . $slug                       => [ 'purge_cache_reject_uri_partially', 10, 2 ],
+			'update_option_blog_public'                    => 'purge_cache',
+			'wp_rocket_upgrade'                            => [ 'on_update', 10, 2 ],
 		];
 	}
 

--- a/inc/Engine/Common/PerformanceHints/Admin/Controller.php
+++ b/inc/Engine/Common/PerformanceHints/Admin/Controller.php
@@ -152,7 +152,6 @@ class Controller {
 		/**
 		 * Fires after clearing performance hints data for specific url.
 		 *
-		 *
 		 * @param string $url Current page URL.
 		 */
 		do_action( 'rocket_performance_hints_data_after_clearing', $url );

--- a/inc/Engine/Common/PerformanceHints/Admin/Controller.php
+++ b/inc/Engine/Common/PerformanceHints/Admin/Controller.php
@@ -149,6 +149,14 @@ class Controller {
 			$url       = $parse_url['scheme'] . '://' . $parse_url['host'] . $url;
 		}
 
+		/**
+		 * Fires after clearing performance hints data for specific url.
+		 *
+		 *
+		 * @param string $url Current page URL.
+		 */
+		do_action( 'rocket_performance_hints_data_after_clearing', $url );
+
 		$this->delete_by_url( $url );
 	}
 


### PR DESCRIPTION
# Description
This should be merge after this is merge https://github.com/wp-media/wp-rocket/pull/6858
Fixes #6883

## Documentation

### User documentation
Make sure cache are cleared when it's cleared.

### Technical documentation
Add a hook `rocket_performance_hints_data_after_clearing` whenever a current url performance hints data is clear.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue).


## New dependencies
N/A


# Checklists

## Feature validation
- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.

## Documentation

- [x] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [x] The user documentation covers new/changed entry points (endpoints, WP hooks, configuration files, ...).
- [x] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I wrote comments to explain why it does it.

