### PR TITLE
Closes #7413: Remove '&amp' from self hosted GF font family

### DIFF
--- a/inc/Engine/Common/Head/Subscriber.php
+++ b/inc/Engine/Common/Head/Subscriber.php
@@ -173,7 +173,7 @@ class Subscriber implements Subscriber_Interface {
 	 * @param string $attribute_value Attribute value.
 	 * @return string
 	 */
-	private function esc_attribute($attribute_name, $attribute_value ) {
+	private function esc_attribute( $attribute_name, $attribute_value ) {
 		if ( 'data-wpr-hosted-gf-parameters' === $attribute_name ) {
 			return $attribute_value;
 		}

--- a/inc/Engine/Common/Head/Subscriber.php
+++ b/inc/Engine/Common/Head/Subscriber.php
@@ -133,7 +133,7 @@ class Subscriber implements Subscriber_Interface {
 				$attributes[] = $value;
 				continue;
 			}
-			$attributes[] = $key . '="' . esc_attr( $value ) . '"';
+			$attributes[] = $key . '="' . $this->esc_attribute( $key, $value ) . '"';
 		}
 
 		$attributes_html = ! empty( $attributes ) ? ' ' . implode( ' ', $attributes ) : '';
@@ -164,5 +164,20 @@ class Subscriber implements Subscriber_Interface {
 		}
 
 		return $filtered_buffer;
+	}
+
+	/**
+	 * Escape attribute value before printing it.
+	 *
+	 * @param string $attribute_name Attribute name.
+	 * @param string $attribute_value Attribute value.
+	 * @return string
+	 */
+	private function esc_attribute($attribute_name, $attribute_value ) {
+		if ( 'data-wpr-hosted-gf-parameters' === $attribute_name ) {
+			return $attribute_value;
+		}
+
+		return esc_attr( $attribute_value );
 	}
 }

--- a/inc/Engine/Optimization/GoogleFonts/Combine.php
+++ b/inc/Engine/Optimization/GoogleFonts/Combine.php
@@ -134,12 +134,12 @@ class Combine extends AbstractGFOptimization {
 				$font_family = rtrim( $font_family, '%7C' );
 				$font_family = rtrim( $font_family, '|' );
 				// Add font to the collection.
-				$fonts_array[] = rawurlencode( htmlentities( $font_family ) );
+				$fonts_array[] = rawurlencode( $font_family );
 			}
 
 			// Add subset to collection.
 			if ( isset( $font['subset'] ) ) {
-				$subsets_array[] = rawurlencode( htmlentities( $font['subset'] ) );
+				$subsets_array[] = rawurlencode( $font['subset'] );
 			}
 		}
 

--- a/inc/Engine/Optimization/GoogleFonts/Combine.php
+++ b/inc/Engine/Optimization/GoogleFonts/Combine.php
@@ -134,12 +134,12 @@ class Combine extends AbstractGFOptimization {
 				$font_family = rtrim( $font_family, '%7C' );
 				$font_family = rtrim( $font_family, '|' );
 				// Add font to the collection.
-				$fonts_array[] = rawurlencode( $font_family );
+				$fonts_array[] = rawurlencode( htmlentities( $font_family ) );
 			}
 
 			// Add subset to collection.
 			if ( isset( $font['subset'] ) ) {
-				$subsets_array[] = rawurlencode( $font['subset'] );
+				$subsets_array[] = rawurlencode( htmlentities( $font['subset'] ) );
 			}
 		}
 


### PR DESCRIPTION
# Description

Fixes #7413 
Avoid getting `&amp;`, instead we should get `&`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

Integration test are making sure we are getting `&` instead of `&amp;`

### How to test

Follow issue.

## Technical description

### Documentation

This pull request includes a small change to the `parse` function in `inc/Engine/Optimization/GoogleFonts/Combine.php`. The change removes the use of `htmlentities` when encoding font families and subsets before adding them to their respective collections.
### New dependencies

None

### Risks

None

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.
