### PR TITLE
Fixes #6922 3.17: Hashes are not removed from the source when there is no LRC data

### DIFF
--- a/inc/Engine/Optimization/LazyRenderContent/Database/Rows/LazyRenderContent.php
+++ b/inc/Engine/Optimization/LazyRenderContent/Database/Rows/LazyRenderContent.php
@@ -92,7 +92,7 @@ class LazyRenderContent extends Row {
 	/**
 	 * Checks if the object has a valid LRC (Lazy Render Content) value.
 	 *
-	 * @return bool Returns true if the object's status is 'completed' and the Below the fold value is not empty or 'not found', false otherwise.
+	 * @return bool Returns true if the object's status is 'completed' and the Below the fold value is not empty or '[]', false otherwise.
 	 */
 	public function has_lrc() {
 		if ( 'completed' !== $this->status ) {
@@ -103,7 +103,7 @@ class LazyRenderContent extends Row {
 			return false;
 		}
 
-		if ( 'not found' === $this->below_the_fold ) {
+		if ( '[]' === $this->below_the_fold ) {
 			return false;
 		}
 

--- a/inc/Engine/Optimization/LazyRenderContent/Frontend/Controller.php
+++ b/inc/Engine/Optimization/LazyRenderContent/Frontend/Controller.php
@@ -42,15 +42,14 @@ class Controller implements ControllerInterface {
 	 * @return string
 	 */
 	public function optimize( string $html, $row ): string {
-		$html_without_hashes = $this->remove_hashes( $html );
 		if ( ! $row->has_lrc() ) {
-			return $html_without_hashes;
+			return $this->remove_hashes( $html );
 		}
 
 		$hashes = json_decode( $row->below_the_fold );
 
-		if ( null === $hashes || ! is_array( $hashes ) ) {
-			return $html_without_hashes;
+		if ( ! is_array( $hashes ) ) {
+			return $this->remove_hashes( $html );
 		}
 
 		$result = preg_replace( '/data-rocket-location-hash="(?:' . implode( '|', $hashes ) . ')"/i', 'data-wpr-lazyrender="1"', $html, -1, $count );
@@ -60,7 +59,7 @@ class Controller implements ControllerInterface {
 			||
 			0 === $count
 		) {
-			return $html_without_hashes;
+			return $this->remove_hashes( $html );
 		}
 
 		$html = $result;

--- a/inc/Engine/Optimization/LazyRenderContent/Frontend/Controller.php
+++ b/inc/Engine/Optimization/LazyRenderContent/Frontend/Controller.php
@@ -42,14 +42,15 @@ class Controller implements ControllerInterface {
 	 * @return string
 	 */
 	public function optimize( string $html, $row ): string {
+		$html_without_hashes = $this->remove_hashes( $html );
 		if ( ! $row->has_lrc() ) {
-			return $html;
+			return $html_without_hashes;
 		}
 
 		$hashes = json_decode( $row->below_the_fold );
 
 		if ( null === $hashes || ! is_array( $hashes ) ) {
-			return $html;
+			return $html_without_hashes;
 		}
 
 		$result = preg_replace( '/data-rocket-location-hash="(?:' . implode( '|', $hashes ) . ')"/i', 'data-wpr-lazyrender="1"', $html, -1, $count );
@@ -59,7 +60,7 @@ class Controller implements ControllerInterface {
 			||
 			0 === $count
 		) {
-			return $html;
+			return $html_without_hashes;
 		}
 
 		$html = $result;

--- a/tests/Fixtures/inc/Engine/Optimization/LazyRenderContent/Frontend/Controller/optimize.php
+++ b/tests/Fixtures/inc/Engine/Optimization/LazyRenderContent/Frontend/Controller/optimize.php
@@ -46,4 +46,12 @@ return [
 		'html'     => $single_line_hashed,
 		'expected' => $single_line_expected,
 	],
+	'testShouldReturnEarlyWhenDBHasEmptyArray' => [
+		'config'   => [
+			'has_lrc' => true,
+			'below_the_fold' => '[]',
+		],
+		'html'     => '<html><head></head><body><div data-rocket-location-hash="adc285f638b63c4110da1d803b711c40">hello here</div></body></html>',
+		'expected' => '<html><head></head><body><div >hello here</div></body></html>',
+	],
 ];


### PR DESCRIPTION
# Description
Hashes should be removed when visiting uncached page that have [] LRC in DB

Fixes #6922


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).


## Detailed scenario
Please check #6922 for detailed scenario.

## Technical description
Update`has_lrc` method in LazyRenderContent database row to check for `'[]'` instead of 'not found' which doesn't exist in db records and updated the `optimize` method to return html without hashes when the logic checks passed.
  
### Documentation

Hashes should be removed when visiting uncached page that have [] LRC in DB


# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I did not introduce unnecessary complexity.
