### PR TITLE
Fix: Strip 'OK:' prefix from valid_key API error responses

### DIFF
--- a/inc/functions/options.php
+++ b/inc/functions/options.php
@@ -494,6 +494,11 @@ function rocket_check_key() {
 			return $return;
 		}
 
+		// Strip 'OK:' prefix if present for backward compatibility with new API format.
+		if ( str_starts_with( $body, 'OK:' ) ) {
+			$body = substr( $body, 3 );
+		}
+
 		Logger::error(
 			'License validation failed.',
 			[


### PR DESCRIPTION
# Description

Fixes #xx
The valid_key endpoint now returns error codes with an 'OK:' prefix (e.g., 'OK:USER_BLOCKED' instead of 'USER_BLOCKED'). This change strips the prefix before checking error codes to ensure blocked/banned users are properly rejected.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

Nothing at the moment

### How to test

https://group-onecom.slack.com/archives/C08EFCYRQ2X/p1770213730902139

### Affected Features & Quality Assurance Scope

Rocket Insights

## Technical description

### Documentation

This pull request introduces a small but important update to the `rocket_check_key` function to ensure compatibility with a new API response format. The change strips the `'OK:'` prefix from API responses, maintaining backward compatibility with previous behavior.

* Added logic to remove the `'OK:'` prefix from the `$body` variable in the `rocket_check_key` function for backward compatibility with the new API format.

# Mandatory Checklist

## Code validation

- [ ] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [ ] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [ ] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [ ] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

Nothing at the moment
