### PR TITLE
Closes #7308 Add text/javascript to htaccess expire & compression

### DIFF
--- a/inc/functions/htaccess.php
+++ b/inc/functions/htaccess.php
@@ -500,7 +500,7 @@ function get_rocket_htaccess_mod_deflate() { // phpcs:ignore WordPress.NamingCon
 		                          image/svg+xml \
 		                          image/x-icon \
 		                          text/css \
-								  text/javascript \
+		                          text/javascript \
 		                          text/html \
 		                          text/plain \
 		                          text/x-component \

--- a/inc/functions/htaccess.php
+++ b/inc/functions/htaccess.php
@@ -500,6 +500,7 @@ function get_rocket_htaccess_mod_deflate() { // phpcs:ignore WordPress.NamingCon
 		                          image/svg+xml \
 		                          image/x-icon \
 		                          text/css \
+								  text/javascript \
 		                          text/html \
 		                          text/plain \
 		                          text/x-component \

--- a/inc/functions/htaccess.php
+++ b/inc/functions/htaccess.php
@@ -575,6 +575,7 @@ function get_rocket_htaccess_mod_expires() { // phpcs:ignore WordPress.NamingCon
 	ExpiresByType application/vnd.ms-fontobject "access plus 1 month"
 	# CSS and JavaScript
 	ExpiresByType text/css                      "access plus 1 year"
+	ExpiresByType text/javascript               "access plus 1 year"
 	ExpiresByType application/javascript        "access plus 1 year"
 </IfModule>
 

--- a/tests/Fixtures/content/htaccessContent.php
+++ b/tests/Fixtures/content/htaccessContent.php
@@ -112,6 +112,7 @@ Header append Cache-Control "public"
 	ExpiresByType application/vnd.ms-fontobject "access plus 1 month"
 	# CSS and JavaScript
 	ExpiresByType text/css                      "access plus 1 year"
+	ExpiresByType text/javascript               "access plus 1 year"
 	ExpiresByType application/javascript        "access plus 1 year"
 </IfModule>
 # Gzip compression
@@ -142,6 +143,7 @@ AddOutputFilterByType DEFLATE application/atom+xml \
 		                          image/svg+xml \
 		                          image/x-icon \
 		                          text/css \
+								  text/javascript \
 		                          text/html \
 		                          text/plain \
 		                          text/x-component \


### PR DESCRIPTION
# Description

Fixes #7308

Update `.htaccess` to add `text/javascript` for expire & compression headers

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

### What was tested

Tested correct expire headers and compression for JS files

### How to test

On an Apache server, check the expire and compression headers for JS files

### Affected Features & Quality Assurance Scope

Expire and compression for JS files on Apache server

## Technical description

### Documentation

This PR addresses issue #7308 by adding the `text/javascript` MIME type to Apache htaccess configuration for both compression (mod_deflate) and expiration headers (mod_expires). According to IANA standards, `application/javascript` is obsolete and has been replaced by `text/javascript`. However, this PR correctly keeps both MIME types for backward compatibility, ensuring JavaScript files receive the proper 1-year cache expiration instead of the default 1-month expiration.

**Changes:**
- Added `text/javascript` to the mod_deflate compression list alongside `application/javascript`
- Added `text/javascript` to the mod_expires headers with 1-year expiration alongside `application/javascript`

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

TBD