### PR TITLE
Add a filter to disable Homepage cache clearing in function rocket_clean_post

### DIFF
--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -249,7 +249,9 @@ function rocket_clean_post( $post_id, $post = null ) {
 	rocket_clean_files( $purge_urls );
 
 	// Never forget to purge homepage and their pagination.
-	rocket_clean_home( $lang );
+	if(apply_filters( 'rocket_clean_home_after_clean_post', true, $post_id ) === true ) {
+		rocket_clean_home( $lang );
+	}
 
 	// Purge home feeds (blog & comments).
 	if ( has_filter( 'rocket_cache_reject_uri', 'wp_rocket_cache_feed' ) !== false ) {


### PR DESCRIPTION

# Description

Fixes #7187
Adds a filter which gives developers the opportunity to disable the purging of the homepage cache whenever the function rocket_clean_post is triggered.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

I some cases the automatic purging of the homepage cache whenever the function rocket_clean_post is called is not desirable. For example if you run a WooCommerce webshop with stock management. Whenever an order is placed the function rocket_clean_post will get called. If you have a busy webshop, for example every 5 minutes an order, the homepage cache would be cleared every 5 minutes. Pre-loading the cache won't help if the webshop has a lot of products, it would take too long before the homepage would get pre-loaded.

## Technical description

### Documentation

The filter itself does nothing, developers can hook into it and return false to prevent the homepage cache from being cleared.

### New dependencies

None.

### Risks

None.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [ ] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

I'm uncertain in which style WP Rocket likes to have the comments. The change is simple enough to add.

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
