### PR TITLE
fix(rocket-insights): make "See Report" icon clickable

### DIFF
--- a/views/settings/partials/rocket-insights/table-row.php
+++ b/views/settings/partials/rocket-insights/table-row.php
@@ -198,13 +198,20 @@ $rocket_formatted_metrics = $data->formatted_metrics ?? [];
 			<div class="row-left">
 				<div class="report-link <?php echo esc_attr( $rocket_report_url_icon_state ); ?>">
 					<?php
-					$this->render_action_button(
-						'link',
-						'gtmetrix_open',
-						$rocket_insights_show_report_btn_args
+					$rocket_link_tag   = ! empty( $rocket_insights_show_report_btn_args['url'] ) ? 'a' : 'span';
+					$rocket_link_href  = ! empty( $rocket_insights_show_report_btn_args['url'] ) ? 'href="' . esc_url( $rocket_insights_show_report_btn_args['url'] ) . '" ' : '';
+					$rocket_attributes = '';
+					foreach ( $rocket_insights_show_report_btn_args['attributes'] as $key => $value ) {
+						$rocket_attributes .= ' ' . esc_attr( $key ) . ( true === $value ? '' : '="' . esc_attr( $value ) . '"' );
+					}
+					printf(
+						'<%1$s %2$s%3$s>%4$s<div class="icon-frame"></div></%1$s>',
+						$rocket_link_tag,
+						$rocket_link_href,
+						$rocket_attributes,
+						esc_html( $rocket_insights_show_report_btn_args['label'] )
 					);
 					?>
-					<div class="icon-frame"></div>
 				</div>
 			</div>
 		</div>

--- a/views/settings/partials/rocket-insights/table-row.php
+++ b/views/settings/partials/rocket-insights/table-row.php
@@ -215,21 +215,21 @@ $rocket_formatted_metrics = $data->formatted_metrics ?? [];
 
 					echo wp_kses(
 						$rocket_link_html,
-						array(
-							'a'    => array(
+						[
+							'a'    => [
 								'href'   => true,
 								'target' => true,
 								'class'  => true,
 								'data-*' => true,
-							),
-							'span' => array(
+							],
+							'span' => [
 								'class'  => true,
 								'data-*' => true,
-							),
-							'div'  => array(
+							],
+							'div'  => [
 								'class' => true,
-							),
-						)
+							],
+						]
 					);
 					?>
 				</div>

--- a/views/settings/partials/rocket-insights/table-row.php
+++ b/views/settings/partials/rocket-insights/table-row.php
@@ -201,15 +201,35 @@ $rocket_formatted_metrics = $data->formatted_metrics ?? [];
 					$rocket_link_tag   = ! empty( $rocket_insights_show_report_btn_args['url'] ) ? 'a' : 'span';
 					$rocket_link_href  = ! empty( $rocket_insights_show_report_btn_args['url'] ) ? 'href="' . esc_url( $rocket_insights_show_report_btn_args['url'] ) . '" ' : '';
 					$rocket_attributes = '';
-					foreach ( $rocket_insights_show_report_btn_args['attributes'] as $key => $value ) {
-						$rocket_attributes .= ' ' . esc_attr( $key ) . ( true === $value ? '' : '="' . esc_attr( $value ) . '"' );
+					foreach ( $rocket_insights_show_report_btn_args['attributes'] as $rocket_attr_key => $rocket_attr_value ) {
+						$rocket_attributes .= ' ' . esc_attr( $rocket_attr_key ) . ( true === $rocket_attr_value ? '' : '="' . esc_attr( $rocket_attr_value ) . '"' );
 					}
-					printf(
+
+					$rocket_link_html = sprintf(
 						'<%1$s %2$s%3$s>%4$s<div class="icon-frame"></div></%1$s>',
 						$rocket_link_tag,
 						$rocket_link_href,
 						$rocket_attributes,
 						esc_html( $rocket_insights_show_report_btn_args['label'] )
+					);
+
+					echo wp_kses(
+						$rocket_link_html,
+						array(
+							'a'    => array(
+								'href'   => true,
+								'target' => true,
+								'class'  => true,
+								'data-*' => true,
+							),
+							'span' => array(
+								'class'  => true,
+								'data-*' => true,
+							),
+							'div'  => array(
+								'class' => true,
+							),
+						)
 					);
 					?>
 				</div>


### PR DESCRIPTION
## Summary

Fixes the "See Report" icon in Rocket Insights results not being clickable. The icon was rendered outside the anchor tag, making it decorative only.

Fixes #8116

## Problem

The "See Report" icon (`.icon-frame`) was placed as a sibling element to the link button instead of inside the anchor tag. Only the text was clickable, not the icon.

## Solution

Moved the icon inside the anchor tag by inlining the button rendering logic. Builds the HTML string and outputs it with `wp_kses()` for proper escaping.

## Changes

### views/settings/partials/rocket-insights/table-row.php

**Before:**
```php
<div class="report-link">
    <?php
    $this->render_action_button('link', 'gtmetrix_open', $args);
    ?>
    <div class="icon-frame"></div>
</div>
```

**After:**
```php
<div class="report-link">
    <?php
    $rocket_link_tag   = ! empty($args['url']) ? 'a' : 'span';
    $rocket_link_href  = ! empty($args['url']) ? 'href="' . esc_url($args['url']) . '" ' : '';
    $rocket_attributes = '';
    foreach ($args['attributes'] as $rocket_attr_key => $rocket_attr_value) {
        $rocket_attributes .= ' ' . esc_attr($rocket_attr_key) . (true === $rocket_attr_value ? '' : '="' . esc_attr($rocket_attr_value) . '"');
    }

    $rocket_link_html = sprintf(
        '<%1$s %2$s%3$s>%4$s<div class="icon-frame"></div></%1$s>',
        $rocket_link_tag,
        $rocket_link_href,
        $rocket_attributes,
        esc_html($args['label'])
    );

    echo wp_kses($rocket_link_html, [
        'a'    => ['href' => true, 'target' => true, 'class' => true, 'data-*' => true],
        'span' => ['class' => true, 'data-*' => true],
        'div'  => ['class' => true],
    ]);
    ?>
</div>
```

**Why:** Uses `wp_kses()` with explicitly allowed HTML tags and attributes for secure output. Dynamic tag selection (`a` vs `span`) handles both linked and disabled states. All variables use proper `rocket_` prefix per WordPress coding standards.

## Testing

**Test 1: Icon is clickable**
1. Navigate to WP Rocket Settings → Rocket Insights
2. Expand a completed test result
3. Click the icon next to "See Report"
4. Result: Opens report URL in new tab

**Test 2: Disabled state works**
1. View result with no report URL (empty or plan restriction)
2. Result: Icon is not clickable, shows disabled styling

**Test 3: Tooltip displays**
1. Hover over disabled icon (plan restriction)
2. Result: Shows "Upgrade your plan to see the report" tooltip