### PR TITLE
Closes #7294: Update banner for 3.19

### DIFF
--- a/inc/Engine/Admin/Beacon/Beacon.php
+++ b/inc/Engine/Admin/Beacon/Beacon.php
@@ -821,16 +821,6 @@ class Beacon extends Abstract_Render implements Subscriber_Interface {
 					'url' => 'https://fr.docs.wp-rocket.me/article/1833-impossible-creer-table-rucssusedcss/?utm_source=wp_plugin&utm_medium=wp_rocket',
 				],
 			],
-			'lazy_render_content'        => [
-				'en' => [
-					'id'  => '66b11e26a62a7505fcf339e7',
-					'url' => 'https://docs.wp-rocket.me/article/1835-lazy-render-content/?utm_source=wp_plugin&utm_medium=wp_rocket',
-				],
-				'fr' => [
-					'id'  => '66ba0e8e082392452a0773ea',
-					'url' => 'https://fr.docs.wp-rocket.me/article/1836-rendu-differe-automatique/?utm_source=wp_plugin&utm_medium=wp_rocket',
-				],
-			],
 			'host_fonts_locally'         => [
 				'en' => [
 					'id'  => '673358b02ddbd952f6241b38',

--- a/inc/Engine/Admin/Beacon/Beacon.php
+++ b/inc/Engine/Admin/Beacon/Beacon.php
@@ -833,12 +833,12 @@ class Beacon extends Abstract_Render implements Subscriber_Interface {
 			],
 			'preconnect_domains'         => [
 				'en' => [
-					'id'  => '',
-					'url' => '',
+					'id'  => '681b61d889bd957cd04bd2d9',
+					'url' => 'https://docs.wp-rocket.me/article/1869-preconnect-to-external-domains',
 				],
 				'fr' => [
-					'id'  => '',
-					'url' => '',
+					'id'  => '681da5ae11561a04f5de356e',
+					'url' => 'https://fr.docs.wp-rocket.me/article/1870-preconnexion-aux-domaines-externes',
 				],
 			],
 		];

--- a/inc/Engine/Admin/Beacon/Beacon.php
+++ b/inc/Engine/Admin/Beacon/Beacon.php
@@ -841,6 +841,16 @@ class Beacon extends Abstract_Render implements Subscriber_Interface {
 					'url' => 'https://fr.docs.wp-rocket.me/article/1852-auto-heberger-google-fonts?utm_source=wp_plugin&utm_medium=wp_rocket',
 				],
 			],
+			'preconnect_domains'         => [
+				'en' => [
+					'id'  => '',
+					'url' => '',
+				],
+				'fr' => [
+					'id'  => '',
+					'url' => '',
+				],
+			],
 		];
 
 		return isset( $suggest[ $doc_id ][ $this->get_user_locale() ] )

--- a/inc/Engine/Admin/Settings/Page.php
+++ b/inc/Engine/Admin/Settings/Page.php
@@ -2255,11 +2255,6 @@ class Page extends Abstract_Render {
 
 		$previous_version = $this->options->get( 'previous_version' );
 
-		// Bail-out for fresh install.
-		if ( empty( $previous_version ) ) {
-			return;
-		}
-
 		// Bail-out if previous version is greater than or equal to 3.19.
 		if ( version_compare( $previous_version, '3.19', '>=' ) ) {
 			return;

--- a/inc/Engine/Admin/Settings/Page.php
+++ b/inc/Engine/Admin/Settings/Page.php
@@ -2260,24 +2260,24 @@ class Page extends Abstract_Render {
 			return;
 		}
 
-		// Bail-out if previous version is greater than 3.17.
-		if ( $previous_version > '3.17' ) {
+		// Bail-out if previous version is greater than or equal to 3.19.
+		if ( version_compare( $previous_version, '3.19', '>=' ) ) {
 			return;
 		}
 
-		$lazy_render_content = $this->beacon->get_suggest( 'lazy_render_content' );
+		$preconnect_content = $this->beacon->get_suggest( 'preconnect_domains' );
 
 		rocket_notice_html(
 			[
 				'status'         => 'info',
 				'dismissible'    => '',
 				'message'        => sprintf(
-					// translators: %1$s: opening strong tag, %2$s: closing strong tag, %3$s: opening a tag, %4$s: opening a tag.
-					__( '%1$sWP Rocket:%2$s the plugin has been updated to the 3.17 version. New feature: %3$sAutomatic Lazy Rendering%4$s. Check out our documentation to learn more about it.', 'rocket' ),
-					'<strong>',
-					'</strong>',
-					'<a href="' . esc_url( $lazy_render_content['url'] ) . '" data-beacon-article="' . esc_attr( $lazy_render_content['id'] ) . '" target="_blank" rel="noopener noreferrer">',
-					'</a>'
+						// translators: %1$s: opening strong tag, %2$s: closing strong tag, %3$s: opening a tag, %4$s: closing a tag.
+						__( '%1$sWP Rocket:%2$s the plugin has been updated to the 3.19 version. New feature: %3$sPreconnect to external domains%4$s. Check out our documentation to learn more about it.', 'rocket' ),
+						'<strong>',
+						'</strong>',
+						'<a href="' . esc_url( $preconnect_content['url'] ) . '" data-beacon-article="' . esc_attr( $preconnect_content['id'] ) . '" target="_blank" rel="noopener noreferrer">',
+						'</a>'
 				),
 				'dismiss_button' => 'rocket_update_notice',
 			]

--- a/inc/Engine/Admin/Settings/Subscriber.php
+++ b/inc/Engine/Admin/Settings/Subscriber.php
@@ -73,7 +73,21 @@ class Subscriber implements Subscriber_Interface, PluginFamilyInterface {
 			'admin_notices'                        => 'display_update_notice',
 		];
 
-		return array_merge( $events, PluginFamily::get_subscribed_events() );
+		foreach ( PluginFamily::get_subscribed_events() as $hook => $callback ) {
+			if ( isset( $events[ $hook ] ) ) {
+				// Make sure it's an array of callbacks.
+				if ( ! is_array( $events[ $hook ][0] ) ) {
+					$events[ $hook ] = [ $events[ $hook ] ];
+				}
+
+				// Wrap single callback in array if needed.
+				$events[ $hook ][] = is_array( $callback ) ? $callback : [ $callback ];
+			} else {
+				$events[ $hook ] = is_array( $callback ) ? $callback : [ [ $callback ] ];
+			}
+		}
+
+		return $events;
 	}
 
 	/**

--- a/tests/Fixtures/inc/Engine/Admin/Settings/Page/displayUpdateNotice.php
+++ b/tests/Fixtures/inc/Engine/Admin/Settings/Page/displayUpdateNotice.php
@@ -70,7 +70,7 @@ return [
 				'id' => 'settings_page_wprocket',
 			],
 			'boxes'            => [],
-			'previous_version' => '3.17.1',
+			'previous_version' => '3.19.1',
 			'beacon'           => null,
 		],
 		'expected' => null,
@@ -91,7 +91,7 @@ return [
 		'expected' => [
 			'status'         => 'info',
 			'dismissible'    => '',
-			'message'        => '<strong>WP Rocket:</strong> the plugin has been updated to the 3.17 version. New feature: <a href="http://example.org" data-beacon-article="123" target="_blank" rel="noopener noreferrer">Automatic Lazy Rendering</a>. Check out our documentation to learn more about it.',
+			'message'        => '<strong>WP Rocket:</strong> the plugin has been updated to the 3.19 version. New feature: <a href="http://example.org" data-beacon-article="123" target="_blank" rel="noopener noreferrer">Preconnect to external domains</a>. Check out our documentation to learn more about it.',
 			'dismiss_button' => 'rocket_update_notice',
 		],
 	],

--- a/tests/Fixtures/inc/Engine/Admin/Settings/Page/displayUpdateNotice.php
+++ b/tests/Fixtures/inc/Engine/Admin/Settings/Page/displayUpdateNotice.php
@@ -48,7 +48,7 @@ return [
 		],
 		'expected' => null,
 	],
-	'testShouldDoNothingWhenFirstInstall' => [
+	'testShouldShowNoticeWhenFirstInstall' => [
 		'config' => [
 			'capability' => true,
 			'screen'     => (object) [
@@ -61,7 +61,12 @@ return [
 				'url' => 'http://example.org',
 			],
 		],
-		'expected' => null,
+		'expected' => [
+			'status'         => 'info',
+			'dismissible'    => '',
+			'message'        => '<strong>WP Rocket:</strong> the plugin has been updated to the 3.19 version. New feature: <a href="http://example.org" data-beacon-article="123" target="_blank" rel="noopener noreferrer">Preconnect to external domains</a>. Check out our documentation to learn more about it.',
+			'dismiss_button' => 'rocket_update_notice',
+		],
 	],
 	'testShouldDoNothingWhenVersionGT317' => [
 		'config' => [


### PR DESCRIPTION
# Description

Fixes #7294
Display a banner after update according to ACs.
## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

### What was tested

Updating the plugin should display the banner according to ACs.

### How to test

Update the plugin according to ACs.

## Technical description

### Documentation
This pull request introduces a new feature for preconnecting to external domains and updates related functionality in the admin settings and beacon suggestions. The most notable changes include adding support for the new feature in the beacon suggestions and updating the update notice logic to reflect the new version and feature.

### Feature Addition: Preconnect to External Domains
* [`inc/Engine/Admin/Beacon/Beacon.php`](diffhunk://#diff-b60c6494e363479e3ccd827a3e428311c7787995a032ab6d0cdc9dce2e4e168eR844-R853): Added a new suggestion type, `preconnect_domains`, with placeholders for English and French documentation.

### Update Notice Enhancements
* [`inc/Engine/Admin/Settings/Page.php`](diffhunk://#diff-1f8a05a3d25f121c99e4c387a399983759c6fe94f8b72d480dfe1e7978789241L2263-R2279): Updated the version comparison logic to check for version `3.19` or higher, replaced the lazy rendering content suggestion with the new `preconnect_domains` suggestion, and updated the update notice message to highlight the new preconnect feature.

### New dependencies

None

### Risks

None

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.
