### PR TITLE
FIX #7442: Add fonts_section to Beacon for Fonts Need Help button

### DIFF
--- a/inc/Engine/Admin/Beacon/Beacon.php
+++ b/inc/Engine/Admin/Beacon/Beacon.php
@@ -455,6 +455,10 @@ class Beacon extends Abstract_Render implements Subscriber_Interface {
 				'en' => '5c884cf80428633d2cf38314,54b85754e4b0512429883a86,5418c792e4b0e7b8127bed99,569ec4a69033603f7da32c93,5419e246e4b099def9b5561e',
 				'fr' => '56967a859033603f7da30858,56967952c69791436155e60a,56cb9c9d90336008e9e9e3dc,569676ea9033603f7da3083d',
 			],
+			'fonts_section'              => [
+				'en' => '5eab7729042863474d19f647,673358b02ddbd952f6241b38',
+				'fr' => '5eb3add02c7d3a5ea54aa66d,675ab51d46b8d26833b2af82',
+			],
 			'sitemap_preload'            => [
 				'en' => '541780fde4b005ed2d11784c,5a71c8ab2c7d3a4a4198a9b3,55b282ede4b0b0593824f852',
 				'fr' => '5693d582c69791436155d645',

--- a/inc/Engine/Admin/Settings/Page.php
+++ b/inc/Engine/Admin/Settings/Page.php
@@ -961,7 +961,10 @@ class Page extends Abstract_Render {
 				'font_optimization_section' => [
 					'title' => __( 'Fonts', 'rocket' ),
 					'type'  => 'fields_container',
-					'help'  => $fonts,
+					'help'  => [
+						'id'  => $this->beacon->get_suggest( 'fonts_section' ),
+						'url' => $fonts['url'],
+					],
 					'page'  => 'media',
 				],
 			]


### PR DESCRIPTION
# Description

Fixes #7442
Add new `fonts_section` entry with both Preload fonts and Self-host Google Fonts article IDs. Update `font_optimization_section` to use `fonts_section` for help suggestions.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

### What was tested

Clicking on the `Need help` button now opens: 
<img width="539" height="708" alt="Screenshot 2026-02-10 at 04 22 35" src="https://github.com/user-attachments/assets/7bbbf48f-08e0-4013-8079-0bfc73026b0d" />



### How to test

Click `Need help` on fonts section.

### Affected Features & Quality Assurance Scope

UI

## Technical description

### Documentation

This pull request adds support for contextual help links in the Fonts optimization section of the media settings. The main changes involve updating how help content is retrieved and displayed for this section.

Enhancements to Fonts Section Help:

* Added a new `fonts_section` entry to the list of suggest beacons in `get_suggest`, providing language-specific beacon IDs for contextual help.
* Updated the `media_section` method to use the new beacon IDs for the Fonts section help, now passing both the beacon ID and help URL as an array instead of just the URL.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.
