### PR TITLE
Closes #6946 Ignore PHPstan error related to require

### DIFF
--- a/inc/Engine/Admin/Settings/Render.php
+++ b/inc/Engine/Admin/Settings/Render.php
@@ -131,6 +131,7 @@ class Render extends Abstract_render {
 	 */
 	public function render_imagify_section() {
 
+		// @phpstan-ignore-next-line
 		require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
 
 		$plugin_data = get_transient( 'rocket_imagify_plugin_data' );

--- a/inc/Engine/Plugin/UpdaterSubscriber.php
+++ b/inc/Engine/Plugin/UpdaterSubscriber.php
@@ -470,6 +470,7 @@ class UpdaterSubscriber implements Event_Manager_Aware_Subscriber_Interface {
 
 		set_site_transient( 'update_plugins', $plugin_transient );
 
+		// @phpstan-ignore-next-line
 		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 
 		// translators: %s is the plugin name.


### PR DESCRIPTION
# Description

Fixes #6946

Ignore the new PHPStan error from 1.12.1 related to require

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

The error is reported in 2 places by PHPStan where we require files from WordPress.

## Technical description

### Documentation

Following the discussion on https://github.com/szepeviktor/phpstan-wordpress/issues/239, the best approach seems to be to ignore the error in a case by case basis.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I did not introduce unnecessary complexity.