### PR TITLE
Closes #6943 Change the way the description for the Clear button is displayed

### DIFF
--- a/inc/Engine/Admin/Settings/AdminBarMenuTrait.php
+++ b/inc/Engine/Admin/Settings/AdminBarMenuTrait.php
@@ -111,20 +111,20 @@ trait AdminBarMenuTrait {
 	 * @param string $title The button title.
 	 * @param string $label Button label.
 	 * @param string $action Button action.
-	 * @param string $hover_text Button Hover text.
+	 * @param string $description Button description text.
 	 *
 	 * @return void
 	 */
-	public function dashboard_button( bool $context, string $title, string $label, string $action, string $hover_text = '' ): void {
+	public function dashboard_button( bool $context, string $title, string $label, string $action, string $description = '' ): void {
 		if ( ! $context ) {
 			return;
 		}
 
 		$data = [
-			'action'     => $action,
-			'title'      => $title,
-			'label'      => $label,
-			'hover_text' => $hover_text,
+			'action'      => $action,
+			'title'       => $title,
+			'label'       => $label,
+			'description' => $description,
 		];
 
 		echo $this->generate( 'sections/clean-section', $data ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/tests/Fixtures/inc/Engine/Admin/Settings/Settings/displayDashboardButton.php
+++ b/tests/Fixtures/inc/Engine/Admin/Settings/Settings/displayDashboardButton.php
@@ -1,9 +1,9 @@
 <?php
 
 return [
-	'shouldOutputLinkButton' => [
+	'shouldOutputLinkButtonWithDescription' => [
 		'config'   => [
-			'title_attr_text' => 'Title text',
+			'description'     => 'Short description for button',
 			'environment'     => 'production',
 			'label'           => 'Button label',
 			'action'          => 'menu-action',
@@ -13,40 +13,41 @@ return [
 		'expected' => <<<HTML
 <div class="wpr-field">
 	<h4 class="wpr-title3">Button label</h4>
-	<a href="" class="wpr-button wpr-button--icon wpr-button--small wpr-icon-trash" title="Title text">Menu title</a>
+	<p>Short description for button</p>
+	<a href="" class="wpr-button wpr-button--icon wpr-button--small wpr-icon-trash">Menu title</a>
 </div>
 HTML
 	],
 	'shouldOutputEmptyWhenContextIsFalse' => [
 		'config'   => [
-			'title_attr_text' => 'Title text',
-			'environment'     => 'production',
-			'label'           => 'Button label',
-			'action'          => 'menu-action',
-			'title'           => 'Menu title',
-			'context'         => false,
+			'description' => 'Title text',
+			'environment' => 'production',
+			'label'       => 'Button label',
+			'action'      => 'menu-action',
+			'title'       => 'Menu title',
+			'context'     => false,
 		],
 		'expected' => null
 	],
 	'shouldOutputEmptyWhenEnvironmentIsLocal' => [
 		'config'   => [
-			'title_attr_text' => 'Title text',
-			'environment'     => 'local',
-			'label'           => 'Button label',
-			'action'          => 'menu-action',
-			'title'           => 'Menu title',
-			'context'         => false,
+			'description' => 'Title text',
+			'environment' => 'local',
+			'label'       => 'Button label',
+			'action'      => 'menu-action',
+			'title'       => 'Menu title',
+			'context'     => false,
 		],
 		'expected' => null
 	],
-	'shouldOutputLinkButtonWithoutLinkTitleAttribute' => [
+	'shouldOutputLinkButtonWithoutLinkDescription' => [
 		'config'   => [
-			'title_attr_text' => '',
-			'environment'     => 'production',
-			'label'           => 'label',
-			'action'          => 'menu-action',
-			'title'           => 'Title',
-			'context'         => true,
+			'description' => '',
+			'environment' => 'production',
+			'label'       => 'label',
+			'action'      => 'menu-action',
+			'title'       => 'Title',
+			'context'     => true,
 		],
 		'expected' => <<<HTML
 <div class="wpr-field">

--- a/tests/Unit/inc/Engine/Admin/Settings/Settings/displayDashboardButton.php
+++ b/tests/Unit/inc/Engine/Admin/Settings/Settings/displayDashboardButton.php
@@ -45,7 +45,7 @@ class Test_DisplayDashboardButton extends TestCase {
 			'title' => $config['title'],
 			'action' => $config['action'],
 			'label' => $config['label'],
-			'hover_text' => $config['title_attr_text']
+			'description' => $config['description']
 		];
 
 		if ( null !== $expected ) {
@@ -61,7 +61,7 @@ class Test_DisplayDashboardButton extends TestCase {
 			$config['title'],
 			$config['label'],
 			$config['action'],
-			$config['title_attr_text']
+			$config['description']
 		);
 		$output = ob_get_clean();
 

--- a/views/settings/sections/clean-section.php
+++ b/views/settings/sections/clean-section.php
@@ -15,6 +15,9 @@ defined( 'ABSPATH' ) || exit;
 ?>
 <div class="wpr-field">
 	<h4 class="wpr-title3"><?php echo esc_html( $data['title'] ); ?></h4>
+	<?php if ( ! empty( $data['description'] ) ) { ?>
+		<p><?php echo esc_html( $data['description'] ); ?></p>
+	<?php } ?>
 	<?php
 	$this->render_action_button(
 			'link',
@@ -23,7 +26,6 @@ defined( 'ABSPATH' ) || exit;
 				'label'      => $data['label'],
 				'attributes' => [
 					'class' => 'wpr-button wpr-button--icon wpr-button--no-min-width wpr-button--small wpr-icon-trash',
-					'title' => $data['hover_text'],
 				],
 			]
 	);


### PR DESCRIPTION
# Description

Fixes #6943 
Moved the text from the hover section of the Clear button to above it.

## Type of change
- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario
Please check #6943 for detailed scenario.

## Technical description

### Documentation

Add text description to generate button file.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I did not introduce unnecessary complexity.
