### PR TITLE
Make sure taxonomy non-latin base slugs are cached

### DIFF
--- a/inc/Engine/Cache/TaxonomySubscriber.php
+++ b/inc/Engine/Cache/TaxonomySubscriber.php
@@ -69,6 +69,6 @@ class TaxonomySubscriber implements Subscriber_Interface {
 			$term_link = trailingslashit( $term_link ) . 'page/' . get_query_var( 'paged' );
 		}
 
-		return untrailingslashit( $term_link ) !== untrailingslashit( $current_link );
+		return urldecode( untrailingslashit( $term_link ) ) !== urldecode( untrailingslashit( $current_link ) );
 	}
 }

--- a/tests/Fixtures/inc/Engine/Cache/TaxonomySubscriber/disableCacheOnNotValidTaxonomyPages.php
+++ b/tests/Fixtures/inc/Engine/Cache/TaxonomySubscriber/disableCacheOnNotValidTaxonomyPages.php
@@ -91,5 +91,16 @@ return [
 			],
 			'can_cache' => false,
 		],
+		'testValidTaxonomyPageWithNonLatinCharactersInUrl' => [
+			'config' => [
+				'is_category' => true,
+				'is_tag' => false,
+				'is_tax' => false,
+				'current_term_id' => 1,
+				'current_term_link' => 'http://example.com/%D0%BF%D1%80%D0%BE%D0%B4%D1%83%D0%BA%D1%82%D0%BE%D0%B2%D0%B0-%D0%BA%D0%B0%D1%82%D0%B5%D0%B3%D0%BE%D1%80%D0%B8%D1%8F/test1',
+				'current_page_url' => 'http://example.com/продуктова-категория/test1/',
+			],
+			'can_cache' => true,
+		],
 	],
 ];


### PR DESCRIPTION
# Description

Fixes #7106 

This should fix the issue of having non-latin characters in base slugs for any taxonomy, the terms' pages for those taxonomies are not being cached.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

1. Go to WP dashboard >> Settings >> Permalinks
2. Change the `Category base` to be `продуктова-категория` then save permalinks.
3. Visit any category page in frontend.
4. The page is not cached before this PR, u can check our HTML comment signature at the end of the page.

## Technical description

### Documentation

As I mentioned in the issue itself, there is a discussion in the core here:
https://core.trac.wordpress.org/ticket/16839

The main issue here is that When using `get_term_link` function, it puts the base slug without encoding it at all, but encoding the rest of the url (term slug) so when comparing the current page url with the term url, it fails, so here I decoded both urls before comparing them, and this works perfectly.

### New dependencies

No

### Risks

I can't think of any risk here, this should work with encoded and non-encoded urls.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)