### PR TITLE
Update google fonts option's label and docs urls

### DIFF
--- a/inc/Engine/Admin/Beacon/Beacon.php
+++ b/inc/Engine/Admin/Beacon/Beacon.php
@@ -834,11 +834,11 @@ class Beacon extends Abstract_Render implements Subscriber_Interface {
 			'host_fonts_locally'         => [
 				'en' => [
 					'id'  => '673358b02ddbd952f6241b38',
-					'url' => 'https://docs.wp-rocket.me/article/1847-host-google-fonts-locally?utm_source=wp_plugin&utm_medium=wp_rocket',
+					'url' => 'https://docs.wp-rocket.me/article/1847-self-host-google-fonts?utm_source=wp_plugin&utm_medium=wp_rocket',
 				],
 				'fr' => [
-					'id'  => '6733652e2ddbd952f6241b67',
-					'url' => 'https://fr.docs.wp-rocket.me/article/1848-heberger-localement-les-polices-google-fonts?utm_source=wp_plugin&utm_medium=wp_rocket',
+					'id'  => '675ab51d46b8d26833b2af82',
+					'url' => 'https://fr.docs.wp-rocket.me/article/1852-auto-heberger-google-fonts?utm_source=wp_plugin&utm_medium=wp_rocket',
 				],
 			],
 		];

--- a/inc/Engine/Admin/Settings/Page.php
+++ b/inc/Engine/Admin/Settings/Page.php
@@ -1020,7 +1020,7 @@ class Page extends Abstract_Render {
 				],
 				'host_fonts_locally'  => [
 					'type'              => 'checkbox',
-					'label'             => __( 'Host Google Fonts locally', 'rocket' ),
+					'label'             => __( 'Self-host Google Fonts', 'rocket' ),
 					'section'           => 'font_optimization_section',
 					'page'              => 'media',
 					'default'           => 0,


### PR DESCRIPTION
# Description

Closes https://github.com/orgs/wp-media/projects/109/views/1?pane=issue&itemId=90666760

This is a very minor change to update the option's label along with the docs urls.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

As mentioned, very minor, u need to check our settings page to make sure that the label is changed but for the docs, because they are not published yet, we just need to make sure that this is as mentioned in the draft issue.

## Technical description

### Documentation

N/A

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

Very minor change doesn't need any tests changes

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
