### PR TITLE
Update LRC filters prefix

### DIFF
--- a/inc/Engine/Optimization/LazyRenderContent/Context/Context.php
+++ b/inc/Engine/Optimization/LazyRenderContent/Context/Context.php
@@ -22,6 +22,6 @@ class Context implements ContextInterface {
 		 *
 		 * @param bool $allow True to allow, false otherwise.
 		 */
-		return wpm_apply_filters_typed( 'boolean', 'rocket_lazy_render_content_optimization', true );
+		return wpm_apply_filters_typed( 'boolean', 'rocket_lrc_optimization', true );
 	}
 }

--- a/inc/Engine/Optimization/LazyRenderContent/Frontend/Processor/HelperTrait.php
+++ b/inc/Engine/Optimization/LazyRenderContent/Frontend/Processor/HelperTrait.php
@@ -13,11 +13,11 @@ trait HelperTrait {
 	protected function get_depth() {
 		/**
 		 * Filter the depth integer value.
-		 * The actual applied depth in the source is the default + 1 after the body or rocket_lazy_render_content_depth+1 after the body if the filter is set
+		 * The actual applied depth in the source is the default + 1 after the body or rocket_lrc_depth+1 after the body if the filter is set
 		 *
 		 * @param int $depth Depth value.
 		 */
-		return wpm_apply_filters_typed( 'integer', 'rocket_lazy_render_content_depth', 2 );
+		return wpm_apply_filters_typed( 'integer', 'rocket_lrc_depth', 2 );
 	}
 
 	/**
@@ -33,7 +33,7 @@ trait HelperTrait {
 		 */
 		return wpm_apply_filters_typed(
 			'array',
-			'rocket_lazy_render_content_processed_tags',
+			'rocket_lrc_processed_tags',
 			[
 				'DIV',
 				'MAIN',

--- a/tests/Integration/bootstrap.php
+++ b/tests/Integration/bootstrap.php
@@ -19,7 +19,7 @@ tests_add_filter(
 
 		// Disable ATF & LRC optimizations to prevent DB requests (unrelated to other tests).
 		add_filter( 'rocket_above_the_fold_optimization', '__return_false' );
-		add_filter( 'rocket_lazy_render_content_optimization', '__return_false' );
+		add_filter( 'rocket_lrc_optimization', '__return_false' );
 
 		if ( BootstrapManager::isGroup( 'TranslatePress' ) ) {
 			require WP_ROCKET_TESTS_FIXTURES_DIR . '/classes/TRP_Translate_Press.php';
@@ -265,7 +265,7 @@ tests_add_filter(
 
 		if ( BootstrapManager::isGroup( 'PerformanceHints' ) ) {
 			add_filter( 'rocket_above_the_fold_optimization', '__return_true' );
-			add_filter( 'rocket_lazy_render_content_optimization', '__return_true' );
+			add_filter( 'rocket_lrc_optimization', '__return_true' );
 		}
 
 		// Load the plugin.

--- a/tests/Integration/inc/Engine/Optimization/LazyRenderContent/Frontend/Filter/lrcProcessedTagsFilter.php
+++ b/tests/Integration/inc/Engine/Optimization/LazyRenderContent/Frontend/Filter/lrcProcessedTagsFilter.php
@@ -14,7 +14,7 @@ use ReflectionClass;
 class Test_lrcProcessedTagsFilter extends TestCase
 {
 	public function testShouldReturnAsExpected() {
-		add_filter( 'rocket_lazy_render_content_processed_tags', function( $tags ) {
+		add_filter( 'rocket_lrc_processed_tags', function( $tags ) {
 			$tags[]= 'h2';
 			$tags[]= 'h1';
 			$tags[]= 'li';

--- a/tests/Integration/inc/Engine/Optimization/LazyRenderContent/Frontend/Subscriber/add_hashes.php
+++ b/tests/Integration/inc/Engine/Optimization/LazyRenderContent/Frontend/Subscriber/add_hashes.php
@@ -33,7 +33,7 @@ class Test_add_hashes extends TestCase
 	public function tear_down()
 	{
 		$this->restoreWpHook('rocket_critical_image_saas_visit_buffer');
-		remove_filter( 'rocket_lazy_render_content_optimization', '__return_false' );
+		remove_filter( 'rocket_lrc_optimization', '__return_false' );
 
 		parent::tear_down();
 	}
@@ -44,7 +44,7 @@ class Test_add_hashes extends TestCase
 	public function testShouldWorkAsExpected( $config, $expected ) {
 		self::addLrc($config['row']);
 
-		add_filter( 'rocket_lazy_render_content_optimization', '__return_true' );
+		add_filter( 'rocket_lrc_optimization', '__return_true' );
 
 		$this->assertSame(
 			$expected['html'],

--- a/tests/Unit/inc/Engine/Optimization/LazyRenderContent/Context/Context/isAllowed.php
+++ b/tests/Unit/inc/Engine/Optimization/LazyRenderContent/Context/Context/isAllowed.php
@@ -24,7 +24,7 @@ class TestIsAllowed extends TestCase {
 	 */
 	public function testShouldReturnExpected( $config, $expected ) {
 		Functions\when( 'get_option' )->justReturn( $config['licence'] );
-		Filters\expectApplied( 'rocket_lazy_render_content_optimization' )
+		Filters\expectApplied( 'rocket_lrc_optimization' )
 			->andReturn( $config['filter'] );
 
 		$this->assertSame(


### PR DESCRIPTION
# Description

Standardize the prefix for LRC filters from `rocket_lazy_render_content_`  to `rocket_lrc_`.

## Type of change

- [x] Sub-task of #3843 

## Detailed scenario

The new filters directly replace the old one with no deprecation since it was not publicly released.

## Technical description

### Documentation

For consistancy, renaming the LRC filters so they all use the same prefix.

# Mandatory Checklist

## Code validation

- [x] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.