### PR TITLE
Fix #7265 fatal error with 3.18.1.2

### DIFF
--- a/inc/Engine/Common/PerformanceHints/Frontend/Processor.php
+++ b/inc/Engine/Common/PerformanceHints/Frontend/Processor.php
@@ -191,8 +191,14 @@ class Processor {
 		// Create the script tag.
 		$script_tag             = "<script data-name=\"wpr-wpr-beacon\" src='{$script_url}' async></script>"; // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 		$last_body_tag_position = strrpos( $html, '</body>' );
-		// Append the script tag just before the last closing body tag especially in cases where there's an iframe.
-		$html = substr_replace( $html, $inline_script . $script_tag . '</body>', $last_body_tag_position, 7 );
+
+		if ( false !== $last_body_tag_position ) {
+			// Append the script tag just before the last closing body tag especially in cases where there's an iframe.
+			$html = substr_replace( $html, $inline_script . $script_tag . '</body>', $last_body_tag_position, 7 );
+		} else {
+			// Append to the end of html if </body> is not found.
+			$html .= $inline_script . $script_tag;
+		}
 
 		return $html;
 	}

--- a/tests/Fixtures/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/HTML/no_closing_body_tag_input.html
+++ b/tests/Fixtures/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/HTML/no_closing_body_tag_input.html
@@ -1,0 +1,6 @@
+<html>
+<head>
+	<title>Test</title>
+</head>
+
+</html>

--- a/tests/Fixtures/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/HTML/no_closing_body_tag_input.html
+++ b/tests/Fixtures/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/HTML/no_closing_body_tag_input.html
@@ -2,5 +2,5 @@
 <head>
 	<title>Test</title>
 </head>
-
+<body>
 </html>

--- a/tests/Fixtures/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/HTML/no_closing_body_tag_output.html
+++ b/tests/Fixtures/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/HTML/no_closing_body_tag_output.html
@@ -1,0 +1,7 @@
+<html>
+<head>
+	<title>Test</title>
+</head>
+
+<script>var rocket_beacon_data = {"ajax_url":"http:\/\/example.org\/wp-admin\/admin-ajax.php","nonce":"96ac96b69e","url":"http:\/\/example.org","is_mobile":false,"width_threshold":1600,"height_threshold":700,"delay":500,"debug":false,"status":{"atf":true,"lrc":true},"elements":"img, video, picture, p, main, div, li, svg, section, header, span","lrc_threshold":1800}</script><script data-name="wpr-wpr-beacon" src='http://example.org/wp-content/plugins/wp-rocket/assets/js/wpr-beacon.min.js' async></script></body>
+</html>

--- a/tests/Fixtures/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/HTML/no_closing_body_tag_output.html
+++ b/tests/Fixtures/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/HTML/no_closing_body_tag_output.html
@@ -2,6 +2,6 @@
 <head>
 	<title>Test</title>
 </head>
-
-<script>var rocket_beacon_data = {"ajax_url":"http:\/\/example.org\/wp-admin\/admin-ajax.php","nonce":"96ac96b69e","url":"http:\/\/example.org","is_mobile":false,"width_threshold":1600,"height_threshold":700,"delay":500,"debug":false,"status":{"atf":true,"lrc":true},"elements":"img, video, picture, p, main, div, li, svg, section, header, span","lrc_threshold":1800}</script><script data-name="wpr-wpr-beacon" src='http://example.org/wp-content/plugins/wp-rocket/assets/js/wpr-beacon.min.js' async></script>
+<body>
 </html>
+<script>var rocket_beacon_data = {"ajax_url":"http:\/\/example.org\/wp-admin\/admin-ajax.php","nonce":"96ac96b69e","url":"http:\/\/example.org","is_mobile":false,"width_threshold":1600,"height_threshold":700,"delay":500,"debug":false,"status":{"atf":true,"lrc":true},"elements":"img, video, picture, p, main, div, li, svg, section, header, span","lrc_threshold":1800}</script><script data-name="wpr-wpr-beacon" src='http://example.org/wp-content/plugins/wp-rocket/assets/js/wpr-beacon.min.js' async></script>

--- a/tests/Fixtures/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/HTML/no_closing_body_tag_output.html
+++ b/tests/Fixtures/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/HTML/no_closing_body_tag_output.html
@@ -3,5 +3,5 @@
 	<title>Test</title>
 </head>
 
-<script>var rocket_beacon_data = {"ajax_url":"http:\/\/example.org\/wp-admin\/admin-ajax.php","nonce":"96ac96b69e","url":"http:\/\/example.org","is_mobile":false,"width_threshold":1600,"height_threshold":700,"delay":500,"debug":false,"status":{"atf":true,"lrc":true},"elements":"img, video, picture, p, main, div, li, svg, section, header, span","lrc_threshold":1800}</script><script data-name="wpr-wpr-beacon" src='http://example.org/wp-content/plugins/wp-rocket/assets/js/wpr-beacon.min.js' async></script></body>
+<script>var rocket_beacon_data = {"ajax_url":"http:\/\/example.org\/wp-admin\/admin-ajax.php","nonce":"96ac96b69e","url":"http:\/\/example.org","is_mobile":false,"width_threshold":1600,"height_threshold":700,"delay":500,"debug":false,"status":{"atf":true,"lrc":true},"elements":"img, video, picture, p, main, div, li, svg, section, header, span","lrc_threshold":1800}</script><script data-name="wpr-wpr-beacon" src='http://example.org/wp-content/plugins/wp-rocket/assets/js/wpr-beacon.min.js' async></script>
 </html>

--- a/tests/Fixtures/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/maybe_apply_optimizations.php
+++ b/tests/Fixtures/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/maybe_apply_optimizations.php
@@ -1,6 +1,8 @@
 <?php
 
 $html_input = file_get_contents(__DIR__ . '/HTML/input.html');
+$html_input_without_closing_body_tag = file_get_contents(__DIR__ . '/HTML/no_closing_body_tag_input.html');
+$html_input_without_closing_body_tag_output = file_get_contents(__DIR__ . '/HTML/no_closing_body_tag_output.html');
 $html_with_double_body = file_get_contents(__DIR__ . '/HTML/double_body_tag.html');
 $html_with_double_body_output = file_get_contents(__DIR__ . '/HTML/output_double_body_tag.html');
 $html_output = file_get_contents(__DIR__ . '/HTML/output.html');
@@ -628,6 +630,18 @@ return [
 				],
 			],
 			'expected' => $html_with_double_body_output,
+		],
+		'shouldAddBeaconWithoutClosingBodyTag' => [
+			'config' => [
+				'html' => $html_input_without_closing_body_tag,
+				'atf' => [
+					'row' => null,
+				],
+				'lrc' => [
+					'row' => null,
+				],
+			],
+			'expected' => $html_input_without_closing_body_tag_output,
 		],
 	],
 ];

--- a/tests/Integration/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/maybe_apply_optimizations.php
+++ b/tests/Integration/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/maybe_apply_optimizations.php
@@ -91,7 +91,7 @@ class Test_MaybeApplyOptimizations extends FilesystemTestCase {
 		add_filter( 'pre_get_rocket_option_cache_logged_user', [ $this, 'get_cache_user' ] );
 
 		$this->assertSame(
-			$expected,
+			trim($expected),
 			apply_filters( 'rocket_buffer', $config['html'] )
 		);
 	}

--- a/tests/Integration/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/maybe_apply_optimizations.php
+++ b/tests/Integration/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/maybe_apply_optimizations.php
@@ -92,7 +92,7 @@ class Test_MaybeApplyOptimizations extends FilesystemTestCase {
 
 		$this->assertSame(
 			trim($expected),
-			apply_filters( 'rocket_buffer', $config['html'] )
+			trim(apply_filters( 'rocket_buffer', $config['html'] ))
 		);
 	}
 


### PR DESCRIPTION
# Description
Fixed fatal error with 3.18.2

Fixes #7265 


## Type of change


- [x] Bug fix (non-breaking change which fixes an issue).


## Detailed scenario
Create a template that doesn't have a closing `</body>` tag 

## Technical description
Check if the closing body tag is present and if not, add the script to the html

### Documentation



# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.