### PR TITLE
Make rollback version 3.16.4

### DIFF
--- a/wp-rocket.php
+++ b/wp-rocket.php
@@ -82,7 +82,7 @@ if ( ! defined( 'CHMOD_WP_ROCKET_CACHE_DIRS' ) ) {
 	define( 'CHMOD_WP_ROCKET_CACHE_DIRS', 0755 ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
 }
 if ( ! defined( 'WP_ROCKET_LASTVERSION' ) ) {
-	define( 'WP_ROCKET_LASTVERSION', '3.15.10' );
+	define( 'WP_ROCKET_LASTVERSION', '3.16.4' );
 }
 
 /**


### PR DESCRIPTION
# Description

Fixes #6893 

## Documentation

### User documentation

On 3.17, users will be able to rollback to 3.16.4

<img width="771" alt="image" src="https://github.com/user-attachments/assets/4abfcbb5-2e3d-4412-b0cf-a7eaf48a47ce">


### Technical documentation

Changed WP_ROCKET_LASTVERSION

## Type of change
*Delete options that are not relevant.*

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).

## New dependencies
NA

## Risks
The rollback must be tested properly once the 3.17 release is ready.

# Checklists

## Feature validation

- [ ] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [ ] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Documentation

- [x] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [x] The user documentation covers new/changed entry points (endpoints, WP hooks, configuration files, ...).
- [x] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I wrote comments to explain why it does it.
- [x] I named variables and functions explicitely.
- [x]  I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.
- [x] I listed the introduced external dependencies explicitely on the PR.
- [x] I validated the repo-specific guidelines from CONTRIBUTING.md.

## Observability
- [x] I handled errors when needed.
- [x] I wrote user-facing messages that are understandable and provide actionable feedbacks.
- [x] I prepared ways to observe the implemented system (logs, data, etc.).

## Risks
- [x] I explicitely mentioned performance risks in the PR.
- [x] I explicitely mentioned security risks in the PR.
