### PR TITLE
Remove fonts data collection transient with uninstall

### DIFF
--- a/inc/Engine/Media/Fonts/Admin/Data.php
+++ b/inc/Engine/Media/Fonts/Admin/Data.php
@@ -7,6 +7,7 @@ use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\Common\Queue\AbstractASQueue;
+use Exception;
 
 class Data extends AbstractASQueue {
 	/**
@@ -72,7 +73,11 @@ class Data extends AbstractASQueue {
 			return;
 		}
 
-		$fonts = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $this->base_path . 'google-fonts/fonts/' ) );
+		try {
+			$fonts = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $this->base_path . 'google-fonts/fonts/' ) );
+		} catch ( Exception $exception ) {
+			return;
+		}
 
 		$allowed_extensions = [
 			'woff',

--- a/inc/Engine/WPRocketUninstall.php
+++ b/inc/Engine/WPRocketUninstall.php
@@ -87,6 +87,7 @@ class WPRocketUninstall {
 		'rocket_preload_check_duration',
 		'wpr_user_information_timeout_active',
 		'wpr_user_information_timeout',
+		'rocket_fonts_data_collection',
 	];
 
 	/**


### PR DESCRIPTION
# Description

Fixes #7209

We need to remove the transient `rocket_fonts_data_collection` when we remove the plugin not to track wrong data.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

Install v3.18-alpha3 and deactivate then remove completely, u will notice that we leave the mentioned transient without removal.

## Technical description

### Documentation

Nothing more than removing the transient with plugin removal/deactivation.

### New dependencies

No

### Risks

No

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

All should be good with this small change.

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
