### PR TITLE
Closes #7123: Rules about get_subscribed_events

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -234,6 +234,8 @@
 			"@test-integration-pressidium"
 		],
 		"run-stan": "vendor/bin/phpstan analyze --memory-limit=2G --no-progress",
+		"run-stan-reset-baseline": "vendor/bin/phpstan analyze --memory-limit=2G --no-progress --generate-baseline",
+		"run-stan-test": "vendor/bin/phpstan analyze inc/Engine/Common/ExtractCSS/Subscriber.php --memory-limit=2G --no-progress --debug",
 		"install-codestandards": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",
 		"phpcs": "phpcs --basepath=.",
 		"phpcs-changed": "./bin/phpcs-changed.sh",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,8 +1,11 @@
 includes:
 	- phar://phpstan.phar/conf/bleedingEdge.neon
+#	- phpstan-baseline.neon
+
 parameters:
 	level: 4
 	inferPrivatePropertyTypeFromConstructor: true
+#	reportUnmatchedIgnoredErrors: false
 	paths:
 		# Test only the new architecture for now.
 		- %currentWorkingDirectory%/inc/Engine/
@@ -10,6 +13,7 @@ parameters:
 		- %currentWorkingDirectory%/inc/ThirdParty/
 		- %currentWorkingDirectory%/tests/Integration/
 		- %currentWorkingDirectory%/tests/Unit/
+		- %currentWorkingDirectory%/tests/phpstan/Rules/
 	bootstrapFiles:
 		# Must be first
 		- %currentWorkingDirectory%/inc/functions/options.php
@@ -51,3 +55,5 @@ parameters:
 		 # These need plugin stubs!
 		 - %currentWorkingDirectory%/inc/classes/subscriber/third-party/
 		 - %currentWorkingDirectory%/inc/3rd-party/
+rules:
+	- WP_Rocket\Tests\phpstan\Rules\EnsureCallbackMethodsExistsInSubscribedEvents

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,10 +1,10 @@
 includes:
 	- phar://phpstan.phar/conf/bleedingEdge.neon
-#	- phpstan-baseline.neon
+	- phpstan-baseline.neon
 parameters:
 	level: 4
 	inferPrivatePropertyTypeFromConstructor: true
-#	reportUnmatchedIgnoredErrors: false
+	reportUnmatchedIgnoredErrors: false
 	paths:
 		# Test only the new architecture for now.
 		- %currentWorkingDirectory%/inc/Engine/

--- a/tests/phpstan/Rules/EnsureCallbackMethodsExistsInSubscribedEvents.php
+++ b/tests/phpstan/Rules/EnsureCallbackMethodsExistsInSubscribedEvents.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace WP_Rocket\Tests\phpstan\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Return_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+class EnsureCallbackMethodsExistsInSubscribedEvents implements Rule
+{
+	public function getNodeType(): string
+	{
+		return Return_::class; // We want to inspect return statements
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		$errors = [];
+
+		// Check if the node is a return statement
+		if ($node instanceof Return_ && $node->expr) {
+
+			// Get the function/method name from the scope
+			$functionName = $scope->getFunctionName();
+			if ('get_subscribed_events' === $functionName) {
+				// Check if the return expression is an array
+				if ($node->expr instanceof Node\Expr\Array_) {
+					foreach ($node->expr->items as $item) {
+						if ($item instanceof Node\Expr\ArrayItem) {
+							// Ensure the key exists and is a valid type (like a string) before accessing the value
+							$hookName = null;
+							if ($item->key instanceof Node\Scalar\String_) {
+								$hookName = $item->key->value;
+							}
+
+							// Analyze the value of the array item
+							$methodValue = $item->value;
+							$errors = array_merge($errors, $this->analyzeMethodValue($methodValue, $scope));
+						}
+					}
+				}
+			}
+		}
+
+		return $errors; // Return all collected errors
+	}
+
+	/**
+	 * Analyze the method value from the array structure.
+	 */
+	private function analyzeMethodValue(Node $methodValue, Scope $scope): array
+	{
+		$errors = [];
+
+		if ($methodValue instanceof Node\Scalar\String_) {
+			// Simple structure: array('hook_name' => 'method_name')
+			$errors = $this->checkIfMethodExistsInClass($methodValue->value, $scope, $methodValue);
+		} elseif ($methodValue instanceof Node\Expr\Array_) {
+			// More complex structures: array or nested array
+			foreach ($methodValue->items as $subItem) {
+				if ($subItem instanceof Node\Expr\ArrayItem) {
+					if ($subItem->value instanceof Node\Scalar\String_) {
+						$errors = array_merge($errors, $this->checkIfMethodExistsInClass($subItem->value->value, $scope, $subItem->value));
+					}
+				}
+			}
+		}
+
+		return $errors;
+	}
+
+	public function checkIfMethodExistsInClass(string $methodName, Scope $scope, Node $node): array
+	{
+		$classReflection = $scope->getClassReflection();
+
+		// Check if the class reflection is available and the method exists
+		if ($classReflection && $classReflection->hasMethod($methodName)) {
+			return [];
+		}
+
+		// Check if the method exists in the parent class or interfaces
+		$parentClass = $classReflection ? $classReflection->getParentClass() : null;
+		if ($parentClass && $parentClass->hasMethod($methodName)) {
+			return [];
+		}
+
+		foreach ($classReflection->getInterfaces() as $interface) {
+			if ($interface->hasMethod($methodName)) {
+				return [];
+			}
+		}
+
+		// If the method doesn't exist, return an error using RuleErrorBuilder
+		$errorMessage = sprintf(
+			"The callback function '%s' declared within 'get_subscribed_events' does not exist in the class '%s'.",
+			$methodName,
+			$classReflection ? $classReflection->getName() : 'unknown'
+		);
+
+		return [
+			RuleErrorBuilder::message($errorMessage)
+				->line($node->getLine()) // Add the line number
+				->build()
+		];
+	}
+}

--- a/tests/phpstan/Rules/EnsureCallbackMethodsExistsInSubscribedEvents.php
+++ b/tests/phpstan/Rules/EnsureCallbackMethodsExistsInSubscribedEvents.php
@@ -3,67 +3,105 @@
 namespace WP_Rocket\Tests\phpstan\Rules;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Stmt\Return_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 
-class EnsureCallbackMethodsExistsInSubscribedEvents implements Rule
-{
-	public function getNodeType(): string
-	{
-		return Return_::class; // We want to inspect return statements
-	}
+class EnsureCallbackMethodsExistsInSubscribedEvents implements Rule {
 
-	public function processNode(Node $node, Scope $scope): array
-	{
-		$errors = [];
-
-		// Check if the node is a return statement
-		if ($node instanceof Return_ && $node->expr) {
-
-			// Get the function/method name from the scope
-			$functionName = $scope->getFunctionName();
-			if ('get_subscribed_events' === $functionName) {
-				// Check if the return expression is an array
-				if ($node->expr instanceof Node\Expr\Array_) {
-					foreach ($node->expr->items as $item) {
-						if ($item instanceof Node\Expr\ArrayItem) {
-							// Ensure the key exists and is a valid type (like a string) before accessing the value
-							$hookName = null;
-							if ($item->key instanceof Node\Scalar\String_) {
-								$hookName = $item->key->value;
-							}
-
-							// Analyze the value of the array item
-							$methodValue = $item->value;
-							$errors = array_merge($errors, $this->analyzeMethodValue($methodValue, $scope));
-						}
-					}
-				}
-			}
-		}
-
-		return $errors; // Return all collected errors
+	/**
+	 * Returns the type of the node that this rule is interested in.
+	 *
+	 * @return string The class name of the node type.
+	 */
+	public function getNodeType(): string {
+		return Return_::class;
 	}
 
 	/**
-	 * Analyze the method value from the array structure.
+	 * Processes a node to ensure that callback methods exist in subscribed events.
+	 *
+	 * @param Node  $node The node to process.
+	 * @param Scope $scope The scope in which the node is being processed.
+	 * @return array An array of errors found during the processing of the node.
 	 */
-	private function analyzeMethodValue(Node $methodValue, Scope $scope): array
-	{
+	public function processNode( Node $node, Scope $scope ): array {
+		// Bail out early if the node is not a return statement with an expression.
+		if ( ! ( $node instanceof Return_ && $node->expr ) ) {
+			return [];
+		}
+
+		$function_name = $scope->getFunctionName();
+		// Bail out early if the method is not `get_subscribed_events`.
+		if ( 'get_subscribed_events' !== $function_name ) {
+			return [];
+		}
+
+		// Check if the return expression is an array.
+		if ( $node->expr instanceof Node\Expr\Array_ ) {
+			return $this->analyzeArray( $node->expr, $scope );
+		}
+
+		return [];
+	}
+
+	/**
+	 * Analyzes the array structure returned by `get_subscribed_events`.
+	 *
+	 * @param Node\Expr\Array_ $array_expr The array expression node to analyze.
+	 * @param Scope            $scope The scope in which the array expression is being analyzed.
+	 * @return array An array of errors found during the analysis of the array structure.
+	 */
+	private function analyzeArray( Node\Expr\Array_ $array_expr, Scope $scope ): array {
 		$errors = [];
 
-		if ($methodValue instanceof Node\Scalar\String_) {
-			// Simple structure: array('hook_name' => 'method_name')
-			$errors = $this->checkIfMethodExistsInClass($methodValue->value, $scope, $methodValue);
-		} elseif ($methodValue instanceof Node\Expr\Array_) {
-			// More complex structures: array or nested array
-			foreach ($methodValue->items as $subItem) {
-				if ($subItem instanceof Node\Expr\ArrayItem) {
-					if ($subItem->value instanceof Node\Scalar\String_) {
-						$errors = array_merge($errors, $this->checkIfMethodExistsInClass($subItem->value->value, $scope, $subItem->value));
-					}
+		foreach ( $array_expr->items as $item ) {
+			// Skip invalid array items.
+			if ( ! $item instanceof ArrayItem ) { // @phpstan-ignore-line PHPStan mess up with the type, and report a false positive error.
+				continue;
+			}
+
+			$method_value = $item->value; // @phpstan-ignore-line Because of the above issue, we need to ignore the error here as it thinks it's unreachable.
+
+			// Analyze the method value.
+			$errors = array_merge( $errors, $this->analyzeMethodValue( $method_value, $scope ) );
+		}
+
+		return $errors;
+	}
+
+	/**
+	 * Analyzes the method value from the array structure.
+	 *
+	 * @param Node  $method_value The method value node to analyze.
+	 * @param Scope $scope The scope in which the method value is being analyzed.
+	 * @return array An array of errors found during the analysis of the method value.
+	 * @phpstan-ignore-next-line While running phpstan, it can't detect it's being used while in real it is.
+	 */
+	private function analyzeMethodValue( Node $method_value, Scope $scope ): array {
+		$errors = [];
+
+		if ( $method_value instanceof Node\Scalar\String_ ) {
+			// Simple structure: array('hook_name' => 'method_name').
+			return $this->checkIfMethodExistsInClass( $method_value->value, $scope, $method_value );
+		}
+
+		if ( $method_value instanceof Node\Expr\Array_ ) {
+			// More complex structures: array or nested array.
+			foreach ( $method_value->items as $sub_item ) {
+				if ( ! ( $sub_item instanceof ArrayItem ) ) { // @phpstan-ignore-line
+					continue;
+				}
+
+				// @phpstan-ignore-next-line While running phpstan, it can't detect it's being used while in real it is.
+				if ( $sub_item->value instanceof Node\Scalar\String_ ) {
+					// Handle string callback in nested array.
+					$errors = array_merge( $errors, $this->checkIfMethodExistsInClass( $sub_item->value->value, $scope, $sub_item->value ) );
+				} elseif ( $sub_item->value instanceof Node\Expr\Array_ ) {
+					// Recursively analyze nested arrays.
+					$errors = array_merge( $errors, $this->analyzeMethodValue( $sub_item->value, $scope ) );
 				}
 			}
 		}
@@ -71,38 +109,44 @@ class EnsureCallbackMethodsExistsInSubscribedEvents implements Rule
 		return $errors;
 	}
 
-	public function checkIfMethodExistsInClass(string $methodName, Scope $scope, Node $node): array
-	{
-		$classReflection = $scope->getClassReflection();
+	/**
+	 * Checks if a method exists in the class, its parent class, or its interfaces.
+	 *
+	 * @param string $method_name The name of the method to check.
+	 * @param Scope  $scope The scope in which the method is being checked.
+	 * @param Node   $node The node representing the method call.
+	 * @return array An array of errors if the method does not exist, otherwise an empty array.
+	 */
+	public function checkIfMethodExistsInClass( string $method_name, Scope $scope, Node $node ): array {
+		$class_reflection = $scope->getClassReflection();
 
-		// Check if the class reflection is available and the method exists
-		if ($classReflection && $classReflection->hasMethod($methodName)) {
+		// Bail out early if the class reflection or method is found.
+		if ( $class_reflection && $class_reflection->hasMethod( $method_name ) ) {
 			return [];
 		}
 
-		// Check if the method exists in the parent class or interfaces
-		$parentClass = $classReflection ? $classReflection->getParentClass() : null;
-		if ($parentClass && $parentClass->hasMethod($methodName)) {
+		$parent_class = $class_reflection ? $class_reflection->getParentClass() : null;
+		if ( $parent_class && $parent_class->hasMethod( $method_name ) ) {
 			return [];
 		}
 
-		foreach ($classReflection->getInterfaces() as $interface) {
-			if ($interface->hasMethod($methodName)) {
+		foreach ( $class_reflection->getInterfaces() as $interface ) {
+			if ( $interface->hasMethod( $method_name ) ) {
 				return [];
 			}
 		}
 
-		// If the method doesn't exist, return an error using RuleErrorBuilder
-		$errorMessage = sprintf(
+		// If the method doesn't exist, return an error.
+		$error_message = sprintf(
 			"The callback function '%s' declared within 'get_subscribed_events' does not exist in the class '%s'.",
-			$methodName,
-			$classReflection ? $classReflection->getName() : 'unknown'
+			$method_name,
+			$class_reflection ? $class_reflection->getName() : 'unknown'
 		);
 
 		return [
-			RuleErrorBuilder::message($errorMessage)
-				->line($node->getLine()) // Add the line number
-				->build()
+			RuleErrorBuilder::message( $error_message )
+				->line( $node->getLine() ) // Add the line number.
+				->build(),
 		];
 	}
 }

--- a/tests/phpstan/Rules/EnsureCallbackMethodsExistsInSubscribedEvents.php
+++ b/tests/phpstan/Rules/EnsureCallbackMethodsExistsInSubscribedEvents.php
@@ -146,6 +146,7 @@ class EnsureCallbackMethodsExistsInSubscribedEvents implements Rule {
 		return [
 			RuleErrorBuilder::message( $error_message )
 				->line( $node->getLine() ) // Add the line number.
+				->identifier( 'callbackMethodNotFound' )
 				->build(),
 		];
 	}

--- a/tests/phpstan/tests/Rules/EnsureCallbackMethodsExistsInSubscribedEventsTest.php
+++ b/tests/phpstan/tests/Rules/EnsureCallbackMethodsExistsInSubscribedEventsTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace WP_Rocket\Tests\phpstan\tests\Rules;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use WP_Rocket\Tests\phpstan\Rules\EnsureCallbackMethodsExistsInSubscribedEvents;
+
+class EnsureCallbackMethodsExistsInSubscribedEventsTest extends RuleTestCase {
+
+	protected function getRule(): Rule {
+		return new EnsureCallbackMethodsExistsInSubscribedEvents();
+	}
+
+	public function testValidSubscriberShouldNotHaveErrors() {
+		$this->analyse([__DIR__ . '/../data/EnsureCallbackMethodsExistsInSubscribedEventsTest/valid.php'], [
+		]);
+	}
+
+	public function testMethodNotExistingShouldHaveErrors() {
+		$this->analyse([__DIR__ . '/../data/EnsureCallbackMethodsExistsInSubscribedEventsTest/not-existing.php'], [
+			[
+				"The callback function 'return_falses' declared within 'get_subscribed_events' does not exist in the class 'WP_Rocket\Engine\Admin\ActionSchedulerSubscriber'.",
+				19
+			],
+			[
+				"The callback function 'hide_pastdue_status_filterss' declared within 'get_subscribed_events' does not exist in the class 'WP_Rocket\Engine\Admin\ActionSchedulerSubscriber'.",
+				21
+			],
+			[
+				"The callback function 'hide_pastdue_status_filterss' declared within 'get_subscribed_events' does not exist in the class 'WP_Rocket\Engine\Admin\ActionSchedulerSubscriber'.",
+				22
+			]
+		]);
+	}
+
+	public function testComplexSyntaxNotExistingShouldHaveErrors() {
+		$this->analyse([__DIR__ . '/../data/EnsureCallbackMethodsExistsInSubscribedEventsTest/complex-syntax.php'], [
+			[
+				"The callback function 'exclude_inline_from_rucsss' declared within 'get_subscribed_events' does not exist in the class 'WP_Rocket\ThirdParty\Plugins\InlineRelatedPosts'.",
+				23
+			]
+		]);
+	}
+}

--- a/tests/phpstan/tests/bootstrap.php
+++ b/tests/phpstan/tests/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+require_once __DIR__ . '/../../../vendor/autoload.php';

--- a/tests/phpstan/tests/data/EnsureCallbackMethodsExistsInSubscribedEventsTest/complex-syntax.php
+++ b/tests/phpstan/tests/data/EnsureCallbackMethodsExistsInSubscribedEventsTest/complex-syntax.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace WP_Rocket\ThirdParty\Plugins;
+
+use WP_Rocket\Event_Management\Subscriber_Interface;
+
+/**
+ * Subscriber for compatibility with Inline Related Posts.
+ */
+class InlineRelatedPosts implements Subscriber_Interface {
+
+
+	/**
+	 * Subscriber for Inline Related Posts.
+	 *
+	 * @return array
+	 */
+	public static function get_subscribed_events() {
+		if ( ! defined( 'IRP_PLUGIN_SLUG' ) ) {
+			return [];
+		}
+
+		return [ 'rocket_rucss_inline_content_exclusions' => 'exclude_inline_from_rucsss' ];
+	}
+
+	/**
+	 * Exclude inline style from RUCSS.
+	 *
+	 * @param array $excluded excluded css.
+	 * @return array
+	 */
+	public function exclude_inline_from_rucss( $excluded ) {
+		$excluded[] = '.centered-text-area';
+		$excluded[] = '.ctaText';
+
+		return $excluded;
+	}
+}

--- a/tests/phpstan/tests/data/EnsureCallbackMethodsExistsInSubscribedEventsTest/not-existing.php
+++ b/tests/phpstan/tests/data/EnsureCallbackMethodsExistsInSubscribedEventsTest/not-existing.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace WP_Rocket\Engine\Admin;
+
+use WP_Rocket\Event_Management\Subscriber_Interface;
+use WP_Rocket\ThirdParty\ReturnTypesTrait;
+
+class ActionSchedulerSubscriber implements Subscriber_Interface {
+
+	use ReturnTypesTrait;
+
+	/**
+	 * Return an array of events that this subscriber wants to listen to.
+	 *
+	 * @return array
+	 */
+	public static function get_subscribed_events() {
+		return [
+			'action_scheduler_check_pastdue_actions' => 'return_falses',
+			'action_scheduler_extra_action_counts'   => [
+				['hide_pastdue_status_filterss'],
+				['hide_pastdue_status_filterss', 10, 3],
+			],
+		];
+	}
+
+	/**
+	 * Hide past-due from status filter in Action Scheduler tools page.
+	 *
+	 * @param array $extra_actions Array with format action_count_identifier => action count.
+	 *
+	 * @return array
+	 */
+	public function hide_pastdue_status_filter( array $extra_actions ) {
+		if ( ! isset( $extra_actions['past-due'] ) ) {
+			return $extra_actions;
+		}
+
+		unset( $extra_actions['past-due'] );
+		return $extra_actions;
+	}
+}

--- a/tests/phpstan/tests/data/EnsureCallbackMethodsExistsInSubscribedEventsTest/valid.php
+++ b/tests/phpstan/tests/data/EnsureCallbackMethodsExistsInSubscribedEventsTest/valid.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace WP_Rocket\Engine\Admin;
+
+use WP_Rocket\Event_Management\Subscriber_Interface;
+use WP_Rocket\ThirdParty\ReturnTypesTrait;
+
+class ActionSchedulerSubscriber implements Subscriber_Interface {
+
+	use ReturnTypesTrait;
+
+	/**
+	 * Return an array of events that this subscriber wants to listen to.
+	 *
+	 * @return array
+	 */
+	public static function get_subscribed_events() {
+		return [
+			'action_scheduler_check_pastdue_actions' => 'return_false',
+			'action_scheduler_extra_action_counts'   => [
+				['hide_pastdue_status_filter'],
+				['hide_pastdue_status_filter', 10, 3],
+			],
+		];
+	}
+
+	/**
+	 * Hide past-due from status filter in Action Scheduler tools page.
+	 *
+	 * @param array $extra_actions Array with format action_count_identifier => action count.
+	 *
+	 * @return array
+	 */
+	public function hide_pastdue_status_filter( array $extra_actions ) {
+		if ( ! isset( $extra_actions['past-due'] ) ) {
+			return $extra_actions;
+		}
+
+		unset( $extra_actions['past-due'] );
+		return $extra_actions;
+	}
+}

--- a/tests/phpstan/tests/phpunit.xml
+++ b/tests/phpstan/tests/phpunit.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+         bootstrap="bootstrap.php"
+         cacheResultFile=".phpunit.cache/test-results"
+         executionOrder="depends,defects"
+         forceCoversAnnotation="false"
+         beStrictAboutCoversAnnotation="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         convertDeprecationsToExceptions="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         verbose="true">
+    <testsuites>
+        <testsuite name="default">
+            <directory>Rules</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage cacheDirectory=".phpunit.cache/code-coverage"
+              processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">Rules</directory>
+        </include>
+    </coverage>
+</phpunit>


### PR DESCRIPTION
# Description

Fixes #7123 

This won't impact users.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).
- [x] Sub-task of #7122 

## Detailed scenario

Just run PHPStan

## Technical description

### Documentation

This pull request introduces several changes related to PHPStan integration and testing in the project. The most significant updates include adding new PHPStan rules and tests, modifying the configuration files, and ensuring callback methods exist in subscribed events.

### PHPStan Integration and Configuration:
* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R237-R238): Added new scripts to run PHPStan with specific options (`run-stan-reset-baseline`, `run-stan-test`).
* [`phpstan.neon.dist`](diffhunk://#diff-6f19df6a6307a48db0940e6897591fb08776d2db8a6134737aa708defdb5c92dR3-R16): Updated parameters to include new paths and rules, and modified reporting settings. [[1]](diffhunk://#diff-6f19df6a6307a48db0940e6897591fb08776d2db8a6134737aa708defdb5c92dR3-R16) [[2]](diffhunk://#diff-6f19df6a6307a48db0940e6897591fb08776d2db8a6134737aa708defdb5c92dR58-R59)

### New PHPStan Rule:
* [`tests/phpstan/Rules/EnsureCallbackMethodsExistsInSubscribedEvents.php`](diffhunk://#diff-a11739111a2dd639d556c619f12f45f865a31811fb9c3e6becb7f60e884c0406R1-R152): Implemented a new PHPStan rule to ensure callback methods exist in subscribed events.

### Tests for New Rule:
* [`tests/phpstan/tests/Rules/EnsureCallbackMethodsExistsInSubscribedEventsTest.php`](diffhunk://#diff-4013e141054338bdda841d49497f0cb638e537988adbd81d5c425120f60f4186R1-R45): Added tests to validate the new PHPStan rule, including tests for valid subscribers, non-existing methods, and complex syntax.
* Added supporting test data files for the new rule:
  * `tests/phpstan/tests/data/EnsureCallbackMethodsExistsInSubscribedEventsTest/complex-syntax.php`
  * `tests/phpstan/tests/data/EnsureCallbackMethodsExistsInSubscribedEventsTest/not-existing.php`
  * `tests/phpstan/tests/data/EnsureCallbackMethodsExistsInSubscribedEventsTest/valid.php`

### PHPUnit Configuration:
* [`tests/phpstan/tests/bootstrap.php`](diffhunk://#diff-49fb88d28df699b5707a934fea9b23df83a82dd59ef84fa0825c088747ca680eR1-R3): Added bootstrap file for PHPUnit tests.
* [`tests/phpstan/tests/phpunit.xml`](diffhunk://#diff-5048354aeca46b8554885e0820d189163b77ae2fa3e177a36cb9418bd7d476e2R1-R27): Added PHPUnit configuration file to define test suites and coverage settings.

### New dependencies

None

### Risks

None

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.
