### PR TITLE
Closes #7396: WP Rocket should be in full control over fonts priority

### DIFF
--- a/inc/Engine/Media/PreloadFonts/Frontend/Controller.php
+++ b/inc/Engine/Media/PreloadFonts/Frontend/Controller.php
@@ -165,6 +165,7 @@ class Controller implements ControllerInterface {
 	 *
 	 * This method scans the given HTML string and removes any <link rel="preload" as="font"> tags
 	 * that match certain criteria, to prevent duplicate or unnecessary font preloads.
+	 * Only removes preloaded fonts when WP Rocket's font optimization is actually applied.
 	 *
 	 * @param string $html The HTML content to process.
 	 * @return string The modified HTML content with preloaded font links removed if applicable.
@@ -173,19 +174,32 @@ class Controller implements ControllerInterface {
 		if ( ! $this->context->is_allowed() ) {
 			return $html;
 		}
+		$row = $this->get_current_url_row();
+		if ( ! $row ) {
+			return $html;
+		}
 
 		/**
-		 * Filter to enable or disable the deleting of existing preloaded tags.
+		 * Filter to enable or disable deleting existing preloaded tags.
 		 *
-		 * @param bool $should_remove Enable or disable the removal of existing preloaded tags.
+		 * @param bool $should_remove
 		 */
 		$should_remove = wpm_apply_filters_typed( 'boolean', 'rocket_remove_existing_preloaded_fonts', true );
-
 		if ( ! $should_remove ) {
 			return $html;
 		}
 
-		// Use regex to remove <link rel="preload" as="font"> tags.
-		return preg_replace( '/<link[^>]*rel=["\']preload["\'][^>]*as=["\']font["\'][^>]*>\s*/i', '', $html );
+		// One regex to skip scripts and remove any <link rel=preload as=font…> tag (entire line, including indentation and newline):.
+		$html = preg_replace(
+			'#<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>(*SKIP)(*FAIL)'    // skip <script> blocks.
+			. '|^[ \t]*<link\b'                                           // OR match a <link at line start (with optional indent).
+			. '(?=[^>]*\brel\s*=\s*(["\']?)preload\1)'                 // lookahead rel=preload.
+			. '(?=[^>]*\bas\s*=\s*(["\']?)font\2)'                     // lookahead as=font.
+			. '[^>]*?\/?>[ \t]*(?:\r?\n|$)#im',                        // up to /> or >, then trim whitespace and newline.
+			'',
+			$html
+		);
+
+		return $html;
 	}
 }

--- a/inc/Engine/Media/PreloadFonts/Frontend/Controller.php
+++ b/inc/Engine/Media/PreloadFonts/Frontend/Controller.php
@@ -169,20 +169,19 @@ class Controller implements ControllerInterface {
 	 * @param string $html The HTML content to process.
 	 * @return string The modified HTML content with preloaded font links removed if applicable.
 	 */
-	public function maybe_remove_existing_preloaded_fonts( string $html ): string
-	{
-		if (!$this->context->is_allowed()) {
+	public function maybe_remove_existing_preloaded_fonts( string $html ): string {
+		if ( ! $this->context->is_allowed() ) {
 			return $html;
 		}
 
 		// Apply a filter to allow overriding the removal of preloaded font tags.
-		$should_remove = wpm_apply_filters_typed('boolean', 'rocket_remove_existing_preloaded_fonts', true);
+		$should_remove = wpm_apply_filters_typed( 'boolean', 'rocket_remove_existing_preloaded_fonts', true );
 
-		if (!$should_remove) {
+		if ( ! $should_remove ) {
 			return $html;
 		}
 
 		// Use regex to remove <link rel="preload" as="font"> tags.
-		return preg_replace('/<link[^>]*rel=["\']preload["\'][^>]*as=["\']font["\'][^>]*>\s*/i', '', $html);
+		return preg_replace( '/<link[^>]*rel=["\']preload["\'][^>]*as=["\']font["\'][^>]*>\s*/i', '', $html );
 	}
 }

--- a/inc/Engine/Media/PreloadFonts/Frontend/Controller.php
+++ b/inc/Engine/Media/PreloadFonts/Frontend/Controller.php
@@ -169,19 +169,20 @@ class Controller implements ControllerInterface {
 	 * @param string $html The HTML content to process.
 	 * @return string The modified HTML content with preloaded font links removed if applicable.
 	 */
-	public function maybe_remove_existing_preloaded_fonts( string $html ): string {
-		if ( ! $this->context->is_allowed() ) {
+	public function maybe_remove_existing_preloaded_fonts( string $html ): string
+	{
+		if (!$this->context->is_allowed()) {
 			return $html;
 		}
 
 		// Apply a filter to allow overriding the removal of preloaded font tags.
-		$should_remove = wpm_apply_filters_typed( 'boolean', 'rocket_remove_existing_preloaded_fonts', true );
+		$should_remove = wpm_apply_filters_typed('boolean', 'rocket_remove_existing_preloaded_fonts', true);
 
-		if ( ! $should_remove ) {
+		if (!$should_remove) {
 			return $html;
 		}
 
 		// Use regex to remove <link rel="preload" as="font"> tags.
-		return preg_replace( '/^\s*<link[^>]*rel=["\']preload["\'][^>]*as=["\']font["\'][^>]*>\s*$/m', '', $html );
+		return preg_replace('/<link[^>]*rel=["\']preload["\'][^>]*as=["\']font["\'][^>]*>\s*/i', '', $html);
 	}
 }

--- a/inc/Engine/Media/PreloadFonts/Frontend/Controller.php
+++ b/inc/Engine/Media/PreloadFonts/Frontend/Controller.php
@@ -174,7 +174,11 @@ class Controller implements ControllerInterface {
 			return $html;
 		}
 
-		// Apply a filter to allow overriding the removal of preloaded font tags.
+		/**
+		 * Filter to enable or disable the deleting of existing preloaded tags.
+		 *
+		 * @param bool $should_remove Enable or disable the removal of existing preloaded tags.
+		 */
 		$should_remove = wpm_apply_filters_typed( 'boolean', 'rocket_remove_existing_preloaded_fonts', true );
 
 		if ( ! $should_remove ) {

--- a/inc/Engine/Media/PreloadFonts/Frontend/Controller.php
+++ b/inc/Engine/Media/PreloadFonts/Frontend/Controller.php
@@ -159,4 +159,29 @@ class Controller implements ControllerInterface {
 
 		return false;
 	}
+
+	/**
+	 * Removes existing preloaded font links from the provided HTML content if necessary.
+	 *
+	 * This method scans the given HTML string and removes any <link rel="preload" as="font"> tags
+	 * that match certain criteria, to prevent duplicate or unnecessary font preloads.
+	 *
+	 * @param string $html The HTML content to process.
+	 * @return string The modified HTML content with preloaded font links removed if applicable.
+	 */
+	public function maybe_remove_existing_preloaded_fonts( string $html ): string {
+		if ( ! $this->context->is_allowed() ) {
+			return $html;
+		}
+
+		// Apply a filter to allow overriding the removal of preloaded font tags.
+		$should_remove = wpm_apply_filters_typed( 'boolean', 'rocket_remove_existing_preloaded_fonts', true );
+
+		if ( ! $should_remove ) {
+			return $html;
+		}
+
+		// Use regex to remove <link rel="preload" as="font"> tags.
+		return preg_replace( '/^\s*<link[^>]*rel=["\']preload["\'][^>]*as=["\']font["\'][^>]*>\s*$/m', '', $html );
+	}
 }

--- a/inc/Engine/Media/PreloadFonts/Frontend/Subscriber.php
+++ b/inc/Engine/Media/PreloadFonts/Frontend/Subscriber.php
@@ -46,7 +46,7 @@ class Subscriber implements Subscriber_Interface {
 			'rocket_head_items'                   => [ 'add_preload_fonts_in_head', 30 ],
 			'rocket_enable_rucss_fonts_preload'   => 'disable_rucss_preload_fonts',
 			'rocket_preload_fonts_excluded_fonts' => 'get_exclusions',
-			'rocket_buffer'                       => [ 'maybe_remove_existing_preloaded_fonts', 10 ],
+			'rocket_buffer'                       => 'maybe_remove_existing_preloaded_fonts',
 		];
 	}
 

--- a/inc/Engine/Media/PreloadFonts/Frontend/Subscriber.php
+++ b/inc/Engine/Media/PreloadFonts/Frontend/Subscriber.php
@@ -46,6 +46,7 @@ class Subscriber implements Subscriber_Interface {
 			'rocket_head_items'                   => [ 'add_preload_fonts_in_head', 30 ],
 			'rocket_enable_rucss_fonts_preload'   => 'disable_rucss_preload_fonts',
 			'rocket_preload_fonts_excluded_fonts' => 'get_exclusions',
+			'rocket_buffer'                       => [ 'maybe_remove_existing_preloaded_fonts', 10 ],
 		];
 	}
 
@@ -85,5 +86,15 @@ class Subscriber implements Subscriber_Interface {
 		 * Handle empty arrays gracefully.
 		 */
 		return array_merge( $exclusions, (array) $lists );
+	}
+
+	/**
+	 * Removes existing preloaded font tags from the HTML buffer.
+	 *
+	 * @param string $html The HTML content.
+	 * @return string Modified HTML content.
+	 */
+	public function maybe_remove_existing_preloaded_fonts( string $html ): string {
+		return $this->preload_fonts->maybe_remove_existing_preloaded_fonts( $html );
 	}
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -533,11 +533,6 @@ parameters:
 		-
 			message: "#^Usage of apply_filters\\(\\) is discouraged\\. Use wpm_apply_filters_typed\\(\\) instead\\.$#"
 			count: 2
-			path: inc/Engine/Preload/Fonts.php
-
-		-
-			message: "#^Usage of apply_filters\\(\\) is discouraged\\. Use wpm_apply_filters_typed\\(\\) instead\\.$#"
-			count: 2
 			path: inc/Engine/Preload/Frontend/FetchSitemap.php
 
 		-
@@ -1351,6 +1346,11 @@ parameters:
 			path: tests/Integration/inc/Engine/Media/Lazyload/Subscriber/maybeDisableCoreLazyload.php
 
 		-
+			message: "#^Usage of get_option\\(\\) is discouraged\\. Use the Option object instead\\.$#"
+			count: 1
+			path: tests/Integration/inc/Engine/Media/PreconnectExternalDomains/Admin/Subscriber/maybeClearDnsPrefetchValues.php
+
+		-
 			message: "#^Usage of apply_filters\\(\\) is discouraged\\. Use wpm_apply_filters_typed\\(\\) instead\\.$#"
 			count: 25
 			path: tests/Integration/inc/Engine/Media/PreconnectExternalDomains/Admin/Subscriber/maybeClearPreconnectDomains.php
@@ -1358,12 +1358,12 @@ parameters:
 		-
 			message: "#^Usage of get_option\\(\\) is discouraged\\. Use the Option object instead\\.$#"
 			count: 1
-			path: tests/Integration/inc/Engine/Media/PreconnectExternalDomains/Admin/Subscriber/maybeClearDnsPrefetchValues.php
+			path: tests/Integration/inc/Engine/Media/PreloadFonts/Admin/Subscriber/MaybeEnableAutoPreloadTest.php
 
 		-
-			message: "#^Usage of get_option\\(\\) is discouraged\\. Use the Option object instead\\.$#"
-			count: 1
-			path: tests/Integration/inc/Engine/Media/PreloadFonts/Admin/Subscriber/MaybeEnableAutoPreloadTest.php
+			message: "#^Usage of apply_filters\\(\\) is discouraged\\. Use wpm_apply_filters_typed\\(\\) instead\\.$#"
+			count: 24
+			path: tests/Integration/inc/Engine/Media/PreloadFonts/Frontend/Subscriber/maybeRemoveExistingPreloadedFonts.php
 
 		-
 			message: "#^Usage of apply_filters\\(\\) is discouraged\\. Use wpm_apply_filters_typed\\(\\) instead\\.$#"
@@ -1631,21 +1631,6 @@ parameters:
 			path: tests/Integration/inc/Engine/Optimization/RUCSS/Admin/Subscriber/updateSafelistItems.php
 
 		-
-			message: "#^Usage of apply_filters\\(\\) is discouraged\\. Use wpm_apply_filters_typed\\(\\) instead\\.$#"
-			count: 1
-			path: tests/Integration/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/maybeDisablePreloadFonts.php
-
-		-
-			message: "#^Usage of get_option\\(\\) is discouraged\\. Use the Option object instead\\.$#"
-			count: 1
-			path: tests/Integration/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/maybeDisablePreloadFonts.php
-
-		-
-			message: "#^Usage of update_option\\(\\) is discouraged\\. Use the Option object instead\\.$#"
-			count: 1
-			path: tests/Integration/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/maybeDisablePreloadFonts.php
-
-		-
 			message: "#^Usage of delete_option\\(\\) is discouraged\\. Use the Option object instead\\.$#"
 			count: 2
 			path: tests/Integration/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/onUpdate.php
@@ -1656,19 +1641,9 @@ parameters:
 			path: tests/Integration/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/onUpdate.php
 
 		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
-			count: 1
-			path: tests/Integration/inc/Engine/Optimization/RUCSS/Frontend/Subscriber/treeshake.php
-
-		-
 			message: "#^Usage of apply_filters\\(\\) is discouraged\\. Use wpm_apply_filters_typed\\(\\) instead\\.$#"
 			count: 1
 			path: tests/Integration/inc/Engine/Preload/Cron/Subscriber/processPendingUrls.php
-
-		-
-			message: "#^Usage of apply_filters\\(\\) is discouraged\\. Use wpm_apply_filters_typed\\(\\) instead\\.$#"
-			count: 1
-			path: tests/Integration/inc/Engine/Preload/Fonts/preloadFonts.php
 
 		-
 			message: "#^Usage of apply_filters\\(\\) is discouraged\\. Use wpm_apply_filters_typed\\(\\) instead\\.$#"

--- a/tests/Fixtures/inc/Engine/Media/PreloadFonts/Frontend/Subscriber/HTML/preloadfonts_customDifferentTill1200.php
+++ b/tests/Fixtures/inc/Engine/Media/PreloadFonts/Frontend/Subscriber/HTML/preloadfonts_customDifferentTill1200.php
@@ -11,6 +11,27 @@
 	<!-- used -->
 	<link rel="preload" href="/wp-content/rocket-test-data/fonts/OpenSans-Regular.woff2" as="font" type="font/woff2" crossorigin="anonymous">
 
+	<!-- Edge case: No quotes around attribute values -->
+	<link rel=preload as=font href="https://new.rocketlabsqa.ovh/wp-content/rocket-test-data/fonts/OpenSans-Regular.woff2">
+
+	<!-- Edge case: rel after as -->
+	<link href="https://new.rocketlabsqa.ovh/wp-content/rocket-test-data/fonts/OpenSans-Regular.woff2"  as="font" type="font/woff2" rel="preload" crossorigin="anonymous"/>
+
+	<!-- Edge case: Mixed quotes -->
+	<link rel='preload' as="font" href="/wp-content/rocket-test-data/fonts/mixed-quotes.woff2" type="font/woff2" crossorigin="anonymous">
+
+	<!-- Regular preload - should be removed -->
+	<link rel="preload" as="font" href="/wp-content/rocket-test-data/fonts/regular.woff2" type="font/woff2" crossorigin="anonymous">
+
+	<!-- Without any quotes -->
+	<link rel=preload as=font href="/wp-content/rocket-test-data/fonts/without-quotes.woff2" type="font/woff2" crossorigin="anonymous">
+
+	<script>
+		// This is JavaScript, not markup!
+		var preloadTag = '<link rel="preload" as="font" href="fake.woff2">';
+		// The script might dynamically inject this OR just use it as a string for any purpose
+		console.log(preloadTag);
+	</script>
 
 	<style>
 

--- a/tests/Fixtures/inc/Engine/Media/PreloadFonts/Frontend/Subscriber/HTML/preloadfonts_customDifferentTill1200.php
+++ b/tests/Fixtures/inc/Engine/Media/PreloadFonts/Frontend/Subscriber/HTML/preloadfonts_customDifferentTill1200.php
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+	<title>Multiple Fonts Every 100px</title>
+	<!-- already preloaded -->
+	<!-- unused -->
+	<link rel="preload" href="/wp-content/rocket-test-data/fonts/bellefair-v6-latin-regular.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+
+	<!-- used -->
+	<link rel="preload" href="/wp-content/rocket-test-data/fonts/OpenSans-Regular.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+
+
+	<style>
+
+		@font-face {
+			font-family: "フォント";
+			src: url("/wp-content/rocket-test-data/fonts/フォント.woff2") format("woff2"),
+			url("/wp-content/rocket-test-data/fonts/フォント.woff") format("woff");
+			font-weight: normal;
+			font-style: normal;
+		}
+		/* Load your custom fonts */
+		@font-face {
+			font-family: 'FontOne';
+			src: url('/wp-content/rocket-test-data/fonts/OpenSans-Regular.woff2') format('woff2');
+		}
+
+		@font-face {
+			font-family: 'FontTwo';
+			src: Url('/wp-content/rocket-test-data/fonts/OpenSans-Bold.ttf') format('truetype');
+		}
+
+		/* Font URL have space added with %20 */
+		@font-face {
+			font-family: 'FontThree';
+
+			src: url('/wp-content/rocket-test-data/fonts/test%20font/fa-solid-900.ttf') format('truetype');
+		}
+
+		/* font with non-latin char */
+		@font-face {
+			font-family: 'FontFour';
+			src: url('https://new.rocketlabsqa.ovh/wp-content/rocket-test-data/fonts/test-font-with-nonlatinCharÖ.woff') format('woff');
+		}
+		@font-face {
+			font-family: 'FontFive';
+			src: url('https://rocketlabsqa.ovh/wp-content/rocket-test-data/fonts/ballet-v3-latin-regular.ttf') format('truetype');
+		}
+		@font-face {
+			font-family: 'FontSix';
+			src: url('/wp-content/rocket-test-data/fonts/fa-solid-900.woff2') format('woff2');
+		}
+		@font-face {
+			font-family: 'FontSeven';
+			src: url('/wp-content/rocket-test-data/fonts/Softizen.ttf') format('truetype');
+		}
+		@font-face {
+			font-family: 'FontEight';
+			src: url('/wp-content/rocket-test-data/fonts/fa-solid-900.woff') format('woff');
+		}
+		@font-face {
+			font-family: 'FontNine';
+			src: url('/wp-content/rocket-test-data/fonts/ceviche-one-v11-latin-regular.woff2') format('woff2');
+		}
+		@font-face {
+			font-family: 'FontTen';
+			src: URL('/wp-content/rocket-test-data/fonts/OpenSans-Regular.woff') format('woff');
+		}
+		.systemFontused {
+			font-family: Arial;
+			margin: 0;
+			padding: 0;
+			background-color: #f4f4f4;
+		}
+
+		.systemFontNotused {
+			font-family: sans-serif;
+			margin: 0;
+			padding: 0;
+			background-color: #f4f4f4;
+		}
+
+
+
+
+		/* Unused Fonts */
+		@font-face {
+			font-family: 'UnusedFontOne';
+			src: url('/wp-content/rocket-test-data/fonts/bellefair-v6-latin-regular.woff2') format('woff2');
+		}
+
+		@font-face {
+			font-family: 'UnusedFontTwo';
+			src: url('/wp-content/rocket-test-data/fonts/bellefair-v6-latin-regular.woff') format('woff');
+		}
+
+
+
+		body {
+			margin: 0;
+			padding: 0;
+		}
+
+		.font-section {
+			height: 100px;
+			padding: 20px;
+			border-bottom: 1px solid #ccc;
+			box-sizing: border-box;
+		}
+
+		.font-0{font-family:"フォント";}
+
+		.font-1 { font-family: 'FontOne'; }
+		.font-2 { font-family: 'FontTwo'; }
+		.font-3 { font-family: 'FontThree'; }
+		.font-4 { font-family: 'FontFour'; }
+		.font-5 { font-family: 'FontFive'; }
+		.font-6 { font-family: 'FontSix'; }
+
+		.font-7 { font-family: 'FontSeven'; }
+		.font-8 { font-family: 'FontEight'; }
+		.font-9 { font-family: 'FontNine'; }
+		.font-10 { font-family: 'FontTen'; }
+
+
+	</style>
+	<?php wp_head() ?>
+</head>
+<body>
+<div class="font-0">This is Font Zero family "フォント";</div>
+<div class="font-section font-1">This is Font One (0–100px)</div>
+<div class="font-section font-2">This is Font Two (100–200px)</div>
+<div class="font-section font-3">This is Font Three (200–300px)</div>
+<div class="font-section systemFont">This is system Font ATF (300–400px)</div>
+
+<div class="font-section font-4">This is Font four(400–500px)</div>
+<div class="font-section font-5">This is Font Five (500–600px)</div>
+<div class="font-section font-6">This is Font 6 (500–600px)</div>
+<div class="font-section font-7">This is Font 7(600–700px)</div>
+<div class="font-section font-8">.This is Font 8 (700–800px)</div>
+<div class="font-section font-9">.This is Font 9 (800–900px)</div>
+<div class="font-section font-10">.This is Font 10 (900–1000px)</div>
+<div class="font-section systemFont">.This is system font below fold (1000–1100px)</div>
+<!-- Continue until 1200px -->
+<?php wp_footer() ?>
+</body>
+</html>

--- a/tests/Fixtures/inc/Engine/Media/PreloadFonts/Frontend/Subscriber/HTML/preloadfonts_customDifferentTill1200_output.php
+++ b/tests/Fixtures/inc/Engine/Media/PreloadFonts/Frontend/Subscriber/HTML/preloadfonts_customDifferentTill1200_output.php
@@ -6,7 +6,26 @@
 	<title>Multiple Fonts Every 100px</title>
 	<!-- already preloaded -->
 	<!-- unused -->
+
 	<!-- used -->
+
+	<!-- Edge case: No quotes around attribute values -->
+
+	<!-- Edge case: rel after as -->
+
+	<!-- Edge case: Mixed quotes -->
+
+	<!-- Regular preload - should be removed -->
+
+	<!-- Without any quotes -->
+
+	<script>
+		// This is JavaScript, not markup!
+		var preloadTag = '<link rel="preload" as="font" href="fake.woff2">';
+		// The script might dynamically inject this OR just use it as a string for any purpose
+		console.log(preloadTag);
+	</script>
+
 	<style>
 
 		@font-face {

--- a/tests/Fixtures/inc/Engine/Media/PreloadFonts/Frontend/Subscriber/HTML/preloadfonts_customDifferentTill1200_output.php
+++ b/tests/Fixtures/inc/Engine/Media/PreloadFonts/Frontend/Subscriber/HTML/preloadfonts_customDifferentTill1200_output.php
@@ -6,9 +6,7 @@
 	<title>Multiple Fonts Every 100px</title>
 	<!-- already preloaded -->
 	<!-- unused -->
-
 	<!-- used -->
-
 	<style>
 
 		@font-face {

--- a/tests/Fixtures/inc/Engine/Media/PreloadFonts/Frontend/Subscriber/HTML/preloadfonts_customDifferentTill1200_output.php
+++ b/tests/Fixtures/inc/Engine/Media/PreloadFonts/Frontend/Subscriber/HTML/preloadfonts_customDifferentTill1200_output.php
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+	<title>Multiple Fonts Every 100px</title>
+	<!-- already preloaded -->
+	<!-- unused -->
+
+	<!-- used -->
+
+	<style>
+
+		@font-face {
+			font-family: "フォント";
+			src: url("/wp-content/rocket-test-data/fonts/フォント.woff2") format("woff2"),
+			url("/wp-content/rocket-test-data/fonts/フォント.woff") format("woff");
+			font-weight: normal;
+			font-style: normal;
+		}
+		/* Load your custom fonts */
+		@font-face {
+			font-family: 'FontOne';
+			src: url('/wp-content/rocket-test-data/fonts/OpenSans-Regular.woff2') format('woff2');
+		}
+
+		@font-face {
+			font-family: 'FontTwo';
+			src: Url('/wp-content/rocket-test-data/fonts/OpenSans-Bold.ttf') format('truetype');
+		}
+
+		/* Font URL have space added with %20 */
+		@font-face {
+			font-family: 'FontThree';
+
+			src: url('/wp-content/rocket-test-data/fonts/test%20font/fa-solid-900.ttf') format('truetype');
+		}
+
+		/* font with non-latin char */
+		@font-face {
+			font-family: 'FontFour';
+			src: url('https://new.rocketlabsqa.ovh/wp-content/rocket-test-data/fonts/test-font-with-nonlatinCharÖ.woff') format('woff');
+		}
+		@font-face {
+			font-family: 'FontFive';
+			src: url('https://rocketlabsqa.ovh/wp-content/rocket-test-data/fonts/ballet-v3-latin-regular.ttf') format('truetype');
+		}
+		@font-face {
+			font-family: 'FontSix';
+			src: url('/wp-content/rocket-test-data/fonts/fa-solid-900.woff2') format('woff2');
+		}
+		@font-face {
+			font-family: 'FontSeven';
+			src: url('/wp-content/rocket-test-data/fonts/Softizen.ttf') format('truetype');
+		}
+		@font-face {
+			font-family: 'FontEight';
+			src: url('/wp-content/rocket-test-data/fonts/fa-solid-900.woff') format('woff');
+		}
+		@font-face {
+			font-family: 'FontNine';
+			src: url('/wp-content/rocket-test-data/fonts/ceviche-one-v11-latin-regular.woff2') format('woff2');
+		}
+		@font-face {
+			font-family: 'FontTen';
+			src: URL('/wp-content/rocket-test-data/fonts/OpenSans-Regular.woff') format('woff');
+		}
+		.systemFontused {
+			font-family: Arial;
+			margin: 0;
+			padding: 0;
+			background-color: #f4f4f4;
+		}
+
+		.systemFontNotused {
+			font-family: sans-serif;
+			margin: 0;
+			padding: 0;
+			background-color: #f4f4f4;
+		}
+
+
+
+
+		/* Unused Fonts */
+		@font-face {
+			font-family: 'UnusedFontOne';
+			src: url('/wp-content/rocket-test-data/fonts/bellefair-v6-latin-regular.woff2') format('woff2');
+		}
+
+		@font-face {
+			font-family: 'UnusedFontTwo';
+			src: url('/wp-content/rocket-test-data/fonts/bellefair-v6-latin-regular.woff') format('woff');
+		}
+
+
+
+		body {
+			margin: 0;
+			padding: 0;
+		}
+
+		.font-section {
+			height: 100px;
+			padding: 20px;
+			border-bottom: 1px solid #ccc;
+			box-sizing: border-box;
+		}
+
+		.font-0{font-family:"フォント";}
+
+		.font-1 { font-family: 'FontOne'; }
+		.font-2 { font-family: 'FontTwo'; }
+		.font-3 { font-family: 'FontThree'; }
+		.font-4 { font-family: 'FontFour'; }
+		.font-5 { font-family: 'FontFive'; }
+		.font-6 { font-family: 'FontSix'; }
+
+		.font-7 { font-family: 'FontSeven'; }
+		.font-8 { font-family: 'FontEight'; }
+		.font-9 { font-family: 'FontNine'; }
+		.font-10 { font-family: 'FontTen'; }
+
+
+	</style>
+	<?php wp_head() ?>
+</head>
+<body>
+<div class="font-0">This is Font Zero family "フォント";</div>
+<div class="font-section font-1">This is Font One (0–100px)</div>
+<div class="font-section font-2">This is Font Two (100–200px)</div>
+<div class="font-section font-3">This is Font Three (200–300px)</div>
+<div class="font-section systemFont">This is system Font ATF (300–400px)</div>
+
+<div class="font-section font-4">This is Font four(400–500px)</div>
+<div class="font-section font-5">This is Font Five (500–600px)</div>
+<div class="font-section font-6">This is Font 6 (500–600px)</div>
+<div class="font-section font-7">This is Font 7(600–700px)</div>
+<div class="font-section font-8">.This is Font 8 (700–800px)</div>
+<div class="font-section font-9">.This is Font 9 (800–900px)</div>
+<div class="font-section font-10">.This is Font 10 (900–1000px)</div>
+<div class="font-section systemFont">.This is system font below fold (1000–1100px)</div>
+<!-- Continue until 1200px -->
+<?php wp_footer() ?>
+</body>
+</html>

--- a/tests/Fixtures/inc/Engine/Media/PreloadFonts/Frontend/Subscriber/maybeRemoveExistingPreloadedFonts.php
+++ b/tests/Fixtures/inc/Engine/Media/PreloadFonts/Frontend/Subscriber/maybeRemoveExistingPreloadedFonts.php
@@ -1,19 +1,37 @@
 <?php
 
 return [
+	'shouldNotRemoveExistingPreloadedFontsWhenFirstVisit' => [
+		'config' => [
+			'remove_existing_preloaded_fonts' => true,
+			'html' => file_get_contents( WP_ROCKET_TESTS_FIXTURES_DIR . '/inc/Engine/Media/PreloadFonts/Frontend/Subscriber/HTML/preloadfonts_customDifferentTill1200.php' ),
+			'row' => [],
+		],
+		'expected' => [
+			'html' => file_get_contents( WP_ROCKET_TESTS_FIXTURES_DIR . '/inc/Engine/Media/PreloadFonts/Frontend/Subscriber/HTML/preloadfonts_customDifferentTill1200.php' ),
+		]
+	],
 	'shouldRemoveExistingPreloadedFonts' => [
 		'config' => [
 			'remove_existing_preloaded_fonts' => true,
 			'html' => file_get_contents( WP_ROCKET_TESTS_FIXTURES_DIR . '/inc/Engine/Media/PreloadFonts/Frontend/Subscriber/HTML/preloadfonts_customDifferentTill1200.php' ),
+			'row' => [
+				'status' => 'completed',
+				'url' => 'http://example.org',
+				'fonts' => json_encode( [
+					'path/to/font1.woff2',
+				] ),
+			],
 		],
 		'expected' => [
 			'html' => file_get_contents( WP_ROCKET_TESTS_FIXTURES_DIR . '/inc/Engine/Media/PreloadFonts/Frontend/Subscriber/HTML/preloadfonts_customDifferentTill1200_output.php' ),
 		]
 	],
-	'shouldNotRemoveExistingPreloadedFonts' => [
+	'shouldNotRemoveExistingPreloadedFontsWhenFilterFalse' => [
 		'config' => [
 			'remove_existing_preloaded_fonts' => false,
 			'html' => file_get_contents( WP_ROCKET_TESTS_FIXTURES_DIR . '/inc/Engine/Media/PreloadFonts/Frontend/Subscriber/HTML/preloadfonts_customDifferentTill1200.php' ),
+			'row' => [],
 		],
 		'expected' => [
 			'html' => file_get_contents( WP_ROCKET_TESTS_FIXTURES_DIR . '/inc/Engine/Media/PreloadFonts/Frontend/Subscriber/HTML/preloadfonts_customDifferentTill1200.php' ),

--- a/tests/Fixtures/inc/Engine/Media/PreloadFonts/Frontend/Subscriber/maybeRemoveExistingPreloadedFonts.php
+++ b/tests/Fixtures/inc/Engine/Media/PreloadFonts/Frontend/Subscriber/maybeRemoveExistingPreloadedFonts.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+	'shouldRemoveExistingPreloadedFonts' => [
+		'config' => [
+			'remove_existing_preloaded_fonts' => true,
+			'html' => file_get_contents( WP_ROCKET_TESTS_FIXTURES_DIR . '/inc/Engine/Media/PreloadFonts/Frontend/Subscriber/HTML/preloadfonts_customDifferentTill1200.php' ),
+		],
+		'expected' => [
+			'html' => file_get_contents( WP_ROCKET_TESTS_FIXTURES_DIR . '/inc/Engine/Media/PreloadFonts/Frontend/Subscriber/HTML/preloadfonts_customDifferentTill1200_output.php' ),
+		]
+	],
+	'shouldNotRemoveExistingPreloadedFonts' => [
+		'config' => [
+			'remove_existing_preloaded_fonts' => false,
+			'html' => file_get_contents( WP_ROCKET_TESTS_FIXTURES_DIR . '/inc/Engine/Media/PreloadFonts/Frontend/Subscriber/HTML/preloadfonts_customDifferentTill1200.php' ),
+		],
+		'expected' => [
+			'html' => file_get_contents( WP_ROCKET_TESTS_FIXTURES_DIR . '/inc/Engine/Media/PreloadFonts/Frontend/Subscriber/HTML/preloadfonts_customDifferentTill1200.php' ),
+		]
+	],
+];

--- a/tests/Integration/inc/Engine/Media/PreloadFonts/Frontend/Subscriber/maybeRemoveExistingPreloadedFonts.php
+++ b/tests/Integration/inc/Engine/Media/PreloadFonts/Frontend/Subscriber/maybeRemoveExistingPreloadedFonts.php
@@ -19,7 +19,7 @@ class Test_MaybeRemoveExistingPreloadedFonts extends TestCase
 	public function set_up() {
 		parent::set_up();
 
-		$this->unregisterAllCallbacksExcept( 'rocket_buffer', 'maybe_remove_existing_preloaded_fonts', 10 );
+		$this->unregisterAllCallbacksExcept( 'rocket_buffer', 'maybe_remove_existing_preloaded_fonts' );
 		add_filter( 'rocket_remove_existing_preloaded_fonts', [ $this, 'remove_existing_preloaded_fonts' ] );
 		add_filter( 'pre_get_rocket_option_auto_preload_fonts', '__return_true' );
 

--- a/tests/Integration/inc/Engine/Media/PreloadFonts/Frontend/Subscriber/maybeRemoveExistingPreloadedFonts.php
+++ b/tests/Integration/inc/Engine/Media/PreloadFonts/Frontend/Subscriber/maybeRemoveExistingPreloadedFonts.php
@@ -1,0 +1,50 @@
+<?php
+
+
+namespace WP_Rocket\Tests\Integration\inc\Media\PreloadFonts\Frontend\Subscriber;
+
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * Test class covering \WP_Rocket\Engine\Media\PreloadFonts\Frontend\Subscriber::get_exclusions
+ *
+ * @group PerformanceHints
+ * @group PreloadFonts
+ */
+class Test_MaybeRemoveExistingPreloadedFonts extends TestCase
+{
+
+	protected $config;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->unregisterAllCallbacksExcept( 'rocket_buffer', 'maybe_remove_existing_preloaded_fonts', 10 );
+		add_filter( 'rocket_remove_existing_preloaded_fonts', [ $this, 'remove_existing_preloaded_fonts' ] );
+		add_filter( 'pre_get_rocket_option_auto_preload_fonts', '__return_true' );
+
+	}
+
+	public function tear_down() {
+		parent::tear_down();
+
+		$this->restoreWpHook('rocket_buffer');
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnAsExpected($config, $expected)
+	{
+		$this->config = $config;
+
+		$this->assertSame(
+			$expected['html'],
+			wpm_apply_filters_typed( 'string', 'rocket_buffer', $config['html'] )
+		);
+	}
+
+	public function remove_existing_preloaded_fonts() {
+		return $this->config['remove_existing_preloaded_fonts'];
+	}
+}

--- a/tests/Integration/inc/Engine/Media/PreloadFonts/Frontend/Subscriber/maybeRemoveExistingPreloadedFonts.php
+++ b/tests/Integration/inc/Engine/Media/PreloadFonts/Frontend/Subscriber/maybeRemoveExistingPreloadedFonts.php
@@ -1,20 +1,34 @@
 <?php
 
 
-namespace WP_Rocket\Tests\Integration\inc\Media\PreloadFonts\Frontend\Subscriber;
+namespace WP_Rocket\Tests\Integration\inc\Engine\Media\PreloadFonts\Frontend\Subscriber;
 
+use WP_Rocket\Tests\Integration\DBTrait;
 use WP_Rocket\Tests\Integration\TestCase;
 
 /**
- * Test class covering \WP_Rocket\Engine\Media\PreloadFonts\Frontend\Subscriber::get_exclusions
+ * Test class covering \WP_Rocket\Engine\Media\PreloadFonts\Frontend\Subscriber::maybe_remove_existing_preloaded_fonts
  *
  * @group PerformanceHints
  * @group PreloadFonts
  */
 class Test_MaybeRemoveExistingPreloadedFonts extends TestCase
 {
+	use DBTrait;
 
 	protected $config;
+
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		self::installPreloadFontsTable();
+	}
+
+	public static function tear_down_after_class() {
+		self::uninstallPreloadFontsTable();
+
+		parent::tear_down_after_class();
+	}
 
 	public function set_up() {
 		parent::set_up();
@@ -22,7 +36,6 @@ class Test_MaybeRemoveExistingPreloadedFonts extends TestCase
 		$this->unregisterAllCallbacksExcept( 'rocket_buffer', 'maybe_remove_existing_preloaded_fonts' );
 		add_filter( 'rocket_remove_existing_preloaded_fonts', [ $this, 'remove_existing_preloaded_fonts' ] );
 		add_filter( 'pre_get_rocket_option_auto_preload_fonts', '__return_true' );
-
 	}
 
 	public function tear_down() {
@@ -37,7 +50,9 @@ class Test_MaybeRemoveExistingPreloadedFonts extends TestCase
 	public function testShouldReturnAsExpected($config, $expected)
 	{
 		$this->config = $config;
-
+		if ( !empty( $this->config['row'] ) ) {
+			$this->addPreloadFonts($this->config['row']);
+		}
 		$this->assertSame(
 			$expected['html'],
 			wpm_apply_filters_typed( 'string', 'rocket_buffer', $config['html'] )


### PR DESCRIPTION
# Description

Fixes #7396 
It removes existing preload tags from the HTML.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

### What was tested

It uses the same template as e2e (`preloadfonts_customDifferentTill1200.php` from `rocket-test-data` to make sure existing preload tags are removed or kept depending on the filter `rocket_remove_existing_preloaded_fonts` value).

### How to test

To test manually, we would need a page with already preloaded fonts to make sure they are deleted or not (depending on the mentioned filter). 

## Technical description

### Documentation

This pull request introduces functionality to remove existing preloaded font tags from HTML content when necessary, along with corresponding tests and fixtures. The changes ensure better control over font preloading to prevent redundancy and improve performance.

### New functionality for removing preloaded fonts:
* Added the `maybe_remove_existing_preloaded_fonts` method in `Frontend/Controller.php`, which removes `<link rel="preload" as="font">` tags from HTML content based on specific criteria and a filter (`rocket_remove_existing_preloaded_fonts`).
* Registered the `maybe_remove_existing_preloaded_fonts` method in the `rocket_buffer` event within `Frontend/Subscriber.php`.
* Implemented a wrapper method for `maybe_remove_existing_preloaded_fonts` in `Frontend/Subscriber.php` to integrate with the event system.

### Test fixtures and integration tests:
* Added a new test fixture (`preloadfonts_customDifferentTill1200.php`) to simulate HTML content with various font preloads, and its expected output (`preloadfonts_customDifferentTill1200_output.php`). [[1]](diffhunk://#diff-b0b756648ae77a7155e6462d1f8acc0470085e4c946d3ed019fb7e3c7ab2ab0dR1-R149) [[2]](diffhunk://#diff-999cbee072ce3c57d706c426f30de5eda89974fb9f45601293cc4259c7cbc5a8R1-R146)
* Created a configuration file (`maybeRemoveExistingPreloadedFonts.php`) to define test cases for removing or retaining preloaded fonts.
* Developed an integration test (`maybeRemoveExistingPreloadedFonts.php`) to validate the behavior of the `maybe_remove_existing_preloaded_fonts` method under different configurations.
### New dependencies

None

### Risks

None

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.
