### PR TITLE
Closes #7181 fonts data collection

### DIFF
--- a/inc/Engine/Media/Fonts/Admin/Data.php
+++ b/inc/Engine/Media/Fonts/Admin/Data.php
@@ -1,0 +1,105 @@
+<?php
+declare( strict_types=1 );
+
+namespace WP_Rocket\Engine\Media\Fonts\Admin;
+
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Engine\Common\Queue\AbstractASQueue;
+
+class Data extends AbstractASQueue {
+	/**
+	 * Options data instance.
+	 *
+	 * @var Options_Data
+	 */
+	private $options;
+
+	/**
+	 * Base path.
+	 *
+	 * @var string
+	 */
+	private $base_path;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Options_Data $options Options data instance.
+	 */
+	public function __construct( Options_Data $options ) {
+		$this->options   = $options;
+		$this->base_path = rocket_get_constant( 'WP_ROCKET_CACHE_ROOT_PATH', '' ) . 'fonts/' . get_current_blog_id() . '/';
+	}
+
+	/**
+	 * Schedule data collection.
+	 *
+	 * @return void
+	 */
+    public function schedule_data_collection() {
+		if ( ! $this->is_enabled() ) {
+			return;
+		}
+
+        $this->schedule_recurring( time(), WEEK_IN_SECONDS, 'rocket_fonts_data_collection' );
+    }
+
+	/**
+	 * Collect data.
+	 *
+	 * @return void
+	 */
+	public function collect_data() {
+		if ( ! $this->is_enabled() ) {
+			return;
+		}
+
+		$fonts_data = get_transient( 'rocket_fonts_data_collection' );
+
+		// If data has been populated, bail out early.
+		if ( false !== $fonts_data ) {
+			return;
+		}
+
+		$fonts = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $this->base_path ) );
+
+		$allowed_extensions = [
+			'woff',
+			'woff2',
+			'ttf',
+			'otf',
+		];
+		$total_font_count = 0;
+		$total_font_size  = 0;
+
+		foreach( $fonts as $file ) {
+			//check file is not a directory.
+			if ( $file->isDir() ) {
+				continue;
+			}
+
+			$extension = strtolower( pathinfo( $file->getFilename(), PATHINFO_EXTENSION ) );
+
+			if ( in_array( $extension, $allowed_extensions, true ) ) {
+				$total_font_count++;
+				$total_font_size += $file->getSize();
+			}
+		}
+
+		set_transient( 'rocket_fonts_data_collection', [
+			'fonts_total_number' => $total_font_count,
+			'fonts_total_size'   => size_format( $total_font_size )
+		], WEEK_IN_SECONDS );
+	}
+
+	/**
+	 * Check if the feature & analytics are enabled.
+	 *
+	 * @return bool
+	 */
+	private function is_enabled(): bool {
+		return $this->options->get( 'host_fonts_locally', 0 ) && $this->options->get( 'analytics_enabled', 0 );
+	}
+}

--- a/inc/Engine/Media/Fonts/Admin/Data.php
+++ b/inc/Engine/Media/Fonts/Admin/Data.php
@@ -38,13 +38,13 @@ class Data extends AbstractASQueue {
 	 *
 	 * @return void
 	 */
-    public function schedule_data_collection() {
+	public function schedule_data_collection() {
 		if ( ! $this->is_enabled() ) {
 			return;
 		}
 
-        $this->schedule_recurring( time(), WEEK_IN_SECONDS, 'rocket_fonts_data_collection' );
-    }
+		$this->schedule_recurring( time(), WEEK_IN_SECONDS, 'rocket_fonts_data_collection' );
+	}
 
 	/**
 	 * Collect data.
@@ -71,11 +71,12 @@ class Data extends AbstractASQueue {
 			'ttf',
 			'otf',
 		];
+
 		$total_font_count = 0;
 		$total_font_size  = 0;
 
-		foreach( $fonts as $file ) {
-			//check file is not a directory.
+		foreach ( $fonts as $file ) {
+			// check file is not a directory.
 			if ( $file->isDir() ) {
 				continue;
 			}
@@ -83,15 +84,19 @@ class Data extends AbstractASQueue {
 			$extension = strtolower( pathinfo( $file->getFilename(), PATHINFO_EXTENSION ) );
 
 			if ( in_array( $extension, $allowed_extensions, true ) ) {
-				$total_font_count++;
+				++$total_font_count;
 				$total_font_size += $file->getSize();
 			}
 		}
 
-		set_transient( 'rocket_fonts_data_collection', [
-			'fonts_total_number' => $total_font_count,
-			'fonts_total_size'   => size_format( $total_font_size )
-		], WEEK_IN_SECONDS );
+		set_transient(
+			'rocket_fonts_data_collection',
+			[
+				'fonts_total_number' => $total_font_count,
+				'fonts_total_size'   => size_format( $total_font_size ),
+			],
+			WEEK_IN_SECONDS
+		);
 	}
 
 	/**

--- a/inc/Engine/Media/Fonts/Admin/Data.php
+++ b/inc/Engine/Media/Fonts/Admin/Data.php
@@ -47,6 +47,15 @@ class Data extends AbstractASQueue {
 	}
 
 	/**
+	 * Unschedule data collection.
+	 *
+	 * @return void
+	 */
+	public function unschedule_data_collection() {
+		$this->cancel( 'rocket_fonts_data_collection' );
+	}
+
+	/**
 	 * Collect data.
 	 *
 	 * @return void

--- a/inc/Engine/Media/Fonts/Admin/Data.php
+++ b/inc/Engine/Media/Fonts/Admin/Data.php
@@ -63,7 +63,7 @@ class Data extends AbstractASQueue {
 			return;
 		}
 
-		$fonts = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $this->base_path ) );
+		$fonts = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $this->base_path . 'google-fonts/fonts/' ) );
 
 		$allowed_extensions = [
 			'woff',

--- a/inc/Engine/Media/Fonts/Admin/Subscriber.php
+++ b/inc/Engine/Media/Fonts/Admin/Subscriber.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 namespace WP_Rocket\Engine\Media\Fonts\Admin;
 
 use WP_Rocket\Engine\Admin\Settings\Settings;
+use WP_Rocket\Engine\Media\Fonts\Admin\Data;
 use WP_Rocket\Engine\Media\Fonts\Admin\Settings as FontsSettings;
 use WP_Rocket\Event_Management\Subscriber_Interface;
-
 
 class Subscriber implements Subscriber_Interface {
 	/**
@@ -17,12 +17,21 @@ class Subscriber implements Subscriber_Interface {
 	private $settings;
 
 	/**
+	 * Fonts Data instance
+	 *
+	 * @var Data
+	 */
+	private $data;
+
+	/**
 	 * Instantiate the class
 	 *
 	 * @param FontsSettings $settings Fonts Settings instance.
+	 * @param Data          $data     Fonts Data instance.
 	 */
-	public function __construct( FontsSettings $settings ) {
+	public function __construct( FontsSettings $settings, Data $data ) {
 		$this->settings = $settings;
+		$this->data     = $data;
 	}
 
 	/**
@@ -34,6 +43,8 @@ class Subscriber implements Subscriber_Interface {
 		return [
 			'rocket_first_install_options' => [ 'add_option', 16 ],
 			'rocket_input_sanitize'        => [ 'sanitize_option', 10, 2 ],
+			'admin_init'                   => 'schedule_data_collection',
+			'rocket_fonts_data_collection' => 'collect_data',
 		];
 	}
 
@@ -58,5 +69,23 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	public function sanitize_option( array $input, Settings $settings ): array {
 		return $this->settings->sanitize_option_value( $input, $settings );
+	}
+
+	/**
+	 * Schedule data collection
+	 *
+	 * @return void
+	 */
+	public function schedule_data_collection() {
+		$this->data->schedule_data_collection();
+	}
+
+	/**
+	 * Collect data
+	 *
+	 * @return void
+	 */
+	public function collect_data() {
+		$this->data->collect_data();
 	}
 }

--- a/inc/Engine/Media/Fonts/Admin/Subscriber.php
+++ b/inc/Engine/Media/Fonts/Admin/Subscriber.php
@@ -45,6 +45,7 @@ class Subscriber implements Subscriber_Interface {
 			'rocket_input_sanitize'        => [ 'sanitize_option', 10, 2 ],
 			'admin_init'                   => 'schedule_data_collection',
 			'rocket_fonts_data_collection' => 'collect_data',
+			'rocket_deactivation'          => 'unschedule_data_collection',
 		];
 	}
 
@@ -78,6 +79,15 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	public function schedule_data_collection() {
 		$this->data->schedule_data_collection();
+	}
+
+	/**
+	 * Unschedule data collection
+	 *
+	 * @return void
+	 */
+	public function unschedule_data_collection() {
+		$this->data->unschedule_data_collection();
 	}
 
 	/**

--- a/inc/Engine/Media/Fonts/ServiceProvider.php
+++ b/inc/Engine/Media/Fonts/ServiceProvider.php
@@ -6,6 +6,7 @@ namespace WP_Rocket\Engine\Media\Fonts;
 use WP_Rocket\Dependencies\League\Container\ServiceProvider\AbstractServiceProvider;
 use WP_Rocket\Engine\Media\Fonts\Context\OptimizationContext;
 use WP_Rocket\Engine\Media\Fonts\Context\SaasContext;
+use WP_Rocket\Engine\Media\Fonts\Admin\Data;
 use WP_Rocket\Engine\Media\Fonts\Admin\Settings;
 use WP_Rocket\Engine\Media\Fonts\Admin\Subscriber as AdminSubscriber;
 use WP_Rocket\Engine\Media\Fonts\Clean\Clean;
@@ -29,6 +30,7 @@ class ServiceProvider extends AbstractServiceProvider {
 	protected $provides = [
 		'media_fonts_filesystem',
 		'media_fonts_settings',
+		'media_fonts_data',
 		'media_fonts_admin_subscriber',
 		'media_fonts_optimization_context',
 		'media_fonts_saas_context',
@@ -60,8 +62,15 @@ class ServiceProvider extends AbstractServiceProvider {
 			->addArgument( rocket_direct_filesystem() );
 
 		$this->getContainer()->add( 'media_fonts_settings', Settings::class );
+		$this->getContainer()->add( 'media_fonts_data', Data::class )
+			->addArgument( 'options' );
 		$this->getContainer()->addShared( 'media_fonts_admin_subscriber', AdminSubscriber::class )
-			->addArgument( 'media_fonts_settings' );
+			->addArguments(
+				[
+					'media_fonts_settings',
+					'media_fonts_data',
+				]
+			);
 
 		$this->getContainer()->add( 'media_fonts_clean', Clean::class )
 			->addArgument( 'media_fonts_filesystem' );

--- a/inc/admin/admin.php
+++ b/inc/admin/admin.php
@@ -329,6 +329,12 @@ function rocket_analytics_data() {
 		$data['license_type'] = rocket_get_license_type( $customer_data );
 	}
 
+	$media_font_data = get_transient( 'rocket_fonts_data_collection' );
+
+	if ( false !== $media_font_data ) {
+		$data = array_merge( $data, $media_font_data );
+	}
+
 	return $data;
 }
 

--- a/inc/functions/admin.php
+++ b/inc/functions/admin.php
@@ -430,6 +430,15 @@ function rocket_data_collection_preview_table() {
 
 	$html .= '<tr>';
 	$html .= '<td class="column-primary">';
+	$html .= sprintf( '<strong>%s</strong>', __( 'Anonymized WP Rocket statistics:', 'rocket' ) );
+	$html .= '</td>';
+	$html .= '<td>';
+	$html .= sprintf( '<em>%s</em>', __( 'How WP Rocket features function and perform.', 'rocket' ) );
+	$html .= '</td>';
+	$html .= '</tr>';
+
+	$html .= '<tr>';
+	$html .= '<td class="column-primary">';
 	$html .= sprintf( '<strong>%s</strong>', __( 'WP Rocket license type', 'rocket' ) );
 	$html .= '</td>';
 	$html .= '<td>';

--- a/tests/Fixtures/inc/Engine/Media/Fonts/Admin/Data/collectData.php
+++ b/tests/Fixtures/inc/Engine/Media/Fonts/Admin/Data/collectData.php
@@ -1,0 +1,88 @@
+<?php
+
+return [
+	'structure' => [
+		'wp-content' => [
+			'cache' => [
+				'fonts' => [
+					'1' => [
+						'google-fonts' => [
+							'fonts' => [
+								's' => [
+									'lato' => [
+										'v24' => [
+											'S6uyw4BMUTPHjx4wXg.woff2' => '',
+										],
+									],
+									'montserrat' => [
+										'v40' => [
+											'memSYaGs126MiZpBA-UvWbX2vVnXBbObj2OVZyOOSr4dVJWUgsjZ0B4gaVI.woff2' => '',
+										],
+									],
+									'oswald' => [
+										'v53' => [
+											'TK3_WkUHHAIjg75cFRf3bXL8LICs1_FvsUZiZQ.woff2' => '',
+										],
+									],
+									'roboto' => [
+										'v32' => [
+											'KFOmCnqEu92Fr1Mu4mxK.woff2' => '',
+										],
+									],
+								],
+							],
+						],
+					],
+				],
+			],
+		],
+	],
+	'test_data' => [
+		'shouldDoNothingWhenOptionIsDisabled' => [
+			'config' => [
+				'options' => [
+					'host_fonts_locally' => 0,
+					'analytics_enabled'   => 1,
+				],
+				'transient' => false,
+			],
+			'expected' => false,
+		],
+		'shouldDoNothingWhenAnalyticsDisabled' => [
+			'config' => [
+				'options' => [
+					'host_fonts_locally' => 1,
+					'analytics_enabled'   => 0,
+				],
+				'transient' => false,
+			],
+			'expected' => false,
+		],
+		'shouldDoNothingWhenDataAlreadyExists' => [
+			'config' => [
+				'options' => [
+					'host_fonts_locally' => 1,
+					'analytics_enabled'  => 1,
+				],
+				'transient' => [
+					'fonts_total_number' => 4,
+					'fonts_total_size'   => '1.2 MB',
+				],
+			],
+			'expected' => false,
+		],
+		'shouldCollectData' => [
+			'config' => [
+				'options' => [
+					'host_fonts_locally' => 1,
+					'analytics_enabled'   => 1,
+				],
+				'transient' => false,
+			],
+			'expected' => [
+				'fonts_total_number' => 4,
+				'fonts_total_size'   => '1.2 MB',
+			],
+		],
+	],
+];

--- a/tests/Unit/inc/Engine/Media/Fonts/Admin/Data/collectData.php
+++ b/tests/Unit/inc/Engine/Media/Fonts/Admin/Data/collectData.php
@@ -10,7 +10,7 @@ use WP_Rocket\Engine\Media\Fonts\Admin\Data;
 use WP_Rocket\Tests\Unit\FilesystemTestCase;
 
 /**
- * @covers \WP_Rocket\Engine\Media\Fonts\Admin\Data::collectData
+ * Test class covering  \WP_Rocket\Engine\Media\Fonts\Admin\Data::collect_data
  * @group  HostFontsLocally
  */
 class Test_CollectData extends FilesystemTestCase {

--- a/tests/Unit/inc/Engine/Media/Fonts/Admin/Data/collectData.php
+++ b/tests/Unit/inc/Engine/Media/Fonts/Admin/Data/collectData.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\Media\Fonts\Admin\Data;
+
+use Brain\Monkey\Functions;
+use Mockery;
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Engine\Media\Fonts\Admin\Data;
+use WP_Rocket\Tests\Unit\FilesystemTestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\Media\Fonts\Admin\Data::collectData
+ * @group  HostFontsLocally
+ */
+class Test_CollectData extends FilesystemTestCase {
+	protected $path_to_test_data = '/inc/Engine/Media/Fonts/Admin/Data/collectData.php';
+
+	private $options;
+	private $data;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		Functions\when( 'get_current_blog_id' )->justReturn( 1 );
+
+		$this->options = Mockery::mock( Options_Data::class );
+		$this->data    = new Data( $this->options );
+	}
+
+	/**
+	 * @dataProvider providerTestData
+	 */
+	public function testShouldDoExpected( $config, $expected ) {
+		$this->options->shouldReceive( 'get' )
+			->with( 'host_fonts_locally', 0 )
+			->andReturn( $config['options']['host_fonts_locally'] );
+
+		$this->options->shouldReceive( 'get')
+			->with( 'analytics_enabled', 0 )
+			->andReturn( $config['options']['analytics_enabled'] );
+
+		Functions\when( 'get_transient' )->justReturn( $config['transient'] );
+
+		Functions\when( 'size_format' )->justReturn( '1.2 MB' );
+
+		if ( $expected ) {
+			Functions\expect( 'set_transient' )
+				->once()
+				->with( 'rocket_fonts_data_collection', $expected, WEEK_IN_SECONDS );
+		} else {
+			Functions\expect( 'set_transient' )->never();
+		}
+
+		$this->data->collect_data();
+	}
+}


### PR DESCRIPTION
# Description

Fixes #7181 

Collect fonts data weekly

## Type of change

- [x] Sub-task of #7039 

## Detailed scenario

With self-host google fonts and analytics enabled, fonts data should be collected and sent to mixpanel.

data collected is stored in a transient `rocket_fonts_data_collection` for a week.

## Technical description

### Documentation

If the options are enabled, and the transient is not yet set, with recursively look into the `cache/fonts/blog_id/google-fonts/fonts/` folder to count all fonts and and the total size.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
