### PR TITLE
Closes #6618: Autodelete wp-rocket-debug.log.html if it grows bigger than a specifc size

### DIFF
--- a/inc/Engine/WPRocketUninstall.php
+++ b/inc/Engine/WPRocketUninstall.php
@@ -93,6 +93,7 @@ class WPRocketUninstall {
 		'wpr_user_information_timeout',
 		'rocket_fonts_data_collection',
 		'wpr_global_score_data',
+		'wp_rocket_log_file_size_check',
 	];
 
 	/**

--- a/inc/Logger/Logger.php
+++ b/inc/Logger/Logger.php
@@ -558,7 +558,7 @@ class Logger {
 		$log_file_stats = self::get_log_file_stats();
 
 		// Bail out if there is an error getting the log file stats.
-		if ( is_wp_error( $log_file_size ) ) {
+		if ( is_wp_error( $log_file_stats ) ) {
 			return;
 		}
 

--- a/inc/Logger/Logger.php
+++ b/inc/Logger/Logger.php
@@ -154,6 +154,9 @@ class Logger {
 	 * @return Logger A Logger instance.
 	 */
 	public static function get_logger() {
+		// Automatically delete the log file if it exceeds the maximum allowed size.
+		static::auto_delete_log_file();
+
 		$logger_name = static::LOGGER_NAME;
 		$log_level   = Monologger::DEBUG;
 
@@ -273,11 +276,12 @@ class Logger {
 
 		$entries  = $entries ? number_format_i18n( count( $entries ) ) : '0';
 		$bytes    = $filesystem->size( $file_path );
+		$raw_size = $bytes;
 		$decimals = $bytes > pow( 1024, 3 ) ? 1 : 0;
 		$bytes    = @size_format( $bytes, $decimals ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 		$bytes    = str_replace( ' ', ' ', $bytes ); // Non-breaking space character.
 
-		return compact( 'entries', 'bytes' );
+		return compact( 'entries', 'bytes', 'raw_size' );
 	}
 
 	/**
@@ -504,5 +508,34 @@ class Logger {
 		}
 
 		return $cookies;
+	}
+
+	/**
+	 * Automatically deletes the log file if it exceeds a maximum file size.
+	 *
+	 * The maximum file size before deletion is controlled by the 'rocket_debug_log_auto_delete_max_file_size' filter,
+	 * with a default of 30,000,000 bytes (approximately 30MB).
+	 *
+	 * @since 3.20.4
+	 *
+	 * @return void
+	 */
+	private static function auto_delete_log_file(): void {
+		$log_file_stats = static::get_log_file_stats();
+
+		/**
+		 * Filters the maximum file size (in bytes) before the log file is automatically deleted.
+		 *
+		 * @param int $max_file_size The maximum file size in bytes. Default is 30,000,000 (30MB).
+		 *
+		 * @since 3.20.4
+		 */
+		$max_file_size = wpm_apply_filters_typed( 'integer', 'rocket_debug_log_auto_delete_max_file_size', 30000000 );
+
+		if ( $log_file_stats['raw_size'] < $max_file_size ) {
+			return;
+		}
+
+		static::delete_log_file();
 	}
 }

--- a/inc/Logger/Logger.php
+++ b/inc/Logger/Logger.php
@@ -154,9 +154,6 @@ class Logger {
 	 * @return Logger A Logger instance.
 	 */
 	public static function get_logger() {
-		// Automatically delete the log file if it exceeds the maximum allowed size.
-		static::auto_delete_log_file();
-
 		$logger_name = static::LOGGER_NAME;
 		$log_level   = Monologger::DEBUG;
 
@@ -388,7 +385,18 @@ class Logger {
 	 * @return bool
 	 */
 	public static function debug_enabled() {
-		return defined( 'WP_ROCKET_DEBUG' ) && WP_ROCKET_DEBUG;
+		$debug_enabled = defined( 'WP_ROCKET_DEBUG' ) && WP_ROCKET_DEBUG;
+
+		/**
+		 * Fires before checking if debug is enabled for the logger.
+		 * 
+		 * @param boolean $debug_status Returns if debug is enabled.
+		 *
+		 * @since 3.20.4
+		 */
+		do_action( 'rocket_before_debug_status_check', $debug_enabled );
+
+		return $debug_enabled;
 	}
 
 	/**
@@ -516,12 +524,27 @@ class Logger {
 	 * The maximum file size before deletion is controlled by the 'rocket_debug_log_auto_delete_max_file_size' filter,
 	 * with a default of 30,000,000 bytes (approximately 30MB).
 	 *
-	 * @since 3.20.4
-	 *
+	 * @param bool $debug_enabled Whether debug is enabled and log file auto-delete should proceed.
 	 * @return void
 	 */
-	private static function auto_delete_log_file(): void {
-		$log_file_stats = static::get_log_file_stats();
+	public static function maybe_delete_log_file( $debug_enabled ): void {
+		// Bail out if debug is not enabled.
+		if ( ! $debug_enabled ) {
+			return;
+		}
+
+		// Bail out if debug.log file does not exist.
+		if ( ! rocket_direct_filesystem()->exists( self::get_log_file_path() ) ) {
+			return;
+		}
+
+		// Bail out if transient cache is still valid.
+		if ( get_transient( 'wp_rocket_log_file_size_check' ) ) {
+			return;
+		}
+
+		// Do transient cache for one hour.
+		set_transient( 'wp_rocket_log_file_size_check', true, HOUR_IN_SECONDS );
 
 		/**
 		 * Filters the maximum file size (in bytes) before the log file is automatically deleted.
@@ -532,10 +555,12 @@ class Logger {
 		 */
 		$max_file_size = wpm_apply_filters_typed( 'integer', 'rocket_debug_log_auto_delete_max_file_size', 30000000 );
 
-		if ( $log_file_stats['raw_size'] < $max_file_size ) {
+		$log_file_size = self::get_log_file_stats()['raw_size'];
+
+		if ( $log_file_size < $max_file_size ) {
 			return;
 		}
 
-		static::delete_log_file();
+		self::delete_log_file();
 	}
 }

--- a/inc/Logger/Logger.php
+++ b/inc/Logger/Logger.php
@@ -389,7 +389,7 @@ class Logger {
 
 		/**
 		 * Fires before checking if debug is enabled for the logger.
-		 * 
+		 *
 		 * @param boolean $debug_status Returns if debug is enabled.
 		 *
 		 * @since 3.20.4

--- a/inc/Logger/Logger.php
+++ b/inc/Logger/Logger.php
@@ -555,7 +555,14 @@ class Logger {
 		 */
 		$max_file_size = wpm_apply_filters_typed( 'integer', 'rocket_debug_log_auto_delete_max_file_size', 30000000 );
 
-		$log_file_size = self::get_log_file_stats()['raw_size'];
+		$log_file_stats = self::get_log_file_stats();
+
+		// Bail out if there is an error getting the log file stats.
+		if ( is_wp_error( $log_file_size ) ) {
+			return;
+		}
+
+		$log_file_size = $log_file_stats['raw_size'];
 
 		if ( $log_file_size < $max_file_size ) {
 			return;

--- a/inc/Logger/ServiceProvider.php
+++ b/inc/Logger/ServiceProvider.php
@@ -13,6 +13,7 @@ class ServiceProvider extends AbstractServiceProvider {
 	 */
 	protected $provides = [
 		'logger',
+		'logger_subscriber',
 	];
 
 	/**
@@ -34,5 +35,6 @@ class ServiceProvider extends AbstractServiceProvider {
 		$this->getContainer()
 			->inflector( LoggerAwareInterface::class )
 			->invokeMethod( 'set_logger', [ $this->getContainer()->get( 'logger' ) ] );
+		$this->getContainer()->addShared( 'logger_subscriber', Subscriber::class );
 	}
 }

--- a/inc/Logger/Subscriber.php
+++ b/inc/Logger/Subscriber.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Logger;
+
+use WP_Rocket\Event_Management\Subscriber_Interface;
+use WP_Rocket\Logger\Logger;
+
+class Subscriber implements Subscriber_Interface {
+	/**
+	 * Events this subscriber listens to.
+	 *
+	 * @return array
+	 */
+	public static function get_subscribed_events() {
+		return [
+			'rocket_before_debug_status_check' => 'maybe_delete_log_file',
+		];
+	}
+
+	/**
+	 * Automatically deletes the log file if it exceeds a maximum file size.
+     * 
+     * @param bool $debug_enabled Whether debug is enabled and log file auto-delete should proceed.
+	 * @return void
+	 */
+	public function maybe_delete_log_file( $debug_enabled ): void {
+		Logger::maybe_delete_log_file( $debug_enabled );
+	}
+}

--- a/inc/Logger/Subscriber.php
+++ b/inc/Logger/Subscriber.php
@@ -20,8 +20,8 @@ class Subscriber implements Subscriber_Interface {
 
 	/**
 	 * Automatically deletes the log file if it exceeds a maximum file size.
-     * 
-     * @param bool $debug_enabled Whether debug is enabled and log file auto-delete should proceed.
+	 *
+	 * @param bool $debug_enabled Whether debug is enabled and log file auto-delete should proceed.
 	 * @return void
 	 */
 	public function maybe_delete_log_file( $debug_enabled ): void {

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -415,6 +415,7 @@ class Plugin {
 			'ri_post_listing_subscriber',
 			'post_subscriber',
 			'tracking_subscriber',
+			'logger_subscriber',
 		];
 
 		$host_type = HostResolver::get_host_service();


### PR DESCRIPTION
# Description

Fixes #6618 
This PR fixes issue of growing WPR log file size when WPR debug is enabled by automatically deleting file when a specific max size is hit.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

### What was tested
Manually tested that when WPR log file size hits the max, log is automatically deleted

### How to test

Less than max default 30MB
- Have log size less than the max default (30MB)
- See that log isn't deleted

>= max default 30MB
- Have log size >= max default (30MB)
- See that log file is automatically deleted

Filtered max size
```PHP
add_filter( 'rocket_debug_log_auto_delete_max_file_size', function( $max_file_size ) {
	return 50000000;
} );
```

### Affected Features & Quality Assurance Scope

WPR Logger.

## Technical description

### Documentation
An action (`rocket_before_debug_status_check`) is added in WP_Rocket\Logger\Logger::debug_enabled with a single param which is the debug status, this was done because the debug_enabled method is called before the start of every log:
- https://github.com/wp-media/wp-rocket/blob/1cb3a79cbfca9a2d78f94b14d3fc21e2c738ba99/inc/Logger/Logger.php#L68
- https://github.com/wp-media/wp-rocket/blob/1cb3a79cbfca9a2d78f94b14d3fc21e2c738ba99/inc/Logger/Logger.php#L81
- https://github.com/wp-media/wp-rocket/blob/1cb3a79cbfca9a2d78f94b14d3fc21e2c738ba99/inc/Logger/Logger.php#L94
- https://github.com/wp-media/wp-rocket/blob/1cb3a79cbfca9a2d78f94b14d3fc21e2c738ba99/inc/Logger/Logger.php#L120
- https://github.com/wp-media/wp-rocket/blob/1cb3a79cbfca9a2d78f94b14d3fc21e2c738ba99/inc/Logger/Logger.php#L133
- https://github.com/wp-media/wp-rocket/blob/1cb3a79cbfca9a2d78f94b14d3fc21e2c738ba99/inc/Logger/Logger.php#L146

A callback is hooked to this action which deletes the debug log file if it exceeds the configured maximum size (default 30MB). Checks are :
- bail out if WPR debug is disabled
- bail out if log file don't exist
- Bail out if transient is not expired( Basic caching to reduce file processing logic every page visit for every 1 hour)
- Bail out if log size is < max size.

Maximum file size is filterable for flexibility and value is in bytes:
```PHP
add_filter( 'rocket_debug_log_auto_delete_max_file_size', function( $max_file_size ) {
	return 50000000;
} );
```

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

Not applicable to changes in this PR
For the test, I got some challenges writing it and don't have more time to invest in this at the moment.

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
