### PR TITLE
Check RocketCDN free subscription's status

### DIFF
--- a/inc/Engine/CDN/RocketCDN/APIHandler/CheckStatusAPIClient.php
+++ b/inc/Engine/CDN/RocketCDN/APIHandler/CheckStatusAPIClient.php
@@ -3,28 +3,30 @@ declare(strict_types=1);
 
 namespace WP_Rocket\Engine\CDN\RocketCDN\APIHandler;
 
+use WP_Rocket\Engine\CDN\RocketCDN\APIClient;
 use WP_Rocket\Engine\Common\JobManager\APIHandler\AbstractSafeAPIClient;
 use WP_Rocket\Engine\License\API\User;
 
 /**
- * Class to Interact with the RocketCDN API
+ * Class to Interact with the RocketCDN API - check creation status.
  */
-class CreateAPIClient extends AbstractSafeAPIClient {
+class CheckStatusAPIClient extends AbstractSafeAPIClient {
 
 	/**
-	 * Free url from user endpoint.
+	 * Task ID to check the status.
 	 *
 	 * @var string
 	 */
-	private $free_url;
+	private $task_id;
 
 	/**
-	 * Constructor to get the rocketcdn free url from user endpoint to be used later.
+	 * Set task ID.
 	 *
-	 * @param User $user User instance.
+	 * @param string $task_id Task ID.
+	 * @return void
 	 */
-	public function __construct( User $user ) {
-		$this->free_url = $user->get_rocketcdn_free_url();
+	public function set_task_id( string $task_id ): void {
+		$this->task_id = $task_id;
 	}
 
 	/**
@@ -33,7 +35,7 @@ class CreateAPIClient extends AbstractSafeAPIClient {
 	 * @return string The transient key for plugin updates.
 	 */
 	protected function get_transient_key() {
-		return 'rocket_cdn_create_request';
+		return 'rocket_cdn_check_status_request';
 	}
 
 	/**
@@ -42,16 +44,19 @@ class CreateAPIClient extends AbstractSafeAPIClient {
 	 * @return string The API URL.
 	 */
 	protected function get_api_url() {
-		return $this->free_url;
+		if ( empty( $this->task_id ) ) {
+			return '';
+		}
+		return sprintf( '%1$swebsite/task/%2$s/', APIClient::ROCKETCDN_API, $this->task_id );
 	}
 
 	/**
-	 * Create RocketCDN free account.
+	 * Check RocketCDN free account creation status.
 	 *
 	 * @return array|false
 	 */
-	public function create() {
-		$response = $this->send_post_request( [], true );
+	public function check() {
+		$response = $this->send_get_request( [], true );
 
 		if ( is_wp_error( $response ) ) {
 			return false;

--- a/inc/Engine/CDN/RocketCDN/CDNOptionsManager.php
+++ b/inc/Engine/CDN/RocketCDN/CDNOptionsManager.php
@@ -41,9 +41,10 @@ class CDNOptionsManager {
 	 * @since 3.5
 	 *
 	 * @param string $cdn_url CDN URL.
+	 * @param bool   $clear_cache Clear website whole cache.
 	 * @return void
 	 */
-	public function enable( $cdn_url ) {
+	public function enable( $cdn_url, bool $clear_cache = true ) {
 		$this->options->set( 'cdn', 1 );
 		$this->options->set( 'cdn_cnames', [ $cdn_url ] );
 		$this->options->set( 'cdn_zone', [ 'all' ] );
@@ -51,7 +52,9 @@ class CDNOptionsManager {
 		$this->options_api->set( 'settings', $this->options->get_options() );
 
 		delete_transient( 'rocketcdn_status' );
-		rocket_clean_domain();
+		if ( $clear_cache ) {
+			rocket_clean_domain();
+		}
 	}
 
 	/**

--- a/inc/Engine/CDN/RocketCDN/RESTSubscriber.php
+++ b/inc/Engine/CDN/RocketCDN/RESTSubscriber.php
@@ -60,12 +60,13 @@ class RESTSubscriber implements Subscriber_Interface {
 	 */
 	public static function get_subscribed_events() {
 		return [
-			'rest_api_init'               => [
+			'rest_api_init'                        => [
 				[ 'register_enable_route' ],
 				[ 'register_disable_route' ],
 				[ 'register_routes' ],
 			],
-			'rocket_cdnfree_can_add_page' => 'maybe_create_rocketcdn_free',
+			'rocket_cdnfree_can_add_page'          => 'maybe_create_rocketcdn_free',
+			'rocket_cdnfree_website_create_status' => 'check_status',
 		];
 	}
 
@@ -237,5 +238,18 @@ class RESTSubscriber implements Subscriber_Interface {
 		}
 
 		return $can_save_page;
+	}
+
+	/**
+	 * Check subscription creation status.
+	 *
+	 * @param string $task_id Task ID to check.
+	 * @return void
+	 */
+	public function check_status( string $task_id ) {
+		if ( empty( $task_id ) ) {
+			return;
+		}
+		$this->subscription_controller->check_status( $task_id );
 	}
 }

--- a/inc/Engine/CDN/RocketCDN/ServiceProvider.php
+++ b/inc/Engine/CDN/RocketCDN/ServiceProvider.php
@@ -5,6 +5,7 @@ namespace WP_Rocket\Engine\CDN\RocketCDN;
 
 use WP_Rocket\Dependencies\League\Container\Argument\Literal\StringArgument;
 use WP_Rocket\Dependencies\League\Container\ServiceProvider\AbstractServiceProvider;
+use WP_Rocket\Engine\CDN\RocketCDN\APIHandler\CheckStatusAPIClient;
 use WP_Rocket\Engine\CDN\RocketCDN\APIHandler\CreateAPIClient;
 use WP_Rocket\Engine\CDN\RocketCDN\Database\Queries\RocketCDN as RocketCDNQuery;
 use WP_Rocket\Engine\CDN\RocketCDN\Database\Tables\RocketCDN as RocketCDNTable;
@@ -31,6 +32,7 @@ class ServiceProvider extends AbstractServiceProvider {
 		'rocketcdn_subscription_controller',
 		'rocketcdn_create_api_client',
 		'rocketcdn_queue',
+		'rocketcdn_check_status_api_client',
 	];
 
 	/**
@@ -108,6 +110,7 @@ class ServiceProvider extends AbstractServiceProvider {
 
 		$this->getContainer()->add( 'rocketcdn_queue', Queue::class );
 		$this->getContainer()->add( 'rocketcdn_create_api_client', CreateAPIClient::class )->addArgument( 'user' );
+		$this->getContainer()->add( 'rocketcdn_check_status_api_client', CheckStatusAPIClient::class );
 		$this->getContainer()->add( 'rocketcdn_subscription_controller', SubscriptionController::class )
 			->addArguments(
 				[
@@ -115,6 +118,7 @@ class ServiceProvider extends AbstractServiceProvider {
 					'rocketcdn_create_api_client',
 					'rocketcdn_options_manager',
 					'rocketcdn_queue',
+					'rocketcdn_check_status_api_client',
 				]
 				);
 

--- a/inc/Engine/CDN/RocketCDN/SubscriptionController.php
+++ b/inc/Engine/CDN/RocketCDN/SubscriptionController.php
@@ -153,13 +153,10 @@ class SubscriptionController implements LoggerAwareInterface {
 			return;
 		}
 
-		if ( ! $status || ! $status['success'] ) {
+		if ( ! $status['success'] ) {
 			$this->logger::error(
 				'RocketCDN: Failed to check creation status.',
-				[
-					'code'    => $created['data']['code'] ?? 'Unknown',
-					'message' => $created['data']['message'] ?? 'Unknown',
-				]
+				$status
 			);
 			return;
 		}

--- a/inc/Engine/CDN/RocketCDN/SubscriptionController.php
+++ b/inc/Engine/CDN/RocketCDN/SubscriptionController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace WP_Rocket\Engine\CDN\RocketCDN;
 
 use WP_Error;
+use WP_Rocket\Engine\CDN\RocketCDN\APIHandler\CheckStatusAPIClient;
 use WP_Rocket\Engine\CDN\RocketCDN\APIHandler\CreateAPIClient;
 use WP_Rocket\Logger\LoggerAware;
 use WP_Rocket\Logger\LoggerAwareInterface;
@@ -40,18 +41,27 @@ class SubscriptionController implements LoggerAwareInterface {
 	private $queue;
 
 	/**
+	 * Check Status API Client instance.
+	 *
+	 * @var CheckStatusAPIClient
+	 */
+	private $check_status_api_client;
+
+	/**
 	 * Constructor.
 	 *
-	 * @param APIClient         $api_client API Client instance.
-	 * @param CreateAPIClient   $create_api_client Create API Client instance.
-	 * @param CDNOptionsManager $options_manager Options Manager instance.
-	 * @param Queue             $queue Queue instance.
+	 * @param APIClient            $api_client API Client instance.
+	 * @param CreateAPIClient      $create_api_client Create API Client instance.
+	 * @param CDNOptionsManager    $options_manager Options Manager instance.
+	 * @param Queue                $queue Queue instance.
+	 * @param CheckStatusAPIClient $check_status_api_client Check Status API Client instance.
 	 */
-	public function __construct( APIClient $api_client, CreateAPIClient $create_api_client, CDNOptionsManager $options_manager, Queue $queue ) {
-		$this->api_client        = $api_client;
-		$this->create_api_client = $create_api_client;
-		$this->options_manager   = $options_manager;
-		$this->queue             = $queue;
+	public function __construct( APIClient $api_client, CreateAPIClient $create_api_client, CDNOptionsManager $options_manager, Queue $queue, CheckStatusAPIClient $check_status_api_client ) {
+		$this->api_client              = $api_client;
+		$this->create_api_client       = $create_api_client;
+		$this->options_manager         = $options_manager;
+		$this->queue                   = $queue;
+		$this->check_status_api_client = $check_status_api_client;
 	}
 
 	/**
@@ -124,5 +134,54 @@ class SubscriptionController implements LoggerAwareInterface {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Check subscription's creation status.
+	 *
+	 * @param string $task_id Task ID.
+	 * @return void
+	 */
+	public function check_status( string $task_id ) {
+		if ( $this->has_active_subscription() ) {
+			return;
+		}
+
+		$this->check_status_api_client->set_task_id( $task_id );
+		$status = $this->check_status_api_client->check();
+		if ( ! $status ) {
+			return;
+		}
+
+		if ( ! $status || ! $status['success'] ) {
+			$this->logger::error(
+				'RocketCDN: Failed to check creation status.',
+				[
+					'code'    => $created['data']['code'] ?? 'Unknown',
+					'message' => $created['data']['message'] ?? 'Unknown',
+				]
+			);
+			return;
+		}
+
+		switch ( $status['status'] ) {
+			case 'PENDING':
+				// Re-add the action scheduler task to check status again after 30 seconds.
+				$this->queue->schedule_create_status_job( $task_id );
+				break;
+			case 'SUCCESS':
+				$this->options_manager->enable( $status['cdn_url'], false );
+
+				/**
+				 * Fires when rocketcdn subscription's creation is finished successfully.
+				 */
+				do_action( 'rocket_cdnfree_website_created' );
+				break;
+			default:
+				$this->logger::error(
+					'RocketCDN: Received not known response code when check subscription\'s status.',
+					$status
+				);
+		}
 	}
 }


### PR DESCRIPTION
# Description

Fixes #8303

As mentioned in the issue, here we will keep sending a request to check the status of account creation process in RocketCDN.

## Type of change

- [x] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

- Use a site without RocketCDN subscription.
- Add a page into RocketCDN free inclusion pages.
- If everything went well, you will find a single action scheduler's job with the hook `rocket_cdnfree_website_create_status` with the task ID as an argument
- After 30 seconds, you will find the status changed and CNAME is set correctly.

### How to test

Mentioned above.

### Affected Features & Quality Assurance Scope

RocketCDN

## Technical description

### Documentation

Everything is mentioned in the issue itself.

### New dependencies

we now depend on a new endpoint.

### Risks

- In case of check status failure, we will not schedule the action scheduler job again and customer will need to wait sometime to get this reflected in the plugin (we need to validate this)

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

We will create a dedicated GH issue for adding more tests.

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
