### PR TITLE
Closes #7187: Add filter to disable Homepage cache clearing in rocket_clean_post

### DIFF
--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -248,7 +248,7 @@ function rocket_clean_post( $post_id, $post = null ) {
 	// Purge all files.
 	rocket_clean_files( $purge_urls );
 
-	if ( wpm_apply_filters_typed( 'boolean', 'rocket_clean_home_after_clean_post', true, $post_id ) === true ) {
+	if ( wpm_apply_filters_typed( 'boolean', 'rocket_clean_home_after_clean_post', true, $post_id ) ) {
 		// Never forget to purge homepage and their pagination.
 		rocket_clean_home( $lang );
 	}

--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -248,8 +248,10 @@ function rocket_clean_post( $post_id, $post = null ) {
 	// Purge all files.
 	rocket_clean_files( $purge_urls );
 
-	// Never forget to purge homepage and their pagination.
-	rocket_clean_home( $lang );
+	if ( wpm_apply_filters_typed( 'boolean', 'rocket_clean_home_after_clean_post', true, $post_id ) === true ) {
+		// Never forget to purge homepage and their pagination.
+		rocket_clean_home( $lang );
+	}
 
 	// Purge home feeds (blog & comments).
 	if ( has_filter( 'rocket_cache_reject_uri', 'wp_rocket_cache_feed' ) !== false ) {

--- a/tests/Fixtures/inc/common/doAdminPostRocketPurgeCache.php
+++ b/tests/Fixtures/inc/common/doAdminPostRocketPurgeCache.php
@@ -46,6 +46,25 @@ return [
 				],
 				'config' => [
 					'type'      => 'post',
+					'rocket_clean_home_after_clean_post' => true,
+					'post_id'   => 123, // Auto populated in integration tests.
+					'lang'      => 'en',
+					'file'      => 'lorem-ipsum-dolor',
+					'post_data' => [
+						'post_name'  => 'lorem-ipsum-dolor',
+						'post_title' => 'Lorem ipsum dolor',
+					],
+				],
+			],
+			[
+				'$_GET'  => [
+					'type'     => 'post-123',
+					'_wpnonce' => 'post-123',
+					'lang'     => 'en',
+				],
+				'config' => [
+					'type'      => 'post',
+					'rocket_clean_home_after_clean_post' => false,
 					'post_id'   => 123, // Auto populated in integration tests.
 					'lang'      => 'en',
 					'file'      => 'lorem-ipsum-dolor',
@@ -63,6 +82,7 @@ return [
 				],
 				'config' => [
 					'type'    => 'all',
+					'rocket_clean_home_after_clean_post' => true,
 					'lang'    => 'en',
 				],
 			],

--- a/tests/Integration/inc/common/doAdminPostRocketPurgeCache.php
+++ b/tests/Integration/inc/common/doAdminPostRocketPurgeCache.php
@@ -29,6 +29,7 @@ class Test_DoAdminPostRocketPurgeCache extends FilesystemTestCase {
 	protected $path_to_test_data = '/inc/common/doAdminPostRocketPurgeCache.php';
 	protected static $original_transients = [];
 	protected static $user_id;
+	protected $before_rocket_clean_home;
 
 	public static function wpSetUpBeforeClass( $factory ) {
 		self::$original_transients = [
@@ -54,6 +55,8 @@ class Test_DoAdminPostRocketPurgeCache extends FilesystemTestCase {
 
 	public function set_up() {
 		parent::set_up();
+		add_filter( 'rocket_clean_home_after_clean_post', [ $this, 'rocket_clean_home_after_clean_post'] );
+		add_action( 'before_rocket_clean_home', [ $this, 'before_rocket_clean_home'] );
 	}
 
 	public function tear_down() {
@@ -62,12 +65,17 @@ class Test_DoAdminPostRocketPurgeCache extends FilesystemTestCase {
 		foreach ( array_keys( self::$original_transients ) as $transient ) {
 			delete_transient( $transient );
 		}
+
+		remove_filter( 'rocket_clean_home_after_clean_post', [ $this, 'rocket_clean_home_after_clean_post'] );
+		remove_action( 'before_rocket_clean_home', [ $this, 'before_rocket_clean_home'] );
 	}
 
 	/**
 	 * @dataProvider purgeTestData
 	 */
 	public function testShouldPurge( $_get, array $config ) {
+		$this->config = $config;
+		$this->before_rocket_clean_home = false;
 		wp_set_current_user( self::$user_id );
 
 		if ( 'post' === $config['type'] ) {
@@ -92,12 +100,19 @@ class Test_DoAdminPostRocketPurgeCache extends FilesystemTestCase {
 		$this->assertSame( 1, did_action( 'rocket_purge_cache' ) );
 		$this->assertGreaterThan( 0, did_action( 'before_rocket_clean_post' ) );
 		$this->assertSame( $config['type'], get_transient( 'rocket_clear_cache' ) );
+
+		if ( $this->config['rocket_clean_home_after_clean_post'] && 'post' === $config['type'] ) {
+			$this->assertTrue(  $this->before_rocket_clean_home );
+		} else {
+			$this->assertFalse( $this->before_rocket_clean_home );
+		}
 	}
 
 	/**
 	 * @dataProvider wontPurgeTestData
 	 */
 	public function testShouldNotPurge( $_get, array $config ) {
+		$this->config = $config;
 		foreach ( $_get as $key => $value ) {
 			$_GET[ $key ] = $value;
 		}
@@ -130,5 +145,13 @@ class Test_DoAdminPostRocketPurgeCache extends FilesystemTestCase {
 		$this->loadConfig();
 
 		return $this->config['test_data']['wontpurge'];
+	}
+
+	public function rocket_clean_home_after_clean_post() {
+		return $this->config['rocket_clean_home_after_clean_post'] ?? true;
+	}
+
+	public function before_rocket_clean_home() {
+		$this->before_rocket_clean_home = true;
 	}
 }


### PR DESCRIPTION
# Description

Fixes #7187 
Adds a filter to disable clearing cache homepage following user suggestion

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

Refer to initial issue. 

## Technical description

### Documentation

This pull request includes a small change to the `inc/common/purge.php` file. The change adds a conditional check before purging the homepage and its pagination.

* [`inc/common/purge.php`](diffhunk://#diff-f4e9e6a9b8eadb156618700920eb8e454ecf8c0efbc1d9fcefb5951b5b82e31dR251-R254): Added a conditional check using `wpm_apply_filters_typed` to determine if the homepage and its pagination should be purged after cleaning a post.
### New dependencies

None

### Risks

None

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.
