### PR TITLE
Fix #7498: Apply non-render blocking attributes to self-hosted Google Fonts

### DIFF
--- a/inc/Engine/Media/Fonts/Frontend/Controller.php
+++ b/inc/Engine/Media/Fonts/Frontend/Controller.php
@@ -298,21 +298,6 @@ class Controller {
 	}
 
 	/**
-	 * Disables the preload of Google Fonts.
-	 *
-	 * @param bool $disable Whether to disable the preload of Google Fonts.
-	 *
-	 * @return bool
-	 */
-	public function disable_google_fonts_preload( $disable ): bool {
-		if ( ! $this->optimization_context->is_allowed() ) {
-			return $disable;
-		}
-
-		return true;
-	}
-
-	/**
 	 * Gets the font inline css.
 	 *
 	 * @param string $local_css_path CSS file path.

--- a/inc/Engine/Media/Fonts/Frontend/Subscriber.php
+++ b/inc/Engine/Media/Fonts/Frontend/Subscriber.php
@@ -31,10 +31,9 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events(): array {
 		return [
-			'rocket_buffer'                       => [ 'rewrite_fonts_for_optimizations', 18 ],
-			'rocket_disable_google_fonts_preload' => 'disable_google_fonts_preload',
-			'rocket_performance_hints_buffer'     => 'rewrite_fonts_for_saas',
-			'rocket_head_items'                   => [ 'rewrite_fonts_in_head', 1000 ],
+			'rocket_buffer'                   => [ 'rewrite_fonts_for_optimizations', 18 ],
+			'rocket_performance_hints_buffer' => 'rewrite_fonts_for_saas',
+			'rocket_head_items'               => [ 'rewrite_fonts_in_head', 1000 ],
 		];
 	}
 
@@ -56,17 +55,6 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	public function rewrite_fonts_for_saas( $html ): string {
 		return $this->frontend_controller->rewrite_fonts_for_saas( $html );
-	}
-
-	/**
-	 * Disables the preload of Google Fonts.
-	 *
-	 * @param bool $disable Whether to disable the preload of Google Fonts.
-	 *
-	 * @return bool
-	 */
-	public function disable_google_fonts_preload( $disable ): bool {
-		return $this->frontend_controller->disable_google_fonts_preload( $disable );
 	}
 
 	/**

--- a/inc/Engine/Optimization/GoogleFonts/AbstractGFOptimization.php
+++ b/inc/Engine/Optimization/GoogleFonts/AbstractGFOptimization.php
@@ -163,7 +163,10 @@ abstract class AbstractGFOptimization {
 			$items[]        = $item;
 
 			$items[] = $this->noscript_tag(
-				sprintf( '<link rel="stylesheet" href="%1$s">', $font_url ) // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+				sprintf( '<link rel="stylesheet" href="%1$s">', $font_url ), // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+				[
+					'data-wpr-hosted-gf-parameters' => '',
+				]
 			);
 		}
 

--- a/inc/Engine/Optimization/GoogleFonts/AbstractGFOptimization.php
+++ b/inc/Engine/Optimization/GoogleFonts/AbstractGFOptimization.php
@@ -108,12 +108,14 @@ abstract class AbstractGFOptimization {
 	}
 
 	/**
-	 * Check if preload google fonts is enabled or not using filter.
+	 * Check if preload google fonts is enabled or not using WP Rocket settings.
+	 *
+	 * @since 3.20.2
 	 *
 	 * @return bool
 	 */
 	protected function is_preload_enabled() {
-		return ! wpm_apply_filters_typed( 'boolean', 'rocket_disable_google_fonts_preload', false );
+		return (bool) get_rocket_option( 'auto_preload_fonts', false );
 	}
 
 	/**

--- a/inc/Engine/Optimization/GoogleFonts/AbstractGFOptimization.php
+++ b/inc/Engine/Optimization/GoogleFonts/AbstractGFOptimization.php
@@ -108,7 +108,7 @@ abstract class AbstractGFOptimization {
 	}
 
 	/**
-	 * Check if preload google fonts is enabled or not using WP Rocket settings.
+	 * Check if preload google fonts is enabled or not using filter.
 	 *
 	 * @since 3.20.2
 	 *

--- a/inc/Engine/Optimization/GoogleFonts/AbstractGFOptimization.php
+++ b/inc/Engine/Optimization/GoogleFonts/AbstractGFOptimization.php
@@ -115,7 +115,7 @@ abstract class AbstractGFOptimization {
 	 * @return bool
 	 */
 	protected function is_preload_enabled() {
-		return (bool) get_rocket_option( 'auto_preload_fonts', false );
+		return (bool) get_rocket_option( 'auto_preload_fonts', true );
 	}
 
 	/**

--- a/inc/Engine/Optimization/GoogleFonts/AbstractGFOptimization.php
+++ b/inc/Engine/Optimization/GoogleFonts/AbstractGFOptimization.php
@@ -115,7 +115,7 @@ abstract class AbstractGFOptimization {
 	 * @return bool
 	 */
 	protected function is_preload_enabled() {
-		return (bool) get_rocket_option( 'auto_preload_fonts', true );
+		return ! wpm_apply_filters_typed( 'boolean', 'rocket_disable_google_fonts_preload', false );
 	}
 
 	/**

--- a/inc/Engine/Optimization/GoogleFonts/AbstractGFOptimization.php
+++ b/inc/Engine/Optimization/GoogleFonts/AbstractGFOptimization.php
@@ -110,8 +110,6 @@ abstract class AbstractGFOptimization {
 	/**
 	 * Check if preload google fonts is enabled or not using filter.
 	 *
-	 * @since 3.20.2
-	 *
 	 * @return bool
 	 */
 	protected function is_preload_enabled() {

--- a/tests/Fixtures/inc/Engine/Optimization/GoogleFonts/Combine/optimize.php
+++ b/tests/Fixtures/inc/Engine/Optimization/GoogleFonts/Combine/optimize.php
@@ -23,7 +23,7 @@ return [
 				<title>Sample Page</title>
 				<link data-rocket-preload as="style" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=swap" rel="preload">
 				<link href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=swap" media="print" onload="this.media=&#039;all&#039;" rel="stylesheet">
-				<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=swap"></noscript>
+				<noscript data-wpr-hosted-gf-parameters=""><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=swap"></noscript>
 			</head>
 			<body>
 			</body>
@@ -54,7 +54,7 @@ return [
 				<title>Sample Page</title>
 				<link data-rocket-preload as="style" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=optional" rel="preload">
 				<link href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=optional" media="print" onload="this.media=&#039;all&#039;" rel="stylesheet">
-				<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=optional"></noscript>
+				<noscript data-wpr-hosted-gf-parameters=""><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=optional"></noscript>
 			</head>
 			<body>
 			</body>
@@ -85,7 +85,7 @@ return [
 				<title>Sample Page</title>
 				<link data-rocket-preload as="style" href="https://fonts.googleapis.com/css?family=Lato%3A100%2C300%2C400%2C600%2C700%2C900%7COpen%20Sans%3A700%2C300%2C600%2C400%7CRaleway%3A900%7CPlayfair%20Display%7COpen%20Sans%7CJockey%20One%3A400%7CAbril%20Fatface%3Aregular&#038;subset=latin&#038;display=swap" rel="preload">
 				<link href="https://fonts.googleapis.com/css?family=Lato%3A100%2C300%2C400%2C600%2C700%2C900%7COpen%20Sans%3A700%2C300%2C600%2C400%7CRaleway%3A900%7CPlayfair%20Display%7COpen%20Sans%7CJockey%20One%3A400%7CAbril%20Fatface%3Aregular&#038;subset=latin&#038;display=swap" media="print" onload="this.media=&#039;all&#039;" rel="stylesheet">
-				<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato%3A100%2C300%2C400%2C600%2C700%2C900%7COpen%20Sans%3A700%2C300%2C600%2C400%7CRaleway%3A900%7CPlayfair%20Display%7COpen%20Sans%7CJockey%20One%3A400%7CAbril%20Fatface%3Aregular&#038;subset=latin&#038;display=swap"></noscript>
+				<noscript data-wpr-hosted-gf-parameters=""><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato%3A100%2C300%2C400%2C600%2C700%2C900%7COpen%20Sans%3A700%2C300%2C600%2C400%7CRaleway%3A900%7CPlayfair%20Display%7COpen%20Sans%7CJockey%20One%3A400%7CAbril%20Fatface%3Aregular&#038;subset=latin&#038;display=swap"></noscript>
 			</head>
 			<body>
 			</body>
@@ -116,7 +116,7 @@ return [
 				<title>Sample Page</title>
 				<link data-rocket-preload as="style" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=swap" rel="preload">
 				<link href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=swap" media="print" onload="this.media=&#039;all&#039;" rel="stylesheet">
-				<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=swap"></noscript>
+				<noscript data-wpr-hosted-gf-parameters=""><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=swap"></noscript>
 			</head>
 			<body>
 			</body>
@@ -147,7 +147,7 @@ return [
 				<title>Sample Page</title>
 				<link data-rocket-preload as="style" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3Aregular%2C300%7CLato%3Aregular%2C300&#038;display=swap" rel="preload">
 				<link href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3Aregular%2C300%7CLato%3Aregular%2C300&#038;display=swap" media="print" onload="this.media=&#039;all&#039;" rel="stylesheet">
-				<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3Aregular%2C300%7CLato%3Aregular%2C300&#038;display=swap"></noscript>
+				<noscript data-wpr-hosted-gf-parameters=""><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3Aregular%2C300%7CLato%3Aregular%2C300&#038;display=swap"></noscript>
 			</head>
 			<body>
 			</body>
@@ -178,7 +178,7 @@ return [
 			<title>Sample Page</title>
 			<link data-rocket-preload as="style" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3Aregular%2C300%7CLato%3Aregular%2C300&#038;display=swap" rel="preload">
 			<link href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3Aregular%2C300%7CLato%3Aregular%2C300&#038;display=swap" media="print" onload="this.media=&#039;all&#039;" rel="stylesheet">
-			<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3Aregular%2C300%7CLato%3Aregular%2C300&#038;display=swap"></noscript>
+			<noscript data-wpr-hosted-gf-parameters=""><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3Aregular%2C300%7CLato%3Aregular%2C300&#038;display=swap"></noscript>
 			<link href="https://fonts.googleapis.com/css?" rel="stylesheet" property="stylesheet" type"text/css" media="all">
 			</head>
 			<body>
@@ -209,7 +209,7 @@ return [
 				<title>Sample Page</title>
 				<link data-rocket-preload as="style" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A300&#038;display=swap" rel="preload">
 				<link href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A300&#038;display=swap" media="print" onload="this.media=&#039;all&#039;" rel="stylesheet">
-				<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A300&#038;display=swap"></noscript>
+				<noscript data-wpr-hosted-gf-parameters=""><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A300&#038;display=swap"></noscript>
 			</head>
 			<body>
 			</body>
@@ -238,7 +238,7 @@ return [
 				<title>Sample Page</title>
 				<link data-rocket-preload as="style" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A300&#038;display=swap" rel="preload">
 				<link href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A300&#038;display=swap" media="print" onload="this.media=&#039;all&#039;" rel="stylesheet">
-				<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A300&#038;display=swap"></noscript>
+				<noscript data-wpr-hosted-gf-parameters=""><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A300&#038;display=swap"></noscript>
 			</head>
 			<body>
 			</body>
@@ -267,7 +267,7 @@ return [
 				<title>Sample Page</title>
 				<link data-rocket-preload as="style" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A300&#038;display=swap" rel="preload">
 				<link href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A300&#038;display=swap" media="print" onload="this.media=&#039;all&#039;" rel="stylesheet">
-				<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A300&#038;display=swap"></noscript>
+				<noscript data-wpr-hosted-gf-parameters=""><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A300&#038;display=swap"></noscript>
 			</head>
 			<body>
 			</body>
@@ -296,7 +296,7 @@ return [
 				<title>Sample Page</title>
 				<link data-rocket-preload as="style" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700&#038;display=swap" rel="preload">
 				<link href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700&#038;display=swap" media="print" onload="this.media=&#039;all&#039;" rel="stylesheet">
-				<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700&#038;display=swap"></noscript>
+				<noscript data-wpr-hosted-gf-parameters=""><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700&#038;display=swap"></noscript>
 			</head>
 			<body>
 			</body>
@@ -328,7 +328,7 @@ return [
 				<title>Sample Page</title>
 				<link data-rocket-preload as="style" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=swap" rel="preload">
 				<link href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=swap" media="print" onload="this.media=&#039;all&#039;" rel="stylesheet">
-				<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=swap"></noscript>
+				<noscript data-wpr-hosted-gf-parameters=""><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=swap"></noscript>
 				<title>Sample Title 2</title>
 			</head>
 			<body>
@@ -361,7 +361,7 @@ return [
 				<title>Sample Page</title>
 				<link data-rocket-preload as="style" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=swap" rel="preload">
 				<link href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=swap" media="print" onload="this.media=&#039;all&#039;" rel="stylesheet">
-				<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=swap"></noscript>
+				<noscript data-wpr-hosted-gf-parameters=""><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=swap"></noscript>
 			</head>
 			<body>
 				<title>Sample Title 2</title>
@@ -395,7 +395,7 @@ return [
 				<title>Sample Page</title>
 				<link data-rocket-preload as="style" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=swap" rel="preload">
 				<link href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=swap" media="print" onload="this.media=&#039;all&#039;" rel="stylesheet">
-				<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=swap"></noscript>
+				<noscript data-wpr-hosted-gf-parameters=""><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=swap"></noscript>
 			</head>
 			<body>
 				<!-- JetMenu Menu markup -->
@@ -464,7 +464,7 @@ return [
 			Sample Page</title>
 			<link data-rocket-preload as="style" href="https://fonts.googleapis.com/css?family=Roboto%7CMontSerra%7CComfortaa&#038;display=optional" rel="preload">
 			<link href="https://fonts.googleapis.com/css?family=Roboto%7CMontSerra%7CComfortaa&#038;display=optional" media="print" onload="this.media=&#039;all&#039;" rel="stylesheet">
-			<noscript>
+			<noscript data-wpr-hosted-gf-parameters="">
 			<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto%7CMontSerra%7CComfortaa&#038;display=optional">
 			</noscript>
 			<link rel="preconnect" href="https://fonts.gstatic.com">

--- a/tests/Fixtures/inc/Engine/Optimization/GoogleFonts/CombineV1V2/optimize.php
+++ b/tests/Fixtures/inc/Engine/Optimization/GoogleFonts/CombineV1V2/optimize.php
@@ -29,9 +29,9 @@ return [
 					<link data-rocket-preload as="style" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=swap" rel="preload">
 
 					<link href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@450&#038;display=swap" media="print" onload="this.media=&#039;all&#039;" rel="stylesheet">
-					<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@450&#038;display=swap"></noscript>
+					<noscript data-wpr-hosted-gf-parameters=""><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@450&#038;display=swap"></noscript>
 					<link href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=swap" media="print" onload="this.media=&#039;all&#039;" rel="stylesheet">
-					<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=swap"></noscript>
+					<noscript data-wpr-hosted-gf-parameters=""><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=swap"></noscript>
 				</head>
 				<body>
 				</body>
@@ -65,9 +65,9 @@ return [
 					<link data-rocket-preload as="style" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=optional" rel="preload">
 
 					<link href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@450&#038;display=optional" media="print" onload="this.media=&#039;all&#039;" rel="stylesheet">
-					<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@450&#038;display=optional"></noscript>
+					<noscript data-wpr-hosted-gf-parameters=""><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@450&#038;display=optional"></noscript>
 					<link href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=optional" media="print" onload="this.media=&#039;all&#039;" rel="stylesheet">
-					<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=optional"></noscript>
+					<noscript data-wpr-hosted-gf-parameters=""><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=optional"></noscript>
 				</head>
 				<body>
 				</body>
@@ -103,9 +103,9 @@ return [
 					<link data-rocket-preload as="style" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=swap" rel="preload">
 
 					<link href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@450&#038;display=swap" media="print" onload="this.media=&#039;all&#039;" rel="stylesheet">
-					<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@450&#038;display=swap"></noscript>
+					<noscript data-wpr-hosted-gf-parameters=""><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@450&#038;display=swap"></noscript>
 					<link href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=swap" media="print" onload="this.media=&#039;all&#039;" rel="stylesheet">
-					<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=swap"></noscript>
+					<noscript data-wpr-hosted-gf-parameters=""><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=swap"></noscript>
 					<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Comfortaa&text=Hello" type="text/css" media="all" />
 				</head>
 				<body>
@@ -141,9 +141,9 @@ return [
 					<link data-rocket-preload as="style" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=swap" rel="preload">
 
 					<link href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@450&#038;family=Comfortaa&#038;display=swap" media="print" onload="this.media=&#039;all&#039;" rel="stylesheet">
-					<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@450&#038;family=Comfortaa&#038;display=swap"></noscript>
+					<noscript data-wpr-hosted-gf-parameters=""><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@450&#038;family=Comfortaa&#038;display=swap"></noscript>
 					<link href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=swap" media="print" onload="this.media=&#039;all&#039;" rel="stylesheet">
-					<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=swap"></noscript>
+					<noscript data-wpr-hosted-gf-parameters=""><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=swap"></noscript>
 				</head>
 				<body>
 				</body>
@@ -179,9 +179,9 @@ return [
 					<link data-rocket-preload as="style" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=swap" rel="preload">
 
 					<link href="https://fonts.googleapis.com/css2?family=Goldman:wght@700&#038;family=Roboto:ital,wght@0,100;0,400;0,500;1,500;1,900&#038;family=Comfortaa&#038;display=swap" media="print" onload="this.media=&#039;all&#039;" rel="stylesheet">
-					<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Goldman:wght@700&#038;family=Roboto:ital,wght@0,100;0,400;0,500;1,500;1,900&#038;family=Comfortaa&#038;display=swap"></noscript>
+					<noscript data-wpr-hosted-gf-parameters=""><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Goldman:wght@700&#038;family=Roboto:ital,wght@0,100;0,400;0,500;1,500;1,900&#038;family=Comfortaa&#038;display=swap"></noscript>
 					<link href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=swap" media="print" onload="this.media=&#039;all&#039;" rel="stylesheet">
-					<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=swap"></noscript>
+					<noscript data-wpr-hosted-gf-parameters=""><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Josefin%20Sans%3A100%2C300%2C300italic%2C400%2C600%2C700%7CRoboto%3A100italic%2C300italic%2C400%2C500%2C600%2C700%7CUnica%20One%3A400%2C600%2C700%7CJosefin%20Sans%3Aregular%2C300%7CJosefin%20Sans%3A300&#038;display=swap"></noscript>
 					<link rel="preconnect" href="https://fonts.gstatic.com">
 				</head>
 				<body>

--- a/tests/Fixtures/inc/Engine/Optimization/GoogleFonts/CombineV2/optimize.php
+++ b/tests/Fixtures/inc/Engine/Optimization/GoogleFonts/CombineV2/optimize.php
@@ -49,7 +49,7 @@ return [
 					<title>Sample Page</title>
 					<link data-rocket-preload as="style" href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@450&#038;display=swap" rel="preload">
 					<link href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@450&#038;display=swap" media="print" onload="this.media=&#039;all&#039;" rel="stylesheet">
-					<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@450&#038;display=swap"></noscript>
+					<noscript data-wpr-hosted-gf-parameters=""><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@450&#038;display=swap"></noscript>
 				</head>
 				<body>
 				</body>
@@ -81,7 +81,7 @@ return [
 					<title>Sample Page</title>
 					<link data-rocket-preload as="style" href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@450&#038;display=swap" rel="preload">
 					<link href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@450&#038;display=swap" media="print" onload="this.media=&#039;all&#039;" rel="stylesheet">
-					<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@450&#038;display=swap"></noscript>
+					<noscript data-wpr-hosted-gf-parameters=""><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@450&#038;display=swap"></noscript>
 					<link rel="stylesheet" id="dt-more-fonts-css" href="https://fonts.googleapis.com/css2?family=Comfortaa&text=Hello" type="text/css" media="all" />
 				</head>
 				<body>
@@ -115,7 +115,7 @@ return [
 					<title>Sample Page</title>
 					<link data-rocket-preload as="style" href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@450&#038;family=Comfortaa&#038;display=swap" rel="preload">
 					<link href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@450&#038;family=Comfortaa&#038;display=swap" media="print" onload="this.media=&#039;all&#039;" rel="stylesheet">
-					<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@450&#038;family=Comfortaa&#038;display=swap"></noscript>
+					<noscript data-wpr-hosted-gf-parameters=""><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@450&#038;family=Comfortaa&#038;display=swap"></noscript>
 				</head>
 				<body>
 				</body>
@@ -150,7 +150,7 @@ return [
 					<title>Sample Page</title>
 					<link data-rocket-preload as="style" href="https://fonts.googleapis.com/css2?family=Goldman:wght@700&#038;family=Roboto:ital,wght@0,100;0,400;0,500;1,500;1,900&#038;family=Comfortaa&#038;display=swap" rel="preload">
 					<link href="https://fonts.googleapis.com/css2?family=Goldman:wght@700&#038;family=Roboto:ital,wght@0,100;0,400;0,500;1,500;1,900&#038;family=Comfortaa&#038;display=swap" media="print" onload="this.media=&#039;all&#039;" rel="stylesheet">
-					<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Goldman:wght@700&#038;family=Roboto:ital,wght@0,100;0,400;0,500;1,500;1,900&#038;family=Comfortaa&#038;display=swap"></noscript>
+					<noscript data-wpr-hosted-gf-parameters=""><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Goldman:wght@700&#038;family=Roboto:ital,wght@0,100;0,400;0,500;1,500;1,900&#038;family=Comfortaa&#038;display=swap"></noscript>
 					<link rel="preconnect" href="https://fonts.gstatic.com">
 				</head>
 				<body>
@@ -186,7 +186,7 @@ return [
 			<title>Sample Page</title>
 			<link data-rocket-preload as="style" href="https://fonts.googleapis.com/css2?family=Goldman:wght@700&#038;family=Roboto:ital,wght@0,100;0,400;0,500;1,500;1,900&#038;family=Comfortaa&#038;display=swap" rel="preload">
 			<link href="https://fonts.googleapis.com/css2?family=Goldman:wght@700&#038;family=Roboto:ital,wght@0,100;0,400;0,500;1,500;1,900&#038;family=Comfortaa&#038;display=swap" media="print" onload="this.media=&#039;all&#039;" rel="stylesheet">
-			<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Goldman:wght@700&#038;family=Roboto:ital,wght@0,100;0,400;0,500;1,500;1,900&#038;family=Comfortaa&#038;display=swap"></noscript>
+			<noscript data-wpr-hosted-gf-parameters=""><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Goldman:wght@700&#038;family=Roboto:ital,wght@0,100;0,400;0,500;1,500;1,900&#038;family=Comfortaa&#038;display=swap"></noscript>
 			<link rel="preconnect" href="https://fonts.gstatic.com">
 			</head>
 			<body>
@@ -222,7 +222,7 @@ return [
 			<title>Sample Page</title>
 			<link data-rocket-preload as="style" href="https://fonts.googleapis.com/css2?family=Goldman:wght@700&#038;family=Roboto:ital,wght@0,100;0,400;0,500;1,500;1,900&#038;family=Comfortaa&#038;display=optional" rel="preload">
 			<link href="https://fonts.googleapis.com/css2?family=Goldman:wght@700&#038;family=Roboto:ital,wght@0,100;0,400;0,500;1,500;1,900&#038;family=Comfortaa&#038;display=optional" media="print" onload="this.media=&#039;all&#039;" rel="stylesheet">
-			<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Goldman:wght@700&#038;family=Roboto:ital,wght@0,100;0,400;0,500;1,500;1,900&#038;family=Comfortaa&#038;display=optional"></noscript>
+			<noscript data-wpr-hosted-gf-parameters=""><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Goldman:wght@700&#038;family=Roboto:ital,wght@0,100;0,400;0,500;1,500;1,900&#038;family=Comfortaa&#038;display=optional"></noscript>
 			<link rel="preconnect" href="https://fonts.gstatic.com">
 			</head>
 			<body>
@@ -293,7 +293,7 @@ return [
 			Sample Page</title>
 			<link data-rocket-preload as="style" href="https://fonts.googleapis.com/css2?family=Goldman:wght@700&#038;family=Roboto:ital,wght@0,100;0,400;0,500;1,500;1,900&#038;family=MontSerra:ital,wght@0,100;0,400;0,500;1,500;1,900&#038;family=Comfortaa&#038;display=optional" rel="preload">
 			<link href="https://fonts.googleapis.com/css2?family=Goldman:wght@700&#038;family=Roboto:ital,wght@0,100;0,400;0,500;1,500;1,900&#038;family=MontSerra:ital,wght@0,100;0,400;0,500;1,500;1,900&#038;family=Comfortaa&#038;display=optional" media="print" onload="this.media=&#039;all&#039;" rel="stylesheet">
-			<noscript>
+			<noscript data-wpr-hosted-gf-parameters="">
 			<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Goldman:wght@700&#038;family=Roboto:ital,wght@0,100;0,400;0,500;1,500;1,900&#038;family=MontSerra:ital,wght@0,100;0,400;0,500;1,500;1,900&#038;family=Comfortaa&#038;display=optional">
 			</noscript>
 			<link rel="preconnect" href="https://fonts.gstatic.com">


### PR DESCRIPTION
Fixes #7498

# Description

Fixes #7499 
- Ensures self-hosted fonts behave consistently with external optimized fonts

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

The template mentioned by QA.

### How to test

refer to issue

## Technical description

### Documentation

- Add is_preload_enabled() method to check auto_preload_fonts setting
- Apply media='print' and onload='this.media="all"' when preload is enabled
- Include noscript fallback for users without JavaScript
- Ensures self-hosted fonts behave consistently with external optimized fonts

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification
E2E tests for this.