### PR TITLE
Drop the support for txt import files

### DIFF
--- a/inc/admin/admin.php
+++ b/inc/admin/admin.php
@@ -387,8 +387,8 @@ function rocket_handle_settings_import() {
 		rocket_settings_import_redirect( __( 'Settings import failed: no file uploaded.', 'rocket' ), 'error' );
 	}
 
-	if ( isset( $_FILES['import']['name'] ) && ! preg_match( '/wp-rocket-settings(?:-.*)?-20\d{2}-\d{2}-\d{2}-[a-f0-9]{13}\.(?:txt|json)/', sanitize_file_name( $_FILES['import']['name'] ) ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-		rocket_settings_import_redirect( __( 'Settings import failed: incorrect filename.', 'rocket' ), 'error' );
+	if ( isset( $_FILES['import']['name'] ) && ! preg_match( '/wp-rocket-settings(?:-.*)?-20\d{2}-\d{2}-\d{2}-[a-f0-9]{13}\.json/', sanitize_file_name( $_FILES['import']['name'] ) ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+		rocket_settings_import_redirect( __( 'Settings import failed: incorrect filename. Only JSON format is supported.', 'rocket' ), 'error' );
 	}
 
 	add_filter( 'mime_types', 'rocket_allow_json_mime_type' );
@@ -398,8 +398,8 @@ function rocket_handle_settings_import() {
 	$mimes     = rocket_allow_json_mime_type( $mimes );
 	$file_data = wp_check_filetype_and_ext( $_FILES['import']['tmp_name'], sanitize_file_name( $_FILES['import']['name'] ), $mimes ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 
-	if ( 'text/plain' !== $file_data['type'] && 'application/json' !== $file_data['type'] ) {
-		rocket_settings_import_redirect( __( 'Settings import failed: incorrect filetype.', 'rocket' ), 'error' );
+	if ( 'application/json' !== $file_data['type'] ) {
+		rocket_settings_import_redirect( __( 'Settings import failed: only JSON format is supported for security reasons.', 'rocket' ), 'error' );
 	}
 
 	$_post_action       = isset( $_POST['action'] ) ? wp_unslash( sanitize_key( $_POST['action'] ) ) : '';
@@ -417,16 +417,10 @@ function rocket_handle_settings_import() {
 	remove_filter( 'mime_types', 'rocket_allow_json_mime_type' );
 	remove_filter( 'wp_check_filetype_and_ext', 'rocket_check_json_filetype', 10 );
 
-	if ( 'text/plain' === $file_data['type'] ) {
-		$gz       = 'gz' . strrev( 'etalfni' );
-		$settings = $gz( $settings );
-		$settings = maybe_unserialize( $settings );
-	} elseif ( 'application/json' === $file_data['type'] ) {
-		$settings = json_decode( $settings, true );
+	$settings = json_decode( $settings, true );
 
-		if ( null === $settings ) {
-			rocket_settings_import_redirect( __( 'Settings import failed: unexpected file content.', 'rocket' ), 'error' );
-		}
+	if ( null === $settings ) {
+		rocket_settings_import_redirect( __( 'Settings import failed: unexpected file content.', 'rocket' ), 'error' );
 	}
 
 	rocket_put_content( $file['file'], '' );

--- a/inc/admin/admin.php
+++ b/inc/admin/admin.php
@@ -419,7 +419,7 @@ function rocket_handle_settings_import() {
 
 	$settings = json_decode( $settings, true );
 
-	if ( null === $settings ) {
+	if ( ! is_array( $settings ) ) {
 		rocket_settings_import_redirect( __( 'Settings import failed: unexpected file content.', 'rocket' ), 'error' );
 	}
 


### PR DESCRIPTION
# Description

Fixes https://github.com/wp-media/wp-rocket.me/issues/5660

No need to support old txt files and only support json files.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

Steps in the issue itself, but we should no more support old .txt files when trying to import settings

### How to test

Mentioned above and in the issue.

### Affected Features & Quality Assurance Scope

- Tools > Import Settings

## Technical description

### Documentation

N/A

### New dependencies

N/A

### Risks

We should be fine with backward compatibility because .txt settings generation was dropped from long time.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

No Tests

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
