### PR TITLE
Fix: Safeguard schedule_retest_task against type errors

### DIFF
--- a/inc/Engine/Admin/PerformanceMonitoring/Queue/Queue.php
+++ b/inc/Engine/Admin/PerformanceMonitoring/Queue/Queue.php
@@ -77,10 +77,12 @@ class Queue extends AbstractASQueue {
 	 * @return void
 	 */
 	public function schedule_retest_task( $interval = null ) {
+		$interval = (int) ( $interval ?? MONTH_IN_SECONDS );
+
 		// Schedule weekly cleanup.
 		$this->schedule_recurring(
 			time() + $interval,
-			$interval ?? MONTH_IN_SECONDS,
+			$interval,
 			$this->retest_hook,
 			[],
 			1


### PR DESCRIPTION
# Description

Fixes #NaN
- Cast interval parameter to int to prevent 'Unsupported operand types' error
- Handle null values before addition operation
- Ensures compatibility with database options that may return strings
- Fixes TypeError when options->get() returns string instead of int

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

Refer to https://group-onecom.slack.com/archives/C08EFCYRQ2X/p1759740884319159

### How to test

Refer to https://group-onecom.slack.com/archives/C08EFCYRQ2X/p1759740884319159

## Technical description

### Documentation

- Cast interval parameter to int to prevent 'Unsupported operand types' error
- Handle null values before addition operation
- Ensures compatibility with database options that may return strings
- Fixes TypeError when options->get() returns string instead of int

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification
No tests for this. 