### PR TITLE
FIX #7873: Change position of RI Column

### DIFF
--- a/inc/Engine/Admin/RocketInsights/PostListing/Subscriber.php
+++ b/inc/Engine/Admin/RocketInsights/PostListing/Subscriber.php
@@ -233,9 +233,24 @@ class Subscriber implements Subscriber_Interface {
 			return $columns;
 		}
 
-		$columns['rocket_insights'] = __( 'Rocket Insights', 'rocket' );
+		// Insert Rocket Insights column before the Date column.
+		$new_columns = [];
+		$inserted    = false;
 
-		return $columns;
+		foreach ( $columns as $key => $value ) {
+			if ( 'date' === $key ) {
+				$new_columns['rocket_insights'] = __( 'Rocket Insights', 'rocket' );
+				$inserted                       = true;
+			}
+			$new_columns[ $key ] = $value;
+		}
+
+		// Fallback: If no date column exists, add at the end.
+		if ( ! $inserted ) {
+			$new_columns['rocket_insights'] = __( 'Rocket Insights', 'rocket' );
+		}
+
+		return $new_columns;
 	}
 
 	/**


### PR DESCRIPTION
# Description

Fixes #7873 
Until now, we were having the column after `Date`. Now it's added before `Date`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

<img width="1494" height="521" alt="Screenshot 2025-11-03 at 13 26 40" src="https://github.com/user-attachments/assets/e0314519-91dc-4b24-b354-d2971f3b0976" />

### How to test

Load post listing

## Technical description

### Documentation

This pull request updates how the Rocket Insights column is added to the post listing table in the admin interface. The main improvement is that the column is now inserted directly before the Date column if it exists, rather than always being added at the end. This enhances the usability and organization of the table for users.

**Admin UI improvements:**

* In `Subscriber.php`, the logic for adding the `rocket_insights` column was changed so that the column is inserted before the Date column if present; if not, it falls back to adding it at the end.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

No test for this.