### PR TITLE
Adjust priority for rocket buffer

### DIFF
--- a/inc/Engine/CDN/Subscriber.php
+++ b/inc/Engine/CDN/Subscriber.php
@@ -45,8 +45,8 @@ class Subscriber implements Subscriber_Interface {
 	public static function get_subscribed_events() {
 		return [
 			'rocket_buffer'           => [
-				[ 'rewrite', 20 ],
-				[ 'rewrite_srcset', 21 ],
+				[ 'rewrite', 2 ],
+				[ 'rewrite_srcset', 3 ],
 			],
 			'rocket_css_content'      => 'rewrite_css_properties',
 			'rocket_usedcss_content'  => 'rewrite_css_properties',

--- a/tests/Integration/inc/Engine/CDN/Subscriber/rewrite.php
+++ b/tests/Integration/inc/Engine/CDN/Subscriber/rewrite.php
@@ -12,7 +12,7 @@ class Test_Rewrite extends TestCase {
 	public function set_up() {
 		parent::set_up();
 
-		$this->unregisterAllCallbacksExcept( 'rocket_buffer', 'rewrite', 20 );
+		$this->unregisterAllCallbacksExcept( 'rocket_buffer', 'rewrite', 2 );
 	}
 
 	public function tear_down() {


### PR DESCRIPTION
# Description

Fixes https://github.com/wp-media/imagify-plugin/issues/891

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario
Check here for https://github.com/wp-media/imagify-plugin/pull/893#issuecomment-2298451180


## Technical description
Changed the priority of rocket buffer callbacks to 2/3 to fix the conflict issue with imagify image rewrite.

### Documentation

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
