### PR TITLE
Fixes #6948 -- rocket_lrc_processed_tags should be case insensitive

### DIFF
--- a/inc/Engine/Optimization/LazyRenderContent/Frontend/Processor/HelperTrait.php
+++ b/inc/Engine/Optimization/LazyRenderContent/Frontend/Processor/HelperTrait.php
@@ -31,7 +31,7 @@ trait HelperTrait {
 		 *
 		 * @param array|string[] $tags Tags to be processed.
 		 */
-		return wpm_apply_filters_typed(
+		$tags = wpm_apply_filters_typed(
 			'array',
 			'rocket_lazy_render_content_processed_tags',
 			[
@@ -43,5 +43,10 @@ trait HelperTrait {
 				'HEADER',
 			]
 		);
+
+		/**
+		 * Convert tags to upper case here before
+		 */
+		return array_map( 'strtoupper', $tags );
 	}
 }

--- a/tests/Integration/inc/Engine/Optimization/LazyRenderContent/Frontend/Filter/lrcProcessedTagsFilter.php
+++ b/tests/Integration/inc/Engine/Optimization/LazyRenderContent/Frontend/Filter/lrcProcessedTagsFilter.php
@@ -1,0 +1,36 @@
+<?php
+namespace WP_Rocket\Tests\Integration\inc\Engine\Optimization\LazyRenderContent\Frontend\Filter;
+
+use WP_Rocket\Engine\Optimization\LazyRenderContent\Frontend\Processor\Dom;
+use WP_Rocket\Engine\Optimization\LazyRenderContent\Frontend\Processor\HelperTrait;
+use WP_Rocket\Tests\Integration\TestCase;
+use ReflectionClass;
+
+/**
+ * Test class covering \WP_Rocket\Engine\Optimization\LazyRenderContent\Frontend\ProcessorHelperTrait::get_processed_tags()
+ *
+ * @group PerformanceHints
+ */
+class Test_lrcProcessedTagsFilter extends TestCase
+{
+	public function testShouldReturnAsExpected() {
+		add_filter( 'rocket_lazy_render_content_processed_tags', function( $tags ) {
+			$tags[]= 'h2';
+			$tags[]= 'h1';
+			$tags[]= 'li';
+
+			return $tags;
+		});
+
+		$dom      = new Dom();
+		$instance = new ReflectionClass( $dom );
+		$method   = $instance->getMethod( 'get_processed_tags' );
+
+		$method->setAccessible(true);
+		$result = $method->invoke( $dom );
+
+		$expected = [ 'DIV', 'MAIN', 'FOOTER', 'SECTION', 'ARTICLE', 'HEADER', 'H2', 'H1', 'LI' ];
+
+		$this->assertSame( $expected, $result );
+	}
+}


### PR DESCRIPTION
# Description
Make filter value case insensitive

Fixes #6948 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue).


## Detailed scenario
Check #6948 for scenario

## Technical description
Convert filter values to upper case in `get_processed_tags` method.
### Documentation
Make sure filter value are case insensitive.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I did not introduce unnecessary complexity.
