### PR TITLE
Closes #7170 Fonts download data measurement

### DIFF
--- a/inc/Engine/Media/Fonts/Filesystem.php
+++ b/inc/Engine/Media/Fonts/Filesystem.php
@@ -84,6 +84,9 @@ class Filesystem extends AbstractFileSystem {
 		$font_urls = $matches[1];
 		$local_css = $css_content;
 
+		$count_fonts      = 0;
+		$download_average = 0;
+
 		foreach ( $font_urls as $font_url ) {
 			$font_path = wp_parse_url( $font_url, PHP_URL_PATH );
 
@@ -99,6 +102,7 @@ class Filesystem extends AbstractFileSystem {
 			}
 
 			if ( ! $this->filesystem->exists( $local_path ) ) {
+				$download_start = microtime( true );
 				$font_content = $this->get_remote_content( $font_url );
 
 				if ( ! $font_content ) {
@@ -107,6 +111,15 @@ class Filesystem extends AbstractFileSystem {
 				}
 
 				$this->write_file( $local_path, $font_content );
+
+				$download_end  = microtime( true );
+				$download_time = $download_end - $download_start;
+
+				$download_average += $download_time;
+
+				++$count_fonts;
+
+				Logger::debug( "Font download duration -- $download_time", [ 'Host Fonts Locally' ] );
 			}
 
 			$local_url = content_url( $this->get_fonts_relative_path( $font_provider_path, $font_path ) );
@@ -118,6 +131,8 @@ class Filesystem extends AbstractFileSystem {
 
 		// Add for test purpose.
 		Logger::debug( "Font download and optimization duration in seconds -- $duration", [ 'Host Fonts Locally' ] );
+		Logger::debug( "Number of fonts downloaded -- $count_fonts", [ 'Host Fonts Locally' ] );
+		Logger::debug( "Average download time per font -- " . ( $count_fonts ? $download_average / $count_fonts : 0 ), [ 'Host Fonts Locally' ] );
 
 		return $this->write_file( $css_filepath, $local_css );
 	}

--- a/inc/Engine/Media/Fonts/Filesystem.php
+++ b/inc/Engine/Media/Fonts/Filesystem.php
@@ -103,6 +103,7 @@ class Filesystem extends AbstractFileSystem {
 
 			if ( ! $this->filesystem->exists( $local_path ) ) {
 				$download_start = microtime( true );
+
 				$font_content = $this->get_remote_content( $font_url );
 
 				if ( ! $font_content ) {
@@ -132,7 +133,7 @@ class Filesystem extends AbstractFileSystem {
 		// Add for test purpose.
 		Logger::debug( "Font download and optimization duration in seconds -- $duration", [ 'Host Fonts Locally' ] );
 		Logger::debug( "Number of fonts downloaded -- $count_fonts", [ 'Host Fonts Locally' ] );
-		Logger::debug( "Average download time per font -- " . ( $count_fonts ? $download_average / $count_fonts : 0 ), [ 'Host Fonts Locally' ] );
+		Logger::debug( 'Average download time per font -- ' . ( $count_fonts ? $download_average / $count_fonts : 0 ), [ 'Host Fonts Locally' ] );
 
 		return $this->write_file( $css_filepath, $local_css );
 	}

--- a/inc/Engine/Media/Fonts/Filesystem.php
+++ b/inc/Engine/Media/Fonts/Filesystem.php
@@ -56,16 +56,16 @@ class Filesystem extends AbstractFileSystem {
 	}
 
 	/**
-	 * Writes font css to path
+	 * Writes CSS & fonts locally
 	 *
-	 * @param string $font_url The font url to save locally.
-	 * @param string $provider The url of the page.
+	 * @param string $css_url The CSS url to save locally.
+	 * @param string $provider The font provider.
 	 *
 	 * @return bool
 	 */
-	public function write_font_css( string $font_url, string $provider ): bool {
+	public function write_font_css( string $css_url, string $provider ): bool {
 		$font_provider_path = $this->get_font_provider_path( $provider );
-		$css_filepath       = $this->get_absolute_path( $font_provider_path, 'css/' . $this->hash_to_path( $this->hash_url( $font_url ) ) . '.css' );
+		$css_filepath       = $this->get_absolute_path( $font_provider_path, 'css/' . $this->hash_to_path( $this->hash_url( $css_url ) ) . '.css' );
 		$fonts_basepath     = $this->get_absolute_path( $font_provider_path, 'fonts' );
 
 		if ( ! rocket_mkdir_p( dirname( $css_filepath ) ) ) {
@@ -74,7 +74,7 @@ class Filesystem extends AbstractFileSystem {
 
 		$start_time = microtime( true );
 
-		$css_content = $this->get_remote_content( html_entity_decode( $font_url ) );
+		$css_content = $this->get_remote_content( html_entity_decode( $css_url ) );
 
 		if ( ! $css_content ) {
 			return false;
@@ -120,7 +120,7 @@ class Filesystem extends AbstractFileSystem {
 
 				++$count_fonts;
 
-				Logger::debug( "Font download duration -- $download_time", [ 'Host Fonts Locally' ] );
+				Logger::debug( "Font $font_url download duration -- $download_time", [ 'Host Fonts Locally' ] );
 			}
 
 			$local_url = content_url( $this->get_fonts_relative_path( $font_provider_path, $font_path ) );
@@ -132,7 +132,7 @@ class Filesystem extends AbstractFileSystem {
 
 		// Add for test purpose.
 		Logger::debug( "Font download and optimization duration in seconds -- $duration", [ 'Host Fonts Locally' ] );
-		Logger::debug( "Number of fonts downloaded -- $count_fonts", [ 'Host Fonts Locally' ] );
+		Logger::debug( "Number of fonts downloaded for $css_url -- $count_fonts", [ 'Host Fonts Locally' ] );
 		Logger::debug( 'Average download time per font -- ' . ( $count_fonts ? $download_average / $count_fonts : 0 ), [ 'Host Fonts Locally' ] );
 
 		return $this->write_file( $css_filepath, $local_css );

--- a/inc/Engine/Media/Fonts/Frontend/Controller.php
+++ b/inc/Engine/Media/Fonts/Frontend/Controller.php
@@ -105,7 +105,7 @@ class Controller {
 
 		// Log the total execution time and number of fonts processed, with breakdown.
 		$duration = $end_time - $start_time;
-		Logger::debug( "Total execution time for Host Google Fonts Feature in seconds -- $duration. Fonts processed: $total_fonts | Total v1: $total_v1 | Total v2: $total_v2", [ 'Host Fonts Locally' ] );
+		Logger::debug( "Total execution time for Host Google Fonts Feature in seconds -- $duration. CSS files processed: $total_fonts | Total v1: $total_v1 | Total v2: $total_v2", [ 'Host Fonts Locally' ] );
 
 		return $html;
 	}


### PR DESCRIPTION
# Description

Fixes #7170

## Type of change

- [x] Sub-task of #7039 

## Detailed scenario

With rocket debug log enabled, load a page. Data will be available in the log:
- Number of fonts downloaded for each CSS file
- Download time for each font
- Average download time of fonts in each CSS file

## Technical description

### Documentation

Count the number of fonts downloaded in each CSS files. Measure the download time for each font. Use those values to generate an average download time per CSS file.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I did not introduce unnecessary complexity.

## Unticked items justification

No tests to add