### PR TITLE
Fixes #6972 Prevent injecting Beacon script when DONOTROCKETOPTIMIZE is defined

### DIFF
--- a/inc/Engine/Common/PerformanceHints/Frontend/Processor.php
+++ b/inc/Engine/Common/PerformanceHints/Frontend/Processor.php
@@ -95,7 +95,7 @@ class Processor {
 	 * @return string The modified HTML content with the beacon script injected just before the closing body tag.
 	 */
 	private function inject_beacon( $html, $url, $is_mobile ): string {
-		if ( rocket_get_constant( 'DONOTROCKETOPTIMIZE' ) ) {
+		if ( rocket_get_constant( 'DONOTROCKETOPTIMIZE' ) && empty( $_GET['wpr_imagedimensions'] ) ) {
 			return $html;
 		}
 

--- a/inc/Engine/Common/PerformanceHints/Frontend/Processor.php
+++ b/inc/Engine/Common/PerformanceHints/Frontend/Processor.php
@@ -95,7 +95,7 @@ class Processor {
 	 * @return string The modified HTML content with the beacon script injected just before the closing body tag.
 	 */
 	private function inject_beacon( $html, $url, $is_mobile ): string {
-		if ( rocket_get_constant( 'DONOTROCKETOPTIMIZE' ) && empty( $_GET['wpr_imagedimensions'] ) ) {
+		if ( rocket_get_constant( 'DONOTROCKETOPTIMIZE' ) && empty( $_GET['wpr_imagedimensions'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return $html;
 		}
 

--- a/tests/Fixtures/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/maybe_apply_optimizations.php
+++ b/tests/Fixtures/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/maybe_apply_optimizations.php
@@ -71,6 +71,7 @@ return [
 		'shouldReturnOriginalWhenDonotoptimize' => [
 			'config' => [
 				'donotrocketoptimize' => true,
+				'sass_visit' => false,
 				'html' => $html_input,
 				'atf' => [
 					'row' => null,
@@ -80,6 +81,20 @@ return [
 				],
 			],
 			'expected' => $html_input,
+		],
+		'shouldAddBeaconWhenDonotoptimizeAndSaaSVisit' => [
+			'config' => [
+				'donotrocketoptimize' => true,
+				'sass_visit' => true,
+				'html' => $html_input,
+				'atf' => [
+					'row' => null,
+				],
+				'lrc' => [
+					'row' => null,
+				],
+			],
+			'expected' => $html_output_with_beacon,
 		],
 		'shouldAddBeaconToPage' => [
 			'config' => [

--- a/tests/Integration/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/maybe_apply_optimizations.php
+++ b/tests/Integration/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/maybe_apply_optimizations.php
@@ -62,6 +62,10 @@ class Test_MaybeApplyOptimizations extends FilesystemTestCase {
 			$_GET[ $config['query_string'] ] = 1;
 		}
 
+		if ( isset( $config['sass_visit'] ) ) {
+			$_GET[ 'wpr_imagedimensions' ] = $config['sass_visit'];
+		}
+
 		if ( ! empty( $config['atf']['row'] ) ) {
 			self::addLcp( $config['atf']['row'] );
 		}


### PR DESCRIPTION
# Description

Fixes #6972 
Prevent injecting Beacon script when DONOTROCKETOPTIMIZE is defined and allow SaaS visit 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario
Steps are available in the issue https://github.com/wp-media/wp-rocket/issues/6972

## Technical description

### Documentation

Check for `DONOTROCKETOPTIMIZE` before injecting beacon and check if it's visit for SaaS

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
