### PR TITLE
Rmove only the version in the meta generator content attribute

### DIFF
--- a/inc/Engine/Support/Meta.php
+++ b/inc/Engine/Support/Meta.php
@@ -123,20 +123,20 @@ class Meta {
 			return '';
 		}
 
-		$content = '';
+		$version = '';
 
 		/**
-		 * Filters the display of the content attribute in the meta generator tag.
+		 * Filters the display of WP Rocket version in the content attribute of the meta generator tag.
 		 *
 		 * @since 3.17.2
 		 *
 		 * @param bool $display True to display, false otherwise.
 		 */
-		if ( wpm_apply_filters_typed( 'boolean', 'rocket_display_meta_generator_content', true ) ) {
-			$content = ' content="WP Rocket ' . rocket_get_constant( 'WP_ROCKET_VERSION', '' ) . '"';
+		if ( wpm_apply_filters_typed( 'boolean', 'rocket_display_meta_generator_content_version', true ) ) {
+			$version = ' ' . rocket_get_constant( 'WP_ROCKET_VERSION', '' );
 		}
 
-		$meta = '<meta name="generator"' . $content . ' data-wpr-features="' . implode( ' ', $features ) . '" />';
+		$meta = '<meta name="generator" content="WP Rocket' . $version . '" data-wpr-features="' . implode( ' ', $features ) . '" />';
 
 		return $meta;
 	}


### PR DESCRIPTION
# Description

Remove only the version instead of the full content attribute when we use the related filter.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

New filter name is `rocket_display_meta_generator_content_version`. By default, it adds the version to the `content` attribute. When `false`, the version is removed.

## Technical description

### Documentation

Updated the code to only change the display of the version

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.