### PR TITLE
Closes #7357: Compatibility between ALR and GeneratePress footer element

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -133,8 +133,8 @@
 	"scripts": {
 		"test-unit": "\"vendor/bin/phpunit\" --testsuite unit --colors=always --configuration tests/Unit/phpunit.xml.dist",
 		"test-unit-coverage": "\"vendor/bin/phpunit\" --testsuite unit --colors=always --configuration tests/Unit/phpunit.xml.dist --coverage-php tests/report/unit.cov",
-		"test-integration": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --exclude-group AdminOnly,BeaverBuilder,Elementor,Hummingbird,WithSmush,WithWoo,WithAmp,WithAmpAndCloudflare,WithSCCSS,Cloudways,Dreampress,Cloudflare,CloudflareAdmin,Multisite,WPEngine,SpinUpWP,WordPressCom,O2Switch,PDFEmbedder,PDFEmbedderPremium,PDFEmbedderSecure,Godaddy,LiteSpeed,RevolutionSlider,WordFence,ConvertPlug,Kinsta,Jetpack,RankMathSEO,AllInOneSeoPack,SEOPress,TheSEOFramework,OneCom,RocketLazyLoad,WPXCloud,TheEventsCalendar,Perfmatters,RapidLoad,ProIsp,TranslatePress,WPGeotargeting,Weglot,Pressidium,PerformanceHints",
-		"test-integration-coverage": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --exclude-group AdminOnly,BeaverBuilder,Elementor,Hummingbird,WithSmush,WithWoo,WithAmp,WithAmpAndCloudflare,WithSCCSS,Cloudways,Dreampress,Cloudflare,CloudflareAdmin,Multisite,WPEngine,SpinUpWP,WordPressCom,O2Switch,PDFEmbedder,PDFEmbedderPremium,PDFEmbedderSecure,Godaddy,LiteSpeed,RevolutionSlider,WordFence,ConvertPlug,Kinsta,Jetpack,RankMathSEO,AllInOneSeoPack,SEOPress,TheSEOFramework,OneCom,RocketLazyLoad,WPXCloud,TheEventsCalendar,Perfmatters,RapidLoad,ProIsp,TranslatePress,WPGeotargeting,Weglot,Pressidium,PerformanceHints --coverage-php tests/report/integration.cov",
+		"test-integration": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --exclude-group AdminOnly,BeaverBuilder,Elementor,Hummingbird,WithSmush,WithWoo,WithAmp,WithAmpAndCloudflare,WithSCCSS,Cloudways,Dreampress,Cloudflare,CloudflareAdmin,Multisite,WPEngine,SpinUpWP,WordPressCom,O2Switch,PDFEmbedder,PDFEmbedderPremium,PDFEmbedderSecure,Godaddy,LiteSpeed,RevolutionSlider,WordFence,ConvertPlug,Kinsta,Jetpack,RankMathSEO,AllInOneSeoPack,SEOPress,TheSEOFramework,OneCom,RocketLazyLoad,WPXCloud,TheEventsCalendar,Perfmatters,RapidLoad,ProIsp,TranslatePress,WPGeotargeting,Weglot,Pressidium,PerformanceHints,GeneratePress",
+		"test-integration-coverage": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --exclude-group AdminOnly,BeaverBuilder,Elementor,Hummingbird,WithSmush,WithWoo,WithAmp,WithAmpAndCloudflare,WithSCCSS,Cloudways,Dreampress,Cloudflare,CloudflareAdmin,Multisite,WPEngine,SpinUpWP,WordPressCom,O2Switch,PDFEmbedder,PDFEmbedderPremium,PDFEmbedderSecure,Godaddy,LiteSpeed,RevolutionSlider,WordFence,ConvertPlug,Kinsta,Jetpack,RankMathSEO,AllInOneSeoPack,SEOPress,TheSEOFramework,OneCom,RocketLazyLoad,WPXCloud,TheEventsCalendar,Perfmatters,RapidLoad,ProIsp,TranslatePress,WPGeotargeting,Weglot,Pressidium,PerformanceHints,GeneratePress --coverage-php tests/report/integration.cov",
 		"test-integration-adminonly": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group AdminOnly",
 		"test-integration-adminonly-coverage": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group AdminOnly --coverage-php tests/report/integration-adminonly.cov",
 		"test-integration-performancehints": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group PerformanceHints",
@@ -181,6 +181,7 @@
         "test-integration-translatepress": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group TranslatePress",
         "test-integration-weglot": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group Weglot",
 		"test-integration-pressidium": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group Pressidium",
+		"test-integration-generatepress": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist --group GeneratePress",
 		"run-tests": [
 			"@test-unit",
 			"@test-integration",
@@ -234,7 +235,8 @@
 			"@test-integration-wp-geotargeting",
       "@test-integration-translatepress",
       "@test-integration-weglot",
-			"@test-integration-pressidium"
+			"@test-integration-pressidium",
+			"@test-integration-generatepress"
 		],
 		"run-stan": "vendor/bin/phpstan analyze --memory-limit=2G --no-progress",
 		"run-stan-reset-baseline": "vendor/bin/phpstan analyze --memory-limit=2G --no-progress --generate-baseline",

--- a/inc/ThirdParty/Themes/GeneratePress.php
+++ b/inc/ThirdParty/Themes/GeneratePress.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace WP_Rocket\ThirdParty\Themes;
+
+use WP_Rocket\Event_Management\Subscriber_Interface;
+
+class GeneratePress implements Subscriber_Interface {
+	/**
+	 * Return an array of events that this subscriber wants to listen to.
+	 *
+	 * @return array
+	 */
+	public static function get_subscribed_events() {
+		return [
+			'generate_footer_class' => 'inject_exclusions_class',
+		];
+	}
+
+	/**
+	 * Injects exclusion class into GeneratePress footer classes.
+	 *
+	 * @since 3.20.3
+	 *
+	 * @param array $class Array of footer classes.
+	 *
+	 * @return array The modified array of footer classes.
+	 */
+	public function inject_exclusions_class( array $class ): array {
+        $class[] = 'no-wpr-lazyrender';
+
+        return $class;
+	}
+}

--- a/inc/ThirdParty/Themes/GeneratePress.php
+++ b/inc/ThirdParty/Themes/GeneratePress.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace WP_Rocket\ThirdParty\Themes;
 

--- a/inc/ThirdParty/Themes/GeneratePress.php
+++ b/inc/ThirdParty/Themes/GeneratePress.php
@@ -21,13 +21,13 @@ class GeneratePress implements Subscriber_Interface {
 	 *
 	 * @since 3.20.3
 	 *
-	 * @param array $class Array of footer classes.
+	 * @param array $classes Array of footer classes.
 	 *
 	 * @return array The modified array of footer classes.
 	 */
-	public function inject_exclusions_class( array $class ): array {
-        $class[] = 'no-wpr-lazyrender';
+	public function inject_exclusions_class( array $classes ): array {
+		$classes[] = 'no-wpr-lazyrender';
 
-        return $class;
+		return $classes;
 	}
 }

--- a/inc/ThirdParty/Themes/SubscriberFactory.php
+++ b/inc/ThirdParty/Themes/SubscriberFactory.php
@@ -47,7 +47,7 @@ class SubscriberFactory {
 					'class'     => Jevelin::class,
 					'arguments' => [],
 				];
-			case 'minimalist_blogger':
+			case 'minimalistblogger':
 				return [
 					'class'     => MinimalistBlogger::class,
 					'arguments' => [],
@@ -77,6 +77,11 @@ class SubscriberFactory {
 			case 'shoptimizer':
 				return [
 					'class'     => Shoptimizer::class,
+					'arguments' => [],
+				];
+			case 'generatepress':
+				return [
+					'class'     => GeneratePress::class,
 					'arguments' => [],
 				];
 			default:

--- a/inc/ThirdParty/Themes/ThemeResolver.php
+++ b/inc/ThirdParty/Themes/ThemeResolver.php
@@ -15,12 +15,13 @@ class ThemeResolver {
 		'divi',
 		'flatsome',
 		'jevelin',
-		'minimalist_blogger',
+		'minimalistblogger',
 		'polygon',
 		'uncode',
 		'xstore',
 		'themify',
 		'shoptimizer',
+		'generatepress',
 	];
 
 	/**

--- a/tests/Fixtures/inc/ThirdParty/Themes/GeneratePress/injectExclusionsClass.php
+++ b/tests/Fixtures/inc/ThirdParty/Themes/GeneratePress/injectExclusionsClass.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+    'shouldAddExclusionClass' => [
+        'config' => [
+            'default_class' => [
+                'site-footer',
+            ],
+        ],
+        'expected' => [
+            'site-footer',
+            'no-wpr-lazyrender',
+        ],
+    ],
+];

--- a/tests/Fixtures/inc/ThirdParty/Themes/themes.php
+++ b/tests/Fixtures/inc/ThirdParty/Themes/themes.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * Array mapping the theme test group to the theme slug.
+ *
+ * Example:
+ * [
+ *     'ThemeTestGroup' => 'theme-slug',
+ * ]
+ */
+return [
+    'GeneratePress' => 'generatepress',
+];

--- a/tests/Integration/bootstrap.php
+++ b/tests/Integration/bootstrap.php
@@ -16,7 +16,6 @@ define( 'WP_ROCKET_IS_TESTING', true );
 tests_add_filter(
 	'muplugins_loaded',
 	function () {
-
 		// Disable ATF, LRC, Preload fonts, and Preconnect external domains optimizations to prevent DB requests (unrelated to other tests).
 		add_filter( 'rocket_above_the_fold_optimization', '__return_false' );
 		add_filter( 'rocket_lrc_optimization', '__return_false' );
@@ -274,6 +273,15 @@ tests_add_filter(
 			add_filter( 'rocket_lrc_optimization', '__return_true' );
 			add_filter( 'rocket_preconnect_external_domains_optimization', '__return_true' );
 			add_filter( 'pre_get_rocket_option_auto_preload_fonts', '__return_true' );
+		}
+
+		// Load theme definitions for test groups.
+		$themes = require WP_ROCKET_TESTS_FIXTURES_DIR . '/inc/ThirdParty/Themes/themes.php';
+
+		foreach ( $themes as $theme_group => $theme_slug ) {
+			if ( BootstrapManager::isGroup( $theme_group ) ) {
+				switch_theme( $theme_slug );
+			}
 		}
 
 		// Load the plugin.

--- a/tests/Integration/inc/ThirdParty/Themes/GeneratePress/injectExclusionsClass.php
+++ b/tests/Integration/inc/ThirdParty/Themes/GeneratePress/injectExclusionsClass.php
@@ -9,13 +9,19 @@ use WP_Rocket\Tests\Integration\TestCase;
  * @group Themes
  * @group GeneratePress
  */
-class Test_injectExclusionsClass extends TestCase {
+class Test_InjectExclusionsClass extends TestCase {
 	/**
+	 * Test that the exclusion class is added to footer classes.
+	 *
 	 * @dataProvider configTestData
+	 *
+	 * @param array $config   Test configuration.
+	 * @param array $expected Expected result.
 	 */
 	public function testShouldReturnExpected( $config, $expected ) {
 		$this->assertSame(
 			$expected,
+			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Third-party hook from GeneratePress theme.
 			apply_filters( 'generate_footer_class', $config['default_class'] )
 		);
 	}

--- a/tests/Integration/inc/ThirdParty/Themes/GeneratePress/injectExclusionsClass.php
+++ b/tests/Integration/inc/ThirdParty/Themes/GeneratePress/injectExclusionsClass.php
@@ -21,7 +21,6 @@ class Test_InjectExclusionsClass extends TestCase {
 	public function testShouldReturnExpected( $config, $expected ) {
 		$this->assertSame(
 			$expected,
-			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Third-party hook from GeneratePress theme.
 			apply_filters( 'generate_footer_class', $config['default_class'] )
 		);
 	}

--- a/tests/Integration/inc/ThirdParty/Themes/GeneratePress/injectExclusionsClass.php
+++ b/tests/Integration/inc/ThirdParty/Themes/GeneratePress/injectExclusionsClass.php
@@ -1,0 +1,22 @@
+<?php
+namespace WP_Rocket\Tests\Integration\inc\ThirdParty\Themes\GeneratePress;
+
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * Test class covering \WP_Rocket\ThirdParty\Themes\GeneratePress::inject_exclusions_class
+ *
+ * @group Themes
+ * @group GeneratePress
+ */
+class Test_injectExclusionsClass extends TestCase {
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnExpected( $config, $expected ) {
+		$this->assertSame(
+			$expected,
+			apply_filters( 'generate_footer_class', $config['default_class'] )
+		);
+	}
+}


### PR DESCRIPTION
# Description

Fixes #7357 
Fix footer layout issue for Generate Press theme by adding a generic exclusion class to exclude from ALR

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

- Install & Activate Generate Press
- Inspect element and look for `site-footer`
- See that `no-wpr-lazyrender` is also added to the class

NB: We need to add `no-wpr-lazyrender` to the lists of exclusions for ALR in the backend to see the exclusion take effect.

### How to test

Same as what was tested.

## Technical description

### Documentation

Add a 3rd party compatibility class to cater for adding generic class to exclude element from ALR.

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

Not applicable to the changes in this PR.

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
