### PR TITLE
Closes #7142: 3.18: data-wpr-hosted-gf-parameters sometimes isnot having the original data structure with some templates

### DIFF
--- a/inc/Engine/Media/Fonts/Frontend/Controller.php
+++ b/inc/Engine/Media/Fonts/Frontend/Controller.php
@@ -133,7 +133,9 @@ class Controller {
 		string $font_provider
 	): string {
 		$font_provider_path = sprintf( '%s/', $font_provider );
-		$gf_parameters      = wp_parse_url( $original_url, PHP_URL_QUERY );
+
+		$original_url  = html_entity_decode( $original_url, ENT_QUOTES );
+		$gf_parameters = wp_parse_url( $original_url, PHP_URL_QUERY );
 
 		/**
 		 * Filters to enable the inline css output.


### PR DESCRIPTION
# Description

Fixes #7142

This fix ensures the data-wpr-hosted-gf-parameters contains the full query string by decoding the URL before processing. Previously, the query string was truncated due to improperly encoded characters like &#038; breaking the URL structure.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

To reproduce the issue:
	1.	Enable “Host Google Fonts Locally.”
	2.	Visit a page with the following URL: https://fonts.googleapis.com/css?family=Roboto%3A400%2C100%2C300%2C100italic%2C300italic%2C400italic%2C500%2C500italic%2C700%2C700italic%2C900%2C900italic%7CPT%20Sans%3A400%2C700%2C400italic%7CMontserrat%3A400%2C600%2C700%7CTangerine&#038;display=swap.
	3.	Check the data-wpr-hosted-gf-parameters attribute in the page’s source.

You will notice the query string is incomplete or truncated, especially after the &display=swap portion.

The fix ensures the full value of the data-wpr-hosted-gf-parameters attribute is present.
## Technical description

### Documentation

This fix involves decoding the URL using html_entity_decode() before parsing it with wp_parse_url(). This prevents issues with broken query parameters caused by HTML-encoded characters like &#038;.

The updated code now ensures the query string is fully captured by handling the decoding step before URL parsing.

### New dependencies

None

### Risks

None

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.
