### PR TITLE
Closes #6993: Add a condition to bailout

### DIFF
--- a/inc/Engine/Optimization/RegexTrait.php
+++ b/inc/Engine/Optimization/RegexTrait.php
@@ -144,7 +144,7 @@ trait RegexTrait {
 	 * @return string
 	 */
 	protected function restore_html_comments( $html ) {
-		if ( empty( $this->html_replace ) ) {
+		if ( ! is_string( $html ) || empty( $this->html_replace ) ) {
 			return $html;
 		}
 

--- a/inc/Engine/Optimization/RegexTrait.php
+++ b/inc/Engine/Optimization/RegexTrait.php
@@ -144,7 +144,7 @@ trait RegexTrait {
 	 * @return string
 	 */
 	protected function restore_html_comments( $html ) {
-		if ( ! is_string( $html ) || empty( $this->html_replace ) ) {
+		if ( ! is_string( $html ) || empty( $this->html_replace ) ) { // @phpstan-ignore-line For some reason, html could be null for some users, and we can't find a way to reproduce it.
 			return $html;
 		}
 


### PR DESCRIPTION
# Description

Fixes #6993 

It won't show a fatal error if the string is the wrong type. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

Refer to the issue.

## Technical description

### Documentation

This pull request includes a small but important change to the `inc/Engine/Optimization/RegexTrait.php` file. The change ensures that the `html_replace` property is a string before checking if it is empty.

* [`inc/Engine/Optimization/RegexTrait.php`](diffhunk://#diff-765b1b5b1f908053a1ce47c7af5d96c07ee359b562e9eb4f69c6e3d8b792410dL147-R147): Modified the `restore_html_comments` method to check if `html_replace` is a string before verifying if it is empty.
### New dependencies

None

### Risks

None


# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.
