### PR TITLE
Closes #7418: 3.19 preconnect external domain old dns-prefetch data

### DIFF
--- a/inc/Engine/Media/PreconnectExternalDomains/Admin/Settings.php
+++ b/inc/Engine/Media/PreconnectExternalDomains/Admin/Settings.php
@@ -2,6 +2,8 @@
 namespace WP_Rocket\Engine\Media\PreconnectExternalDomains\Admin;
 
 use WP_Rocket\Engine\Media\PreconnectExternalDomains\Database\Table\PreconnectExternalDomains as PreconnectExternalDomainsTable;
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Admin\Options as Options_API;
 
 class Settings {
 	/**
@@ -12,14 +14,33 @@ class Settings {
 	private $table;
 
 	/**
+	 * WP Rocket options instance.
+	 *
+	 * @var Options_Data
+	 */
+	private $options;
+
+
+	/**
+	 * WP Rocket Options API Instance.
+	 *
+	 * @var Options_API
+	 */
+	private $options_api;
+
+	/**
 	 * Constructor for the Settings class.
 	 *
 	 * Initializes the Settings instance with a PreconnectExternalDomainsTable object.
 	 *
 	 * @param PreconnectExternalDomainsTable $table The table instance used to manage preconnect external domains.
+	 * @param Options_Data $options Instance of the Option_Data class.
+	 * @param Options_API  $options_api WP Rocket Options API instance.
 	 */
-	public function __construct( PreconnectExternalDomainsTable $table ) {
+	public function __construct( PreconnectExternalDomainsTable $table, Options_Data $options, Options_API $options_api ) {
 		$this->table = $table;
+		$this->options = $options;
+		$this->options_api = $options_api;
 	}
 
 	/**
@@ -68,5 +89,20 @@ class Settings {
 			&&
 			$old_value[ $setting ] !== $value[ $setting ]
 		);
+	}
+
+	/**
+	 * Removes old DNS prefetch values from settings.
+	 *
+	 * @return void
+	 */
+	public function maybe_clear_dns_prefetch_values(): void {
+		$options = $this->options_api->get( 'settings', [] );
+		if ( empty( $options['dns_prefetch'] ) ) {
+			return;
+		}
+
+		$this->options->set( 'dns_prefetch', [] );
+		$this->options_api->set( 'settings', $this->options->get_options() );
 	}
 }

--- a/inc/Engine/Media/PreconnectExternalDomains/Admin/Settings.php
+++ b/inc/Engine/Media/PreconnectExternalDomains/Admin/Settings.php
@@ -34,12 +34,12 @@ class Settings {
 	 * Initializes the Settings instance with a PreconnectExternalDomainsTable object.
 	 *
 	 * @param PreconnectExternalDomainsTable $table The table instance used to manage preconnect external domains.
-	 * @param Options_Data $options Instance of the Option_Data class.
-	 * @param Options_API  $options_api WP Rocket Options API instance.
+	 * @param Options_Data                   $options Instance of the Option_Data class.
+	 * @param Options_API                    $options_api WP Rocket Options API instance.
 	 */
 	public function __construct( PreconnectExternalDomainsTable $table, Options_Data $options, Options_API $options_api ) {
-		$this->table = $table;
-		$this->options = $options;
+		$this->table       = $table;
+		$this->options     = $options;
 		$this->options_api = $options_api;
 	}
 

--- a/inc/Engine/Media/PreconnectExternalDomains/Admin/Subscriber.php
+++ b/inc/Engine/Media/PreconnectExternalDomains/Admin/Subscriber.php
@@ -33,7 +33,7 @@ class Subscriber implements Subscriber_Interface {
 	public static function get_subscribed_events(): array {
 		return [
 			'update_option_wp_rocket_settings' => [ 'maybe_clear_preconnect_domains', 12, 2 ],
-			'wp_rocket_upgrade' => [ 'maybe_clear_dns_prefetch_values', 10, 2 ],
+			'wp_rocket_upgrade'                => [ 'maybe_clear_dns_prefetch_values', 10, 2 ],
 		];
 	}
 
@@ -49,18 +49,18 @@ class Subscriber implements Subscriber_Interface {
 	}
 
 	/**
-	* Removes old DNS prefetch values when upgrading from versions prior to 3.19.
-	* 
-	* @param string $new_version New plugin version.
-	* @param string $old_version Previous plugin version.
-	* 
-	* @return void
-	*/
+	 * Removes old DNS prefetch values when upgrading from versions prior to 3.19.
+	 *
+	 * @param string $new_version New plugin version.
+	 * @param string $old_version Previous plugin version.
+	 *
+	 * @return void
+	 */
 	public function maybe_clear_dns_prefetch_values( $new_version, $old_version ): void {
 		if ( version_compare( $old_version, '3.19', '>' ) ) {
 			return;
 		}
-		
+
 		$this->settings->maybe_clear_dns_prefetch_values();
 	}
 }

--- a/inc/Engine/Media/PreconnectExternalDomains/Admin/Subscriber.php
+++ b/inc/Engine/Media/PreconnectExternalDomains/Admin/Subscriber.php
@@ -33,6 +33,7 @@ class Subscriber implements Subscriber_Interface {
 	public static function get_subscribed_events(): array {
 		return [
 			'update_option_wp_rocket_settings' => [ 'maybe_clear_preconnect_domains', 12, 2 ],
+			'wp_rocket_upgrade' => [ 'maybe_clear_dns_prefetch_values', 10, 2 ],
 		];
 	}
 
@@ -45,5 +46,21 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	public function maybe_clear_preconnect_domains( array $old_settings, array $new_settings ): void {
 		$this->settings->maybe_clear_preconnect_external_domains( $old_settings, $new_settings );
+	}
+
+	/**
+	* Removes old DNS prefetch values when upgrading from versions prior to 3.19.
+	* 
+	* @param string $new_version New plugin version.
+	* @param string $old_version Previous plugin version.
+	* 
+	* @return void
+	*/
+	public function maybe_clear_dns_prefetch_values( $new_version, $old_version ): void {
+		if ( version_compare( $old_version, '3.19', '>' ) ) {
+			return;
+		}
+		
+		$this->settings->maybe_clear_dns_prefetch_values();
 	}
 }

--- a/inc/Engine/Media/PreconnectExternalDomains/ServiceProvider.php
+++ b/inc/Engine/Media/PreconnectExternalDomains/ServiceProvider.php
@@ -98,7 +98,13 @@ class ServiceProvider extends AbstractServiceProvider {
 			);
 
 		$this->getContainer()->add( 'preconnect_external_domains_admin_settings', AdminSettings::class )
-			->addArgument( 'preconnect_external_domains_table' );
+			->addArguments( 
+				[
+					'preconnect_external_domains_table',
+					'options',
+					'options_api',
+				]
+			 );
 
 			$this->getContainer()->addShared( 'preconnect_external_domains_admin_subscriber', AdminSubscriber::class )
 			->addArgument( 'preconnect_external_domains_admin_settings' );

--- a/inc/Engine/Media/PreconnectExternalDomains/ServiceProvider.php
+++ b/inc/Engine/Media/PreconnectExternalDomains/ServiceProvider.php
@@ -98,13 +98,13 @@ class ServiceProvider extends AbstractServiceProvider {
 			);
 
 		$this->getContainer()->add( 'preconnect_external_domains_admin_settings', AdminSettings::class )
-			->addArguments( 
+			->addArguments(
 				[
 					'preconnect_external_domains_table',
 					'options',
 					'options_api',
 				]
-			 );
+			);
 
 			$this->getContainer()->addShared( 'preconnect_external_domains_admin_subscriber', AdminSubscriber::class )
 			->addArgument( 'preconnect_external_domains_admin_settings' );

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1358,6 +1358,11 @@ parameters:
 		-
 			message: "#^Usage of get_option\\(\\) is discouraged\\. Use the Option object instead\\.$#"
 			count: 1
+			path: tests/Integration/inc/Engine/Media/PreconnectExternalDomains/Admin/Subscriber/maybeClearDnsPrefetchValues.php
+
+		-
+			message: "#^Usage of get_option\\(\\) is discouraged\\. Use the Option object instead\\.$#"
+			count: 1
 			path: tests/Integration/inc/Engine/Media/PreloadFonts/Admin/Subscriber/MaybeEnableAutoPreloadTest.php
 
 		-

--- a/tests/Fixtures/inc/Engine/Media/PreconnectExternalDomains/Admin/Subscriber/maybeClearDnsPrefetchValues.php
+++ b/tests/Fixtures/inc/Engine/Media/PreconnectExternalDomains/Admin/Subscriber/maybeClearDnsPrefetchValues.php
@@ -1,0 +1,50 @@
+<?php
+
+return [
+	'testShouldDoNothingWhenVersionAbove319' => [
+		'config' => [
+			'new' => '3.20',
+			'old' => '3.19',
+			'options' => [
+				'dns_prefetch' => []
+			]
+		],
+		'expected' => [
+			'options' => [
+				'dns_prefetch' => []
+			]
+		],
+	],
+	'testShouldDoNothingIfDnsPrefetchValueIsEmpty' => [
+		'config' => [
+			'new' => '3.19',
+			'old' => '3.18',
+			'options' => [
+				'dns_prefetch' => []
+			]
+		],
+		'expected' => [
+			'options' => [
+				'dns_prefetch' => [],
+			],
+		],
+	],
+	'testShouldDeleteDnsPrefetchValueWhenNotEmptyAndVersionUnder319' => [
+		'config' => [
+			'new' => '3.19',
+			'old' => '3.18',
+			'options' => [
+				'dns_prefetch' => [
+					'//example.org',
+                    '//example2.org',
+                    '//example3.org',
+                ],
+			]
+		],
+		'expected' => [
+			'options' => [
+				'dns_prefetch' => []
+			]
+		],
+	],
+];

--- a/tests/Integration/inc/Engine/Media/PreconnectExternalDomains/Admin/Subscriber/maybeClearDnsPrefetchValues.php
+++ b/tests/Integration/inc/Engine/Media/PreconnectExternalDomains/Admin/Subscriber/maybeClearDnsPrefetchValues.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\Media\PreconnectExternalDomains\Admin\Subscriber;
+
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * Test class covering \WP_Rocket\Engine\Media\PreconnectExternalDomains\Admin\Subscriber::maybe_clear_dns_prefetch_values
+ *
+ * @group PreconnectExternalDomains
+ * @group AdminOnly
+ * @group Media
+ */
+class Test_MaybeClearDnsPrefetchSetting extends TestCase {
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->setUpSettings();
+		$this->unregisterAllCallbacksExcept( 'wp_rocket_upgrade', 'maybe_clear_dns_prefetch_values' );
+
+	}
+
+	public function tear_down() {
+		$this->tearDownSettings();
+		$this->restoreWpHook( 'wp_rocket_upgrade' );
+		parent::tear_down();
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldDoAsExpected( $config, $expected ) {
+		$this->mergeExistingSettingsAndUpdate( $config['options'] );
+
+		do_action( 'wp_rocket_upgrade', $config['new'], $config['old'] );
+
+		$options = get_option( 'wp_rocket_settings' );
+
+		foreach ( $expected['options'] as $key => $value ) {
+			$this->assertArrayHasKey( $key, $options );
+			$this->assertSame( $value, $options[ $key ] );
+		}
+	}
+
+}


### PR DESCRIPTION
# Description

Fixes #7418 
Avoid prefetching dns prefetch values

## Type of change

- [x] New feature (non-breaking change which adds functionality).
- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

### What was tested

Check that after upgrade to 3.19, dns prefetch values from previous version is not preloaded on page.

### How to test
- Add domains to the dns prefetch field under preload in <=3.18.3
- Upgrade to version 3.19
- Check that domains added in previous version is no longer prefetched on page.

## Technical description

### Documentation

Add a callback to the `wp_rocket_upgrade` hook to check if old version is < 3.19, then check if dns_prefetch option is populated and set value to an empty array.

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

Not applicable to changes in this PR.

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
