### PR TITLE
Closes #7111: Change the folder where fonts are being laoded

### DIFF
--- a/inc/Engine/Media/Fonts/Frontend/Controller.php
+++ b/inc/Engine/Media/Fonts/Frontend/Controller.php
@@ -31,7 +31,7 @@ class Controller {
 	 */
 	public function __construct( Context $context ) {
 		$this->context  = $context;
-		$this->base_url = rocket_get_constant( 'WP_ROCKET_CACHE_ROOT_URL', '' ) . 'fonts/' . get_current_blog_id() . '/';
+		$this->base_url = rocket_get_constant( 'WP_ROCKET_CACHE_ROOT_URL', '' ) . 'fonts/google-fonts/' . get_current_blog_id() . '/';
 	}
 
 	/**

--- a/tests/Fixtures/inc/Engine/Media/Fonts/Frontend/Controller/HTML/expected_v1.php
+++ b/tests/Fixtures/inc/Engine/Media/Fonts/Frontend/Controller/HTML/expected_v1.php
@@ -9,8 +9,8 @@
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Google Font V1 Template</title>
-	<link rel="stylesheet" href="http://example.org/wp-content/cache/fonts/1/e/b/c/173c0fc97eef86a6e51ada56c5a9a.css" data-wpr-hosted-gf-parameters="family=Roboto"/>
-	<link rel="stylesheet" href="http://example.org/wp-content/cache/fonts/1/5/9/5/cb6ccb56826a802ed411cef875f0e.css" data-wpr-hosted-gf-parameters="family=Open+Sans"/>
+	<link rel="stylesheet" href="http://example.org/wp-content/cache/fonts/google-fonts/1/e/b/c/173c0fc97eef86a6e51ada56c5a9a.css" data-wpr-hosted-gf-parameters="family=Roboto"/>
+	<link rel="stylesheet" href="http://example.org/wp-content/cache/fonts/google-fonts/1/5/9/5/cb6ccb56826a802ed411cef875f0e.css" data-wpr-hosted-gf-parameters="family=Open+Sans"/>
 	<style>
 		.roboto-font {
 			font-family: 'Roboto', sans-serif;

--- a/tests/Fixtures/inc/Engine/Media/Fonts/Frontend/Controller/HTML/expected_v1_v2.php
+++ b/tests/Fixtures/inc/Engine/Media/Fonts/Frontend/Controller/HTML/expected_v1_v2.php
@@ -9,8 +9,8 @@
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Google Font V1 and V2 Template</title>
-	<link rel="stylesheet" href="http://example.org/wp-content/cache/fonts/1/6/2/4/f2c2b9858423d0688793189f6e6cb.css" data-wpr-hosted-gf-parameters="family=Roboto|Open+Sans"/> <!-- V1 Fonts -->
-	<link rel="stylesheet" href="http://example.org/wp-content/cache/fonts/1/8/d/4/e42f26da0305c49cd3264956d8329.css" data-wpr-hosted-gf-parameters="family=Lato:wght@400;700&family=Montserrat:wght@400;700&display=swap"/> <!-- V2 Fonts -->
+	<link rel="stylesheet" href="http://example.org/wp-content/cache/fonts/google-fonts/1/6/2/4/f2c2b9858423d0688793189f6e6cb.css" data-wpr-hosted-gf-parameters="family=Roboto|Open+Sans"/> <!-- V1 Fonts -->
+	<link rel="stylesheet" href="http://example.org/wp-content/cache/fonts/google-fonts/1/8/d/4/e42f26da0305c49cd3264956d8329.css" data-wpr-hosted-gf-parameters="family=Lato:wght@400;700&family=Montserrat:wght@400;700&display=swap"/> <!-- V2 Fonts -->
 	<style>
 		.v1-font-roboto {
 			font-family: 'Roboto', sans-serif;

--- a/tests/Fixtures/inc/Engine/Media/Fonts/Frontend/Controller/HTML/expected_v2.php
+++ b/tests/Fixtures/inc/Engine/Media/Fonts/Frontend/Controller/HTML/expected_v2.php
@@ -9,8 +9,8 @@
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Google Font V2 Template</title>
-	<link rel="stylesheet" href="http://example.org/wp-content/cache/fonts/1/a/b/2/8ffb4f83584e9add1be594dd90dfd.css" data-wpr-hosted-gf-parameters="family=Roboto:wght@400;700&display=swap"/>
-	<link rel="stylesheet" href="http://example.org/wp-content/cache/fonts/1/b/4/d/9ffca0114d3acb6ab0b068feaf933.css" data-wpr-hosted-gf-parameters="family=Lato:wght@400;700&display=swap"/>
+	<link rel="stylesheet" href="http://example.org/wp-content/cache/fonts/google-fonts/1/a/b/2/8ffb4f83584e9add1be594dd90dfd.css" data-wpr-hosted-gf-parameters="family=Roboto:wght@400;700&display=swap"/>
+	<link rel="stylesheet" href="http://example.org/wp-content/cache/fonts/google-fonts/1/b/4/d/9ffca0114d3acb6ab0b068feaf933.css" data-wpr-hosted-gf-parameters="family=Lato:wght@400;700&display=swap"/>
 	<style>
 		.roboto-font {
 			font-family: 'Roboto', sans-serif;


### PR DESCRIPTION
# Description

Fixes #7111 

It changes the folder where fonts are being loaded from. 
Now it will look into `/wp-content/cache/fonts/google-fonts/` instead of `/wp-content/cache/fonts/`

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).
- [x] Sub-task of #7063 

## Detailed scenario

Just load a page with google fonts, and check the added tag to load the local file. 

## Technical description

### Documentation

N/a

### New dependencies

N/a

### Risks

N/a

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.
