### PR TITLE
Closes #7387: truncate external domain on settings change

### DIFF
--- a/inc/Engine/Media/PreconnectExternalDomains/Admin/Settings.php
+++ b/inc/Engine/Media/PreconnectExternalDomains/Admin/Settings.php
@@ -41,6 +41,7 @@ class Settings {
 			'exclude_js',
 			'cdn',
 			'cdn_cnames',
+			'host_fonts_locally',
 		];
 		foreach ( $keys as $key ) {
 			if ( $this->did_setting_change( $key, $old, $new ) ) {
@@ -65,7 +66,7 @@ class Settings {
 			&&
 			array_key_exists( $setting, $value )
 			&&
-			(int) $old_value[ $setting ] !== (int) $value[ $setting ]
+			$old_value[ $setting ] !== $value[ $setting ]
 		);
 	}
 }

--- a/inc/Engine/Media/PreconnectExternalDomains/Admin/Settings.php
+++ b/inc/Engine/Media/PreconnectExternalDomains/Admin/Settings.php
@@ -1,0 +1,58 @@
+<?php
+namespace WP_Rocket\Engine\Media\PreconnectExternalDomains\Admin;
+
+use WP_Rocket\Engine\Media\PreconnectExternalDomains\Database\Table\PreconnectExternalDomains as PreconnectExternalDomainsTable;
+
+class Settings {
+	/**
+	 * PreconnectExternalDomainsTable Instance.
+	 *
+	 * @var PreconnectExternalDomainsTable
+	 */
+	private PreconnectExternalDomainsTable $table;
+
+	public function __construct( PreconnectExternalDomainsTable $table ) {
+		$this->table = $table;
+	}
+
+	/**
+	 * Clears the preconnect external domains cache if relevant settings have changed.
+	 *
+	 * This method compares the old and new settings arrays, and if changes affecting
+	 * preconnect external domains are detected, it triggers a cache clear or update.
+	 *
+	 * @param array $old The previous settings values.
+	 * @param array $new The new settings values.
+	 *
+	 * @return void
+	 */
+	public function maybe_clear_preconnect_external_domains( array $old, array $new ): void {
+		$keys = [ 'minify_css', 'minify_js', 'exclude_css', 'exclude_js', 'cdn', 'cdn_cnames' ];
+		foreach ( $keys as $key ) {
+			if ( $this->did_setting_change( $key, $old, $new ) ) {
+				$this->table->truncate_table();
+				break;
+			}
+		}
+	}
+
+	/**
+	 * Checks if the given setting's value changed.
+	 *
+	 * @param string $setting The settings's value to check in the old and new values.
+	 * @param mixed  $old_value Old option value.
+	 * @param mixed  $value     New option value.
+	 *
+	 * @return bool
+	 */
+	private function did_setting_change( $setting, $old_value, $value ) {
+		return (
+			array_key_exists( $setting, $old_value )
+			&&
+			array_key_exists( $setting, $value )
+			&&
+			// phpcs:ignore Universal.Operators.StrictComparisons.LooseNotEqual
+			$old_value[ $setting ] != $value[ $setting ]
+		);
+	}
+}

--- a/inc/Engine/Media/PreconnectExternalDomains/Admin/Settings.php
+++ b/inc/Engine/Media/PreconnectExternalDomains/Admin/Settings.php
@@ -44,7 +44,7 @@ class Settings {
 			'host_fonts_locally',
 		];
 		foreach ( $keys as $key ) {
-			if ( $this->did_setting_change( $key, $old, $new ) ) {
+			if ( $this->did_setting_change( $key, $old_settings, $new_settings ) ) {
 				$this->table->truncate_table();
 				break;
 			}

--- a/inc/Engine/Media/PreconnectExternalDomains/Admin/Settings.php
+++ b/inc/Engine/Media/PreconnectExternalDomains/Admin/Settings.php
@@ -9,8 +9,15 @@ class Settings {
 	 *
 	 * @var PreconnectExternalDomainsTable
 	 */
-	private PreconnectExternalDomainsTable $table;
+	private $table;
 
+	/**
+	 * Constructor for the Settings class.
+	 *
+	 * Initializes the Settings instance with a PreconnectExternalDomainsTable object.
+	 *
+	 * @param PreconnectExternalDomainsTable $table The table instance used to manage preconnect external domains.
+	 */
 	public function __construct( PreconnectExternalDomainsTable $table ) {
 		$this->table = $table;
 	}
@@ -26,8 +33,15 @@ class Settings {
 	 *
 	 * @return void
 	 */
-	public function maybe_clear_preconnect_external_domains( array $old, array $new ): void {
-		$keys = [ 'minify_css', 'minify_js', 'exclude_css', 'exclude_js', 'cdn', 'cdn_cnames' ];
+	public function maybe_clear_preconnect_external_domains( array $old, array $new ): void { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.newFound
+		$keys = [
+			'minify_css',
+			'minify_js',
+			'exclude_css',
+			'exclude_js',
+			'cdn',
+			'cdn_cnames',
+		];
 		foreach ( $keys as $key ) {
 			if ( $this->did_setting_change( $key, $old, $new ) ) {
 				$this->table->truncate_table();
@@ -51,8 +65,7 @@ class Settings {
 			&&
 			array_key_exists( $setting, $value )
 			&&
-			// phpcs:ignore Universal.Operators.StrictComparisons.LooseNotEqual
-			$old_value[ $setting ] != $value[ $setting ]
+			(int) $old_value[ $setting ] !== (int) $value[ $setting ]
 		);
 	}
 }

--- a/inc/Engine/Media/PreconnectExternalDomains/Admin/Settings.php
+++ b/inc/Engine/Media/PreconnectExternalDomains/Admin/Settings.php
@@ -28,12 +28,12 @@ class Settings {
 	 * This method compares the old and new settings arrays, and if changes affecting
 	 * preconnect external domains are detected, it triggers a cache clear or update.
 	 *
-	 * @param array $old The previous settings values.
-	 * @param array $new The new settings values.
+	 * @param array $old_settings The previous settings values.
+	 * @param array $new_settings The new settings values.
 	 *
 	 * @return void
 	 */
-	public function maybe_clear_preconnect_external_domains( array $old, array $new ): void { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.newFound
+	public function maybe_clear_preconnect_external_domains( array $old_settings, array $new_settings ): void {
 		$keys = [
 			'minify_css',
 			'minify_js',

--- a/inc/Engine/Media/PreconnectExternalDomains/Admin/Subscriber.php
+++ b/inc/Engine/Media/PreconnectExternalDomains/Admin/Subscriber.php
@@ -39,11 +39,11 @@ class Subscriber implements Subscriber_Interface {
 	/**
 	 * Clears the preconnect domains table if relevant settings are changed.
 	 *
-	 * @param array $old Old settings.
-	 * @param array $new New settings.
+	 * @param array $old_settings Old settings.
+	 * @param array $new_settings New settings.
 	 * @return void
 	 */
-	public function maybe_clear_preconnect_domains( array $old, array $new ): void { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.newFound
-		$this->settings->maybe_clear_preconnect_external_domains( $old, $new );
+	public function maybe_clear_preconnect_domains( array $old_settings, array $new_settings ): void {
+		$this->settings->maybe_clear_preconnect_external_domains( $old_settings, $new_settings );
 	}
 }

--- a/inc/Engine/Media/PreconnectExternalDomains/Admin/Subscriber.php
+++ b/inc/Engine/Media/PreconnectExternalDomains/Admin/Subscriber.php
@@ -37,7 +37,7 @@ class Subscriber implements Subscriber_Interface {
 	}
 
 	/**
-	 * Clears the preconnect domains table if relevant settings is changed.
+	 * Clears the preconnect domains table if relevant settings are changed.
 	 *
 	 * @param array $old Old settings.
 	 * @param array $new New settings.

--- a/inc/Engine/Media/PreconnectExternalDomains/Admin/Subscriber.php
+++ b/inc/Engine/Media/PreconnectExternalDomains/Admin/Subscriber.php
@@ -2,7 +2,6 @@
 namespace WP_Rocket\Engine\Media\PreconnectExternalDomains\Admin;
 
 use WP_Rocket\Event_Management\Subscriber_Interface;
-use WP_Rocket\Engine\Media\PreconnectExternalDomains\Admin\Settings;
 
 /**
  * Preconnect External Domains admin controller
@@ -38,13 +37,13 @@ class Subscriber implements Subscriber_Interface {
 	}
 
 	/**
-	 * Clears the preconnect domains table if relevant minify settings changed.
+	 * Clears the preconnect domains table if relevant settings is changed.
 	 *
 	 * @param array $old Old settings.
 	 * @param array $new New settings.
 	 * @return void
 	 */
-	public function maybe_clear_preconnect_domains( array $old, array $new ): void {
+	public function maybe_clear_preconnect_domains( array $old, array $new ): void { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.newFound
 		$this->settings->maybe_clear_preconnect_external_domains( $old, $new );
 	}
 }

--- a/inc/Engine/Media/PreconnectExternalDomains/Admin/Subscriber.php
+++ b/inc/Engine/Media/PreconnectExternalDomains/Admin/Subscriber.php
@@ -1,0 +1,50 @@
+<?php
+namespace WP_Rocket\Engine\Media\PreconnectExternalDomains\Admin;
+
+use WP_Rocket\Event_Management\Subscriber_Interface;
+use WP_Rocket\Engine\Media\PreconnectExternalDomains\Admin\Settings;
+
+/**
+ * Preconnect External Domains admin controller
+ *
+ * @since 3.19
+ */
+class Subscriber implements Subscriber_Interface {
+	/**
+	 * Controller instance
+	 *
+	 * @var Settings
+	 */
+	private $settings;
+
+	/**
+	 *  Creates an instance of the object.
+	 *
+	 * @param Settings $settings Settings instance.
+	 */
+	public function __construct( Settings $settings ) {
+		$this->settings = $settings;
+	}
+
+	/**
+	 * Returns an array of events this subscriber listens to
+	 *
+	 * @return array[]
+	 */
+	public static function get_subscribed_events(): array {
+		return [
+			'update_option_wp_rocket_settings' => [ 'maybe_clear_preconnect_domains', 12, 2 ],
+		];
+	}
+
+	/**
+	 * Clears the preconnect domains table if relevant minify settings changed.
+	 *
+	 * @param array $old Old settings.
+	 * @param array $new New settings.
+	 * @return void
+	 */
+	public function maybe_clear_preconnect_domains( array $old, array $new ): void {
+		$this->settings->maybe_clear_preconnect_external_domains( $old, $new );
+	}
+}

--- a/inc/Engine/Media/PreconnectExternalDomains/ServiceProvider.php
+++ b/inc/Engine/Media/PreconnectExternalDomains/ServiceProvider.php
@@ -9,8 +9,10 @@ use WP_Rocket\Engine\Media\PreconnectExternalDomains\Database\Queries\Preconnect
 use WP_Rocket\Engine\Media\PreconnectExternalDomains\AJAX\Controller as AJAXController;
 use WP_Rocket\Engine\Media\PreconnectExternalDomains\Database\Table\PreconnectExternalDomains as PreconnectTable;
 use WP_Rocket\Engine\Media\PreconnectExternalDomains\Frontend\{Controller as FrontController, Subscriber as FrontendSubscriber};
-use WP_Rocket\Engine\Media\PreconnectExternalDomains\Admin\Settings as AdminSettings;
-use WP_Rocket\Engine\Media\PreconnectExternalDomains\Admin\Subscriber as AdminSubscriber;
+use WP_Rocket\Engine\Media\PreconnectExternalDomains\Admin\{
+	Settings as AdminSettings,
+	Subscriber as AdminSubscriber
+};
 
 class ServiceProvider extends AbstractServiceProvider {
 	/**

--- a/inc/Engine/Media/PreconnectExternalDomains/ServiceProvider.php
+++ b/inc/Engine/Media/PreconnectExternalDomains/ServiceProvider.php
@@ -9,6 +9,8 @@ use WP_Rocket\Engine\Media\PreconnectExternalDomains\Database\Queries\Preconnect
 use WP_Rocket\Engine\Media\PreconnectExternalDomains\AJAX\Controller as AJAXController;
 use WP_Rocket\Engine\Media\PreconnectExternalDomains\Database\Table\PreconnectExternalDomains as PreconnectTable;
 use WP_Rocket\Engine\Media\PreconnectExternalDomains\Frontend\{Controller as FrontController, Subscriber as FrontendSubscriber};
+use WP_Rocket\Engine\Media\PreconnectExternalDomains\Admin\Settings as AdminSettings;
+use WP_Rocket\Engine\Media\PreconnectExternalDomains\Admin\Subscriber as AdminSubscriber;
 
 class ServiceProvider extends AbstractServiceProvider {
 	/**
@@ -21,6 +23,8 @@ class ServiceProvider extends AbstractServiceProvider {
 	 * @var array
 	 */
 	protected $provides = [
+		'preconnect_external_domains_admin_settings',
+		'preconnect_external_domains_admin_subscriber',
 		'preconnect_external_domains_query',
 		'preconnect_external_domains_context',
 		'preconnect_external_domains_ajax_controller',
@@ -85,5 +89,11 @@ class ServiceProvider extends AbstractServiceProvider {
 					'preconnect_external_domains_controller',
 				]
 			);
+
+		$this->getContainer()->add( 'preconnect_external_domains_admin_settings', AdminSettings::class )
+			->addArgument( 'preconnect_external_domains_table' );
+
+			$this->getContainer()->addShared( 'preconnect_external_domains_admin_subscriber', AdminSubscriber::class )
+			->addArgument( 'preconnect_external_domains_admin_settings' );
 	}
 }

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -236,6 +236,9 @@ class Plugin {
 			'domain_change_subscriber',
 			'lazyload_css_admin_subscriber',
 			'post_edit_options_subscriber',
+			'preconnect_external_domains_admin_subscriber',
+			'media_fonts_admin_subscriber',
+			'preload_fonts_admin_subscriber',
 		];
 	}
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1351,6 +1351,11 @@ parameters:
 			path: tests/Integration/inc/Engine/Media/Lazyload/Subscriber/maybeDisableCoreLazyload.php
 
 		-
+			message: "#^Usage of apply_filters\\(\\) is discouraged\\. Use wpm_apply_filters_typed\\(\\) instead\\.$#"
+			count: 25
+			path: tests/Integration/inc/Engine/Media/PreconnectExternalDomains/Admin/Subscriber/maybeClearPreconnectDomains.php
+
+		-
 			message: "#^Usage of get_option\\(\\) is discouraged\\. Use the Option object instead\\.$#"
 			count: 1
 			path: tests/Integration/inc/Engine/Media/PreloadFonts/Admin/Subscriber/MaybeEnableAutoPreloadTest.php
@@ -2169,11 +2174,6 @@ parameters:
 			message: "#^Usage of update_option\\(\\) is discouraged\\. Use the Option object instead\\.$#"
 			count: 1
 			path: tests/Integration/inc/functions/rocketIsPluginActive.php
-
-		-
-			message: "#^Path in include_once\\(\\) \"vfs\\://public/wp\\-content/plugins/wp\\-rocket/inc/classes/dependencies/mobiledetect/mobiledetectlib/Mobile_Detect\\.php\" is not a file or it does not exist\\.$#"
-			count: 1
-			path: tests/Integration/vfs:/public/wp-content/advanced-cache.php
 
 		-
 			message: "#^Usage of apply_filters\\(\\) is discouraged\\. Use wpm_apply_filters_typed\\(\\) instead\\.$#"

--- a/tests/Fixtures/inc/Engine/Media/PreconnectExternalDomains/Admin/Subscriber/maybeClearPreconnectDomains.php
+++ b/tests/Fixtures/inc/Engine/Media/PreconnectExternalDomains/Admin/Subscriber/maybeClearPreconnectDomains.php
@@ -2,7 +2,7 @@
 
 
 return [
-	'testShouldClearPreconnectDomains' => [
+	'testShouldClearPreconnectDomainsWhenMinifyCssChanged' => [
 		'config' => [
 			'rows' => [
 				[
@@ -28,6 +28,200 @@ return [
 				'exclude_js' => '',
 				'cdn' => 'https://cdn.example.com',
 				'cdn_cnames' => 'example.com',
+			],
+		],
+		'expected' => [
+			'row_count' => 0,
+		],
+	],
+	'testShouldClearPreconnectDomainsWhenMinifyJsChanged' => [
+		'config' => [
+			'rows' => [
+				[
+					'url' => 'https://example.com',
+					'is_mobile' => false,
+					'domains' => 'example.com',
+					'error_message' => '',
+					'status' => 'active',
+				],
+			],
+			'old' => [
+				'minify_css' => true,
+				'minify_js' => true,
+				'exclude_css' => '',
+				'exclude_js' => '',
+				'cdn' => 'https://cdn.example.com',
+				'cdn_cnames' => 'example.com',
+			],
+			'new' => [
+				'minify_css' => true,
+				'minify_js' => false,
+				'exclude_css' => '',
+				'exclude_js' => '',
+				'cdn' => 'https://cdn.example.com',
+				'cdn_cnames' => 'example.com',
+			],
+		],
+		'expected' => [
+			'row_count' => 0,
+		],
+	],
+	'testShouldClearPreconnectDomainsWhenExcludeCssChanged' => [
+		'config' => [
+			'rows' => [
+				[
+					'url' => 'https://example.com',
+					'is_mobile' => false,
+					'domains' => 'example.com',
+					'error_message' => '',
+					'status' => 'active',
+				],
+			],
+			'old' => [
+				'minify_css' => true,
+				'minify_js' => true,
+				'exclude_css' => '',
+				'exclude_js' => '',
+				'cdn' => 'https://cdn.example.com',
+				'cdn_cnames' => 'example.com',
+			],
+			'new' => [
+				'minify_css' => true,
+				'minify_js' => true,
+				'exclude_css' => 'style.css',
+				'exclude_js' => '',
+				'cdn' => 'https://cdn.example.com',
+				'cdn_cnames' => 'example.com',
+			],
+		],
+		'expected' => [
+			'row_count' => 0,
+		],
+	],
+	'testShouldClearPreconnectDomainsWhenExcludeJsChanged' => [
+		'config' => [
+			'rows' => [
+				[
+					'url' => 'https://example.com',
+					'is_mobile' => false,
+					'domains' => 'example.com',
+					'error_message' => '',
+					'status' => 'active',
+				],
+			],
+			'old' => [
+				'minify_css' => true,
+				'minify_js' => true,
+				'exclude_css' => '',
+				'exclude_js' => '',
+				'cdn' => 'https://cdn.example.com',
+				'cdn_cnames' => 'example.com',
+			],
+			'new' => [
+				'minify_css' => true,
+				'minify_js' => true,
+				'exclude_css' => '',
+				'exclude_js' => 'script.js',
+				'cdn' => 'https://cdn.example.com',
+				'cdn_cnames' => 'example.com',
+			],
+		],
+		'expected' => [
+			'row_count' => 0,
+		],
+	],
+	'testShouldClearPreconnectDomainsWhenCdnChanged' => [
+		'config' => [
+			'rows' => [
+				[
+					'url' => 'https://example.com',
+					'is_mobile' => false,
+					'domains' => 'example.com',
+					'error_message' => '',
+					'status' => 'active',
+				],
+			],
+			'old' => [
+				'minify_css' => true,
+				'minify_js' => true,
+				'exclude_css' => '',
+				'exclude_js' => '',
+				'cdn' => 'https://cdn.example.com',
+				'cdn_cnames' => 'example.com',
+			],
+			'new' => [
+				'minify_css' => true,
+				'minify_js' => true,
+				'exclude_css' => '',
+				'exclude_js' => '',
+				'cdn' => '',
+				'cdn_cnames' => 'example.com',
+			],
+		],
+		'expected' => [
+			'row_count' => 0,
+		],
+	],
+	'testShouldClearPreconnectDomainsWhenCdnCnamesChanged' => [
+		'config' => [
+			'rows' => [
+				[
+					'url' => 'https://example.com',
+					'is_mobile' => false,
+					'domains' => 'example.com',
+					'error_message' => '',
+					'status' => 'active',
+				],
+			],
+			'old' => [
+				'minify_css' => true,
+				'minify_js' => true,
+				'exclude_css' => '',
+				'exclude_js' => '',
+				'cdn' => 'https://cdn.example.com',
+				'cdn_cnames' => 'example.com',
+			],
+			'new' => [
+				'minify_css' => true,
+				'minify_js' => true,
+				'exclude_css' => '',
+				'exclude_js' => '',
+				'cdn' => 'https://cdn.example.com',
+				'cdn_cnames' => '',
+			],
+		],
+		'expected' => [
+			'row_count' => 0,
+		],
+	],
+	'testShouldClearPreconnectDomainsWhenHostFontLocallyChanged' => [
+		'config' => [
+			'rows' => [
+				[
+					'url' => 'https://example.com',
+					'is_mobile' => false,
+					'domains' => 'example.com',
+					'error_message' => '',
+					'status' => 'active',
+				],
+			],
+			'old' => [
+				'minify_css' => true,
+				'minify_js' => true,
+				'exclude_css' => '',
+				'exclude_js' => '',
+				'cdn' => 'https://cdn.example.com',
+				'cdn_cnames' => 'example.com',
+				'host_fonts_locally' => true
+			],
+			'new' => [
+				'minify_css' => true,
+				'minify_js' => true,
+				'exclude_css' => '',
+				'exclude_js' => '',
+				'cdn' => 'https://cdn.example.com',
+				'cdn_cnames' => 'example.com',
+				'host_fonts_locally' => false,
 			],
 		],
 		'expected' => [

--- a/tests/Fixtures/inc/Engine/Media/PreconnectExternalDomains/Admin/Subscriber/maybeClearPreconnectDomains.php
+++ b/tests/Fixtures/inc/Engine/Media/PreconnectExternalDomains/Admin/Subscriber/maybeClearPreconnectDomains.php
@@ -1,0 +1,69 @@
+<?php
+
+
+return [
+	'testShouldClearPreconnectDomains' => [
+		'config' => [
+			'rows' => [
+				[
+					'url' => 'https://example.com',
+					'is_mobile' => false,
+					'domains' => 'example.com',
+					'error_message' => '',
+					'status' => 'active',
+				],
+			],
+			'old' => [
+				'minify_css' => true,
+				'minify_js' => true,
+				'exclude_css' => '',
+				'exclude_js' => '',
+				'cdn' => 'https://cdn.example.com',
+				'cdn_cnames' => 'example.com',
+			],
+			'new' => [
+				'minify_css' => false,
+				'minify_js' => true,
+				'exclude_css' => '',
+				'exclude_js' => '',
+				'cdn' => 'https://cdn.example.com',
+				'cdn_cnames' => 'example.com',
+			],
+		],
+		'expected' => [
+			'row_count' => 0,
+		],
+	],
+	'testShouldNotClearPreconnectDomains' => [
+		'config' => [
+			'rows' => [
+				[
+					'url' => 'https://example.com',
+					'is_mobile' => false,
+					'domains' => 'example.com',
+					'error_message' => '',
+					'status' => 'active',
+				],
+			],
+			'old' => [
+				'minify_css' => true,
+				'minify_js' => true,
+				'exclude_css' => '',
+				'exclude_js' => '',
+				'cdn' => 'https://cdn.example.com',
+				'cdn_cnames' => 'example.com',
+			],
+			'new' => [
+				'minify_css' => true,
+				'minify_js' => true,
+				'exclude_css' => '',
+				'exclude_js' => '',
+				'cdn' => 'https://cdn.example.com',
+				'cdn_cnames' => 'example.com',
+			],
+		],
+		'expected' => [
+			'row_count' => 1,
+		],
+	],
+];

--- a/tests/Integration/inc/Engine/Media/PreconnectExternalDomains/Admin/Subscriber/maybeClearPreconnectDomains.php
+++ b/tests/Integration/inc/Engine/Media/PreconnectExternalDomains/Admin/Subscriber/maybeClearPreconnectDomains.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\Media\PreconnectExternalDomains\Admin\Subscriber;
+
+use WP_Rocket\Tests\Integration\TestCase;
+use WP_Rocket\Tests\Integration\DBTrait;
+
+/**
+ * Test class covering \WP_Rocket\Engine\Media\PreconnectExternalDomains\Admin\Subscriber::maybe_clear_preconnect_domains
+ *
+ * @group PreconnectExternalDomains
+ * @group Media
+ */
+class MaybeClearPreconnectDomains extends TestCase {
+	use DBTrait;
+
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		self::installPreconnectExternalDomainsTable();
+	}
+
+	public static function tear_down_after_class() {
+		self::uninstallPreconnectDomainsTable();
+
+		parent::tear_down_after_class();
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->unregisterAllCallbacksExcept( 'update_option_wp_rocket_settings', 'maybe_clear_preconnect_domains', 12 );
+	}
+
+
+	public function tear_down() {
+		parent::tear_down();
+
+		$this->restoreWpHook( 'update_option_wp_rocket_settings' );
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnAsExpected( $config, $expected ) {
+		// Add rows to the database using DBTrait.
+		foreach ( $config['rows'] as $row ) {
+			self::addPreconnectExternalDomains( $row );
+		}
+
+		// Trigger the action to test the logic.
+		 do_action( 'update_option_wp_rocket_settings', $config['old'], $config['new'] );
+
+		// Assert the table state matches the expected row count.
+		$actual_row_count = count( apply_filters( 'rocket_container', null )
+			->get( 'preconnect_external_domains_query' )
+			->query( [] ) );
+
+		$this->assertSame( $expected['row_count'], $actual_row_count );
+	}
+}

--- a/tests/Integration/inc/Engine/Media/PreconnectExternalDomains/Admin/Subscriber/maybeClearPreconnectDomains.php
+++ b/tests/Integration/inc/Engine/Media/PreconnectExternalDomains/Admin/Subscriber/maybeClearPreconnectDomains.php
@@ -9,6 +9,7 @@ use WP_Rocket\Tests\Integration\DBTrait;
  * Test class covering \WP_Rocket\Engine\Media\PreconnectExternalDomains\Admin\Subscriber::maybe_clear_preconnect_domains
  *
  * @group PreconnectExternalDomains
+ * @group AdminOnly
  * @group Media
  */
 class MaybeClearPreconnectDomains extends TestCase {
@@ -24,19 +25,6 @@ class MaybeClearPreconnectDomains extends TestCase {
 		self::uninstallPreconnectDomainsTable();
 
 		parent::tear_down_after_class();
-	}
-
-	public function set_up() {
-		parent::set_up();
-
-		$this->unregisterAllCallbacksExcept( 'update_option_wp_rocket_settings', 'maybe_clear_preconnect_domains', 12 );
-	}
-
-
-	public function tear_down() {
-		parent::tear_down();
-
-		$this->restoreWpHook( 'update_option_wp_rocket_settings' );
 	}
 
 	/**


### PR DESCRIPTION
# Description

Fixes #7387
This will clear the preconnect external data when modifying the following settings:
`[ 'minify_css', 'minify_js', 'exclude_css', 'exclude_js', 'cdn', 'cdn_cnames' ]`
## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

### What was tested

Change of these settings

### How to test

Just go in the backend of WP Rocket, and change the settings and check the DB if it does get cleared. 

## Technical description

### Documentation
This pull request introduces functionality to manage and clear the preconnect external domains cache when specific WP Rocket settings are updated. It includes the addition of new classes for handling settings and event subscriptions, as well as updates to the service provider for dependency injection. Below are the key changes grouped by theme:

### New Classes for Settings and Event Handling

* Added the `Settings` class in `inc/Engine/Media/PreconnectExternalDomains/Admin/Settings.php` to manage the preconnect external domains cache. This includes a method to clear the cache when relevant settings change and a helper method to detect setting changes.
* Added the `Subscriber` class in `inc/Engine/Media/PreconnectExternalDomains/Admin/Subscriber.php` to listen for changes to WP Rocket settings and trigger the cache-clearing logic in the `Settings` class.

### Service Provider Updates for Dependency Injection

* Updated `inc/Engine/Media/PreconnectExternalDomains/ServiceProvider.php` to include the new `AdminSettings` and `AdminSubscriber` classes in the list of provided services.
* Modified the `register` method in the `ServiceProvider` to register the `AdminSettings` service with its dependency and the `AdminSubscriber` service as a shared instance.

These changes enhance the plugin's modularity and ensure that the preconnect external domains cache is properly managed in response to relevant setting updates.

### New dependencies

None

### Risks

None

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.
