### PR TITLE
Closes #7146: 3.18: Preconnect for Google fonts isnot removed when Host Google fonts locally option is enabled

### DIFF
--- a/inc/Engine/Media/Fonts/Frontend/Controller.php
+++ b/inc/Engine/Media/Fonts/Frontend/Controller.php
@@ -183,7 +183,7 @@ class Controller {
 			return $html;
 		}
 
-		$pattern = '/<link[^>]*\bhref\s*=\s*[\'"](?:https?:)?\/\/(?:fonts\.(?:googleapis|gstatic)\.com)[\'"][^>]*\brel\s*=\s*[\'"](?:preconnect|dns-prefetch)[\'"][^>]*>/i';
+		$pattern = '/<link[^>]*\b(rel\s*=\s*[\'"](?:preconnect|dns-prefetch)[\'"]|href\s*=\s*[\'"](?:https?:)?\/\/(?:fonts\.(?:googleapis|gstatic)\.com)[\'"])[^>]*\b(rel\s*=\s*[\'"](?:preconnect|dns-prefetch)[\'"]|href\s*=\s*[\'"](?:https?:)?\/\/(?:fonts\.(?:googleapis|gstatic)\.com)[\'"])[^>]*>/i';
 
 		$html = preg_replace( $pattern, '', $html );
 

--- a/inc/Engine/Media/Fonts/Frontend/Controller.php
+++ b/inc/Engine/Media/Fonts/Frontend/Controller.php
@@ -183,7 +183,7 @@ class Controller {
 			return $html;
 		}
 
-		$pattern = '/<link(?:[^>]*)(?:rel=["\'](?:dns-prefetch|preconnect)["\'])(?:[^>]*)(?:href=["\'](?:https?:)?\/\/(?:fonts\.(?:googleapis|gstatic)\.com)["\'])(?:[^>]*)>/i';
+		$pattern = '/<link\s+([^>]+[\s"\'])?rel\s*=\s*[\'"]((preconnect)|(dns-prefetch))[\'"]([^>]+)?\/?>/i';
 
 		$html = preg_replace( $pattern, '', $html );
 

--- a/inc/Engine/Media/Fonts/Frontend/Controller.php
+++ b/inc/Engine/Media/Fonts/Frontend/Controller.php
@@ -183,7 +183,7 @@ class Controller {
 			return $html;
 		}
 
-		$pattern = '/<link\s+([^>]+[\s"\'])?rel\s*=\s*[\'"]((preconnect)|(dns-prefetch))[\'"]([^>]+)?\/?>/i';
+		$pattern = '/<link[^>]*\bhref\s*=\s*[\'"](?:https?:)?\/\/(?:fonts\.(?:googleapis|gstatic)\.com)[\'"][^>]*\brel\s*=\s*[\'"](?:preconnect|dns-prefetch)[\'"][^>]*>/i';
 
 		$html = preg_replace( $pattern, '', $html );
 


### PR DESCRIPTION
# Description

Fixes #7146 
It'll remove the preconnect tag when google font hosting is ON and loaded from a local font. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

Just follow the issue scenario.

## Technical description

### Documentation

This pull request involves a significant update to the pattern used for removing preconnect and prefetch links in the `remove_preconnect_and_prefetch` function within the `Controller.php` file. The main change is the adjustment of the regular expression pattern to improve its accuracy and efficiency.

Changes to the regular expression pattern:

* [`inc/Engine/Media/Fonts/Frontend/Controller.php`](diffhunk://#diff-3f1e418966792d4b51109c090fb00e9fe1ec75469559e0ce738d27d386e0f974L186-R186): Updated the regular expression pattern in the `remove_preconnect_and_prefetch` function to better match and remove preconnect and prefetch links. The new pattern is more precise in identifying the `rel` attribute and its values, ensuring that it correctly handles various whitespace and attribute order scenarios.
### New dependencies

None

### Risks

None

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.
