### PR TITLE
Replace Lazy Render Content strings with Automatic Lazy Rendering

### DIFF
--- a/inc/Engine/Admin/Settings/Page.php
+++ b/inc/Engine/Admin/Settings/Page.php
@@ -2248,7 +2248,7 @@ class Page extends Abstract_Render {
 				'dismissible'    => '',
 				'message'        => sprintf(
 					// translators: %1$s: opening strong tag, %2$s: closing strong tag, %3$s: opening a tag, %4$s: opening a tag.
-					__( '%1$sWP Rocket:%2$s the plugin has been updated to the 3.17 version. New feature: %3$sLazy Render Content%4$s. Check out our documentation to learn more about it.', 'rocket' ),
+					__( '%1$sWP Rocket:%2$s the plugin has been updated to the 3.17 version. New feature: %3$sAutomatic Lazy Rendering%4$s. Check out our documentation to learn more about it.', 'rocket' ),
 					'<strong>',
 					'</strong>',
 					'<a href="' . esc_url( $lazy_render_content['url'] ) . '" data-beacon-article="' . esc_attr( $lazy_render_content['id'] ) . '" target="_blank" rel="noopener noreferrer">',

--- a/tests/Fixtures/inc/Engine/Admin/Settings/Page/displayUpdateNotice.php
+++ b/tests/Fixtures/inc/Engine/Admin/Settings/Page/displayUpdateNotice.php
@@ -91,7 +91,7 @@ return [
 		'expected' => [
 			'status'         => 'info',
 			'dismissible'    => '',
-			'message'        => '<strong>WP Rocket:</strong> the plugin has been updated to the 3.17 version. New feature: <a href="http://example.org" data-beacon-article="123" target="_blank" rel="noopener noreferrer">Lazy Render Content</a>. Check out our documentation to learn more about it.',
+			'message'        => '<strong>WP Rocket:</strong> the plugin has been updated to the 3.17 version. New feature: <a href="http://example.org" data-beacon-article="123" target="_blank" rel="noopener noreferrer">Automatic Lazy Rendering</a>. Check out our documentation to learn more about it.',
 			'dismiss_button' => 'rocket_update_notice',
 		],
 	],


### PR DESCRIPTION
# Description

Fixes #6974 

Here we replace `Lazy Render Content` string with `Automatic Lazy Rendering`

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

We only found that we use this string in one place as mentioned by @piotrbak and I can confirm that.

## Technical description

### Documentation

Nothing changed, just the string.

### New dependencies

No

### Risks

No

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)