### PR TITLE
Fix RUCSS button is not showing in quick actions

### DIFF
--- a/inc/Engine/Saas/ServiceProvider.php
+++ b/inc/Engine/Saas/ServiceProvider.php
@@ -46,7 +46,7 @@ class ServiceProvider extends AbstractServiceProvider {
 				[
 					'options',
 					'rucss_optimize_context',
-					new StringArgument( $this->getContainer()->get( 'template_path' ) ),
+					new StringArgument( $this->getContainer()->get( 'template_path' ) . '/settings' ),
 				]
 			);
 		$this->getContainer()->add( 'saas_clean', Clean::class );


### PR DESCRIPTION
# Description

Fixes #7331

That's a fix for a regression from the PR #7215

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

Now the button is showing in quick actions inside our settings page.

### How to test

Enable RUCSS and visit our admin page, and check the RUCSS clear button in the first tab inside quick actions.

![image](https://github.com/user-attachments/assets/07a0f808-56e6-482d-a3ec-58df2222ad3d)

## Technical description

### Documentation

Template path was wrong.

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

*If some mandatory items are not relevant, explain why in this section.*

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
