### PR TITLE
Remove some DB columns with retest

### DIFF
--- a/inc/Engine/Admin/PerformanceMonitoring/AJAX/Controller.php
+++ b/inc/Engine/Admin/PerformanceMonitoring/AJAX/Controller.php
@@ -337,12 +337,16 @@ class Controller {
 				);
 		}
 
-		$this->manager->add_url_to_the_queue( $row->url, true, [
-			'data' => '',
-			'score' => '',
-			'report_url' => '',
-			'is_blurred' => 0,
-		] ); // @phpstan-ignore-line
+		$this->manager->add_url_to_the_queue(
+			$row->url,
+			true,
+			[
+				'data'       => '',
+				'score'      => '',
+				'report_url' => '',
+				'is_blurred' => 0,
+			]
+			); // @phpstan-ignore-line
 
 		/**
 		 * Fires when a performance monitoring job is reset/retested.

--- a/inc/Engine/Admin/PerformanceMonitoring/AJAX/Controller.php
+++ b/inc/Engine/Admin/PerformanceMonitoring/AJAX/Controller.php
@@ -338,7 +338,7 @@ class Controller {
 		}
 
 		$this->manager->add_url_to_the_queue(
-			$row->url,
+			$row->url, // @phpstan-ignore-line
 			true,
 			[
 				'data'       => '',
@@ -346,7 +346,7 @@ class Controller {
 				'report_url' => '',
 				'is_blurred' => 0,
 			]
-			); // @phpstan-ignore-line
+			);
 
 		/**
 		 * Fires when a performance monitoring job is reset/retested.

--- a/inc/Engine/Admin/PerformanceMonitoring/AJAX/Controller.php
+++ b/inc/Engine/Admin/PerformanceMonitoring/AJAX/Controller.php
@@ -337,7 +337,12 @@ class Controller {
 				);
 		}
 
-		$this->manager->add_url_to_the_queue( $row->url, true ); // @phpstan-ignore-line
+		$this->manager->add_url_to_the_queue( $row->url, true, [
+			'data' => '',
+			'score' => '',
+			'report_url' => '',
+			'is_blurred' => 0,
+		] ); // @phpstan-ignore-line
 
 		/**
 		 * Fires when a performance monitoring job is reset/retested.

--- a/inc/Engine/Common/Database/Queries/AbstractQuery.php
+++ b/inc/Engine/Common/Database/Queries/AbstractQuery.php
@@ -309,6 +309,7 @@ class AbstractQuery extends Query {
 	 *
 	 * @param int    $id DB row ID.
 	 * @param string $job_id API job_id.
+	 * @param array  $additional_details Additional details to be saved into DB.
 	 *
 	 * @return bool
 	 */

--- a/inc/Engine/Common/Database/Queries/AbstractQuery.php
+++ b/inc/Engine/Common/Database/Queries/AbstractQuery.php
@@ -312,13 +312,12 @@ class AbstractQuery extends Query {
 	 *
 	 * @return bool
 	 */
-	public function reset_job( int $id, string $job_id = '' ) {
+	public function reset_job( int $id, string $job_id = '', array $additional_details = [] ) {
 		if ( ! self::$table_exists && ! $this->table_exists() ) {
 			return false;
 		}
 
-		return $this->update_item(
-			$id,
+		$item = wp_parse_args(
 			[
 				'job_id'        => $job_id,
 				'status'        => 'to-submit',
@@ -327,7 +326,12 @@ class AbstractQuery extends Query {
 				'retries'       => 0,
 				'modified'      => current_time( 'mysql', true ),
 				'submitted_at'  => current_time( 'mysql', true ),
-			]
+			],
+			$additional_details );
+
+		return $this->update_item(
+			$id,
+			$item
 		);
 	}
 

--- a/inc/Engine/Common/Database/Queries/AbstractQuery.php
+++ b/inc/Engine/Common/Database/Queries/AbstractQuery.php
@@ -317,21 +317,26 @@ class AbstractQuery extends Query {
 			return false;
 		}
 
-		$item = wp_parse_args(
-			[
-				'job_id'        => $job_id,
-				'status'        => 'to-submit',
-				'error_code'    => '',
-				'error_message' => '',
-				'retries'       => 0,
-				'modified'      => current_time( 'mysql', true ),
-				'submitted_at'  => current_time( 'mysql', true ),
-			],
-			$additional_details );
+		$updates = [
+			'job_id'        => $job_id,
+			'status'        => 'to-submit',
+			'error_code'    => '',
+			'error_message' => '',
+			'retries'       => 0,
+			'modified'      => current_time( 'mysql', true ),
+			'submitted_at'  => current_time( 'mysql', true ),
+		];
+
+		if ( ! empty( $additional_details ) ) {
+			$updates = wp_parse_args(
+				$updates,
+				$additional_details
+			);
+		}
 
 		return $this->update_item(
 			$id,
-			$item
+			$updates
 		);
 	}
 

--- a/inc/Engine/Common/JobManager/Managers/AbstractManager.php
+++ b/inc/Engine/Common/JobManager/Managers/AbstractManager.php
@@ -60,7 +60,7 @@ trait AbstractManager {
 		if ( empty( $row ) ) {
 			return $this->query->create_new_job( $url, '', '', $is_mobile, $additional_details );
 		}
-		$this->query->reset_job( (int) $row->id );
+		$this->query->reset_job( (int) $row->id, $additional_details );
 	}
 
 	/**

--- a/inc/Engine/Common/JobManager/Managers/AbstractManager.php
+++ b/inc/Engine/Common/JobManager/Managers/AbstractManager.php
@@ -60,7 +60,7 @@ trait AbstractManager {
 		if ( empty( $row ) ) {
 			return $this->query->create_new_job( $url, '', '', $is_mobile, $additional_details );
 		}
-		$this->query->reset_job( (int) $row->id, $additional_details );
+		$this->query->reset_job( (int) $row->id, '', $additional_details );
 	}
 
 	/**


### PR DESCRIPTION
# Description

Fixes #7597 

Here we need to remove the old job data, score, report_url, and is_blurred when doing the retest.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

Do a test for a url and then click retest, you shouldn't see the old report while it's in-progress.

### How to test

Mentioned above.

## Technical description

### Documentation

Update this retested row to remove those columns.

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

*If some mandatory items are not relevant, explain why in this section.*

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
