### PR TITLE
Fix #7923: Rocket Insights - Fix extra space on notice link

### DIFF
--- a/inc/admin/ui/notices.php
+++ b/inc/admin/ui/notices.php
@@ -455,7 +455,7 @@ function rocket_thank_you_license() {
 
 		$message = sprintf(
 		/* translators: %1$s = plugin name, %2$s = opening link tag, %3$s = closing link tag */
-		__( '%1$s %2$s is good to go! %3$s Your website is already faster. Visit %4$s Rocket Insights %5$s to check your homepage\'s performance, add more pages to measure WP Rocket\'s impact, and keep your site fast.', 'rocket' ),
+		__( '%1$s %2$s is good to go! %3$s Your website is already faster. Visit %4$sRocket Insights%5$s to check your homepage\'s performance, add more pages to measure WP Rocket\'s impact, and keep your site fast.', 'rocket' ),
 		'<strong>',
 		WP_ROCKET_PLUGIN_NAME,
 		'</strong>',


### PR DESCRIPTION
# Description

Fixes #7923
Remove an extra space in the link tag within an Rocket Insights notice when first install WP Rocket 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

Installing for the first time WP Rocket. 
<img width="1301" height="178" alt="Screenshot 2025-11-27 at 04 12 42" src="https://github.com/user-attachments/assets/fe5e545b-fc99-4820-b88a-c28a474a91f4" />

### How to test

Install for the first time the plugin. Check the notice about RocketInsights.

## Technical description

### Documentation
Remove an extra space in the notice

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification
No tests for this