### PR TITLE
Fix #7389: Crossorigin shouldn't be added with prefetch filter

### DIFF
--- a/inc/Engine/Media/PreconnectExternalDomains/Frontend/Controller.php
+++ b/inc/Engine/Media/PreconnectExternalDomains/Frontend/Controller.php
@@ -154,8 +154,7 @@ class Controller implements ControllerInterface {
 			return $this->dns_prefetch_link(
 				[
 					'href' => esc_url( $domain ),
-					1      => 'crossorigin',
-					2      => 'data-rocket-prefetch',
+					1      => 'data-rocket-prefetch',
 				]
 			);
 		}


### PR DESCRIPTION
# Description

Fixes #7389
It removes the cross-origin attribute from the prefetch tag. 
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

Loading a page with a prefetch tags added. 

### How to test

Loading a page with a prefetch tags added. 

## Technical description

### Documentation

This pull request includes a minor update to the `get_domain_preconnect_item` function in the `Controller.php` file. The change removes the `crossorigin` attribute from the DNS prefetch link configuration.

* [`inc/Engine/Media/PreconnectExternalDomains/Frontend/Controller.php`](diffhunk://#diff-508ead676d469e0d24ac44854b3e83c75e56426b27b30ac09ab7a2b319ec7d15L157-R157): Updated the `get_domain_preconnect_item` function to remove the `crossorigin` attribute from the array passed to `dns_prefetch_link`.
### New dependencies

None

### Risks

None

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.
