### PR TITLE
Remove @since as mandatory from copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -104,7 +104,8 @@ public function process_data( $data ) {
 
 **PHPDoc Blocks:**
 - All public methods MUST have complete PHPDoc
-- Include `@since`, `@param`, and `@throws` when applicable
+- Include `@param`, `@return`, and `@throws` when applicable
+- `@since` is optional
 - Document complex private methods
 - Keep inline comments minimal and meaningful
 
@@ -754,8 +755,6 @@ $expiration = apply_filters( 'rocket_cache_expiration', 3600 );
 // ✅ GOOD: Type-safe filter with documentation
 /**
  * Filters the cache expiration time.
- *
- * @since 3.0
  * 
  * @param int $expiration Cache expiration in seconds.
  * @return int
@@ -773,8 +772,9 @@ $expiration = wpm_apply_filters_typed( 'integer', 'rocket_cache_expiration', 360
 **Documentation Requirements:**
 Every `wpm_apply_filters_typed()` call MUST have a docblock that includes:
 - Description of what the filter does
-- `@since` version tag
 - `@param` for all parameters with types
+- `@return` for the return type
+- `@since` is optional
 
 **Real Example:**
 ```php


### PR DESCRIPTION
# Description

Fixes #xx
Nothing impacting users. Just removing the mention of `@since` being mandatory.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

Nothing to be tested.

### How to test

Nothing to be tested 
## Technical description

### Documentation

Remove `@since` from mandatory tags.

# Mandatory Checklist

## Code validation

- [ ] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [ ] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [ ] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [ ] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

Nothing is code related.