### PR TITLE
FIX #8205: 3.21 RI Recommendations: Recommendations will be in loading state when updating while no URL added.

### DIFF
--- a/inc/Engine/Admin/RocketInsights/Recommendations/DataManager.php
+++ b/inc/Engine/Admin/RocketInsights/Recommendations/DataManager.php
@@ -606,10 +606,6 @@ class DataManager implements LoggerAwareInterface {
 			$this->save_empty_recommendations();
 			return;
 		}
-		// If tests are in progress, bail early to show loading state.
-		if ( 'in-progress' === $status ) {
-			return;
-		}
 
 		// Save empty state if metrics not ready (e.g., all tests failed).
 		if ( ! $this->has_required_metrics() ) {

--- a/inc/Engine/Admin/RocketInsights/Recommendations/DataManager.php
+++ b/inc/Engine/Admin/RocketInsights/Recommendations/DataManager.php
@@ -596,8 +596,9 @@ class DataManager implements LoggerAwareInterface {
 			return;
 		}
 
-		// Bail if metrics not ready.
+		// Save empty state if metrics not ready (e.g., no pages tested).
 		if ( ! $this->has_required_metrics() ) {
+			$this->save_empty_recommendations();
 			return;
 		}
 
@@ -623,6 +624,27 @@ class DataManager implements LoggerAwareInterface {
 	 */
 	public function get_section_from_option_slug( string $option_slug ): string {
 		return self::TRACKED_OPTIONS[ $option_slug ] ?? 'dashboard';
+	}
+
+	/**
+	 * Save empty recommendations state when no metrics are available.
+	 *
+	 * This prevents the widget from showing a loading spinner when there are no pages to test.
+	 *
+	 * @return void
+	 */
+	private function save_empty_recommendations(): void {
+		$this->save_recommendations(
+			[
+				'status'          => 'failed',
+				'recommendations' => [],
+				'metadata'        => [],
+				'timestamp'       => time(),
+				'error'           => 'No pages tested yet',
+			]
+		);
+
+		$this->logger::debug( 'Recommendations: Saved failed state (no metrics available)' );
 	}
 
 	/**

--- a/inc/Engine/Admin/RocketInsights/Recommendations/DataManager.php
+++ b/inc/Engine/Admin/RocketInsights/Recommendations/DataManager.php
@@ -596,7 +596,23 @@ class DataManager implements LoggerAwareInterface {
 			return;
 		}
 
-		// Save empty state if metrics not ready (e.g., no pages tested).
+		// Get global score data to check for URLs.
+		$global_score_data = $this->global_score->get_global_score_data();
+		$status            = $global_score_data['status'] ?? 'complete';
+
+		// If no URLs in Performance Monitoring, save failed state.
+		// There's nothing to analyze yet, so show failed state.
+		if ( 'no-url' === $status ) {
+			$this->save_empty_recommendations();
+			return;
+		}
+
+		// If tests are in progress, bail early to show loading state.
+		if ( 'in-progress' === $status ) {
+			return;
+		}
+
+		// Save empty state if metrics not ready (e.g., all tests failed).
 		if ( ! $this->has_required_metrics() ) {
 			$this->save_empty_recommendations();
 			return;
@@ -627,9 +643,12 @@ class DataManager implements LoggerAwareInterface {
 	}
 
 	/**
-	 * Save empty recommendations state when no metrics are available.
+	 * Save empty recommendations state when metrics are not available.
 	 *
-	 * This prevents the widget from showing a loading spinner when there are no pages to test.
+	 * This displays the failed state when:
+	 * - No URLs exist in Performance Monitoring yet
+	 * - All tests have failed
+	 * - Metrics are incomplete
 	 *
 	 * @return void
 	 */
@@ -640,11 +659,11 @@ class DataManager implements LoggerAwareInterface {
 				'recommendations' => [],
 				'metadata'        => [],
 				'timestamp'       => time(),
-				'error'           => 'No pages tested yet',
+				'error'           => 'Recommendations unavailable',
 			]
 		);
 
-		$this->logger::debug( 'Recommendations: Saved failed state (no metrics available)' );
+		$this->logger::debug( 'Recommendations: Saved failed state (no recommendations available)' );
 	}
 
 	/**

--- a/inc/Engine/Admin/RocketInsights/Recommendations/DataManager.php
+++ b/inc/Engine/Admin/RocketInsights/Recommendations/DataManager.php
@@ -598,7 +598,7 @@ class DataManager implements LoggerAwareInterface {
 
 		// Get global score data to check for URLs.
 		$global_score_data = $this->global_score->get_global_score_data();
-		$status            = $global_score_data['status'] ?? 'complete';
+		$status            = $global_score_data['status'];
 
 		// If no URLs in Performance Monitoring, save failed state.
 		// There's nothing to analyze yet, so show failed state.
@@ -606,7 +606,6 @@ class DataManager implements LoggerAwareInterface {
 			$this->save_empty_recommendations();
 			return;
 		}
-
 		// If tests are in progress, bail early to show loading state.
 		if ( 'in-progress' === $status ) {
 			return;

--- a/inc/Engine/Admin/RocketInsights/Recommendations/DataManager.php
+++ b/inc/Engine/Admin/RocketInsights/Recommendations/DataManager.php
@@ -613,7 +613,6 @@ class DataManager implements LoggerAwareInterface {
 
 		// Save empty state if metrics not ready (e.g., all tests failed).
 		if ( ! $this->has_required_metrics() ) {
-			$this->save_empty_recommendations();
 			return;
 		}
 

--- a/inc/Engine/Admin/RocketInsights/Recommendations/Subscriber.php
+++ b/inc/Engine/Admin/RocketInsights/Recommendations/Subscriber.php
@@ -63,6 +63,7 @@ class Subscriber implements Subscriber_Interface, LoggerAwareInterface {
 			'rocket_insights_global_score_status_changed' => 'handle_status_change',
 			'rocket_insights_recommendations_rest_response' => 'output_recommendations_rest_response',
 			'wp_rocket_upgrade'                           => [ 'force_global_metrics_recalculation', 10, 2 ],
+			'rocket_rocket_insights_job_deleted'          => 'maybe_clear_recommendations_on_delete',
 		];
 	}
 
@@ -124,6 +125,19 @@ class Subscriber implements Subscriber_Interface, LoggerAwareInterface {
 				// No action for other statuses.
 				break;
 		}
+	}
+
+	/**
+	 * Update recommendations when a page is deleted.
+	 *
+	 * If no metrics remain after deletion, saves an empty state to prevent
+	 * the widget from showing an infinite loading spinner.
+	 *
+	 * @return void
+	 */
+	public function maybe_clear_recommendations_on_delete(): void {
+		// Trigger recommendations refresh after deletion.
+		$this->data_manager->maybe_fetch_recommendations();
 	}
 
 	/**

--- a/tests/Fixtures/inc/Engine/Admin/RocketInsights/Recommendations/Subscriber/RenderRecommendationsWidget.php
+++ b/tests/Fixtures/inc/Engine/Admin/RocketInsights/Recommendations/Subscriber/RenderRecommendationsWidget.php
@@ -4,6 +4,14 @@ return [
 	'testShouldDisplayLoadingStateWhenNoTransientData' => [
 		'config'   => [
 			'transient_data' => null,
+			'pm_data'        => [
+				[
+					'url'       => 'http://example.org',
+					'status'    => 'in-progress',
+					'is_mobile' => 0,
+					'job_id'    => 'test_job_123',
+				],
+			],
 		],
 		'expected' => [
 			'state'        => 'loading',

--- a/tests/Integration/inc/Engine/Admin/RocketInsights/Recommendations/Subscriber/RenderRecommendationsWidget.php
+++ b/tests/Integration/inc/Engine/Admin/RocketInsights/Recommendations/Subscriber/RenderRecommendationsWidget.php
@@ -112,10 +112,55 @@ class Test_RenderRecommendationsWidget extends TestCase {
 	 * @return void
 	 */
 	private function setUpTest( array $config ): void {
+		// Set up Performance Monitoring data if provided.
+		if ( isset( $config['pm_data'] ) && is_array( $config['pm_data'] ) ) {
+			foreach ( $config['pm_data'] as $pm_row ) {
+				$this->addPmRow( $pm_row );
+			}
+		}
+
 		// Set up transient data if provided.
 		if ( isset( $config['transient_data'] ) ) {
 			set_transient( self::TRANSIENT_NAME, $config['transient_data'], DAY_IN_SECONDS );
 		}
+	}
+
+	/**
+	 * Add a row to the Performance Monitoring table.
+	 *
+	 * @param array $data Row data.
+	 * @return void
+	 */
+	private function addPmRow( array $data ): void {
+		global $wpdb;
+
+		$table_name = $wpdb->prefix . 'wpr_performance_monitoring';
+
+		$defaults = [
+			'url'            => '',
+			'title'          => '',
+			'is_mobile'      => 0,
+			'job_id'         => '',
+			'queue_name'     => '',
+			'retries'        => 1,
+			'status'         => null,
+			'data'           => '',
+			'modified'       => current_time( 'mysql', true ),
+			'last_accessed'  => current_time( 'mysql', true ),
+			'submitted_at'   => null,
+			'next_retry_time' => '0000-00-00 00:00:00',
+			'score'          => 0,
+			'report_url'     => '',
+			'is_blurred'     => 0,
+			'metric_data'    => null,
+			'error_code'     => null,
+			'error_message'  => null,
+		];
+
+		$data = wp_parse_args( $data, $defaults );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+		$wpdb->insert( $table_name, $data );
 	}
 
 	/**

--- a/tests/Integration/inc/Engine/Admin/RocketInsights/Recommendations/Subscriber/RenderRecommendationsWidget.php
+++ b/tests/Integration/inc/Engine/Admin/RocketInsights/Recommendations/Subscriber/RenderRecommendationsWidget.php
@@ -35,6 +35,9 @@ class Test_RenderRecommendationsWidget extends TestCase {
 	public function set_up() {
 		parent::set_up();
 
+		// Install Performance Monitoring table to avoid database errors.
+		$this->installPerformanceMonitoringTable();
+
 		// Clear transients before each test.
 		delete_transient( self::TRANSIENT_NAME );
 		delete_transient( self::GLOBAL_SCORE_TRANSIENT );
@@ -57,6 +60,9 @@ class Test_RenderRecommendationsWidget extends TestCase {
 
 		// Remove Rocket Insights enabled filter.
 		remove_filter( 'rocket_rocket_insights_enabled', '__return_true' );
+
+		// Clean up Performance Monitoring table.
+		$this->truncatePerformanceMonitoringTable();
 
         $this->restoreWpHook( 'rocket_sidebar' );
 


### PR DESCRIPTION
# Description

Fixes #8205 #8207 
Add handling for empty recommendations state on metrics absence
Also handle 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

Described in respective issues

### How to test

Described in issues

### Affected Features & Quality Assurance Scope

Recommendations RI

## Technical description

### Documentation

This pull request improves the handling of recommendations in the Rocket Insights widget, particularly when there are no metrics available (such as after deleting all tested pages). The changes ensure that the widget displays an appropriate empty state instead of an infinite loading spinner, and that recommendations are refreshed when relevant jobs are deleted.

Handling empty recommendations and widget state:

* Added a new private method `save_empty_recommendations()` in `DataManager.php` to save a failed recommendations state when no metrics are available, preventing the widget from showing a loading spinner.
* Updated `maybe_fetch_recommendations()` in `DataManager.php` to call `save_empty_recommendations()` when required metrics are not present.

Recommendations refresh on job deletion:

* Registered a new event `rocket_rocket_insights_job_deleted` in `Subscriber.php` to trigger recommendations refresh when a job is deleted.
* Added `maybe_clear_recommendations_on_delete()` in `Subscriber.php` to update recommendations and save empty state if no metrics remain after deletion.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.
