### PR TITLE
Fixes #4628 Remove decoding attribute and triggering a layout reflow to fix rendering issues on WebKit 

### DIFF
--- a/assets/js/lazyload/17.8.3/lazyload.js
+++ b/assets/js/lazyload/17.8.3/lazyload.js
@@ -519,13 +519,12 @@
 		addClass(element, settings.class_loaded);
 		setStatus(element, statusLoaded);
 
-		// Force browser repaint after programmatic src change.
-		// Fixes rendering issues where the image is loaded but not painted.
 		if (element.tagName === 'IMG') {
 			element.removeAttribute('decoding');
-			element.style.display = 'none';
-			void element.offsetHeight;
-			element.style.display = '';
+			element.style.opacity = '0.99';
+			requestAnimationFrame(function () {
+				element.style.opacity = '';
+			});
 		}
 
 		safeCallback(settings.callback_loaded, element, instance);

--- a/assets/js/lazyload/17.8.3/lazyload.js
+++ b/assets/js/lazyload/17.8.3/lazyload.js
@@ -27,7 +27,7 @@
 	var supportsIntersectionObserver = runningOnBrowser && "IntersectionObserver" in window;
 	var supportsClassList = runningOnBrowser && "classList" in document.createElement("p");
 	var isHiDpi = runningOnBrowser && window.devicePixelRatio > 1;
-	var isWebKit = runningOnBrowser && /webkit/i.test(navigator.userAgent);
+	var isWebKit = runningOnBrowser && /AppleWebKit/.test(navigator.userAgent) && !/Chrome|Chromium/.test(navigator.userAgent);
 
 	var defaultSettings = {
 		elements_selector: ".lazy",

--- a/assets/js/lazyload/17.8.3/lazyload.js
+++ b/assets/js/lazyload/17.8.3/lazyload.js
@@ -27,6 +27,7 @@
 	var supportsIntersectionObserver = runningOnBrowser && "IntersectionObserver" in window;
 	var supportsClassList = runningOnBrowser && "classList" in document.createElement("p");
 	var isHiDpi = runningOnBrowser && window.devicePixelRatio > 1;
+	var isWebKit = runningOnBrowser && /webkit/i.test(navigator.userAgent);
 
 	var defaultSettings = {
 		elements_selector: ".lazy",
@@ -519,7 +520,7 @@
 		addClass(element, settings.class_loaded);
 		setStatus(element, statusLoaded);
 
-		if (element.tagName === 'IMG') {
+		if (element.tagName === 'IMG' && isWebKit) {
 			element.removeAttribute('decoding');
 			element.style.opacity = '0.99';
 			requestAnimationFrame(function () {

--- a/assets/js/lazyload/17.8.3/lazyload.js
+++ b/assets/js/lazyload/17.8.3/lazyload.js
@@ -370,6 +370,8 @@
 			setImageAttributes(sourceTag, settings);
 		});
 		setOriginalsObject(imgEl, attrsSrcSrcsetSizes);
+		// Remove decoding="async" before setting sources to prevent render stall
+		imgEl.removeAttribute('decoding');
 		setImageAttributes(imgEl, settings);
 	};
 	var setSourcesIframe = function setSourcesIframe(iframe, settings) {
@@ -516,6 +518,16 @@
 		doneHandler(element, settings, instance);
 		addClass(element, settings.class_loaded);
 		setStatus(element, statusLoaded);
+
+		// Force browser repaint after programmatic src change.
+		// Fixes rendering issues where the image is loaded but not painted.
+		if (element.tagName === 'IMG') {
+			element.removeAttribute('decoding');
+			element.style.display = 'none';
+			void element.offsetHeight;
+			element.style.display = '';
+		}
+
 		safeCallback(settings.callback_loaded, element, instance);
 		if (!goingNative) checkFinish(settings, instance);
 	};


### PR DESCRIPTION
Description

Fixes #4628 

This pull request introduces targeted fixes to the lazy loading behavior for images, addressing rendering stalls and repaint issues. The main changes focus on improving image loading reliability and ensuring images are properly displayed after their sources are set.

This is a known WebKit compositing/rendering behavior where programmatic attribute changes on elements that were initially decoded asynchronously do not always trigger a paint update.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue).


## Detailed scenario

### What was tested

As described in Issue.

To make sure this is realy a WebKit problem I tested several Browsers on several platforms. All using the most recent version available.

Browsers & platforms tested
|Browser|Engine|Version|Platform|Affected|
|---------|---------|---------|---------|---------|
|Safari|WebKit|18.3|macOS Sequoia 15.3|**Yes**|
|Safari|WebKit|18.3|iOS 18.3|**Yes**|
|Chrome|Blink|13.3|macOS Sequoia 15.3|No|
|Chrome|Blink|133|Windows 11|No|
|Chrome|Webkit|133|iOS 18.3 (WKWebView/WebKit)|**Yes**|
|Firefox|Gecko|135|macOS Sequoia 15.3	|No|
|Firefox|Gecko|135|Windows 11|No|
|Firefox|WebKit|135|iOS 18.3 (WKWebView/WebKit)|**Yes**|
|Edge|Blink|133|macOS Sequoia 15.3|No|
|Edge|Blink|133|Windows 11|No|
|Edge|Webkit|133|iOS 18.3 (WKWebView/WebKit)|**Yes**|

Note: On iOS, all browsers are required by Apple to use WebKit as their underlying engine (WKWebView). This means Chrome, Firefox, and Edge on iOS are all affected, confirming that the root cause is WebKit itself, not a browser-specific issue.

### How to test

As described in Issue.

## Technical description

### Documentation

Rendering and repaint improvements:

* Removed the `decoding="async"` attribute from images before setting their sources to prevent rendering stalls during lazy loading.
* Added logic to force a browser repaint after changing an image's src programmatically, which fixes cases where the image is loaded but not visually rendered (e.g. in Safari). This includes removing the decoding attribute and triggering a repaint via an opacity change combined with requestAnimationFrame, avoiding forced synchronous layout (layout thrashing).

### New dependencies

None.

### Risks

None.

# Mandatory Checklist

## Code validation

- [X] I triggered all changed lines of code at least once without new errors/warnings/notices.

## Code style

- [X] I wrote a self-explanatory code about what it does.
- [X] I did not introduce unnecessary complexity.

## Unticked items justification

None

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
