### PR TITLE
Closes #7239: 3.19 - User interface

### DIFF
--- a/inc/Engine/Admin/Settings/Page.php
+++ b/inc/Engine/Admin/Settings/Page.php
@@ -2302,4 +2302,20 @@ class Page extends Abstract_Render {
 			]
 		);
 	}
+
+	/**
+	 * Enables the auto preload fonts option if the old preload fonts option is not empty.
+	 *
+	 * This function checks the value of the `rocket_preload_fonts` option.
+	 * If it contains a non-empty value, it updates the `auto_preload_fonts` option to `true`.
+	 * This is useful for ensuring that automatic font preloading is enabled based on legacy settings.
+	 *
+	 * @return void
+	 */
+	public function maybe_enable_auto_preload_fonts(): void {
+		$old_preload_fonts = $this->options->get( 'rocket_preload_fonts', [] );
+		if ( ! empty( $old_preload_fonts ) ) {
+			$this->options->set( 'auto_preload_fonts', true );
+		}
+	}
 }

--- a/inc/Engine/Admin/Settings/Page.php
+++ b/inc/Engine/Admin/Settings/Page.php
@@ -847,6 +847,7 @@ class Page extends Abstract_Render {
 		$exclude_lazyload = $this->beacon->get_suggest( 'exclude_lazyload' );
 		$dimensions       = $this->beacon->get_suggest( 'image_dimensions' );
 		$fonts            = $this->beacon->get_suggest( 'host_fonts_locally' );
+		$fonts_preload    = $this->beacon->get_suggest( 'fonts_preload' );
 
 		$this->settings->add_page_section(
 			'media',
@@ -1041,7 +1042,9 @@ class Page extends Abstract_Render {
 				],
 				'auto_preload_fonts'  => [
 					'type'              => 'checkbox',
-					'label'             => __( 'Preload Fonts', 'rocket' ),
+					'label'             => __( 'Preload fonts', 'rocket' ),
+					// translators: %1$s = opening <a> tag, %2$s = closing </a> tag.
+					'description'       => sprintf( __( 'Preload above-the-fold fonts to enhance layout stability and optimize text-based LCP elements. %1$sMore info%2$s', 'rocket' ), '<a href="' . esc_url( $fonts_preload['url'] ) . '" data-beacon-article="' . esc_attr( $fonts_preload['id'] ) . '" target="_blank" rel="noopener noreferrer">', '</a>' ),
 					'section'           => 'font_optimization_section',
 					'page'              => 'media',
 					'default'           => 0,

--- a/inc/Engine/Admin/Settings/Page.php
+++ b/inc/Engine/Admin/Settings/Page.php
@@ -936,12 +936,10 @@ class Page extends Abstract_Render {
 					'page'        => 'media',
 				],
 				'font_optimization_section' => [
-					'title'       => __( 'Fonts', 'rocket' ),
-					'type'        => 'fields_container',
-					// translators: %1$s = opening <a> tag, %2$s = closing </a> tag.
-					'description' => sprintf( __( 'Download and serve fonts directly from your server. Reduces connections to external servers and minimizes font shifts. %1$sMore info%2$s', 'rocket' ), '<a href="' . esc_url( $fonts['url'] ) . '" data-beacon-article="' . esc_attr( $fonts['id'] ) . '" target="_blank" rel="noopener noreferrer">', '</a>' ),
-					'help'        => $fonts,
-					'page'        => 'media',
+					'title' => __( 'Fonts', 'rocket' ),
+					'type'  => 'fields_container',
+					'help'  => $fonts,
+					'page'  => 'media',
 				],
 			]
 		);
@@ -1044,6 +1042,8 @@ class Page extends Abstract_Render {
 				'host_fonts_locally'  => [
 					'type'              => 'checkbox',
 					'label'             => __( 'Self-host Google Fonts', 'rocket' ),
+					// translators: %1$s = opening <a> tag, %2$s = closing </a> tag.
+					'description'       => sprintf( __( 'Download and serve fonts directly from your server. Reduces connections to external servers and minimizes font shifts. %1$sMore info%2$s', 'rocket' ), '<a href="' . esc_url( $fonts['url'] ) . '" data-beacon-article="' . esc_attr( $fonts['id'] ) . '" target="_blank" rel="noopener noreferrer">', '</a>' ),
 					'section'           => 'font_optimization_section',
 					'page'              => 'media',
 					'default'           => 0,

--- a/inc/Engine/Admin/Settings/Page.php
+++ b/inc/Engine/Admin/Settings/Page.php
@@ -1039,6 +1039,14 @@ class Page extends Abstract_Render {
 					'default'           => 0,
 					'sanitize_callback' => 'sanitize_checkbox',
 				],
+				'auto_preload_fonts'  => [
+					'type'              => 'checkbox',
+					'label'             => __( 'Preload Fonts', 'rocket' ),
+					'section'           => 'font_optimization_section',
+					'page'              => 'media',
+					'default'           => 0,
+					'sanitize_callback' => 'sanitize_checkbox',
+				],
 				'host_fonts_locally'  => [
 					'type'              => 'checkbox',
 					'label'             => __( 'Self-host Google Fonts', 'rocket' ),

--- a/inc/Engine/Admin/Settings/Subscriber.php
+++ b/inc/Engine/Admin/Settings/Subscriber.php
@@ -66,7 +66,10 @@ class Subscriber implements Subscriber_Interface, PluginFamilyInterface {
 			'rocket_after_settings_radio_options'  => [ 'display_radio_options_sub_fields', 11 ],
 			'rocket_settings_tools_content'        => 'display_mobile_cache_option',
 			'wp_ajax_rocket_enable_mobile_cache'   => 'enable_mobile_cache',
-			'wp_rocket_upgrade'                    => [ 'enable_separate_cache_files_mobile', 9, 2 ],
+			'wp_rocket_upgrade'                    => [
+				[ 'enable_separate_cache_files_mobile', 9, 2 ],
+				[ 'maybe_enable_auto_preload_fonts', 9 ],
+			],
 			'admin_notices'                        => 'display_update_notice',
 		];
 
@@ -283,6 +286,22 @@ class Subscriber implements Subscriber_Interface, PluginFamilyInterface {
 		}
 
 		$this->page->enable_separate_cache_files_mobile();
+	}
+
+	/**
+	 * Enables the auto preload fonts option if the old preload fonts option is not empty.
+	 *
+	 * This function checks the value of the `rocket_preload_fonts` option. 
+	 * If it contains a non-empty value, it updates the `auto_preload_fonts` option to `true`. 
+	 * This is useful for ensuring that automatic font preloading is enabled based on legacy settings.
+	 *
+	 * @return void
+	 */
+	public function maybe_enable_auto_preload_fonts(): void {
+		$old_preload_fonts = get_option( 'rocket_preload_fonts', [] );
+		if ( ! empty( $old_preload_fonts ) ) {
+			update_option( 'auto_preload_fonts', true );
+		}
 	}
 
 	/**

--- a/inc/Engine/Admin/Settings/Subscriber.php
+++ b/inc/Engine/Admin/Settings/Subscriber.php
@@ -291,8 +291,8 @@ class Subscriber implements Subscriber_Interface, PluginFamilyInterface {
 	/**
 	 * Enables the auto preload fonts option if the old preload fonts option is not empty.
 	 *
-	 * This function checks the value of the `rocket_preload_fonts` option. 
-	 * If it contains a non-empty value, it updates the `auto_preload_fonts` option to `true`. 
+	 * This function checks the value of the `rocket_preload_fonts` option.
+	 * If it contains a non-empty value, it updates the `auto_preload_fonts` option to `true`.
 	 * This is useful for ensuring that automatic font preloading is enabled based on legacy settings.
 	 *
 	 * @return void

--- a/inc/Engine/Admin/Settings/Subscriber.php
+++ b/inc/Engine/Admin/Settings/Subscriber.php
@@ -298,10 +298,7 @@ class Subscriber implements Subscriber_Interface, PluginFamilyInterface {
 	 * @return void
 	 */
 	public function maybe_enable_auto_preload_fonts(): void {
-		$old_preload_fonts = get_option( 'rocket_preload_fonts', [] );
-		if ( ! empty( $old_preload_fonts ) ) {
-			update_option( 'auto_preload_fonts', true );
-		}
+		$this->page->maybe_enable_auto_preload_fonts();
 	}
 
 	/**

--- a/inc/Engine/Media/Fonts/Admin/Settings.php
+++ b/inc/Engine/Media/Fonts/Admin/Settings.php
@@ -9,12 +9,15 @@ class Settings {
 	/**
 	 * Adds the host fonts locally option to WP Rocket options array
 	 *
+	 * @since 3.19 adds auto preload fonts
+	 *
 	 * @param array $options WP Rocket options array.
 	 *
 	 * @return array
 	 */
 	public function add_option( array $options ): array {
 		$options['host_fonts_locally'] = 0;
+		$options['auto_preload_fonts'] = 0;
 
 		return $options;
 	}
@@ -22,13 +25,16 @@ class Settings {
 	/**
 	 * Sanitizes the option value when saving from the settings page
 	 *
+	 * @since 3.19 adds auto preload fonts
+	 *
 	 * @param array         $input    Array of sanitized values after being submitted by the form.
 	 * @param AdminSettings $settings Settings class instance.
 	 *
 	 * @return array
 	 */
 	public function sanitize_option_value( array $input, AdminSettings $settings ): array {
-		$input['host_fonts_locally'] = $settings->sanitize_checkbox( $input, 'host_fonts_locally' );
+		$input['host_fonts_locally']  = $settings->sanitize_checkbox( $input, 'host_fonts_locally' );
+		$intput['auto_preload_fonts'] = $settings->sanitize_checkbox( $input, 'auto_preload_fonts' );
 
 		return $input;
 	}

--- a/tests/Fixtures/inc/admin/rocketFirstInstall.php
+++ b/tests/Fixtures/inc/admin/rocketFirstInstall.php
@@ -78,6 +78,7 @@ $integration[ 'preload_links' ]              					 = 1;
 $integration[ 'image_dimensions' ]           	 				 = 0;
 $integration[ 'exclude_lazyload' ]           					 = [];
 $integration['host_fonts_locally']           					 = 0;
+$integration['auto_preload_fonts']  	   					     = 0;
 
 return [
 	'test_data' => [


### PR DESCRIPTION
# Description

Fixes #7239 
Display the newly added preload fonts to the media - fonts section of settings page. 

## Type of change

- [x] New feature (non-breaking change which adds functionality).

## Detailed scenario

Refer to issue

## Technical description

### Documentation

This pull request introduces several changes to the font optimization settings in the WP Rocket plugin, adding a new auto preload fonts option and ensuring compatibility with legacy settings. The most important changes include adding the new option, updating the settings page, and ensuring the new option is enabled based on existing settings.

### Font Optimization Settings:

* Added a new `auto_preload_fonts` checkbox option to the `font_optimization_section` in `media_section()` to allow users to preload fonts automatically.
* Updated the description for the `host_fonts_locally` option to include a link with more information.

### Legacy Settings Compatibility:

* Introduced the `maybe_enable_auto_preload_fonts()` method in `Settings/Page.php` to enable the new `auto_preload_fonts` option if the old `rocket_preload_fonts` option is not empty.
* Added the `maybe_enable_auto_preload_fonts()` method to the `wp_rocket_upgrade` event in `Settings/Subscriber.php` to ensure it runs during upgrades. [[1]](diffhunk://#diff-fc05e3a2422a5be1348634dbe69358325e7665e59b8d6beab9439e453edd5676L69-R72) [[2]](diffhunk://#diff-fc05e3a2422a5be1348634dbe69358325e7665e59b8d6beab9439e453edd5676R291-R303)

### Additional Changes:

* Updated the `add_option()` and `sanitize_option_value()` methods in `Fonts/Admin/Settings.php` to include the new `auto_preload_fonts` option.

### New dependencies

None
### Risks

None
# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.
