### PR TITLE
Make the default value for preload_fonts option is disabled

### DIFF
--- a/inc/Engine/Media/PreloadFonts/Context/Context.php
+++ b/inc/Engine/Media/PreloadFonts/Context/Context.php
@@ -34,7 +34,7 @@ class Context implements ContextInterface {
 			return false;
 		}
 
-		return wpm_apply_filters_typed( 'boolean', 'rocket_preload_fonts_optimization', (bool) $this->options->get( 'rocket_preload_fonts', 1 ) );
+		return wpm_apply_filters_typed( 'boolean', 'rocket_preload_fonts_optimization', (bool) $this->options->get( 'rocket_preload_fonts', 0 ) );
 	}
 
 	/**

--- a/inc/admin/upgrader.php
+++ b/inc/admin/upgrader.php
@@ -142,6 +142,7 @@ function rocket_first_install() {
 				'analytics_enabled'           => 0,
 				'sucury_waf_cache_sync'       => 0,
 				'sucury_waf_api_key'          => '',
+				'rocket_preload_fonts'        => 0,
 			]
 		)
 	);

--- a/tests/Fixtures/inc/admin/rocketFirstInstall.php
+++ b/tests/Fixtures/inc/admin/rocketFirstInstall.php
@@ -62,6 +62,7 @@ $default = [
 	'analytics_enabled'           => 0,
 	'sucury_waf_cache_sync'       => 0,
 	'sucury_waf_api_key'          => '',
+	'rocket_preload_fonts'        => 0,
 ];
 
 $integration                                 					 = $default;


### PR DESCRIPTION
# Description

Fixes #7324

As Gael groomed, Here we are setting the default value for preload_fonts to be `0`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

Tested the mentioned steps in the main issue and now it's working properly with that PR.

### How to test

1. Fresh install
2. Check preload fonts DB table => warm up done there although option is off by default
3. Manual visit of new page => page is added to preload fonts table
4. Clear and preload cache then revisit the page in 3 => preload fonts is applied to FE

## Technical description

### Documentation

Here we set the default value of `rocket_preload_fonts` setting to be `0`

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

*If some mandatory items are not relevant, explain why in this section.*

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
