### PR TITLE
Closes #8249 Send additional data on data consent changed

### DIFF
--- a/inc/Engine/Admin/RocketInsights/Controller.php
+++ b/inc/Engine/Admin/RocketInsights/Controller.php
@@ -490,4 +490,40 @@ class Controller {
 
 		wp_send_json_success();
 	}
+
+	/**
+	 * Tracks the home page event after the user opts in to analytics.
+	 *
+	 * This method checks if the analytics notice has already been displayed and dismissed to ensure events are not tracked multiple times.
+	 * If not, it triggers the tracking of the Rocket Insights test.
+	 *
+	 * @param bool $status Indicates the current status of the analytics opt-in.
+	 *
+	 * @return void
+	 */
+	public function track_home_after_analytics_optin( bool $status ): void {
+		// Bail out if user disabled analytics.
+		if ( ! $status ) {
+			return;
+		}
+
+		// Bail out if analytics already enabled before and notice was dismissed.
+		if ( 1 === (int) get_option( 'rocket_analytics_notice_displayed' ) ) {
+			return;
+		}
+
+		$row_details = $this->query->get_row( home_url(), true );
+
+		// Bail out if row details is not found.
+		if ( empty( $row_details ) ) {
+			return;
+		}
+
+		// Bail out if test is still in progress.
+		if ( ! in_array( $row_details->status, [ 'completed', 'failed' ], true ) ) {
+			return;
+		}
+
+		$this->tracking->track_rocket_insights_test( $row_details, [], $this->plan->get_current_plan() );
+	}
 }

--- a/inc/Engine/Admin/RocketInsights/Subscriber.php
+++ b/inc/Engine/Admin/RocketInsights/Subscriber.php
@@ -190,6 +190,7 @@ class Subscriber implements Subscriber_Interface, LoggerAwareInterface {
 			'rest_api_init'                               => [ 'register_routes' ],
 			'wp_ajax_rocket_insight_track_metric_actions' => 'track_metric_actions',
 			'rocket_settings_saved_message'               => 'update_settings_saved_message',
+			'rocket_mixpanel_optin_changed'               => 'track_home_after_analytics_optin',
 		];
 	}
 
@@ -785,5 +786,16 @@ class Subscriber implements Subscriber_Interface, LoggerAwareInterface {
 			'<a href="' . esc_url( $insights_url ) . '" id="rocket_ri_new_test_save_settings_link">',
 			'</a>'
 		);
+	}
+
+	/**
+	 * Tracks the home page event after the user opts in to analytics for the first time.
+	 *
+	 * @param bool $status Indicates the current status of the analytics opt-in.
+	 *
+	 * @return void
+	 */
+	public function track_home_after_analytics_optin( bool $status ): void {
+		$this->controller->track_home_after_analytics_optin( $status );
 	}
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -61,6 +61,11 @@ parameters:
 			path: inc/Engine/Admin/Metaboxes/PostEditOptionsSubscriber.php
 
 		-
+			message: "#^Usage of get_option\\(\\) is discouraged\\. Use the Option object instead\\.$#"
+			count: 1
+			path: inc/Engine/Admin/RocketInsights/Controller.php
+
+		-
 			message: "#^Usage of apply_filters\\(\\) is discouraged\\. Use wpm_apply_filters_typed\\(\\) instead\\.$#"
 			count: 12
 			path: inc/Engine/Admin/Settings/Page.php

--- a/tests/Fixtures/inc/Engine/Admin/RocketInsights/Controller/trackHomeAfterAnalyticsOptin.php
+++ b/tests/Fixtures/inc/Engine/Admin/RocketInsights/Controller/trackHomeAfterAnalyticsOptin.php
@@ -1,0 +1,117 @@
+<?php
+
+return [
+	'test_data' => [
+		'shouldBailOutWhenStatusIsFalse' => [
+			'config' => [
+				'status' => false,
+			],
+			'expected' => [
+				'should_track' => false,
+			],
+		],
+
+		'shouldBailOutWhenAnalyticsNoticeAlreadyDisplayed' => [
+			'config' => [
+				'status'           => true,
+				'notice_displayed' => 1,
+			],
+			'expected' => [
+				'should_track' => false,
+			],
+		],
+
+		'shouldBailOutWhenRowDetailsIsEmpty' => [
+			'config' => [
+				'status'           => true,
+				'notice_displayed' => 0,
+				'home_url'         => 'https://example.com',
+				'row_details'      => null,
+			],
+			'expected' => [
+				'should_track' => false,
+			],
+		],
+
+		'shouldBailOutWhenTestStatusIsToSubmit' => [
+			'config' => [
+				'status'           => true,
+				'notice_displayed' => 0,
+				'home_url'         => 'https://example.com',
+				'row_details'      => (object) [
+					'id'     => 1,
+					'url'    => 'https://example.com',
+					'status' => 'to-submit',
+				],
+			],
+			'expected' => [
+				'should_track' => false,
+			],
+		],
+		'shouldBailOutWhenTestStatusIsPending' => [
+			'config' => [
+				'status'           => true,
+				'notice_displayed' => 0,
+				'home_url'         => 'https://example.com',
+				'row_details'      => (object) [
+					'id'     => 1,
+					'url'    => 'https://example.com',
+					'status' => 'pending',
+				],
+			],
+			'expected' => [
+				'should_track' => false,
+			],
+		],
+
+		'shouldBailOutWhenTestStatusIsInProgress' => [
+			'config' => [
+				'status'           => true,
+				'notice_displayed' => 0,
+				'home_url'         => 'https://example.com',
+				'row_details'      => (object) [
+					'id'     => 1,
+					'url'    => 'https://example.com',
+					'status' => 'in-progress',
+				],
+			],
+			'expected' => [
+				'should_track' => false,
+			],
+		],
+
+		'shouldTrackWhenTestStatusIsCompleted' => [
+			'config' => [
+				'status'           => true,
+				'notice_displayed' => 0,
+				'home_url'         => 'https://example.com',
+				'row_details'      => (object) [
+					'id'     => 1,
+					'url'    => 'https://example.com',
+					'status' => 'completed',
+				],
+				'current_plan'     => 'perf-monitor-free',
+			],
+			'expected' => [
+				'should_track' => true,
+			],
+		],
+
+		'shouldTrackWhenTestStatusIsFailed' => [
+			'config' => [
+				'status'           => true,
+				'notice_displayed' => 0,
+				'home_url'         => 'https://example.com',
+				'row_details'      => (object) [
+					'id'     => 1,
+					'url'    => 'https://example.com',
+					'status' => 'failed',
+				],
+				'current_plan'     => 'perf-monitor-free',
+			],
+			'expected' => [
+				'should_track' => true,
+			],
+		],
+	],
+];

--- a/tests/Unit/inc/Engine/Admin/RocketInsights/Controller/trackHomeAfterAnalyticsOptin.php
+++ b/tests/Unit/inc/Engine/Admin/RocketInsights/Controller/trackHomeAfterAnalyticsOptin.php
@@ -1,0 +1,93 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\Admin\RocketInsights\Controller;
+
+use Brain\Monkey\Functions;
+use Mockery;
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Engine\Admin\RocketInsights\Context\Context;
+use WP_Rocket\Engine\Admin\RocketInsights\Controller;
+use WP_Rocket\Engine\Admin\RocketInsights\Database\Queries\RocketInsights;
+use WP_Rocket\Engine\Admin\RocketInsights\GlobalScore;
+use WP_Rocket\Engine\Admin\RocketInsights\Jobs\Manager;
+use WP_Rocket\Engine\Admin\RocketInsights\Managers\Plan;
+use WP_Rocket\Engine\License\API\User;
+use WP_Rocket\Engine\Tracking\Tracking;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * Test class covering \WP_Rocket\Engine\Admin\RocketInsights\Controller::track_home_after_analytics_optin
+ *
+ * @group Admin
+ * @group RocketInsights
+ */
+class Test_TrackHomeAfterAnalyticsOptin extends TestCase {
+	private $query;
+	private $plan;
+	private $tracking;
+	private $controller;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->query    = $this->createMock( RocketInsights::class );
+		$this->plan     = Mockery::mock( Plan::class );
+		$this->tracking = Mockery::mock( Tracking::class );
+
+		$this->controller = new Controller(
+			$this->query,
+			Mockery::mock( Manager::class ),
+			Mockery::mock( Context::class ),
+			$this->plan,
+			Mockery::mock( GlobalScore::class ),
+			Mockery::mock( User::class ),
+			Mockery::mock( Options_Data::class ),
+			$this->tracking
+		);
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldHandleTrackingAfterOptIn( $config, $expected ) {
+		if ( isset( $config['notice_displayed'] ) ) {
+			Functions\when( 'get_option' )
+				->justReturn( $config['notice_displayed'] );
+		}
+
+		if ( isset( $config['home_url'] ) ) {
+			Functions\when( 'home_url' )
+				->justReturn( $config['home_url'] );
+		}
+
+		if ( array_key_exists( 'row_details', $config ) ) {
+			$this->query
+				->expects( $this->once() )
+				->method( 'get_row' )
+				->with( $config['home_url'], true )
+				->willReturn( $config['row_details'] );
+		} else {
+			$this->query
+				->expects( $this->never() )
+				->method( 'get_row' );
+		}
+
+		if ( $expected['should_track'] ) {
+			$this->plan
+				->shouldReceive( 'get_current_plan' )
+				->once()
+				->andReturn( $config['current_plan'] );
+
+			$this->tracking
+				->shouldReceive( 'track_rocket_insights_test' )
+				->once()
+				->with( $config['row_details'], [], $config['current_plan'] );
+		} else {
+			$this->plan->shouldNotReceive( 'get_current_plan' );
+			$this->tracking->shouldNotReceive( 'track_rocket_insights_test' );
+		}
+
+		$this->controller->track_home_after_analytics_optin( $config['status'] );
+	}
+}


### PR DESCRIPTION
# Description

Fixes #8249 
Tracks home page test after consent is granted.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

### What was tested

- Make sure completed/failed home page tests are tracked after consent is granted.

### How to test

- Fresh install
- Wait for home test to complete
- Grant consent

### Affected Features & Quality Assurance Scope

N/A

## Technical description

### Documentation

- Hooked a callback to `rocket_mixpanel_optin_changed` to trigger on optin status change
- Callback sends event for home test if:
- Optin status is enabled.
- Consent has never been granted
- Homepage test exists and the test is not in progress

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

Not applicable to the changes in this PR

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
