### PR TITLE
FIX #7717: Ensure global score resets during plan URL cleanup

### DIFF
--- a/inc/Engine/Admin/PerformanceMonitoring/URLLimit/Subscriber.php
+++ b/inc/Engine/Admin/PerformanceMonitoring/URLLimit/Subscriber.php
@@ -83,6 +83,7 @@ class Subscriber implements Subscriber_Interface {
 			return;
 		}
 		$this->pm_query->prune_old_items( $limit );
+		$this->global_score->reset();
 	}
 
 	/**


### PR DESCRIPTION
# Description

Fixes #7717 
Ensure the global score refresh during plan URL cleanup.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

Refer to issue

### How to test

Refer to issue

## Technical description

### Documentation

This pull request makes a small change to the performance monitoring logic by ensuring that the global score is reset whenever old upgrade plan URLs are cleaned up. This helps maintain accurate scoring after URL pruning.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification
No tests for this.
