### PR TITLE
Install SVN in workflows requiring WordPress install

### DIFF
--- a/.github/workflows/test_wprocket.yml
+++ b/.github/workflows/test_wprocket.yml
@@ -49,6 +49,9 @@ jobs:
         coverage: none  # XDebug can be enabled here 'coverage: xdebug'
         tools: composer:v2, phpunit
 
+    - name: Install SVN
+      run: sudo apt-get install subversion
+
     - name: Start mysql service
       run: sudo /etc/init.d/mysql start
 

--- a/.github/workflows/test_wprocket_latest_general_coverage.yml
+++ b/.github/workflows/test_wprocket_latest_general_coverage.yml
@@ -49,6 +49,9 @@ jobs:
         coverage: xdebug
         tools: composer:v2, phpunit
 
+    - name: Install SVN
+      run: sudo apt-get install subversion
+
     - name: Start mysql service
       run: sudo /etc/init.d/mysql start
 

--- a/.github/workflows/test_wprocket_latest_specific.yml
+++ b/.github/workflows/test_wprocket_latest_specific.yml
@@ -49,6 +49,9 @@ jobs:
         coverage: none  # XDebug can be enabled here 'coverage: xdebug'
         tools: composer:v2, phpunit
 
+    - name: Install SVN
+      run: sudo apt-get install subversion
+
     - name: Start mysql service
       run: sudo /etc/init.d/mysql start
 

--- a/.github/workflows/test_wprocket_php8.yml
+++ b/.github/workflows/test_wprocket_php8.yml
@@ -49,6 +49,9 @@ jobs:
         coverage: none  # XDebug can be enabled here 'coverage: xdebug'
         tools: composer:v2, phpunit
 
+    - name: Install SVN
+      run: sudo apt-get install subversion
+
     - name: Start mysql service
       run: sudo /etc/init.d/mysql start
 


### PR DESCRIPTION
# Description

New version of Ubuntu used in GH actions images doesn't have SVN installed by default. This PR fixes the issue in workflows requiring WP installation by installing SVN during the steps.

## Type of change

- [x] Chore

## Detailed scenario

- Nothing to test

## Technical description

### Documentation

Install SVN in workflow