### PR TITLE
Preconnect external domains frontend

### DIFF
--- a/inc/Engine/Media/PreconnectExternalDomains/Context/Context.php
+++ b/inc/Engine/Media/PreconnectExternalDomains/Context/Context.php
@@ -43,4 +43,15 @@ class Context implements ContextInterface {
 		 */
 		return wpm_apply_filters_typed( 'boolean', 'rocket_preconnect_external_domains_optimization', true );
 	}
+
+	/**
+	 * Determines if the page is mobile and separate cache for mobile files is enabled.
+	 *
+	 * @return bool
+	 */
+	public function is_mobile_allowed(): bool {
+		return $this->options->get( 'cache_mobile', 0 )
+			&& $this->options->get( 'do_caching_mobile_files', 0 )
+			&& wp_is_mobile();
+	}
 }

--- a/inc/Engine/Media/PreconnectExternalDomains/Frontend/Controller.php
+++ b/inc/Engine/Media/PreconnectExternalDomains/Frontend/Controller.php
@@ -3,42 +3,38 @@ declare(strict_types=1);
 
 namespace WP_Rocket\Engine\Media\PreconnectExternalDomains\Frontend;
 
-use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Engine\Common\Head\ElementTrait;
 use WP_Rocket\Engine\Common\PerformanceHints\Frontend\ControllerInterface;
 use WP_Rocket\Engine\Media\PreconnectExternalDomains\Context\Context;
 use WP_Rocket\Engine\Media\PreconnectExternalDomains\Database\Queries\PreconnectExternalDomains as PreconnectDomains;
+use WP_Rocket\Engine\Media\PreconnectExternalDomains\Database\Row\PreconnectExternalDomains;
+use WP_Rocket\Engine\Support\CommentTrait;
 
 class Controller implements ControllerInterface {
-	/**
-	 * Options instance
-	 *
-	 * @var Options_Data
-	 */
-	private $options; // @phpstan-ignore-line Use of this will come later.
+	use CommentTrait;
+	use ElementTrait;
 
 	/**
 	 * Queries instance
 	 *
 	 * @var PreconnectDomains
 	 */
-	private $query; // @phpstan-ignore-line Use of this will come later.
+	private $query;
 
 	/**
 	 * Context instance.
 	 *
 	 * @var Context
 	 */
-	private $context; // @phpstan-ignore-line Use of this will come later.
+	private $context;
 
 	/**
 	 * Constructor
 	 *
-	 * @param Options_Data      $options Options instance.
 	 * @param PreconnectDomains $query Queries instance.
 	 * @param Context           $context Context instance.
 	 */
-	public function __construct( Options_Data $options, PreconnectDomains $query, Context $context ) {
-		$this->options = $options;
+	public function __construct( PreconnectDomains $query, Context $context ) {
 		$this->query   = $query;
 		$this->context = $context;
 	}
@@ -51,11 +47,11 @@ class Controller implements ControllerInterface {
 	 * @return string
 	 */
 	public function optimize( string $html, $row ): string {
-		if ( ! $row->has_preconnect_external_domains() ) {
+		if ( ! $this->context->is_allowed() || ! $row->has_preconnect_external_domains() ) {
 			return $html;
 		}
 
-		return $html;
+		return $this->add_meta_comment( 'preconnect_external_domains', $html );
 	}
 
 	/**
@@ -66,6 +62,90 @@ class Controller implements ControllerInterface {
 	 * @return array
 	 */
 	public function add_custom_data( array $data ): array {
+		if ( ! $this->context->is_allowed() ) {
+			return $data;
+		}
+
 		return $data;
+	}
+
+	/**
+	 * Add preconnect item into head.
+	 *
+	 * @param array $items Head items.
+	 * @return mixed
+	 */
+	public function add_preconnect_to_head( $items ) {
+		if ( ! $this->context->is_allowed() ) {
+			return $items;
+		}
+
+		$row = $this->get_current_url_row();
+		if ( empty( $row ) || ! $row->has_preconnect_external_domains() ) {
+			return $items;
+		}
+
+		$domains = json_decode( $row->domains, true );
+		foreach ( $domains as $domain ) {
+			$domain_item = $this->get_domain_preconnect_item( $domain );
+			if ( empty( $domain_item ) ) {
+				continue;
+			}
+			$items[] = $domain_item;
+		}
+
+		return $items;
+	}
+
+	/**
+	 * Get current visited page row in DB.
+	 *
+	 * @return false|PreconnectExternalDomains
+	 */
+	private function get_current_url_row() {
+		global $wp;
+
+		$url       = untrailingslashit( home_url( add_query_arg( [], $wp->request ) ) );
+		$is_mobile = $this->context->is_mobile_allowed();
+
+		return $this->query->get_row( $url, $is_mobile );
+	}
+
+	/**
+	 * Get specific domain preconnect item to be added to head.
+	 *
+	 * @param string $domain Domain url.
+	 * @return array|string[]
+	 */
+	private function get_domain_preconnect_item( $domain ) {
+		if ( $this->use_prefetch( $domain ) ) {
+			// Use dns-prefetch.
+			return $this->prefetch_link(
+				[
+					'href' => $domain,
+					1      => 'crossorigin',
+					2      => 'data-rocket-prefetch',
+				]
+				);
+		}
+
+		// Use preconnect by default.
+		return $this->preconnect_link(
+			[
+				'href' => $domain,
+				1      => 'crossorigin',
+				2      => 'data-rocket-preconnect',
+			]
+			);
+	}
+
+	/**
+	 * Check if we need to use prefetch instead of preconnect.
+	 *
+	 * @param string $domain Domain url.
+	 * @return bool
+	 */
+	private function use_prefetch( $domain ) {
+		return wpm_apply_filters_typed( 'boolean', 'rocket_preconnect_external_domains_use_prefetch', false, $domain );
 	}
 }

--- a/inc/Engine/Media/PreconnectExternalDomains/Frontend/Subscriber.php
+++ b/inc/Engine/Media/PreconnectExternalDomains/Frontend/Subscriber.php
@@ -7,13 +7,39 @@ use WP_Rocket\Event_Management\Subscriber_Interface;
 
 class Subscriber implements Subscriber_Interface {
 	/**
-	 * Returns an array of events that this subscriber wants to listen to.
+	 * Controller instance.
 	 *
-	 * @since  3.19
+	 * @var Controller
+	 */
+	private $controller;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Controller $controller Controller instance.
+	 */
+	public function __construct( Controller $controller ) {
+		$this->controller = $controller;
+	}
+
+	/**
+	 * Returns an array of events that this subscriber wants to listen to.
 	 *
 	 * @return array
 	 */
 	public static function get_subscribed_events(): array {
-		return [];
+		return [
+			'rocket_head_items' => [ 'preconnect_domains', 10 ],
+		];
+	}
+
+	/**
+	 * Preconnect current page domains into head.
+	 *
+	 * @param array $items Head items.
+	 * @return array
+	 */
+	public function preconnect_domains( array $items ) {
+		return $this->controller->add_preconnect_to_head( $items );
 	}
 }

--- a/inc/Engine/Media/PreconnectExternalDomains/ServiceProvider.php
+++ b/inc/Engine/Media/PreconnectExternalDomains/ServiceProvider.php
@@ -54,37 +54,35 @@ class ServiceProvider extends AbstractServiceProvider {
 		$this->getContainer()->get( 'preconnect_external_domains_table' );
 
 		$this->getContainer()->add( 'preconnect_external_domains_context', Context::class )
-			->addArgument(
-				$this->getContainer()->get( 'options' )
-			);
+			->addArgument( 'options' );
 
 		$this->getContainer()->add( 'preconnect_external_domains_ajax_controller', AJAXController::class )
 			->addArguments(
 				[
-					$this->getContainer()->get( 'preconnect_external_domains_query' ),
-					$this->getContainer()->get( 'preconnect_external_domains_context' ),
+					'preconnect_external_domains_query',
+					'preconnect_external_domains_context',
 				]
 			);
-
-		$this->getContainer()->addShared( 'preconnect_frontend_subscriber', FrontendSubscriber::class );
 
 		$this->getContainer()->add( 'preconnect_external_domains_controller', FrontController::class )
 			->addArguments(
 				[
-					$this->getContainer()->get( 'options' ),
-					$this->getContainer()->get( 'preconnect_external_domains_query' ),
-					$this->getContainer()->get( 'preconnect_external_domains_context' ),
+					'preconnect_external_domains_query',
+					'preconnect_external_domains_context',
 				]
 			);
+
+		$this->getContainer()->addShared( 'preconnect_frontend_subscriber', FrontendSubscriber::class )
+			->addArgument( 'preconnect_external_domains_controller' );
 
 		$this->getContainer()->addShared( 'preconnect_external_domains_factory', Factory::class )
 			->addArguments(
 				[
-					$this->getContainer()->get( 'preconnect_external_domains_query' ),
-					$this->getContainer()->get( 'preconnect_external_domains_context' ),
-					$this->getContainer()->get( 'preconnect_external_domains_ajax_controller' ),
-					$this->getContainer()->get( 'preconnect_external_domains_table' ),
-					$this->getContainer()->get( 'preconnect_external_domains_controller' ),
+					'preconnect_external_domains_query',
+					'preconnect_external_domains_context',
+					'preconnect_external_domains_ajax_controller',
+					'preconnect_external_domains_table',
+					'preconnect_external_domains_controller',
 				]
 			);
 	}


### PR DESCRIPTION
# Description

Fixes #7249

This is the frontend part of preconnect external domains feature.

## Type of change

- [x] New feature (non-breaking change which adds functionality).

## Detailed scenario

### What was tested

Manually tested:

![image](https://github.com/user-attachments/assets/014343f7-1795-443f-8b6b-916e9d5738c0)

I added a new row in the database directly and validated that it's showing in the frontend.

### How to test

We will merge this into 3.19 branch so we can validate the whole feature together but for this PR specifically, we can insert the following row into the database and clear cache to see the preconnect link there.

![image](https://github.com/user-attachments/assets/0912ef8a-e93f-4a54-9e07-19fcf98b0015)

## Technical description

### Documentation

N/A

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

Once merging this PR into the 3.19 feature branch, I'll create a quick PR to add some tests to cover this part not to conflict with the preload fonts added fixtures here:
https://github.com/wp-media/wp-rocket/pull/7312/files#diff-7b3c7fad3e68b5eb75cb875fb7129adf61931bedcd0f5dbb9221750b2f2d013b

# Additional Checks*If some mandatory items are not relevant, explain why in this section.*
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
