### PR TITLE
Add method to update lists from JSON files and clear cache

### DIFF
--- a/inc/Engine/Optimization/DynamicLists/AbstractDataManager.php
+++ b/inc/Engine/Optimization/DynamicLists/AbstractDataManager.php
@@ -157,4 +157,13 @@ abstract class AbstractDataManager {
 	private function set_lists_cache( $content ) {
 		set_transient( $this->get_cache_transient_name(), $content, $this->cache_duration );
 	}
+
+	/**
+	 * Removes the lists cache
+	 *
+	 * @return void
+	 */
+	public function remove_lists_cache() {
+		delete_transient( $this->get_cache_transient_name() );
+	}
 }

--- a/inc/Engine/Optimization/DynamicLists/DynamicLists.php
+++ b/inc/Engine/Optimization/DynamicLists/DynamicLists.php
@@ -313,4 +313,30 @@ class DynamicLists extends Abstract_Render {
 
 		return $lists->lazy_rendering_exclusions ?? [];
 	}
+
+	/**
+	 * Updates the lists from JSON files and clears the transient cache.
+	 *
+	 * @return array
+	 */
+	public function update_lists_from_files() {
+		if ( $this->user->is_license_expired() ) {
+			return [
+				'success' => false,
+				'data'    => '',
+				'message' => __( 'You need an active license to get the latest version of the lists from our server.', 'rocket' ),
+			];
+		}
+
+		foreach ( $this->providers as $provider ) {
+			$provider->data_manager->remove_lists_cache();
+			$provider->data_manager->get_lists();
+		}
+
+		return [
+			'success' => true,
+			'data'    => '',
+			'message' => __( 'Lists are successfully updated from JSON files.', 'rocket' ),
+		];
+	}
 }

--- a/inc/Engine/Optimization/DynamicLists/Subscriber.php
+++ b/inc/Engine/Optimization/DynamicLists/Subscriber.php
@@ -44,6 +44,7 @@ class Subscriber implements Subscriber_Interface {
 			'rocket_plugins_to_deactivate'       => 'add_incompatible_plugins_to_deactivate',
 			'rocket_staging_list'                => 'add_staging_exclusions',
 			'rocket_lrc_exclusions'              => 'add_lrc_exclusions',
+			'wp_rocket_upgrade'                  => 'update_lists_from_files',
 		];
 	}
 
@@ -201,5 +202,14 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	public function add_lrc_exclusions( $exclusions ): array {
 		return array_merge( (array) $exclusions, $this->dynamic_lists->get_lrc_exclusions() );
+	}
+
+	/**
+	 * Update dynamic lists from JSON files.
+	 *
+	 * @return void
+	 */
+	public function update_lists_from_files() {
+		$this->dynamic_lists->update_lists_from_files();
 	}
 }


### PR DESCRIPTION
* **DynamicLists.php**
  - Add `update_lists_from_files` method to clear transient cache and update lists from JSON files
  - Call `remove_lists_cache` and `get_lists` methods from each provider's data manager in `update_lists_from_files`

* **AbstractDataManager.php**
  - Add `remove_lists_cache` method to delete transient cache

* **Subscriber.php**
  - Modify `wp_rocket_upgrade` callback to call `update_lists_from_files` method
  - Add `update_lists_from_files` method to call `$this->dynamic_lists->update_lists_from_files()`

# Description

Fixes #6920 
This update modifies the dynamic lists handling, improving the performance and reliability of the feature as the customer won't have to wait a week before getting the new exclusions updated.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

Update WP Rocket

## Technical description

### Documentation

We simply delete the transient cache before fetching the dynamic list from the file within the ZIP archive. 

### New dependencies


### Risks


# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.
