### PR TITLE
Closes #6714: Fatal Error: Argument #3 ($code) must be of type int, string given

### DIFF
--- a/inc/Engine/Common/JobManager/Managers/AbstractManager.php
+++ b/inc/Engine/Common/JobManager/Managers/AbstractManager.php
@@ -190,7 +190,7 @@ trait AbstractManager {
 	 *
 	 * @param string  $url Url from DB row.
 	 * @param boolean $is_mobile Is mobile from DB row.
-	 * @param int  $error_code error code.
+	 * @param int     $error_code error code.
 	 * @param string  $error_message error message.
 	 * @param string  $previous_message Previous saved message.
 	 *

--- a/inc/Engine/Common/JobManager/Managers/AbstractManager.php
+++ b/inc/Engine/Common/JobManager/Managers/AbstractManager.php
@@ -190,13 +190,13 @@ trait AbstractManager {
 	 *
 	 * @param string  $url Url from DB row.
 	 * @param boolean $is_mobile Is mobile from DB row.
-	 * @param string  $error_code error code.
+	 * @param int  $error_code error code.
 	 * @param string  $error_message error message.
 	 * @param string  $previous_message Previous saved message.
 	 *
 	 * @return void
 	 */
-	public function update_message( string $url, bool $is_mobile, string $error_code, string $error_message, string $previous_message ): void {
+	public function update_message( string $url, bool $is_mobile, int $error_code, string $error_message, string $previous_message ): void {
 		if ( ! $this->is_allowed() ) {
 			return;
 		}

--- a/inc/Engine/Common/JobManager/Strategy/Strategies/DefaultProcess.php
+++ b/inc/Engine/Common/JobManager/Strategy/Strategies/DefaultProcess.php
@@ -117,7 +117,7 @@ class DefaultProcess implements StrategyInterface {
 		// update the `next_retry_time` column.
 		$next_retry_time = $this->clock->current_time( 'timestamp', true ) + $saas_retry_duration;
 
-		$this->manager->update_message( $row_details->url, $row_details->is_mobile, $job_details['code'], $job_details['message'], $row_details->error_message );
+		$this->manager->update_message( $row_details->url, $row_details->is_mobile, (int) $job_details['code'], $job_details['message'], $row_details->error_message );
 		$this->manager->update_next_retry_time( $row_details->url, $row_details->is_mobile, $next_retry_time );
 	}
 }


### PR DESCRIPTION
# Description

Fixes #6714 
This PR brings a change to the `update_message` `$code` parameter to align everything in the code. 
Also a force typecast to `int` has been added in order to avoid `Fatal Errors`. 


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

Well, there isn't a proper way to reproduce the issue, however, we could hard code a string in $job_details['code'] here

[wp-rocket/inc/Engine/Optimization/RUCSS/Strategy/Strategies/DefaultProcess.php](https://github.com/wp-media/wp-rocket/blob/2b2243e08aecf0d7618179106c2a133749762e47/inc/Engine/Optimization/RUCSS/Strategy/Strategies/DefaultProcess.php#L108)

Line 108 in [2b2243e](https://github.com/wp-media/wp-rocket/commit/2b2243e08aecf0d7618179106c2a133749762e47)

 $this->used_css_query->update_message( $row_details->id, $job_details['code'], $job_details['message'], $row_details->error_message ); 

This would ensure to get the same error as reported.
## Technical description

### Documentation

The type of the `update_message` `$code` parameter has been changed to `int` and the type has been force type while calling `update_message`. 

### New dependencies
None

### Risks

None
# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)