### PR TITLE
Closes #6736 Clear Used CSS button in Divi notice results in white screen

### DIFF
--- a/inc/admin/ui/notices.php
+++ b/inc/admin/ui/notices.php
@@ -672,7 +672,7 @@ function rocket_notice_html( $args ) {
 			break;
 		case 'clear_used_css':
 			$params = [
-				'action' => 'rocket_clear_usedcss',
+				'action' => 'rocket_clean_saas',
 			];
 
 			if ( ! empty( $_SERVER['REQUEST_URI'] ) ) {

--- a/tests/Fixtures/inc/ThirdParty/Themes/Divi/handleDiviAdminNotice.php
+++ b/tests/Fixtures/inc/ThirdParty/Themes/Divi/handleDiviAdminNotice.php
@@ -57,7 +57,7 @@ return [
 		Your Divi template was updated. Clear the Used CSS if the layout, design or CSS styles were changed.
 	</p>
 	<p>
-		<a class="wp-core-ui button" href="http://example.org/wp-admin/admin-post.php?_wpnonce=12345&action=rocket_clear_usedcss&_wp_http_referer=%2Fwp-admin%2Foptions-general.php">
+		<a class="wp-core-ui button" href="http://example.org/wp-admin/admin-post.php?_wpnonce=12345&action=rocket_clean_saas&_wp_http_referer=%2Fwp-admin%2Foptions-general.php">
 			Clear Used CSS
 		</a>
 		<a class="rocket-dismiss " href="http://example.org/wp-admin/admin-post.php?action=rocket_ignore&amp;box=rocket_divi_notice&amp;_wpnonce=12345">


### PR DESCRIPTION
# Description
Fix white screen issue with Divi theme after clear used css link
Fixes #6736


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario
Check #6736 

## Technical description

### Documentation
Changed the action from `rocket_clear_usedcss` to `rocket_clean_saas`, which was changed in 3.16.1(not entirely sure)


# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.
