### PR TITLE
FIX: Add upgrade callback to reset credit on version update

### DIFF
--- a/inc/Engine/Admin/PerformanceMonitoring/Subscriber.php
+++ b/inc/Engine/Admin/PerformanceMonitoring/Subscriber.php
@@ -520,7 +520,7 @@ class Subscriber implements Subscriber_Interface, LoggerAwareInterface {
 	 */
 	public function on_update_reset_credit( $new_version, $old_version ) {
 		if ( version_compare( $old_version, '3.20.0', '<' ) ) {
-			$this->reset_credit_monthly();
+			$this->controller->reset_credit();
 		}
 	}
 }

--- a/inc/Engine/Admin/PerformanceMonitoring/Subscriber.php
+++ b/inc/Engine/Admin/PerformanceMonitoring/Subscriber.php
@@ -520,7 +520,7 @@ class Subscriber implements Subscriber_Interface, LoggerAwareInterface {
 	 */
 	public function on_update_reset_credit( $new_version, $old_version ) {
 		if ( version_compare( $old_version, '3.20.0', '<' ) ) {
-			$this->plan->reset_credit();
+			$this->reset_credit_monthly();
 		}
 	}
 }

--- a/inc/Engine/Admin/PerformanceMonitoring/Subscriber.php
+++ b/inc/Engine/Admin/PerformanceMonitoring/Subscriber.php
@@ -518,7 +518,7 @@ class Subscriber implements Subscriber_Interface, LoggerAwareInterface {
 	 * @param string $old_version Previous plugin version.
 	 * @return void
 	 */
-	public function on_update_reset_credit( $old_version, $new_version ) {
+	public function on_update_reset_credit( $new_version, $old_version ) {
 		if ( version_compare( $old_version, '3.20.0', '<' ) ) {
 			$this->plan->reset_credit();
 		}

--- a/inc/Engine/Admin/PerformanceMonitoring/Subscriber.php
+++ b/inc/Engine/Admin/PerformanceMonitoring/Subscriber.php
@@ -166,6 +166,7 @@ class Subscriber implements Subscriber_Interface, LoggerAwareInterface {
 			],
 			'rocket_options_changed'            => 'maybe_cancel_automatic_retest_job',
 			'rocket_insights_retest'            => 'retest_all_pages',
+			'wp_rocket_upgrade'                 => [ 'on_update_reset_credit', 10, 2 ],
 		];
 	}
 
@@ -508,5 +509,18 @@ class Subscriber implements Subscriber_Interface, LoggerAwareInterface {
 	 */
 	public function maybe_cancel_automatic_retest_job() {
 		$this->queue->cancel_retest_job();
+	}
+
+	/**
+	 * Callback for the wp_rocket_upgrade action to reset credit on version update.
+	 *
+	 * @param string $new_version New plugin version.
+	 * @param string $old_version Previous plugin version.
+	 * @return void
+	 */
+	public function on_update_reset_credit( $old_version, $new_version ) {
+		if ( version_compare( $old_version, '3.20.0', '<' ) ) {
+			$this->plan->reset_credit();
+		}
 	}
 }

--- a/wp-rocket.php
+++ b/wp-rocket.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Rocket
  * Plugin URI: https://wp-rocket.me
  * Description: The best WordPress performance plugin.
- * Version: 3.20.0.1-alpha2
+ * Version: 3.20.0.1
  * Requires at least: 5.8
  * Requires PHP: 7.3
  * Code Name: Iego
@@ -20,7 +20,7 @@
 defined( 'ABSPATH' ) || exit;
 
 // Rocket defines.
-define( 'WP_ROCKET_VERSION',               '3.20.0.1-alpha2' );
+define( 'WP_ROCKET_VERSION',               '3.20.0.1' );
 define( 'WP_ROCKET_WP_VERSION',            '5.8' );
 define( 'WP_ROCKET_WP_VERSION_TESTED',     '6.3.1' );
 define( 'WP_ROCKET_PHP_VERSION',           '7.3' );

--- a/wp-rocket.php
+++ b/wp-rocket.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Rocket
  * Plugin URI: https://wp-rocket.me
  * Description: The best WordPress performance plugin.
- * Version: 3.20
+ * Version: 3.20.0.1-alpha
  * Requires at least: 5.8
  * Requires PHP: 7.3
  * Code Name: Iego
@@ -20,7 +20,7 @@
 defined( 'ABSPATH' ) || exit;
 
 // Rocket defines.
-define( 'WP_ROCKET_VERSION',               '3.20' );
+define( 'WP_ROCKET_VERSION',               '3.20.0.1-alpha' );
 define( 'WP_ROCKET_WP_VERSION',            '5.8' );
 define( 'WP_ROCKET_WP_VERSION_TESTED',     '6.3.1' );
 define( 'WP_ROCKET_PHP_VERSION',           '7.3' );

--- a/wp-rocket.php
+++ b/wp-rocket.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Rocket
  * Plugin URI: https://wp-rocket.me
  * Description: The best WordPress performance plugin.
- * Version: 3.20.0.1-alpha
+ * Version: 3.20.0.1-alpha2
  * Requires at least: 5.8
  * Requires PHP: 7.3
  * Code Name: Iego
@@ -20,7 +20,7 @@
 defined( 'ABSPATH' ) || exit;
 
 // Rocket defines.
-define( 'WP_ROCKET_VERSION',               '3.20.0.1-alpha' );
+define( 'WP_ROCKET_VERSION',               '3.20.0.1-alpha2' );
 define( 'WP_ROCKET_WP_VERSION',            '5.8' );
 define( 'WP_ROCKET_WP_VERSION_TESTED',     '6.3.1' );
 define( 'WP_ROCKET_PHP_VERSION',           '7.3' );


### PR DESCRIPTION
# Description

Fixes #NaN
Adds a callback on upgrade to force credit reset when previous version is < 3.20
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

Upgrading WP Rocket from < 3.20
### How to test

Upgrade WP Rocket from < 3.20
## Technical description

### Documentation

This pull request adds a new feature to the performance monitoring subscriber to automatically reset credit when the WP Rocket plugin is upgraded to version 3.20.0 or higher. The main changes include registering a new event listener and implementing a callback method to handle the credit reset logic.

**Performance Monitoring Upgrade Handling:**

* Registered the `wp_rocket_upgrade` event to trigger the new `on_update_reset_credit` callback in the `get_subscribed_events` method of `Subscriber.php`.
* Added the `on_update_reset_credit` method to reset credit when upgrading from a version lower than 3.20.0, using `version_compare` and the `plan->reset_credit()` call.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

No tests
