### PR TITLE
Closes #8034: Data Consent Changed event not sent on banner consent

### DIFF
--- a/inc/admin/admin.php
+++ b/inc/admin/admin.php
@@ -357,6 +357,13 @@ function rocket_analytics_optin() {
 	if ( isset( $_GET['value'] ) && 'yes' === $_GET['value'] ) {
 		update_option( 'rocket_mixpanel_optin', 1 );
 		set_transient( 'rocket_analytics_optin', 1 );
+
+		/**
+		 * Fires when the Mixpanel opt-in status changes to enabled.
+		 *
+		 * @param bool $status The opt-in status.
+		 */
+		do_action( 'rocket_mixpanel_optin_changed', true );
 	}
 
 	update_option( 'rocket_analytics_notice_displayed', 1 );


### PR DESCRIPTION
# Description

Fixes #8034 
Sends mixpanel event when consent is granted from analytics consent banner.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

### What was tested

Tested that mixpanel event was sent when consent was granted from consent  banner.

### How to test

- Fresh install
- Agree to share analytics data
- Check that mixpanel event reaches mixpanel dashboard.

### Affected Features & Quality Assurance Scope

Mixpanel consent banner.

## Technical description

### Documentation

Added existing [action hook](https://github.com/wp-media/wp-mixpanel/blob/dfedab2014e816a1040c57d544a6180f1d446624/src/Optin.php#L77) from our lib to be fired when analytics is enabled from consent banner.

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

Not applicable to the changes in this PR.

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
