### PR TITLE
Fix #6960 Beacon script can be injected multiple times when there are multiple </body> in the page.

### DIFF
--- a/inc/Engine/Common/PerformanceHints/Frontend/Processor.php
+++ b/inc/Engine/Common/PerformanceHints/Frontend/Processor.php
@@ -192,7 +192,7 @@ class Processor {
 		$script_tag = "<script data-name=\"wpr-wpr-beacon\" src='{$script_url}' async></script>"; // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 
 		// Append the script tag just before the closing body tag.
-		return str_replace( '</body>', $inline_script . $script_tag . '</body>', $html );
+		return preg_replace( '/<\/body>/', $inline_script . $script_tag . '</body>', $html, 1 );
 	}
 
 	/**

--- a/inc/Engine/Common/PerformanceHints/Frontend/Processor.php
+++ b/inc/Engine/Common/PerformanceHints/Frontend/Processor.php
@@ -189,13 +189,10 @@ class Processor {
 		$script_url = rocket_get_constant( 'WP_ROCKET_ASSETS_JS_URL' ) . 'wpr-beacon' . $min . '.js';
 
 		// Create the script tag.
-		$script_tag = "<script data-name=\"wpr-wpr-beacon\" src='{$script_url}' async></script>"; // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
-		$body_tag   = strrpos( $html, '</body>' );
-
-		if ( false !== $body_tag ) {
-			// Append the script tag just before the last closing body tag especially in cases where there's an iframe.
-			$html = substr_replace( $html, $inline_script . $script_tag . '</body>', $body_tag, 7 );
-		}
+		$script_tag             = "<script data-name=\"wpr-wpr-beacon\" src='{$script_url}' async></script>"; // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		$last_body_tag_position = strrpos( $html, '</body>' );
+		// Append the script tag just before the last closing body tag especially in cases where there's an iframe.
+		$html = substr_replace( $html, $inline_script . $script_tag . '</body>', $last_body_tag_position, 7 );
 
 		return $html;
 	}

--- a/inc/Engine/Common/PerformanceHints/Frontend/Processor.php
+++ b/inc/Engine/Common/PerformanceHints/Frontend/Processor.php
@@ -190,9 +190,14 @@ class Processor {
 
 		// Create the script tag.
 		$script_tag = "<script data-name=\"wpr-wpr-beacon\" src='{$script_url}' async></script>"; // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		$body_tag   = strrpos( $html, '</body>' );
 
-		// Append the script tag just before the closing body tag.
-		return preg_replace( '/<\/body>/', $inline_script . $script_tag . '</body>', $html, 1 );
+		if ( false !== $body_tag ) {
+			// Append the script tag just before the last closing body tag especially in cases where there's an iframe.
+			$html = substr_replace( $html, $inline_script . $script_tag . '</body>', $body_tag, 7 );
+		}
+
+		return $html;
 	}
 
 	/**

--- a/tests/Fixtures/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/HTML/double_body_tag.html
+++ b/tests/Fixtures/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/HTML/double_body_tag.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+	<title>Test</title>
+</head>
+<body>
+</body>
+<body>
+</body>
+</html>

--- a/tests/Fixtures/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/HTML/double_body_tag.html
+++ b/tests/Fixtures/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/HTML/double_body_tag.html
@@ -3,7 +3,20 @@
 	<title>Test</title>
 </head>
 <body>
-</body>
-<body>
+<iframe srcdoc="
+        <!DOCTYPE html>
+        <html lang='en'>
+        <head>
+            <meta charset='UTF-8'>
+            <meta name='viewport' content='width=device-width, initial-scale=1.0'>
+            <title>Iframe Content</title>
+        </head>
+        <body>
+            <header>
+                <h1>Iframe Header</h1>
+            </header>
+        </body>
+        </html>
+    " width="600" height="400" style="border:none;"></iframe>
 </body>
 </html>

--- a/tests/Fixtures/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/HTML/output_double_body_tag.html
+++ b/tests/Fixtures/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/HTML/output_double_body_tag.html
@@ -3,7 +3,20 @@
 	<title>Test</title>
 </head>
 <body>
+<iframe srcdoc="
+        <!DOCTYPE html>
+        <html lang='en'>
+        <head>
+            <meta charset='UTF-8'>
+            <meta name='viewport' content='width=device-width, initial-scale=1.0'>
+            <title>Iframe Content</title>
+        </head>
+        <body>
+            <header>
+                <h1>Iframe Header</h1>
+            </header>
+        </body>
+        </html>
+    " width="600" height="400" style="border:none;"></iframe>
 <script>var rocket_beacon_data = {"ajax_url":"http:\/\/example.org\/wp-admin\/admin-ajax.php","nonce":"96ac96b69e","url":"http:\/\/example.org","is_mobile":false,"width_threshold":1600,"height_threshold":700,"delay":500,"debug":false,"status":{"atf":true,"lrc":true},"elements":"img, video, picture, p, main, div, li, svg, section, header, span","lrc_threshold":1800}</script><script data-name="wpr-wpr-beacon" src='http://example.org/wp-content/plugins/wp-rocket/assets/js/wpr-beacon.min.js' async></script></body>
-<body>
-</body>
 </html>

--- a/tests/Fixtures/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/HTML/output_double_body_tag.html
+++ b/tests/Fixtures/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/HTML/output_double_body_tag.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+	<title>Test</title>
+</head>
+<body>
+<script>var rocket_beacon_data = {"ajax_url":"http:\/\/example.org\/wp-admin\/admin-ajax.php","nonce":"96ac96b69e","url":"http:\/\/example.org","is_mobile":false,"width_threshold":1600,"height_threshold":700,"delay":500,"debug":false,"status":{"atf":true,"lrc":true},"elements":"img, video, picture, p, main, div, li, svg, section, header, span","lrc_threshold":1800}</script><script data-name="wpr-wpr-beacon" src='http://example.org/wp-content/plugins/wp-rocket/assets/js/wpr-beacon.min.js' async></script></body>
+<body>
+</body>
+</html>

--- a/tests/Fixtures/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/maybe_apply_optimizations.php
+++ b/tests/Fixtures/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/maybe_apply_optimizations.php
@@ -1,6 +1,8 @@
 <?php
 
 $html_input = file_get_contents(__DIR__ . '/HTML/input.html');
+$html_with_double_body = file_get_contents(__DIR__ . '/HTML/double_body_tag.html');
+$html_with_double_body_output = file_get_contents(__DIR__ . '/HTML/output_double_body_tag.html');
 $html_output = file_get_contents(__DIR__ . '/HTML/output.html');
 $html_output_with_preload = file_get_contents(__DIR__ . '/HTML/output_w_preload.html');
 $html_output_with_beacon = file_get_contents(__DIR__ . '/HTML/output_w_beacon.html');
@@ -614,6 +616,18 @@ return [
 				'lrc' => $lrc,
 			],
 			'expected' => $html_output_with_beacon_and_only_lrc_opt,
+		],
+		'shouldNotDuplicateBeaconOnAPage' => [
+			'config' => [
+				'html' => $html_with_double_body,
+				'atf' => [
+					'row' => null,
+				],
+				'lrc' => [
+					'row' => null,
+				],
+			],
+			'expected' => $html_with_double_body_output,
 		],
 	],
 ];


### PR DESCRIPTION
# Description
Fix multiple </body> tag beacon script issue.

Fixes #6960 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario
Create a template with multiple `</body>` tag and open in a browser, check the script and notice that the beacon script is run twice(inserted twice)

## Technical description

### Documentation
Change the beacon script insertion with `str_replace` to `preg_replace`


# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.