### PR TITLE
Add ability to get WP Rocket options

### DIFF
--- a/inc/Engine/Abilities/Options.php
+++ b/inc/Engine/Abilities/Options.php
@@ -395,9 +395,9 @@ class Options {
 				],
 				'execute_callback'    => [ $this, 'execute' ],
 				'permission_callback' => [ $this, 'check_permissions' ],
-				'show_in_rest'        => true,
 				'meta'                => [
-					'mcp' => [
+					'show_in_rest' => true,
+					'mcp'          => [
 						'public' => true,
 					],
 				],

--- a/inc/Engine/Abilities/Options.php
+++ b/inc/Engine/Abilities/Options.php
@@ -6,35 +6,435 @@ namespace WP_Rocket\Engine\Abilities;
 use WP_Rocket\Admin\Options_Data;
 
 class Options {
+	/**
+	 * Options data instance.
+	 *
+	 * @var Options_Data
+	 */
 	private $options;
 
+	/**
+	 * Constructor.
+	 *
+	 * @param Options_Data $options Options data instance.
+	 */
 	public function __construct( Options_Data $options ) {
 		$this->options = $options;
 	}
 
-	public function get_options_ability() {
-		wp_register_ability(
-			'wp-media/get-options',
+	/**
+	 * Register the WP Rocket options ability category.
+	 *
+	 * @return void
+	 */
+	public function register_options_category(): void {
+		wp_register_ability_category(
+			'wp-rocket-options',
 			[
-				'label' => __( 'Get WP Rocket options', 'rocket' ),
-				'description' => __( 'Get all WP Rocket options and their current values.', 'rocket' ),
-				'category' => 'wp-rocket-options',
-				'output_schema' => [
-					'type' => 'array',
-					'items' => [],
-				],
-				'execute_callback' => [ $this, 'get_filtered_options' ],
-				'permission_callback' => function() {
-					return current_user_can( 'rocket_manage_options' );
-				},
-				'show_in_rest' => true,
+				'label'       => __( 'WP Rocket Options', 'rocket' ),
+				'description' => __( 'Abilities that retrieve or update WP Rocket options', 'rocket' ),
 			]
 		);
 	}
 
-	public function get_filtered_options() {
+	/**
+	 * Registers the ability to get WP Rocket options.
+	 *
+	 * @return void
+	 */
+	public function register_get_options_ability(): void {
+		wp_register_ability(
+			'wp-media/get-options',
+			[
+				'label'               => __( 'Get WP Rocket options', 'rocket' ),
+				'description'         => __( 'Get all WP Rocket options and their current values.', 'rocket' ),
+				'category'            => 'wp-rocket-options',
+				'output_schema'       => [
+					'type'       => 'object',
+					'properties' => [
+						// Cache settings.
+						'cache_webp'                   => [
+							'type'        => 'integer',
+							'description' => 'Enable WebP caching.',
+							'enum'        => [ 0, 1 ],
+						],
+						'cache_logged_user'            => [
+							'type'        => 'integer',
+							'description' => 'Enable caching for logged-in users.',
+							'enum'        => [ 0, 1 ],
+						],
+						'cache_reject_uri'             => [
+							'type'        => 'array',
+							'items'       => [ 'type' => 'string' ],
+							'description' => 'URLs to exclude from caching.',
+						],
+						'cache_reject_cookies'         => [
+							'type'        => 'array',
+							'items'       => [ 'type' => 'string' ],
+							'description' => 'Cookies that prevent caching.',
+						],
+						'cache_reject_ua'              => [
+							'type'        => 'array',
+							'items'       => [ 'type' => 'string' ],
+							'description' => 'User agents to exclude from caching.',
+						],
+						'cache_query_strings'          => [
+							'type'        => 'array',
+							'items'       => [ 'type' => 'string' ],
+							'description' => 'Query strings to cache.',
+						],
+						'cache_purge_pages'            => [
+							'type'        => 'array',
+							'items'       => [ 'type' => 'string' ],
+							'description' => 'URLs to always purge.',
+						],
+						'purge_cron_interval'          => [
+							'type'        => 'integer',
+							'description' => 'Cache lifespan interval value.',
+						],
+						'purge_cron_unit'              => [
+							'type'        => 'string',
+							'description' => 'Cache lifespan time unit.',
+							'enum'        => [ 'MINUTE_IN_SECONDS', 'HOUR_IN_SECONDS', 'DAY_IN_SECONDS' ],
+						],
+
+						// File optimization - CSS.
+						'minify_css'                   => [
+							'type'        => 'integer',
+							'description' => 'Enable CSS minification.',
+							'enum'        => [ 0, 1 ],
+						],
+						'exclude_css'                  => [
+							'type'        => 'array',
+							'items'       => [ 'type' => 'string' ],
+							'description' => 'CSS files to exclude from minification.',
+						],
+						'async_css'                    => [
+							'type'        => 'integer',
+							'description' => 'Enable asynchronous CSS loading.',
+							'enum'        => [ 0, 1 ],
+						],
+						'async_css_mobile'             => [
+							'type'        => 'integer',
+							'description' => 'Enable asynchronous CSS loading on mobile.',
+							'enum'        => [ 0, 1 ],
+						],
+						'critical_css'                 => [
+							'type'        => 'string',
+							'description' => 'Fallback critical CSS content.',
+						],
+						'remove_unused_css'            => [
+							'type'        => 'integer',
+							'description' => 'Enable Remove Unused CSS (RUCSS).',
+							'enum'        => [ 0, 1 ],
+						],
+						'remove_unused_css_safelist'   => [
+							'type'        => 'array',
+							'items'       => [ 'type' => 'string' ],
+							'description' => 'CSS selectors to always keep.',
+						],
+						'optimize_css_delivery'        => [
+							'type'        => 'integer',
+							'description' => 'Enable CSS delivery optimization.',
+							'enum'        => [ 0, 1 ],
+						],
+
+						// File optimization - JS.
+						'minify_js'                    => [
+							'type'        => 'integer',
+							'description' => 'Enable JavaScript minification.',
+							'enum'        => [ 0, 1 ],
+						],
+						'minify_concatenate_js'        => [
+							'type'        => 'integer',
+							'description' => 'Enable JavaScript concatenation.',
+							'enum'        => [ 0, 1 ],
+						],
+						'exclude_js'                   => [
+							'type'        => 'array',
+							'items'       => [ 'type' => 'string' ],
+							'description' => 'JavaScript files to exclude from minification.',
+						],
+						'exclude_inline_js'            => [
+							'type'        => 'array',
+							'items'       => [ 'type' => 'string' ],
+							'description' => 'Inline JavaScript patterns to exclude.',
+						],
+						'defer_all_js'                 => [
+							'type'        => 'integer',
+							'description' => 'Enable JavaScript defer loading.',
+							'enum'        => [ 0, 1 ],
+						],
+						'exclude_defer_js'             => [
+							'type'        => 'array',
+							'items'       => [ 'type' => 'string' ],
+							'description' => 'JavaScript files to exclude from defer.',
+						],
+						'delay_js'                     => [
+							'type'        => 'integer',
+							'description' => 'Enable Delay JavaScript execution.',
+							'enum'        => [ 0, 1 ],
+						],
+						'delay_js_exclusions'          => [
+							'type'        => 'array',
+							'items'       => [ 'type' => 'string' ],
+							'description' => 'JavaScript files to exclude from delay.',
+						],
+						'delay_js_execution_safe_mode' => [
+							'type'        => 'integer',
+							'description' => 'Enable safe mode for Delay JavaScript.',
+							'enum'        => [ 0, 1 ],
+						],
+						'delay_js_exclusions_selected' => [
+							'type'        => 'array',
+							'items'       => [ 'type' => 'string' ],
+							'description' => 'Selected plugin/theme keys for delay JS exclusions.',
+						],
+						'delay_js_exclusions_selected_exclusions' => [
+							'type'        => 'array',
+							'items'       => [ 'type' => 'string' ],
+							'description' => 'Resolved exclusion patterns from selected items.',
+						],
+
+						// Media.
+						'lazyload'                     => [
+							'type'        => 'integer',
+							'description' => 'Enable image lazy loading.',
+							'enum'        => [ 0, 1 ],
+						],
+						'lazyload_iframes'             => [
+							'type'        => 'integer',
+							'description' => 'Enable iframe/video lazy loading.',
+							'enum'        => [ 0, 1 ],
+						],
+						'lazyload_youtube'             => [
+							'type'        => 'integer',
+							'description' => 'Replace YouTube videos with preview image.',
+							'enum'        => [ 0, 1 ],
+						],
+						'lazyload_css_bg_img'          => [
+							'type'        => 'integer',
+							'description' => 'Enable CSS background image lazy loading.',
+							'enum'        => [ 0, 1 ],
+						],
+						'exclude_lazyload'             => [
+							'type'        => 'array',
+							'items'       => [ 'type' => 'string' ],
+							'description' => 'Patterns to exclude from lazy loading.',
+						],
+						'image_dimensions'             => [
+							'type'        => 'integer',
+							'description' => 'Add missing image dimensions.',
+							'enum'        => [ 0, 1 ],
+						],
+
+						// Fonts.
+						'host_fonts_locally'           => [
+							'type'        => 'integer',
+							'description' => 'Host Google Fonts locally.',
+							'enum'        => [ 0, 1 ],
+						],
+						'auto_preload_fonts'           => [
+							'type'        => 'integer',
+							'description' => 'Automatically preload fonts.',
+							'enum'        => [ 0, 1 ],
+						],
+
+						// Preload.
+						'manual_preload'               => [
+							'type'        => 'integer',
+							'description' => 'Enable cache preloading.',
+							'enum'        => [ 0, 1 ],
+						],
+						'preload_links'                => [
+							'type'        => 'integer',
+							'description' => 'Enable link preloading on hover.',
+							'enum'        => [ 0, 1 ],
+						],
+
+						// Database.
+						'database_revisions'           => [
+							'type'        => 'integer',
+							'description' => 'Clean post revisions.',
+							'enum'        => [ 0, 1 ],
+						],
+						'database_auto_drafts'         => [
+							'type'        => 'integer',
+							'description' => 'Clean auto drafts.',
+							'enum'        => [ 0, 1 ],
+						],
+						'database_trashed_posts'       => [
+							'type'        => 'integer',
+							'description' => 'Clean trashed posts.',
+							'enum'        => [ 0, 1 ],
+						],
+						'database_spam_comments'       => [
+							'type'        => 'integer',
+							'description' => 'Clean spam comments.',
+							'enum'        => [ 0, 1 ],
+						],
+						'database_trashed_comments'    => [
+							'type'        => 'integer',
+							'description' => 'Clean trashed comments.',
+							'enum'        => [ 0, 1 ],
+						],
+						'database_all_transients'      => [
+							'type'        => 'integer',
+							'description' => 'Clean all transients.',
+							'enum'        => [ 0, 1 ],
+						],
+						'database_optimize_tables'     => [
+							'type'        => 'integer',
+							'description' => 'Optimize database tables.',
+							'enum'        => [ 0, 1 ],
+						],
+						'schedule_automatic_cleanup'   => [
+							'type'        => 'integer',
+							'description' => 'Enable automatic database cleanup.',
+							'enum'        => [ 0, 1 ],
+						],
+						'automatic_cleanup_frequency'  => [
+							'type'        => 'string',
+							'description' => 'Frequency of automatic cleanup.',
+							'enum'        => [ 'daily', 'weekly', 'monthly' ],
+						],
+
+						// CDN.
+						'cdn'                          => [
+							'type'        => 'integer',
+							'description' => 'Enable CDN.',
+							'enum'        => [ 0, 1 ],
+						],
+						'cdn_cnames'                   => [
+							'type'        => 'array',
+							'items'       => [ 'type' => 'string' ],
+							'description' => 'CDN CNAME URLs.',
+						],
+						'cdn_zone'                     => [
+							'type'        => 'array',
+							'items'       => [ 'type' => 'string' ],
+							'description' => 'CDN zones for each CNAME.',
+						],
+						'cdn_reject_files'             => [
+							'type'        => 'array',
+							'items'       => [ 'type' => 'string' ],
+							'description' => 'Files to exclude from CDN.',
+						],
+
+						// Cloudflare.
+						'do_cloudflare'                => [
+							'type'        => 'integer',
+							'description' => 'Enable Cloudflare integration.',
+							'enum'        => [ 0, 1 ],
+						],
+						'cloudflare_devmode'           => [
+							'type'        => 'integer',
+							'description' => 'Enable Cloudflare development mode.',
+							'enum'        => [ 0, 1 ],
+						],
+						'cloudflare_protocol_rewrite'  => [
+							'type'        => 'integer',
+							'description' => 'Enable Cloudflare protocol rewrite.',
+							'enum'        => [ 0, 1 ],
+						],
+						'cloudflare_auto_settings'     => [
+							'type'        => 'integer',
+							'description' => 'Apply optimal Cloudflare settings.',
+							'enum'        => [ 0, 1 ],
+						],
+
+						// Heartbeat.
+						'control_heartbeat'            => [
+							'type'        => 'integer',
+							'description' => 'Enable Heartbeat control.',
+							'enum'        => [ 0, 1 ],
+						],
+						'heartbeat_site_behavior'      => [
+							'type'        => 'string',
+							'description' => 'Heartbeat behavior on frontend.',
+							'enum'        => [ '', 'reduce_periodicity', 'disable' ],
+						],
+						'heartbeat_admin_behavior'     => [
+							'type'        => 'string',
+							'description' => 'Heartbeat behavior in admin.',
+							'enum'        => [ '', 'reduce_periodicity', 'disable' ],
+						],
+						'heartbeat_editor_behavior'    => [
+							'type'        => 'string',
+							'description' => 'Heartbeat behavior in post editor.',
+							'enum'        => [ '', 'reduce_periodicity', 'disable' ],
+						],
+
+						// Add-ons.
+						'varnish_auto_purge'           => [
+							'type'        => 'integer',
+							'description' => 'Enable Varnish auto purge.',
+							'enum'        => [ 0, 1 ],
+						],
+						'sucury_waf_cache_sync'        => [
+							'type'        => 'integer',
+							'description' => 'Enable Sucuri WAF cache sync.',
+							'enum'        => [ 0, 1 ],
+						],
+
+						// Analytics.
+						'analytics_enabled'            => [
+							'type'        => 'integer',
+							'description' => 'Enable anonymous analytics.',
+							'enum'        => [ 0, 1 ],
+						],
+					],
+				],
+				'execute_callback'    => [ $this, 'execute' ],
+				'permission_callback' => [ $this, 'check_permissions' ],
+				'show_in_rest'        => true,
+				'meta'                => [
+					'mcp' => [
+						'public' => true,
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Checks if the current user has permission to get WP Rocket options.
+	 *
+	 * @return bool
+	 */
+	public function check_permissions(): bool {
+		return current_user_can( 'rocket_manage_options' );
+	}
+
+	/**
+	 * Executes the ability to get WP Rocket options, returning all options except those on the denylist.
+	 *
+	 * @return array
+	 */
+	public function execute(): array {
+		$denylist = [
+			'cache_mobile',
+			'do_caching_mobile_files',
+			'secret_cache_key',
+			'cache_ssl',
+			'minify_css_key',
+			'minify_js_key',
+			'defer_all_js_safe',
+			'preload_fonts',
+			'dns_prefetch',
+			'cloudflare_email',
+			'cloudflare_api_key',
+			'cloudflare_zone_id',
+			'cloudflare_old_settings',
+			'sucury_waf_api_key',
+			'consumer_key',
+			'consumer_email',
+			'secret_key',
+			'license',
+		];
+
 		$options = $this->options->get_options();
 
-		return $options;
+		return array_diff_key( $options, array_flip( $denylist ) );
 	}
 }

--- a/inc/Engine/Abilities/Options.php
+++ b/inc/Engine/Abilities/Options.php
@@ -12,7 +12,7 @@ class Options {
 		$this->options = $options;
 	}
 
-	public function get_options() {
+	public function get_options_ability() {
 		wp_register_ability(
 			'wp-media/get-options',
 			[

--- a/inc/Engine/Abilities/Options.php
+++ b/inc/Engine/Abilities/Options.php
@@ -28,6 +28,10 @@ class Options {
 	 * @return void
 	 */
 	public function register_options_category(): void {
+		if ( ! function_exists( 'wp_register_ability_category' ) ) {
+			return;
+		}
+
 		wp_register_ability_category(
 			'wp-rocket-options',
 			[
@@ -43,6 +47,10 @@ class Options {
 	 * @return void
 	 */
 	public function register_get_options_ability(): void {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			return;
+		}
+
 		wp_register_ability(
 			'wp-media/get-options',
 			[

--- a/inc/Engine/Abilities/Options.php
+++ b/inc/Engine/Abilities/Options.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Engine\Abilities;
+
+use WP_Rocket\Admin\Options_Data;
+
+class Options {
+	private $options;
+
+	public function __construct( Options_Data $options ) {
+		$this->options = $options;
+	}
+
+	public function get_options() {
+		wp_register_ability(
+			'wp-media/get-options',
+			[
+				'label' => __( 'Get WP Rocket options', 'rocket' ),
+				'description' => __( 'Get all WP Rocket options and their current values.', 'rocket' ),
+				'category' => 'wp-rocket-options',
+				'output_schema' => [
+					'type' => 'array',
+					'items' => [],
+				],
+				'execute_callback' => [ $this, 'get_filtered_options' ],
+				'permission_callback' => function() {
+					return current_user_can( 'rocket_manage_options' );
+				},
+				'show_in_rest' => true,
+			]
+		);
+	}
+
+	public function get_filtered_options() {
+		$options = $this->options->get_options();
+
+		return $options;
+	}
+}

--- a/inc/Engine/Abilities/ServiceProvider.php
+++ b/inc/Engine/Abilities/ServiceProvider.php
@@ -27,6 +27,11 @@ class ServiceProvider extends AbstractServiceProvider {
 		return in_array( $id, $this->provides, true );
 	}
 
+	/**
+	 * Register the services provided by this service provider.
+	 *
+	 * @return void
+	 */
 	public function register(): void {
 		$this->getContainer()->add( 'abilities_options', Options::class )
 			->addArgument( 'options' );

--- a/inc/Engine/Abilities/Subscriber.php
+++ b/inc/Engine/Abilities/Subscriber.php
@@ -7,20 +7,45 @@ use WP\MCP\Core\McpAdapter;
 use WP_Rocket\Event_Management\Subscriber_Interface;
 
 class Subscriber implements Subscriber_Interface {
+	/**
+	 * Options ability instance.
+	 *
+	 * @var Options
+	 */
 	private $options;
 
+	/**
+	 * Constructor.
+	 *
+	 * @param Options $options The options ability instance.
+	 */
 	public function __construct( Options $options ) {
 		$this->options = $options;
 	}
 
+	/**
+	 * Get the events to which this subscriber wants to listen.
+	 *
+	 * @return array The events and their corresponding callback methods.
+	 */
 	public static function get_subscribed_events(): array {
 		return [
-			'init' => 'init_mcp',
-			'wp_abilities_api_categories_init' => 'register_wpr_category',
+			'plugins_loaded'                   => [ 'init_mcp', 99 ],
+			'wp_abilities_api_categories_init' => [
+				[ 'register_options_category' ],
+			],
+			'wp_abilities_api_init'            => [
+				[ 'register_get_options_ability' ],
+			],
 		];
 	}
 
-	public function init_mcp() {
+	/**
+	 * Initialize the MCP adapter if the class exists.
+	 *
+	 * @return void
+	 */
+	public function init_mcp(): void {
 		if ( ! class_exists( McpAdapter::class ) ) {
 			return;
 		}
@@ -28,13 +53,21 @@ class Subscriber implements Subscriber_Interface {
 		McpAdapter::instance();
 	}
 
-	public function register_wpr_category() {
-		wp_register_ability_category(
-			'wp-rocket-options',
-			[
-				'label' => __( 'WP Rocket Options', 'rocket' ),
-				'description' => __( 'Abilities that retrieve or update WP Rocket options', 'rocket' ),
-			]
-		);
+	/**
+	 * Register the WP Rocket options ability category.
+	 *
+	 * @return void
+	 */
+	public function register_options_category(): void {
+		$this->options->register_options_category();
+	}
+
+	/**
+	 * Register the ability to get WP Rocket options.
+	 *
+	 * @return void
+	 */
+	public function register_get_options_ability(): void {
+		$this->options->register_get_options_ability();
 	}
 }

--- a/inc/Engine/Abilities/Subscriber.php
+++ b/inc/Engine/Abilities/Subscriber.php
@@ -46,6 +46,10 @@ class Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function init_mcp(): void {
+		if ( ! function_exists( 'wp_get_abilities' ) ) {
+			return;
+		}
+
 		if ( ! class_exists( McpAdapter::class ) ) {
 			return;
 		}

--- a/inc/Engine/Abilities/Subscriber.php
+++ b/inc/Engine/Abilities/Subscriber.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace WP_Rocket\Engine\Abilities;
 
-use WP\MCP\Core\McpAdapter;
 use WP_Rocket\Event_Management\Subscriber_Interface;
 
 class Subscriber implements Subscriber_Interface {
@@ -30,7 +29,6 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events(): array {
 		return [
-			'plugins_loaded'                   => [ 'init_mcp', 99 ],
 			'wp_abilities_api_categories_init' => [
 				[ 'register_options_category' ],
 			],
@@ -38,23 +36,6 @@ class Subscriber implements Subscriber_Interface {
 				[ 'register_get_options_ability' ],
 			],
 		];
-	}
-
-	/**
-	 * Initialize the MCP adapter if the class exists.
-	 *
-	 * @return void
-	 */
-	public function init_mcp(): void {
-		if ( ! function_exists( 'wp_get_abilities' ) ) {
-			return;
-		}
-
-		if ( ! class_exists( McpAdapter::class ) ) {
-			return;
-		}
-
-		McpAdapter::instance();
 	}
 
 	/**

--- a/inc/classes/admin/class-options-data.php
+++ b/inc/classes/admin/class-options-data.php
@@ -119,6 +119,18 @@ class Options_Data {
 	 * @return array
 	 */
 	public function get_options() {
+		/**
+		 * Pre-filters the WP Rocket options array
+		 *
+		 * @param mixed $value   The value to return. Default null.
+		 * @param array $options The options array.
+		 */
+		$value = apply_filters( 'pre_get_rocket_options', null, $this->options ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+
+		if ( null !== $value ) {
+			return $value;
+		}
+
 		return $this->options;
 	}
 }

--- a/inc/main.php
+++ b/inc/main.php
@@ -1,5 +1,6 @@
 <?php
 
+use WP\MCP\Core\McpAdapter;
 use WP_Rocket\Addon\Cloudflare\Cloudflare;
 use WP_Rocket\Dependencies\League\Container\Container;
 use WP_Rocket\Plugin;
@@ -9,6 +10,10 @@ defined( 'ABSPATH' ) || exit;
 // Composer autoload.
 if ( file_exists( WP_ROCKET_PATH . 'vendor/autoload.php' ) ) {
 	require WP_ROCKET_PATH . 'vendor/autoload.php';
+}
+
+if ( class_exists( McpAdapter::class ) ) {
+	McpAdapter::instance();
 }
 
 require_once WP_ROCKET_FUNCTIONS_PATH . 'files.php';

--- a/tests/Fixtures/inc/Engine/Abilities/Options/ExecuteTest.php
+++ b/tests/Fixtures/inc/Engine/Abilities/Options/ExecuteTest.php
@@ -1,0 +1,137 @@
+<?php
+
+return [
+	'testShouldReturnEmptyArrayWhenOptionsAreEmpty' => [
+		'config'   => [
+			'options' => [],
+		],
+		'expected' => [],
+	],
+	'testShouldFilterOutAllDenylistKeysWhenAllPresent' => [
+		'config'   => [
+			'options' => [
+				'cache_mobile'            => 1,
+				'do_caching_mobile_files' => 1,
+				'secret_cache_key'        => 'abc123secret',
+				'cache_ssl'               => 1,
+				'minify_css_key'          => 'css-key-123',
+				'minify_js_key'           => 'js-key-456',
+				'defer_all_js_safe'       => 1,
+				'preload_fonts'           => 1,
+				'dns_prefetch'            => [ 'example.com' ],
+				'cloudflare_email'        => 'admin@example.com',
+				'cloudflare_api_key'      => 'cf-api-key-secret',
+				'cloudflare_zone_id'      => 'zone-123',
+				'cloudflare_old_settings' => [ 'old' => 'settings' ],
+				'sucury_waf_api_key'      => 'sucuri-key',
+				'consumer_key'            => 'consumer-key-secret',
+				'consumer_email'          => 'consumer@example.com',
+				'secret_key'              => 'top-secret-key',
+				'license'                 => 'license-data',
+			],
+		],
+		'expected' => [],
+	],
+	'testShouldReturnAllOptionsWhenNoDenylistKeysPresent' => [
+		'config'   => [
+			'options' => [
+				'cache_webp'        => 1,
+				'cache_logged_user' => 0,
+				'minify_css'        => 1,
+				'minify_js'         => 1,
+				'lazyload'          => 1,
+				'cdn'               => 0,
+			],
+		],
+		'expected' => [
+			'cache_webp'        => 1,
+			'cache_logged_user' => 0,
+			'minify_css'        => 1,
+			'minify_js'         => 1,
+			'lazyload'          => 1,
+			'cdn'               => 0,
+		],
+	],
+	'testShouldFilterOnlyDenylistKeysWhenMixed' => [
+		'config'   => [
+			'options' => [
+				// Allowed keys.
+				'cache_webp'           => 1,
+				'minify_css'           => 1,
+				'delay_js'             => 1,
+				'remove_unused_css'    => 0,
+				'lazyload'             => 1,
+				'manual_preload'       => 1,
+				'cdn'                  => 1,
+				'cdn_cnames'           => [ 'cdn.example.com' ],
+				'varnish_auto_purge'   => 0,
+				// Denylist keys - should be filtered out.
+				'secret_cache_key'     => 'secret-value',
+				'consumer_key'         => 'consumer-secret',
+				'consumer_email'       => 'secret@example.com',
+				'license'              => 'license-secret',
+				'cloudflare_api_key'   => 'cf-secret',
+				'sucury_waf_api_key'   => 'sucuri-secret',
+			],
+		],
+		'expected' => [
+			'cache_webp'         => 1,
+			'minify_css'         => 1,
+			'delay_js'           => 1,
+			'remove_unused_css'  => 0,
+			'lazyload'           => 1,
+			'manual_preload'     => 1,
+			'cdn'                => 1,
+			'cdn_cnames'         => [ 'cdn.example.com' ],
+			'varnish_auto_purge' => 0,
+		],
+	],
+	'testShouldHandleArrayValuesCorrectly' => [
+		'config'   => [
+			'options' => [
+				'cache_reject_uri'           => [ '/cart/', '/checkout/' ],
+				'cache_reject_cookies'       => [ 'woocommerce_items_in_cart' ],
+				'exclude_css'                => [ 'plugin.css', 'theme.css' ],
+				'exclude_js'                 => [ 'analytics.js' ],
+				'cdn_cnames'                 => [ 'cdn1.example.com', 'cdn2.example.com' ],
+				'remove_unused_css_safelist' => [ '.keep-this', '#important' ],
+				// Denylist - should be filtered.
+				'dns_prefetch'               => [ 'prefetch.example.com' ],
+			],
+		],
+		'expected' => [
+			'cache_reject_uri'           => [ '/cart/', '/checkout/' ],
+			'cache_reject_cookies'       => [ 'woocommerce_items_in_cart' ],
+			'exclude_css'                => [ 'plugin.css', 'theme.css' ],
+			'exclude_js'                 => [ 'analytics.js' ],
+			'cdn_cnames'                 => [ 'cdn1.example.com', 'cdn2.example.com' ],
+			'remove_unused_css_safelist' => [ '.keep-this', '#important' ],
+		],
+	],
+	'testShouldPreserveOptionValuesOfDifferentTypes' => [
+		'config'   => [
+			'options' => [
+				'cache_webp'                  => 1,
+				'minify_css'                  => 0,
+				'critical_css'                => 'body{margin:0}',
+				'purge_cron_interval'         => 10,
+				'purge_cron_unit'             => 'HOUR_IN_SECONDS',
+				'automatic_cleanup_frequency' => 'weekly',
+				'heartbeat_site_behavior'     => '',
+				'cdn_cnames'                  => [ 'cdn.example.com' ],
+				// Denylist.
+				'secret_key'                  => 'should-be-filtered',
+			],
+		],
+		'expected' => [
+			'cache_webp'                  => 1,
+			'minify_css'                  => 0,
+			'critical_css'                => 'body{margin:0}',
+			'purge_cron_interval'         => 10,
+			'purge_cron_unit'             => 'HOUR_IN_SECONDS',
+			'automatic_cleanup_frequency' => 'weekly',
+			'heartbeat_site_behavior'     => '',
+			'cdn_cnames'                  => [ 'cdn.example.com' ],
+		],
+	],
+];

--- a/tests/Fixtures/inc/Engine/Abilities/Options/RegisterGetOptionsAbilityTest.php
+++ b/tests/Fixtures/inc/Engine/Abilities/Options/RegisterGetOptionsAbilityTest.php
@@ -1,0 +1,46 @@
+<?php
+
+return [
+	'test_data' => [
+		'testShouldReturnOptionsWhenUserHasPermission' => [
+			'config'   => [
+				'has_permission' => true,
+				'settings'       => [
+					'cache_webp'        => 1,
+					'cache_logged_user' => 0,
+					'minify_css'        => 1,
+					'lazyload'          => 1,
+					'cdn'               => 0,
+					// Denylist keys - should be filtered out.
+					'secret_cache_key'  => 'secret-value',
+					'consumer_key'      => 'consumer-secret',
+					'license'           => 'license-secret',
+				],
+			],
+			'expected' => [
+				'is_error' => false,
+				'data'     => [
+					'cache_webp'        => 1,
+					'cache_logged_user' => 0,
+					'minify_css'        => 1,
+					'lazyload'          => 1,
+					'cdn'               => 0,
+				],
+			],
+		],
+
+		'testShouldReturnErrorWhenUserLacksPermission' => [
+			'config'   => [
+				'has_permission' => false,
+				'settings'       => [
+					'cache_webp'   => 1,
+					'minify_css'   => 1,
+					'consumer_key' => 'consumer-secret',
+				],
+			],
+			'expected' => [
+				'is_error' => true,
+			],
+		],
+	],
+];

--- a/tests/Fixtures/inc/Engine/Abilities/Options/RegisterGetOptionsAbilityTest.php
+++ b/tests/Fixtures/inc/Engine/Abilities/Options/RegisterGetOptionsAbilityTest.php
@@ -1,21 +1,21 @@
 <?php
 
 return [
+	'settings'  => [
+		'cache_webp'        => 1,
+		'cache_logged_user' => 0,
+		'minify_css'        => 1,
+		'lazyload'          => 1,
+		'cdn'               => 0,
+		// Denylist keys - should be filtered out.
+		'secret_cache_key'  => 'secret-value',
+		'consumer_key'      => 'consumer-secret',
+		'license'           => 'license-secret',
+	],
 	'test_data' => [
 		'testShouldReturnOptionsWhenUserHasPermission' => [
 			'config'   => [
 				'has_permission' => true,
-				'settings'       => [
-					'cache_webp'        => 1,
-					'cache_logged_user' => 0,
-					'minify_css'        => 1,
-					'lazyload'          => 1,
-					'cdn'               => 0,
-					// Denylist keys - should be filtered out.
-					'secret_cache_key'  => 'secret-value',
-					'consumer_key'      => 'consumer-secret',
-					'license'           => 'license-secret',
-				],
 			],
 			'expected' => [
 				'is_error' => false,
@@ -32,11 +32,6 @@ return [
 		'testShouldReturnErrorWhenUserLacksPermission' => [
 			'config'   => [
 				'has_permission' => false,
-				'settings'       => [
-					'cache_webp'   => 1,
-					'minify_css'   => 1,
-					'consumer_key' => 'consumer-secret',
-				],
 			],
 			'expected' => [
 				'is_error' => true,

--- a/tests/Integration/inc/Engine/Abilities/Options/RegisterGetOptionsAbilityTest.php
+++ b/tests/Integration/inc/Engine/Abilities/Options/RegisterGetOptionsAbilityTest.php
@@ -38,6 +38,19 @@ class RegisterGetOptionsAbilityTest extends TestCase {
 		if ( ! function_exists( 'wp_get_ability' ) ) {
 			$this->markTestSkipped( 'WordPress Abilities API is not available.' );
 		}
+
+		add_filter( 'pre_get_rocket_options', [ $this, 'set_settings' ] );
+	}
+
+	/**
+	 * Tear down the test.
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		remove_filter( 'pre_get_rocket_options', [ $this, 'set_settings' ] );
+
+		parent::tear_down();
 	}
 
 	/**
@@ -65,6 +78,15 @@ class RegisterGetOptionsAbilityTest extends TestCase {
 			$this->assertIsArray( $result, 'Should return array when user has permission.' );
 			$this->assertSame( $expected['data'], $result, 'Returned options should match expected.' );
 		}
+	}
+
+	/**
+	 * Set WP Rocket settings
+	 *
+	 * @return array
+	 */
+	public function set_settings() {
+		return $this->config['settings'];
 	}
 
 	/**

--- a/tests/Integration/inc/Engine/Abilities/Options/RegisterGetOptionsAbilityTest.php
+++ b/tests/Integration/inc/Engine/Abilities/Options/RegisterGetOptionsAbilityTest.php
@@ -1,0 +1,91 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\Abilities\Options;
+
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * Integration tests for wp-media/get-options ability execution.
+ *
+ * @group Abilities
+ */
+class RegisterGetOptionsAbilityTest extends TestCase {
+	/**
+	 * Minimum WordPress version required.
+	 */
+	private const MIN_WP_VERSION = '6.9';
+
+	/**
+	 * Ability ID.
+	 */
+	private const ABILITY_ID = 'wp-media/get-options';
+
+	/**
+	 * Set up the test.
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		global $wp_version;
+
+		parent::set_up();
+
+		if ( version_compare( $wp_version, self::MIN_WP_VERSION, '<' ) ) {
+			$this->markTestSkipped( 'WordPress Abilities API requires WordPress ' . self::MIN_WP_VERSION . ' or higher.' );
+		}
+
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			$this->markTestSkipped( 'WordPress Abilities API is not available.' );
+		}
+	}
+
+	/**
+	 * Test ability execution with permission scenarios.
+	 *
+	 * @dataProvider configTestData
+	 *
+	 * @param array $config   Test configuration.
+	 * @param array $expected Expected result.
+	 *
+	 * @return void
+	 */
+	public function testShouldReturnExpected( array $config, array $expected ): void {
+		$this->set_up_user( $config['has_permission'] );
+
+		$ability = wp_get_ability( self::ABILITY_ID );
+
+		$this->assertNotNull( $ability, 'Ability should be registered.' );
+
+		$result = $ability->execute();
+
+		if ( $expected['is_error'] ) {
+			$this->assertInstanceOf( 'WP_Error', $result, 'Should return WP_Error when user lacks permission.' );
+		} else {
+			$this->assertIsArray( $result, 'Should return array when user has permission.' );
+			$this->assertNotInstanceOf( 'WP_Error', $result );
+			$this->assertSame( $expected['data'], $result, 'Returned options should match expected.' );
+		}
+	}
+
+	/**
+	 * Set up user with or without permission.
+	 *
+	 * @param bool $has_permission Whether user should have permission.
+	 *
+	 * @return void
+	 */
+	private function set_up_user( bool $has_permission ): void {
+		$admin = get_role( 'administrator' );
+
+		if ( $has_permission ) {
+			$admin->add_cap( 'rocket_manage_options' );
+			$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		} else {
+			$admin->remove_cap( 'rocket_manage_options' );
+			$user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		}
+
+		wp_set_current_user( $user_id );
+	}
+}

--- a/tests/Integration/inc/Engine/Abilities/Options/RegisterGetOptionsAbilityTest.php
+++ b/tests/Integration/inc/Engine/Abilities/Options/RegisterGetOptionsAbilityTest.php
@@ -63,7 +63,6 @@ class RegisterGetOptionsAbilityTest extends TestCase {
 			$this->assertInstanceOf( 'WP_Error', $result, 'Should return WP_Error when user lacks permission.' );
 		} else {
 			$this->assertIsArray( $result, 'Should return array when user has permission.' );
-			$this->assertNotInstanceOf( 'WP_Error', $result );
 			$this->assertSame( $expected['data'], $result, 'Returned options should match expected.' );
 		}
 	}

--- a/tests/Unit/inc/Engine/Abilities/Options/ExecuteTest.php
+++ b/tests/Unit/inc/Engine/Abilities/Options/ExecuteTest.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\Abilities\Options;
+
+use Mockery;
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Engine\Abilities\Options;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * Tests for WP_Rocket\Engine\Abilities\Options::execute()
+ *
+ * @group Abilities
+ */
+class ExecuteTest extends TestCase {
+	/**
+	 * Options_Data mock.
+	 *
+	 * @var Options_Data|Mockery\MockInterface
+	 */
+	private $options_data;
+
+	/**
+	 * Options instance under test.
+	 *
+	 * @var Options
+	 */
+	private $options;
+
+	/**
+	 * Set up the test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->options_data = Mockery::mock( Options_Data::class );
+		$this->options      = new Options( $this->options_data );
+	}
+
+	/**
+	 * Test execute() filters out denylist keys and returns allowed options.
+	 *
+	 * @dataProvider configTestData
+	 *
+	 * @param array $config   Test configuration containing 'options' key.
+	 * @param array $expected Expected result array.
+	 *
+	 * @return void
+	 */
+	public function testShouldReturnExpected( array $config, array $expected ): void {
+		$this->options_data
+			->shouldReceive( 'get_options' )
+			->once()
+			->andReturn( $config['options'] );
+
+		$result = $this->options->execute();
+
+		$this->assertSame( $expected, $result );
+	}
+}


### PR DESCRIPTION
# Description

Add WP ability to get WP Rocket options

## Type of change

- [x] Sub-task

## Detailed scenario

### What was tested

Tested requesting WP Rocket options through the MCP server with copilot

### How to test

TBD

### Affected Features & Quality Assurance Scope

MCP & abilities

## Technical description

### Documentation

TBD

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.