### PR TITLE
Fix #7473: Add conditional loading for TrackingServiceProvider based on cURL availability (setting manually true to the condition as I can't disable this extension)

### DIFF
--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -212,35 +212,7 @@ class Plugin {
 			$this->container->addServiceProvider( new TrackingServiceProvider() );
 		}
 
-		return [
-			'beacon',
-			'settings_page_subscriber',
-			'deactivation_intent_subscriber',
-			'hummingbird_subscriber',
-			'rocketcdn_admin_subscriber',
-			'rocketcdn_notices_subscriber',
-			'rocketcdn_data_manager_subscriber',
-			'critical_css_admin_subscriber',
-			'health_check',
-			'minify_css_admin_subscriber',
-			'admin_cache_subscriber',
-			'google_fonts_admin_subscriber',
-			'image_dimensions_admin_subscriber',
-			'defer_js_admin_subscriber',
-			'lazyload_admin_subscriber',
-			'preload_admin_subscriber',
-			'minify_admin_subscriber',
-			'action_scheduler_check',
-			'actionscheduler_admin_subscriber',
-			'domain_change_subscriber',
-			'lazyload_css_admin_subscriber',
-			'post_edit_options_subscriber',
-			'preconnect_external_domains_admin_subscriber',
-			'media_fonts_admin_subscriber',
-			'preload_fonts_admin_subscriber',
-		// Conditionally add tracking_subscriber only if cURL is available.
-		// to prevent fatal errors from MixPanel dependency.
-		array_merge(
+		return array_merge(
 			[
 				'beacon',
 				'settings_page_subscriber',

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -204,7 +204,13 @@ class Plugin {
 		$this->container->addServiceProvider( new OptimizationAdminServiceProvider() );
 		$this->container->addServiceProvider( new DomainChangeServiceProvider() );
 		$this->container->addServiceProvider( new AdminLazyloadCSSServiceProvider() );
-		$this->container->addServiceProvider( new TrackingServiceProvider() );
+		
+		// Only add tracking service provider if cURL extension is loaded.
+		// MixPanel (used by TrackingServiceProvider) requires cURL and will throw a fatal error if not available.
+		// This prevents crashes when WP Rocket is installed on servers without cURL support.
+		if ( extension_loaded( 'curl' ) ) {
+			$this->container->addServiceProvider( new TrackingServiceProvider() );
+		}
 
 		return [
 			'beacon',
@@ -232,8 +238,9 @@ class Plugin {
 			'preconnect_external_domains_admin_subscriber',
 			'media_fonts_admin_subscriber',
 			'preload_fonts_admin_subscriber',
-			'tracking_subscriber',
-		];
+		// Conditionally add tracking_subscriber only if cURL is available.
+		// to prevent fatal errors from MixPanel dependency.
+		] + ( extension_loaded( 'curl' ) ? [ 'tracking_subscriber' ] : [] );
 	}
 
 	/**

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -240,7 +240,36 @@ class Plugin {
 			'preload_fonts_admin_subscriber',
 		// Conditionally add tracking_subscriber only if cURL is available.
 		// to prevent fatal errors from MixPanel dependency.
-		] + ( extension_loaded( 'curl' ) ? [ 'tracking_subscriber' ] : [] );
+		array_merge(
+			[
+				'beacon',
+				'settings_page_subscriber',
+				'deactivation_intent_subscriber',
+				'hummingbird_subscriber',
+				'rocketcdn_admin_subscriber',
+				'rocketcdn_notices_subscriber',
+				'rocketcdn_data_manager_subscriber',
+				'critical_css_admin_subscriber',
+				'health_check',
+				'minify_css_admin_subscriber',
+				'admin_cache_subscriber',
+				'google_fonts_admin_subscriber',
+				'image_dimensions_admin_subscriber',
+				'defer_js_admin_subscriber',
+				'lazyload_admin_subscriber',
+				'preload_admin_subscriber',
+				'minify_admin_subscriber',
+				'action_scheduler_check',
+				'actionscheduler_admin_subscriber',
+				'domain_change_subscriber',
+				'lazyload_css_admin_subscriber',
+				'post_edit_options_subscriber',
+				'preconnect_external_domains_admin_subscriber',
+				'media_fonts_admin_subscriber',
+				'preload_fonts_admin_subscriber',
+			],
+			extension_loaded( 'curl' ) ? [ 'tracking_subscriber' ] : []
+		);
 	}
 
 	/**

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -205,43 +205,43 @@ class Plugin {
 		$this->container->addServiceProvider( new DomainChangeServiceProvider() );
 		$this->container->addServiceProvider( new AdminLazyloadCSSServiceProvider() );
 
+		$subscribers = [
+			'beacon',
+			'settings_page_subscriber',
+			'deactivation_intent_subscriber',
+			'hummingbird_subscriber',
+			'rocketcdn_admin_subscriber',
+			'rocketcdn_notices_subscriber',
+			'rocketcdn_data_manager_subscriber',
+			'critical_css_admin_subscriber',
+			'health_check',
+			'minify_css_admin_subscriber',
+			'admin_cache_subscriber',
+			'google_fonts_admin_subscriber',
+			'image_dimensions_admin_subscriber',
+			'defer_js_admin_subscriber',
+			'lazyload_admin_subscriber',
+			'preload_admin_subscriber',
+			'minify_admin_subscriber',
+			'action_scheduler_check',
+			'actionscheduler_admin_subscriber',
+			'domain_change_subscriber',
+			'lazyload_css_admin_subscriber',
+			'post_edit_options_subscriber',
+			'preconnect_external_domains_admin_subscriber',
+			'media_fonts_admin_subscriber',
+			'preload_fonts_admin_subscriber',
+		];
+
 		// Only add tracking service provider if cURL extension is loaded.
 		// MixPanel (used by TrackingServiceProvider) requires cURL and will throw a fatal error if not available.
 		// This prevents crashes when WP Rocket is installed on servers without cURL support.
 		if ( extension_loaded( 'curl' ) ) {
 			$this->container->addServiceProvider( new TrackingServiceProvider() );
+			$subscribers[] = 'tracking_subscriber';
 		}
 
-		return array_merge(
-			[
-				'beacon',
-				'settings_page_subscriber',
-				'deactivation_intent_subscriber',
-				'hummingbird_subscriber',
-				'rocketcdn_admin_subscriber',
-				'rocketcdn_notices_subscriber',
-				'rocketcdn_data_manager_subscriber',
-				'critical_css_admin_subscriber',
-				'health_check',
-				'minify_css_admin_subscriber',
-				'admin_cache_subscriber',
-				'google_fonts_admin_subscriber',
-				'image_dimensions_admin_subscriber',
-				'defer_js_admin_subscriber',
-				'lazyload_admin_subscriber',
-				'preload_admin_subscriber',
-				'minify_admin_subscriber',
-				'action_scheduler_check',
-				'actionscheduler_admin_subscriber',
-				'domain_change_subscriber',
-				'lazyload_css_admin_subscriber',
-				'post_edit_options_subscriber',
-				'preconnect_external_domains_admin_subscriber',
-				'media_fonts_admin_subscriber',
-				'preload_fonts_admin_subscriber',
-			],
-			extension_loaded( 'curl' ) ? [ 'tracking_subscriber' ] : []
-		);
+		return $subscribers;
 	}
 
 	/**

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -204,7 +204,7 @@ class Plugin {
 		$this->container->addServiceProvider( new OptimizationAdminServiceProvider() );
 		$this->container->addServiceProvider( new DomainChangeServiceProvider() );
 		$this->container->addServiceProvider( new AdminLazyloadCSSServiceProvider() );
-		
+
 		// Only add tracking service provider if cURL extension is loaded.
 		// MixPanel (used by TrackingServiceProvider) requires cURL and will throw a fatal error if not available.
 		// This prevents crashes when WP Rocket is installed on servers without cURL support.

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -236,7 +236,7 @@ class Plugin {
 		// Only add tracking service provider if cURL extension is loaded.
 		// MixPanel (used by TrackingServiceProvider) requires cURL and will throw a fatal error if not available.
 		// This prevents crashes when WP Rocket is installed on servers without cURL support.
-		if ( extension_loaded( 'curl' ) ) {
+		if ( function_exists( 'curl_init' ) ) {
 			$this->container->addServiceProvider( new TrackingServiceProvider() );
 			$subscribers[] = 'tracking_subscriber';
 		}


### PR DESCRIPTION
# Description

Fixes #7473 
If `cURL` extension isn't available we won't load the subscriber related to MixPanel. 

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

### What was tested

The whole plugin without curl extension.

### How to test

Disable the curl extension on the server and enable tracking, then load WP Rocket.

## Technical description

### Documentation

This pull request introduces a conditional check to ensure compatibility with servers that lack cURL support. It modifies the initialization of services and subscribers in the `Plugin.php` file to prevent fatal errors caused by the MixPanel dependency when cURL is unavailable.

### Compatibility Improvements:

* [`inc/Plugin.php`](diffhunk://#diff-b591480fdcd92670a10d4e86f4f973f95ad761f81d44ce8f04109579a10dfebfR207-R213): Added a conditional check in the `init_admin_subscribers` method to include the `TrackingServiceProvider` only if the cURL extension is loaded. This prevents crashes on servers without cURL support.
* [`inc/Plugin.php`](diffhunk://#diff-b591480fdcd92670a10d4e86f4f973f95ad761f81d44ce8f04109579a10dfebfL235-R243): Updated the `init_admin_subscribers` method to conditionally add `tracking_subscriber` to the subscribers list only if cURL is available, avoiding fatal errors from the MixPanel dependency.
### New dependencies

None

### Risks

None

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.
