### PR TITLE
Fixes #6972 Prevent injecting Beacon script when DONOTROCKETOPTIMIZE is defined

### DIFF
--- a/inc/Engine/Common/PerformanceHints/Frontend/Processor.php
+++ b/inc/Engine/Common/PerformanceHints/Frontend/Processor.php
@@ -95,6 +95,10 @@ class Processor {
 	 * @return string The modified HTML content with the beacon script injected just before the closing body tag.
 	 */
 	private function inject_beacon( $html, $url, $is_mobile ): string {
+		if ( rocket_get_constant( 'DONOTROCKETOPTIMIZE' ) ) {
+			return $html;
+		}
+
 		$min = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 
 		if ( ! $this->filesystem->exists( rocket_get_constant( 'WP_ROCKET_ASSETS_JS_PATH' ) . 'wpr-beacon' . $min . '.js' ) ) {

--- a/tests/Fixtures/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/maybe_apply_optimizations.php
+++ b/tests/Fixtures/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/maybe_apply_optimizations.php
@@ -68,6 +68,19 @@ return [
 			],
 			'expected' => $html_input,
 		],
+		'shouldReturnOriginalWhenDonotoptimize' => [
+			'config' => [
+				'donotrocketoptimize' => true,
+				'html' => $html_input,
+				'atf' => [
+					'row' => null,
+				],
+				'lrc' => [
+					'row' => null,
+				],
+			],
+			'expected' => $html_input,
+		],
 		'shouldAddBeaconToPage' => [
 			'config' => [
 				'html' => $html_input,

--- a/tests/Integration/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/maybe_apply_optimizations.php
+++ b/tests/Integration/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/maybe_apply_optimizations.php
@@ -56,6 +56,7 @@ class Test_MaybeApplyOptimizations extends FilesystemTestCase {
 	public function testShouldReturnAsExpected( $config, $expected ) {
 		$this->config = $config;
 		$this->cached_user = $config['user_cache_enabled'] ?? false;
+		$this->donotrocketoptimize = $config['donotrocketoptimize'] ?? null;
 
 		if ( isset( $config['query_string'] ) ) {
 			$_GET[ $config['query_string'] ] = 1;


### PR DESCRIPTION
# Description

Fixes #6972

Prevent injecting Beacon script when DONOTROCKETOPTIMIZE is defined

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

Steps are available in the issue #6972 

## Technical description

### Documentation

Check for `DONOTROCKETOPTIMIZE` before injecting beacon

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.