### PR TITLE
Closes #6901: LRC style is not added to used CSS when enable RUCSS

### DIFF
--- a/inc/Engine/Optimization/LazyRenderContent/Frontend/Controller.php
+++ b/inc/Engine/Optimization/LazyRenderContent/Frontend/Controller.php
@@ -93,7 +93,7 @@ class Controller implements ControllerInterface {
 	 * @return string
 	 */
 	private function add_css( $html ) {
-		$css = '<style>[data-wpr-lazyrender] {content-visibility: auto;}</style>';
+		$css = '<style id="rocket-lazyrender-inline-css">[data-wpr-lazyrender] {content-visibility: auto;}</style>';
 
 		$result = preg_replace( '/<\/head>/i', $css . '</head>', $html, 1 );
 

--- a/tests/Fixtures/inc/Engine/Optimization/LazyRenderContent/Frontend/Controller/expected.html
+++ b/tests/Fixtures/inc/Engine/Optimization/LazyRenderContent/Frontend/Controller/expected.html
@@ -1,7 +1,7 @@
 <html>
 	<head>
 		<title>Original</title>
-		<style>[data-wpr-lazyrender] {content-visibility: auto;}</style>
+		<style id="rocket-lazyrender-inline-css">[data-wpr-lazyrender] {content-visibility: auto;}</style>
 	</head>
 	<body>
 		<main data-wpr-lazyrender="1">


### PR DESCRIPTION
# Description
When enabling RUCSS while LRC is already created, the used CSS does not contain the LRC CSS.

Fixes #6901
This code adds an ID Attribute to the `<style>` tag generated by LRC so the used CSS feature will contain the LRC css. 

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Release

## Detailed scenario

Steps to reproduce the behavior:
1. Visit a page => LRC added to DB
2. Clear cache and revisit the page => LRC style added to the page
3. Enable RUCSS 
4. revisit the page and wait till the used CSS is created then revisit the page => LRC style is not in the source
```
[data-wpr-lazyrender] {
content-visibility: auto;
} 

```
## Technical description

### Documentation

This code adds an ID Attribute to the `<style>` tag generated by LRC so the used CSS feature will contain the LRC css. 

### New dependencies

### Risks


# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)