### PR TITLE
FIX #7914: Guard against fatal error Rocket Insights

### DIFF
--- a/inc/Engine/Admin/RocketInsights/PostListing/Subscriber.php
+++ b/inc/Engine/Admin/RocketInsights/PostListing/Subscriber.php
@@ -115,7 +115,7 @@ class Subscriber implements Subscriber_Interface {
 	 * @param string   $post_type Post type.
 	 * @return array
 	 */
-	public function add_column_to_posts( $columns, $post_type ): array {
+	public function add_column_to_posts( $columns, $post_type = 'post' ): array {
 		// Don't add for products again, because it's added above.
 		if ( 'product' === $post_type ) {
 			return $columns;


### PR DESCRIPTION
# Description

Fixes #7914 
Adding a default value to `add_column_to_posts` to guard against fatal error cause by 3rd parties.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

Refer to issue

### How to test

Refer to issue

### Affected Features & Quality Assurance Scope

Rocket Insights

## Technical description

### Documentation

This pull request makes a minor change to the `add_column_to_posts` function in `inc/Engine/Admin/RocketInsights/PostListing/Subscriber.php`, setting a default value for the `$post_type` parameter to `'post'`.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.
