### PR TITLE
Displays the new licence->name instead of license_account matching licence

### DIFF
--- a/inc/functions/admin.php
+++ b/inc/functions/admin.php
@@ -550,6 +550,12 @@ function rocket_get_license_type( $customer_data ) {
 		return __( 'Unavailable', 'rocket' );
 	}
 
+	// The licence name directly from User endpoint.
+	if ( ! empty ( $customer_data->licence->name ) ) {
+		return esc_html( $customer_data->licence->name );
+	}
+
+	// Fallback to licence account.
 	if ( 1 <= $customer_data->licence_account
 		&&
 		$customer_data->licence_account < 3

--- a/inc/functions/admin.php
+++ b/inc/functions/admin.php
@@ -551,7 +551,7 @@ function rocket_get_license_type( $customer_data ) {
 	}
 
 	// The licence name directly from User endpoint.
-	if ( ! empty ( $customer_data->licence->name ) ) {
+	if ( ! empty( $customer_data->licence->name ) ) {
 		return esc_html( $customer_data->licence->name );
 	}
 


### PR DESCRIPTION
# Description

Fixes #7096

The PR only changes dashboard view (Your licence) with a fallback:

- Display the `user->licence->name` is if exists in the user endpoint
- Display the regular `licence_account` matching licence name if `user->licence->name` is empty

The user endpoint will soon include new values under `licence`, like `name`, `expiration`, `type`, `version`.
Until this is the case, this code will just fallback to current way of displaying the license name in the dashboard.

After the new license data is available to the plugin (once service team deploys and repopulate Redis for users), the plugin will have `user->licence->name` set and then can display it directly.
[See the new user endpoint data JSON response format.](https://github.com/wp-media/wp-rocket.me/issues/4255#issuecomment-2462212159)

Back-compatibility: Users with previous plugin versions will not be able to see their accurate license name. A fallback was made on service side to display Infinite, for new licenses.

![image](https://github.com/user-attachments/assets/55b6cc58-d588-49f6-b644-9b531a79bb2b)

## Type of change

- [x] New feature (non-breaking change which adds functionality).
- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

A missing `licence->name` value should not trigger any error and fallback to legacy way to matching the licence name.

[See two types of user, one with new license data, one without.](https://github.com/wp-media/wp-rocket.me/pull/4266#issuecomment-2462223217)


## Technical description

### Documentation

The new user endpoint JSON format:

```json
{
    "ID": "1",
    "licence": {
        "type": "infinite",
        "name": "Infinite",
        "websites": "-1",
        "version": "3.14.1",
        "expiration": "1793187043"
    },
    "first_name": "Xxx",
    "email": "xxx@wp-rocket.me",
    "date_created": "1370596455",
    "licence_account": "-1",
    "licence_version": "3.14.1",
    "licence_expiration": "1793187043",
    "consumer_key": "xxxx",
    "is_blocked": "0",
    "is_staggered": "0",
    "has_auto_renew": "1",
    "has_one-com_account": "0",
    "status": "active",
    "last_order_reseller_id": "0",
    "renewal_url": "https://wp-rocket.me/checkout/renew/xxxx/xxxxxxxxx/",
    "upgrade_plus_url": "https://wp-rocket.me/checkout/upgrade/xxxx/xxxx/plus/",
    "upgrade_infinite_url": "https://wp-rocket.me/checkout/upgrade/xxxx/xxxx/infinite/"
}
```
### Risks

If the license->name is missing, the plugin will behave just as before.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)