### PR TITLE
fixes #7002 - filter rocket_lrc_processor to use regex if DOM extension is not found 

### DIFF
--- a/inc/Engine/Optimization/LazyRenderContent/Frontend/Controller.php
+++ b/inc/Engine/Optimization/LazyRenderContent/Frontend/Controller.php
@@ -147,7 +147,7 @@ class Controller implements ControllerInterface {
 		 *
 		 * @param string $processor The processor to use.
 		 */
-		$processor = wpm_apply_filters_typed( 'string', 'rocket_lrc_processor', 'dom' );
+		$processor = wpm_apply_filters_typed( 'string', 'rocket_lrc_processor', extension_loaded( 'dom' ) ? 'dom' : 'regex' );
 
 		$this->processor->set_processor( $processor );
 		$this->processor->get_processor()->set_exclusions( $this->get_exclusions() );


### PR DESCRIPTION
as discussed with @wordpressfan switch `rocket_lrc_processor` to regex if PHP `dom` extension is not found

# Description

Fixes #7002

Here we check if the dom module is loaded in php so use the dom processor other than that use the regex which should do the same functionality.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

Disable the DOM extension, see a 500 error in the site frontend, in the console (As described in the issue).

With the new code, if DOM extension is not available it should switch rocket_lrc_processor to use regex instead, preventing the error

## Technical description

### Documentation

Mentioned above.

### New dependencies

No.

### Risks

In a few cases we may face slowness when using regex but I believe this will be better than the error 500.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

Because results for dom and regex are the same so we don't need to change anything in tests, we have integration tests covering this method.

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
