### PR TITLE
Improve plugin compatibility with HealthCheck - PageCache

### DIFF
--- a/inc/Engine/HealthCheck/PageCache.php
+++ b/inc/Engine/HealthCheck/PageCache.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace WP_Rocket\Engine\HealthCheck;
+
+use WP_Rocket\Event_Management\Subscriber_Interface;
+
+class PageCache implements Subscriber_Interface {
+	/**
+	 * Returns an array of events that this subscriber wants to listen to.
+	 *
+	 * @return array
+	 */
+	public static function get_subscribed_events() {
+		return [
+			'http_headers_useragent' => [ 'page_cache_useragent', 10, 2 ],
+		];
+	}
+
+	/**
+	 * Pass plugin header to skip test "mandatory cookie".
+	 *
+	 * @param string $user_agent WordPress user agent string.
+	 * @param string $url        The request URL.
+	 * @return string
+	 */
+	public function page_cache_useragent( $user_agent, $url = null ) {
+		$uri = sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ) );
+		if (
+			strpos( $uri, 'wp-site-health' ) !== false &&
+			strpos( $uri, 'page-cache' ) !== false
+		) {
+			$user_agent = 'WP Rocket';
+		}
+
+		return $user_agent;
+	}
+}

--- a/inc/Engine/HealthCheck/ServiceProvider.php
+++ b/inc/Engine/HealthCheck/ServiceProvider.php
@@ -16,6 +16,7 @@ class ServiceProvider extends AbstractServiceProvider {
 	 */
 	protected $provides = [
 		'health_check',
+		'health_check_page_cache',
 		'action_scheduler_check',
 	];
 
@@ -38,6 +39,7 @@ class ServiceProvider extends AbstractServiceProvider {
 	public function register(): void {
 		$this->getContainer()->addShared( 'health_check', HealthCheck::class )
 			->addArgument( 'options' );
+		$this->getContainer()->addShared( 'health_check_page_cache', PageCache::class );
 		$this->getContainer()->addShared( 'action_scheduler_check', ActionSchedulerCheck::class );
 	}
 }

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -389,6 +389,7 @@ class Plugin {
 			'media_fonts_frontend_subscriber',
 			'media_fonts_admin_subscriber',
 			'media_fonts_clean_subscriber',
+			'health_check_page_cache',
 		];
 
 		$host_type = HostResolver::get_host_service();

--- a/tests/Fixtures/inc/Engine/HealthCheck/PageCache/userAgent.php
+++ b/tests/Fixtures/inc/Engine/HealthCheck/PageCache/userAgent.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+	'null' => [
+		'request_uri' => null,
+		'user_agent_default' => 'WordPress',
+		'user_agent_expected' => 'WordPress',
+	],
+	'default' => [
+		'request_uri' => '/wp-json/wp-site-health/v1/tests/https-status?_locale=user',
+		'user_agent_default' => 'WordPress',
+		'user_agent_expected' => 'WordPress',
+	],
+	'plugin' => [
+		'request_uri' => '/wp-json/wp-site-health/v1/tests/page-cache?_locale=user',
+		'user_agent_default' => 'WP Rocket',
+		'user_agent_expected' => 'WP Rocket',
+	],
+];

--- a/tests/Unit/inc/Engine/HealthCheck/PageCache/userAgent.php
+++ b/tests/Unit/inc/Engine/HealthCheck/PageCache/userAgent.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\HealthCheck\PageCache;
+
+use Brain\Monkey\Functions;
+use WP_Rocket\Engine\HealthCheck\PageCache;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @covers \WP_Rocket\Engine\HealthCheck\PageCache::page_cache_useragent
+ *
+ * @group  zzz
+ */
+class Test_UserAgent extends TestCase {
+	private $health;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->health = new PageCache();
+
+		Functions\when( 'sanitize_text_field' )->alias(
+			function ( $value ) {
+				return $value;
+			}
+		);
+
+		Functions\when( 'wp_unslash' )->alias(
+			function ( $value ) {
+				return stripslashes( $value );
+			}
+		);
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnExpected( $request_uri, $user_agent_default, $user_agent_expected ) {
+		$_SERVER['REQUEST_URI'] = $request_uri;
+
+		$user_agent = $this->health->page_cache_useragent( $user_agent_default );
+		$this->assertSame( $user_agent_expected, $user_agent );
+	}
+}


### PR DESCRIPTION
## Description

When mandatory cookies are set for the plugin, the home page speed check from WordPress SiteHealth does not return the correct result, the page is not cached.

The SiteHealth tool should be thought of as a "speed tool".

In order for the is_speed_tool method to return true, the request from SiteHealth must be defined as "speed tool".

This can be easily achieved as there is a "UserAgent" check in the is_speed_tool method. Requests sent from SiteHealth will pass the "WP Rocket" header, allowing the mandatory cookie test to be skipped.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)

## How Has This Been Tested?

1. Place in header.php themes sleep(1);
2. Install the YayCurrency plugin or add the following lines to the wp-rocket-config/site.php config
```
$rocket_cache_mandatory_cookies = 'yay_currency_widget';
$rocket_cache_dynamic_cookies = array(
	0 => 'yay_currency_widget',
);
```
3. Open WordPress SiteHealth (/wp-admin/site-health.php)
4. Verify that the error has appeared:
`Median server response time was 1068 milliseconds. It should be less than the recommended 600 milliseconds threshold.`
5. Apply the changes from the commit, the error should no longer appear when the WP Rocket plugin is enabled.
# Checklist:

Please delete the options that are not relevant.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
