### PR TITLE
Avoid expensive information_schema query for checking table existence

### DIFF
--- a/inc/Dependencies/BerlinDB/Database/Table.php
+++ b/inc/Dependencies/BerlinDB/Database/Table.php
@@ -359,7 +359,7 @@ abstract class Table extends Base {
 		}
 
 		// Query statement to check if table exists.
-		$query    = "SELECT table_name FROM information_schema.TABLES WHERE table_name = %s LIMIT 1";
+		$query    = 'SHOW TABLES LIKE %s';
 		$prepared = $db->prepare( $query, $this->table_name );
 		$result   = $db->get_var( $prepared );
 

--- a/inc/Engine/Common/Database/Queries/AbstractQuery.php
+++ b/inc/Engine/Common/Database/Queries/AbstractQuery.php
@@ -535,8 +535,8 @@ class AbstractQuery extends Query {
 		}
 
 		// Query statement.
-		$query    = 'SELECT table_name FROM information_schema.tables WHERE table_schema = %s AND table_name = %s LIMIT 1';
-		$prepared = $db->prepare( $query, $db->__get( 'dbname' ), $db->{$this->table_name} );
+		$query    = 'SHOW TABLES LIKE %s';
+		$prepared = $db->prepare( $query, $db->{$this->table_name} );
 		$result   = $db->get_var( $prepared );
 
 		// Does the table exist?

--- a/inc/Engine/Common/PerformanceHints/Database/Queries/AbstractQueries.php
+++ b/inc/Engine/Common/PerformanceHints/Database/Queries/AbstractQueries.php
@@ -132,8 +132,8 @@ class AbstractQueries extends Query {
 		}
 
 		// Query statement.
-		$query    = 'SELECT table_name FROM information_schema.tables WHERE table_schema = %s AND table_name = %s LIMIT 1';
-		$prepared = $db->prepare( $query, $db->__get( 'dbname' ), $db->{$this->table_name} );
+		$query    = 'SHOW TABLES LIKE %s';
+		$prepared = $db->prepare( $query, $db->{$this->table_name} );
 		$result   = $db->get_var( $prepared );
 
 		// Does the table exist?


### PR DESCRIPTION
# Description

Fixes / improves: https://github.com/wp-media/wp-rocket/issues/7049

On MySQL < 8.0, information_schema is implemented as on-demand views that scan metadata files, which is very slow on servers with many databases. MySQL >= 8.0 uses a data dictionary, making these queries much faster.

We can avoid this performance issue by using SHOW TABLES LIKE instead, which is fast on both older and newer MySQL servers.

## Detailed scenario

Example performance difference on a busy server with thousands of databases and users:

````
mysql{1}> SELECT table_name FROM information_schema.TABLES WHERE table_name = 'wp_wpr_preconnect_external_domains' LIMIT 1;
+------------------------------------+
| table_name                         |
+------------------------------------+
| wp_wpr_preconnect_external_domains |
+------------------------------------+
1 row in set (22,02 sec)
````

````
mysql{2}> SHOW TABLES LIKE 'wp_wpr_preconnect_external_domains';
+----------------------------------------------------------+
| Tables_in_testdb (wp_wpr_preconnect_external_domains).   | 
+----------------------------------------------------------+
| wp_wpr_preconnect_external_domains                       |
+----------------------------------------------------------+
1 row in set (0,00 sec)
````

Note: MySQL 5.7 is still supported by Oracle ("Oracle Lifetime Sustaining Support") and Percona ("MySQL 5.7 Post-EOL Support from Percona"), and it remains widely used.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release
