### PR TITLE
Fix #7745:  Immediate retest occurs the very first time activating Automatic Scheduling

### DIFF
--- a/inc/Engine/Admin/PerformanceMonitoring/Subscriber.php
+++ b/inc/Engine/Admin/PerformanceMonitoring/Subscriber.php
@@ -503,7 +503,16 @@ class Subscriber implements Subscriber_Interface, LoggerAwareInterface {
 
 		$schedule = $this->options->get( 'performance_monitoring_schedule_frequency', 'monthly' );
 
-		wp_schedule_event( time(), $schedule, 'wpr_pma_retest_all_pages' );
+		// Calculate the next run time based on the schedule frequency.
+		$intervals = [
+			'daily'   => DAY_IN_SECONDS,
+			'weekly'  => WEEK_IN_SECONDS,
+			'monthly' => MONTH_IN_SECONDS,
+		];
+
+		$interval = $intervals[ $schedule ] ?? MONTH_IN_SECONDS;
+
+		wp_schedule_event( time() + $interval, $schedule, 'wpr_pma_retest_all_pages' );
 	}
 
 	/**


### PR DESCRIPTION
# Description

Fixes #7745 
This PR fixes an issue where the performance monitoring retest event was being scheduled to run immediately upon first activation of Automatic Scheduling, instead of at the appropriate future interval.

Modified the schedule_retest_event function to calculate the next run time based on the selected frequency
Added logic to schedule the event at the proper future time (daily, weekly, or monthly) rather than immediately

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

Scenario explained in issue

### How to test

Refer to issue

## Technical description

### Documentation
This pull request updates the scheduling logic for the performance monitoring retest event to ensure the event is scheduled at the correct future interval rather than immediately. The main change is in how the next run time is calculated based on the selected frequency.

Scheduling improvements:

* In the `schedule_retest_event` function in `inc/Engine/Admin/PerformanceMonitoring/Subscriber.php`, the next retest event is now scheduled at the appropriate future time by adding the interval (daily, weekly, or monthly) to the current time, instead of scheduling it to run immediately.


### New dependencies

None

### Risks

None

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification
No tests for this