### PR TITLE
Hotfix: return the correct script type with older delayJS version

### DIFF
--- a/inc/Engine/Optimization/DelayJS/HTML.php
+++ b/inc/Engine/Optimization/DelayJS/HTML.php
@@ -224,10 +224,10 @@ class HTML {
 			}
 		}
 
-		if ( empty( $matches['attr'] ) ) {
-			// This filter is documented in inc/Engine/Optimization/DelayJS/Subscriber.php.
-			$version = wpm_apply_filters_typesafe( 'rocket_delay_js_version_js_script', '' );
+		// This filter is documented in inc/Engine/Optimization/DelayJS/Subscriber.php.
+		$version = wpm_apply_filters_typesafe( 'rocket_delay_js_version_js_script', '' );
 
+		if ( empty( $matches['attr'] ) ) {
 			if ( ! empty( $version ) ) {
 				return '<script type="rocketlazyloadscript">' . $matches['content'] . '</script>';
 			}
@@ -254,6 +254,10 @@ class HTML {
 		// Checks if script has src attribute so then treat as external script and replace src with data-rocket-src.
 		$src_regex       = '/src\s*=\s*(["\'])(.*)\1/i';
 		$matches['attr'] = preg_replace( $src_regex, 'data-rocket-src=$1$2$1', $matches['attr'] );
+
+		if ( ! empty( $version ) ) {
+			return '<script type="rocketlazyloadscript" ' . trim( $matches['attr'] ) . '>' . $matches['content'] . '</script>';
+		}
 
 		return '<script type="text/rocketlazyloadscript" ' . trim( $matches['attr'] ) . '>' . $matches['content'] . '</script>';
 	}

--- a/wp-rocket.php
+++ b/wp-rocket.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Rocket
  * Plugin URI: https://wp-rocket.me
  * Description: The best WordPress performance plugin.
- * Version: 3.20.6
+ * Version: 3.20.6.1
  * Requires at least: 5.8
  * Requires PHP: 7.3
  * Code Name: Iego
@@ -20,7 +20,7 @@
 defined( 'ABSPATH' ) || exit;
 
 // Rocket defines.
-define( 'WP_ROCKET_VERSION',               '3.20.6' );
+define( 'WP_ROCKET_VERSION',               '3.20.6.1' );
 define( 'WP_ROCKET_WP_VERSION',            '5.8' );
 define( 'WP_ROCKET_WP_VERSION_TESTED',     '6.3.1' );
 define( 'WP_ROCKET_PHP_VERSION',           '7.3' );


### PR DESCRIPTION
# Description

Fixes #8148 

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [x] Release

## Detailed scenario

### What was tested

mentioned in the issue itself.

### How to test

Steps are there in the issue.

### Affected Features & Quality Assurance Scope

Delay JS

## Technical description

### Documentation

We used the check on the delay js script version only inside inline scripts but we needed to do the same with external scripts (with src attribute) to add the correct type to those scripts.

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

No tests

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
