### PR TITLE
Closes #7080: Remove the 'RUCSS' acronym from the Remove Unused CSS button

### DIFF
--- a/inc/Engine/Admin/Settings/Page.php
+++ b/inc/Engine/Admin/Settings/Page.php
@@ -600,7 +600,7 @@ class Page extends Abstract_Render {
 					'sanitize_callback'       => 'sanitize_checkbox',
 					'options'                 => [
 						'remove_unused_css' => [
-							'label'       => __( 'Remove Unused CSS (RUCSS)', 'rocket' ),
+							'label'       => __( 'Remove Unused CSS', 'rocket' ),
 							'disabled'    => $invalid_license || $rucss_status['disable'] ? 'disabled' : false,
 							// translators: %1$s = opening <a> tag, %2$s = closing </a> tag.
 							'description' => sprintf( __( 'Removes unused CSS per page and helps to reduce page size and HTTP requests. Recommended for best performance. Test thoroughly! %1$sMore info%2$s', 'rocket' ), '<a href="' . esc_url( $rucss_beacon['url'] ) . '" data-beacon-article="' . esc_attr( $rucss_beacon['id'] ) . '" target="_blank">', '</a>' ),


### PR DESCRIPTION
# Description

Fixes #7080 
It only changes the text displayed to the user from `Remove Unused CSS (RUCSS)` to `Remove Unused CSS`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

Just visit the File optimisation tab of the setting

## Technical description

### Documentation

N/a

### New dependencies

None
### Risks

None
# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.
