### PR TITLE
[PMA] Revert the job to pending if it's still not processed by SaaS to be checked again

### DIFF
--- a/inc/Engine/Admin/PerformanceMonitoring/Jobs/Manager.php
+++ b/inc/Engine/Admin/PerformanceMonitoring/Jobs/Manager.php
@@ -116,11 +116,24 @@ class Manager implements ManagerInterface, LoggerAwareInterface {
 	 * @return void
 	 */
 	public function process( array $job_details, $row_details, string $optimization_type ): void {
+		if ( ! empty( $job_details['status'] ) && 'pending' === $job_details['status'] ) {
+			$this->logger::info(
+				'Performance Monitoring: Revert to pending because of API status is pending',
+				[
+					'job_id' => $row_details->job_id,
+					'status' => $job_details['status'],
+				]
+			);
+
+			$this->query->revert_to_pending( $row_details->id );
+			return;
+		}
+
 		$this->logger::info(
 			'Performance Monitoring: Test completed successfully',
 			[
-				'test_id' => $row_details->job_id,
-				'score'   => $job_details['performance_score'] ?? null,
+				'job_id' => $row_details->job_id,
+				'score'  => $job_details['performance_score'] ?? null,
 			]
 		);
 

--- a/inc/Engine/Admin/PerformanceMonitoring/Jobs/Manager.php
+++ b/inc/Engine/Admin/PerformanceMonitoring/Jobs/Manager.php
@@ -121,7 +121,6 @@ class Manager implements ManagerInterface, LoggerAwareInterface {
 				'Performance Monitoring: Revert to pending because of API status is pending',
 				[
 					'job_id' => $row_details->job_id,
-					'status' => $job_details['status'],
 				]
 			);
 


### PR DESCRIPTION
# Description

When we check the job status, we may be in a state where job is not processed yet by SaaS and here we receive `pending` status, in this case we need to revert the status in our DB to be `pending` to be checked again later on.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

Tested to get status API request very early to see the `pending` status, it'll be pending until the next status check being handled.

### How to test

Fire the cron job called `rocket_saas_pending_jobs_cron` quickly after creating the page and check our logs.

## Technical description

### Documentation

N/A

### New dependencies

N/A

### Risks

If the status kept in pending status in SaaS we will keep sending the request until status changes.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

Will cover tests in a dedicated PR.

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
