### PR TITLE
FIX #7612: Enable prefetch for external domains in optimization

### DIFF
--- a/inc/Engine/Media/PreconnectExternalDomains/Frontend/Controller.php
+++ b/inc/Engine/Media/PreconnectExternalDomains/Frontend/Controller.php
@@ -176,7 +176,7 @@ class Controller implements ControllerInterface {
 	 * @return bool
 	 */
 	private function use_prefetch( $domain ) {
-		return wpm_apply_filters_typed( 'boolean', 'rocket_preconnect_external_domains_use_prefetch', false, $domain );
+		return wpm_apply_filters_typed( 'boolean', 'rocket_preconnect_external_domains_use_prefetch', true, $domain );
 	}
 
 	/**


### PR DESCRIPTION
# Description

Fixes #7612 
Enable dns-prefetch by default
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

Refer to issue

### How to test

Refer to issue

## Technical description

### Documentation
This pull request updates the default behavior for the `use_prefetch` method in the `Controller.php` file. The main change is to enable prefetching by default when applying the `rocket_preconnect_external_domains_use_prefetch` filter.

Default behavior update:

* Changed the default value for the `rocket_preconnect_external_domains_use_prefetch` filter from `false` to `true` in the `use_prefetch` method of `Controller.php`, enabling prefetching for external domains by default.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

No tests for this.
