### PR TITLE
Fixes #7133 Correctly load translations in some cases + remaining doing_it_wrong warning

### DIFF
--- a/inc/Engine/Common/JobManager/APIHandler/AbstractSafeAPIClient.php
+++ b/inc/Engine/Common/JobManager/APIHandler/AbstractSafeAPIClient.php
@@ -65,7 +65,7 @@ abstract class AbstractSafeAPIClient {
 
 		$transient_key = $this->get_transient_key();
 		if ( get_transient( $transient_key . '_timeout_active' ) ) {
-			return new WP_Error( 429, __( 'Too many requests.', 'rocket' ) );
+			return new WP_Error( 429, 'Too many requests.' );
 		}
 		// Get previous_expiration early to avoid multiple parallel requests increasing the expiration multiple times.
 		$previous_expiration = (int) get_transient( $transient_key . '_timeout' );
@@ -82,7 +82,7 @@ abstract class AbstractSafeAPIClient {
 		$body = wp_remote_retrieve_body( $response );
 		if ( empty( $body ) || ( ! empty( $response['response']['code'] ) && 200 !== $response['response']['code'] ) ) {
 			$this->set_timeout_transients( $previous_expiration );
-			return new WP_Error( 500, __( 'Not valid response.', 'rocket' ) );
+			return new WP_Error( 500, 'Not valid response.' );
 		}
 
 		$this->delete_timeout_transients();
@@ -148,6 +148,6 @@ abstract class AbstractSafeAPIClient {
 				return wp_safe_remote_post( $api_url, $params );
 		}
 
-		return new WP_Error( 400, __( 'Not valid request type.', 'rocket' ) );
+		return new WP_Error( 400, 'Not valid request type.' );
 	}
 }

--- a/wp-rocket.php
+++ b/wp-rocket.php
@@ -12,7 +12,7 @@
  * Licence: GPLv2 or later
  *
  * Text Domain: rocket
- * Domain Path: languages
+ * Domain Path: /languages
  *
  * Copyright 2013-2024 WP Rocket
  */


### PR DESCRIPTION
# Description

Fixes #7133

Make sure the translations are always correctly loaded

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

First example:
- using Divi, translation is not loaded on any admin apge

Second example:
- using any theme on plugins page, translation is not loaded (but they are on other pages)

## Technical description

### Documentation

The value in the `Domain` of the main plugin file was missing the `/` at the start.

Also removes translation in API requests (they were not used and causing a doing_it_wrong() warning).

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.