### PR TITLE
Hotfix Respect rucss option

### DIFF
--- a/inc/Engine/Common/JobManager/JobProcessor.php
+++ b/inc/Engine/Common/JobManager/JobProcessor.php
@@ -461,6 +461,9 @@ class JobProcessor implements LoggerAwareInterface {
 		$rows = [];
 
 		foreach ( $this->factories as $factory ) {
+			if ( ! $factory->manager()->is_allowed() ) {
+				continue;
+			}
 			switch ( $type ) {
 				case 'pending':
 					$rows = array_merge( $rows, $factory->manager()->get_pending_jobs( $num_rows ) );


### PR DESCRIPTION
# Description

We need not to send the RUCSS requests only when we have the option enabled.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

1. on 3.19.4 enable RUCSS and preload
2. Having many URLs in DB of RUCSS of different status
3. Disable RUCSS on 3.19.4
4. Update to 3.20 => check if we still send request to saas or not====> we shouldn't

The main issue happens because we try to send the request and when getting the response we don't update the database so it keeps sending the requests forever, we shouldn't send the request at all.

### How to test

Mentioned above.

## Technical description

### Documentation

N/A

### New dependencies

N/A

### Risks

I'm checking now if we want to add this check in any other part of code

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

It's a hotfix so if tests are passing we may add more tests later-on

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
