### PR TITLE
Fixes #6898 'Clear performance Hints data' in the WPR admin dropdown menu when env is set to local

### DIFF
--- a/inc/Engine/Admin/Settings/AdminBarMenuTrait.php
+++ b/inc/Engine/Admin/Settings/AdminBarMenuTrait.php
@@ -24,10 +24,6 @@ trait AdminBarMenuTrait {
 			return;
 		}
 
-		if ( 'local' === wp_get_environment_type() ) {
-			return;
-		}
-
 		if ( ! is_admin() ) {
 			return;
 		}
@@ -67,9 +63,6 @@ trait AdminBarMenuTrait {
 		bool $context
 	) {
 		global $post;
-		if ( 'local' === wp_get_environment_type() && $context ) {
-			return;
-		}
 
 		if ( is_admin() ) {
 			return;
@@ -123,14 +116,6 @@ trait AdminBarMenuTrait {
 	 * @return void
 	 */
 	public function dashboard_button( bool $context, string $title, string $label, string $action, string $hover_text = '' ): void {
-		if (
-			'local' === wp_get_environment_type()
-			&&
-			$context
-		) {
-			return;
-		}
-
 		if ( ! $context ) {
 			return;
 		}

--- a/inc/Engine/Saas/Admin/AdminBar.php
+++ b/inc/Engine/Saas/Admin/AdminBar.php
@@ -51,6 +51,10 @@ class AdminBar extends Abstract_Render {
 		$title  = __( 'Clear RUCSS optimizations', 'rocket' );
 		$action = 'rocket_clean_saas';
 
+		if ( 'local' === wp_get_environment_type() ) {
+			return;
+		}
+
 		if (
 			'local' === wp_get_environment_type()
 			&&
@@ -79,6 +83,10 @@ class AdminBar extends Abstract_Render {
 	 * @return void
 	 */
 	public function add_clean_url_menu_item( WP_Admin_Bar $wp_admin_bar ) {
+		if ( 'local' === wp_get_environment_type() && $this->rucss_url_context->is_allowed() ) {
+			return;
+		}
+
 		global $post;
 
 		/**
@@ -112,6 +120,14 @@ class AdminBar extends Abstract_Render {
 	 * @return void
 	 */
 	public function display_dashboard_button() {
+		if (
+			'local' === wp_get_environment_type()
+			&&
+			$this->rucss_url_context->is_allowed()
+		) {
+			return;
+		}
+
 		$this->dashboard_button(
 			$this->rucss_url_context->is_allowed(),
 			__( 'Remove Unused CSS', 'rocket' ),

--- a/tests/Fixtures/inc/Engine/Common/PerformanceHints/Admin/AdminBar/addCleanPerformanceHintsItem.php
+++ b/tests/Fixtures/inc/Engine/Common/PerformanceHints/Admin/AdminBar/addCleanPerformanceHintsItem.php
@@ -54,17 +54,6 @@ return [
 			'title' => 'Clear Performance Hints data',
 		],
 	],
-	'testShouldReturnNullWhenLocalEnvironment' => [
-		'config'   => [
-			'rocket_valid_key' 	=> true,
-			'environment'       => 'local',
-			'is_admin'          => false,
-			'atf_context'       => false,
-			'lrc_context'       => false,
-			'current_user_can'  => true,
-		],
-		'expected' => null,
-	],
 	'testShouldReturnNullWhenNotAdmin' => [
 		'config'   => [
 			'rocket_valid_key' 	=> true,

--- a/tests/Fixtures/inc/Engine/Common/PerformanceHints/Admin/AdminBar/addPerformanceHintsClearUrlMenuItem.php
+++ b/tests/Fixtures/inc/Engine/Common/PerformanceHints/Admin/AdminBar/addPerformanceHintsClearUrlMenuItem.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-	'testShouldReturnNullWhenLocalEnvironment' => [
+	'testShouldReturnMenuWhenLocalEnvironment' => [
 		'config'   => [
 			'environment'       => 'local',
 			'is_admin'          => false,
@@ -12,7 +12,10 @@ return [
 			'can_display_options' => true,
 			'factories'         => true,
 		],
-		'expected' => null,
+		'expected' => [
+			'id'    => 'clear-performance-hints-data-url',
+			'title' => 'Clear Performance Hints data of this URL',
+		],
 	],
 	'testShouldReturnNullWhenAdmin' => [
 		'config'   => [

--- a/tests/Unit/inc/Engine/Common/PerformanceHints/Admin/AdminBar/addCleanPerformanceHintsItem.php
+++ b/tests/Unit/inc/Engine/Common/PerformanceHints/Admin/AdminBar/addCleanPerformanceHintsItem.php
@@ -51,8 +51,6 @@ class Test_AddCleanPerformanceHintsItem extends TestCase {
 	public function testShouldDoExpected( $config, $expected ) {
 		Functions\when( 'rocket_valid_key' )
 			->justReturn( $config['rocket_valid_key'] );
-		Functions\when( 'wp_get_environment_type' )
-			->justReturn( $config['environment'] );
 		Functions\when( 'is_admin' )
 			->justReturn( $config['is_admin'] );
 


### PR DESCRIPTION
# Description

Fixes #6898 

## Documentation

### User documentation
Show performance hints data url when environment is set to local
*Explain how this code impacts users.*

### Technical documentation

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue).


## New dependencies
N/A


# Checklists

## Feature validation
- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Documentation
- [x] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [x] The user documentation covers new/changed entry points (endpoints, WP hooks, configuration files, ...).
- [x] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I did not introduce unecessary complexity.


