### PR TITLE
Fix the conflict with wpbackery plugin

### DIFF
--- a/inc/Engine/Media/Lazyload/Subscriber.php
+++ b/inc/Engine/Media/Lazyload/Subscriber.php
@@ -439,7 +439,7 @@ class Subscriber implements Subscriber_Interface {
 	 *
 	 * @return bool
 	 */
-	public function maybe_disable_core_lazyload( $value, $tag_name ) {
+	public function maybe_disable_core_lazyload( $value, $tag_name = 'img' ) {
 		if ( false === $value || rocket_bypass() ) {
 			return $value;
 		}


### PR DESCRIPTION
# Description

WPBakery is misusing the core filter `wp_lazy_loading_enabled` passing only one argument but it should pass three arguments.
Our code needs at least two arguments to be passed here:

https://github.com/wp-media/wp-rocket/blob/v3.19.2.1/inc/Engine/Media/Lazyload/Subscriber.php#L90

So here in this PR, we are defaulting this second argument to be `img` as exactly mentioned by @alfonso100 to fix it from our side.

WPBackery team will need to worry about other plugins that use the same filter without any defaults.

Slack discussion: 
https://group-onecom.slack.com/archives/C08F4M3BBJL/p1754329793627109

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

Use the following code to simulate what wpbakery is doing in their code:

```
add_action( 'init', function () {
    apply_filters( 'wp_lazy_loading_enabled', true );
} );
```
Then visit any frontend page, u will see the following fatal error:
```
PHP Fatal error:  Uncaught ArgumentCountError: Too few arguments to function WP_Rocket\Engine\Media\Lazyload\Subscriber::maybe_disable_core_lazyload(), 1 passed in /home/wordpressfan/Local Sites/wprocket/app/public/wp-includes/class-wp-hook.php on line 324 and exactly 2 expected in /home/wordpressfan/Local Sites/wprocket/app/public/wp-content/plugins/wp-rocket/inc/Engine/Media/Lazyload/Subscriber.php:442
Stack trace:
#0 /home/wordpressfan/Local Sites/wprocket/app/public/wp-includes/class-wp-hook.php(324): WP_Rocket\Engine\Media\Lazyload\Subscriber->maybe_disable_core_lazyload(true)
#1 /home/wordpressfan/Local Sites/wprocket/app/public/wp-includes/plugin.php(205): WP_Hook->apply_filters(true, Array)
#2 /home/wordpressfan/Local Sites/wprocket/app/public/wp-content/themes/twentytwentyone/functions.php(682): apply_filters('wp_lazy_loading...', true)
#3 /home/wordpressfan/Local Sites/wprocket/app/public/wp-includes/class-wp-hook.php(324): {closure}('')
#4 /home/wordpressfan/Local Sites/wprocket/app/public/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters(NULL, Array)
#5 /home/wordpressfan/Local Sites/wprocket/app/public/wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#6 /home/wordpressfan/Local Sites/wprocket/app/public/wp-settings.php(727): do_action('init')
#7 /home/wordpressfan/Local Sites/wprocket/app/public/wp-config.php(138): require_once('/home/wordpress...')
#8 /home/wordpressfan/Local Sites/wprocket/app/public/wp-load.php(50): require_once('/home/wordpress...')
#9 /home/wordpressfan/Local Sites/wprocket/app/public/wp-blog-header.php(13): require_once('/home/wordpress...')
#10 /home/wordpressfan/Local Sites/wprocket/app/public/index.php(17): require('/home/wordpress...')
#11 {main}
  thrown in /home/wordpressfan/Local Sites/wprocket/app/public/wp-content/plugins/wp-rocket/inc/Engine/Media/Lazyload/Subscriber.php on line 442
```

### How to test

Mentioned above.

## Technical description

### Documentation

We just added a default value for the second argument.

### New dependencies

N/A

### Risks

WPBakery will need to worry about other plugins, this workaround will work with our plugin's only.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

No Tests

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
