### PR TITLE
FIX #7877: Validate preg_replace result and return original HTML on failure

### DIFF
--- a/inc/Engine/Media/PreloadFonts/Frontend/Controller.php
+++ b/inc/Engine/Media/PreloadFonts/Frontend/Controller.php
@@ -198,8 +198,8 @@ class Controller implements ControllerInterface {
 			return $html;
 		}
 
-		// One regex to skip scripts and remove any <link rel=preload as=font…> tag (entire line, including indentation and newline):.
-		$html = preg_replace(
+		// One regex to skip scripts and remove any <link rel=preload as=font…> tag (entire line, including indentation and newline).
+		$result = preg_replace(
 			'#<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>(*SKIP)(*FAIL)'    // skip <script> blocks.
 			. '|^[ \t]*<link\b'                                           // OR match a <link at line start (with optional indent).
 			. '(?=[^>]*\brel\s*=\s*(["\']?)preload\1)'                 // lookahead rel=preload.
@@ -209,6 +209,10 @@ class Controller implements ControllerInterface {
 			$html
 		);
 
-		return $html;
+		if ( null === $result ) {
+			return $html;
+		}
+
+		return $result;
 	}
 }


### PR DESCRIPTION
# Description

Fixes #7877 
Avoid Fatal Error

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

Trigger fatal error

### How to test

Refer to issue

## Technical description

### Documentation

This pull request refactors the `maybe_remove_existing_preloaded_fonts` method to improve its handling of regular expression results. The main change is to ensure the function only returns the modified HTML if the regex operation succeeds, and otherwise returns the original HTML.

Error handling and code clarity improvements:

* Changed the use of `preg_replace` to store the result in a `$result` variable, and added a check to return the original `$html` if the regex operation fails (i.e., if `preg_replace` returns `null`) in `Controller.php` [[1]](diffhunk://#diff-6a194dad014bc0d821609d4cb742dd477bd0ed83bc77d13eb3fc33f32402186cL201-R202) [[2]](diffhunk://#diff-6a194dad014bc0d821609d4cb742dd477bd0ed83bc77d13eb3fc33f32402186cR212-R217).
# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification
No test for this.