### PR TITLE
Closes #6413 Remove tags from services

### DIFF
--- a/inc/Addon/Cloudflare/ServiceProvider.php
+++ b/inc/Addon/Cloudflare/ServiceProvider.php
@@ -58,8 +58,7 @@ class ServiceProvider extends AbstractServiceProvider {
 			->addArgument( $this->getContainer()->get( 'cloudflare' ) )
 			->addArgument( $options )
 			->addArgument( $this->getContainer()->get( 'options_api' ) )
-			->addArgument( $this->getContainer()->get( 'cloudflare_auth_factory' ) )
-			->addTag( 'cloudflare_subscriber' );
+			->addArgument( $this->getContainer()->get( 'cloudflare_auth_factory' ) );
 		$this->getContainer()->addShared(
 			'cloudflare_admin_subscriber',
 			CloudflareAdminSubscriber::class

--- a/inc/Addon/ServiceProvider.php
+++ b/inc/Addon/ServiceProvider.php
@@ -40,19 +40,16 @@ class ServiceProvider extends AbstractServiceProvider {
 
 		// Sucuri Addon.
 		$this->getContainer()->addShared( 'sucuri_subscriber', SucuriSubscriber::class )
-			->addArgument( $options )
-			->addTag( 'common_subscriber' );
+			->addArgument( $options );
 
 		$this->getContainer()->addShared( 'webp_admin_subscriber', WebPAdminSubscriber::class )
 			->addArgument( $options )
 			->addArgument( $this->getContainer()->get( 'cdn_subscriber' ) )
-			->addArgument( $this->getContainer()->get( 'beacon' ) )
-			->addTag( 'common_subscriber' );
+			->addArgument( $this->getContainer()->get( 'beacon' ) );
 
 		$this->getContainer()->addShared( 'webp_subscriber', WebPSubscriber::class )
 			->addArgument( $options )
 			->addArgument( $this->getContainer()->get( 'options_api' ) )
-			->addArgument( $this->getContainer()->get( 'cdn_subscriber' ) )
-			->addTag( 'common_subscriber' );
+			->addArgument( $this->getContainer()->get( 'cdn_subscriber' ) );
 	}
 }

--- a/inc/Addon/Varnish/ServiceProvider.php
+++ b/inc/Addon/Varnish/ServiceProvider.php
@@ -37,7 +37,6 @@ class ServiceProvider extends AbstractServiceProvider {
 		$this->getContainer()->add( 'varnish', Varnish::class );
 		$this->getContainer()->addShared( 'varnish_subscriber', Subscriber::class )
 			->addArgument( $this->getContainer()->get( 'varnish' ) )
-			->addArgument( $this->getContainer()->get( 'options' ) )
-			->addTag( 'common_subscriber' );
+			->addArgument( $this->getContainer()->get( 'options' ) );
 	}
 }

--- a/inc/Engine/Admin/Beacon/ServiceProvider.php
+++ b/inc/Engine/Admin/Beacon/ServiceProvider.php
@@ -36,7 +36,6 @@ class ServiceProvider extends AbstractServiceProvider {
 		$this->getContainer()->addShared( 'beacon', Beacon::class )
 			->addArgument( $this->getContainer()->get( 'options' ) )
 			->addArgument( $this->getContainer()->get( 'template_path' ) . '/settings' )
-			->addArgument( $this->getContainer()->get( 'support_data' ) )
-			->addTag( 'admin_subscriber' );
+			->addArgument( $this->getContainer()->get( 'support_data' ) );
 	}
 }

--- a/inc/Engine/Admin/Database/ServiceProvider.php
+++ b/inc/Engine/Admin/Database/ServiceProvider.php
@@ -40,7 +40,6 @@ class ServiceProvider extends AbstractServiceProvider {
 			->addArgument( $this->getContainer()->get( 'db_optimization_process' ) );
 		$this->getContainer()->addShared( 'db_optimization_subscriber', Subscriber::class )
 			->addArgument( $this->getContainer()->get( 'db_optimization' ) )
-			->addArgument( $this->getContainer()->get( 'options' ) )
-			->addTag( 'common_subscriber' );
+			->addArgument( $this->getContainer()->get( 'options' ) );
 	}
 }

--- a/inc/Engine/Admin/ServiceProvider.php
+++ b/inc/Engine/Admin/ServiceProvider.php
@@ -47,15 +47,12 @@ class ServiceProvider extends AbstractServiceProvider {
 			->addArgument( $this->getContainer()->get( 'options_api' ) )
 			->addArgument( $options );
 		$this->getContainer()->addShared( 'deactivation_intent_subscriber', Subscriber::class )
-			->addArgument( $this->getContainer()->get( 'deactivation_intent' ) )
-			->addTag( 'admin_subscriber' );
+			->addArgument( $this->getContainer()->get( 'deactivation_intent' ) );
 		$this->getContainer()->addShared( 'hummingbird_subscriber', Hummingbird::class )
-			->addArgument( $options )
-			->addTag( 'admin_subscriber' );
+			->addArgument( $options );
 		$this->getContainer()->addShared( 'actionscheduler_admin_subscriber', ActionSchedulerSubscriber::class );
 		$this->getContainer()->addShared( 'post_edit_options_subscriber', PostEditOptionsSubscriber::class )
 			->addArgument( $options )
-			->addArgument( $this->getContainer()->get( 'template_path' ) . '/metaboxes' )
-			->addTag( 'admin_subscriber' );
+			->addArgument( $this->getContainer()->get( 'template_path' ) . '/metaboxes' );
 	}
 }

--- a/inc/Engine/Admin/Settings/ServiceProvider.php
+++ b/inc/Engine/Admin/Settings/ServiceProvider.php
@@ -51,7 +51,6 @@ class ServiceProvider extends AbstractServiceProvider {
 			->addArgument( $this->getContainer()->get( 'template_path' ) )
 			->addArgument( $this->getContainer()->get( 'options' ) );
 		$this->getContainer()->addShared( 'settings_page_subscriber', Subscriber::class )
-			->addArgument( $this->getContainer()->get( 'settings_page' ) )
-			->addTag( 'admin_subscriber' );
+			->addArgument( $this->getContainer()->get( 'settings_page' ) );
 	}
 }

--- a/inc/Engine/CDN/RocketCDN/ServiceProvider.php
+++ b/inc/Engine/CDN/RocketCDN/ServiceProvider.php
@@ -48,25 +48,21 @@ class ServiceProvider extends AbstractServiceProvider {
 		// RocketCDN Data manager subscriber.
 		$this->getContainer()->addShared( 'rocketcdn_data_manager_subscriber', DataManagerSubscriber::class )
 			->addArgument( $this->getContainer()->get( 'rocketcdn_api_client' ) )
-			->addArgument( $this->getContainer()->get( 'rocketcdn_options_manager' ) )
-			->addTag( 'admin_subscriber' );
+			->addArgument( $this->getContainer()->get( 'rocketcdn_options_manager' ) );
 		// RocketCDN REST API Subscriber.
 		$this->getContainer()->addShared( 'rocketcdn_rest_subscriber', RESTSubscriber::class )
 			->addArgument( $this->getContainer()->get( 'rocketcdn_options_manager' ) )
-			->addArgument( $options )
-			->addTag( 'common_subscriber' );
+			->addArgument( $options );
 		// RocketCDN Notices Subscriber.
 		$this->getContainer()->addShared( 'rocketcdn_notices_subscriber', NoticesSubscriber::class )
 			->addArgument( $this->getContainer()->get( 'rocketcdn_api_client' ) )
 			->addArgument( $this->getContainer()->get( 'beacon' ) )
-			->addArgument( __DIR__ . '/views' )
-			->addTag( 'admin_subscriber' );
+			->addArgument( __DIR__ . '/views' );
 		// RocketCDN settings page subscriber.
 		$this->getContainer()->addShared( 'rocketcdn_admin_subscriber', AdminPageSubscriber::class )
 			->addArgument( $this->getContainer()->get( 'rocketcdn_api_client' ) )
 			->addArgument( $options )
 			->addArgument( $this->getContainer()->get( 'beacon' ) )
-			->addArgument( __DIR__ . '/views' )
-			->addTag( 'admin_subscriber' );
+			->addArgument( __DIR__ . '/views' );
 	}
 }

--- a/inc/Engine/CDN/ServiceProvider.php
+++ b/inc/Engine/CDN/ServiceProvider.php
@@ -42,9 +42,7 @@ class ServiceProvider extends AbstractServiceProvider {
 			->addArgument( $options );
 		$this->getContainer()->addShared( 'cdn_subscriber', Subscriber::class )
 			->addArgument( $options )
-			->addArgument( $this->getContainer()->get( 'cdn' ) )
-			->addTag( 'common_subscriber' );
-		$this->getContainer()->addShared( 'cdn_admin_subscriber', AdminSubscriber::class )
-		->addTag( 'admin_subscriber' );
+			->addArgument( $this->getContainer()->get( 'cdn' ) );
+		$this->getContainer()->addShared( 'cdn_admin_subscriber', AdminSubscriber::class );
 	}
 }

--- a/inc/Engine/Cache/ServiceProvider.php
+++ b/inc/Engine/Cache/ServiceProvider.php
@@ -62,22 +62,18 @@ class ServiceProvider extends AbstractServiceProvider {
 			->addArgument( $cache_query );
 		$this->getContainer()->addShared( 'purge_actions_subscriber', PurgeActionsSubscriber::class )
 			->addArgument( $this->getContainer()->get( 'options' ) )
-			->addArgument( $this->getContainer()->get( 'purge' ) )
-			->addTag( 'common_subscriber' );
+			->addArgument( $this->getContainer()->get( 'purge' ) );
 		$this->getContainer()->addShared( 'admin_cache_subscriber', AdminSubscriber::class )
 			->addArgument( $this->getContainer()->get( 'advanced_cache' ) )
-			->addArgument( $this->getContainer()->get( 'wp_cache' ) )
-			->addTag( 'admin_subscriber' );
+			->addArgument( $this->getContainer()->get( 'wp_cache' ) );
 
 		$this->getContainer()->add( 'expired_cache_purge', PurgeExpiredCache::class )
 			->addArgument( rocket_get_constant( 'WP_ROCKET_CACHE_PATH' ) );
 		$this->getContainer()->addShared( 'expired_cache_purge_subscriber', Subscriber::class )
 			->addArgument( $this->getContainer()->get( 'options' ) )
-			->addArgument( $this->getContainer()->get( 'expired_cache_purge' ) )
-			->addTag( 'common_subscriber' );
+			->addArgument( $this->getContainer()->get( 'expired_cache_purge' ) );
 		$this->getContainer()->add( 'cache_config', ConfigSubscriber::class )
 			->addArgument( $this->getContainer()->get( 'options' ) )
-			->addArgument( $this->getContainer()->get( 'options_api' ) )
-			->addTag( 'common_subscriber' );
+			->addArgument( $this->getContainer()->get( 'options_api' ) );
 	}
 }

--- a/inc/Engine/Capabilities/ServiceProvider.php
+++ b/inc/Engine/Capabilities/ServiceProvider.php
@@ -36,7 +36,6 @@ class ServiceProvider extends AbstractServiceProvider {
 	public function register(): void {
 		$this->getContainer()->add( 'capabilities_manager', Manager::class );
 		$this->getContainer()->addShared( 'capabilities_subscriber', Subscriber::class )
-			->addArgument( $this->getContainer()->get( 'capabilities_manager' ) )
-			->addTag( 'common_subscriber' );
+			->addArgument( $this->getContainer()->get( 'capabilities_manager' ) );
 	}
 }

--- a/inc/Engine/CriticalPath/ServiceProvider.php
+++ b/inc/Engine/CriticalPath/ServiceProvider.php
@@ -67,8 +67,7 @@ class ServiceProvider extends AbstractServiceProvider {
 			->addArgument( $processor_service )
 			->addArgument( $options );
 		$this->getContainer()->addShared( 'rest_cpcss_subscriber', RESTCSSSubscriber::class )
-			->addArgument( $this->getContainer()->get( 'rest_cpcss_wp_post' ) )
-			->addTag( 'common_subscriber' );
+			->addArgument( $this->getContainer()->get( 'rest_cpcss_wp_post' ) );
 		// REST CPCSS END.
 
 		$this->getContainer()->add( 'critical_css_generation', CriticalCSSGeneration::class )
@@ -86,8 +85,7 @@ class ServiceProvider extends AbstractServiceProvider {
 			->addArgument( $options )
 			->addArgument( $this->getContainer()->get( 'options_api' ) )
 			->addArgument( $this->getContainer()->get( 'user' ) )
-			->addArgument( $filesystem )
-			->addTag( 'common_subscriber' );
+			->addArgument( $filesystem );
 
 		$this->getContainer()->add( 'cpcss_post',  Post::class )
 			->addArgument( $options )
@@ -105,7 +103,6 @@ class ServiceProvider extends AbstractServiceProvider {
 		$this->getContainer()->addShared( 'critical_css_admin_subscriber', Subscriber::class )
 			->addArgument( $this->getContainer()->get( 'cpcss_post' ) )
 			->addArgument( $this->getContainer()->get( 'cpcss_settings' ) )
-			->addArgument( $this->getContainer()->get( 'cpcss_admin' ) )
-			->addTag( 'admin_subscriber' );
+			->addArgument( $this->getContainer()->get( 'cpcss_admin' ) );
 	}
 }

--- a/inc/Engine/Deactivation/ServiceProvider.php
+++ b/inc/Engine/Deactivation/ServiceProvider.php
@@ -56,8 +56,7 @@ class ServiceProvider extends AbstractServiceProvider implements BootableService
 			->addArgument( $this->getContainer()->get( 'options' ) )
 			->addArgument( $this->getContainer()->get( 'options_api' ) )
 			->addArgument( $this->getContainer()->get( 'beacon' ) )
-			->addArgument( $this->getContainer()->get( 'cloudflare_plugin_facade' ) )
-			->addTag( 'common_subscriber' );
+			->addArgument( $this->getContainer()->get( 'cloudflare_plugin_facade' ) );
 
 		$this->getContainer()->add( 'advanced_cache', AdvancedCache::class )
 			->addArgument( $this->getContainer()->get( 'template_path' ) . '/cache/' )

--- a/inc/Engine/HealthCheck/ServiceProvider.php
+++ b/inc/Engine/HealthCheck/ServiceProvider.php
@@ -35,9 +35,7 @@ class ServiceProvider extends AbstractServiceProvider {
 	 */
 	public function register(): void {
 		$this->getContainer()->addShared( 'health_check', HealthCheck::class )
-			->addArgument( $this->getContainer()->get( 'options' ) )
-			->addTag( 'admin_subscriber' );
-		$this->getContainer()->addShared( 'action_scheduler_check', ActionSchedulerCheck::class )
-			->addTag( 'common_subscriber' );
+			->addArgument( $this->getContainer()->get( 'options' ) );
+		$this->getContainer()->addShared( 'action_scheduler_check', ActionSchedulerCheck::class );
 	}
 }

--- a/inc/Engine/Heartbeat/ServiceProvider.php
+++ b/inc/Engine/Heartbeat/ServiceProvider.php
@@ -34,7 +34,6 @@ class ServiceProvider extends AbstractServiceProvider {
 	 */
 	public function register(): void {
 		$this->getContainer()->addShared( 'heartbeat_subscriber', HeartbeatSubscriber::class )
-			->addArgument( $this->getContainer()->get( 'options' ) )
-			->addTag( 'common_subscriber' );
+			->addArgument( $this->getContainer()->get( 'options' ) );
 	}
 }

--- a/inc/Engine/License/ServiceProvider.php
+++ b/inc/Engine/License/ServiceProvider.php
@@ -62,7 +62,6 @@ class ServiceProvider extends AbstractServiceProvider {
 			->addArgument( $views );
 		$this->getContainer()->addShared( 'license_subscriber', Subscriber::class )
 			->addArgument( $this->getContainer()->get( 'upgrade' ) )
-			->addArgument( $this->getContainer()->get( 'renewal' ) )
-			->addTag( 'admin_subscriber' );
+			->addArgument( $this->getContainer()->get( 'renewal' ) );
 	}
 }

--- a/inc/Engine/Media/ServiceProvider.php
+++ b/inc/Engine/Media/ServiceProvider.php
@@ -70,21 +70,16 @@ class ServiceProvider extends AbstractServiceProvider {
 			->addArgument( $options )
 			->addArgument( $this->getContainer()->get( 'lazyload_assets' ) )
 			->addArgument( $this->getContainer()->get( 'lazyload_image' ) )
-			->addArgument( $this->getContainer()->get( 'lazyload_iframe' ) )
-			->addTag( 'lazyload_subscriber' );
-		$this->getContainer()->addShared( 'lazyload_admin_subscriber', LazyloadAdminSubscriber::class )
-			->addTag( 'admin_subscriber' );
+			->addArgument( $this->getContainer()->get( 'lazyload_iframe' ) );
+		$this->getContainer()->addShared( 'lazyload_admin_subscriber', LazyloadAdminSubscriber::class );
 		$this->getContainer()->addShared( 'emojis_subscriber', EmojisSubscriber::class )
-			->addArgument( $options )
-			->addTag( 'front_subscriber' );
+			->addArgument( $options );
 		$this->getContainer()->add( 'image_dimensions', ImageDimensions::class )
 			->addArgument( $options );
 		$this->getContainer()->addShared( 'image_dimensions_subscriber', ImageDimensionsSubscriber::class )
 			->addArgument( $this->getContainer()->get( 'image_dimensions' ) )
-			->addArgument( $this->getContainer()->get( 'tests' ) )
-			->addTag( 'front_subscriber' );
+			->addArgument( $this->getContainer()->get( 'tests' ) );
 		$this->getContainer()->addShared( 'image_dimensions_admin_subscriber', ImageDimensionsAdminSubscriber::class )
-			->addArgument( $this->getContainer()->get( 'image_dimensions' ) )
-			->addTag( 'admin_subscriber' );
+			->addArgument( $this->getContainer()->get( 'image_dimensions' ) );
 	}
 }

--- a/inc/Engine/Optimization/AdminServiceProvider.php
+++ b/inc/Engine/Optimization/AdminServiceProvider.php
@@ -36,17 +36,14 @@ class AdminServiceProvider extends AbstractServiceProvider {
 	 * @return void
 	 */
 	public function register(): void {
-		$this->getContainer()->addShared( 'minify_css_admin_subscriber', 'WP_Rocket\Engine\Optimization\Minify\CSS\AdminSubscriber' )
-			->addTag( 'admin_subscriber' );
+		$this->getContainer()->addShared( 'minify_css_admin_subscriber', 'WP_Rocket\Engine\Optimization\Minify\CSS\AdminSubscriber' );
 		$this->getContainer()->add( 'google_fonts_settings', 'WP_Rocket\Engine\Optimization\GoogleFonts\Admin\Settings' )
 			->addArgument( $this->getContainer()->get( 'options' ) )
 			->addArgument( $this->getContainer()->get( 'beacon' ) )
 			->addArgument( $this->getContainer()->get( 'template_path' ) );
 		$this->getContainer()->addShared( 'google_fonts_admin_subscriber', 'WP_Rocket\Engine\Optimization\GoogleFonts\Admin\Subscriber' )
-			->addArgument( $this->getContainer()->get( 'google_fonts_settings' ) )
-			->addTag( 'admin_subscriber' );
+			->addArgument( $this->getContainer()->get( 'google_fonts_settings' ) );
 		$this->getContainer()->addShared( 'minify_admin_subscriber', 'WP_Rocket\Engine\Optimization\Minify\AdminSubscriber' )
-			->addTag( 'admin_subscriber' )
 			->addArgument( $this->getContainer()->get( 'options' ) );
 	}
 }

--- a/inc/Engine/Optimization/DeferJS/ServiceProvider.php
+++ b/inc/Engine/Optimization/DeferJS/ServiceProvider.php
@@ -39,10 +39,8 @@ class ServiceProvider extends AbstractServiceProvider {
 			->addArgument( $this->getContainer()->get( 'options' ) )
 			->addArgument( $this->getContainer()->get( 'dynamic_lists_defaultlists_data_manager' ) );
 		$this->getContainer()->addShared( 'defer_js_admin_subscriber', AdminSubscriber::class )
-			->addArgument( $this->getContainer()->get( 'defer_js' ) )
-			->addTag( 'admin_subscriber' );
+			->addArgument( $this->getContainer()->get( 'defer_js' ) );
 		$this->getContainer()->addShared( 'defer_js_subscriber', Subscriber::class )
-			->addArgument( $this->getContainer()->get( 'defer_js' ) )
-			->addTag( 'front_subscriber' );
+			->addArgument( $this->getContainer()->get( 'defer_js' ) );
 	}
 }

--- a/inc/Engine/Optimization/DelayJS/ServiceProvider.php
+++ b/inc/Engine/Optimization/DelayJS/ServiceProvider.php
@@ -51,8 +51,7 @@ class ServiceProvider extends AbstractServiceProvider {
 			->addArgument( $this->getContainer()->get( 'options_api' ) );
 		$this->getContainer()->addShared( 'delay_js_admin_subscriber', AdminSubscriber::class )
 			->addArgument( $this->getContainer()->get( 'delay_js_settings' ) )
-			->addArgument( $this->getContainer()->get( 'delay_js_sitelist' ) )
-			->addTag( 'admin_subscriber' );
+			->addArgument( $this->getContainer()->get( 'delay_js_sitelist' ) );
 		$this->getContainer()->add( 'delay_js_html', HTML::class )
 			->addArgument( $this->getContainer()->get( 'options' ) )
 			->addArgument( $this->getContainer()->get( 'dynamic_lists_defaultlists_data_manager' ) )
@@ -60,7 +59,6 @@ class ServiceProvider extends AbstractServiceProvider {
 		$this->getContainer()->addShared( 'delay_js_subscriber', Subscriber::class )
 			->addArgument( $this->getContainer()->get( 'delay_js_html' ) )
 			->addArgument( rocket_direct_filesystem() )
-			->addArgument( $this->getContainer()->get( 'options' ) )
-			->addTag( 'front_subscriber' );
+			->addArgument( $this->getContainer()->get( 'options' ) );
 	}
 }

--- a/inc/Engine/Optimization/ServiceProvider.php
+++ b/inc/Engine/Optimization/ServiceProvider.php
@@ -50,29 +50,23 @@ class ServiceProvider extends AbstractServiceProvider {
 		$this->getContainer()->add( 'buffer_optimization', Optimization::class )
 			->addArgument( $this->getContainer()->get( 'tests' ) );
 		$this->getContainer()->addShared( 'buffer_subscriber', BufferSubscriber::class )
-			->addArgument( $this->getContainer()->get( 'buffer_optimization' ) )
-			->addTag( 'front_subscriber' );
+			->addArgument( $this->getContainer()->get( 'buffer_optimization' ) );
 		$this->getContainer()->addShared( 'cache_dynamic_resource', CacheDynamicResource::class )
 			->addArgument( $options )
 			->addArgument( WP_ROCKET_CACHE_BUSTING_PATH )
-			->addArgument( WP_ROCKET_CACHE_BUSTING_URL )
-			->addTag( 'front_subscriber' );
+			->addArgument( WP_ROCKET_CACHE_BUSTING_URL );
 		$this->getContainer()->add( 'optimize_google_fonts', Combine::class );
 		$this->getContainer()->add( 'optimize_google_fonts_v2', CombineV2::class );
 		$this->getContainer()->addShared( 'combine_google_fonts_subscriber', Subscriber::class )
 			->addArgument( $this->getContainer()->get( 'optimize_google_fonts' ) )
 			->addArgument( $this->getContainer()->get( 'optimize_google_fonts_v2' ) )
-			->addArgument( $options )
-			->addTag( 'front_subscriber' );
+			->addArgument( $options );
 		$this->getContainer()->addShared( 'minify_css_subscriber', Minify\CSS\Subscriber::class )
 			->addArgument( $options )
-			->addArgument( $filesystem )
-			->addTag( 'front_subscriber' );
+			->addArgument( $filesystem );
 		$this->getContainer()->addShared( 'minify_js_subscriber', Minify\JS\Subscriber::class )
 			->addArgument( $options )
-			->addArgument( $filesystem )
-			->addTag( 'front_subscriber' );
-		$this->getContainer()->addShared( 'ie_conditionals_subscriber', IEConditionalSubscriber::class )
-			->addTag( 'front_subscriber' );
+			->addArgument( $filesystem );
+		$this->getContainer()->addShared( 'ie_conditionals_subscriber', IEConditionalSubscriber::class );
 	}
 }

--- a/inc/Engine/Plugin/ServiceProvider.php
+++ b/inc/Engine/Plugin/ServiceProvider.php
@@ -38,8 +38,7 @@ class ServiceProvider extends AbstractServiceProvider {
 	public function register(): void {
 		$this->getContainer()->add( 'plugin_renewal_notice', RenewalNotice::class )
 			->addArgument( $this->getContainer()->get( 'user' ) )
-			->addArgument( $this->getContainer()->get( 'template_path' ) . '/plugins/' )
-			->addTag( 'common_subscriber' );
+			->addArgument( $this->getContainer()->get( 'template_path' ) . '/plugins/' );
 
 		$this->getContainer()->addShared( 'plugin_updater_common_subscriber', UpdaterApiCommonSubscriber::class )
 			->addArgument(
@@ -50,16 +49,14 @@ class ServiceProvider extends AbstractServiceProvider {
 					'settings_nonce_key' => WP_ROCKET_PLUGIN_SLUG,
 					'plugin_options'     => $this->getContainer()->get( 'options' ),
 				]
-			)
-			->addTag( 'common_subscriber' );
+			);
 
 		$this->getContainer()->addShared( 'plugin_information_subscriber', InformationSubscriber::class )
 			->addArgument(
 				[
 					'plugin_file' => WP_ROCKET_FILE,
 				]
-			)
-			->addTag( 'common_subscriber' );
+			);
 
 		$this->getContainer()->addShared( 'plugin_updater_subscriber', UpdaterSubscriber::class )
 			->addArgument( $this->getContainer()->get( 'plugin_renewal_notice' ) )
@@ -73,7 +70,6 @@ class ServiceProvider extends AbstractServiceProvider {
 						'1x' => WP_ROCKET_ASSETS_IMG_URL . 'icon-128x128.png',
 					],
 				]
-			)
-			->addTag( 'common_subscriber' );
+			);
 	}
 }

--- a/inc/Engine/Preload/Links/ServiceProvider.php
+++ b/inc/Engine/Preload/Links/ServiceProvider.php
@@ -37,11 +37,9 @@ class ServiceProvider extends AbstractServiceProvider {
 		$options = $this->getContainer()->get( 'options' );
 
 		$this->getContainer()->addShared( 'preload_links_admin_subscriber', AdminSubscriber::class )
-			->addArgument( $options )
-			->addTag( 'common_subscriber' );
+			->addArgument( $options );
 		$this->getContainer()->addShared( 'preload_links_subscriber', Subscriber::class )
 			->addArgument( $options )
-			->addArgument( rocket_direct_filesystem() )
-			->addTag( 'common_subscriber' );
+			->addArgument( rocket_direct_filesystem() );
 	}
 }

--- a/inc/Engine/Preload/ServiceProvider.php
+++ b/inc/Engine/Preload/ServiceProvider.php
@@ -133,8 +133,7 @@ class ServiceProvider extends AbstractServiceProvider {
 			->addArgument( $fetch_sitemap_controller )
 			->addArgument( $preload_url_controller )
 			->addArgument( $check_finished_controller )
-			->addArgument( $this->getContainer()->get( 'load_initial_sitemap_controller' ) )
-			->addTag( 'common_subscriber' );
+			->addArgument( $this->getContainer()->get( 'load_initial_sitemap_controller' ) );
 
 		$this->getContainer()->add( 'preload_clean_controller', ClearCache::class )
 			->addArgument( $cache_query );
@@ -148,22 +147,18 @@ class ServiceProvider extends AbstractServiceProvider {
 			->addArgument( $this->getContainer()->get( 'preload_activation' ) )
 			->addArgument( $this->getContainer()->get( 'preload_mobile_detect' ) )
 			->addArgument( $clean_controller )
-			->addArgument( $queue )
-			->addTag( 'common_subscriber' );
+			->addArgument( $queue );
 
 		$this->getContainer()->addShared( 'preload_cron_subscriber', CronSubscriber::class )
 			->addArgument( $preload_settings )
 			->addArgument( $cache_query )
-			->addArgument( $preload_url_controller )
-			->addTag( 'common_subscriber' );
+			->addArgument( $preload_url_controller );
 
 		$this->getContainer()->addShared( 'fonts_preload_subscriber', Fonts::class )
 			->addArgument( $options )
-			->addArgument( $this->getContainer()->get( 'cdn' ) )
-			->addTag( 'common_subscriber' );
+			->addArgument( $this->getContainer()->get( 'cdn' ) );
 
 		$this->getContainer()->add( 'preload_admin_subscriber', AdminSubscriber::class )
-			->addArgument( $preload_settings )
-			->addTag( 'common_subscriber' );
+			->addArgument( $preload_settings );
 	}
 }

--- a/inc/Engine/Support/ServiceProvider.php
+++ b/inc/Engine/Support/ServiceProvider.php
@@ -44,7 +44,6 @@ class ServiceProvider extends AbstractServiceProvider {
 			->addArgument( $this->getContainer()->get( 'support_data' ) )
 			->addArgument( $options );
 		$this->getContainer()->addShared( 'support_subscriber', Subscriber::class )
-			->addArgument( $this->getContainer()->get( 'rest_support' ) )
-			->addTag( 'common_subscriber' );
+			->addArgument( $this->getContainer()->get( 'rest_support' ) );
 	}
 }

--- a/inc/ThirdParty/Hostings/ServiceProvider.php
+++ b/inc/ThirdParty/Hostings/ServiceProvider.php
@@ -54,8 +54,7 @@ class ServiceProvider extends AbstractServiceProvider implements BootableService
 
 		if ( ! empty( $hosting_service ) ) {
 			$this->getContainer()
-				->addShared( $hosting_service, ( new HostSubscriberFactory() )->get_subscriber() )
-				->addTag( 'hosting_subscriber' );
+				->addShared( $hosting_service, ( new HostSubscriberFactory() )->get_subscriber() );
 		}
 	}
 }

--- a/inc/ThirdParty/ServiceProvider.php
+++ b/inc/ThirdParty/ServiceProvider.php
@@ -122,144 +122,105 @@ class ServiceProvider extends AbstractServiceProvider {
 		$options = $this->getContainer()->get( 'options' );
 
 		$this->getContainer()
-			->addShared( 'mobile_subscriber', Mobile_Subscriber::class )
-			->addTag( 'common_subscriber' );
+			->addShared( 'mobile_subscriber', Mobile_Subscriber::class );
 		$this->getContainer()
 			->addShared( 'elementor_subscriber', Elementor::class )
 			->addArgument( $options )
 			->addArgument( rocket_direct_filesystem() )
-			->addArgument( $this->getContainer()->get( 'delay_js_html' ) )
-			->addTag( 'common_subscriber' );
+			->addArgument( $this->getContainer()->get( 'delay_js_html' ) );
 		$this->getContainer()
 			->addShared( 'woocommerce_subscriber', WooCommerceSubscriber::class )
-			->addArgument( $this->getContainer()->get( 'delay_js_html' ) )
-			->addTag( 'common_subscriber' );
+			->addArgument( $this->getContainer()->get( 'delay_js_html' ) );
 		$this->getContainer()
-			->addShared( 'syntaxhighlighter_subscriber', SyntaxHighlighter_Subscriber::class )
-			->addTag( 'common_subscriber' );
+			->addShared( 'syntaxhighlighter_subscriber', SyntaxHighlighter_Subscriber::class );
 		$this->getContainer()
-			->addShared( 'ngg_subscriber', NGG_Subscriber::class )
-			->addTag( 'common_subscriber' );
+			->addShared( 'ngg_subscriber', NGG_Subscriber::class );
 		$this->getContainer()
 			->addShared( 'smush_subscriber', Smush::class )
 			->addArgument( $this->getContainer()->get( 'options_api' ) )
-			->addArgument( $this->getContainer()->get( 'options' ) )
-			->addTag( 'common_subscriber' );
+			->addArgument( $this->getContainer()->get( 'options' ) );
 		$this->getContainer()
 			->addShared( 'imagify_webp_subscriber', Imagify_Subscriber::class )
-			->addArgument( $options )
-			->addTag( 'common_subscriber' );
+			->addArgument( $options );
 		$this->getContainer()
 			->addShared( 'shortpixel_webp_subscriber', ShortPixel_Subscriber::class )
-			->addArgument( $options )
-			->addTag( 'common_subscriber' );
+			->addArgument( $options );
 		$this->getContainer()
 			->addShared( 'ewww_webp_subscriber', EWWW_Subscriber::class )
-			->addArgument( $options )
-			->addTag( 'common_subscriber' );
+			->addArgument( $options );
 		$this->getContainer()
-			->addShared( 'optimus_webp_subscriber', Optimus_Subscriber::class )
-			->addTag( 'common_subscriber' );
+			->addShared( 'optimus_webp_subscriber', Optimus_Subscriber::class );
 		$this->getContainer()
-			->addShared( 'bigcommerce_subscriber', BigCommerce::class )
-			->addTag( 'common_subscriber' );
+			->addShared( 'bigcommerce_subscriber', BigCommerce::class );
 		$this->getContainer()
-			->addShared( 'beaverbuilder_subscriber', BeaverBuilder::class )
-			->addTag( 'common_subscriber' );
+			->addShared( 'beaverbuilder_subscriber', BeaverBuilder::class );
 		$this->getContainer()
 			->addShared( 'amp_subscriber', AMP::class )
-			->addArgument( $options )->addArgument( $this->getContainer()->get( 'cdn_subscriber' ) )
-			->addTag( 'common_subscriber' );
+			->addArgument( $options )->addArgument( $this->getContainer()->get( 'cdn_subscriber' ) );
 		$this->getContainer()
 			->addShared( 'simple_custom_css', SimpleCustomCss::class )
-			->addArgument( WP_ROCKET_CACHE_BUSTING_PATH )->addArgument( WP_ROCKET_CACHE_BUSTING_URL )
-			->addTag( 'common_subscriber' );
+			->addArgument( WP_ROCKET_CACHE_BUSTING_PATH )->addArgument( WP_ROCKET_CACHE_BUSTING_URL );
 		$this->getContainer()
-			->addShared( 'pdfembedder', PDFEmbedder::class )
-			->addTag( 'common_subscriber' );
+			->addShared( 'pdfembedder', PDFEmbedder::class );
 		$this->getContainer()
-			->addShared( 'mod_pagespeed', ModPagespeed::class )
-			->addTag( 'common_subscriber' );
+			->addShared( 'mod_pagespeed', ModPagespeed::class );
 		$this->getContainer()
-			->addShared( 'adthrive', Adthrive::class )
-			->addTag( 'common_subscriber' );
+			->addShared( 'adthrive', Adthrive::class );
 		$this->getContainer()
 			->addShared( 'autoptimize', Autoptimize::class )
-			->addArgument( $options )
-			->addTag( 'common_subscriber' );
+			->addArgument( $options );
 		$this->getContainer()
-			->addShared( 'wp-meteor', WPMeteor::class )
-			->addTag( 'common_subscriber' );
+			->addShared( 'wp-meteor', WPMeteor::class );
 		$this->getContainer()
-			->addShared( 'revolution_slider_subscriber', RevolutionSlider::class )
-			->addTag( 'common_subscriber' );
+			->addShared( 'revolution_slider_subscriber', RevolutionSlider::class );
 		$this->getContainer()
-			->addShared( 'wordfence_subscriber', WordFenceCompatibility::class )
-			->addTag( 'common_subscriber' );
+			->addShared( 'wordfence_subscriber', WordFenceCompatibility::class );
 		$this->getContainer()
-			->addShared( 'ezoic', Ezoic::class )
-			->addTag( 'common_subscriber' );
+			->addShared( 'ezoic', Ezoic::class );
 		$this->getContainer()
-			->addShared( 'thirstyaffiliates', ThirstyAffiliates::class )
-			->addTag( 'common_subscriber' );
+			->addShared( 'thirstyaffiliates', ThirstyAffiliates::class );
 		$this->getContainer()
-			->addShared( 'pwa', PWA::class )
-			->addTag( 'common_subscriber' );
+			->addShared( 'pwa', PWA::class );
 		$this->getContainer()
 			->addShared( 'yoast_seo', Yoast::class )
-			->addArgument( $options )
-			->addTag( 'common_subscriber' );
+			->addArgument( $options );
 		$this->getContainer()
-			->addShared( 'convertplug', ConvertPlug::class )
-			->addTag( 'common_subscriber' );
+			->addShared( 'convertplug', ConvertPlug::class );
 		$this->getContainer()
-			->addShared( 'unlimited_elements', UnlimitedElements::class )
-			->addTag( 'common_subscriber' );
+			->addShared( 'unlimited_elements', UnlimitedElements::class );
 		$this->getContainer()
-			->addShared( 'inline_related_posts', InlineRelatedPosts::class )
-			->addTag( 'common_subscriber' );
+			->addShared( 'inline_related_posts', InlineRelatedPosts::class );
 		$this->getContainer()
-			->addShared( 'wpml', WPML::class )
-			->addTag( 'common_subscriber' );
+			->addShared( 'wpml', WPML::class );
 		$this->getContainer()->add( 'cloudflare_plugin_facade', CloudflareFacade::class );
 		$this->getContainer()
 			->addShared( 'cloudflare_plugin_subscriber', Cloudflare::class )
 			->addArgument( $options )
 			->addArgument( $this->getContainer()->get( 'options_api' ) )
 			->addArgument( $this->getContainer()->get( 'beacon' ) )
-			->addArgument( $this->getContainer()->get( 'cloudflare_plugin_facade' ) )
-			->addTag( 'common_subscriber' );
+			->addArgument( $this->getContainer()->get( 'cloudflare_plugin_facade' ) );
 		$this->getContainer()
 			->addShared( 'jetpack', Jetpack::class )
-			->addArgument( $options )
-			->addTag( 'common_subscriber' );
+			->addArgument( $options );
 		$this->getContainer()
-			->addShared( 'convertplug', ConvertPlug::class )
-			->addTag( 'common_subscriber' );
+			->addShared( 'convertplug', ConvertPlug::class );
 		$this->getContainer()
-			->addShared( 'rank_math_seo', RankMathSEO::class )
-			->addTag( 'common_subscriber' );
+			->addShared( 'rank_math_seo', RankMathSEO::class );
 		$this->getContainer()
 			->addShared( 'all_in_one_seo_pack', AllInOneSEOPack::class )
-			->addArgument( $options )
-			->addTag( 'common_subscriber' );
+			->addArgument( $options );
 		$this->getContainer()
 			->addShared( 'seopress', SEOPress::class )
-			->addArgument( $options )
-			->addTag( 'common_subscriber' );
+			->addArgument( $options );
 		$this->getContainer()
 			->addShared( 'the_seo_framework', TheSEOFramework::class )
-			->addArgument( $options )
-			->addTag( 'common_subscriber' );
+			->addArgument( $options );
 		$this->getContainer()
-			->addShared( 'rocket_lazy_load', RocketLazyLoad::class )
-			->addTag( 'common_subscriber' );
+			->addShared( 'rocket_lazy_load', RocketLazyLoad::class );
 		$this->getContainer()
-			->addShared( 'the_events_calendar', TheEventsCalendar::class )
-			->addTag( 'common_subscriber' );
+			->addShared( 'the_events_calendar', TheEventsCalendar::class );
 		$this->getContainer()
-			->addShared( 'perfmatters', Perfmatters::class )
-			->addTag( 'common_subscriber' );
+			->addShared( 'perfmatters', Perfmatters::class );
 		$this->getContainer()
 			->addShared( 'rapidload', RapidLoad::class );
 		$this->getContainer()

--- a/inc/classes/ServiceProvider/class-common-subscribers.php
+++ b/inc/classes/ServiceProvider/class-common-subscribers.php
@@ -34,7 +34,6 @@ class Common_Subscribers extends AbstractServiceProvider {
 	 * @return void
 	 */
 	public function register(): void {
-		$this->getContainer()->addShared( 'detect_missing_tags_subscriber', Detect_Missing_Tags_Subscriber::class )
-			->addTag( 'common_subscriber' );
+		$this->getContainer()->addShared( 'detect_missing_tags_subscriber', Detect_Missing_Tags_Subscriber::class );
 	}
 }


### PR DESCRIPTION
# Description

Fixes #6413

Remove tagging services in the service providers, as we are not using the tags system (incompatible with the way we use service providers)

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

The removed code was not used

## Technical description

### Documentation

Removed usage of `addTag()` in service providers

# Mandatory Checklist

## Code validation

- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.

## Code style
- [x] I did not introduce unnecessary complexity.