### PR TITLE
Closes #7064 CDN Compatibility for host fonts locally

### DIFF
--- a/inc/Engine/Media/Fonts/Filesystem.php
+++ b/inc/Engine/Media/Fonts/Filesystem.php
@@ -113,6 +113,9 @@ class Filesystem extends AbstractFileSystem {
 			$local_css = str_replace( $font_url, $local_url, $local_css );
 		}
 
+		// This filter is documented in inc/Engine/Optimization/CSSTrait.php.
+		$local_css = wpm_apply_filters_typed( 'string', 'rocket_css_content', $local_css );
+
 		$end_time = microtime( true );
 		$duration = $end_time - $start_time;
 

--- a/inc/Engine/Media/Fonts/Frontend/Controller.php
+++ b/inc/Engine/Media/Fonts/Frontend/Controller.php
@@ -162,7 +162,8 @@ class Controller {
 			}
 		}
 
-		$url = $this->base_url . $font_provider_path . 'css/' . $this->filesystem->hash_to_path( $hash ) . '.css';
+		// This filter is documented in inc/classes/optimization/css/class-abstract-css-optimization.php.
+		$url = wpm_apply_filters_typed( 'string', 'rocket_css_url', $this->base_url . $font_provider_path . 'css/' . $this->filesystem->hash_to_path( $hash ) . '.css' );
 
 		return sprintf(
 			'<link rel="stylesheet" href="%1$s" data-wpr-hosted-gf-parameters="%2$s"/>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet


### PR DESCRIPTION
# Description

Fixes #7064 

Apply CDN URL on local fonts CSS & fonts files

## Type of change

- [x] Sub-task of #7039 

## Detailed scenario

- Enable CDN
- local CSS and fonts should have their URLs rewrittent to the CDN URL

## Technical description

### Documentation

Use the existing filters we have `rocket_css_url` and `rocket_css_content` to apply CDN.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
