### PR TITLE
Closes #6878 Activation and deactivation of Performance hints data filters

### DIFF
--- a/inc/Engine/Common/PerformanceHints/Admin/Controller.php
+++ b/inc/Engine/Common/PerformanceHints/Admin/Controller.php
@@ -27,10 +27,6 @@ class Controller {
 	 * @return void
 	 */
 	public function truncate_tables() {
-		if ( empty( $this->factories ) ) {
-			return;
-		}
-
 		$this->delete_rows();
 	}
 
@@ -68,10 +64,6 @@ class Controller {
 	 * @return void
 	 */
 	public function delete_post( $post_id ) {
-		if ( empty( $this->factories ) ) {
-			return;
-		}
-
 		$url = get_permalink( $post_id );
 
 		if ( false === $url ) {
@@ -89,10 +81,6 @@ class Controller {
 	 * @return void
 	 */
 	public function delete_term( $term_id ) {
-		if ( empty( $this->factories ) ) {
-			return;
-		}
-
 		$url = get_term_link( (int) $term_id );
 
 		if ( is_wp_error( $url ) ) {
@@ -169,6 +157,10 @@ class Controller {
 	 */
 	public function truncate_on_update( $new_version, $old_version ) {
 		if ( version_compare( $old_version, '3.16.1', '>=' ) ) {
+			return;
+		}
+
+		if ( empty( $this->factories ) ) {
 			return;
 		}
 

--- a/inc/Engine/Common/PerformanceHints/Admin/Controller.php
+++ b/inc/Engine/Common/PerformanceHints/Admin/Controller.php
@@ -91,6 +91,24 @@ class Controller {
 	}
 
 	/**
+	 * Should allow early if true.
+	 *
+	 * @return bool
+	 */
+	private function is_allowed(): bool {
+		$allowed = false;
+
+		foreach ( $this->factories as $factory ) {
+			if ( $factory->get_context()->is_allowed() ) {
+				$allowed = true;
+				break;
+			}
+		}
+
+		return $allowed;
+	}
+
+	/**
 	 * Deletes rows when triggering clean from admin
 	 *
 	 * @param array $clean An array containing the status and message.
@@ -98,7 +116,7 @@ class Controller {
 	 * @return array
 	 */
 	public function truncate_from_admin( $clean ) {
-		if ( empty( $this->factories ) ) {
+		if ( ! $this->is_allowed() ) {
 			return $clean;
 		}
 
@@ -160,7 +178,7 @@ class Controller {
 			return;
 		}
 
-		if ( empty( $this->factories ) ) {
+		if ( ! $this->is_allowed() ) {
 			return;
 		}
 

--- a/inc/Engine/Common/PerformanceHints/ServiceProvider.php
+++ b/inc/Engine/Common/PerformanceHints/ServiceProvider.php
@@ -110,7 +110,7 @@ class ServiceProvider extends AbstractServiceProvider {
 		$this->getContainer()->add( 'performance_hints_admin_controller', AdminController::class )
 			->addArguments(
 				[
-					$factories,
+					$factory_array,
 				]
 			);
 

--- a/tests/Integration/bootstrap.php
+++ b/tests/Integration/bootstrap.php
@@ -273,6 +273,23 @@ tests_add_filter(
 	}
 );
 
+tests_add_filter(
+	'wp_loaded',
+	function() {
+
+		if ( BootstrapManager::isGroup( 'PerformanceHints' ) ) {
+			return;
+		}
+		global $wpdb;
+
+		$table_name = $wpdb->prefix . 'wpr_above_the_fold';
+		$wpdb->query( "DROP TABLE IF EXISTS {$table_name}" );
+
+		$table_name = $wpdb->prefix . 'wpr_lazy_render_content';
+		$wpdb->query( "DROP TABLE IF EXISTS {$table_name}" );
+	}
+);
+
 // install WC.
 tests_add_filter(
 	'setup_theme',

--- a/tests/Integration/bootstrap.php
+++ b/tests/Integration/bootstrap.php
@@ -280,13 +280,12 @@ tests_add_filter(
 		if ( BootstrapManager::isGroup( 'PerformanceHints' ) ) {
 			return;
 		}
-		global $wpdb;
+		$container = apply_filters( 'rocket_container', null );
+		$atf_table = $container->get( 'atf_table' );
+		$atf_table->uninstall();
 
-		$table_name = $wpdb->prefix . 'wpr_above_the_fold';
-		$wpdb->query( "DROP TABLE IF EXISTS {$table_name}" );
-
-		$table_name = $wpdb->prefix . 'wpr_lazy_render_content';
-		$wpdb->query( "DROP TABLE IF EXISTS {$table_name}" );
+		$lrc_table = $container->get( 'lrc_table' );
+		$lrc_table->uninstall();
 	}
 );
 

--- a/tests/Unit/inc/Engine/Common/PerformanceHints/Admin/Controller/truncateOnUpdate.php
+++ b/tests/Unit/inc/Engine/Common/PerformanceHints/Admin/Controller/truncateOnUpdate.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace WP_Rocket\tests\Unit\inc\Engine\Common\PerformanceHints\Admin\Controller;
 
 use Mockery;
+use WP_Rocket\Engine\Common\Context\ContextInterface;
 use WP_Rocket\Tests\Unit\TestCase;
 use WP_Rocket\Engine\Common\PerformanceHints\Admin\Controller;
 use WP_Rocket\Engine\Media\AboveTheFold\Factory as ATFFactory;
@@ -15,10 +16,11 @@ use WP_Rocket\Engine\Media\AboveTheFold\Database\Tables\AboveTheFold as ATFTable
  *
  * @group PerformanceHints
  */
-class TestTruncateOnUpdate extends TestCase {
+class Test_TruncateOnUpdate extends TestCase {
 	private $factories;
 	private $queries;
 	private $table;
+	private $context;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -26,8 +28,10 @@ class TestTruncateOnUpdate extends TestCase {
 		$this->queries = $this->createMock(AboveTheFold::class);
 		$this->table = $this->createMock(ATFTable::class);
 		$atf_factory = $this->createMock(ATFFactory::class);
+		$this->context = $this->createMock(ContextInterface::class);
 		$atf_factory->method('queries')->willReturn($this->queries);
 		$atf_factory->method('table')->willReturn($this->table);
+		$atf_factory->method('get_context')->willReturn($this->context);
 
 		$this->factories = [
 			$atf_factory,
@@ -44,6 +48,10 @@ class TestTruncateOnUpdate extends TestCase {
 			$this->queries->expects( $this->never() )
 				->method( 'get_not_completed_count' );
 		} else {
+			$this->context->expects( $this->once() )
+				->method('is_allowed')
+				->willReturn(true);
+
 			$this->queries->expects( $this->once() )
 				->method( 'get_not_completed_count' )
 				->willReturn( $config['not_completed'] );


### PR DESCRIPTION
# Description
Make sure data are cleared when filters are deactivated.

Fixes #6878


## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

Disabled the performance filters and try to switch theme, change permalinks, post trash or delete, the data aren't cleared. Data should be cleared as [specified in the Epic Card](https://www.notion.so/wpmedia/Lazy-render-content-bf707b5f731a426cb5d1294beb770540?pvs=4#550a738c5dd54e0f8f4ba31d62fac421)


## Technical description
Remove the logic check for filters when any of this action is taken.

### Documentation
Ensure the data are cleared as specified either when the filters are activated or deactivated. 

### New dependencies

N/A

### Risks

N//A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I did not introduce unnecessary complexity.
