### PR TITLE
Fix #2698: Prevent unnecessary cache purges for hierarchical pages

### DIFF
--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -131,11 +131,11 @@ if ( ! function_exists( 'rocket_get_purge_urls' ) ) {
 			$purge_urls[] = $author_url;
 		}
 
-		// Add all parents.
-		$parents = get_post_ancestors( $post_id );
-		if ( (bool) $parents ) {
-			foreach ( $parents as $parent_id ) {
-				$purge_urls[] = get_permalink( $parent_id );
+		// Add all children.
+		$children = get_all_descendant( $post_id );
+		if ( (bool) $children ) {
+			foreach ( $children as $child_id ) {
+				$purge_urls[] = get_permalink( $child_id );
 			}
 		}
 
@@ -145,6 +145,27 @@ if ( ! function_exists( 'rocket_get_purge_urls' ) ) {
 		return array_flip( array_flip( $purge_urls ) );
 	}
 }
+
+/**
+ * Recursively retrieves all descendant page IDs for a given parent page ID.
+ *
+ * @param int $parent_id The ID of the parent page.
+ * @return int[] A flat array with all descendant page IDs (children, grandchildren, etc.).
+ */
+function get_all_descendant( $parent_id ) {
+	// 'child_of' retrieves all descendants, not just direct children.
+	$all_descendants = get_pages( [
+		'child_of' => $parent_id,
+	] );
+
+	if ( empty( $all_descendants ) ) {
+		return [];
+	}
+
+	// Convert the array of page objects to an array of IDs only.
+	return wp_list_pluck( $all_descendants, 'ID' );
+}
+
 
 /**
  * Update cache when a post is updated or commented
@@ -617,6 +638,7 @@ add_action( 'upgrader_process_complete', 'rocket_clean_cache_theme_update', 10, 
  *
  * @param int   $post_id   The post ID.
  * @param array $post_data Array of unslashed post data.
+ * 
  */
 function rocket_clean_post_cache_on_slug_change( $post_id, $post_data ) {
 	if ( rocket_is_importing() ) {
@@ -636,6 +658,19 @@ function rocket_clean_post_cache_on_slug_change( $post_id, $post_data ) {
 	if ( empty( $post_name ) ) {
 		return;
 	}
-	rocket_clean_files( get_the_permalink( $post_id ) );
+
+	$purge_urls = [];
+	$purge_urls[] = get_the_permalink( $post_id );
+
+	// Clear cache for all child pages.
+	$children = get_all_descendant( $post_id );
+	if ( (bool) $children ) {
+		foreach ( $children as $child_id ) {
+			$purge_urls[] = get_the_permalink( $child_id );
+		}
+	}
+
+	rocket_clean_files( $purge_urls );
+
 }
 add_action( 'pre_post_update', 'rocket_clean_post_cache_on_slug_change', PHP_INT_MAX, 2 );

--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -131,6 +131,18 @@ if ( ! function_exists( 'rocket_get_purge_urls' ) ) {
 			$purge_urls[] = $author_url;
 		}
 
+		$post_name = get_post_field( 'post_name', $post_id );
+		// If the slug has changed, add all children pages with the new slug.
+		if ( $post_name != $post['post_name'] ) {
+			// Add all children.
+			$children = rocket_get_all_descendant( $post_id );
+			if ( (bool) $children ) {
+				foreach ( $children as $child_id ) {
+					$purge_urls[] = get_permalink( $child_id );
+				}
+			}
+		}
+
 		// Remove entries with empty values in array.
 		$purge_urls = array_filter( $purge_urls, 'is_string' );
 
@@ -665,3 +677,4 @@ function rocket_clean_post_cache_on_slug_change( $post_id, $post_data ) {
 
 }
 add_action( 'pre_post_update', 'rocket_clean_post_cache_on_slug_change', PHP_INT_MAX, 2 );
+

--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -133,7 +133,7 @@ if ( ! function_exists( 'rocket_get_purge_urls' ) ) {
 
 		$post_name = get_post_field( 'post_name', $post_id );
 		// If the slug has changed, add all children pages with the new slug.
-		if ( $post_name !== $post['post_name'] ) {
+		if ( $post_name !== $post->post_name ) {
 			// Add all children.
 			$children = rocket_get_all_descendant( $post_id );
 			if ( (bool) $children ) {

--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -131,18 +131,6 @@ if ( ! function_exists( 'rocket_get_purge_urls' ) ) {
 			$purge_urls[] = $author_url;
 		}
 
-		$post_name = get_post_field( 'post_name', $post_id );
-		// If the slug has changed, add all children pages with the new slug.
-		if ( $post_name != $post_data['post_name'] ) {
-			// Add all children.
-			$children = rocket_get_all_descendant( $post_id );
-			if ( (bool) $children ) {
-				foreach ( $children as $child_id ) {
-					$purge_urls[] = get_permalink( $child_id );
-				}
-			}
-		}
-
 		// Remove entries with empty values in array.
 		$purge_urls = array_filter( $purge_urls, 'is_string' );
 

--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -133,7 +133,7 @@ if ( ! function_exists( 'rocket_get_purge_urls' ) ) {
 
 		$post_name = get_post_field( 'post_name', $post_id );
 		// If the slug has changed, add all children pages with the new slug.
-		if ( $post_name != $post['post_name'] ) {
+		if ( $post_name !== $post['post_name'] ) {
 			// Add all children.
 			$children = rocket_get_all_descendant( $post_id );
 			if ( (bool) $children ) {

--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -131,11 +131,15 @@ if ( ! function_exists( 'rocket_get_purge_urls' ) ) {
 			$purge_urls[] = $author_url;
 		}
 
-		// Add all children.
-		$children = rocket_get_all_descendant( $post_id );
-		if ( (bool) $children ) {
-			foreach ( $children as $child_id ) {
-				$purge_urls[] = get_permalink( $child_id );
+		$post_name = get_post_field( 'post_name', $post_id );
+		// If the slug has changed, add all children pages with the new slug.
+		if ( $post_name != $post_data['post_name'] ) {
+			// Add all children.
+			$children = rocket_get_all_descendant( $post_id );
+			if ( (bool) $children ) {
+				foreach ( $children as $child_id ) {
+					$purge_urls[] = get_permalink( $child_id );
+				}
 			}
 		}
 

--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -151,23 +151,33 @@ if ( ! function_exists( 'rocket_get_purge_urls' ) ) {
 }
 
 /**
- * Recursively retrieves all descendant page IDs for a given parent page ID.
+ * Recursively retrieves all descendant post IDs for a given parent post ID.
  *
- * @param int $parent_id The ID of the parent page.
- * @return int[] A flat array with all descendant page IDs (children, grandchildren, etc.).
+ * @param int $parent_id The ID of the parent post.
+ * @return int[] A flat array with all descendant post IDs (children, grandchildren, etc.).
  */
 function rocket_get_all_descendant( $parent_id ) {
+	$post_type = get_post_type( $parent_id );
+
+	if ( ! $post_type ) {
+		return [];
+	}
+
 	// 'child_of' retrieves all descendants, not just direct children.
 	$all_descendants = get_pages(
-		[ 'child_of' => $parent_id ]
+		[
+			'child_of'  => $parent_id,
+			'post_type' => $post_type,
+			'fields'    => 'ids',
+		]
 	);
 
 	if ( empty( $all_descendants ) ) {
 		return [];
 	}
 
-	// Convert the array of page objects to an array of IDs only.
-	return wp_list_pluck( $all_descendants, 'ID' );
+	// Ensure we return a flat array of integer IDs.
+	return array_map( 'intval', $all_descendants );
 }
 
 

--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -132,7 +132,7 @@ if ( ! function_exists( 'rocket_get_purge_urls' ) ) {
 		}
 
 		// Add all children.
-		$children = get_all_descendant( $post_id );
+		$children = rocket_get_all_descendant( $post_id );
 		if ( (bool) $children ) {
 			foreach ( $children as $child_id ) {
 				$purge_urls[] = get_permalink( $child_id );
@@ -152,7 +152,7 @@ if ( ! function_exists( 'rocket_get_purge_urls' ) ) {
  * @param int $parent_id The ID of the parent page.
  * @return int[] A flat array with all descendant page IDs (children, grandchildren, etc.).
  */
-function get_all_descendant( $parent_id ) {
+function rocket_get_all_descendant( $parent_id ) {
 	// 'child_of' retrieves all descendants, not just direct children.
 	$all_descendants = get_pages( [
 		'child_of' => $parent_id,
@@ -663,7 +663,7 @@ function rocket_clean_post_cache_on_slug_change( $post_id, $post_data ) {
 	$purge_urls[] = get_the_permalink( $post_id );
 
 	// Clear cache for all child pages.
-	$children = get_all_descendant( $post_id );
+	$children = rocket_get_all_descendant( $post_id );
 	if ( (bool) $children ) {
 		foreach ( $children as $child_id ) {
 			$purge_urls[] = get_the_permalink( $child_id );

--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -176,8 +176,8 @@ function rocket_get_all_descendant( $parent_id ) {
 		return [];
 	}
 
-	// Ensure we return a flat array of integer IDs.
-	return array_map( 'intval', $all_descendants );
+	// Convert the array of page objects to an array of IDs only.
+	return wp_list_pluck( $all_descendants, 'ID' );
 }
 
 

--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -154,9 +154,9 @@ if ( ! function_exists( 'rocket_get_purge_urls' ) ) {
  */
 function rocket_get_all_descendant( $parent_id ) {
 	// 'child_of' retrieves all descendants, not just direct children.
-	$all_descendants = get_pages( [
-		'child_of' => $parent_id,
-	] );
+	$all_descendants = get_pages(
+		[ 'child_of' => $parent_id ] 
+	);
 
 	if ( empty( $all_descendants ) ) {
 		return [];
@@ -638,7 +638,6 @@ add_action( 'upgrader_process_complete', 'rocket_clean_cache_theme_update', 10, 
  *
  * @param int   $post_id   The post ID.
  * @param array $post_data Array of unslashed post data.
- * 
  */
 function rocket_clean_post_cache_on_slug_change( $post_id, $post_data ) {
 	if ( rocket_is_importing() ) {
@@ -659,7 +658,7 @@ function rocket_clean_post_cache_on_slug_change( $post_id, $post_data ) {
 		return;
 	}
 
-	$purge_urls = [];
+	$purge_urls   = [];
 	$purge_urls[] = get_the_permalink( $post_id );
 
 	// Clear cache for all child pages.

--- a/inc/common/purge.php
+++ b/inc/common/purge.php
@@ -159,7 +159,7 @@ if ( ! function_exists( 'rocket_get_purge_urls' ) ) {
 function rocket_get_all_descendant( $parent_id ) {
 	// 'child_of' retrieves all descendants, not just direct children.
 	$all_descendants = get_pages(
-		[ 'child_of' => $parent_id ] 
+		[ 'child_of' => $parent_id ]
 	);
 
 	if ( empty( $all_descendants ) ) {

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -634,28 +634,28 @@ function rocket_clean_files( $urls, $filesystem = null, $run_actions = true ) {
 
 		$parsed_url = get_rocket_parse_url( $url );
 
-		if ( !empty( $parsed_url['host'] ) ) {
+		if ( ! empty( $parsed_url['host'] ) ) {
 
 			foreach ( _rocket_get_cache_dirs( $parsed_url['host'], $cache_path ) as $dir ) {
 				// Decode url path.
 				$url_chunks = explode( '/', $parsed_url['path'] );
 				$matches    = preg_grep( '/%/', $url_chunks );
-	
+				
 				if ( ! empty( $matches ) ) {
 					$parsed_url['path'] = rawurldecode( $parsed_url['path'] );
 				}
-	
+				
 				// Encode Non-latin characters if found in url path.
 				if ( false !== preg_match_all( '/(?<non_latin>[^\x00-\x7F]+)/', $parsed_url['path'], $matches ) ) {
 					$cb_encode_non_latin = function ( $non_latin ) {
 						return strtolower( rawurlencode( $non_latin ) );
 					};
-	
+
 					$parsed_url['path'] = str_replace( $matches['non_latin'], array_map( $cb_encode_non_latin, $matches['non_latin'] ), $parsed_url['path'] );
 				}
-	
+				
 				$entry = $dir . $parsed_url['path'];
-	
+
 				// For regex we use it for file names only, and it should include the * character.
 				if ( str_contains( $entry, '*' ) ) {
 					$regex_part    = basename( $entry );
@@ -671,17 +671,17 @@ function rocket_clean_files( $urls, $filesystem = null, $run_actions = true ) {
 					$url              = str_replace( $regex_part, '', $url );
 					$urls[ $url_key ] = $url;
 				}
-	
+
 				// Skip if the dir/file does not exist.
 				if ( ! $filesystem->exists( $entry ) ) {
 					continue;
 				}
-	
+
 				if ( ! $filesystem->is_dir( $entry ) ) {
 					$filesystem->delete( $entry );
 					continue;
 				}
-	
+
 				// Check whether the directory contains subfolders (vs only files).
 				$has_subdirs = false;
 				try {
@@ -695,13 +695,13 @@ function rocket_clean_files( $urls, $filesystem = null, $run_actions = true ) {
 					// If we can't inspect the directory, be conservative and only delete files.
 					$has_subdirs = true;
 				}
-	
+
 				if ( ! $has_subdirs ) {
 					// Directory contains only files: remove it entirely.
 					rocket_rrmdir( $entry, [], $filesystem );
 					continue;
 				}
-	
+
 				// Directory contains subfolders: delete only the files in the top-level.
 				foreach ( _rocket_get_dir_files_by_regex( $entry, '#.+#' ) as $child ) {
 					if ( $child->isFile() ) {

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -591,6 +591,10 @@ function rocket_clean_files( $urls, $filesystem = null, $run_actions = true ) {
 
 		$parsed_url = get_rocket_parse_url( $url );
 
+		$structure = get_option( 'permalink_structure' );
+
+		$is_permalink = !empty($structure) && $parsed_url['path'] === rtrim('/' . trim(strstr($structure, '%', true) ?: '', '/'), '/');
+
 		if ( ! empty( $parsed_url['host'] ) ) {
 			foreach ( _rocket_get_cache_dirs( $parsed_url['host'], $cache_path ) as $dir ) {
 				// Decode url path.
@@ -611,6 +615,10 @@ function rocket_clean_files( $urls, $filesystem = null, $run_actions = true ) {
 				}
 
 				$entry = $dir . $parsed_url['path'];
+
+				if ( ! empty( $parsed_url['query'] ) ) {
+					$entry = trailingslashit( $entry ) . '#' . str_replace( '&', '#', $parsed_url['query'] );
+				}
 
 				// For regex we use it for file names only, and it should include the * character.
 				if ( str_contains( $entry, '*' ) ) {
@@ -634,7 +642,20 @@ function rocket_clean_files( $urls, $filesystem = null, $run_actions = true ) {
 				}
 
 				if ( $filesystem->is_dir( $entry ) ) {
-					rocket_rrmdir( $entry, [], $filesystem );
+					if ( $is_permalink ) {
+						// Delete only cache files inside the directory
+						$cache_files = glob( $entry . '/index*.*' );
+						if ( ! $cache_files ) {
+							$cache_files = [];
+						}
+						foreach ( $cache_files as $cache_file ) {
+							if ( $filesystem->exists( $cache_file ) ) {
+								$filesystem->delete( $cache_file );
+							}
+						}
+					} else {
+						rocket_rrmdir( $entry, [], $filesystem );
+					}
 				} else {
 					$filesystem->delete( $entry );
 				}

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -616,10 +616,6 @@ function rocket_clean_files( $urls, $filesystem = null, $run_actions = true ) {
 
 				$entry = $dir . $parsed_url['path'];
 
-				if ( ! empty( $parsed_url['query'] ) ) {
-					$entry = trailingslashit( $entry ) . '#' . str_replace( '&', '#', $parsed_url['query'] );
-				}
-
 				// For regex we use it for file names only, and it should include the * character.
 				if ( str_contains( $entry, '*' ) ) {
 					$regex_part    = basename( $entry );

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -546,7 +546,7 @@ function rocket_maybe_find_right_trash_url( array $parsed_url, int $post_id ) {
  * @return int Number of segments in the URL path (0 if empty or no path).
  */
 function rocket_count_path_segments( string $url ): int {
-	$path = parse_url( $url, PHP_URL_PATH ) ?? '';
+	$path = wp_parse_url( $url, PHP_URL_PATH ) ?? '';
 	$path = trim( $path, '/' );              // "/" -> ""
 
 	if ( '' === $path ) {

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -530,6 +530,28 @@ function rocket_maybe_find_right_trash_url( array $parsed_url, int $post_id ) {
 	return get_rocket_parse_url( $new_permalink );
 }
 
+
+/**
+ * Count the number of path segments in a URL.
+ *
+ * Parses the given URL, extracts its path component, trims leading/trailing
+ * slashes, and counts the remaining segments separated by '/'.
+ *
+ * Examples:
+ * - "https://example.com/" => 0
+ * - "https://example.com/a/b/c" => 3
+ * - "/a/b/" => 2
+ *
+ * @param string $url The URL (absolute or relative) to analyze.
+ * @return int Number of segments in the URL path (0 if empty or no path).
+ */
+function rocket_count_path_segments(string $url): int {
+    $path = parse_url($url, PHP_URL_PATH) ?? '';
+    $path = trim($path, '/');              // "/" -> ""
+    if ($path === '') return 0;
+    return count(explode('/', $path));     // "a/b/c" -> 3
+}
+
 /**
  * Delete one or several cache files.
  *
@@ -563,6 +585,24 @@ function rocket_clean_files( $urls, $filesystem = null, $run_actions = true ) {
 		$filesystem = rocket_direct_filesystem();
 	}
 
+	// Sort: most segments first (deepest URLs first).
+	usort(
+		$urls,
+		static function ( $a, $b ) {
+			$da = rocket_count_path_segments( (string) $a );
+			$db = rocket_count_path_segments( (string) $b );
+
+			// First by depth (descending)
+			if ( $da !== $db ) {
+				return $db <=> $da;
+			}
+
+			// If depth is equal, alphabetically
+			return strcmp( (string) $a, (string) $b );
+		}
+	);
+
+
 	if ( $run_actions ) {
 		/**
 		 * Fires before all cache files are deleted.
@@ -575,6 +615,7 @@ function rocket_clean_files( $urls, $filesystem = null, $run_actions = true ) {
 	}
 
 	foreach ( $urls as $url_key => $url ) {
+		
 		if ( $run_actions ) {
 			/**
 			 * Fires before the cache file is deleted.
@@ -591,72 +632,85 @@ function rocket_clean_files( $urls, $filesystem = null, $run_actions = true ) {
 
 		$parsed_url = get_rocket_parse_url( $url );
 
-		$structure = get_option( 'permalink_structure' );
+		if ( empty( $parsed_url['host'] ) ) {
+			continue;
+		}
 
-		$is_permalink = !empty($structure) && $parsed_url['path'] === rtrim('/' . trim(strstr($structure, '%', true) ?: '', '/'), '/');
+		foreach ( _rocket_get_cache_dirs( $parsed_url['host'], $cache_path ) as $dir ) {
+			// Decode url path.
+			$url_chunks = explode( '/', $parsed_url['path'] );
+			$matches    = preg_grep( '/%/', $url_chunks );
 
-		if ( ! empty( $parsed_url['host'] ) ) {
-			foreach ( _rocket_get_cache_dirs( $parsed_url['host'], $cache_path ) as $dir ) {
-				// Decode url path.
-				$url_chunks = explode( '/', $parsed_url['path'] );
-				$matches    = preg_grep( '/%/', $url_chunks );
+			if ( ! empty( $matches ) ) {
+				$parsed_url['path'] = rawurldecode( $parsed_url['path'] );
+			}
 
-				if ( ! empty( $matches ) ) {
-					$parsed_url['path'] = rawurldecode( $parsed_url['path'] );
-				}
+			// Encode Non-latin characters if found in url path.
+			if ( false !== preg_match_all( '/(?<non_latin>[^\x00-\x7F]+)/', $parsed_url['path'], $matches ) ) {
+				$cb_encode_non_latin = function ( $non_latin ) {
+					return strtolower( rawurlencode( $non_latin ) );
+				};
 
-				// Encode Non-latin characters if found in url path.
-				if ( false !== preg_match_all( '/(?<non_latin>[^\x00-\x7F]+)/', $parsed_url['path'], $matches ) ) {
-					$cb_encode_non_latin = function ( $non_latin ) {
-						return strtolower( rawurlencode( $non_latin ) );
-					};
+				$parsed_url['path'] = str_replace( $matches['non_latin'], array_map( $cb_encode_non_latin, $matches['non_latin'] ), $parsed_url['path'] );
+			}
 
-					$parsed_url['path'] = str_replace( $matches['non_latin'], array_map( $cb_encode_non_latin, $matches['non_latin'] ), $parsed_url['path'] );
-				}
+			$entry = $dir . $parsed_url['path'];
 
-				$entry = $dir . $parsed_url['path'];
-
-				// For regex we use it for file names only, and it should include the * character.
-				if ( str_contains( $entry, '*' ) ) {
-					$regex_part    = basename( $entry );
-					$search_dir    = str_replace( $regex_part, '', $entry );
-					$matched_files = _rocket_get_dir_files_by_regex( $search_dir, '#' . $regex_part . '#i' );
-					foreach ( $matched_files as $item ) {
-						$current_file = $item->getPath() . DIRECTORY_SEPARATOR . $item->getFilename();
-						if ( $filesystem->exists( $current_file ) ) {
-							$filesystem->delete( $current_file );
-						}
+			// For regex we use it for file names only, and it should include the * character.
+			if ( str_contains( $entry, '*' ) ) {
+				$regex_part    = basename( $entry );
+				$search_dir    = str_replace( $regex_part, '', $entry );
+				$matched_files = _rocket_get_dir_files_by_regex( $search_dir, '#' . $regex_part . '#i' );
+				foreach ( $matched_files as $item ) {
+					$current_file = $item->getPath() . DIRECTORY_SEPARATOR . $item->getFilename();
+					if ( $filesystem->exists( $current_file ) ) {
+						$filesystem->delete( $current_file );
 					}
-					// Remove the regex part from the url.
-					$url              = str_replace( $regex_part, '', $url );
-					$urls[ $url_key ] = $url;
 				}
+				// Remove the regex part from the url.
+				$url              = str_replace( $regex_part, '', $url );
+				$urls[ $url_key ] = $url;
+			}
 
-				// Skip if the dir/file does not exist.
-				if ( ! $filesystem->exists( $entry ) ) {
-					continue;
-				}
+			// Skip if the dir/file does not exist.
+			if ( ! $filesystem->exists( $entry ) ) {
+				continue;
+			}
 
-				if ( $filesystem->is_dir( $entry ) ) {
-					if ( $is_permalink ) {
-						// Delete only cache files inside the directory
-						$cache_files = glob( $entry . '/index*.*' );
-						if ( ! $cache_files ) {
-							$cache_files = [];
-						}
-						foreach ( $cache_files as $cache_file ) {
-							if ( $filesystem->exists( $cache_file ) ) {
-								$filesystem->delete( $cache_file );
-							}
-						}
-					} else {
-						rocket_rrmdir( $entry, [], $filesystem );
+			if ( ! $filesystem->is_dir( $entry ) ) {
+				$filesystem->delete( $entry );
+				continue;
+			}
+
+			// Check whether the directory contains subfolders (vs only files).
+			$has_subdirs = false;
+			try {
+				foreach ( new FilesystemIterator( $entry, FilesystemIterator::SKIP_DOTS ) as $child ) {
+					if ( $child->isDir() ) {
+						$has_subdirs = true;
+						break;
 					}
-				} else {
-					$filesystem->delete( $entry );
+				}
+			} catch ( Exception $e ) {
+				// If we can't inspect the directory, be conservative and only delete files.
+				$has_subdirs = true;
+			}
+
+			if ( ! $has_subdirs ) {
+				// Directory contains only files: remove it entirely.
+				rocket_rrmdir( $entry, [], $filesystem );
+				continue;
+			}
+
+			// Directory contains subfolders: delete only the files in the top-level.
+			foreach ( _rocket_get_dir_files_by_regex( $entry, '#.+#' ) as $child ) {
+				if ( $child->isFile() ) {
+					$filesystem->delete( $child->getPathname() );
 				}
 			}
+
 		}
+
 		if ( $run_actions ) {
 			/**
 			 * Fires after the cache file is deleted.

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -545,11 +545,15 @@ function rocket_maybe_find_right_trash_url( array $parsed_url, int $post_id ) {
  * @param string $url The URL (absolute or relative) to analyze.
  * @return int Number of segments in the URL path (0 if empty or no path).
  */
-function rocket_count_path_segments(string $url): int {
-    $path = parse_url($url, PHP_URL_PATH) ?? '';
-    $path = trim($path, '/');              // "/" -> ""
-    if ($path === '') return 0;
-    return count(explode('/', $path));     // "a/b/c" -> 3
+function rocket_count_path_segments( string $url ): int {
+	$path = parse_url( $url, PHP_URL_PATH ) ?? '';
+	$path = trim( $path, '/' );              // "/" -> ""
+
+	if ( '' === $path ) {
+		return 0;
+	}
+
+	return count( explode( '/', $path ) );   // "a/b/c" -> 3
 }
 
 /**

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -634,80 +634,79 @@ function rocket_clean_files( $urls, $filesystem = null, $run_actions = true ) {
 
 		$parsed_url = get_rocket_parse_url( $url );
 
-		if ( empty( $parsed_url['host'] ) ) {
-			continue;
-		}
+		if ( !empty( $parsed_url['host'] ) ) {
 
-		foreach ( _rocket_get_cache_dirs( $parsed_url['host'], $cache_path ) as $dir ) {
-			// Decode url path.
-			$url_chunks = explode( '/', $parsed_url['path'] );
-			$matches    = preg_grep( '/%/', $url_chunks );
-
-			if ( ! empty( $matches ) ) {
-				$parsed_url['path'] = rawurldecode( $parsed_url['path'] );
-			}
-
-			// Encode Non-latin characters if found in url path.
-			if ( false !== preg_match_all( '/(?<non_latin>[^\x00-\x7F]+)/', $parsed_url['path'], $matches ) ) {
-				$cb_encode_non_latin = function ( $non_latin ) {
-					return strtolower( rawurlencode( $non_latin ) );
-				};
-
-				$parsed_url['path'] = str_replace( $matches['non_latin'], array_map( $cb_encode_non_latin, $matches['non_latin'] ), $parsed_url['path'] );
-			}
-
-			$entry = $dir . $parsed_url['path'];
-
-			// For regex we use it for file names only, and it should include the * character.
-			if ( str_contains( $entry, '*' ) ) {
-				$regex_part    = basename( $entry );
-				$search_dir    = str_replace( $regex_part, '', $entry );
-				$matched_files = _rocket_get_dir_files_by_regex( $search_dir, '#' . $regex_part . '#i' );
-				foreach ( $matched_files as $item ) {
-					$current_file = $item->getPath() . DIRECTORY_SEPARATOR . $item->getFilename();
-					if ( $filesystem->exists( $current_file ) ) {
-						$filesystem->delete( $current_file );
-					}
+			foreach ( _rocket_get_cache_dirs( $parsed_url['host'], $cache_path ) as $dir ) {
+				// Decode url path.
+				$url_chunks = explode( '/', $parsed_url['path'] );
+				$matches    = preg_grep( '/%/', $url_chunks );
+	
+				if ( ! empty( $matches ) ) {
+					$parsed_url['path'] = rawurldecode( $parsed_url['path'] );
 				}
-				// Remove the regex part from the url.
-				$url              = str_replace( $regex_part, '', $url );
-				$urls[ $url_key ] = $url;
-			}
-
-			// Skip if the dir/file does not exist.
-			if ( ! $filesystem->exists( $entry ) ) {
-				continue;
-			}
-
-			if ( ! $filesystem->is_dir( $entry ) ) {
-				$filesystem->delete( $entry );
-				continue;
-			}
-
-			// Check whether the directory contains subfolders (vs only files).
-			$has_subdirs = false;
-			try {
-				foreach ( new FilesystemIterator( $entry, FilesystemIterator::SKIP_DOTS ) as $child ) {
-					if ( $child->isDir() ) {
-						$has_subdirs = true;
-						break;
-					}
+	
+				// Encode Non-latin characters if found in url path.
+				if ( false !== preg_match_all( '/(?<non_latin>[^\x00-\x7F]+)/', $parsed_url['path'], $matches ) ) {
+					$cb_encode_non_latin = function ( $non_latin ) {
+						return strtolower( rawurlencode( $non_latin ) );
+					};
+	
+					$parsed_url['path'] = str_replace( $matches['non_latin'], array_map( $cb_encode_non_latin, $matches['non_latin'] ), $parsed_url['path'] );
 				}
-			} catch ( Exception $e ) {
-				// If we can't inspect the directory, be conservative and only delete files.
-				$has_subdirs = true;
-			}
-
-			if ( ! $has_subdirs ) {
-				// Directory contains only files: remove it entirely.
-				rocket_rrmdir( $entry, [], $filesystem );
-				continue;
-			}
-
-			// Directory contains subfolders: delete only the files in the top-level.
-			foreach ( _rocket_get_dir_files_by_regex( $entry, '#.+#' ) as $child ) {
-				if ( $child->isFile() ) {
-					$filesystem->delete( $child->getPathname() );
+	
+				$entry = $dir . $parsed_url['path'];
+	
+				// For regex we use it for file names only, and it should include the * character.
+				if ( str_contains( $entry, '*' ) ) {
+					$regex_part    = basename( $entry );
+					$search_dir    = str_replace( $regex_part, '', $entry );
+					$matched_files = _rocket_get_dir_files_by_regex( $search_dir, '#' . $regex_part . '#i' );
+					foreach ( $matched_files as $item ) {
+						$current_file = $item->getPath() . DIRECTORY_SEPARATOR . $item->getFilename();
+						if ( $filesystem->exists( $current_file ) ) {
+							$filesystem->delete( $current_file );
+						}
+					}
+					// Remove the regex part from the url.
+					$url              = str_replace( $regex_part, '', $url );
+					$urls[ $url_key ] = $url;
+				}
+	
+				// Skip if the dir/file does not exist.
+				if ( ! $filesystem->exists( $entry ) ) {
+					continue;
+				}
+	
+				if ( ! $filesystem->is_dir( $entry ) ) {
+					$filesystem->delete( $entry );
+					continue;
+				}
+	
+				// Check whether the directory contains subfolders (vs only files).
+				$has_subdirs = false;
+				try {
+					foreach ( new FilesystemIterator( $entry, FilesystemIterator::SKIP_DOTS ) as $child ) {
+						if ( $child->isDir() ) {
+							$has_subdirs = true;
+							break;
+						}
+					}
+				} catch ( Exception $e ) {
+					// If we can't inspect the directory, be conservative and only delete files.
+					$has_subdirs = true;
+				}
+	
+				if ( ! $has_subdirs ) {
+					// Directory contains only files: remove it entirely.
+					rocket_rrmdir( $entry, [], $filesystem );
+					continue;
+				}
+	
+				// Directory contains subfolders: delete only the files in the top-level.
+				foreach ( _rocket_get_dir_files_by_regex( $entry, '#.+#' ) as $child ) {
+					if ( $child->isFile() ) {
+						$filesystem->delete( $child->getPathname() );
+					}
 				}
 			}
 

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -589,9 +589,22 @@ function rocket_clean_files( $urls, $filesystem = null, $run_actions = true ) {
 		$filesystem = rocket_direct_filesystem();
 	}
 
+	if ( $run_actions ) {
+		/**
+		 * Fires before all cache files are deleted.
+		 *
+		 * @since  3.2.2
+		 *
+		 * @param array $urls The URLs corresponding to the deleted cache files.
+		 */
+		do_action( 'before_rocket_clean_files', $urls ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
+	}
+
+	$sorted_urls = $urls;
+
 	// Sort: most segments first (deepest URLs first).
 	usort(
-		$urls,
+		$sorted_urls,
 		static function ( $a, $b ) {
 			$da = rocket_count_path_segments( (string) $a );
 			$db = rocket_count_path_segments( (string) $b );
@@ -606,18 +619,7 @@ function rocket_clean_files( $urls, $filesystem = null, $run_actions = true ) {
 		}
 	);
 
-	if ( $run_actions ) {
-		/**
-		 * Fires before all cache files are deleted.
-		 *
-		 * @since  3.2.2
-		 *
-		 * @param array $urls The URLs corresponding to the deleted cache files.
-		 */
-		do_action( 'before_rocket_clean_files', $urls ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
-	}
-
-	foreach ( $urls as $url_key => $url ) {
+	foreach ( $sorted_urls as $url_key => $url ) {
 		if ( $run_actions ) {
 			/**
 			 * Fires before the cache file is deleted.

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -618,7 +618,6 @@ function rocket_clean_files( $urls, $filesystem = null, $run_actions = true ) {
 	}
 
 	foreach ( $urls as $url_key => $url ) {
-		
 		if ( $run_actions ) {
 			/**
 			 * Fires before the cache file is deleted.

--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -596,16 +596,15 @@ function rocket_clean_files( $urls, $filesystem = null, $run_actions = true ) {
 			$da = rocket_count_path_segments( (string) $a );
 			$db = rocket_count_path_segments( (string) $b );
 
-			// First by depth (descending)
+			// First by depth (descending).
 			if ( $da !== $db ) {
 				return $db <=> $da;
 			}
 
-			// If depth is equal, alphabetically
+			// If depth is equal, alphabetically.
 			return strcmp( (string) $a, (string) $b );
 		}
 	);
-
 
 	if ( $run_actions ) {
 		/**


### PR DESCRIPTION

# Description

This pull request is ment to solve issue #2698  

This pull request fixes a critical bug where purging a parent page's cache would unintentionally clear the cache for all of its descendant pages. It also ensures the _wpr_rocket_cache database table is correctly and fully updated, especially when page slugs are modified within a hierarchy.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

*Describe the scenarios that you tested, and specify if it is automated or manual. For manual scenarios, provide a screenshot of the results.*

### How to test

*Describe how the PR can be tested so that the validator can be autonomous: environment, dependencies, specific setup, steps to perform, API requests, etc.*

## Technical description

### Documentation

Problem
The previous implementation purged parent pages when a post was updated. This led to several issues:

1. **Unintentional Cache Deletion**: Purging a parent URL (e.g., /parent/) caused rocket_clean_files to delete the entire directory, which unintentionally wiped out the cache for all child pages (e.g., /parent/child/).
2. **Database Inconsistency on Update**: Because child pages were deleted indirectly via directory removal, they were not explicitly listed in the purge process. This meant their entries in the _wpr_rocket_cache table were not updated, leading to a mismatch between the filesystem cache and the database.
3. **Database Inconsistency on Slug Change**: When a slug was changed for a page in the middle of a page tree, only the cache for that single post was purged. The URLs of all its child pages also change as a result, but their old cached versions were not being purged, and their entries in the _wpr_rocket_cache table were not updated to reflect the new URL structure.

Solution
The logic has been inverted: instead of purging parent pages, the process now explicitly targets all affected child pages.

1. **Added get_all_descendant() function**: A new helper function has been added to recursively retrieve all descendant page IDs (children, grandchildren, etc.) for a given post.
2. **Modified rocket_get_purge_urls() and rocket_clean_post_cache_on_slug_change()**: Both functions have been updated to use the new get_all_descendant() helper. Instead of adding parent URLs to the purge list, they now build a precise list of all individual child pages that need to be purged.

This change ensures that only the intended cache files are removed and that each purged URL is explicitly processed, guaranteeing that the _wpr_rocket_cache table is always kept in sync with the actual state of the cache.

### New dependencies

*List any new dependencies that are required for this change.*

### Risks

*List possible performance & security issues or risks, and explain how they have been mitigated.*

# Mandatory Checklist

## Code validation

- [X] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [X] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [X] I implemented built-in tests to cover the new/changed code.

## Code style

- [X] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

*If some mandatory items are not relevant, explain why in this section.*

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
