### PR TITLE
Closes #7068 admin UI for host fonts locally

### DIFF
--- a/inc/Engine/Admin/Beacon/Beacon.php
+++ b/inc/Engine/Admin/Beacon/Beacon.php
@@ -831,6 +831,16 @@ class Beacon extends Abstract_Render implements Subscriber_Interface {
 					'url' => 'https://fr.docs.wp-rocket.me/article/1836-rendu-differe-automatique/?utm_source=wp_plugin&utm_medium=wp_rocket',
 				],
 			],
+			'host_fonts_locally' => [
+				'en' => [
+					'id'  => '',
+					'url' => '',
+				],
+				'fr' => [
+					'id' => '',
+					'url' => '',
+				],
+			]
 		];
 
 		return isset( $suggest[ $doc_id ][ $this->get_user_locale() ] )

--- a/inc/Engine/Admin/Beacon/Beacon.php
+++ b/inc/Engine/Admin/Beacon/Beacon.php
@@ -831,16 +831,16 @@ class Beacon extends Abstract_Render implements Subscriber_Interface {
 					'url' => 'https://fr.docs.wp-rocket.me/article/1836-rendu-differe-automatique/?utm_source=wp_plugin&utm_medium=wp_rocket',
 				],
 			],
-			'host_fonts_locally' => [
+			'host_fonts_locally'         => [
 				'en' => [
 					'id'  => '',
 					'url' => '',
 				],
 				'fr' => [
-					'id' => '',
+					'id'  => '',
 					'url' => '',
 				],
-			]
+			],
 		];
 
 		return isset( $suggest[ $doc_id ][ $this->get_user_locale() ] )

--- a/inc/Engine/Admin/Settings/Page.php
+++ b/inc/Engine/Admin/Settings/Page.php
@@ -823,12 +823,13 @@ class Page extends Abstract_Render {
 		$lazyload_beacon  = $this->beacon->get_suggest( 'lazyload' );
 		$exclude_lazyload = $this->beacon->get_suggest( 'exclude_lazyload' );
 		$dimensions       = $this->beacon->get_suggest( 'image_dimensions' );
+		$fonts            = $this->beacon->get_suggest( 'host_fonts_locally' );
 
 		$this->settings->add_page_section(
 			'media',
 			[
 				'title'            => __( 'Media', 'rocket' ),
-				'menu_description' => __( 'LazyLoad, image dimensions', 'rocket' ),
+				'menu_description' => __( 'LazyLoad, image dimensions, font optimization', 'rocket' ),
 			]
 		);
 
@@ -909,6 +910,14 @@ class Page extends Abstract_Render {
 					// translators: %1$s = opening <a> tag, %2$s = closing </a> tag.
 					'description' => sprintf( __( 'Add missing width and height attributes to images. Helps prevent layout shifts and improve the reading experience for your visitors. %1$sMore info%2$s', 'rocket' ), '<a href="' . esc_url( $dimensions['url'] ) . '" data-beacon-article="' . esc_attr( $dimensions['id'] ) . '" target="_blank" rel="noopener noreferrer">', '</a>' ),
 					'help'        => $dimensions,
+					'page'        => 'media',
+				],
+				'font_optimization_section' => [
+					'title'       => __( 'Fonts', 'rocket' ),
+					'type'        => 'fields_container',
+					// translators: %1$s = opening <a> tag, %2$s = closing </a> tag.
+					'description' => sprintf( __( 'Download and serve fonts directly from your server. Reduces connections to external servers and minimizes font shifts. %1$sMore info%2$s', 'rocket' ), '<a href="' . esc_url( $fonts['url'] ) . '" data-beacon-article="' . esc_attr( $fonts['id'] ) . '" target="_blank" rel="noopener noreferrer">', '</a>' ),
+					'help'        => $fonts,
 					'page'        => 'media',
 				],
 			]
@@ -1005,6 +1014,14 @@ class Page extends Abstract_Render {
 					'type'              => 'checkbox',
 					'label'             => __( 'Add missing image dimensions', 'rocket' ),
 					'section'           => 'dimensions_section',
+					'page'              => 'media',
+					'default'           => 0,
+					'sanitize_callback' => 'sanitize_checkbox',
+				],
+				'host_fonts_locally' => [
+					'type'              => 'checkbox',
+					'label'             => __( 'Host Google Fonts locally', 'rocket' ),
+					'section'           => 'font_optimization_section',
 					'page'              => 'media',
 					'default'           => 0,
 					'sanitize_callback' => 'sanitize_checkbox',

--- a/inc/Engine/Admin/Settings/Page.php
+++ b/inc/Engine/Admin/Settings/Page.php
@@ -891,7 +891,7 @@ class Page extends Abstract_Render {
 
 		$this->settings->add_settings_sections(
 			[
-				'lazyload_section'   => [
+				'lazyload_section'          => [
 					'title'       => __( 'LazyLoad', 'rocket' ),
 					'type'        => 'fields_container',
 					// translators: %1$s = opening <a> tag, %2$s = closing </a> tag.
@@ -904,7 +904,7 @@ class Page extends Abstract_Render {
 					// translators: %1$s = “WP Rocket”, %2$s = a list of plugin names.
 					'helper'      => ! empty( $disable_lazyload ) ? sprintf( __( 'LazyLoad is currently activated in %2$s. If you want to use WP Rocket’s LazyLoad, disable this option in %2$s.', 'rocket' ), WP_ROCKET_PLUGIN_NAME, $disable_lazyload ) : '',
 				],
-				'dimensions_section' => [
+				'dimensions_section'        => [
 					'title'       => __( 'Image Dimensions', 'rocket' ),
 					'type'        => 'fields_container',
 					// translators: %1$s = opening <a> tag, %2$s = closing </a> tag.
@@ -1018,7 +1018,7 @@ class Page extends Abstract_Render {
 					'default'           => 0,
 					'sanitize_callback' => 'sanitize_checkbox',
 				],
-				'host_fonts_locally' => [
+				'host_fonts_locally'  => [
 					'type'              => 'checkbox',
 					'label'             => __( 'Host Google Fonts locally', 'rocket' ),
 					'section'           => 'font_optimization_section',

--- a/inc/Engine/Media/Fonts/Admin/Settings.php
+++ b/inc/Engine/Media/Fonts/Admin/Settings.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Engine\Media\Fonts\Admin;
+
+use WP_Rocket\Engine\Admin\Settings\Settings as AdminSettings;
+
+class Settings {
+	/**
+	 * Adds the host fonts locally option to WP Rocket options array
+	 *
+	 * @param array $options WP Rocket options array.
+	 *
+	 * @return array
+	 */
+	public function add_option( array $options ): array {
+		$options['host_fonts_locally'] = 0;
+
+		return $options;
+	}
+
+	/**
+	 * Sanitizes the option value when saving from the settings page
+	 *
+	 * @param array    $input    Array of sanitized values after being submitted by the form.
+	 * @param AdminSettings $settings Settings class instance.
+	 *
+	 * @return array
+	 */
+	public function sanitize_option_value( array $input, AdminSettings $settings ): array {
+		$input['host_fonts_locally'] = $settings->sanitize_checkbox( $input, 'host_fonts_locally' );
+
+		return $input;
+	}
+}

--- a/inc/Engine/Media/Fonts/Admin/Settings.php
+++ b/inc/Engine/Media/Fonts/Admin/Settings.php
@@ -22,7 +22,7 @@ class Settings {
 	/**
 	 * Sanitizes the option value when saving from the settings page
 	 *
-	 * @param array    $input    Array of sanitized values after being submitted by the form.
+	 * @param array         $input    Array of sanitized values after being submitted by the form.
 	 * @param AdminSettings $settings Settings class instance.
 	 *
 	 * @return array

--- a/inc/Engine/Media/Fonts/Admin/Subscriber.php
+++ b/inc/Engine/Media/Fonts/Admin/Subscriber.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Engine\Media\Fonts\Admin;
+
+use WP_Rocket\Engine\Admin\Settings\Settings;
+use WP_Rocket\Engine\Media\Fonts\Admin\Settings as FontsSettings;
+use WP_Rocket\Event_Management\Subscriber_Interface;
+
+
+class Subscriber implements Subscriber_Interface {
+	/**
+	 * Fonts Settings instance
+	 *
+	 * @var FontsSettings
+	 */
+	private $settings;
+
+	/**
+	 * Instantiate the class
+	 *
+	 * @param FontsSettings $settings Fonts Settings instance.
+	 */
+	public function __construct( FontsSettings $settings ) {
+		$this->settings = $settings;
+	}
+
+	/**
+	 * Returns an array of events this listens to
+	 *
+	 * @return array
+	 */
+	public static function get_subscribed_events(): array {
+		return [
+			'rocket_first_install_options' => [ 'add_option', 14 ],
+			'rocket_input_sanitize'        => [ 'sanitize_option', 10, 2 ],
+		];
+	}
+
+	/**
+	 * Add the images dimensions option to the WP Rocket options array
+	 *
+	 * @param array $options WP Rocket options array.
+	 *
+	 * @return array
+	 */
+	public function add_option( array $options ): array {
+		return $this->settings->add_option( $options );
+	}
+
+	/**
+	 * Sanitizes the option value when saving from the settings page
+	 *
+	 * @param array    $input    Array of sanitized values after being submitted by the form.
+	 * @param Settings $settings Settings class instance.
+	 *
+	 * @return array
+	 */
+	public function sanitize_option( array $input, Settings $settings ): array {
+		return $this->settings->sanitize_option_value( $input, $settings );
+	}
+}

--- a/inc/Engine/Media/Fonts/Admin/Subscriber.php
+++ b/inc/Engine/Media/Fonts/Admin/Subscriber.php
@@ -32,7 +32,7 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events(): array {
 		return [
-			'rocket_first_install_options' => [ 'add_option', 14 ],
+			'rocket_first_install_options' => [ 'add_option', 16 ],
 			'rocket_input_sanitize'        => [ 'sanitize_option', 10, 2 ],
 		];
 	}

--- a/inc/Engine/Media/Fonts/ServiceProvider.php
+++ b/inc/Engine/Media/Fonts/ServiceProvider.php
@@ -41,6 +41,6 @@ class ServiceProvider extends AbstractServiceProvider {
 	public function register(): void {
 		$this->getContainer()->add( 'media_fonts_settings', Settings::class );
 		$this->getContainer()->addShared( 'media_fonts_admin_subscriber', AdminSubscriber::class )
-			->addArgument( 'media_fonts_settings' );;
+			->addArgument( 'media_fonts_settings' );
 	}
 }

--- a/inc/Engine/Media/Fonts/ServiceProvider.php
+++ b/inc/Engine/Media/Fonts/ServiceProvider.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Engine\Media\Fonts;
+
+use WP_Rocket\Dependencies\League\Container\ServiceProvider\AbstractServiceProvider;
+use WP_Rocket\Engine\Media\Fonts\Admin\Settings;
+use WP_Rocket\Engine\Media\Fonts\Admin\Subscriber as AdminSubscriber;
+
+class ServiceProvider extends AbstractServiceProvider {
+	/**
+	 * The provides array is a way to let the container
+	 * know that a service is provided by this service
+	 * provider. Every service that is registered via
+	 * this service provider must have an alias added
+	 * to this array or it will be ignored.
+	 *
+	 * @var array
+	 */
+	protected $provides = [
+		'media_fonts_settings',
+		'media_fonts_admin_subscriber',
+	];
+
+	/**
+	 * Check if the service provider provides a specific service.
+	 *
+	 * @param string $id The id of the service.
+	 *
+	 * @return bool
+	 */
+	public function provides( string $id ): bool {
+		return in_array( $id, $this->provides, true );
+	}
+
+	/**
+	 * Registers the classes.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		$this->getContainer()->add( 'media_fonts_settings', Settings::class );
+		$this->getContainer()->addShared( 'media_fonts_admin_subscriber', AdminSubscriber::class )
+			->addArgument( 'media_fonts_settings' );;
+	}
+}

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -53,6 +53,7 @@ use WP_Rocket\Engine\Debug\Resolver as DebugResolver;
 use WP_Rocket\Engine\Debug\ServiceProvider as DebugServiceProvider;
 use WP_Rocket\Engine\Common\PerformanceHints\ServiceProvider as PerformanceHintsServiceProvider;
 use WP_Rocket\Engine\Optimization\LazyRenderContent\ServiceProvider as LRCServiceProvider;
+use WP_Rocket\Engine\Media\Fonts\ServiceProvider as MediaFontsServiceProvider;
 
 /**
  * Plugin Manager.
@@ -308,6 +309,7 @@ class Plugin {
 		$this->container->addServiceProvider( new SaasAdminServiceProvider() );
 		$this->container->addServiceProvider( new PerformanceHintsServiceProvider() );
 		$this->container->addServiceProvider( new LRCServiceProvider() );
+		$this->container->addServiceProvider( new MediaFontsServiceProvider() );
 
 		$common_subscribers = [
 			'license_subscriber',
@@ -401,6 +403,7 @@ class Plugin {
 			'performance_hints_admin_subscriber',
 			'lrc_frontend_subscriber',
 			'taxonomy_subscriber',
+			'media_fonts_admin_subscriber',
 		];
 
 		$host_type = HostResolver::get_host_service();

--- a/tests/Fixtures/inc/admin/rocketFirstInstall.php
+++ b/tests/Fixtures/inc/admin/rocketFirstInstall.php
@@ -76,6 +76,7 @@ $integration[ 'remove_unused_css_safelist' ] 					 = [];
 $integration[ 'preload_links' ]              					 = 1;
 $integration[ 'image_dimensions' ]           	 				 = 0;
 $integration[ 'exclude_lazyload' ]           					 = [];
+$integration['host_fonts_locally']           					 = 0;
 
 return [
 	'test_data' => [

--- a/tests/Integration/inc/Engine/Media/ImageDimensions/AdminSubscriber/addOption.php
+++ b/tests/Integration/inc/Engine/Media/ImageDimensions/AdminSubscriber/addOption.php
@@ -18,9 +18,9 @@ class Test_AddOption extends TestCase {
 	}
 
 	public function tear_down() {
-		parent::tear_down();
-
 		$this->restoreWpHook( 'rocket_first_install_options' );
+
+		parent::tear_down();
 	}
 
 	/**


### PR DESCRIPTION
# Description

Fixes #7068

Add admin UI & option sanitization for the new host fonts locally option

## Type of change

- [x] Sub-task of #7039

## Detailed scenario

- Host Google Font option is added in the media tab as a checkbox below the Image Dimensions section
- The text under the media tab changes to “LazyLoad, image dimensions, font optimization”
- The section heading is “Fonts”
- The section description is “Download and serve fonts directly from your server. Reduces connections to external servers and minimizes font shifts. More info” (need links to documentation, FR and EN)
- The checkbox label is “Host Google Fonts locally”
- When enabling the option, the option is there in the options table

## Technical description

### Documentation

Added new sections for the fonts & host fonts locally in the admin.
Added initialization and sanitization of the host fonts locally option in the WPR settings.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.