### PR TITLE
Feature 7595: show pm license

### DIFF
--- a/inc/Engine/Admin/PerformanceMonitoring/ServiceProvider.php
+++ b/inc/Engine/Admin/PerformanceMonitoring/ServiceProvider.php
@@ -39,6 +39,7 @@ class ServiceProvider extends AbstractServiceProvider {
 		'pm_controller',
 		'pm_subscriber',
 		'pm_ajax_controller',
+		'pm_settings_subscriber',
 	];
 
 	/**
@@ -120,6 +121,15 @@ class ServiceProvider extends AbstractServiceProvider {
 					'pm_render',
 					'pm_controller',
 					'pm_ajax_controller',
+				]
+			);
+
+		// Addon Subscriber
+		$this->getContainer()->addShared( 'pm_settings_subscriber', SettingsSubscriber::class )
+			->addArguments(
+				[
+					'user',
+					new StringArgument( __DIR__ . '/../../../Engine/License/views' ),
 				]
 			);
 

--- a/inc/Engine/Admin/PerformanceMonitoring/ServiceProvider.php
+++ b/inc/Engine/Admin/PerformanceMonitoring/ServiceProvider.php
@@ -124,7 +124,7 @@ class ServiceProvider extends AbstractServiceProvider {
 				]
 			);
 
-		// Addon Subscriber
+		// Addon Subscriber.
 		$this->getContainer()->addShared( 'pm_settings_subscriber', SettingsSubscriber::class )
 			->addArguments(
 				[

--- a/inc/Engine/Admin/PerformanceMonitoring/SettingsSubscriber.php
+++ b/inc/Engine/Admin/PerformanceMonitoring/SettingsSubscriber.php
@@ -72,7 +72,7 @@ class SettingsSubscriber extends Abstract_Render implements Subscriber_Interface
 		}
 
 		$data = [
-			'is_live_site'    => true,//rocket_is_live_site(),
+			'is_live_site'    => rocket_is_live_site(),
 			'container_class' => '',
 			'label'           => $label,
 			'status_class'    => $status_class,

--- a/inc/Engine/Admin/PerformanceMonitoring/SettingsSubscriber.php
+++ b/inc/Engine/Admin/PerformanceMonitoring/SettingsSubscriber.php
@@ -1,0 +1,94 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Engine\Admin\PerformanceMonitoring;
+
+use WP_Rocket\Abstract_Render;
+use WP_Rocket\Engine\License\API\User;
+use WP_Rocket\Event_Management\Subscriber_Interface;
+
+/**
+ * Handle Add-On license status display
+ *
+ * @since 3.20
+ */
+class SettingsSubscriber extends Abstract_Render implements Subscriber_Interface {
+    /**
+     * User API client
+     *
+     * @var User
+     */
+    private $user;
+
+    /**
+     * Instantiate the class
+     *
+     * @param User   $user          User API client.
+     * @param string $template_path Path to the templates.
+     */
+    public function __construct(User $user, $template_path) {
+        parent::__construct($template_path);
+        $this->user = $user;
+    }
+
+    /**
+     * Events this subscriber listens to
+     *
+     * @return array
+     */
+    public static function get_subscribed_events() {
+        return [
+            'rocket_dashboard_after_account_data' => ['display_addon_status', 20], // Higher priority than RocketCDN
+        ];
+    }
+
+    /**
+     * Displays the Add-On license status on the dashboard tab
+     *
+     * @since 3.20
+     *
+     * @return void
+     */
+    public function display_addon_status() {
+        // Don't display for white label accounts
+        if ((bool) rocket_get_constant('WP_ROCKET_WHITE_LABEL_ACCOUNT')) {
+            return;
+        }
+
+		$container_class = ' wpr-flex--egal';
+		$status_class    = ' wpr-isInvalid';
+        $label           = '';
+		$status_text     = __('No subscription', 'rocket');
+        $service_name    = __('Rocket Insights', 'rocket');
+		$sku = $this->user->get_pma_addon_sku_active();
+
+
+
+		$is_active = $this->user->is_pma_addon_active($sku);
+
+		$upgrade_link    = $this->user->get_pma_addon_btn_url($sku);
+
+        if ($is_active) {
+            $label        = __('Expiration Date', 'rocket');
+            $status_class = ' wpr-isValid';
+            $status_text  = date_i18n(get_option('date_format'), $this->user->get_pma_license_expiration());
+		}
+
+        $data = [
+            'is_live_site'    => rocket_is_live_site(),
+            'container_class' => $container_class,
+            'label'           => $label,
+            'status_class'    => $status_class,
+            'status_text'     => $status_text,
+            'is_active'       => $is_active,
+            'service_name'    => $service_name,
+        ];
+
+		if($upgrade_link) {
+			$data['upgrade_link'] = $upgrade_link;
+			$data['upgrade_text'] = $this->user->get_pma_addon_btn_text($sku);
+		}
+
+        echo $this->generate('dashboard-addon-status', $data);
+    }
+}

--- a/inc/Engine/Admin/PerformanceMonitoring/SettingsSubscriber.php
+++ b/inc/Engine/Admin/PerformanceMonitoring/SettingsSubscriber.php
@@ -55,11 +55,11 @@ class SettingsSubscriber extends Abstract_Render implements Subscriber_Interface
 			return;
 		}
 
-		$status_class    = ' wpr-isInvalid';
-		$label           = '';
-		$status_text     = __( 'No subscription', 'rocket' );
-		$service_name    = __( 'Rocket Insights', 'rocket' );
-		$sku             = $this->user->get_pma_addon_sku_active();
+		$status_class = ' wpr-isInvalid';
+		$label        = '';
+		$status_text  = __( 'No subscription', 'rocket' );
+		$service_name = __( 'Rocket Insights', 'rocket' );
+		$sku          = $this->user->get_pma_addon_sku_active();
 
 		$upgrade_skus = $this->user->get_pma_addon_upgrade_skus( $sku );
 
@@ -82,10 +82,10 @@ class SettingsSubscriber extends Abstract_Render implements Subscriber_Interface
 		];
 
 		if ( count( $upgrade_skus ) > 0 ) {
-			$upgrade_sku  = array_shift( $upgrade_skus );
-			$upgrade_link = $this->user->get_pma_addon_btn_url( $upgrade_sku );
-			$data['upgrade_link'] = $upgrade_link;
-			$data['upgrade_text'] = $this->user->get_pma_addon_btn_text( $upgrade_sku );
+			$upgrade_sku             = array_shift( $upgrade_skus );
+			$upgrade_link            = $this->user->get_pma_addon_btn_url( $upgrade_sku );
+			$data['upgrade_link']    = $upgrade_link;
+			$data['upgrade_text']    = $this->user->get_pma_addon_btn_text( $upgrade_sku );
 			$data['container_class'] = ' wpr-flex--egal';
 		}
 

--- a/inc/Engine/Admin/PerformanceMonitoring/SettingsSubscriber.php
+++ b/inc/Engine/Admin/PerformanceMonitoring/SettingsSubscriber.php
@@ -38,7 +38,7 @@ class SettingsSubscriber extends Abstract_Render implements Subscriber_Interface
 	 */
 	public static function get_subscribed_events() {
 		return [
-			'rocket_dashboard_after_account_data' => [ 'display_addon_status', 20 ], // Higher priority than RocketCDN.
+			'rocket_dashboard_after_account_data' => [ 'display_addon_status', 9 ], // Higher priority than RocketCDN.
 		];
 	}
 
@@ -57,7 +57,7 @@ class SettingsSubscriber extends Abstract_Render implements Subscriber_Interface
 
 		$status_class = ' wpr-isInvalid';
 		$label        = '';
-		$status_text  = __( 'No subscription', 'rocket' );
+		$status_text  = __( 'No Subscription', 'rocket' );
 		$service_name = __( 'Rocket Insights', 'rocket' );
 		$sku          = $this->user->get_pma_addon_sku_active();
 
@@ -66,7 +66,7 @@ class SettingsSubscriber extends Abstract_Render implements Subscriber_Interface
 		$is_active = $this->user->is_pma_addon_active( $sku );
 
 		if ( $is_active ) {
-			$label        = __( 'Expiration Date', 'rocket' );
+			$label        = __( 'Next Billing Date', 'rocket' );
 			$status_class = ' wpr-isValid';
 			$status_text  = date_i18n( get_option( 'date_format' ), $this->user->get_pma_license_expiration() );
 		}

--- a/inc/Engine/Admin/PerformanceMonitoring/SettingsSubscriber.php
+++ b/inc/Engine/Admin/PerformanceMonitoring/SettingsSubscriber.php
@@ -13,82 +13,82 @@ use WP_Rocket\Event_Management\Subscriber_Interface;
  * @since 3.20
  */
 class SettingsSubscriber extends Abstract_Render implements Subscriber_Interface {
-    /**
-     * User API client
-     *
-     * @var User
-     */
-    private $user;
+	/**
+	 * User API client
+	 *
+	 * @var User
+	 */
+	private $user;
 
-    /**
-     * Instantiate the class
-     *
-     * @param User   $user          User API client.
-     * @param string $template_path Path to the templates.
-     */
-    public function __construct(User $user, $template_path) {
-        parent::__construct($template_path);
-        $this->user = $user;
-    }
+	/**
+	 * Instantiate the class
+	 *
+	 * @param User   $user          User API client.
+	 * @param string $template_path Path to the templates.
+	 */
+	public function __construct( User $user, $template_path ) {
+		parent::__construct( $template_path );
+		$this->user = $user;
+	}
 
-    /**
-     * Events this subscriber listens to
-     *
-     * @return array
-     */
-    public static function get_subscribed_events() {
-        return [
-            'rocket_dashboard_after_account_data' => ['display_addon_status', 20], // Higher priority than RocketCDN
-        ];
-    }
+	/**
+	 * Events this subscriber listens to
+	 *
+	 * @return array
+	 */
+	public static function get_subscribed_events() {
+		return [
+			'rocket_dashboard_after_account_data' => [ 'display_addon_status', 20 ], // Higher priority than RocketCDN.
+		];
+	}
 
-    /**
-     * Displays the Add-On license status on the dashboard tab
-     *
-     * @since 3.20
-     *
-     * @return void
-     */
-    public function display_addon_status() {
-        // Don't display for white label accounts
-        if ((bool) rocket_get_constant('WP_ROCKET_WHITE_LABEL_ACCOUNT')) {
-            return;
-        }
+	/**
+	 * Displays the Add-On license status on the dashboard tab
+	 *
+	 * @since 3.20
+	 *
+	 * @return void
+	 */
+	public function display_addon_status() {
 
-		$container_class = ' wpr-flex--egal';
+		if ( (bool) rocket_get_constant( 'WP_ROCKET_WHITE_LABEL_ACCOUNT' ) ) {
+			return;
+		}
+
 		$status_class    = ' wpr-isInvalid';
-        $label           = '';
-		$status_text     = __('No subscription', 'rocket');
-        $service_name    = __('Rocket Insights', 'rocket');
-		$sku = $this->user->get_pma_addon_sku_active();
+		$label           = '';
+		$status_text     = __( 'No subscription', 'rocket' );
+		$service_name    = __( 'Rocket Insights', 'rocket' );
+		$sku             = $this->user->get_pma_addon_sku_active();
 
+		$upgrade_skus = $this->user->get_pma_addon_upgrade_skus( $sku );
 
+		$is_active = $this->user->is_pma_addon_active( $sku );
 
-		$is_active = $this->user->is_pma_addon_active($sku);
-
-		$upgrade_link    = $this->user->get_pma_addon_btn_url($sku);
-
-        if ($is_active) {
-            $label        = __('Expiration Date', 'rocket');
-            $status_class = ' wpr-isValid';
-            $status_text  = date_i18n(get_option('date_format'), $this->user->get_pma_license_expiration());
+		if ( $is_active ) {
+			$label        = __( 'Expiration Date', 'rocket' );
+			$status_class = ' wpr-isValid';
+			$status_text  = date_i18n( get_option( 'date_format' ), $this->user->get_pma_license_expiration() );
 		}
 
-        $data = [
-            'is_live_site'    => rocket_is_live_site(),
-            'container_class' => $container_class,
-            'label'           => $label,
-            'status_class'    => $status_class,
-            'status_text'     => $status_text,
-            'is_active'       => $is_active,
-            'service_name'    => $service_name,
-        ];
+		$data = [
+			'is_live_site'    => true,//rocket_is_live_site(),
+			'container_class' => '',
+			'label'           => $label,
+			'status_class'    => $status_class,
+			'status_text'     => $status_text,
+			'is_active'       => $is_active,
+			'service_name'    => $service_name,
+		];
 
-		if($upgrade_link) {
+		if ( count( $upgrade_skus ) > 0 ) {
+			$upgrade_sku  = array_shift( $upgrade_skus );
+			$upgrade_link = $this->user->get_pma_addon_btn_url( $upgrade_sku );
 			$data['upgrade_link'] = $upgrade_link;
-			$data['upgrade_text'] = $this->user->get_pma_addon_btn_text($sku);
+			$data['upgrade_text'] = $this->user->get_pma_addon_btn_text( $upgrade_sku );
+			$data['container_class'] = ' wpr-flex--egal';
 		}
 
-        echo $this->generate('dashboard-addon-status', $data);
-    }
+		echo $this->generate( 'dashboard-addon-status', $data ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	}
 }

--- a/inc/Engine/CDN/RocketCDN/AdminPageSubscriber.php
+++ b/inc/Engine/CDN/RocketCDN/AdminPageSubscriber.php
@@ -91,6 +91,9 @@ class AdminPageSubscriber extends Abstract_Render implements Subscriber_Interfac
 		$label           = '';
 		$status_text     = '';
 		$is_active       = false;
+		$service_name    = 'RocketCDN';
+		$upgrade_text    = __( 'Get RocketCDN', 'rocket' );
+		$upgrade_link    = '#page_cdn';
 
 		if ( 'running' === $subscription_data['subscription_status'] ) {
 			$label        = __( 'Next Billing Date', 'rocket' );
@@ -110,9 +113,12 @@ class AdminPageSubscriber extends Abstract_Render implements Subscriber_Interfac
 			'status_class'    => $status_class,
 			'status_text'     => $status_text,
 			'is_active'       => $is_active,
+			'service_name'    => $service_name,
+			'upgrade_link'    => $upgrade_link,
+			'upgrade_text'    => $upgrade_text,
 		];
 
-		echo $this->generate( 'dashboard-status', $data ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Dynamic content is properly escaped in the view.
+		echo $this->generate( '../License/views/dashboard-addon-status', $data ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Dynamic content is properly escaped in the view.
 	}
 
 	/**

--- a/inc/Engine/CDN/RocketCDN/AdminPageSubscriber.php
+++ b/inc/Engine/CDN/RocketCDN/AdminPageSubscriber.php
@@ -113,12 +113,9 @@ class AdminPageSubscriber extends Abstract_Render implements Subscriber_Interfac
 			'status_class'    => $status_class,
 			'status_text'     => $status_text,
 			'is_active'       => $is_active,
-			'service_name'    => $service_name,
-			'upgrade_link'    => $upgrade_link,
-			'upgrade_text'    => $upgrade_text,
 		];
 
-		echo $this->generate( '../License/views/dashboard-addon-status', $data ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Dynamic content is properly escaped in the view.
+		echo $this->generate( 'dashboard-status', $data ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Dynamic content is properly escaped in the view.
 	}
 
 	/**

--- a/inc/Engine/CDN/RocketCDN/AdminPageSubscriber.php
+++ b/inc/Engine/CDN/RocketCDN/AdminPageSubscriber.php
@@ -91,9 +91,6 @@ class AdminPageSubscriber extends Abstract_Render implements Subscriber_Interfac
 		$label           = '';
 		$status_text     = '';
 		$is_active       = false;
-		$service_name    = 'RocketCDN';
-		$upgrade_text    = __( 'Get RocketCDN', 'rocket' );
-		$upgrade_link    = '#page_cdn';
 
 		if ( 'running' === $subscription_data['subscription_status'] ) {
 			$label        = __( 'Next Billing Date', 'rocket' );

--- a/inc/Engine/License/API/User.php
+++ b/inc/Engine/License/API/User.php
@@ -19,6 +19,10 @@ class User {
 		$this->user = is_object( $user ) ? $user : new \stdClass();
 	}
 
+	public function set_user($user) {
+		$this->user = $user;
+	}
+
 	/**
 	 * Gets the user license type
 	 *
@@ -144,5 +148,73 @@ class User {
 			return [];
 		}
 		return (array) $this->user->licence->prices->upgrades;
+	}
+
+	/**
+	 * Gets the addon license expiration timestamp
+	 *
+	 * @since 3.20
+	 *
+	 * @return int
+	 */
+	public function get_pma_license_expiration() {
+		if ( ! isset( $this->user->performance_monitoring->expiration ) ) {
+			return 0;
+		}
+
+		return (int) $this->user->performance_monitoring->expiration;
+	}
+
+	/**
+	 * Checks if the addon license is active
+	 *
+	 * @since 3.20
+	 *
+	 * @return boolean
+	 */
+	public function is_pma_addon_active(string $sku) {
+		return 'perf-monitor-free' !== $sku;
+	}
+
+	public function get_pma_addon_sku_active(): string {
+
+		if( ! isset( $this->user->performance_monitoring ) || ! isset( $this->user->performance_monitoring->active_sku )) {
+			return '';
+		}
+
+		return (string) $this->user->performance_monitoring->active_sku;
+	}
+
+	public function get_pma_addon_btn_text(string $sku) {
+		$plan = $this->get_pma_data($sku);
+		if(! $plan) {
+			return '';
+		}
+
+		return $plan->button->label;
+	}
+
+	public function get_pma_addon_btn_url(string $sku) {
+		$plan = $this->get_pma_data($sku);
+
+		if(! $plan) {
+			return '';
+		}
+
+		return $plan->button->url;
+	}
+
+	protected function get_pma_data(string $sku) {
+
+		if( ! isset( $this->user->performance_monitoring ) || ! isset( $this->user->performance_monitoring->plans )) {
+			return null;
+		}
+
+		foreach ( $this->user->performance_monitoring->plans as $plan ) {
+			if ( $plan->sku === $sku ) {
+				return $plan;
+			}
+		}
+		return null;
 	}
 }

--- a/inc/Engine/License/API/User.php
+++ b/inc/Engine/License/API/User.php
@@ -19,7 +19,14 @@ class User {
 		$this->user = is_object( $user ) ? $user : new \stdClass();
 	}
 
-	public function set_user($user) {
+	/**
+	 * Set the user object.
+	 *
+	 * @param object $user The user object.
+	 *
+	 * @return void
+	 */
+	public function set_user( $user ) {
 		$this->user = $user;
 	}
 
@@ -168,45 +175,91 @@ class User {
 	/**
 	 * Checks if the addon license is active
 	 *
+	 * @param string $sku The SKU of the addon.
+	 *
 	 * @since 3.20
 	 *
 	 * @return boolean
 	 */
-	public function is_pma_addon_active(string $sku) {
+	public function is_pma_addon_active( string $sku ) {
 		return 'perf-monitor-free' !== $sku;
 	}
 
+	/**
+	 * Retrieves the active SKU for the Performance Monitoring Addon.
+	 *
+	 * @since 3.20
+	 *
+	 * @return string
+	 */
 	public function get_pma_addon_sku_active(): string {
 
-		if( ! isset( $this->user->performance_monitoring ) || ! isset( $this->user->performance_monitoring->active_sku )) {
+		if ( ! isset( $this->user->performance_monitoring ) || ! isset( $this->user->performance_monitoring->active_sku ) ) {
 			return '';
 		}
 
 		return (string) $this->user->performance_monitoring->active_sku;
 	}
 
-	public function get_pma_addon_btn_text(string $sku) {
-		$plan = $this->get_pma_data($sku);
-		if(! $plan) {
+	/**
+	 * Retrieves the PMA addon upgrade SKUs based on the provided SKU.
+	 *
+	 * @param string $sku The SKU for which to retrieve the upgrade data.
+	 *
+	 * @return array
+	 */
+	public function get_pma_addon_upgrade_skus( string $sku ) {
+		$plan = $this->get_pma_data( $sku );
+		if ( ! $plan || ! isset( $plan->upgrades ) ) {
+			return [];
+		}
+
+		return $plan->upgrades;
+	}
+
+	/**
+	 * Retrieves the button text for the PMA addon based on the provided SKU.
+	 *
+	 * @param string $sku The SKU used to fetch the PMA addon data.
+	 *
+	 * @return string
+	 */
+	public function get_pma_addon_btn_text( string $sku ) {
+		$plan = $this->get_pma_data( $sku );
+		if ( ! $plan ) {
 			return '';
 		}
 
 		return $plan->button->label;
 	}
 
-	public function get_pma_addon_btn_url(string $sku) {
-		$plan = $this->get_pma_data($sku);
+	/**
+	 * Retrieves the URL for the PMA add-on button associated with the specified SKU.
+	 *
+	 * @param string $sku The SKU identifier used to fetch.
+	 *
+	 * @return string
+	 */
+	public function get_pma_addon_btn_url( string $sku ) {
+		$plan = $this->get_pma_data( $sku );
 
-		if(! $plan) {
+		if ( ! $plan ) {
 			return '';
 		}
 
 		return $plan->button->url;
 	}
 
-	protected function get_pma_data(string $sku) {
+	/**
+	 * Retrieves the performance monitoring plan data associated with the specified SKU.
+	 *
+	 * @param string $sku The SKU identifier used to find the corresponding performance monitoring plan.
+	 *
+	 * @return object|null
+	 */
+	protected function get_pma_data( string $sku ) {
 
-		if( ! isset( $this->user->performance_monitoring ) || ! isset( $this->user->performance_monitoring->plans )) {
+		if ( ! isset( $this->user->performance_monitoring ) || ! isset( $this->user->performance_monitoring->plans ) ) {
 			return null;
 		}
 

--- a/inc/Engine/License/views/dashboard-addon-status.php
+++ b/inc/Engine/License/views/dashboard-addon-status.php
@@ -24,14 +24,22 @@ $data = isset( $data ) && is_array( $data ) ? $data : []; // phpcs:ignore WordPr
 </div>
 <div class="wpr-field wpr-field-account">
 	<?php if ( ! $data['is_live_site'] ) : ?>
-	<span class="wpr-infoAccount wpr-isInvalid"><?php printf( esc_html__( '%s is unavailable on local domains and staging sites.', 'rocket' ), esc_html( $data['service_name'] ) ); ?></span>
+	<span class="wpr-infoAccount wpr-isInvalid">
+		<?php
+		printf(
+		/* translators: %1$s = domain. */
+		esc_html__( '%s is unavailable on local domains and staging sites.', 'rocket' ),
+		esc_html( $data['service_name'] )
+												);
+		?>
+		</span>
 	<?php else : ?>
 	<div class="wpr-flex<?php echo esc_attr( $data['container_class'] ); ?>">
 		<div>
 			<span class="wpr-title3"><?php echo esc_html( $data['label'] ); ?></span>
 			<span class="wpr-infoAccount<?php echo esc_attr( $data['status_class'] ); ?>"><?php echo esc_html( $data['status_text'] ); ?></span>
 		</div>
-		<?php if ( key_exists('upgrade_link', $data) ) : ?>
+		<?php if ( key_exists( 'upgrade_link', $data ) ) : ?>
 		<div>
 			<a href="<?php echo esc_url( $data['upgrade_link'] ); ?>" class="wpr-button"><?php echo esc_html( $data['upgrade_text'] ); ?></a>
 		</div>

--- a/inc/Engine/License/views/dashboard-addon-status.php
+++ b/inc/Engine/License/views/dashboard-addon-status.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Add-On license status on dashboard tab template.
+ *
+ * @since 3.20
+ *
+ * @param array $data {
+ *    @type bool   $is_live_site    Identifies if the current website is a live or local/staging one.
+ *    @type string $container_class Flex container CSS class.
+ *    @type string $label           Content label.
+ *    @type string $status_class    CSS Class to display the status.
+ *    @type string $status_text     Text to display the subscription status.
+ *    @type bool   $is_active       Boolean identifying the activation status.
+ *    @type string $service_name    Name of the service to display.
+ *    @type string $upgrade_link    Link to the upgrade page.
+ *    @type string $upgrade_text    Text for the upgrade button.
+ * }
+ */
+
+$data = isset( $data ) && is_array( $data ) ? $data : []; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+?>
+<div class="wpr-optionHeader">
+	<h3 class="wpr-title2"><?php echo esc_html( $data['service_name'] ); ?></h3>
+</div>
+<div class="wpr-field wpr-field-account">
+	<?php if ( ! $data['is_live_site'] ) : ?>
+	<span class="wpr-infoAccount wpr-isInvalid"><?php printf( esc_html__( '%s is unavailable on local domains and staging sites.', 'rocket' ), esc_html( $data['service_name'] ) ); ?></span>
+	<?php else : ?>
+	<div class="wpr-flex<?php echo esc_attr( $data['container_class'] ); ?>">
+		<div>
+			<span class="wpr-title3"><?php echo esc_html( $data['label'] ); ?></span>
+			<span class="wpr-infoAccount<?php echo esc_attr( $data['status_class'] ); ?>"><?php echo esc_html( $data['status_text'] ); ?></span>
+		</div>
+		<?php if ( key_exists('upgrade_link', $data) ) : ?>
+		<div>
+			<a href="<?php echo esc_url( $data['upgrade_link'] ); ?>" class="wpr-button"><?php echo esc_html( $data['upgrade_text'] ); ?></a>
+		</div>
+		<?php endif; ?>
+	</div>
+	<?php endif; ?>
+</div>

--- a/inc/Engine/Tracking/Subscriber.php
+++ b/inc/Engine/Tracking/Subscriber.php
@@ -31,7 +31,7 @@ class Subscriber implements Subscriber_Interface {
 		return [
 			'update_option_wp_rocket_settings'    => [ 'track_option_change', 10, 2 ],
 			'wp_rocket_upgrade'                   => [ 'migrate_optin', 10, 2 ],
-			'rocket_dashboard_after_account_data' => [ 'render_optin', 9 ],
+			'rocket_dashboard_after_account_data' => [ 'render_optin', 8 ],
 			'wp_ajax_rocket_toggle_optin'         => [ 'ajax_toggle_optin' ],
 			'admin_enqueue_scripts'               => [ 'localize_optin_status', 15 ],
 			'admin_print_scripts'                 => [ 'inject_mixpanel_script' ],

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -234,6 +234,7 @@ class Plugin {
 			'media_fonts_admin_subscriber',
 			'preload_fonts_admin_subscriber',
 			'pm_subscriber',
+			'pm_settings_subscriber',
 		];
 
 		// Only add tracking service provider if cURL extension is loaded.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -66,6 +66,11 @@ parameters:
 			path: inc/Engine/Admin/PerformanceMonitoring/Context/PerformanceMonitoringContext.php
 
 		-
+			message: "#^Usage of get_option\\(\\) is discouraged\\. Use the Option object instead\\.$#"
+			count: 1
+			path: inc/Engine/Admin/PerformanceMonitoring/SettingsSubscriber.php
+
+		-
 			message: "#^Usage of apply_filters\\(\\) is discouraged\\. Use wpm_apply_filters_typed\\(\\) instead\\.$#"
 			count: 12
 			path: inc/Engine/Admin/Settings/Page.php
@@ -899,6 +904,16 @@ parameters:
 			message: "#^Usage of apply_filters\\(\\) is discouraged\\. Use wpm_apply_filters_typed\\(\\) instead\\.$#"
 			count: 29
 			path: tests/Integration/inc/Engine/Admin/PerformanceMonitoring/Database/Tables/truncate_table.php
+
+		-
+			message: "#^Usage of apply_filters\\(\\) is discouraged\\. Use wpm_apply_filters_typed\\(\\) instead\\.$#"
+			count: 1
+			path: tests/Integration/inc/Engine/Admin/PerformanceMonitoring/SettingsSubscriber/displayAddonStatus.php
+
+		-
+			message: "#^Usage of update_option\\(\\) is discouraged\\. Use the Option object instead\\.$#"
+			count: 1
+			path: tests/Integration/inc/Engine/Admin/PerformanceMonitoring/SettingsSubscriber/displayAddonStatus.php
 
 		-
 			message: "#^Usage of apply_filters\\(\\) is discouraged\\. Use wpm_apply_filters_typed\\(\\) instead\\.$#"

--- a/tests/Fixtures/inc/Engine/Admin/PerformanceMonitoring/SettingsSubscriber/UserDataGenerator.php
+++ b/tests/Fixtures/inc/Engine/Admin/PerformanceMonitoring/SettingsSubscriber/UserDataGenerator.php
@@ -23,6 +23,9 @@ class UserDataGenerator {
 		$plans[] = (object) [
 			"sku" => "perf-monitor-free",
 			"status" => $this->pma_sku_active == "perf-monitor-free" ? "active" : "inactive",
+			"upgrades" => [
+				"perf-monitor-advanced"
+			],
 			"button" => (object) [
 				"label" => "Your plan",
 				"action" => "none",
@@ -33,6 +36,7 @@ class UserDataGenerator {
 		$plans[] = (object) [
 			"sku" => "perf-monitor-advanced",
 			"status" => $this->pma_sku_active == "perf-monitor-advanced" ? "active" : "inactive",
+			"upgrades" => [],
 			"button" => (object) [
 				"label" => "Get Advanced",
 				"action" => "purchase",

--- a/tests/Fixtures/inc/Engine/Admin/PerformanceMonitoring/SettingsSubscriber/UserDataGenerator.php
+++ b/tests/Fixtures/inc/Engine/Admin/PerformanceMonitoring/SettingsSubscriber/UserDataGenerator.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace WP_Rocket\Tests\Fixtures\inc\Engine\Admin\PerformanceMonitoring\SettingsSubscriber;
+
+class UserDataGenerator {
+
+	protected $pma_sku_active ='perf-monitor-free';
+
+	protected $expiration = 0;
+
+	public function with_pma_expiration(int $expiration): self {
+		$this->expiration = $expiration;
+		return $this;
+	}
+
+	public function with_pma_active_sku(string $sku): self {
+		$this->pma_sku_active = $sku;
+		return $this;
+	}
+
+	public function generate() {
+
+		$plans[] = (object) [
+			"sku" => "perf-monitor-free",
+			"status" => $this->pma_sku_active == "perf-monitor-free" ? "active" : "inactive",
+			"button" => (object) [
+				"label" => "Your plan",
+				"action" => "none",
+				"url" => null,
+			]
+		];
+
+		$plans[] = (object) [
+			"sku" => "perf-monitor-advanced",
+			"status" => $this->pma_sku_active == "perf-monitor-advanced" ? "active" : "inactive",
+			"button" => (object) [
+				"label" => "Get Advanced",
+				"action" => "purchase",
+				"url" => "https://wp-rocket.me/express-checkout/?user_id=202331&domain=random.app&product_sku=perf-monitor-advanced&consumer_key=12be53be",
+			],
+			"price" => "0.00"
+		];
+
+		return (object)[
+			'performance_monitoring' => (object) [
+				"expiration" => $this->expiration,
+				"active_sku" => $this->pma_sku_active,
+				"plans" => $plans,
+			]
+		];
+	}
+}

--- a/tests/Fixtures/inc/Engine/Admin/PerformanceMonitoring/SettingsSubscriber/displayAddonStatus.php
+++ b/tests/Fixtures/inc/Engine/Admin/PerformanceMonitoring/SettingsSubscriber/displayAddonStatus.php
@@ -12,7 +12,7 @@ return [
 			'customer_data' => (new UserDataGenerator())->generate()
 		],
 		'expected' => <<<HTML
-<span class="wpr-infoAccount wpr-isInvalid">No subscription</span>
+<span class="wpr-infoAccount wpr-isInvalid">No Subscription</span>
 HTML
 	],
 	'testShouldOutputAddonLicenseStatusWhenActive' => [
@@ -27,7 +27,7 @@ HTML
 		],
 		'expected' => <<<HTML
 		<div>
-			<span class="wpr-title3">Expiration Date</span>
+			<span class="wpr-title3">Next Billing Date</span>
 			<span class="wpr-infoAccount wpr-isValid">September 2, 2025</span>
 		</div>
 HTML

--- a/tests/Fixtures/inc/Engine/Admin/PerformanceMonitoring/SettingsSubscriber/displayAddonStatus.php
+++ b/tests/Fixtures/inc/Engine/Admin/PerformanceMonitoring/SettingsSubscriber/displayAddonStatus.php
@@ -1,0 +1,35 @@
+<?php
+
+use WP_Rocket\Tests\Fixtures\inc\Engine\Admin\PerformanceMonitoring\SettingsSubscriber\UserDataGenerator;
+
+require_once __DIR__ . '/UserDataGenerator.php';
+
+return [
+	'testShouldRenderFreeVersionHTMLWhenNotActive' => [
+		'config' => [
+			'rocket_display_addon_status' => true,
+			'is_live_site' => true,
+			'customer_data' => (new UserDataGenerator())->generate()
+		],
+		'expected' => <<<HTML
+<span class="wpr-infoAccount wpr-isInvalid">No subscription</span>
+HTML
+	],
+	'testShouldOutputAddonLicenseStatusWhenActive' => [
+		'config' => [
+			'rocket_display_addon_status' => true,
+			'is_live_site' => true,
+			'date_format' => 'F j, Y',
+			'customer_data' => (new UserDataGenerator())
+				->with_pma_active_sku('perf-monitor-advanced')
+				->with_pma_expiration(1756841100)
+				->generate()
+		],
+		'expected' => <<<HTML
+		<div>
+			<span class="wpr-title3">Expiration Date</span>
+			<span class="wpr-infoAccount wpr-isValid">September 2, 2025</span>
+		</div>
+HTML
+	],
+];

--- a/tests/Integration/inc/Engine/Admin/PerformanceMonitoring/SettingsSubscriber/displayAddonStatus.php
+++ b/tests/Integration/inc/Engine/Admin/PerformanceMonitoring/SettingsSubscriber/displayAddonStatus.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\Admin\PerformanceMonitoring\SettingsSubscriber;
+
+use WP_Rocket\Tests\Integration\TestCase;
+use WP_Rocket\Engine\Admin\PerformanceMonitoring\SettingsSubscriber;
+
+/**
+ * @covers \WP_Rocket\Engine\Admin\PerformanceMonitoring\SettingsSubscriber::display_addon_status
+ *
+ * @group License
+ * @group AdminOnly
+ */
+class Test_DisplayAddonStatus extends TestCase {
+
+	protected $display_addon_status;
+
+	protected $customer_data;
+
+    public function set_up() {
+        parent::set_up();
+
+		add_filter('rocket_display_addon_status', [$this, 'filter_rocket_display_addon_status']);
+	}
+
+    public function tear_down() {
+        remove_filter('rocket_display_addon_status', [$this, 'filter_rocket_display_addon_status']);
+
+        parent::tear_down();
+    }
+
+    /**
+     * @dataProvider configTestData
+     */
+    public function testShouldReturnExpected($config, $expected) {
+		$this->display_addon_status = $config['rocket_display_addon_status'];
+
+		$container = apply_filters('rocket_container', null);
+
+		$container->get('user')->set_user($config['customer_data']);
+
+        if (isset($config['date_format'])) {
+            update_option('date_format', $config['date_format']);
+        }
+
+        ob_start();
+        do_action('rocket_dashboard_after_account_data');
+        $actual = ob_get_clean();
+
+        $this->assertStringContainsString($this->format_the_html($expected), $this->format_the_html($actual));
+    }
+
+    public function filter_rocket_display_addon_status() {
+        return $this->display_addon_status;
+    }
+
+    protected function format_the_html($html) {
+        return preg_replace('/[\s]+/', ' ', trim(preg_replace('/[\r\n\t]+/', '', $html)));
+    }
+}


### PR DESCRIPTION
# Description

Fixes #7595
This code enhances the WP Rocket dashboard by displaying the Performance Monitoring (Rocket Insights) add-on license status, giving website administrators clear visibility into their subscription status, expiration date, and upgrade options.

Issue https://github.com/wp-media/wp-rocket.me/issues/5166 needs to be implemented for the endpoint.

## Type of change

- [x] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

The following scenarios were tested using automated integration tests:
- Display of active license with expiration date
- Display of inactive license with "No subscription" status

### How to test

1. Setup a WordPress installation with WP Rocket
2. Install and activate the Performance Monitoring add-on
3. Navigate to the WP Rocket dashboard
4. Verify that the Performance Monitoring license status appears showing:
   - "Rocket Insights" as the service name
   - License status (active/inactive)
   - Expiration date for active licenses
   - Upgrade button when applicable

Note: to test we need the correct information inside the plugin.

For that we can mock the user.php endpoint.

Inside `wp-rocket.php` add inside ``:
```php
	set_transient( 'wp_rocket_customer_data', json_decode( file_get_contents( __DIR__ . '/payload.json' ) ), DAY_IN_SECONDS );
```
 and create `payload.json`:
```json
{
	"ID": "202331",
	"licence": {
		"type": "infinite",
		"name": "Infinite",
		"websites": "-1",
		"version": "",
		"expiration": "1776853494",
		"prices": {
			"regular": 299,
			"renewal": 299,
			"sale": 209.3,
			"promotion": {
				"name": "Anniversary",
				"discount_percent": 30,
				"start_date": 1750723200,
				"end_date": 1752019199
			},
			"upgrades": [],
			"is_promo_active": false
		},
		"renewal_url": "https://wp-rocket.me/checkout/renew/202331/96434afd8c17fd703e22e73e604a9bb6/"
	},
	"first_name": "Test",
	"email": "test@wp-media.me",
	"date_created": "1643374416",
	"licence_account": "-1",
	"licence_version": "",
	"licence_expiration": "1776853494",
	"consumer_key": "12be53be",
	"is_blocked": "0",
	"is_staggered": "0",
	"has_auto_renew": "0",
	"has_one-com_account": "0",
	"status": "active",
	"last_order_reseller_id": "0",
	"renewal_url": "https://wp-rocket.me/checkout/renew/202331/96434afd8c17fd703e22e73e604a9bb6/",
	"upgrade_plus_url": "https://wp-rocket.me/checkout/upgrade/202331/12be53be/plus/",
	"upgrade_infinite_url": "https://wp-rocket.me/checkout/upgrade/202331/12be53be/infinite/",
	"performance_monitoring": {
		"expiration": null,
		"manage_url": null,
		"active_sku": "perf-monitor-advanced",
		"plans": [
			{
				"sku": "perf-monitor-free",
				"title": "Basic",
				"subtitle": "Free",
				"upgrades" : [
					"perf-monitor-advanced"
				],
				"description": "1 page • 1 monthly update",
				"status": "inactive",
				"button": {
					"label": "Your plan",
					"action": "none",
					"url": null
				},
				"price": "0.00"
			},
			{
				"sku": "perf-monitor-advanced",
				"title": "Advanced",
				"subtitle": "",
				"description": "Up to 10 pages • Weekly updates",
				"status": "active",
				"button": {
					"label": "Get Advanced",
					"action": "purchase",
					"url": "https://wp-rocket.me/express-checkout/?user_id=202331&domain=random.app&product_sku=perf-monitor-advanced&consumer_key=12be53be"
				},
				"price": "2.00"
			}
		]
	}
}

```

## Technical description

### Documentation

This implementation fetches and displays the Performance Monitoring add-on license status in the WP Rocket dashboard. 

The code works through these key components:
1. `SettingsSubscriber` class - Hooks into `rocket_dashboard_after_account_data` and renders the add-on status display
2. Enhanced `User` API client - Provides methods to fetch addon license data, check status, and generate upgrade URLs
3. Dashboard view template - Displays the add-on license status with appropriate styling and layout

The process flow:
1. When dashboard loads, `display_addon_status()` is called
2. API client methods check if addon is active and retrieve license data
3. If active, expiration date is shown; if inactive, "No subscription" is displayed
4. Upgrade options are shown when available based on the current SKU

### New dependencies

No new dependencies were added.

### Risks

No significant performance or security risks as the code follows the existing patterns used for similar functionality like RocketCDN status display.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

All mandatory items are completed.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)