### PR TITLE
Fix #7581: Enhance URL handling non-Latin characters and improve URL validation

### DIFF
--- a/inc/Engine/Admin/PerformanceMonitoring/AJAX/Controller.php
+++ b/inc/Engine/Admin/PerformanceMonitoring/AJAX/Controller.php
@@ -102,6 +102,20 @@ class Controller {
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- URL validation happens in get_url_validation_payload(). Using trim() and wp_unslash() only to preserve percent-encoded non-ASCII characters.
 		$url = isset( $_POST['page_url'] ) ? untrailingslashit( trim( wp_unslash( $_POST['page_url'] ) ) ) : '';
 
+		// Validate URL format before further processing, but allow get_url_validation_payload to handle empty URLs.
+		if ( ! empty( $url ) ) {
+			// Add protocol if missing for validation, but preserve original input.
+			$url_for_validation = rocket_add_url_protocol( $url );
+			if ( ! wp_http_validate_url( $url_for_validation ) ) {
+				wp_send_json_error(
+					[
+						'error'   => true,
+						'message' => __( 'Invalid URL format.', 'rocket' ),
+					]
+				);
+			}
+		}
+
 		$payload = $this->get_url_validation_payload( $url );
 
 		if ( $payload['error'] ) {

--- a/inc/Engine/Admin/PerformanceMonitoring/AJAX/Controller.php
+++ b/inc/Engine/Admin/PerformanceMonitoring/AJAX/Controller.php
@@ -99,7 +99,8 @@ class Controller {
 				);
 		}
 
-		$url = isset( $_POST['page_url'] ) ? untrailingslashit( esc_url_raw( sanitize_text_field( wp_unslash( $_POST['page_url'] ) ) ) ) : '';
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- URL validation happens in get_url_validation_payload(). Using trim() and wp_unslash() only to preserve percent-encoded non-ASCII characters.
+		$url = isset( $_POST['page_url'] ) ? untrailingslashit( trim( wp_unslash( $_POST['page_url'] ) ) ) : '';
 
 		$payload = $this->get_url_validation_payload( $url );
 

--- a/tests/Fixtures/inc/Engine/Admin/PerformanceMonitoring/Subscriber/AddNewPageTest.php
+++ b/tests/Fixtures/inc/Engine/Admin/PerformanceMonitoring/Subscriber/AddNewPageTest.php
@@ -50,6 +50,26 @@ return [
 			'error_message' => 'No url provided',
 		],
 	],
+	'testShouldFailWithInvalidUrl' => [
+		'config' => [
+			'post_data' => [
+				'page_url' => 'invalid-url-format',
+			],
+			'rows' => [
+				[
+					'url' => 'http://example.org',
+					'status' => 'completed',
+					'is_mobile' => 1,
+				],
+			],
+			'customer_data' => (new UserDataGenerator()),
+			'mock_http' => false,
+		],
+		'expected' => [
+			'success' => false,
+			'error_message' => 'Invalid URL format',
+		],
+	],
 	'testShouldFailWithUrlLimitReached' => [
 		'config' => [
 			'post_data' => [

--- a/tests/Fixtures/inc/Engine/Admin/PerformanceMonitoring/Subscriber/AddNewPageTest.php
+++ b/tests/Fixtures/inc/Engine/Admin/PerformanceMonitoring/Subscriber/AddNewPageTest.php
@@ -122,4 +122,100 @@ return [
 			],
 		],
 	],
+	'testShouldStoreUrlWithNonLatinCharactersInCyrillic' => [
+		'config' => [
+			'post_data' => [
+				'page_url' => 'http://example.org/new-page-with-special-char-%d0%bf%d1%80%d0%be%d0%b4%d1%83%d0%ba%d1%82%d0%be%d0%b2%d0%b0-%d0%ba%d0%b0%d1%82%d0%b5%d0%b3%d0%be%d1%80%d0%b8%d1%8f',
+			],
+			'rows' => [],
+			'customer_data' => (new UserDataGenerator()),
+			'mock_http' => true,
+		],
+		'expected' => [
+			'success' => true,
+			'database_entries' => 1,
+			'hook_fired' => true,
+			'verify_url_in_db' => true,
+			'expected_url_pattern' => '/%d0%bf%d1%80%d0%be%d0%b4%d1%83%d0%ba%d1%82%d0%be%d0%b2%d0%b0/',
+			'response_data' => [
+				'id' => null,
+				'html' => null,
+				'global_score_data' => null,
+				'remaining_urls' => null,
+				'can_add_pages' => true,
+			],
+		],
+	],
+	'testShouldStoreUrlWithNonLatinCharactersInArabic' => [
+		'config' => [
+			'post_data' => [
+				'page_url' => 'http://example.org/category/%d8%ba%d9%8a%d8%b1-%d9%85%d8%b5%d9%86%d9%81',
+			],
+			'rows' => [],
+			'customer_data' => (new UserDataGenerator()),
+			'mock_http' => true,
+		],
+		'expected' => [
+			'success' => true,
+			'database_entries' => 1,
+			'hook_fired' => true,
+			'verify_url_in_db' => true,
+			'expected_url_pattern' => '/%d8%ba%d9%8a%d8%b1/',
+			'response_data' => [
+				'id' => null,
+				'html' => null,
+				'global_score_data' => null,
+				'remaining_urls' => null,
+				'can_add_pages' => true,
+			],
+		],
+	],
+	'testShouldStoreUrlWithOnlyNonLatinPath' => [
+		'config' => [
+			'post_data' => [
+				'page_url' => 'http://example.org/%D0%BF%D1%80%D0%BE%D0%B4%D1%83%D0%BA%D1%82%D0%BE%D0%B2%D0%B0/3',
+			],
+			'rows' => [],
+			'customer_data' => (new UserDataGenerator()),
+			'mock_http' => true,
+		],
+		'expected' => [
+			'success' => true,
+			'database_entries' => 1,
+			'hook_fired' => true,
+			'verify_url_in_db' => true,
+			'expected_url_pattern' => '/%D0%BF%D1%80%D0%BE%D0%B4%D1%83%D0%BA%D1%82%D0%BE%D0%B2%D0%B0/',
+			'response_data' => [
+				'id' => null,
+				'html' => null,
+				'global_score_data' => null,
+				'remaining_urls' => null,
+				'can_add_pages' => true,
+			],
+		],
+	],
+	'testShouldStoreUrlWithMixedLatinAndNonLatin' => [
+		'config' => [
+			'post_data' => [
+				'page_url' => 'http://example.org/page-%E4%B8%AD%E6%96%87-test',
+			],
+			'rows' => [],
+			'customer_data' => (new UserDataGenerator()),
+			'mock_http' => true,
+		],
+		'expected' => [
+			'success' => true,
+			'database_entries' => 1,
+			'hook_fired' => true,
+			'verify_url_in_db' => true,
+			'expected_url_pattern' => '/%E4%B8%AD%E6%96%87/',
+			'response_data' => [
+				'id' => null,
+				'html' => null,
+				'global_score_data' => null,
+				'remaining_urls' => null,
+				'can_add_pages' => true,
+			],
+		],
+	],
 ];

--- a/tests/Integration/inc/Engine/Admin/PerformanceMonitoring/Subscriber/AddNewPageTest.php
+++ b/tests/Integration/inc/Engine/Admin/PerformanceMonitoring/Subscriber/AddNewPageTest.php
@@ -139,6 +139,16 @@ class AddNewPageTest extends AjaxTestCase {
 		if ( isset( $expected['database_entries'] ) && $expected['database_entries'] > 0 ) {
 			$items = $this->container->get( 'pm_query' )->query( [] );
 			$this->assertSame( $expected['database_entries'], count( $items ) );
+
+			// Verify URL preservation for non-Latin character tests
+			if ( isset( $expected['verify_url_in_db'] ) && $expected['verify_url_in_db'] ) {
+				$last_item = end( $items );
+				$this->assertStringContainsString( '%', $last_item->url, 'URL should contain percent-encoded characters' );
+				// Verify the percent-encoded parts are preserved
+				if ( isset( $expected['expected_url_pattern'] ) ) {
+					$this->assertMatchesRegularExpression( $expected['expected_url_pattern'], $last_item->url );
+				}
+			}
 		}
 
 		// Check if hook was fired
@@ -196,7 +206,7 @@ class AddNewPageTest extends AjaxTestCase {
 	 */
 	public function mock_http_request( $preempt, $args, $url ) {
 		// Mock successful response for URLs on the test domain (example.org)
-		if ( strpos( $url, 'http://example.org' ) === 0 ) {
+		if ( strpos( $url, 'http://example.org' ) === 0 || strpos( $url, 'https://example.org' ) === 0 ) {
 			return [
 				'response' => [
 					'code' => 200,
@@ -212,16 +222,6 @@ class AddNewPageTest extends AjaxTestCase {
 					'code' => 200,
 				],
 				'body' => '<html><head><title>External Test Page</title></head><body>External test content</body></html>',
-			];
-		}
-
-		// Mock successful response for example.org URL used in tests
-		if ( strpos( $url, 'https://example.org' ) === 0 ) {
-			return [
-				'response' => [
-					'code' => 200,
-				],
-				'body' => '<html><head><title>Example Domain</title></head><body>Example domain content</body></html>',
 			];
 		}
 


### PR DESCRIPTION
# Description

Fixes #7581 
The change has a significant positive impact for international WordPress users who use non-Latin characters in their URLs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

A URL with non-latin characters

### How to test

Refer to issue

## Technical description

### Documentation
This pull request improves the handling and testing of URLs with percent-encoded non-Latin characters in the Performance Monitoring feature. The main change is ensuring that such URLs are correctly preserved and validated when added, with expanded test coverage for Cyrillic, Arabic, and other scripts.

**URL handling improvements:**
* Updated the URL extraction logic in `Controller.php` to use `trim()` and `wp_unslash()` instead of `esc_url_raw()` and `sanitize_text_field()`, preserving percent-encoded non-ASCII characters for validation and storage.

**Test coverage enhancements:**
* Added new test cases in `AddNewPageTest.php` to verify correct storage and database handling of URLs containing percent-encoded Cyrillic, Arabic, and mixed-script paths.
* Enhanced the success response assertion to check that percent-encoded characters are present in stored URLs and match expected patterns for non-Latin tests.

**Test infrastructure improvements:**
* Simplified the HTTP request mocking logic to handle both `http` and `https` URLs for the test domain in a single condition, removing redundant code. [[1]](diffhunk://#diff-17bfe4c4443dd7c15d837cb72ebc70a2098c5268c3de343a5db9a2481a1ff6d9L199-R209) [[2]](diffhunk://#diff-17bfe4c4443dd7c15d837cb72ebc70a2098c5268c3de343a5db9a2481a1ff6d9L218-L227)

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.
