### PR TITLE
Closes #6460 Maybe optimize lookups of tables in DB to stop using SHOW TABLES LIKE

### DIFF
--- a/inc/Engine/Common/Database/Queries/AbstractQuery.php
+++ b/inc/Engine/Common/Database/Queries/AbstractQuery.php
@@ -520,9 +520,8 @@ class AbstractQuery extends Query {
 		}
 
 		// Query statement.
-		$query    = 'SHOW TABLES LIKE %s';
-		$like     = $db->esc_like( $db->{$this->table_name} );
-		$prepared = $db->prepare( $query, $like );
+		$query    = 'SELECT table_name FROM information_schema.tables WHERE table_name = %s LIMIT 1';
+		$prepared = $db->prepare( $query, $this->table_name );
 		$result   = $db->get_var( $prepared );
 
 		// Does the table exist?

--- a/inc/Engine/Common/Database/Queries/AbstractQuery.php
+++ b/inc/Engine/Common/Database/Queries/AbstractQuery.php
@@ -521,7 +521,7 @@ class AbstractQuery extends Query {
 
 		// Query statement.
 		$query    = 'SELECT table_name FROM information_schema.tables WHERE table_name = %s LIMIT 1';
-		$prepared = $db->prepare( $query, $this->table_name );
+		$prepared = $db->prepare( $query, $db->{$this->table_name} );
 		$result   = $db->get_var( $prepared );
 
 		// Does the table exist?

--- a/inc/Engine/Common/PerformanceHints/Database/Queries/AbstractQueries.php
+++ b/inc/Engine/Common/PerformanceHints/Database/Queries/AbstractQueries.php
@@ -122,7 +122,7 @@ class AbstractQueries extends Query {
 
 		// Query statement.
 		$query    = 'SELECT table_name FROM information_schema.tables WHERE table_name = %s LIMIT 1';
-		$prepared = $db->prepare( $query, $this->table_name );
+		$prepared = $db->prepare( $query, $db->{$this->table_name} );
 		$result   = $db->get_var( $prepared );
 
 		// Does the table exist?

--- a/inc/Engine/Common/PerformanceHints/Database/Queries/AbstractQueries.php
+++ b/inc/Engine/Common/PerformanceHints/Database/Queries/AbstractQueries.php
@@ -121,9 +121,8 @@ class AbstractQueries extends Query {
 		}
 
 		// Query statement.
-		$query    = 'SHOW TABLES LIKE %s';
-		$like     = $db->esc_like( $db->{$this->table_name} );
-		$prepared = $db->prepare( $query, $like );
+		$query    = 'SELECT table_name FROM information_schema.tables WHERE table_name = %s LIMIT 1';
+		$prepared = $db->prepare( $query, $this->table_name );
 		$result   = $db->get_var( $prepared );
 
 		// Does the table exist?


### PR DESCRIPTION
# Description
Changed lookup table query.

Fixes #6460 


## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario
With a large site(mostly multisites), the query is run on every page loads and this slows down the page.
More information here https://wp-media.slack.com/archives/C43T1AYMQ/p1709561232039849

## Technical description
Changed the query from `show tables` to select with a limit of 1

### Documentation


# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
