### PR TITLE
Closes #7066: 3.18 - Preconnect and prefetch removal 

### DIFF
--- a/inc/Engine/Media/Fonts/Frontend/Controller.php
+++ b/inc/Engine/Media/Fonts/Frontend/Controller.php
@@ -123,11 +123,11 @@ class Controller {
 	 */
 	private function remove_preconnect_and_prefetch( string $html ) {
 		/**
-		 * Filters the removal of Google preconnect and prefetch links.
+		 * Filters the removal of Google preconnect/prefetch links.
 		 *
 		 * @since 3.18
 		 *
-		 * @param bool $enable_noscript Enable or disable noscript tag.
+		 * @param bool $enable_removal Enable or disable removal of Google preconnect/prefetch links.
 		 */
 		$remove_links = wpm_apply_filters_typed( 'boolean', 'rocket_remove_font_pre_links', true );
 

--- a/inc/Engine/Media/Fonts/Frontend/Controller.php
+++ b/inc/Engine/Media/Fonts/Frontend/Controller.php
@@ -63,6 +63,8 @@ class Controller {
 			$html = $this->replace_font( $font, $html );
 		}
 
+		$html = $this->remove_preconnect_and_prefetch( $html );
+
 		return $html;
 	}
 
@@ -109,5 +111,29 @@ class Controller {
 			$url,
 			$gf_parameters
 		);
+	}
+
+	/**
+	 * Removes preconnect and prefetch links for Google Fonts from the HTML content.
+	 *
+	 * @param string $html HTML content.
+	 *
+	 * @return string Modified HTML content without preconnect and prefetch links.
+	 */
+	private function remove_preconnect_and_prefetch( string $html ) {
+		if ( ! $html ) {
+			return $html;
+		}
+		$remove_links = wpm_apply_filters_typed( 'boolean', 'rocket_remove_font_pre_links', true );
+
+		if ( ! $remove_links ) {
+			return $html;
+		}
+
+		$pattern = '/<link(?:[^>]*)(?:rel=["\'](?:dns-prefetch|preconnect)["\'])(?:[^>]*)(?:href=["\'](?:https?:)?\/\/(?:fonts\.(?:googleapis|gstatic)\.com)["\'])(?:[^>]*)>/i';
+
+		$html = preg_replace( $pattern, '', $html );
+
+		return $html;
 	}
 }

--- a/inc/Engine/Media/Fonts/Frontend/Controller.php
+++ b/inc/Engine/Media/Fonts/Frontend/Controller.php
@@ -121,9 +121,6 @@ class Controller {
 	 * @return string Modified HTML content without preconnect and prefetch links.
 	 */
 	private function remove_preconnect_and_prefetch( string $html ) {
-		if ( ! $html ) {
-			return $html;
-		}
 		$remove_links = wpm_apply_filters_typed( 'boolean', 'rocket_remove_font_pre_links', true );
 
 		if ( ! $remove_links ) {

--- a/inc/Engine/Media/Fonts/Frontend/Controller.php
+++ b/inc/Engine/Media/Fonts/Frontend/Controller.php
@@ -133,9 +133,9 @@ class Controller {
 		$html = preg_replace( $pattern, '', $html );
 
 		return $html;
-  }
-   
-    /**
+	}
+
+	/**
 	 * Disables the preload of Google Fonts.
 	 *
 	 * @param bool $disable Whether to disable the preload of Google Fonts.

--- a/inc/Engine/Media/Fonts/Frontend/Controller.php
+++ b/inc/Engine/Media/Fonts/Frontend/Controller.php
@@ -122,6 +122,13 @@ class Controller {
 	 * @return string Modified HTML content without preconnect and prefetch links.
 	 */
 	private function remove_preconnect_and_prefetch( string $html ) {
+		/**
+		 * Filters the removal of Google preconnect and prefetch links.
+		 *
+		 * @since 3.18
+		 *
+		 * @param bool $enable_noscript Enable or disable noscript tag.
+		 */
 		$remove_links = wpm_apply_filters_typed( 'boolean', 'rocket_remove_font_pre_links', true );
 
 		if ( ! $remove_links ) {

--- a/tests/Fixtures/inc/Engine/Media/Fonts/Frontend/Controller/HTML/input_v1.php
+++ b/tests/Fixtures/inc/Engine/Media/Fonts/Frontend/Controller/HTML/input_v1.php
@@ -9,6 +9,8 @@
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Google Font V1 Template</title>
+	<link rel="preconnect" href="https://fonts.googleapis.com">
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 	<link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
 	<link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
 	<style>

--- a/tests/Fixtures/inc/Engine/Media/Fonts/Frontend/Controller/HTML/input_v1_v2.php
+++ b/tests/Fixtures/inc/Engine/Media/Fonts/Frontend/Controller/HTML/input_v1_v2.php
@@ -9,6 +9,8 @@
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Google Font V1 and V2 Template</title>
+	<link rel="preconnect" href="https://fonts.googleapis.com">
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 	<link href="https://fonts.googleapis.com/css?family=Roboto|Open+Sans" rel="stylesheet"> <!-- V1 Fonts -->
 	<link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&family=Montserrat:wght@400;700&display=swap" rel="stylesheet"> <!-- V2 Fonts -->
 	<style>

--- a/tests/Fixtures/inc/Engine/Media/Fonts/Frontend/Controller/HTML/input_v2.php
+++ b/tests/Fixtures/inc/Engine/Media/Fonts/Frontend/Controller/HTML/input_v2.php
@@ -9,6 +9,8 @@
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Google Font V2 Template</title>
+	<link rel="preconnect" href="https://fonts.googleapis.com">
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 	<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
 	<link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&display=swap" rel="stylesheet">
 	<style>

--- a/tests/Unit/inc/Engine/Media/Fonts/Frontend/Controller/rewriteFonts.php
+++ b/tests/Unit/inc/Engine/Media/Fonts/Frontend/Controller/rewriteFonts.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace WP_Rocket\tests\Unit\inc\Engine\Media\Fonts\Frontend\Controller;
+namespace WP_Rocket\Tests\Unit\inc\Engine\Media\Fonts\Frontend\Controller;
 
 use Brain\Monkey\Functions;
 use Mockery;


### PR DESCRIPTION
# Description

https://github.com/wp-media/wp-rocket/pull/7091 needs to be merged first. This PR is based on the current build of [this](https://github.com/wp-media/wp-rocket/pull/7091) PR. Only the last two commits are for this PR. 

Fixes #7066
We are removing the `prefetch` and `preconnect` tag from the html if we are serving local hosted google fonts.
## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

1. Enable the Host Local Font option under the `Media` tab of WPR settings
2. Load a page with google fonts and prefetch/preconnect tags
3. Check the HTML, both of these tags should be removed. 

## Technical description

### Documentation

This enhancement introduces a method to remove preconnect and prefetch links for Google Fonts from the HTML content. The purpose of this change is to optimize the loading process by eliminating unnecessary DNS prefetch and preconnect requests for Google Fonts.

**How It Works**

**Method Introduction**: A new private method remove_preconnect_and_prefetch is added to the Controller class.

**HTML Content Check**: The method first checks if the provided HTML content is empty. If it is, the original HTML is returned.

**Filter Application**: A filter `rocket_remove_font_pre_links` is applied to determine whether the preconnect and prefetch links should be removed. If the filter returns false, the original HTML is returned.

**Pattern Matching**: A regular expression pattern is used to match `preconnect` and `prefetch` links for Google Fonts.

**Tags Removal**: The matched tags are removed from the HTML content using `preg_replace`.

**Return Modified** HTML: The modified HTML content, without the `preconnect` and `prefetch` links, is returned.

### New dependencies

None

### Risks

None

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.
