### PR TITLE
Make performanceHints and Adminonly run in coverage GH action

### DIFF
--- a/.github/workflows/test_wprocket_latest_general_coverage.yml
+++ b/.github/workflows/test_wprocket_latest_general_coverage.yml
@@ -1,4 +1,4 @@
-name: Unit/Integration General tests Latest version
+name: Unit/Integration General tests Latest version with coverage
 
 on:
   pull_request:
@@ -81,7 +81,7 @@ jobs:
       run: sudo mysql -u root -proot -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';"
 
     - name: Test
-      run: composer run-tests-general
+      run: composer run-tests-coverage
 
     - name: Code Coverage Report
       run: composer report-code-coverage

--- a/composer.json
+++ b/composer.json
@@ -123,10 +123,14 @@
 		}
 	},
 	"scripts": {
-		"test-unit": "\"vendor/bin/phpunit\" --testsuite unit --colors=always --configuration tests/Unit/phpunit.xml.dist --coverage-php tests/report/unit.cov",
-		"test-integration": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --exclude-group AdminOnly,BeaverBuilder,Elementor,Hummingbird,WithSmush,WithWoo,WithAmp,WithAmpAndCloudflare,WithSCCSS,Cloudways,Dreampress,Cloudflare,CloudflareAdmin,Multisite,WPEngine,SpinUpWP,WordPressCom,O2Switch,PDFEmbedder,PDFEmbedderPremium,PDFEmbedderSecure,Godaddy,LiteSpeed,RevolutionSlider,WordFence,ConvertPlug,Kinsta,Jetpack,RankMathSEO,AllInOneSeoPack,SEOPress,TheSEOFramework,OneCom,RocketLazyLoad,WPXCloud,TheEventsCalendar,Perfmatters,RapidLoad,ProIsp,TranslatePress,WPGeotargeting,Weglot,Pressidium,PerformanceHints --coverage-php tests/report/integration.cov",
+		"test-unit": "\"vendor/bin/phpunit\" --testsuite unit --colors=always --configuration tests/Unit/phpunit.xml.dist",
+		"test-unit-coverage": "\"vendor/bin/phpunit\" --testsuite unit --colors=always --configuration tests/Unit/phpunit.xml.dist --coverage-php tests/report/unit.cov",
+		"test-integration": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --exclude-group AdminOnly,BeaverBuilder,Elementor,Hummingbird,WithSmush,WithWoo,WithAmp,WithAmpAndCloudflare,WithSCCSS,Cloudways,Dreampress,Cloudflare,CloudflareAdmin,Multisite,WPEngine,SpinUpWP,WordPressCom,O2Switch,PDFEmbedder,PDFEmbedderPremium,PDFEmbedderSecure,Godaddy,LiteSpeed,RevolutionSlider,WordFence,ConvertPlug,Kinsta,Jetpack,RankMathSEO,AllInOneSeoPack,SEOPress,TheSEOFramework,OneCom,RocketLazyLoad,WPXCloud,TheEventsCalendar,Perfmatters,RapidLoad,ProIsp,TranslatePress,WPGeotargeting,Weglot,Pressidium,PerformanceHints",
+		"test-integration-coverage": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --exclude-group AdminOnly,BeaverBuilder,Elementor,Hummingbird,WithSmush,WithWoo,WithAmp,WithAmpAndCloudflare,WithSCCSS,Cloudways,Dreampress,Cloudflare,CloudflareAdmin,Multisite,WPEngine,SpinUpWP,WordPressCom,O2Switch,PDFEmbedder,PDFEmbedderPremium,PDFEmbedderSecure,Godaddy,LiteSpeed,RevolutionSlider,WordFence,ConvertPlug,Kinsta,Jetpack,RankMathSEO,AllInOneSeoPack,SEOPress,TheSEOFramework,OneCom,RocketLazyLoad,WPXCloud,TheEventsCalendar,Perfmatters,RapidLoad,ProIsp,TranslatePress,WPGeotargeting,Weglot,Pressidium,PerformanceHints --coverage-php tests/report/integration.cov",
 		"test-integration-adminonly": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group AdminOnly",
+		"test-integration-adminonly-coverage": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group AdminOnly --coverage-php tests/report/unit.cov",
 		"test-integration-performancehints": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group PerformanceHints",
+		"test-integration-performancehints-coverage": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group PerformanceHints --coverage-php tests/report/unit.cov",
 		"test-integration-bb": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group BeaverBuilder",
 		"test-integration-cloudflare": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group Cloudflare",
 		"test-integration-cloudflareadmin": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group CloudflareAdmin",
@@ -166,20 +170,23 @@
 	    "test-integration-rapidload": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group RapidLoad",
 	    "test-integration-proisp": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group ProIsp",
 	    "test-integration-wp-geotargeting": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group WPGeotargeting",
-      "test-integration-translatepress": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group TranslatePress",
-      "test-integration-weglot": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group Weglot",
-		  "test-integration-pressidium": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group Pressidium",
+        "test-integration-translatepress": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group TranslatePress",
+        "test-integration-weglot": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group Weglot",
+		"test-integration-pressidium": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group Pressidium",
 		"run-tests": [
-			"@run-tests-general",
-			"@run-tests-integration-specific"
-		],
-		"run-tests-general": [
 			"@test-unit",
-			"@test-integration"
-		],
-		"run-tests-integration-specific": [
+			"@test-integration",
 			"@test-integration-adminonly",
 			"@test-integration-performancehints",
+			"@run-tests-integration-specific"
+		],
+		"run-tests-coverage": [
+			"@test-unit-coverage",
+			"@test-integration-coverage",
+			"@test-integration-adminonly-coverage",
+			"@test-integration-performancehints-coverage"
+		],
+		"run-tests-integration-specific": [
 			"@test-integration-cloudflare",
 			"@test-integration-cloudflareadmin",
 			"@test-integration-bb",

--- a/tests/Integration/inc/Engine/CriticalPath/Admin/Subscriber/addRegenerateMenuItem.php
+++ b/tests/Integration/inc/Engine/CriticalPath/Admin/Subscriber/addRegenerateMenuItem.php
@@ -7,7 +7,8 @@ use WP_Rocket\Tests\Integration\AdminTestCase;
 
 /**
  * Test class covering \WP_Rocket\Engine\CriticalPath\Admin\Subscriber::add_regenerate_menu_item
- * @uses   \WP_Rocket\Tests\CriticalPath\Admin\Admin::add_regenerate_menu_item
+ *
+ * @uses   \WP_Rocket\Engine\CriticalPath\Admin\Admin::add_regenerate_menu_item
  * @uses   \WP_Rocket\Admin\Options_Data::get
  * @uses   ::rocket_has_constant
  *

--- a/tests/Integration/inc/Engine/CriticalPath/Admin/Subscriber/cpcssHeartbeat.php
+++ b/tests/Integration/inc/Engine/CriticalPath/Admin/Subscriber/cpcssHeartbeat.php
@@ -9,12 +9,13 @@ use WP_Rocket\Tests\Integration\AjaxTestCase;
 
 /**
  * Test class covering \WP_Rocket\Engine\CriticalPath\Admin\Subscriber::cpcss_heartbeat
+ *
  * @uses   \WP_Rocket\Admin\Options_Data::get
  * @uses   \WP_Rocket\Engine\CriticalPath\Admin\Admin::cpcss_heartbeat
  * @uses   \WP_Rocket\Engine\CriticalPath\APIClient::send_generation_request
  * @uses   \WP_Rocket\Engine\CriticalPath\DataManager::delete_cache_job_id
  * @uses   \WP_Rocket\Engine\CriticalPath\DataManager::get_cache_job_id
- * @uses   \WP_Rocket\Engine\CriticalPath\DataManager::get_job_details
+ * @uses   \WP_Rocket\Engine\CriticalPath\APIClient::get_job_details
  * @uses   \WP_Rocket\Engine\CriticalPath\DataManager::set_cache_job_id
  * @uses   \WP_Rocket\Engine\CriticalPath\ProcessorService::process_generate
  * @uses   ::rocket_has_constant


### PR DESCRIPTION
# Description

Fixes #6889 

Make performanceHints and Adminonly run in coverage GH action
Add coverage variations for unit, integartion, performanceHints and Adminonly test commands

To showcase the change:
- This is a PR before the change: uncovered lines are actually tested by tests in PerformanceHints: https://github.com/wp-media/wp-rocket/pull/6881
- This is the same PR with the change in composer and GH actions: Codacy sees the code coverage of the warm_up_home method now: https://github.com/wp-media/wp-rocket/pull/6895

## Documentation

### User documentation

composer "run-tests" commands are modified a bit so that AdminOnly and PerformanceHints are running as part of the coverage GH action.

### Technical documentation

For unit, integration general, adminonly and performanceHints, there are now vazriations that do the same but also compute coverage.
A new composer command run those 4 variations to get the coverage. This is now used in the coverage GH action.

## Type of change
*Delete options that are not relevant.*

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).

## New dependencies
NA

## Risks
- The CI will be a bit slower as running more tests with coverage takes longer.
- The AdminOnly group now throws 16 warnings when running, while I could not see them before. But I think they are legit warnings, so I don't think this is a regression from this change. For those warnings, the "uses" seems to reference files that don't exist, hence the warning I think:

```
here were 16 warnings:

1) WP_Rocket\Tests\Integration\inc\Engine\CriticalPath\Admin\Subscriber\Test_AddRegenerateMenuItem::testShouldDoExpected with data set "testShouldDoNothingWhenNoCap" (false, true, true, true, '/wp-admin/', false)
"@uses \WP_Rocket\Tests\CriticalPath\Admin\Admin::add_regenerate_menu_item" is invalid

2) WP_Rocket\Tests\Integration\inc\Engine\CriticalPath\Admin\Subscriber\Test_AddRegenerateMenuItem::testShouldDoExpected with data set "testShouldDoNothingWhenNotAdmin" (true, false, true, true, '/wp-admin/', false)
"@uses \WP_Rocket\Tests\CriticalPath\Admin\Admin::add_regenerate_menu_item" is invalid

3) WP_Rocket\Tests\Integration\inc\Engine\CriticalPath\Admin\Subscriber\Test_AddRegenerateMenuItem::testShouldDoExpected with data set "testShouldDoNothingWhenOptionDisabled" (true, true, false, true, '/wp-admin/', false)
"@uses \WP_Rocket\Tests\CriticalPath\Admin\Admin::add_regenerate_menu_item" is invalid

4) WP_Rocket\Tests\Integration\inc\Engine\CriticalPath\Admin\Subscriber\Test_AddRegenerateMenuItem::testShouldDoExpected with data set "testShouldDoNothingWhenFilterDisabled" (true, true, true, false, '/wp-admin/', false)
"@uses \WP_Rocket\Tests\CriticalPath\Admin\Admin::add_regenerate_menu_item" is invalid

5) WP_Rocket\Tests\Integration\inc\Engine\CriticalPath\Admin\Subscriber\Test_AddRegenerateMenuItem::testShouldDoExpected with data set "testShouldAddMenuItem" (true, true, true, true, '/wp-admin/', stdClass Object (...))
"@uses \WP_Rocket\Tests\CriticalPath\Admin\Admin::add_regenerate_menu_item" is invalid

6) WP_Rocket\Tests\Integration\inc\Engine\CriticalPath\Admin\Subscriber\Test_CpcssHeartbeat::testCallbackIsRegistered
"@uses \WP_Rocket\Engine\CriticalPath\DataManager::get_job_details" is invalid

7) WP_Rocket\Tests\Integration\inc\Engine\CriticalPath\Admin\Subscriber\Test_CpcssHeartbeat::testShouldGenerateCPCSS with data set "testShouldBailOutAtDisabledAsyncCSS" (array(true, array(0)), array(true, 'wp_send_json_error'))
"@uses \WP_Rocket\Engine\CriticalPath\DataManager::get_job_details" is invalid

8) WP_Rocket\Tests\Integration\inc\Engine\CriticalPath\Admin\Subscriber\Test_CpcssHeartbeat::testShouldGenerateCPCSS with data set "testShouldBailOutWithoutRocketPermissions" (array(true, array(1), false), array(true, 'wp_send_json_error'))
"@uses \WP_Rocket\Engine\CriticalPath\DataManager::get_job_details" is invalid

9) WP_Rocket\Tests\Integration\inc\Engine\CriticalPath\Admin\Subscriber\Test_CpcssHeartbeat::testShouldGenerateCPCSS with data set "testShouldBailOutWithoutCriticalCSSPermissions" (array(true, array(1), true, false), array(true, 'wp_send_json_error'))
"@uses \WP_Rocket\Engine\CriticalPath\DataManager::get_job_details" is invalid

10) WP_Rocket\Tests\Integration\inc\Engine\CriticalPath\Admin\Subscriber\Test_CpcssHeartbeat::testShouldGenerateCPCSS with data set "testShouldStopNoDataInTransient" (array(true, array(1), true, true, array(), false), array(false, true, 'wp_send_json_success', array('cpcss_complete')))
"@uses \WP_Rocket\Engine\CriticalPath\DataManager::get_job_details" is invalid

11) WP_Rocket\Tests\Integration\inc\Engine\CriticalPath\Admin\Subscriber\Test_CpcssHeartbeat::testShouldGenerateCPCSS with data set "testShouldRunSingleDataInTransientWithProcessGenerateReturnWPError" (array(true, array(1), true, true, array(array('https://example.org/', 'front_page.css', false, false, 0, 'home')), array(true, 404, false, 'cpcss_generation_failed', 'Critical CSS for home not generated.', array('failed')), array('Critical CSS for home not generated.', array(1, array(array(array(array('Critical CSS for home not generated.', false)))))), true), array(false, true, 'wp_send_json_success', array('cpcss_complete')))
"@uses \WP_Rocket\Engine\CriticalPath\DataManager::get_job_details" is invalid

12) WP_Rocket\Tests\Integration\inc\Engine\CriticalPath\Admin\Subscriber\Test_CpcssHeartbeat::testShouldGenerateCPCSS with data set "testShouldRunSingleDataInTransientWithProcessGenerateReturnSuccess" (array(true, array(1), true, true, array(array('https://example.org/', 'front_page.css', false, false, 0, 'home')), array(200, true, 'cpcss_generation_successful', 'Critical CSS for home generated.', array('complete', '.critical_path { color: red; }')), array(array(1, array(array(array(array('Critical CSS for home generated.', true)))))), true), array(false, true, 'wp_send_json_success', array('cpcss_complete')))
"@uses \WP_Rocket\Engine\CriticalPath\DataManager::get_job_details" is invalid

13) WP_Rocket\Tests\Integration\inc\Engine\CriticalPath\Admin\Subscriber\Test_CpcssHeartbeat::testShouldGenerateCPCSS with data set "testShouldRunSingleDataInTransientWithProcessGenerateReturnFailed" (array(true, array(1), true, true, array(array('https://example.org/', 'front_page.css', false, false, 0, 'home')), array(404, false, 'cpcss_generation_failed', 'Critical CSS for home not generated.', array('failed')), array(array(1, array(array(array(array('Critical CSS for home not generated.', false)))))), true), array(false, true, 'wp_send_json_success', array('cpcss_complete'), array()))
"@uses \WP_Rocket\Engine\CriticalPath\DataManager::get_job_details" is invalid

14) WP_Rocket\Tests\Integration\inc\Engine\CriticalPath\Admin\Subscriber\Test_CpcssHeartbeat::testShouldGenerateCPCSS with data set "testShouldRunSingleDataInTransientWithProcessGenerateReturnTimeout" (array(true, array(1), true, true, array(array('https://example.org/', 'front_page.css', false, false, 11, 'home')), array(200, true, 'cpcss_generation_pending', 'Critical CSS for home in progress.', array('pending')), true, array()), array(false, true, true, true, 'wp_send_json_success', array('cpcss_complete'), array()))
"@uses \WP_Rocket\Engine\CriticalPath\DataManager::get_job_details" is invalid

15) WP_Rocket\Tests\Integration\inc\Engine\CriticalPath\Admin\Subscriber\Test_CpcssHeartbeat::testShouldGenerateCPCSS with data set "testShouldRunSingleDataInTransientWithProcessGeneratePending" (array(true, array(1), true, true, array(array('https://example.org/', 'front_page.css', false, false, 0, 'home')), array(200, true, 'cpcss_generation_pending', 'Critical CSS for home in progress.', array('pending'))), array(false, false, 'wp_send_json_success', array('cpcss_running'), array(array('https://example.org/', 'front_page.css', false, false, 1, 'home'))))
"@uses \WP_Rocket\Engine\CriticalPath\DataManager::get_job_details" is invalid

16) WP_Rocket\Tests\Integration\inc\Engine\CriticalPath\Admin\Subscriber\Test_CpcssHeartbeat::testShouldGenerateCPCSS with data set "testShouldMultipleDataInTransientWithCpcssRunning" (array(true, array(1), true, true, array(array('https://example.org/', 'front_page.css', false, false, 0, 'home'), array('https://example.org/category/', 'category.css', false, false, 0)), array(404, false, 'cpcss_generation_failed', 'Critical CSS for https://exam...rated./', array('failed')), array(array(2, array(array(array(array('Critical CSS for https://exam...rated./', false)))))), true), array(false, false, true, 'wp_send_json_success', array('cpcss_running'), array(array('https://example.org/category/', 'category.css', false, false, 0))))
"@uses \WP_Rocket\Engine\CriticalPath\DataManager::get_job_details" is invalid

--
```

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.

## Documentation

- [x] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [x] The user documentation covers new/changed entry points (endpoints, WP hooks, configuration files, ...).
- [x] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I wrote comments to explain why it does it.
- [x]  I named variables and functions explicitely.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.
- [x] I listed the introduced external dependencies explicitely on the PR.
- [x] I validated the repo-specific guidelines from CONTRIBUTING.md.

## Observability
- [x] I handled errors when needed.
- [x] I wrote user-facing messages that are understandable and provide actionable feedbacks.
- [x] I prepared ways to observe the implemented system (logs, data, etc.).

## Risks
- [x] I explicitely mentioned performance risks in the PR.
- [x] I explicitely mentioned security risks in the PR.
