### PR TITLE
Closes #7189 Update self-host google fonts exclusion

### DIFF
--- a/inc/Engine/Media/Fonts/FontsTrait.php
+++ b/inc/Engine/Media/Fonts/FontsTrait.php
@@ -22,14 +22,14 @@ trait FontsTrait {
 	}
 
 	/**
-	 * Checks if a URL is excluded based on the provided exclusions.
+	 * Checks if a font is excluded based on the provided exclusions.
 	 *
-	 * @param string   $url        The URL to check.
+	 * @param string   $subject    The string to check.
 	 * @param string[] $exclusions The list of exclusions.
 	 *
 	 * @return bool True if the URL is excluded, false otherwise.
 	 */
-	protected function is_excluded( string $url, array $exclusions ): bool {
+	protected function is_excluded( string $subject, array $exclusions ): bool {
 		// Bail out early if there are no exclusions.
 		if ( empty( $exclusions ) ) {
 			return false;
@@ -53,6 +53,6 @@ trait FontsTrait {
 		$exclusions_str = implode( '|', $escaped_exclusions );
 
 		// Check the URL against the combined regex pattern.
-		return (bool) preg_match( '#(' . $exclusions_str . ')#i', $url );
+		return (bool) preg_match( '#(' . $exclusions_str . ')#i', $subject );
 	}
 }

--- a/inc/Engine/Media/Fonts/Frontend/Controller.php
+++ b/inc/Engine/Media/Fonts/Frontend/Controller.php
@@ -99,14 +99,14 @@ class Controller {
 		$total_fonts = $total_v1 + $total_v2;
 
 		foreach ( $v1_fonts as $font ) {
-			if ( $this->is_excluded( $font['url'], $exclusions ) ) {
+			if ( $this->is_excluded( $font[0], $exclusions ) ) {
 				continue;
 			}
 			$html = $this->replace_font( $font, $html );
 		}
 
 		foreach ( $v2_fonts as $font ) {
-			if ( $this->is_excluded( $font['url'], $exclusions ) ) {
+			if ( $this->is_excluded( $font[0], $exclusions ) ) {
 				continue;
 			}
 			$html = $this->replace_font( $font, $html );

--- a/inc/Engine/Optimization/GoogleFonts/Combine.php
+++ b/inc/Engine/Optimization/GoogleFonts/Combine.php
@@ -62,7 +62,7 @@ class Combine extends AbstractGFOptimization {
 		$filtered_fonts = array_filter(
 			$fonts,
 			function ( $font ) use ( $exclusions ) {
-				return ! $this->is_excluded( $font['url'], $exclusions );
+				return ! $this->is_excluded( $font[0], $exclusions );
 			}
 			);
 

--- a/inc/Engine/Optimization/GoogleFonts/CombineV2.php
+++ b/inc/Engine/Optimization/GoogleFonts/CombineV2.php
@@ -45,7 +45,7 @@ class CombineV2 extends AbstractGFOptimization {
 		$filtered_tags = array_filter(
 			$font_tags,
 			function ( $tag ) use ( $exclusions ) {
-				return ! $this->is_excluded( $tag['url'], $exclusions );
+				return ! $this->is_excluded( $tag[0], $exclusions );
 			}
 			);
 

--- a/tests/Fixtures/inc/Engine/Media/Fonts/Frontend/Subscriber/HTML/expected_v1_v2_regex.php
+++ b/tests/Fixtures/inc/Engine/Media/Fonts/Frontend/Subscriber/HTML/expected_v1_v2_regex.php
@@ -12,6 +12,7 @@
 <link href="https://fonts.googleapis.com/css?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="http://example.org/wp-content/cache/fonts/1/google-fonts/css/b/4/d/9ffca0114d3acb6ab0b068feaf933.css" data-wpr-hosted-gf-parameters="family=Lato:wght@400;700&display=swap"/>
 <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
+<link rel='stylesheet' id='astra-google-fonts-css' href='https://fonts.googleapis.com/css?family=Noto+Sans%3A400%2C700%7CMontserrat%3A700&#038;display=fallback&#038;ver=4.7.0' media='all' />
 <style>
 .roboto-font {
 	font-family: 'Roboto', sans-serif;

--- a/tests/Fixtures/inc/Engine/Media/Fonts/Frontend/Subscriber/HTML/input_v1_v2_regex.php
+++ b/tests/Fixtures/inc/Engine/Media/Fonts/Frontend/Subscriber/HTML/input_v1_v2_regex.php
@@ -12,6 +12,7 @@
 <link href="https://fonts.googleapis.com/css?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&display=swap" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
+<link rel='stylesheet' id='astra-google-fonts-css' href='https://fonts.googleapis.com/css?family=Noto+Sans%3A400%2C700%7CMontserrat%3A700&#038;display=fallback&#038;ver=4.7.0' media='all' />
 <style>
 .roboto-font {
 	font-family: 'Roboto', sans-serif;

--- a/tests/Fixtures/inc/Engine/Media/Fonts/Frontend/Subscriber/rewriteFontsForOptimizations.php
+++ b/tests/Fixtures/inc/Engine/Media/Fonts/Frontend/Subscriber/rewriteFontsForOptimizations.php
@@ -151,7 +151,8 @@ return [
 				],
 				'exclude_locally_host_fonts' => [
 					'family=Rob(.*)o',
-					'family(.*)Montserrat(.*)display=swap'
+					'family(.*)Montserrat(.*)display=swap',
+					'astra-google-(.*)-css',
 				]
 			],
 			'expected' => [


### PR DESCRIPTION
# Description

Fixes #7189

## Type of change

- [x] Sub-task of #7039 

## Detailed scenario

It's now possible to exclude based on any element in the HTML tag for google fonts instead of only the URL.

## Technical description

### Documentation

Updated the code to use the full HTML tag as the subject instead of only the URL

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.