### PR TITLE
Fixed certain banner being displayed when license is revoked

### DIFF
--- a/inc/Engine/License/Banned.php
+++ b/inc/Engine/License/Banned.php
@@ -121,10 +121,6 @@ class Banned extends Abstract_Render {
 	 * @return bool True if the notice can be displayed, false otherwise.
 	 */
 	private function can_display(): bool {
-		if ( $this->user->is_license_expired() ) {
-			return false;
-		}
-
 		if ( ! $this->user->is_banned() ) {
 			return false;
 		}

--- a/inc/Engine/License/Renewal.php
+++ b/inc/Engine/License/Renewal.php
@@ -58,6 +58,10 @@ class Renewal extends Abstract_Render {
 			return;
 		}
 
+		if ( $this->user->is_banned() ) {
+			return;
+		}
+
 		if ( $this->user->is_license_expired() ) {
 			return;
 		}

--- a/inc/Engine/License/Renewal.php
+++ b/inc/Engine/License/Renewal.php
@@ -111,6 +111,10 @@ class Renewal extends Abstract_Render {
 		if ( false !== get_transient( 'rocket_renewal_banner_' . get_current_user_id() ) ) {
 			return;
 		}
+		
+		if ( $this->user->is_banned() ) {
+			return;
+		}
 
 		$expiration    = $this->user->get_license_expiration();
 		$expired_since = ( time() - $expiration ) / DAY_IN_SECONDS;

--- a/inc/Engine/License/Renewal.php
+++ b/inc/Engine/License/Renewal.php
@@ -111,7 +111,7 @@ class Renewal extends Abstract_Render {
 		if ( false !== get_transient( 'rocket_renewal_banner_' . get_current_user_id() ) ) {
 			return;
 		}
-		
+
 		if ( $this->user->is_banned() ) {
 			return;
 		}

--- a/inc/Engine/License/Upgrade.php
+++ b/inc/Engine/License/Upgrade.php
@@ -41,6 +41,10 @@ class Upgrade extends Abstract_Render {
 	 * @return void
 	 */
 	public function display_upgrade_section() {
+		if ( $this->user->is_banned() ) {
+			return;
+		}
+
 		if ( ! $this->can_upgrade() ) {
 			return;
 		}
@@ -55,6 +59,10 @@ class Upgrade extends Abstract_Render {
 	 */
 	public function display_upgrade_popin() {
 		if ( rocket_get_constant( 'WP_ROCKET_WHITE_LABEL_ACCOUNT' ) ) {
+			return;
+		}
+
+		if ( $this->user->is_banned() ) {
 			return;
 		}
 

--- a/tests/Fixtures/inc/Engine/License/Renewal/displayRenewalExpiredBanner.php
+++ b/tests/Fixtures/inc/Engine/License/Renewal/displayRenewalExpiredBanner.php
@@ -61,6 +61,22 @@ return [
 		],
 		'expected' => null,
 	],
+	'shouldReturnNullWhenUserIsBanned' => [
+		'config'   => [
+			'user' => [
+				'licence_account'    => 1,
+				'licence_expired'    => false,
+				'licence_expiration' => strtotime( 'last year' ),
+				'auto_renew' => false,
+				'is_banned' => true,
+			],
+			'ocd' => false,
+			'transient' => false,
+			'pricing' => $pricing,
+			'disabled_date' => '',
+		],
+		'expected' => null,
+	],
 	'shouldReturnNullWhenBannerDismissed' => [
 		'config'   => [
 			'user' => [

--- a/tests/Fixtures/inc/Engine/License/Renewal/displayRenewalSoonBanner.php
+++ b/tests/Fixtures/inc/Engine/License/Renewal/displayRenewalSoonBanner.php
@@ -86,6 +86,18 @@ return [
 		],
 		'expected' => null,
 	],
+	'testShouldReturnNullWhenLicenseIsBanned' => [
+		'config'   => [
+			'user' => [
+				'licence_account'    => 1,
+				'licence_expired'    => false,
+				'auto_renew'         => false,
+				'licence_expiration' => strtotime( 'next week' ),
+				'is_banned'			 => true,
+			],
+		],
+		'expected' => null,
+	],
 	'testShouldReturnDataWhenLicenseAndSingleAndNotGrandfathered' => [
 		'config'   => [
 			'user' => [

--- a/tests/Fixtures/inc/Engine/License/Subscriber/displayRenewalExpiredBanner.php
+++ b/tests/Fixtures/inc/Engine/License/Subscriber/displayRenewalExpiredBanner.php
@@ -60,6 +60,21 @@ return [
 		],
 		'expected' => '',
 	],
+	'testShouldReturnNullWhenUserIsBanned' => [
+		'config'   => [
+			'user' => json_decode( json_encode( [
+				'licence_account'    => 1,
+				'licence_expiration' => strtotime( 'last year' ),
+				'is_auto_renew' => false,
+				'licence' => (object) [
+                    'is_banned' => true,
+                ],
+			] ) ),
+			'pricing' => $pricing,
+			'transient' => false,
+		],
+		'expected' => '',
+	],
 	'testShouldReturnNullWhenBannerDismissed' => [
 		'config'   => [
 			'user' => json_decode( json_encode( [

--- a/tests/Fixtures/inc/Engine/License/Subscriber/displayRenewalSoonBanner.php
+++ b/tests/Fixtures/inc/Engine/License/Subscriber/displayRenewalSoonBanner.php
@@ -81,6 +81,20 @@ return [
 		],
 		'expected' => '',
 	],
+	'testShouldReturnNullWhenLicenseIsBanned' => [
+		'config'   => [
+			'user' => json_decode( json_encode( [
+				'licence_account'    => 1,
+				'has_auto_renew'     => false,
+				'licence_expiration' => strtotime( 'next week' ),
+				'licence' => (object) [
+                    'is_banned' => true,
+                ],
+			] ) ),
+			'pricing' => $pricing,
+		],
+		'expected' => '',
+	],
 	'testShouldReturnDataWhenLicenseAndSingleAndNotGrandfathered' => [
 		'config'   => [
 			'user' => json_decode( json_encode( [

--- a/tests/Fixtures/inc/Engine/License/Subscriber/maybeAddBannedBubble.php
+++ b/tests/Fixtures/inc/Engine/License/Subscriber/maybeAddBannedBubble.php
@@ -1,20 +1,6 @@
 <?php
 
 return [
-    'testShouldNotAddBubbleWhenLicenseIsExpired' => [
-        'config' => [
-            'user' => json_decode( json_encode( [
-				'licence_account'    => 1,
-				'has_auto_renew'     => false,
-				'licence_expiration' => strtotime( 'last year' ),
-                'licence' => (object) [
-                    'is_banned' => true,
-                ],
-			] ) ),
-            'current_user_can' => true,
-        ],
-        'expected' => 'WP Rocket',
-    ],
     'testShouldNotAddBubbleWhenUserIsNotBanned' => [
         'config' => [
             'user' => json_decode( json_encode( [
@@ -48,7 +34,7 @@ return [
             'user' => json_decode( json_encode( [
 				'licence_account'    => 1,
 				'has_auto_renew'     => false,
-				'licence_expiration' => strtotime( 'next year' ),
+				'licence_expiration' => strtotime( 'last year' ),
                 'licence' => (object) [
                     'is_banned' => true,
                 ],

--- a/tests/Fixtures/inc/Engine/License/Subscriber/maybeDisplayBannedBanner.php
+++ b/tests/Fixtures/inc/Engine/License/Subscriber/maybeDisplayBannedBanner.php
@@ -1,21 +1,6 @@
 <?php
 
 return [
-    'testShouldNotDisplayBannerWhenLicenseIsExpired' => [
-        'config' => [
-            'user' => json_decode( json_encode( [
-				'licence_account'    => 1,
-				'has_auto_renew'     => false,
-				'licence_expiration' => strtotime( 'last year' ),
-                'licence' => (object) [
-                    'is_banned' => true,
-                ],
-			] ) ),
-            'current_user_can' => true,
-            'current_screen' => 'settings_page_wprocket',
-        ],
-        'expected' => '',
-    ],
     'testShouldNotDisplayBannerWhenUserIsNotBanned' => [
         'config' => [
             'user' => json_decode( json_encode( [
@@ -66,7 +51,7 @@ return [
             'user' => json_decode( json_encode( [
 				'licence_account'    => 1,
 				'has_auto_renew'     => false,
-				'licence_expiration' => strtotime( 'next year' ),
+				'licence_expiration' => strtotime( 'last year' ),
                 'licence' => (object) [
                     'is_banned' => true,
                 ],

--- a/tests/Fixtures/inc/Engine/License/Subscriber/maybeDisplayBannedNotice.php
+++ b/tests/Fixtures/inc/Engine/License/Subscriber/maybeDisplayBannedNotice.php
@@ -1,21 +1,6 @@
 <?php
 
 return [
-    'testShouldNotDisplayNoticeWhenLicenseIsExpired' => [
-        'config' => [
-            'user' => json_decode( json_encode( [
-				'licence_account'    => 1,
-				'has_auto_renew'     => false,
-				'licence_expiration' => strtotime( 'last year' ),
-                'licence' => (object) [
-                    'is_banned' => true,
-                ],
-			] ) ),
-            'current_user_can' => true,
-            'current_screen' => 'settings_page_wp-crontrol-schedules',
-        ],
-        'expected' => '',
-    ],
     'testShouldNotDisplayNoticeWhenUserIsNotBanned' => [
         'config' => [
             'user' => json_decode( json_encode( [
@@ -66,7 +51,7 @@ return [
             'user' => json_decode( json_encode( [
 				'licence_account'    => 1,
 				'has_auto_renew'     => false,
-				'licence_expiration' => strtotime( 'next year' ),
+				'licence_expiration' => strtotime( 'last year' ),
                 'licence' => (object) [
                     'is_banned' => true,
                 ],

--- a/tests/Fixtures/inc/Engine/License/Upgrade/displayUpgradePopin.php
+++ b/tests/Fixtures/inc/Engine/License/Upgrade/displayUpgradePopin.php
@@ -20,6 +20,26 @@ return [
 		],
 		'expected' => null,
 	],
+	'testShouldReturnNullWhenUserIsBanned' => [
+		'config'   => [
+			'license_account'    => 1,
+			'licence_expiration' => false,
+			'is_banned'          => true,
+			'promo_active' => true,
+			'upgrades' => [
+				(object) [
+					'name' => 'Growth',
+					'slug' => 'growth',
+					'saving' => "40",
+					'upgrade_url' => "https://growthupgradeurl.com/",
+					'regular_price' => "50",
+					'websites' => "3",
+					'stack' => false,
+				]
+			],
+		],
+		'expected' => null,
+	],
 	'testShouldDisplayPopInWhenLicenseIsSingle' => [
 		'config'   => [
 			'license_account'    => 1,

--- a/tests/Fixtures/inc/Engine/License/Upgrade/displayUpgradeSection.php
+++ b/tests/Fixtures/inc/Engine/License/Upgrade/displayUpgradeSection.php
@@ -15,6 +15,25 @@ return [
 		],
 		'expected' => null,
 	],
+	'testShouldReturnNullWhenUserIsBanned' => [
+		'config'   => [
+			'license_account'    => 1,
+			'licence_expiration' => false,
+			'is_banned'          => true,
+			'upgrades' => [
+				(object) [
+					'name' => 'Growth',
+					'slug' => 'growth',
+					'saving' => "40",
+					'upgrade_url' => "https://growthupgradeurl.com/",
+					'regular_price' => "50",
+					'websites' => "3",
+					'stack' => false,
+				]
+			],
+		],
+		'expected' => null,
+	],
 	'testShouldDisplaySectionWhenLicenseIsNotExpiredAndNotInfinite' => [
 		'config'   => [
 			'license_account'    => 1,

--- a/tests/Unit/inc/Engine/License/Renewal/displayRenewalExpiredBanner.php
+++ b/tests/Unit/inc/Engine/License/Renewal/displayRenewalExpiredBanner.php
@@ -55,6 +55,11 @@ class DisplayRenewalExpiredBanner extends TestCase {
 		$this->user->shouldReceive( 'is_auto_renew' )
 			->andReturn( $config['user']['auto_renew'] );
 
+		$this->user->shouldReceive( 'is_banned' )
+			->atMost()
+			->once()
+			->andReturn( $config['user']['is_banned'] ?? false );
+
 		$this->options->shouldReceive( 'get' )
 			->with( 'optimize_css_delivery', 0 )
 			->andReturn( $config['ocd'] );

--- a/tests/Unit/inc/Engine/License/Renewal/displayRenewalSoonBanner.php
+++ b/tests/Unit/inc/Engine/License/Renewal/displayRenewalSoonBanner.php
@@ -57,6 +57,11 @@ class DisplayRenewalSoonBanner extends TestCase {
 			->once()
 			->andReturn( $config['user']['auto_renew'] );
 
+		$this->user->shouldReceive( 'is_banned' )
+			->atMost()
+			->once()
+			->andReturn( $config['user']['is_banned'] ?? false );
+
 		$this->user->shouldReceive( 'get_license_expiration' )
 			->andReturn( $config['user']['licence_expiration'] );
 

--- a/tests/Unit/inc/Engine/License/Upgrade/displayUpgradePopin.php
+++ b/tests/Unit/inc/Engine/License/Upgrade/displayUpgradePopin.php
@@ -45,6 +45,11 @@ class DisplayUpgradePopin extends TestCase {
 			->twice()
 			->andReturn( $config['license_account'] );
 
+		$this->user->shouldReceive( 'is_banned' )
+			->atMost()
+			->times( 1 )
+			->andReturn( $config['is_banned'] ?? false );
+
 		$this->user->shouldReceive( 'is_license_expired' )
 			->atMost()
 			->once()

--- a/tests/Unit/inc/Engine/License/Upgrade/displayUpgradeSection.php
+++ b/tests/Unit/inc/Engine/License/Upgrade/displayUpgradeSection.php
@@ -38,6 +38,11 @@ class DisplayUpgradeSection extends TestCase {
 	 * @dataProvider configTestData
 	 */
 	public function testShouldReturnExpected( $config, $expected ) {
+		$this->user->shouldReceive( 'is_banned' )
+			->atMost()
+			->times( 1 )
+			->andReturn( $config['is_banned'] ?? false );
+
 		$this->user->shouldReceive( 'is_license_expired' )
 			->atMost()
 			->times( 1 )


### PR DESCRIPTION
# Description

Fixes #(issue number)
Hides renewal soon and expired banner when license is revoked

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

### What was tested

See that renewal soon banner is not displayed when license is banned.

### How to test

QA already knows how to test this.

### Affected Features & Quality Assurance Scope

Renewal Soon Banner

## Technical description

### Documentation

Bail out of displaying renewal soon banner when license is banned.

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [ ] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

Not applicable to the changes in this PR

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
