### PR TITLE
Make recommendations fail directly when global score fails

### DIFF
--- a/inc/Engine/Admin/RocketInsights/Recommendations/DataManager.php
+++ b/inc/Engine/Admin/RocketInsights/Recommendations/DataManager.php
@@ -533,7 +533,6 @@ class DataManager implements LoggerAwareInterface {
 
 		// Bail if metrics not ready.
 		if ( ! $this->has_required_metrics() ) {
-			$this->set_recommendations_failed( 'Average advanced metrics are not available' );
 			return;
 		}
 

--- a/inc/Engine/Admin/RocketInsights/Recommendations/DataManager.php
+++ b/inc/Engine/Admin/RocketInsights/Recommendations/DataManager.php
@@ -217,20 +217,7 @@ class DataManager implements LoggerAwareInterface {
 				]
 			);
 
-			$this->save_recommendations(
-				[
-					'status'          => 'failed',
-					'recommendations' => [],
-					'metadata'        => [],
-					'timestamp'       => time(),
-					'error'           => $response->get_error_message(),
-					'tracking'        => [
-						'status'   => 'error',
-						'quantity' => 0,
-						'duration' => $duration,
-					],
-				]
-			);
+			$this->set_recommendations_failed( $response->get_error_message(), $duration );
 
 			return false;
 		}
@@ -337,7 +324,7 @@ class DataManager implements LoggerAwareInterface {
 		// Verify core metrics exist.
 		$required = Calculator::METRIC_KEYS;
 		foreach ( $required as $metric ) {
-			if ( ! isset( $average_metrics[ $metric ] ) ) {
+			if ( ! isset( $average_metrics[ $metric ] ) || 'N/A' === $average_metrics[ $metric ] ) {
 				return false;
 			}
 		}
@@ -546,6 +533,7 @@ class DataManager implements LoggerAwareInterface {
 
 		// Bail if metrics not ready.
 		if ( ! $this->has_required_metrics() ) {
+			$this->set_recommendations_failed( 'Average advanced metrics are not available' );
 			return;
 		}
 
@@ -571,5 +559,29 @@ class DataManager implements LoggerAwareInterface {
 	 */
 	public function get_section_from_option_slug( string $option_slug ): string {
 		return self::TRACKED_OPTIONS[ $option_slug ] ?? 'dashboard';
+	}
+
+	/**
+	 * Set recommendations to failed status with error message and tracking info.
+	 *
+	 * @param string $error_message Error message to store (default: 'Failed to fetch recommendations').
+	 * @param float  $duration Duration of the failed fetch attempt in milliseconds (default: 0).
+	 * @return void
+	 */
+	public function set_recommendations_failed( string $error_message = 'Failed to fetch recommendations', float $duration = 0 ): void {
+		$this->save_recommendations(
+			[
+				'status'          => 'failed',
+				'recommendations' => [],
+				'metadata'        => [],
+				'timestamp'       => time(),
+				'error'           => $error_message,
+				'tracking'        => [
+					'status'   => 'error',
+					'quantity' => 0,
+					'duration' => $duration,
+				],
+			]
+		);
 	}
 }

--- a/inc/Engine/Admin/RocketInsights/Recommendations/Subscriber.php
+++ b/inc/Engine/Admin/RocketInsights/Recommendations/Subscriber.php
@@ -107,6 +107,7 @@ class Subscriber implements Subscriber_Interface {
 				break;
 
 			case 'complete':
+			case 'failed':
 				// Maybe fetch recommendations when tests complete.
 				$this->data_manager->maybe_fetch_recommendations();
 				break;

--- a/inc/Engine/Admin/RocketInsights/Recommendations/Subscriber.php
+++ b/inc/Engine/Admin/RocketInsights/Recommendations/Subscriber.php
@@ -107,9 +107,12 @@ class Subscriber implements Subscriber_Interface {
 				break;
 
 			case 'complete':
-			case 'failed':
 				// Maybe fetch recommendations when tests complete.
 				$this->data_manager->maybe_fetch_recommendations();
+				break;
+
+			case 'failed':
+				$this->data_manager->set_recommendations_failed( 'Global score failed' );
 				break;
 
 			default:

--- a/tests/Fixtures/inc/Engine/Admin/RocketInsights/Recommendations/Subscriber/handleStatusChange.php
+++ b/tests/Fixtures/inc/Engine/Admin/RocketInsights/Recommendations/Subscriber/handleStatusChange.php
@@ -85,7 +85,7 @@ return [
 			],
 		],
 
-		'shouldDoNothingWhenStatusIsFailed' => [
+		'shouldFailRecommendationsWhenStatusIsFailed' => [
 			'config'   => [
 				'new_status'           => 'failed',
 				'previous_status'      => 'in-progress',
@@ -95,7 +95,7 @@ return [
 			],
 			'expected' => [
 				'clears_recommendations' => false,
-				'fetches_recommendations' => false,
+				'fetches_recommendations' => true,
 			],
 		],
 	],

--- a/tests/Fixtures/inc/Engine/Admin/RocketInsights/Recommendations/Subscriber/handleStatusChange.php
+++ b/tests/Fixtures/inc/Engine/Admin/RocketInsights/Recommendations/Subscriber/handleStatusChange.php
@@ -95,7 +95,8 @@ return [
 			],
 			'expected' => [
 				'clears_recommendations' => false,
-				'fetches_recommendations' => true,
+				'fetches_recommendations' => false,
+				'failed_recommendations' => true,
 			],
 		],
 	],

--- a/tests/Unit/inc/Engine/Admin/RocketInsights/Recommendations/Subscriber/handleStatusChange.php
+++ b/tests/Unit/inc/Engine/Admin/RocketInsights/Recommendations/Subscriber/handleStatusChange.php
@@ -65,6 +65,10 @@ class Test_HandleStatusChange extends TestCase {
 			$this->data_manager->shouldReceive( 'extend_transient' )->never();
 		}
 
+		if ( ! empty( $expected['failed_recommendations'] ) ){
+			$this->data_manager->shouldReceive( 'set_recommendations_failed' )->once();
+		}
+
 		$this->subscriber->handle_status_change( $config['new_status'] );
 	}
 }


### PR DESCRIPTION
# Description

Fixes #8179

Here we send recommendations to failed state once global score is changed to failed state (which means one of the urls is failed)

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

As mentioned in the issue, when we disable external requests and then try retest any url, so global score fails and also recommendations block.

### How to test

As mentioned in the issue:

1. Install and activate the feature branch [feature/ri-recommendations](https://github.com/wp-media/wp-rocket/tree/feature/ri-recommendations)
2. Wait for homepage to be processed.
3. Block external requests by adding the following to the wp-config.php file:
`define( 'WP_HTTP_BLOCK_EXTERNAL', true );`
4. Re-test the homepage and wait for it to reach a failed state.
5. Notice that while the URL has failed and GS is showing a failed state, the Recommendations section continues loading.

Now it should fail directly.

### Affected Features & Quality Assurance Scope

RI Recommendations

## Technical description

### Documentation

Recommendations now fail when global score goes into the failed state.

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

*If some mandatory items are not relevant, explain why in this section.*

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
