### PR TITLE
Add ability to add page to Rocket Insights monitoring

### DIFF
--- a/inc/Engine/Admin/RocketInsights/Abilities/AddPageInsights.php
+++ b/inc/Engine/Admin/RocketInsights/Abilities/AddPageInsights.php
@@ -1,0 +1,344 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Engine\Admin\RocketInsights\Abilities;
+
+use WP_Rocket\Engine\Abilities\AbilitiesInterface;
+use WP_Rocket\Engine\Admin\RocketInsights\{
+	Jobs\Manager,
+	Context\Context,
+	Database\Queries\RocketInsights as Query,
+	Managers\Plan
+};
+use WP_Rocket\Engine\Admin\RocketInsights\PageHandlerTrait;
+use WP_Rocket\Engine\Common\{
+	JobManager\JobProcessor,
+	JobManager\Queue\Queue,
+	Utils
+};
+use WP_Rocket\Logger\Logger;
+
+class AddPageInsights implements AbilitiesInterface {
+	use PageHandlerTrait;
+
+	/**
+	 * Context instance providing necessary dependencies and configuration.
+	 *
+	 * @var Context
+	 */
+	private $context;
+
+	/**
+	 * Job manager responsible for handling Rocket Insights jobs.
+	 *
+	 * @var Manager
+	 */
+	private $manager;
+
+	/**
+	 * Class responsible for processing jobs and communicating with the API.
+	 *
+	 * @var JobProcessor
+	 */
+	private $job_processor;
+
+	/**
+	 * Queue system for scheduling and managing asynchronous jobs.
+	 *
+	 * @var Queue
+	 */
+	private $queue;
+
+	/**
+	 * Database query class for interacting with Rocket Insights data.
+	 *
+	 * @var Query
+	 */
+	private $query;
+
+	/**
+	 * Class responsible for retrieving information about the user's current plan and limits.
+	 *
+	 * @var Plan
+	 */
+	private $plan;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Context      $context       The context instance providing necessary dependencies and configuration.
+	 * @param Manager      $manager       The job manager responsible for handling Rocket Insights jobs.
+	 * @param JobProcessor $job_processor The class responsible for processing jobs and communicating with the API.
+	 * @param Queue        $queue         The queue system for scheduling and managing asynchronous jobs.
+	 * @param Query        $query         The database query class for interacting with Rocket Insights data.
+	 * @param Plan         $plan          The class responsible for retrieving information about the user's current plan and limits.
+	 */
+	public function __construct( Context $context, Manager $manager, JobProcessor $job_processor, Queue $queue, Query $query, Plan $plan ) {
+		$this->context       = $context;
+		$this->manager       = $manager;
+		$this->job_processor = $job_processor;
+		$this->queue         = $queue;
+		$this->query         = $query;
+		$this->plan          = $plan;
+	}
+
+	/**
+	 * Registers the ability to add page insights.
+	 */
+	public function register_add_page_insights_ability() {
+		wp_register_ability(
+			'wp-rocket/add-page-insights',
+			[
+				'label'               => __( 'Add Page Insights', 'rocket' ),
+				'description'         => __( 'Add a page to be monitored by Rocket Insights.', 'rocket' ),
+				'category'            => 'wp-rocket-insights',
+				'input_schema'        => [
+					'type'       => 'object',
+					'properties' => [
+						'url' => [
+							'type'   => 'string',
+							'format' => 'uri',
+						],
+					],
+					'required'   => [ 'url' ],
+				],
+				'output_schema'       => [
+					'type'       => 'object',
+					'properties' => [
+						'success' => [
+							'type'        => 'boolean',
+							'description' => __( 'Indicates whether the page was successfully added', 'rocket' ),
+						],
+						'error'   => [
+							'type'        => 'string',
+							'description' => __( 'Error message if the page could not be added', 'rocket' ),
+						],
+					],
+				],
+				'execute_callback'    => [ $this, 'execute' ],
+				'permission_callback' => [ $this, 'check_permissions' ],
+				'meta'                => [
+					'mcp'          => [
+						'public' => true,
+					],
+					'show_in_rest' => true,
+				],
+			]
+		);
+	}
+
+	/**
+	 * Checks if the current user has permission to execute this ability.
+	 *
+	 * @return bool
+	 */
+	public function check_permissions(): bool {
+		return current_user_can( 'rocket_manage_options' );
+	}
+
+	/**
+	 * Executes the ability to add page insights.
+	 *
+	 * @param array $input The input data containing the URL to be added.
+	 *
+	 * @return array
+	 */
+	public function execute( $input = null ): array {
+		$payload = $this->get_url_validation_payload( $input['url'] );
+
+		if ( $payload['error'] ) {
+			return [
+				'success' => false,
+				'error'   => $payload['message'],
+			];
+		}
+
+		$url = $payload['processed_url'];
+
+		if ( Utils::is_home( $url ) ) {
+			$page_title = __( 'Homepage', 'rocket' );
+		} else {
+			$page_title = $this->get_page_title( $payload['message'] );
+		}
+
+		$source = 'mcp-ai';
+
+		$additional_details = [
+			'title' => $page_title,
+			'data'  => [
+				'source' => $source,
+			],
+		];
+
+		// Handle synchronous submission using shared method.
+		$row_id = $this->handle_sync_submission( $url, true, $additional_details );
+
+		if ( empty( $row_id ) ) {
+			return [
+				'success' => false,
+				'error'   => 'Failed to add page to monitoring queue.',
+			];
+		}
+
+		// Check URL limit again after insertion to handle race conditions.
+		// If the limit is exceeded, remove the newly added URL and return an error.
+		if ( $this->query->get_total_count() > $this->plan->max_urls() ) {
+			// Delete the newly added URL.
+			$this->query->delete_item( $row_id );
+
+			return [
+				'success' => false,
+				'error'   => 'URL limit exceeded.',
+			];
+		}
+
+		$urls_count   = $this->query->get_total_count();
+		$current_plan = $this->plan->get_current_plan();
+
+		/**
+		 * Fires when a performance monitoring job is added.
+		 *
+		 * @since 3.20
+		 *
+		 * @param string $url        The URL that was added for monitoring.
+		 * @param string $plan       Plan name.
+		 * @param int    $urls_count The current number of URLs being monitored.
+		 * @param string $source     The source of the request.
+		 */
+		do_action( 'rocket_rocket_insights_job_added', $url, $current_plan, $urls_count, $source );
+
+		return [
+			'success' => true,
+			'error'   => '',
+		];
+	}
+
+	/**
+	 * Validates a given URL for performance monitoring eligibility.
+	 *
+	 * @param string $url The URL to validate.
+	 *
+	 * @return array {
+	 *     @type bool   $error        Whether an error occurred during validation.
+	 *     @type string $message      The error message, or an empty string if no error.
+	 *     @type string $processed_url The URL with protocol added if validation passes.
+	 * }
+	 */
+	protected function get_url_validation_payload( string $url ): array {
+		$payload = [
+			'error'         => false,
+			'message'       => '',
+			'processed_url' => '',
+			'data'          => [
+				'status' => 400,
+			],
+		];
+
+		if ( 'local' === wp_get_environment_type() ) {
+			$payload['error']   = true;
+			$payload['message'] = 'Performance monitoring is disabled for local environment';
+
+			return $payload;
+		}
+
+		// Validate that performance monitoring is not disabled.
+		if ( ! $this->context->is_allowed() ) {
+			$payload['error']   = true;
+			$payload['message'] = 'Performance monitoring is disabled.';
+
+			return $payload;
+		}
+
+		// Check if URL has protocol, add if needed.
+		$url                      = rocket_add_url_protocol( $url );
+		$payload['processed_url'] = $url;
+
+		$response = $this->get_page_content( $url );
+
+		if ( ! $response ) {
+			$payload['error']   = true;
+			$payload['message'] = 'Url does not resolve to a valid page.';
+
+			return $payload;
+		}
+
+		// check if url is not from admin.
+		if ( strpos( $url, admin_url() ) === 0 ) {
+			$payload['error']   = true;
+			$payload['message'] = 'Url is an admin page.';
+
+			return $payload;
+		}
+
+		// Check if url has not been submited.
+		if ( false !== $this->manager->get_single_job( $url, true ) ) {
+			$payload['error'] = true;
+
+			return $payload;
+		}
+
+		// Fetch url body and send to payload.
+		$payload['message'] = $response;
+
+		return $payload;
+	}
+
+	/**
+	 * Handle synchronous submission of Rocket Insights job.
+	 *
+	 * This method centralizes the logic for attempting synchronous job submission
+	 * and falling back to async queuing when needed. It uses JobProcessor's send_api
+	 * for the actual API call, then adds Rocket Insights-specific validation and logging.
+	 *
+	 * @since 3.20
+	 *
+	 * @param string $url               The URL to test.
+	 * @param bool   $is_mobile         Whether this is a mobile test.
+	 * @param array  $additional_details Optional additional data to store with the job.
+	 *
+	 * @return bool|null Row ID on success, false on failure, null if not allowed.
+	 */
+	private function handle_sync_submission( string $url, bool $is_mobile, array $additional_details = [] ) {
+		// Attempt synchronous API submission.
+		$sync_response = $this->job_processor->send_api( $url, $is_mobile, 'rocket_insights', true );
+
+		// If sync submission failed or returned WP_Error, fall back to async queue.
+		if ( false === $sync_response || empty( $sync_response['uuid'] ) ) {
+			Logger::error(
+				'Rocket Insights: Synchronous Submission failed, Now falling back to Async Queue.',
+				[
+					'url' => $url,
+				]
+			);
+			return $this->manager->add_to_the_queue( $url, $is_mobile, $additional_details );
+		}
+
+		// Success! Save with the new data.
+		$row_id = $this->manager->add_to_the_queue( $url, $is_mobile, $additional_details );
+
+		if ( empty( $row_id ) ) {
+			// DB insert failed after successful API submission - log orphaned job.
+			Logger::error(
+				'Rocket Insights: Database insert failed after successful sync submission',
+				[
+					'url'    => $url,
+					'job_id' => $sync_response['uuid'],
+				]
+			);
+			return false;
+		}
+
+		Logger::error(
+			'Rocket Insights: Synchronous Submission successful, Now scheduling single job to run in 30 seconds.',
+			[
+				'url' => $url,
+			]
+		);
+
+		// Update to in-progress status immediately with job_id.
+		$this->manager->make_status_inprogress( $url, $is_mobile, 'rocket_insights', [ 'job_id' => $sync_response['uuid'] ] );
+		$this->queue->schedule_job_status_single_task( time() + 30, $url, $is_mobile, 'rocket_insights' );
+
+		return $row_id;
+	}
+}

--- a/inc/Engine/Admin/RocketInsights/Abilities/Subscriber.php
+++ b/inc/Engine/Admin/RocketInsights/Abilities/Subscriber.php
@@ -14,12 +14,21 @@ class Subscriber implements Subscriber_Interface {
 	private $get_insights_score;
 
 	/**
+	 * AddPageInsights ability instance.
+	 *
+	 * @var AddPageInsights
+	 */
+	private $add_page_insights;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param GetInsightsScore $get_insights_score The ability to get insights scores.
+	 * @param AddPageInsights  $add_page_insights  The ability to add page insights.
 	 */
-	public function __construct( GetInsightsScore $get_insights_score ) {
+	public function __construct( GetInsightsScore $get_insights_score, AddPageInsights $add_page_insights ) {
 		$this->get_insights_score = $get_insights_score;
+		$this->add_page_insights  = $add_page_insights;
 	}
 
 	/**
@@ -29,7 +38,10 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events(): array {
 		return [
-			'wp_abilities_api_init'            => 'register_get_insights_scores_ability',
+			'wp_abilities_api_init'            => [
+				[ 'register_get_insights_scores_ability' ],
+				[ 'register_add_page_insights_ability' ],
+			],
 			'wp_abilities_api_categories_init' => 'register_rocket_insights_category',
 		];
 	}
@@ -52,5 +64,12 @@ class Subscriber implements Subscriber_Interface {
 				'description' => __( 'Abilities related to Rocket Insights performance monitoring and scoring.', 'rocket' ),
 			]
 		);
+	}
+
+	/**
+	 * Registers the ability to add page insights.
+	 */
+	public function register_add_page_insights_ability() {
+		$this->add_page_insights->register_add_page_insights_ability();
 	}
 }

--- a/inc/Engine/Admin/RocketInsights/ServiceProvider.php
+++ b/inc/Engine/Admin/RocketInsights/ServiceProvider.php
@@ -7,6 +7,7 @@ use WP_Rocket\Dependencies\League\Container\Argument\Literal\StringArgument;
 use WP_Rocket\Dependencies\League\Container\ServiceProvider\AbstractServiceProvider;
 use WP_Rocket\Engine\Admin\RocketInsights\{
 	Abilities\GetInsightsScore,
+	Abilities\AddPageInsights,
 	Abilities\Subscriber as AbilitiesSubscriber,
 	Database\Tables\RocketInsights as RITable,
 	Database\Queries\RocketInsights as RIQuery,
@@ -57,6 +58,7 @@ class ServiceProvider extends AbstractServiceProvider {
 		'ri_metric_formatter',
 		'job_manager_queue',
 		'ri_get_insights_scores_ability',
+		'ri_add_page_insights_ability',
 		'ri_abilities_subscriber',
 	];
 
@@ -236,8 +238,26 @@ class ServiceProvider extends AbstractServiceProvider {
 					'ri_global_score',
 				]
 			);
+
+		$this->getContainer()->add( 'ri_add_page_insights_ability', AddPageInsights::class )
+			->addArguments(
+				[
+					'ri_context',
+					'ri_manager',
+					'job_processor',
+					'job_manager_queue',
+					'ri_query',
+					'ri_plan',
+				]
+			);
+
 		$this->getContainer()->addShared( 'ri_abilities_subscriber', AbilitiesSubscriber::class )
-			->addArgument( 'ri_get_insights_scores_ability' );
+			->addArguments(
+				[
+					'ri_get_insights_scores_ability',
+					'ri_add_page_insights_ability',
+				]
+			);
 
 		// Ensure the table is created.
 		$this->getContainer()->get( 'ri_table' );

--- a/tests/Fixtures/inc/Engine/Admin/RocketInsights/Abilities/AddPageInsights/ExecuteTest.php
+++ b/tests/Fixtures/inc/Engine/Admin/RocketInsights/Abilities/AddPageInsights/ExecuteTest.php
@@ -1,0 +1,377 @@
+<?php
+
+return [
+	'testShouldReturnErrorWhenEnvironmentIsLocal' => [
+		'config'   => [
+			'input'            => [
+				'url' => 'https://example.com/page',
+			],
+			'environment_type' => 'local',
+		],
+		'expected' => [
+			'result' => [
+				'success' => false,
+				'error'   => 'Performance monitoring is disabled for local environment',
+			],
+		],
+	],
+
+	'testShouldReturnErrorWhenContextNotAllowed' => [
+		'config'   => [
+			'input'              => [
+				'url' => 'https://example.com/page',
+			],
+			'environment_type'   => 'production',
+			'context_is_allowed' => false,
+		],
+		'expected' => [
+			'result' => [
+				'success' => false,
+				'error'   => 'Performance monitoring is disabled.',
+			],
+		],
+	],
+
+	'testShouldReturnErrorWhenUrlDoesNotResolve' => [
+		'config'   => [
+			'input'              => [
+				'url' => 'https://example.com/page',
+			],
+			'environment_type'   => 'production',
+			'context_is_allowed' => true,
+			'http_response'      => [
+				'response'    => [],
+				'is_error'    => true,
+				'status_code' => 0,
+				'body'        => '',
+			],
+		],
+		'expected' => [
+			'result' => [
+				'success' => false,
+				'error'   => 'Url does not resolve to a valid page.',
+			],
+		],
+	],
+
+	'testShouldReturnErrorWhenHttpStatusIsNot200' => [
+		'config'   => [
+			'input'              => [
+				'url' => 'https://example.com/page',
+			],
+			'environment_type'   => 'production',
+			'context_is_allowed' => true,
+			'http_response'      => [
+				'response'    => [],
+				'is_error'    => false,
+				'status_code' => 404,
+				'body'        => '',
+			],
+		],
+		'expected' => [
+			'result' => [
+				'success' => false,
+				'error'   => 'Url does not resolve to a valid page.',
+			],
+		],
+	],
+
+	'testShouldReturnErrorWhenUrlIsAdminPage' => [
+		'config'   => [
+			'input'              => [
+				'url' => 'https://example.com/wp-admin/options.php',
+			],
+			'environment_type'   => 'production',
+			'context_is_allowed' => true,
+			'admin_url'          => 'https://example.com/wp-admin/',
+			'http_response'      => [
+				'response'    => [],
+				'is_error'    => false,
+				'status_code' => 200,
+				'body'        => '<html><head><title>Admin Page</title></head></html>',
+			],
+		],
+		'expected' => [
+			'result' => [
+				'success' => false,
+				'error'   => 'Url is an admin page.',
+			],
+		],
+	],
+
+	'testShouldReturnErrorWhenUrlAlreadySubmitted' => [
+		'config'   => [
+			'input'                  => [
+				'url' => 'https://example.com/page',
+			],
+			'environment_type'       => 'production',
+			'context_is_allowed'     => true,
+			'admin_url'              => 'https://example.com/wp-admin/',
+			'http_response'          => [
+				'response'    => [],
+				'is_error'    => false,
+				'status_code' => 200,
+				'body'        => '<html><head><title>Test Page</title></head></html>',
+			],
+			'manager_get_single_job' => [
+				'id'  => 1,
+				'url' => 'https://example.com/page',
+			],
+		],
+		'expected' => [
+			'result' => [
+				'success' => false,
+				'error'   => '',
+			],
+		],
+	],
+
+	'testShouldReturnErrorWhenDbInsertFailsAfterSyncSuccess' => [
+		'config'   => [
+			'input'                        => [
+				'url' => 'https://example.com/page',
+			],
+			'environment_type'             => 'production',
+			'context_is_allowed'           => true,
+			'admin_url'                    => 'https://example.com/wp-admin/',
+			'home_url'                     => 'https://example.com/',
+			'http_response'                => [
+				'response'    => [],
+				'is_error'    => false,
+				'status_code' => 200,
+				'body'        => '<html><head><title>Test Page</title></head></html>',
+			],
+			'job_processor_send_api_result' => [
+				'uuid' => 'test-uuid-123',
+			],
+			'manager_add_to_queue_result'  => false,
+		],
+		'expected' => [
+			'job_processor_send_api_called' => true,
+			'manager_add_to_queue_called'   => true,
+			'result'                        => [
+				'success' => false,
+				'error'   => 'Failed to add page to monitoring queue.',
+			],
+		],
+	],
+
+	'testShouldFallbackToAsyncAndReturnErrorWhenSyncFailsAndDbInsertFails' => [
+		'config'   => [
+			'input'                         => [
+				'url' => 'https://example.com/page',
+			],
+			'environment_type'              => 'production',
+			'context_is_allowed'            => true,
+			'admin_url'                     => 'https://example.com/wp-admin/',
+			'home_url'                      => 'https://example.com/',
+			'http_response'                 => [
+				'response'    => [],
+				'is_error'    => false,
+				'status_code' => 200,
+				'body'        => '<html><head><title>Test Page</title></head></html>',
+			],
+			'job_processor_send_api_result' => false,
+			'manager_add_to_queue_result'   => false,
+		],
+		'expected' => [
+			'job_processor_send_api_called' => true,
+			'manager_add_to_queue_called'   => true,
+			'result'                        => [
+				'success' => false,
+				'error'   => 'Failed to add page to monitoring queue.',
+			],
+		],
+	],
+
+	'testShouldDeleteAndReturnErrorWhenLimitExceeded' => [
+		'config'   => [
+			'input'                         => [
+				'url' => 'https://example.com/page',
+			],
+			'environment_type'              => 'production',
+			'context_is_allowed'            => true,
+			'admin_url'                     => 'https://example.com/wp-admin/',
+			'home_url'                      => 'https://example.com/',
+			'http_response'                 => [
+				'response'    => [],
+				'is_error'    => false,
+				'status_code' => 200,
+				'body'        => '<html><head><title>Test Page</title></head></html>',
+			],
+			'job_processor_send_api_result' => [
+				'uuid' => 'test-uuid-123',
+			],
+			'manager_add_to_queue_result'   => 5,
+			'query_total_count'             => 11,
+			'plan_max_urls'                 => 10,
+		],
+		'expected' => [
+			'job_processor_send_api_called'          => true,
+			'manager_add_to_queue_called'            => true,
+			'manager_make_status_inprogress_called'  => true,
+			'queue_schedule_called'                  => true,
+			'query_delete_item_called'               => true,
+			'result'                                 => [
+				'success' => false,
+				'error'   => 'URL limit exceeded.',
+			],
+		],
+	],
+
+	'testShouldSucceedForHomepage' => [
+		'config'   => [
+			'input'                         => [
+				'url' => 'https://example.com/',
+			],
+			'environment_type'              => 'production',
+			'context_is_allowed'            => true,
+			'admin_url'                     => 'https://example.com/wp-admin/',
+			'home_url'                      => 'https://example.com/',
+			'http_response'                 => [
+				'response'    => [],
+				'is_error'    => false,
+				'status_code' => 200,
+				'body'        => '<html><head><title>My Site - Welcome</title></head></html>',
+			],
+			'job_processor_send_api_result' => [
+				'uuid' => 'test-uuid-homepage',
+			],
+			'manager_add_to_queue_result'   => 1,
+			'query_total_count'             => 5,
+			'plan_max_urls'                 => 10,
+			'plan_current_plan'             => 'pro',
+		],
+		'expected' => [
+			'job_processor_send_api_called'         => true,
+			'manager_add_to_queue_called'           => true,
+			'manager_make_status_inprogress_called' => true,
+			'queue_schedule_called'                 => true,
+			'plan_get_current_plan_called'          => true,
+			'action_fired'                          => true,
+			'action_url'                            => 'https://example.com/',
+			'action_plan'                           => 'pro',
+			'action_urls_count'                     => 5,
+			'result'                                => [
+				'success' => true,
+				'error'   => '',
+			],
+		],
+	],
+
+	'testShouldSucceedForRegularPage' => [
+		'config'   => [
+			'input'                         => [
+				'url' => 'https://example.com/about-us',
+			],
+			'environment_type'              => 'production',
+			'context_is_allowed'            => true,
+			'admin_url'                     => 'https://example.com/wp-admin/',
+			'home_url'                      => 'https://example.com/',
+			'http_response'                 => [
+				'response'    => [],
+				'is_error'    => false,
+				'status_code' => 200,
+				'body'        => '<html><head><title>About Us | My Site</title></head></html>',
+			],
+			'job_processor_send_api_result' => [
+				'uuid' => 'test-uuid-about',
+			],
+			'manager_add_to_queue_result'   => 2,
+			'query_total_count'             => 3,
+			'plan_max_urls'                 => 10,
+			'plan_current_plan'             => 'free',
+		],
+		'expected' => [
+			'job_processor_send_api_called'         => true,
+			'manager_add_to_queue_called'           => true,
+			'manager_make_status_inprogress_called' => true,
+			'queue_schedule_called'                 => true,
+			'plan_get_current_plan_called'          => true,
+			'action_fired'                          => true,
+			'action_url'                            => 'https://example.com/about-us',
+			'action_plan'                           => 'free',
+			'action_urls_count'                     => 3,
+			'result'                                => [
+				'success' => true,
+				'error'   => '',
+			],
+		],
+	],
+
+	'testShouldSucceedWithAsyncFallbackWhenSyncFails' => [
+		'config'   => [
+			'input'                         => [
+				'url' => 'https://example.com/contact',
+			],
+			'environment_type'              => 'production',
+			'context_is_allowed'            => true,
+			'admin_url'                     => 'https://example.com/wp-admin/',
+			'home_url'                      => 'https://example.com/',
+			'http_response'                 => [
+				'response'    => [],
+				'is_error'    => false,
+				'status_code' => 200,
+				'body'        => '<html><head><title>Contact Us</title></head></html>',
+			],
+			'job_processor_send_api_result' => false,
+			'manager_add_to_queue_result'   => 3,
+			'query_total_count'             => 4,
+			'plan_max_urls'                 => 10,
+			'plan_current_plan'             => 'free',
+		],
+		'expected' => [
+			'job_processor_send_api_called' => true,
+			'manager_add_to_queue_called'   => true,
+			'plan_get_current_plan_called'  => true,
+			'action_fired'                  => true,
+			'action_url'                    => 'https://example.com/contact',
+			'action_plan'                   => 'free',
+			'action_urls_count'             => 4,
+			'result'                        => [
+				'success' => true,
+				'error'   => '',
+			],
+		],
+	],
+
+	'testShouldAddProtocolToUrlWithoutProtocol' => [
+		'config'   => [
+			'input'                         => [
+				'url' => 'example.com/page',
+			],
+			'environment_type'              => 'production',
+			'context_is_allowed'            => true,
+			'admin_url'                     => 'https://example.com/wp-admin/',
+			'home_url'                      => 'https://example.com/',
+			'http_response'                 => [
+				'response'    => [],
+				'is_error'    => false,
+				'status_code' => 200,
+				'body'        => '<html><head><title>Page Title</title></head></html>',
+			],
+			'job_processor_send_api_result' => [
+				'uuid' => 'test-uuid-protocol',
+			],
+			'manager_add_to_queue_result'   => 4,
+			'query_total_count'             => 5,
+			'plan_max_urls'                 => 10,
+			'plan_current_plan'             => 'free',
+		],
+		'expected' => [
+			'job_processor_send_api_called'         => true,
+			'manager_add_to_queue_called'           => true,
+			'manager_make_status_inprogress_called' => true,
+			'queue_schedule_called'                 => true,
+			'plan_get_current_plan_called'          => true,
+			'action_fired'                          => true,
+			'action_url'                            => 'https://example.com/page',
+			'action_plan'                           => 'free',
+			'action_urls_count'                     => 5,
+			'result'                                => [
+				'success' => true,
+				'error'   => '',
+			],
+		],
+	],
+];

--- a/tests/Fixtures/inc/Engine/Admin/RocketInsights/Abilities/AddPageInsights/RegisterAddPageInsightsAbilityTest.php
+++ b/tests/Fixtures/inc/Engine/Admin/RocketInsights/Abilities/AddPageInsights/RegisterAddPageInsightsAbilityTest.php
@@ -1,0 +1,135 @@
+<?php
+
+return [
+	'testShouldReturnWPErrorWhenNoPermissions' => [
+		'config'   => [
+			'has_permission' => false,
+			'input'          => [
+				'url' => 'https://example.com/test-page',
+			],
+			'existing_items' => [],
+			'mock_http'      => false,
+		],
+		'expected' => [
+			'is_error'   => true,
+			'success'    => false,
+			'hook_fired' => false,
+		],
+	],
+
+	'testShouldAddPageSuccessfully' => [
+		'config'   => [
+			'has_permission' => true,
+			'input'          => [
+				'url' => 'https://example.com/test-page',
+			],
+			'existing_items' => [],
+			'mock_http'      => true,
+			'url_limit'      => 10,
+		],
+		'expected' => [
+			'is_error'   => false,
+			'success'    => true,
+			'hook_fired' => true,
+		],
+	],
+
+	'testShouldFailWhenUrlAlreadySubmitted' => [
+		'config'   => [
+			'has_permission' => true,
+			'input'          => [
+				'url' => 'https://example.com/existing-page',
+			],
+			'existing_items' => [
+				[
+					'url'       => 'https://example.com/existing-page',
+					'title'     => 'Existing Page',
+					'is_mobile' => true,
+					'job_id'    => 'test_123',
+					'status'    => 'completed',
+					'score'     => 85,
+					'data'      => '{"status":"complete"}',
+				],
+			],
+			'mock_http'      => true,
+			'url_limit'      => 10,
+		],
+		'expected' => [
+			'is_error'   => false,
+			'success'    => false,
+			'error'      => '',
+			'hook_fired' => false,
+		],
+	],
+
+	'testShouldFailWhenUrlDoesNotResolve' => [
+		'config'   => [
+			'has_permission' => true,
+			'input'          => [
+				'url' => 'https://example.com/non-existent-page',
+			],
+			'existing_items' => [],
+			'mock_http'      => false,
+			'url_limit'      => 10,
+		],
+		'expected' => [
+			'is_error'   => false,
+			'success'    => false,
+			'error'      => 'Url does not resolve to a valid page.',
+			'hook_fired' => false,
+		],
+	],
+
+	'testShouldAddHomepageWithCorrectTitle' => [
+		'config'   => [
+			'has_permission' => true,
+			'input'          => [
+				'url' => 'https://example.org/',
+			],
+			'existing_items' => [],
+			'mock_http'      => true,
+			'url_limit'      => 10,
+		],
+		'expected' => [
+			'is_error'   => false,
+			'success'    => true,
+			'hook_fired' => true,
+		],
+	],
+
+	'testShouldAddMultiplePages' => [
+		'config'   => [
+			'has_permission' => true,
+			'input'          => [
+				'url' => 'https://example.com/new-page',
+			],
+			'existing_items' => [
+				[
+					'url'       => 'https://example.com/page1',
+					'title'     => 'Page 1',
+					'is_mobile' => true,
+					'job_id'    => 'test_1',
+					'status'    => 'completed',
+					'score'     => 90,
+					'data'      => '{"status":"complete"}',
+				],
+				[
+					'url'       => 'https://example.com/page2',
+					'title'     => 'Page 2',
+					'is_mobile' => true,
+					'job_id'    => 'test_2',
+					'status'    => 'completed',
+					'score'     => 85,
+					'data'      => '{"status":"complete"}',
+				],
+			],
+			'mock_http'      => true,
+			'url_limit'      => 10,
+		],
+		'expected' => [
+			'is_error'   => false,
+			'success'    => true,
+			'hook_fired' => true,
+		],
+	],
+];

--- a/tests/Integration/inc/Engine/Admin/RocketInsights/Abilities/RegisterAddPageInsightsAbilityTest.php
+++ b/tests/Integration/inc/Engine/Admin/RocketInsights/Abilities/RegisterAddPageInsightsAbilityTest.php
@@ -1,0 +1,187 @@
+<?php
+declare( strict_types=1 );
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\Admin\RocketInsights\Abilities\AddPageInsights;
+
+use WP_Rocket\Tests\Integration\DBTrait;
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * Test class covering wp-rocket/add-page-insights ability registration and execution.
+ *
+ * @group RocketInsights
+ * @group Abilities
+ * @group AdminOnly
+ */
+class RegisterAddPageInsightsAbilityTest extends TestCase {
+	use DBTrait;
+
+	private $hook_fired = false;
+	private $hook_data = [];
+
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		// Install the Performance Monitoring table.
+		self::installPerformanceMonitoringTable();
+	}
+
+	public static function tear_down_after_class() {
+		self::uninstallPerformanceMonitoringTable();
+
+		parent::tear_down_after_class();
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		// Skip test if WordPress version is less than 6.9 (Abilities API not available).
+		if ( version_compare( $GLOBALS['wp_version'], '6.9', '<' ) ) {
+			$this->markTestSkipped( 'WordPress 6.9+ required for Abilities API' );
+		}
+
+		// Clean up data before each test.
+		self::truncatePerformanceMonitoringTable();
+
+		// Enable Performance Monitoring for the test.
+		add_filter( 'rocket_rocket_insights_enabled', '__return_true' );
+
+		// Add a hook to capture when rocket_rocket_insights_job_added is fired.
+		add_action( 'rocket_rocket_insights_job_added', [ $this, 'capture_hook_fired' ], 10, 4 );
+
+		$this->hook_fired = false;
+		$this->hook_data  = [];
+	}
+
+	public function tear_down() {
+		// Clean up data after each test.
+		self::truncatePerformanceMonitoringTable();
+
+		// Remove filters.
+		remove_filter( 'rocket_rocket_insights_enabled', '__return_true' );
+		remove_action( 'rocket_rocket_insights_job_added', [ $this, 'capture_hook_fired' ] );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Captures when the hook is fired.
+	 *
+	 * @param string $url        The URL that was added.
+	 * @param string $plan       The plan name.
+	 * @param int    $urls_count The number of URLs.
+	 * @param string $source     The source of the request.
+	 */
+	public function capture_hook_fired( $url, $plan, $urls_count, $source ) {
+		$this->hook_fired = true;
+		$this->hook_data  = [
+			'url'        => $url,
+			'plan'       => $plan,
+			'urls_count' => $urls_count,
+			'source'     => $source,
+		];
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnExpectedOutput( $config, $expected ) {
+		$this->set_up_user( $config['has_permission'] );
+
+		// Add existing items if provided.
+		if ( ! empty( $config['existing_items'] ) ) {
+			foreach ( $config['existing_items'] as $item ) {
+				self::addPerformanceMonitoring( $item );
+			}
+		}
+
+		// Mock HTTP response if needed.
+		if ( $config['mock_http'] ?? false ) {
+			add_filter( 'pre_http_request', [ $this, 'mock_http_response' ], 10, 3 );
+		}
+
+		// Set URL limit if provided.
+		if ( isset( $config['url_limit'] ) ) {
+			add_filter( 'rocket_rocket_insights_max_urls', function () use ( $config ) {
+				return $config['url_limit'];
+			} );
+		}
+
+		// Get the ability.
+		$ability = wp_get_ability( 'wp-rocket/add-page-insights' );
+
+		$this->assertNotNull( $ability, 'Ability should be registered' );
+
+		// Execute the ability with input.
+		$result = $ability->execute( $config['input'] ?? null );
+
+		// Remove HTTP mock.
+		if ( $config['mock_http'] ?? false ) {
+			remove_filter( 'pre_http_request', [ $this, 'mock_http_response' ] );
+		}
+
+		if ( $expected['is_error'] ) {
+			$this->assertInstanceOf( 'WP_Error', $result, 'Should return WP_Error when user lacks permission.' );
+			return;
+		}
+
+		// Check the result structure.
+		$this->assertArrayHasKey( 'success', $result );
+		$this->assertArrayHasKey( 'error', $result );
+
+		// Assert expected values.
+		$this->assertSame( $expected['success'], $result['success'] );
+
+		if ( ! $expected['success'] && isset( $expected['error'] ) ) {
+			$this->assertSame( $expected['error'], $result['error'] );
+		}
+
+		// Check hook fired status.
+		$this->assertSame( $expected['hook_fired'] ?? false, $this->hook_fired );
+
+		// Check hook data if hook was fired.
+		if ( $expected['hook_fired'] ?? false ) {
+			$this->assertSame( 'mcp-ai', $this->hook_data['source'] );
+		}
+	}
+
+	/**
+	 * Mock HTTP response for testing.
+	 *
+	 * @param mixed  $preempt Whether to preempt the request.
+	 * @param array  $args    Request arguments.
+	 * @param string $url     Request URL.
+	 *
+	 * @return array|false Mock response or false.
+	 */
+	public function mock_http_response( $preempt, $args, $url ) {
+		return [
+			'response' => [
+				'code'    => 200,
+				'message' => 'OK',
+			],
+			'body'     => '<html><head><title>Test Page Title</title></head><body>Test content</body></html>',
+		];
+	}
+
+	/**
+	 * Set up user with or without permission.
+	 *
+	 * @param bool $has_permission Whether user should have permission.
+	 *
+	 * @return void
+	 */
+	private function set_up_user( bool $has_permission ): void {
+		$admin = get_role( 'administrator' );
+
+		if ( $has_permission ) {
+			$admin->add_cap( 'rocket_manage_options' );
+			$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		} else {
+			$admin->remove_cap( 'rocket_manage_options' );
+			$user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		}
+
+		wp_set_current_user( $user_id );
+	}
+}

--- a/tests/Unit/inc/Engine/Admin/RocketInsights/Abilities/AddPageInsights/ExecuteTest.php
+++ b/tests/Unit/inc/Engine/Admin/RocketInsights/Abilities/AddPageInsights/ExecuteTest.php
@@ -1,0 +1,303 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\Admin\RocketInsights\Abilities\AddPageInsights;
+
+use Brain\Monkey\Actions;
+use Brain\Monkey\Functions;
+use WP_Rocket\Engine\Admin\RocketInsights\Abilities\AddPageInsights;
+use WP_Rocket\Engine\Admin\RocketInsights\Context\Context;
+use WP_Rocket\Engine\Admin\RocketInsights\Database\Queries\RocketInsights as Query;
+use WP_Rocket\Engine\Admin\RocketInsights\Jobs\Manager;
+use WP_Rocket\Engine\Admin\RocketInsights\Managers\Plan;
+use WP_Rocket\Engine\Common\JobManager\JobProcessor;
+use WP_Rocket\Engine\Common\JobManager\Queue\Queue;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * Test class covering \WP_Rocket\Engine\Admin\RocketInsights\Abilities\AddPageInsights::execute
+ *
+ * @group Admin
+ * @group RocketInsights
+ * @group Abilities
+ */
+class ExecuteTest extends TestCase {
+
+	/**
+	 * @var Context|\PHPUnit\Framework\MockObject\MockObject
+	 */
+	private $context;
+
+	/**
+	 * @var Manager|\PHPUnit\Framework\MockObject\MockObject
+	 */
+	private $manager;
+
+	/**
+	 * @var JobProcessor|\PHPUnit\Framework\MockObject\MockObject
+	 */
+	private $job_processor;
+
+	/**
+	 * @var Queue|\PHPUnit\Framework\MockObject\MockObject
+	 */
+	private $queue;
+
+	/**
+	 * @var Query|\PHPUnit\Framework\MockObject\MockObject
+	 */
+	private $query;
+
+	/**
+	 * @var Plan|\PHPUnit\Framework\MockObject\MockObject
+	 */
+	private $plan;
+
+	/**
+	 * @var AddPageInsights
+	 */
+	private $ability;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->context       = $this->createMock( Context::class );
+		$this->manager       = $this->createMock( Manager::class );
+		$this->job_processor = $this->createMock( JobProcessor::class );
+		$this->queue         = $this->createMock( Queue::class );
+		$this->query         = $this->createMock( Query::class );
+		$this->plan          = $this->createMock( Plan::class );
+
+		$this->ability = new AddPageInsights(
+			$this->context,
+			$this->manager,
+			$this->job_processor,
+			$this->queue,
+			$this->query,
+			$this->plan
+		);
+
+		$this->stubTranslationFunctions();
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldDoExpected( $config, $expected ): void {
+		// Stub environment type.
+		Functions\when( 'wp_get_environment_type' )->justReturn( $config['environment_type'] ?? 'production' );
+
+		// Stub URL protocol addition.
+		Functions\when( 'rocket_add_url_protocol' )->alias( function ( $url ) {
+			if ( empty( $url ) ) {
+				return $url;
+			}
+			if ( strpos( $url, 'http://' ) !== 0 && strpos( $url, 'https://' ) !== 0 ) {
+				return 'https://' . $url;
+			}
+			return $url;
+		} );
+
+		// Stub admin_url.
+		Functions\when( 'admin_url' )->justReturn( $config['admin_url'] ?? 'https://example.com/wp-admin/' );
+
+		// Stub home_url for Utils::is_home().
+		Functions\when( 'home_url' )->justReturn( $config['home_url'] ?? 'https://example.com/' );
+
+		// Stub sanitization functions.
+		Functions\when( 'wp_strip_all_tags' )->returnArg();
+		Functions\when( 'sanitize_text_field' )->returnArg();
+
+		// Stub HTTP request functions.
+		$this->stubHttpFunctions( $config );
+
+		// Set up Context mock.
+		if ( isset( $config['context_is_allowed'] ) ) {
+			$this->context
+				->expects( $this->any() )
+				->method( 'is_allowed' )
+				->willReturn( $config['context_is_allowed'] );
+		}
+
+		// Set up Manager mock.
+		$this->setupManagerMock( $config, $expected );
+
+		// Set up JobProcessor mock.
+		$this->setupJobProcessorMock( $config, $expected );
+
+		// Set up Queue mock.
+		$this->setupQueueMock( $config, $expected );
+
+		// Set up Query mock.
+		$this->setupQueryMock( $config, $expected );
+
+		// Set up Plan mock.
+		$this->setupPlanMock( $config, $expected );
+
+		// Set up action expectations.
+		if ( $expected['action_fired'] ?? false ) {
+			Actions\expectDone( 'rocket_rocket_insights_job_added' )
+				->once()
+				->with(
+					$expected['action_url'],
+					$expected['action_plan'],
+					$expected['action_urls_count'],
+					'mcp-ai'
+				);
+		} else {
+			Actions\expectDone( 'rocket_rocket_insights_job_added' )->never();
+		}
+
+		$result = $this->ability->execute( $config['input'] );
+
+		$this->assertSame( $expected['result'], $result );
+	}
+
+	/**
+	 * Stub HTTP functions for get_page_content().
+	 *
+	 * @param array $config Test configuration.
+	 */
+	private function stubHttpFunctions( array $config ): void {
+		$http_response = $config['http_response'] ?? null;
+
+		if ( null === $http_response ) {
+			Functions\when( 'wp_safe_remote_get' )->justReturn( [] );
+			Functions\when( 'is_wp_error' )->justReturn( true );
+			Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 0 );
+			Functions\when( 'wp_remote_retrieve_body' )->justReturn( '' );
+			return;
+		}
+
+		Functions\when( 'wp_safe_remote_get' )->justReturn( $http_response['response'] ?? [] );
+		Functions\when( 'is_wp_error' )->justReturn( $http_response['is_error'] ?? false );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( $http_response['status_code'] ?? 200 );
+		Functions\when( 'wp_remote_retrieve_body' )->justReturn( $http_response['body'] ?? '' );
+	}
+
+	/**
+	 * Set up Manager mock expectations.
+	 *
+	 * @param array $config   Test configuration.
+	 * @param array $expected Expected results.
+	 */
+	private function setupManagerMock( array $config, array $expected ): void {
+		// get_single_job.
+		if ( isset( $config['manager_get_single_job'] ) ) {
+			$this->manager
+				->expects( $this->any() )
+				->method( 'get_single_job' )
+				->willReturn( $config['manager_get_single_job'] );
+		} else {
+			$this->manager
+				->expects( $this->any() )
+				->method( 'get_single_job' )
+				->willReturn( false );
+		}
+
+		// add_to_the_queue.
+		if ( $expected['manager_add_to_queue_called'] ?? false ) {
+			$this->manager
+				->expects( $this->once() )
+				->method( 'add_to_the_queue' )
+				->willReturn( $config['manager_add_to_queue_result'] ?? 1 );
+		} else {
+			$this->manager
+				->expects( $this->never() )
+				->method( 'add_to_the_queue' );
+		}
+
+		// make_status_inprogress.
+		if ( $expected['manager_make_status_inprogress_called'] ?? false ) {
+			$this->manager
+				->expects( $this->once() )
+				->method( 'make_status_inprogress' );
+		}
+	}
+
+	/**
+	 * Set up JobProcessor mock expectations.
+	 *
+	 * @param array $config   Test configuration.
+	 * @param array $expected Expected results.
+	 */
+	private function setupJobProcessorMock( array $config, array $expected ): void {
+		if ( $expected['job_processor_send_api_called'] ?? false ) {
+			$this->job_processor
+				->expects( $this->once() )
+				->method( 'send_api' )
+				->willReturn( $config['job_processor_send_api_result'] ?? false );
+		} else {
+			$this->job_processor
+				->expects( $this->never() )
+				->method( 'send_api' );
+		}
+	}
+
+	/**
+	 * Set up Queue mock expectations.
+	 *
+	 * @param array $config   Test configuration.
+	 * @param array $expected Expected results.
+	 */
+	private function setupQueueMock( array $config, array $expected ): void {
+		if ( $expected['queue_schedule_called'] ?? false ) {
+			$this->queue
+				->expects( $this->once() )
+				->method( 'schedule_job_status_single_task' );
+		} else {
+			$this->queue
+				->expects( $this->never() )
+				->method( 'schedule_job_status_single_task' );
+		}
+	}
+
+	/**
+	 * Set up Query mock expectations.
+	 *
+	 * @param array $config   Test configuration.
+	 * @param array $expected Expected results.
+	 */
+	private function setupQueryMock( array $config, array $expected ): void {
+		// get_total_count.
+		if ( isset( $config['query_total_count'] ) ) {
+			$this->query
+				->expects( $this->any() )
+				->method( 'get_total_count' )
+				->willReturn( $config['query_total_count'] );
+		}
+
+		// delete_item.
+		if ( $expected['query_delete_item_called'] ?? false ) {
+			$this->query
+				->expects( $this->once() )
+				->method( 'delete_item' );
+		} else {
+			$this->query
+				->expects( $this->never() )
+				->method( 'delete_item' );
+		}
+	}
+
+	/**
+	 * Set up Plan mock expectations.
+	 *
+	 * @param array $config   Test configuration.
+	 * @param array $expected Expected results.
+	 */
+	private function setupPlanMock( array $config, array $expected ): void {
+		if ( isset( $config['plan_max_urls'] ) ) {
+			$this->plan
+				->expects( $this->any() )
+				->method( 'max_urls' )
+				->willReturn( $config['plan_max_urls'] );
+		}
+
+		if ( $expected['plan_get_current_plan_called'] ?? false ) {
+			$this->plan
+				->expects( $this->once() )
+				->method( 'get_current_plan' )
+				->willReturn( $config['plan_current_plan'] ?? 'free' );
+		}
+	}
+}


### PR DESCRIPTION
# Description

Add a new ability `wp-rocket/add-page-insights` to add a new page to Rocket Insights monitoring

## Type of change

- [x] Sub-task

## Detailed scenario

### What was tested

Added a new page using MCP server on VSCode chat

### How to test

TBD

### Affected Features & Quality Assurance Scope

Rocket Insights & WP Ability

## Technical description

### Documentation

TBD

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.