### PR TITLE
Fix settings page display issue & translatable strings

### DIFF
--- a/inc/Engine/Admin/PerformanceMonitoring/Render.php
+++ b/inc/Engine/Admin/PerformanceMonitoring/Render.php
@@ -83,6 +83,8 @@ class Render extends Abstract_Render {
 	 * @return void
 	 */
 	public function render_global_score_widget( array $data ) {
+		$data['has_credit'] = $this->credit_manager->has_credit();
+
 		echo $this->get_global_score_widget( $data ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
@@ -103,6 +105,8 @@ class Render extends Abstract_Render {
 	 * @return string The rendered HTML for the performance monitoring row.
 	 */
 	public function get_performance_monitoring_list_row( object $data ): string {
+		$data['has_credit'] = $this->credit_manager->has_credit();
+
 		return $this->generate( 'partials/performance-monitoring/table-row', $data );
 	}
 
@@ -134,16 +138,7 @@ class Render extends Abstract_Render {
 	 * @return bool
 	 */
 	public function is_retest_btn_enabled( $item ) {
-		return ! $item->is_running() && $this->has_credit();
-	}
-
-	/**
-	 * Check there is a credit or not.
-	 *
-	 * @return bool
-	 */
-	public function has_credit() {
-		return $this->credit_manager->has_credit();
+		return ! $item->is_running() && $this->credit_manager->has_credit();
 	}
 
 	/**

--- a/inc/Engine/Admin/PerformanceMonitoring/Render.php
+++ b/inc/Engine/Admin/PerformanceMonitoring/Render.php
@@ -132,16 +132,6 @@ class Render extends Abstract_Render {
 	}
 
 	/**
-	 * Check if the retest button is enabled or not
-	 *
-	 * @param object $item DB row item.
-	 * @return bool
-	 */
-	public function is_retest_btn_enabled( $item ) {
-		return ! $item->is_running() && $this->credit_manager->has_credit();
-	}
-
-	/**
 	 * Render the license banner section from views.
 	 *
 	 * @param array $data Data to render the license banner section.

--- a/views/settings/partials/performance-monitoring/global-score-row.php
+++ b/views/settings/partials/performance-monitoring/global-score-row.php
@@ -13,9 +13,9 @@ defined( 'ABSPATH' ) || exit;
 	</td>
 	<td class="wpr-pma-item-title">
 		<?php if ( 'in-progress' === $data['status'] ) : ?>
-			<span><?php printf( esc_html( 'Tracked pages: %s' ), esc_html( $data['pages_num'] ) ); ?></span>
+			<span><?php printf( esc_html__( 'Tracked pages: %s', 'rocket' ), esc_html( $data['pages_num'] ) ); ?></span>
 		<?php else : ?>
-			<span><?php printf( esc_html( '%s pages monitored' ), esc_html( $data['pages_num'] ) ); ?></span>
+			<span><?php printf( esc_html__( '%s pages monitored', 'rocket' ), esc_html( $data['pages_num'] ) ); ?></span>
 		<?php endif; ?>
 	</td>
 	<td class="wpr-pma-item-actions"></td>

--- a/views/settings/partials/performance-monitoring/global-score-row.php
+++ b/views/settings/partials/performance-monitoring/global-score-row.php
@@ -13,9 +13,25 @@ defined( 'ABSPATH' ) || exit;
 	</td>
 	<td class="wpr-pma-item-title">
 		<?php if ( 'in-progress' === $data['status'] ) : ?>
-			<span><?php printf( esc_html__( 'Tracked pages: %s', 'rocket' ), esc_html( $data['pages_num'] ) ); ?></span>
+			<span>
+				<?php
+				printf(
+					// translators: %s is the number of pages monitored.
+					esc_html__( 'Tracked pages: %s', 'rocket' ),
+					esc_html( $data['pages_num'] )
+				);
+				?>
+			</span>
 		<?php else : ?>
-			<span><?php printf( esc_html__( '%s pages monitored', 'rocket' ), esc_html( $data['pages_num'] ) ); ?></span>
+			<span>
+				<?php
+				printf(
+					// translators: %s is the number of pages monitored.
+					esc_html__( '%s pages monitored', 'rocket' ),
+					esc_html( $data['pages_num'] )
+				);
+				?>
+			</span>
 		<?php endif; ?>
 	</td>
 	<td class="wpr-pma-item-actions"></td>

--- a/views/settings/partials/performance-monitoring/global-score-widget.php
+++ b/views/settings/partials/performance-monitoring/global-score-widget.php
@@ -43,7 +43,7 @@ defined( 'ABSPATH' ) || exit;
 					];
 
 					// Add tooltip if no credit and disable btn.
-					if ( ! $this->has_credit() ) {
+					if ( ! $data['has_credit'] ) {
 						$rocket_pma_add_button_args['attributes']['class'] .= ' wpr-btn-with-tool-tip disabled';
 						$rocket_pma_add_button_args['tool_tip']             = __( 'You don\'t have enough credits', 'rocket' );
 						$rocket_pma_add_button_args['url']                  = '#';

--- a/views/settings/partials/performance-monitoring/license-banner.php
+++ b/views/settings/partials/performance-monitoring/license-banner.php
@@ -5,9 +5,7 @@
  * @package WP_Rocket
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
-}
+defined( 'ABSPATH' ) || exit; // Exit if accessed directly.
 ?>
 
 <div class="wpr-pma-license-banner">

--- a/views/settings/partials/performance-monitoring/table-row.php
+++ b/views/settings/partials/performance-monitoring/table-row.php
@@ -37,7 +37,7 @@ defined( 'ABSPATH' ) || exit;
 		];
 
 		// Retest button should be disabled if the score is zero or this row is still running.
-		if ( ! $this->is_retest_btn_enabled( $data ) ) {
+		if ( ! $data->is_running() && $data['has_credit'] ) {
 			$rocket_pma_retest_button_args['attributes']['class'] .= ' wpr-pma-action--disabled';
 			$rocket_pma_retest_button_args['disabled']             = true;
 		}

--- a/views/settings/partials/performance-monitoring/table-row.php
+++ b/views/settings/partials/performance-monitoring/table-row.php
@@ -42,7 +42,7 @@ defined( 'ABSPATH' ) || exit;
 			$rocket_pma_retest_button_args['disabled']             = true;
 		}
 
-		if ( ! $this->has_credit() ) {
+		if ( ! $data['has_credit'] ) {
 			$rocket_pma_retest_button_args['attributes']['class'] .= ' wpr-btn-with-tool-tip';
 			$rocket_pma_retest_button_args['tool_tip']             = __( 'Upgrade your plan to get access to re-test performance or run new tests', 'rocket' );
 			$rocket_pma_retest_button_args['disabled']             = true;

--- a/views/settings/partials/performance-monitoring/urls-table.php
+++ b/views/settings/partials/performance-monitoring/urls-table.php
@@ -61,7 +61,7 @@ defined( 'ABSPATH' ) || exit;
 		<?php
 		printf(
 		// Translators: %1$s = opening strong tag, %2$s: number of pages, %3$s = closing strong tag, %4$s: number of tests available.
-			esc_html__( 'You can analyze up to %1$s%2$s pages%3$s and run %1$s%4$s test per month.%1$s Want more?', 'rocket' ),
+			esc_html__( 'You can analyze up to %1$s%2$s page%3$s and run %1$s%4$s tests per month%3$s. %1$sWant more?%3$s', 'rocket' ),
 			'<strong>',
 			'1', // number of pages.
 			'</strong>',


### PR DESCRIPTION
# Description

Fix a display issue on the settings page & make some strings translatable

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

- The settings page was not displayed correctly (no tabs) because of HTML tags not closed
- New strings were not translatable

### How to test

- Checking the settings page display (with tabs)

## Technical description

### Documentation

This pull request fixes HTML rendering issues on the settings page and makes several strings translatable that were previously hard-coded in English.

- Fixed HTML tag mismatch in translatable string causing display issues
- Made previously untranslatable strings translatable using WordPress i18n functions
- Refactored ABSPATH check to use more concise syntax

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.