### PR TITLE
Enhancement #7708: Copy improvements

### DIFF
--- a/inc/Engine/Admin/PerformanceMonitoring/AJAX/Controller.php
+++ b/inc/Engine/Admin/PerformanceMonitoring/AJAX/Controller.php
@@ -108,7 +108,7 @@ class Controller {
 		}
 
 		if ( Utils::is_home( $url ) ) {
-			$page_title = __( 'Home Page', 'rocket' );
+			$page_title = __( 'Homepage', 'rocket' );
 		} else {
 			$page_title = $this->get_page_title( $payload['message'] );
 		}

--- a/inc/Engine/Admin/PerformanceMonitoring/Controller.php
+++ b/inc/Engine/Admin/PerformanceMonitoring/Controller.php
@@ -117,7 +117,7 @@ class Controller {
 
 		$url = home_url();
 
-		$page_title = __( 'Home Page', 'rocket' );
+		$page_title = __( 'Homepage', 'rocket' );
 
 		$this->manager->add_to_the_queue(
 			$url,

--- a/inc/Engine/Admin/Settings/Page.php
+++ b/inc/Engine/Admin/Settings/Page.php
@@ -1700,7 +1700,7 @@ class Page extends Abstract_Render {
 			'rocket_insights',
 			[
 				'title'            => __( 'Rocket Insights', 'rocket' ),
-				'menu_description' => __( 'Get performance insights', 'rocket' ),
+				'menu_description' => __( 'Enable automatic performance testing for your pages', 'rocket' ),
 			]
 		);
 

--- a/inc/Engine/Admin/Settings/Page.php
+++ b/inc/Engine/Admin/Settings/Page.php
@@ -1700,7 +1700,7 @@ class Page extends Abstract_Render {
 			'rocket_insights',
 			[
 				'title'            => __( 'Rocket Insights', 'rocket' ),
-				'menu_description' => __( 'Enable automatic performance testing for your pages', 'rocket' ),
+				'menu_description' => __( 'Get performance insights', 'rocket' ),
 			]
 		);
 
@@ -1731,7 +1731,7 @@ class Page extends Abstract_Render {
 				'performance_monitoring' => [
 					'type'              => 'checkbox',
 					'label'             => __( 'Performance Monitoring', 'rocket' ),
-					'description'       => __( 'Automatically test your tracked pages.', 'rocket' ),
+					'description'       => __( 'Enable automatic performance testing for your pages.', 'rocket' ),
 					'section'           => 'performance_monitoring',
 					'page'              => 'rocket_insights',
 					'default'           => 0,

--- a/tests/Fixtures/inc/Engine/Admin/PerformanceMonitoring/Subscriber/html/output_2_urls_enabled.php
+++ b/tests/Fixtures/inc/Engine/Admin/PerformanceMonitoring/Subscriber/html/output_2_urls_enabled.php
@@ -1,6 +1,6 @@
 <div id="wpr_global_score_widget">
 <div class="wpr-optionHeader">
-<h3 class="wpr-title2">Rocket Insights Global Score</h3>
+<h3 class="wpr-title2">Rocket Insights Score</h3>
 </div>
 <div class="wpr-fieldsContainer">
 <fieldset class="wpr-fieldsContainer-fieldset">

--- a/tests/Fixtures/inc/Engine/Admin/PerformanceMonitoring/Subscriber/html/output_3_urls_disabled.php
+++ b/tests/Fixtures/inc/Engine/Admin/PerformanceMonitoring/Subscriber/html/output_3_urls_disabled.php
@@ -1,6 +1,6 @@
 <div id="wpr_global_score_widget">
 <div class="wpr-optionHeader">
-<h3 class="wpr-title2">Rocket Insights Global Score</h3>
+<h3 class="wpr-title2">Rocket Insights Score</h3>
 </div>
 <div class="wpr-fieldsContainer">
 <fieldset class="wpr-fieldsContainer-fieldset">

--- a/tests/Fixtures/inc/Engine/Admin/PerformanceMonitoring/Subscriber/html/output_3_urls_loading_disabled.php
+++ b/tests/Fixtures/inc/Engine/Admin/PerformanceMonitoring/Subscriber/html/output_3_urls_loading_disabled.php
@@ -1,6 +1,6 @@
 <div id="wpr_global_score_widget">
 <div class="wpr-optionHeader">
-<h3 class="wpr-title2">Rocket Insights Global Score</h3>
+<h3 class="wpr-title2">Rocket Insights Score</h3>
 </div>
 <div class="wpr-fieldsContainer">
 <fieldset class="wpr-fieldsContainer-fieldset">

--- a/views/settings/partials/performance-monitoring/global-score-widget.php
+++ b/views/settings/partials/performance-monitoring/global-score-widget.php
@@ -8,7 +8,7 @@ defined( 'ABSPATH' ) || exit;
 <div id="wpr_global_score_widget">
 	<div class="wpr-optionHeader">
 		<h3 class="wpr-title2">
-			<?php echo esc_html__( 'Rocket Insights Global Score', 'rocket' ); ?>
+			<?php echo esc_html__( 'Rocket Insights Score', 'rocket' ); ?>
 		</h3>
 	</div>
 	<div class="wpr-fieldsContainer">


### PR DESCRIPTION
# Description

Fixes #7708 
Change of texts

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

### What was tested

Page loaded

### How to test

Just load the pages were the mentioned texts are appearing (Rocket Insights).

## Technical description

### Documentation

This pull request focuses on improving clarity and consistency in the naming and descriptions related to the Rocket Insights performance monitoring feature. The main changes update user-facing labels and descriptions to be more concise and informative.

**Label and description updates:**

* Updated the menu description for Rocket Insights to "Enable automatic performance testing for your pages" for better clarity in `Page.php`.

**Homepage terminology consistency:**

* Changed the label "Home Page" to "Homepage" in both the AJAX controller and performance monitoring controller to ensure consistent terminology. [[1]](diffhunk://#diff-26007bb022d8ac7e2f984a1965468bf851a0a5c01ab4624694ada073e73250d9L111-R111) [[2]](diffhunk://#diff-f0deed186b1875e34b4fb1dced4935e7d95379016d9394dbff6b39c4e7ac94e5L120-R120)

**Score widget label simplification:**

* Renamed "Rocket Insights Global Score" to "Rocket Insights Score" in the global score widget view and related test fixtures for a simpler, clearer label. [[1]](diffhunk://#diff-10b0d27bad50740a30ec95c09e7dae3645cdc0c031a02cd8c59b5107487fbc9aL11-R11) [[2]](diffhunk://#diff-d1ab9421008304f41d9098b6198f83db65a909733661c374a2ea191a3cf67987L3-R3) [[3]](diffhunk://#diff-80f833f9988bcfd49c80c8c0ca05fd86ed7641fadd4fb2f6d8347d73def5767cL3-R3) [[4]](diffhunk://#diff-819735c6e582bf491394842a8520a778e0fa619752389c6d3af89ab99125c6d2L3-R3)
### New dependencies

None

### Risks

None

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.
