### PR TITLE
fix(license): Cast return values in CustomerDataTrait for PHP 8.5 strict_types

### DIFF
--- a/inc/Engine/License/API/CustomerDataTrait.php
+++ b/inc/Engine/License/API/CustomerDataTrait.php
@@ -29,8 +29,8 @@ trait CustomerDataTrait {
 	 */
 	protected function get_customer_key(): string {
 		return ! empty( $this->options->get( 'consumer_key', '' ) )
-			? $this->options->get( 'consumer_key', '' )
-			: rocket_get_constant( 'WP_ROCKET_KEY', '' );
+			? (string) $this->options->get( 'consumer_key', '' )
+			: (string) rocket_get_constant( 'WP_ROCKET_KEY', '' );
 	}
 
 	/**
@@ -44,7 +44,7 @@ trait CustomerDataTrait {
 	 */
 	protected function get_customer_email(): string {
 		return ! empty( $this->options->get( 'consumer_email', '' ) )
-			? $this->options->get( 'consumer_email', '' )
-			: rocket_get_constant( 'WP_ROCKET_EMAIL', '' );
+			? (string) $this->options->get( 'consumer_email', '' )
+			: (string) rocket_get_constant( 'WP_ROCKET_EMAIL', '' );
 	}
 }


### PR DESCRIPTION
`CustomerDataTrait::get_customer_key()` and `CustomerDataTrait::get_customer_email()` declare `string` return types in a file with `declare(strict_types=1)`. Both methods return values from `Options_Data::get()` and `rocket_get_constant()`, which return `mixed`. On PHP 8.5, when the stored value is not strictly a string, this throws a fatal `TypeError`.

This adds explicit `(string)` casts to all four return branches. The casts are backwards-compatible — casting a string to string is a no-op on older PHP versions.

Fixes #8126