### PR TITLE
Show the notice only for free users

### DIFF
--- a/inc/Engine/Admin/PerformanceMonitoring/Subscriber.php
+++ b/inc/Engine/Admin/PerformanceMonitoring/Subscriber.php
@@ -328,6 +328,7 @@ class Subscriber implements Subscriber_Interface, LoggerAwareInterface {
 				'pma_addon_limit' => $this->controller->get_pma_addon_limit(),
 				'upgrade_url'     => $license_data['btn_url'] ?? '',
 				'can_add_pages'   => wpm_apply_filters_typesafe( 'wpr_pm_allow_add_page', true ),
+				'is_free'         => $this->pma_context->is_free_user(),
 			]
 		);
 	}

--- a/tests/Unit/inc/Engine/Admin/PerformanceMonitoring/Subscriber/renderPerformanceUrlsTable.php
+++ b/tests/Unit/inc/Engine/Admin/PerformanceMonitoring/Subscriber/renderPerformanceUrlsTable.php
@@ -47,6 +47,7 @@ class Test_renderPerformanceUrlsTable extends TestCase {
 				'pma_addon_limit' => 1,
 				'upgrade_url'    => '',
 				'can_add_pages'  => true,
+				'is_free' => false,
 			]);
 
 		$mock_ajax_controller   = $this->createMock(AjaxController::class);

--- a/views/settings/partials/performance-monitoring/urls-table.php
+++ b/views/settings/partials/performance-monitoring/urls-table.php
@@ -42,7 +42,7 @@ if ( ! isset( $data['can_add_pages'] ) || $data['can_add_pages'] ) {
 	</div>
 </div>
 
-<?php if ( ! empty( $data['can_add_pages'] ) ) : ?>
+<?php if ( ! empty( $data['can_add_pages'] ) && ! empty( $data['is_free'] ) ) : ?>
 	<p class="wpr-pma-summary-info">
 		<?php
 		printf(


### PR DESCRIPTION
# Description

Shows the following message only for free users:

<img width="621" height="97" alt="image" src="https://github.com/user-attachments/assets/a321f8f6-f63a-4797-b4bd-c6c1a447b258" />

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

For free users, I can see the notice and for the advanced plan I can't see it.

### How to test

- Use the snippet to make the user on free plan.
- Check our settings page on Rocket Insights tab
- You will find the notice below the banner and before the listing table.
- Repeat the same steps but with advanced plan
- You shouldn't see the notice at all.

## Technical description

### Documentation

N/A

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

*If some mandatory items are not relevant, explain why in this section.*

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
