### PR TITLE
PHPCS configuration file: replace deprecated `Passing an array of values to a property using a comma-separated string`

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -54,17 +54,35 @@
 	</rule>
     <rule ref="WordPress.WP.I18n">
         <properties>
-            <property name="text_domain" type="array" value="rocket" />
+            <property name="text_domain" type="array">
+				<element value="rocket" />
+			</property>
         </properties>
     </rule>
     <rule ref="WordPress.NamingConventions.PrefixAllGlobals">
         <properties>
-            <property name="prefixes" type="array" value="rocket,wp_rocket,WPMedia,WPRocket" />
+            <property name="prefixes" type="array">
+				<element value="rocket" />
+				<element value="wp_rocket" />
+				<element value="WPMedia" />
+				<element value="WPRocket" />
+			</property>
         </properties>
     </rule>
 	<rule ref="WordPress.WP.Capabilities">
         <properties>
-            <property name="custom_capabilities" type="array" value="rocket_manage_options,rocket_remove_unused_css,rocket_purge_sucuri_cache,rocket_preload_cache,rocket_purge_cache,rocket_purge_cloudflare_cache,rocket_purge_posts,rocket_regenerate_critical_css,rocket_purge_terms,rocket_purge_users" />
+            <property name="custom_capabilities" type="array">
+				<element value="rocket_manage_options" />
+				<element value="rocket_remove_unused_css" />
+				<element value="rocket_purge_sucuri_cache" />
+				<element value="rocket_preload_cache" />
+				<element value="rocket_purge_cache" />
+				<element value="rocket_purge_cloudflare_cache" />
+				<element value="rocket_purge_posts" />
+				<element value="rocket_regenerate_critical_css" />
+				<element value="rocket_purge_terms" />
+				<element value="rocket_purge_users" />
+			</property>
         </properties>
     </rule>
     <rule ref="WordPress.Files.FileName">


### PR DESCRIPTION
# Description

The old syntax for the config file using a string with comma-separated values was deprecated in PHPCS 3.3 and remove in PHPCS 4.0.

## Type of change
- [x] Chore

## Detailed scenario

### What was tested

Using the new syntax, there is no longer a deprecated warning when running PHPCS

### How to test

Run PHPCS

## Technical description

### Documentation

Use `element` nodes instead of the old syntax to pass the values necessary.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.
