### PR TITLE
Fixes #6887 Check for string to handle null return from get_permalink()

### DIFF
--- a/inc/Engine/Common/PerformanceHints/Admin/Controller.php
+++ b/inc/Engine/Common/PerformanceHints/Admin/Controller.php
@@ -66,7 +66,8 @@ class Controller {
 	public function delete_post( $post_id ) {
 		$url = get_permalink( $post_id );
 
-		if ( false === $url ) {
+		// get_permalink should return false or string, but some plugins return null.
+		if ( ! is_string( $url ) ) {
 			return;
 		}
 

--- a/inc/Engine/Optimization/LazyRenderContent/Frontend/Processor/Regex.php
+++ b/inc/Engine/Optimization/LazyRenderContent/Frontend/Processor/Regex.php
@@ -34,7 +34,7 @@ class Regex implements ProcessorInterface {
 	 *
 	 * @var array
 	 */
-	private $exclusions;
+	private $exclusions; // @phpstan-ignore-line
 
 	/**
 	 * Sets the exclusions list

--- a/inc/Engine/Optimization/LazyRenderContent/Frontend/Processor/SimpleHtmlDom.php
+++ b/inc/Engine/Optimization/LazyRenderContent/Frontend/Processor/SimpleHtmlDom.php
@@ -37,7 +37,7 @@ class SimpleHtmlDom implements ProcessorInterface {
 	 *
 	 * @var array
 	 */
-	private $exclusions;
+	private $exclusions; // @phpstan-ignore-line
 
 	/**
 	 * Sets the exclusions list

--- a/tests/Fixtures/inc/Engine/Common/PerformanceHints/Admin/Controller/deletePost.php
+++ b/tests/Fixtures/inc/Engine/Common/PerformanceHints/Admin/Controller/deletePost.php
@@ -12,6 +12,14 @@ return [
 		],
 		'expected' => false,
 	],
+	'testShoulDoNothingURLNull' => [
+		'config' => [
+			'filter' => true,
+			'post_id' => 1,
+			'url' => null,
+		],
+		'expected' => false,
+	],
 	'testShoulDoNothingURLFalse' => [
 		'config' => [
 			'filter' => true,


### PR DESCRIPTION
# Description

Fixes #6887

Prevent PHP fatal error when `get_permalink()` returns `null` instead of a string. It should not happen by default but some plugins are doing that.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

Explained in #6887 

## Technical description

### Documentation

Use `is_string()` to make sure the `$url` is a string before passing it to the `delete_by_url()` method

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.