### PR TITLE
Remove Performance Monitoring DB table correctly with plugin removal

### DIFF
--- a/inc/Engine/WPRocketUninstall.php
+++ b/inc/Engine/WPRocketUninstall.php
@@ -104,6 +104,16 @@ class WPRocketUninstall {
 		'rocket_cache_dir_size_check',
 		'rocketcdn_check_subscription_status_event',
 		'rocket_cron_deactivate_cloudflare_devmode',
+		'rocket_saas_clean_rows_time_event',
+		'rocket_saas_on_submit_jobs',
+		'rocket_saas_pending_jobs',
+		'rocket_remove_saas_failed_jobs',
+		'rocket_performance_hints_cleanup',
+		'action_scheduler_run_queue_rucss',
+		'rocket_update_dynamic_lists',
+		'rocket_preload_clean_rows_time_event',
+		'rocket_preload_process_pending',
+		'rocket_preload_revert_old_failed_rows',
 	];
 
 	/**

--- a/inc/Engine/WPRocketUninstall.php
+++ b/inc/Engine/WPRocketUninstall.php
@@ -239,6 +239,9 @@ class WPRocketUninstall {
 		array_walk( $this->options, 'delete_option' );
 
 		foreach ( $this->events as $event ) {
+			if ( ! wp_next_scheduled( $event ) ) {
+				continue;
+			}
 			wp_clear_scheduled_hook( $event );
 		}
 	}

--- a/inc/Engine/WPRocketUninstall.php
+++ b/inc/Engine/WPRocketUninstall.php
@@ -149,35 +149,18 @@ class WPRocketUninstall {
 	/**
 	 * Constructor.
 	 *
-	 * @param string                    $cache_path            Path to the cache folder.
-	 * @param string                    $config_path           Path to the config folder.
-	 * @param UsedCSS                   $rucss_usedcss_table   RUCSS used_css table.
-	 * @param Cache                     $rocket_cache          Preload rocket_cache table.
-	 * @param AboveTheFold              $atf_table             Above the fold table.
-	 * @param LazyRenderContent         $lrc_table Lazy Render content table.
-	 * @param PreloadFonts              $preload_fonts_table   Preload fonts table.
-	 * @param PreconnectExternalDomains $preload_domains_table Preload External Domains content table.
+	 * @param string $cache_path            Path to the cache folder.
+	 * @param string $config_path           Path to the config folder.
+	 * @param array  $tables Array of tables to be dropped.
 	 */
 	public function __construct(
 		$cache_path,
 		$config_path,
-		$rucss_usedcss_table,
-		$rocket_cache,
-		$atf_table,
-		$lrc_table,
-		$preload_fonts_table,
-		$preload_domains_table
+		$tables
 	) {
 		$this->cache_path  = trailingslashit( $cache_path );
 		$this->config_path = $config_path;
-		$this->tables      = [
-			$rucss_usedcss_table,
-			$rocket_cache,
-			$atf_table,
-			$lrc_table,
-			$preload_fonts_table,
-			$preload_domains_table,
-		];
+		$this->tables      = $tables;
 	}
 
 	/**

--- a/tests/Integration/inc/Engine/WPRocketUninstall/uninstall.php
+++ b/tests/Integration/inc/Engine/WPRocketUninstall/uninstall.php
@@ -146,16 +146,22 @@ class Test_Uninstall extends FilesystemTestCase {
 		$lrc_table           = $container->get( 'lrc_table' );
 		$preload_fonts_table = $container->get( 'preload_fonts_table' );
 		$preconnect_table    = $container->get( 'preconnect_external_domains_table' );
+		$pm_table            = $container->get( 'pm_table' );
 
-		$uninstall = new WPRocketUninstall(
-			$cache_path,
-			$config_path,
+		$tables = [
 			$rucss_usedcss_table,
 			$preload_table,
 			$atf_table,
 			$lrc_table,
 			$preload_fonts_table,
-			$preconnect_table
+			$preconnect_table,
+			$pm_table,
+		];
+
+		$uninstall = new WPRocketUninstall(
+			$cache_path,
+			$config_path,
+			$tables
 		);
 
 		$uninstall->uninstall();

--- a/uninstall.php
+++ b/uninstall.php
@@ -32,6 +32,7 @@ require_once __DIR__ . '/inc/Engine/Media/AboveTheFold/Database/Tables/AboveTheF
 require_once __DIR__ . '/inc/Engine/Optimization/LazyRenderContent/Database/Table/LazyRenderContent.php';
 require_once __DIR__ . '/inc/Engine/Media/PreloadFonts/Database/Table/PreloadFonts.php';
 require_once __DIR__ . '/inc/Engine/Media/PreconnectExternalDomains/Database/Table/PreconnectExternalDomains.php';
+require_once __DIR__ . '/inc/Engine/Admin/PerformanceMonitoring/Database/Tables/PerformanceMonitoring.php';
 
 $rocket_rucss_usedcss_table   = new WP_Rocket\Engine\Optimization\RUCSS\Database\Tables\UsedCSS();
 $rocket_cache_table           = new WP_Rocket\Engine\Preload\Database\Tables\Cache();
@@ -39,15 +40,20 @@ $rocket_atf_table             = new WP_Rocket\Engine\Media\AboveTheFold\Database
 $rocket_lrc_table             = new WP_Rocket\Engine\Optimization\LazyRenderContent\Database\Table\LazyRenderContent();
 $rocket_preload_fonts_table   = new WP_Rocket\Engine\Media\PreloadFonts\Database\Table\PreloadFonts();
 $rocket_preload_domains_table = new WP_Rocket\Engine\Media\PreconnectExternalDomains\Database\Table\PreconnectExternalDomains();
-$rocket_uninstall             = new WPRocketUninstall(
+$rocket_pm_table              = new WP_Rocket\Engine\Admin\PerformanceMonitoring\Database\Tables\PerformanceMonitoring();
+
+$rocket_uninstall = new WPRocketUninstall(
 	WP_ROCKET_CACHE_ROOT_PATH,
 	WP_ROCKET_CONFIG_PATH,
-	$rocket_rucss_usedcss_table,
-	$rocket_cache_table,
-	$rocket_atf_table,
-	$rocket_lrc_table,
-	$rocket_preload_fonts_table,
-	$rocket_preload_domains_table
+	[
+		$rocket_rucss_usedcss_table,
+		$rocket_cache_table,
+		$rocket_atf_table,
+		$rocket_lrc_table,
+		$rocket_preload_fonts_table,
+		$rocket_preload_domains_table,
+		$rocket_pm_table,
+	]
 	);
 
 $rocket_uninstall->uninstall();

--- a/uninstall.php
+++ b/uninstall.php
@@ -54,6 +54,6 @@ $rocket_uninstall = new WPRocketUninstall(
 		$rocket_preload_domains_table,
 		$rocket_pm_table,
 	]
-	);
+);
 
 $rocket_uninstall->uninstall();


### PR DESCRIPTION
# Description

Fixes #7562

Remove Performance Monitoring DB table correctly with plugin removal.
This is a leftover from #7553

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

Tested on one of our test sites by installing and then removing the plugin then checked the tables of WPR, I found nothing, then installed it again freshly and it's activated without any error.

### How to test

Mentioned above.

## Technical description

### Documentation

N/A

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

*If some mandatory items are not relevant, explain why in this section.*

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
