### PR TITLE
Fixes #6982 Cache is not purged when the path of cache folder contains a char that is part of the regular expression syntax

### DIFF
--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -1429,7 +1429,7 @@ function _rocket_get_cache_dirs( $url_host, $cache_path = '', $hard_reset = fals
 
 	$regex = sprintf(
 		'/%1$s%2$s(.*)/i',
-		_rocket_normalize_path( $cache_path, true ),
+		preg_quote( $cache_path, '/' ),
 		$url_host
 	);
 

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -1429,7 +1429,7 @@ function _rocket_get_cache_dirs( $url_host, $cache_path = '', $hard_reset = fals
 
 	$regex = sprintf(
 		'/%1$s%2$s(.*)/i',
-		preg_quote( $cache_path, '/' ),
+		preg_quote( _rocket_normalize_path( $cache_path, true ), '/' ),
 		$url_host
 	);
 


### PR DESCRIPTION
# Description

Fixes #6982
Fixes cache purging when the path of cache folder contains a char that is part of the regular expression syntax

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Release

# Mandatory Checklist

## Code validation

- [X] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [X] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [X ] I implemented built-in tests to cover the new/changed code.

## Code style
- [X] I wrote a self-explanatory code about what it does.
- [X] I protected entry points against unexpected inputs.
- [X] I did not introduce unnecessary complexity.
- [X] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

# Additional Checks
- [X] In the case of complex code, I wrote comments to explain it.
- [X] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [X] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)