### PR TITLE
Closes #6914: URLs are not fetched when updating from 3.16+ to 3.17

### DIFF
--- a/inc/Engine/Common/PerformanceHints/WarmUp/Subscriber.php
+++ b/inc/Engine/Common/PerformanceHints/WarmUp/Subscriber.php
@@ -75,7 +75,7 @@ class Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function warm_up_on_update( $new_version, $old_version ) {
-		if ( version_compare( $old_version, '3.16', '>=' ) ) {
+		if ( version_compare( $old_version, '3.17', '>=' ) ) {
 			return;
 		}
 		$this->controller->warm_up();


### PR DESCRIPTION
# Description

Fixes #6914

Fetched URLs are added to the LRC table upon plugin update from 3.16+ to 3.17.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Release

## Detailed scenario

Steps to reproduce the behavior:

Have any of the 3.16 versions of the plugin installed.
Check the ATF table. => table contains warmup links.
Update plugin to 3.17-alpha1 version.
Check the LRC table for fetched URLs. => Table created but empty, no fetched URLs are added.

## Technical description

### Documentation

Just an update of the version. 

### New dependencies

### Risks

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)