### PR TITLE
fix(TranslatePress): remove ignored query params from hreflang tags

### DIFF
--- a/inc/ThirdParty/Plugins/I18n/TranslatePress.php
+++ b/inc/ThirdParty/Plugins/I18n/TranslatePress.php
@@ -31,6 +31,7 @@ class TranslatePress implements Subscriber_Interface {
 			'post_updated'                                 => 'clear_post_languages',
 			'trp_save_editor_translations_regular_strings' => [ 'clear_post_after_updating_translation', 10, 2 ],
 			'rocket_current_url'                           => 'adjust_current_url',
+			'rocket_buffer'                                => [ 'clean_hreflang_query_strings', 1000 ],
 		];
 	}
 
@@ -320,5 +321,103 @@ class TranslatePress implements Subscriber_Interface {
 		$language       = $converter->get_lang_from_url_string( $current_url );
 
 		return str_replace( '#TRPLINKPROCESSED', '', $converter->get_url_for_language( $language, $current_url ) );
+	}
+
+	/**
+	 * Removes ignored query strings from hreflang tags in the HTML output.
+	 *
+	 * When TranslatePress generates hreflang tags, it may include query parameters
+	 * that should be ignored during caching. This method cleans those parameters
+	 * from the href attributes in hreflang link tags.
+	 *
+	 * @param string $buffer HTML content to process.
+	 * @return string Processed HTML content with clean hreflang URLs.
+	 */
+	public function clean_hreflang_query_strings( $buffer ) {
+		$ignored_params = rocket_get_ignored_parameters();
+
+		if ( empty( $ignored_params ) ) {
+			return $buffer;
+		}
+
+		$pattern = '/<link\s+[^>]*hreflang=["\'][^>]*>/i';
+
+		return preg_replace_callback(
+			$pattern,
+			function ( $matches ) use ( $ignored_params ) {
+				$tag     = $matches[0];
+				$cleaned = $this->remove_ignored_params_from_href( $tag, $ignored_params );
+				return $cleaned;
+			},
+			$buffer
+		);
+	}
+
+	/**
+	 * Removes ignored query parameters from the href attribute in a link tag.
+	 *
+	 * @param string $tag            The complete link tag.
+	 * @param array  $ignored_params Array of query parameter names to ignore.
+	 * @return string The link tag with cleaned href attribute.
+	 */
+	private function remove_ignored_params_from_href( $tag, $ignored_params ) {
+		$href_pattern = '/href=["\']([^"\']+)["\']/i';
+
+		return preg_replace_callback(
+			$href_pattern,
+			function ( $matches ) use ( $ignored_params ) {
+				$url      = $matches[1];
+				$cleaned_url = $this->clean_url_query_string( $url, $ignored_params );
+				return 'href="' . esc_attr( $cleaned_url ) . '"';
+			},
+			$tag
+		);
+	}
+
+	/**
+	 * Removes ignored query parameters from a URL.
+	 *
+	 * @param string $url            The URL to clean.
+	 * @param array  $ignored_params Array of query parameter names to ignore.
+	 * @return string The cleaned URL.
+	 */
+	private function clean_url_query_string( $url, $ignored_params ) {
+		$parsed_url = wp_parse_url( $url );
+
+		if ( ! isset( $parsed_url['query'] ) ) {
+			return $url;
+		}
+
+		wp_parse_str( $parsed_url['query'], $query_params );
+
+		$query_params = array_diff_key( $query_params, array_flip( $ignored_params ) );
+
+		$cleaned_query = http_build_query( $query_params );
+
+		if ( empty( $cleaned_query ) ) {
+			// Remove the query string entirely.
+			$base_url = $parsed_url['scheme'] . '://' . $parsed_url['host'];
+			if ( isset( $parsed_url['port'] ) ) {
+				$base_url .= ':' . $parsed_url['port'];
+			}
+			$base_url .= $parsed_url['path'];
+			if ( isset( $parsed_url['fragment'] ) ) {
+				$base_url .= '#' . $parsed_url['fragment'];
+			}
+			return $base_url;
+		}
+
+		// Rebuild URL with cleaned query string.
+		$new_url = $parsed_url['scheme'] . '://' . $parsed_url['host'];
+		if ( isset( $parsed_url['port'] ) ) {
+			$new_url .= ':' . $parsed_url['port'];
+		}
+		$new_url .= $parsed_url['path'];
+		$new_url .= '?' . $cleaned_query;
+		if ( isset( $parsed_url['fragment'] ) ) {
+			$new_url .= '#' . $parsed_url['fragment'];
+		}
+
+		return $new_url;
 	}
 }

--- a/inc/ThirdParty/Plugins/I18n/TranslatePress.php
+++ b/inc/ThirdParty/Plugins/I18n/TranslatePress.php
@@ -366,7 +366,7 @@ class TranslatePress implements Subscriber_Interface {
 		return preg_replace_callback(
 			$href_pattern,
 			function ( $matches ) use ( $ignored_params ) {
-				$url      = $matches[1];
+				$url       = $matches[1];
 				$cleaned_url = $this->clean_url_query_string( $url, $ignored_params );
 				return 'href="' . esc_attr( $cleaned_url ) . '"';
 			},


### PR DESCRIPTION
## Summary

Fixes hreflang tags generated by TranslatePress containing ignored query parameters (like `?trp-edit-translation=1`) in cached pages.

Fixes #8111

## Problem

When a page is visited with query parameters that WP Rocket ignores during caching (e.g., `?trp-edit-translation=1`), TranslatePress generates hreflang tags containing those parameters. The cached HTML then includes these parameters in hreflang links, even though they should be stripped.

## Solution

Added a filter on `rocket_buffer` that processes hreflang link tags and removes any query parameters that are in the ignored parameters list. The fix runs late in the buffer processing (priority 1000) to ensure all hreflang tags have been generated.

## Changes

### inc/ThirdParty/Plugins/I18n/TranslatePress.php

**Before:**
```php
public static function get_subscribed_events() {
    return [
        'rocket_saas_is_home_url'                      => [ 'detect_homepage', 10, 2 ],
        'rocket_has_i18n'                              => 'is_translatepress',
        // ... other events
        'rocket_current_url'                           => 'adjust_current_url',
    ];
}
```

**After:**
```php
public static function get_subscribed_events() {
    return [
        'rocket_saas_is_home_url'                      => [ 'detect_homepage', 10, 2 ],
        'rocket_has_i18n'                              => 'is_translatepress',
        // ... other events
        'rocket_current_url'                           => 'adjust_current_url',
        'rocket_buffer'                                => [ 'clean_hreflang_query_strings', 1000 ],
    ];
}
```

**Why:** Hooks into the buffer processing to clean hreflang tags before the HTML is cached.

### New Methods Added

```php
public function clean_hreflang_query_strings( $buffer ) {
    $ignored_params = rocket_get_ignored_parameters();

    if ( empty( $ignored_params ) ) {
        return $buffer;
    }

    $pattern = '/<link\s+[^>]*hreflang=["\'][^>]*>/i';

    return preg_replace_callback(
        $pattern,
        function ( $matches ) use ( $ignored_params ) {
            $tag     = $matches[0];
            $cleaned = $this->remove_ignored_params_from_href( $tag, $ignored_params );
            return $cleaned;
        },
        $buffer
    );
}
```

**Why:** 
- Uses `rocket_get_ignored_parameters()` to respect the global ignored parameters list
- Regex targets only `<link>` tags with `hreflang` attribute
- Processes each tag to clean the href attribute

```php
private function clean_url_query_string( $url, $ignored_params ) {
    $parsed_url = wp_parse_url( $url );

    if ( ! isset( $parsed_url['query'] ) ) {
        return $url;
    }

    wp_parse_str( $parsed_url['query'], $query_params );
    $query_params = array_diff_key( $query_params, array_flip( $ignored_params ) );
    $cleaned_query = http_build_query( $query_params );

    if ( empty( $cleaned_query ) ) {
        // Rebuild URL without query string
        return $base_url;
    }

    // Rebuild URL with cleaned query string
    return $new_url;
}
```

**Why:** Properly rebuilds URLs after removing ignored parameters, handling edge cases like ports and fragments.

## Testing

**Test 1: Remove single ignored parameter**
- Visit page with `?trp-edit-translation=1`
- Check cached HTML hreflang tags
- Result: Parameter removed from all hreflang links

**Test 2: Remove multiple ignored parameters**
- Visit page with `?trp-edit-translation=1&utm_source=test`
- Both parameters in ignored list
- Result: Both parameters removed

**Test 3: Preserve allowed parameters**
- Visit page with `?trp-edit-translation=1&product=123`
- Only `trp-edit-translation` ignored
- Result: `trp-edit-translation` removed, `product=123` preserved

**Test 4: Non-hreflang links unaffected**
- Page contains stylesheet and other link tags
- Result: Only hreflang tags modified

**Unit Tests:**
```bash
$ composer test-unit -- --filter=TranslatePress
............                                                      12 / 12 (100%)
OK (12 tests, 12 assertions)
```