### PR TITLE
Closes #6934: Beacon script is injected to logged-in users

### DIFF
--- a/inc/Engine/Common/PerformanceHints/Frontend/Processor.php
+++ b/inc/Engine/Common/PerformanceHints/Frontend/Processor.php
@@ -53,6 +53,10 @@ class Processor {
 			return $html;
 		}
 
+		if ( is_user_logged_in() && $this->options->get( 'cache_logged_user', 0 ) ) {
+			return $html;
+		}
+
 		global $wp;
 
 		$url       = untrailingslashit( home_url( add_query_arg( [], $wp->request ) ) );

--- a/tests/Fixtures/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/maybe_apply_optimizations.php
+++ b/tests/Fixtures/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/maybe_apply_optimizations.php
@@ -92,6 +92,16 @@ return [
 			],
 			'expected' => $html_output_with_preload,
 		],
+		'shoudNotAddBeaconToPageWhenLoggedInAndUserCacheEnabled' => [
+			'config' => [
+				'html' => $html_input,
+				'atf' => [],
+				'lrc' => [],
+				'is_logged_in' => true,
+				'user_cache_enabled' => 1,
+			],
+			'expected' => $html_output,
+		],
 		'shouldNotAddBeaconToPageWhenPerformanceHintsFailed' => [
 			'config' => [
 				'html' => $html_input,


### PR DESCRIPTION
# Description

Fixes #6934 

The beacon script will not be injected to logged-user that enables `user cache`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario
https://github.com/wp-media/wp-rocket/issues/6934#issuecomment-2324292228

## Technical description

### Documentation

We are checking if the user is logged-in and if the option `user cache` is enabled or not. If both returns true, then we are bailing out at the beacon injection to avoid it in the source code. 

### New dependencies

None

### Risks

None

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.
