### PR TITLE
Exclude Trust Index Google Widget CSS from LazyLoad for CSS Background Images

### DIFF
--- a/inc/Engine/Media/Lazyload/CSS/Front/Extractor.php
+++ b/inc/Engine/Media/Lazyload/CSS/Front/Extractor.php
@@ -176,7 +176,13 @@ class Extractor {
 		 *
 		 * @param string[] $urls Ignored URLs.
 		 */
-		$ignored_urls = (array) apply_filters( 'rocket_lazyload_css_ignored_urls', [] );
+		$ignored_urls = (array) apply_filters(
+			'rocket_lazyload_css_ignored_urls',
+			[
+				'trustindex-google-widget.css',
+				'cdn.trustindex.io',
+			]
+		);
 
 		foreach ( $matches as $match ) {
 


### PR DESCRIPTION
# Description

Fixes #6957 

We add those two exclusions globally

```
trustindex-google-widget.css
cdn.trustindex.io
```

As mentioned [here](https://github.com/wp-media/wp-rocket/issues/6957#issuecomment-2431767967) by product team.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

Everything is mentioned in the issue itself, we just added the exclusion itself here.

## Technical description

We added those mentioned two items to the lazyload background images exclusions list.

### Documentation

Mentioned above

### New dependencies

No

### Risks

I hoped to add this as a third-party compatibility but I think this has a minimal effect.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)