### PR TITLE
Closes #7639: 3.20 - Global Score Widget: Add Homepage to be monitored from global score widget

### DIFF
--- a/inc/Engine/Admin/PerformanceMonitoring/Controller.php
+++ b/inc/Engine/Admin/PerformanceMonitoring/Controller.php
@@ -141,6 +141,29 @@ class Controller {
 	}
 
 	/**
+	 * Adds homepage for monitoring from the dashboard widget.
+	 *
+	 * @return void
+	 */
+	public function add_homepage_from_widget() {
+		if ( ! $this->context->is_allowed() ) {
+			wp_die();
+		}
+
+		if (
+			! isset( $_GET['_wpnonce'] )
+			||
+			! wp_verify_nonce( sanitize_key( $_GET['_wpnonce'] ), 'rocket_pm_add_homepage' )
+		) {
+			wp_nonce_ays( 'rocket_pm_add_homepage' );
+		}
+
+		$this->add_homepage();
+
+		wp_safe_redirect( esc_url_raw( wp_get_referer() ) );
+	}
+
+	/**
 	 * Get global score data.
 	 *
 	 * @return array

--- a/inc/Engine/Admin/PerformanceMonitoring/Subscriber.php
+++ b/inc/Engine/Admin/PerformanceMonitoring/Subscriber.php
@@ -107,6 +107,7 @@ class Subscriber implements Subscriber_Interface, LoggerAwareInterface {
 			'rocket_pm_job_retest'                => 'reset_global_score',
 			'rocket_pm_job_deleted'               => 'reset_global_score',
 			'rocket_dashboard_sidebar'            => 'render_global_score_widget',
+			'admin_post_rocket_pm_add_homepage'	=> 'add_homepage_from_widget',
 		];
 	}
 
@@ -236,5 +237,14 @@ class Subscriber implements Subscriber_Interface, LoggerAwareInterface {
 	 */
 	public function render_global_score_widget(): void {
 		$this->render->render_global_score_widget( $this->controller->get_global_score() );
+	}
+
+	/**
+	 * Adds homepage for monitoring from the dashboard widget.
+	 *
+	 * @return void
+	 */
+	public function add_homepage_from_widget(): void {
+		$this->controller->add_homepage_from_widget();
 	}
 }

--- a/inc/Engine/Admin/PerformanceMonitoring/Subscriber.php
+++ b/inc/Engine/Admin/PerformanceMonitoring/Subscriber.php
@@ -107,7 +107,7 @@ class Subscriber implements Subscriber_Interface, LoggerAwareInterface {
 			'rocket_pm_job_retest'                => 'reset_global_score',
 			'rocket_pm_job_deleted'               => 'reset_global_score',
 			'rocket_dashboard_sidebar'            => 'render_global_score_widget',
-			'admin_post_rocket_pm_add_homepage'	=> 'add_homepage_from_widget',
+			'admin_post_rocket_pm_add_homepage'   => 'add_homepage_from_widget',
 		];
 	}
 

--- a/inc/classes/class-abstract-render.php
+++ b/inc/classes/class-abstract-render.php
@@ -126,6 +126,7 @@ abstract class Abstract_Render implements Render_Interface {
 			case 'rocket_purge_rocketcdn':
 			case 'rocket_clean_saas':
 			case 'rocket_clean_performance_hints':
+			case 'rocket_pm_add_homepage':
 				$referer = '';
 
 				if ( ! empty( $_SERVER['REQUEST_URI'] ) ) {

--- a/views/settings/partials/performance-monitoring/global-score-widget.php
+++ b/views/settings/partials/performance-monitoring/global-score-widget.php
@@ -33,7 +33,7 @@ defined( 'ABSPATH' ) || exit;
 					<?php
 					$this->render_action_button(
 						'link',
-						'rocket_pm_add_homepage',
+						$data['pages_num'] ? '' : 'rocket_pm_add_homepage',
 						[
 							'label'      => $data['pages_num'] ? __( 'Add Page', 'rocket' ) : __( 'Add Homepage', 'rocket' ),
 							'url'        => '#rocket_insights',

--- a/views/settings/partials/performance-monitoring/global-score-widget.php
+++ b/views/settings/partials/performance-monitoring/global-score-widget.php
@@ -33,12 +33,9 @@ defined( 'ABSPATH' ) || exit;
 					<?php
 					$this->render_action_button(
 						'link',
-						'',
+						'rocket_pm_add_homepage',
 						[
 							'label'      => $data['pages_num'] ? __( 'Add Page', 'rocket' ) : __( 'Add Homepage', 'rocket' ),
-							'parameters' => [
-								'type' => 'all',
-							],
 							'url'        => '#rocket_insights',
 							'attributes' => [
 								'class' => 'wpr-button wpr-button--icon wpr-button--small wpr-button--purple wpr-icon-plus wpr-button--no-min-width',


### PR DESCRIPTION
# Description

Fixes #7639 
Adds the functionality to add homepage directly from the the global score dashboard widget when there are no urls being monitored.

## Type of change

- [x] New feature (non-breaking change which adds functionality).

## Detailed scenario

### What was tested

Clicking the add homepage button on dashboard widget when there are urls being monitored would add the homepage url to be monitored.

### How to test

Same as what was tested.

## Technical description

### Documentation

New callback to admin_post_rocket_pm_add_homepage hook with callback to add homepage to DB for monitoring.

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

Did not add tests for this as the behaviour would change in this [issue](https://github.com/wp-media/wp-rocket/issues/7640) later

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
