### PR TITLE
Closes #7488: 3.19.x LazyLoad for CSS background images doesn’t work when Remove Unused CSS is enabled and the used CSS is applied

### DIFF
--- a/inc/Engine/Media/Lazyload/CSS/Subscriber.php
+++ b/inc/Engine/Media/Lazyload/CSS/Subscriber.php
@@ -144,7 +144,7 @@ class Subscriber implements Subscriber_Interface, LoggerAwareInterface {
 				[ 'create_lazy_inline_css', 21 ],
 				[ 'add_lazy_tag', 24 ],
 			],
-			'rocket_buffer'                         => [ 'maybe_replace_css_images', 1002 ],
+			'rocket_buffer'                         => [ 'maybe_replace_css_images', 110000 ],
 			'rocket_after_clean_domain'             => 'clear_generated_css',
 			'wp_enqueue_scripts'                    => 'insert_lazyload_script',
 			'rocket_css_image_lazyload_images_load' => [ 'exclude_rocket_lazyload_excluded_src', 10, 2 ],

--- a/tests/Integration/inc/Engine/Media/Lazyload/CSS/Subscriber/maybeReplaceCssImages.php
+++ b/tests/Integration/inc/Engine/Media/Lazyload/CSS/Subscriber/maybeReplaceCssImages.php
@@ -18,7 +18,7 @@ class Test_MaybeReplaceCssImages extends FilesystemTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		$this->unregisterAllCallbacksExcept('rocket_buffer', 'maybe_replace_css_images', 1002);
+		$this->unregisterAllCallbacksExcept('rocket_buffer', 'maybe_replace_css_images', 110000);
 
 		add_filter('pre_get_rocket_option_lazyload_css_bg_img', [$this, 'lazyload_css_bg_img']);
 		add_filter('rocket_lazyload_excluded_src', [$this, 'exclude_lazyload']);


### PR DESCRIPTION
# Description

Fixes #7488
Fixes issue with LLCSSBG not working when used css is generated.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

Tested that LLCSSBG works as expected with each background image only loading when in viewport with used css generated for the page.

### How to test
- Enable LLCSSBG
- Enable RUCSS
- Visit page with background images
- Open network tab and select img tab
- Wait for used css to generate
- Refresh page and scroll page
- See that BG images are only loaded in the img tab under the network tab when image hits viewport.

## Technical description

### Documentation

Explained [here](https://github.com/wp-media/wp-rocket/issues/7488#issuecomment-3101401824)

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

Not applicable to the changes in this PR

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
