### PR TITLE
Quickwin: Stop checking for curl support to add the mixpanel tracking part

### DIFF
--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -204,8 +204,9 @@ class Plugin {
 		$this->container->addServiceProvider( new OptimizationAdminServiceProvider() );
 		$this->container->addServiceProvider( new DomainChangeServiceProvider() );
 		$this->container->addServiceProvider( new AdminLazyloadCSSServiceProvider() );
+		$this->container->addServiceProvider( new TrackingServiceProvider() );
 
-		$subscribers = [
+		return [
 			'beacon',
 			'settings_page_subscriber',
 			'deactivation_intent_subscriber',
@@ -231,17 +232,8 @@ class Plugin {
 			'preconnect_external_domains_admin_subscriber',
 			'media_fonts_admin_subscriber',
 			'preload_fonts_admin_subscriber',
+			'tracking_subscriber',
 		];
-
-		// Only add tracking service provider if cURL extension is loaded.
-		// MixPanel (used by TrackingServiceProvider) requires cURL and will throw a fatal error if not available.
-		// This prevents crashes when WP Rocket is installed on servers without cURL support.
-		if ( function_exists( 'curl_init' ) ) {
-			$this->container->addServiceProvider( new TrackingServiceProvider() );
-			$subscribers[] = 'tracking_subscriber';
-		}
-
-		return $subscribers;
 	}
 
 	/**


### PR DESCRIPTION
# Description

Based on our discussion here:
https://group-onecom.slack.com/archives/C08EFCYRQ2X/p1752064231270499
and also here:
https://group-onecom.slack.com/archives/C08EFCYRQ2X/p1751569725073869?thread_ts=1751361983.496509&cid=C08EFCYRQ2X

We no longer depend on curl to send requests to mixpanel but depend mainly on WP HTTP API functions so even when curl is not there on the server we still are able to send the requests.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

Validated that the plugin still works without any error and the tracking subscriber is loaded properly.

### How to test

Testing now on a server without curl to see if it still works or not.

## Technical description

### Documentation

Mentioned above

### New dependencies

No

### Risks

No

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

No tests for this part

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
