### PR TITLE
Fix preload issue with rankmath

### DIFF
--- a/inc/ThirdParty/Plugins/SEO/RankMathSEO.php
+++ b/inc/ThirdParty/Plugins/SEO/RankMathSEO.php
@@ -14,11 +14,7 @@ class RankMathSEO implements Subscriber_Interface {
 	 * @return array
 	 */
 	public static function get_subscribed_events(): array {
-		if ( ! class_exists( 'RankMath\Helper' ) ) {
-			return [];
-		}
-
-		if ( ! defined( 'RANK_MATH_FILE' ) || ! Helper::is_module_active( 'sitemap' ) ) {
+		if ( ! defined( 'RANK_MATH_FILE' ) ) {
 			return [];
 		}
 
@@ -35,6 +31,9 @@ class RankMathSEO implements Subscriber_Interface {
 	 * @return array
 	 */
 	public function add_sitemap( $sitemaps ) {
+		if ( ! class_exists( 'RankMath\Helper' ) || ! Helper::is_module_active( 'sitemap' ) ) {
+			return $sitemaps;
+		}
 		if ( ! class_exists( 'RankMath\Sitemap\Router' ) ) {
 			return $sitemaps;
 		}


### PR DESCRIPTION
# Description

Fixes #7371

After communicating with rankmath team, we needed to move the code that uses their helper class into the callback itself to make sure that it's already loaded.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

Install WPR along with rankmath SEO plugin then enable preload, it loads all urls from the sitemap correctly.

### How to test

- Install+activate WPR
- Install+activate rankmath SEO plugin
- Enable sitemap module in rankmath
- Truncate our cache database table
- Enable preload in WPR
- Check cache table
- You should see all links from the sitemap

## Technical description

### Documentation

N/A

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

*If some mandatory items are not relevant, explain why in this section.*

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
