### PR TITLE
Guard against fatal error with Lazyrender feature with strtoupper

### DIFF
--- a/inc/Engine/Optimization/LazyRenderContent/Frontend/Processor/Dom.php
+++ b/inc/Engine/Optimization/LazyRenderContent/Frontend/Processor/Dom.php
@@ -142,6 +142,8 @@ class Dom implements ProcessorInterface {
 			if (
 				XML_ELEMENT_NODE !== $child->nodeType // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 				||
+				! $child->tagName
+				||
 				! in_array( strtoupper( $child->tagName ), $processed_tags, true ) // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 			) {
 				continue;

--- a/inc/Engine/Optimization/LazyRenderContent/Frontend/Processor/Dom.php
+++ b/inc/Engine/Optimization/LazyRenderContent/Frontend/Processor/Dom.php
@@ -142,7 +142,7 @@ class Dom implements ProcessorInterface {
 			if (
 				XML_ELEMENT_NODE !== $child->nodeType // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 				||
-				! $child->tagName
+				! $child->tagName // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 				||
 				! in_array( strtoupper( $child->tagName ), $processed_tags, true ) // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 			) {

--- a/tests/Fixtures/inc/Engine/Optimization/LazyRenderContent/Frontend/Processor/expected.html
+++ b/tests/Fixtures/inc/Engine/Optimization/LazyRenderContent/Frontend/Processor/expected.html
@@ -3,9 +3,13 @@
 		<title>Original</title>
 	</head>
 	<body>
+		text without tag
 		<main data-rocket-location-hash="adc285f638b63c4110da1d803b711c40">
+			text without tag
 			<article data-rocket-location-hash="d1f41b6001aa95d1577259dd681a9b19">
+				text without tag
 				<header data-rocket-location-hash="fbfcccd11db41b93d3d0676c9e14fdc8">
+					text without tag
 					<h1>Original</h1>
 					<div attribute-added-to-bypass-dom-processor-known-issue="1"></div>
 				</header>

--- a/tests/Fixtures/inc/Engine/Optimization/LazyRenderContent/Frontend/Processor/expectedRegex.html
+++ b/tests/Fixtures/inc/Engine/Optimization/LazyRenderContent/Frontend/Processor/expectedRegex.html
@@ -3,9 +3,13 @@
 		<title>Original</title>
 	</head>
 	<body>
+	text without tag
 		<main data-rocket-location-hash="adc285f638b63c4110da1d803b711c40">
+			text without tag
 			<article data-rocket-location-hash="d1f41b6001aa95d1577259dd681a9b19">
+				text without tag
 				<header data-rocket-location-hash="fbfcccd11db41b93d3d0676c9e14fdc8">
+					text without tag
 					<h1>Original</h1>
 					<div data-rocket-location-hash="d9527fe8d9073f13915c4ae1183acd6a" attribute-added-to-bypass-dom-processor-known-issue="1"></div>
 				</header>

--- a/tests/Fixtures/inc/Engine/Optimization/LazyRenderContent/Frontend/Processor/original.html
+++ b/tests/Fixtures/inc/Engine/Optimization/LazyRenderContent/Frontend/Processor/original.html
@@ -3,9 +3,13 @@
 		<title>Original</title>
 	</head>
 	<body>
+	text without tag
 		<main>
+			text without tag
 			<article>
+				text without tag
 				<header>
+					text without tag
 					<h1>Original</h1>
 					<div attribute-added-to-bypass-dom-processor-known-issue="1"></div>
 				</header>


### PR DESCRIPTION
# Description

Fixes #7084 

Here we guarded against this type of errors where `tagName` property inside `DOMElement` class returns null.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

I wasn't able to replicate it but I 90% think this is something in the server (related to dom module).

## Technical description

### Documentation

Just make sure that the `tagName` is not null before passing it to `strtoupper`.

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

*If some mandatory items are not relevant, explain why in this section.*

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
