### PR TITLE
Fixes #7042 Argument 2 ($url) passed to exclude_rocket_from_wp_updates() must be of the type string

### DIFF
--- a/inc/Engine/Plugin/UpdaterApiCommonSubscriber.php
+++ b/inc/Engine/Plugin/UpdaterApiCommonSubscriber.php
@@ -81,7 +81,11 @@ class UpdaterApiCommonSubscriber implements Subscriber_Interface {
 	 * @param  string $url     Requested URL.
 	 * @return array           An array of requested arguments
 	 */
-	public function maybe_set_rocket_user_agent( $request, string $url ) {
+	public function maybe_set_rocket_user_agent( $request, $url ) {
+		if ( ! is_string( $url ) ) { // @phpstan-ignore-line GH #7042 - $url variable may be change by other plugins to something else than string.
+			return $request;
+		}
+
 		if ( strpos( $url, self::API_HOST ) !== false ) {
 			$request['user-agent'] = sprintf( '%s;%s', $request['user-agent'], $this->get_rocket_user_agent() );
 		}

--- a/inc/Engine/Plugin/UpdaterSubscriber.php
+++ b/inc/Engine/Plugin/UpdaterSubscriber.php
@@ -132,7 +132,11 @@ class UpdaterSubscriber implements Event_Manager_Aware_Subscriber_Interface {
 	 * @param  string $url     The request URL.
 	 * @return array           Updated array of HTTP request arguments.
 	 */
-	public function exclude_rocket_from_wp_updates( $request, string $url ) {
+	public function exclude_rocket_from_wp_updates( $request, $url ) {
+		if ( ! is_string( $url ) ) { // @phpstan-ignore-line GH #7042 - $url variable may be change by other plugins to something else than string.
+			return $request;
+		}
+
 		if ( ! preg_match( '@^https?://api.wordpress.org/plugins/update-check(/|\?|$)@', $url ) || empty( $request['body']['plugins'] ) ) {
 			// Not a plugin update request. Stop immediately.
 			return $request;


### PR DESCRIPTION
# Description

Fixes #7042
Fixed error for some users when updating from one version to another.


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue).


## Detailed scenario
Check #7042 

## Technical description
Revert the phpstan update on the method.

### Documentation


# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
