### PR TITLE
Closes #7258: Add self hosted font to metatag generator

### DIFF
--- a/tests/Fixtures/inc/Engine/Support/Meta/addMetaGenerator.php
+++ b/tests/Fixtures/inc/Engine/Support/Meta/addMetaGenerator.php
@@ -42,6 +42,7 @@ return [
 			'cdn' => 0,
 			'do_caching_mobile_files' => 0,
 			'preload_links' => 0,
+			'host_fonts_locally' => 0,
 		],
 		'html' => '<html><head></head><body></body></html>',
 		'expected' => '<html><head></head><body></body></html>',
@@ -53,8 +54,9 @@ return [
 			'do_caching_mobile_files' => 1,
 			'preload_links' => 1,
 			'is_mobile' => true,
+			'host_fonts_locally' => 1
 		],
 		'html' => '<html><head></head><body></body></html><!-- wpr_remove_unused_css -->',
-		'expected' => '<html><head><meta name="generator" content="WP Rocket 3.17" data-wpr-features="wpr_remove_unused_css wpr_mobile wpr_preload_links" /></head><body></body></html>',
+		'expected' => '<html><head><meta name="generator" content="WP Rocket 3.17" data-wpr-features="wpr_remove_unused_css wpr_preload_links wpr_host_fonts_locally wpr_mobile" /></head><body></body></html>',
 	],
 ];

--- a/tests/Integration/inc/Engine/Media/Fonts/Frontend/Subscriber/rewriteFontsForOptimizations.php
+++ b/tests/Integration/inc/Engine/Media/Fonts/Frontend/Subscriber/rewriteFontsForOptimizations.php
@@ -24,6 +24,7 @@ class Test_RewriteFontsForOptimizations extends FilesystemTestCase {
 		add_filter( 'pre_get_rocket_option_host_fonts_locally', [ $this, 'host_fonts_locally' ] );
 		add_filter( 'rocket_host_fonts_locally_inline_css', [ $this, 'locally_inline_css' ] );
 		add_filter('rocket_exclude_locally_host_fonts', [ $this, 'exclude_locally_host_fonts' ] );
+		add_filter('rocket_disable_meta_generator', '__return_true');
 		$this->setup_http();
 
 	}
@@ -32,6 +33,7 @@ class Test_RewriteFontsForOptimizations extends FilesystemTestCase {
 		remove_filter('pre_get_rocket_option_host_fonts_locally', [$this, 'host_fonts_locally']);
 		remove_filter('rocket_host_fonts_locally_inline_css', [$this, 'locally_inline_css']);
 		remove_filter('rocket_exclude_locally_host_fonts', [ $this, 'exclude_locally_host_fonts' ] );
+		remove_filter('rocket_disable_meta_generator', '__return_true');
 
 		$this->restoreWpHook('rocket_buffer');
 		$this->tear_down_http();

--- a/tests/Unit/inc/Engine/Support/Meta/addMetaGenerator.php
+++ b/tests/Unit/inc/Engine/Support/Meta/addMetaGenerator.php
@@ -68,6 +68,12 @@ class TestAddMetaGenerator extends TestCase {
 			->andReturn( $config['preload_links'] );
 		}
 
+		if ( isset( $config['host_fonts_locally'] ) ) {
+			$this->options->shouldReceive( 'get' )
+			->with( 'host_fonts_locally', 0 )
+			->andReturn( $config['host_fonts_locally'] );
+		}
+
 		$this->mobile_detect->shouldReceive( 'isMobile' )
 			->andReturn( $config['is_mobile'] ?? false );
 


### PR DESCRIPTION
# Description

Fixes #7258 

Self hosted google fonts will be added to the meta tag of enabled features.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

Refer to the issue.

## Technical description

### Documentation

This pull request includes significant refactoring and improvements to the `get_meta_tag` method in the `Meta.php` file. The changes focus on simplifying the code, improving readability, and enhancing the feature mapping for meta tags.

Key changes include:

### Code Simplification and Readability Improvements:
* Refactored the method to use a more readable and maintainable structure by introducing the `$features_to_check` array for feature mapping.
* Simplified the logic for checking and adding features to the `$features` array, reducing redundancy and improving clarity.

### Feature Enhancements:
* Added a new feature mapping mechanism for meta tags, allowing easier addition and management of features.
* Improved the handling of mobile/desktop caching and CDN & DNS prefetch checks by streamlining the conditions and making the code more concise.

### Meta Tag Generation:
* Modified the meta tag generation to use `sprintf` for better readability and maintainability.
* Ensured that the WP Rocket version inclusion is handled through a filter, maintaining flexibility and configurability.
### New dependencies

None

### Risks

None

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.
