### PR TITLE
fix(rucss): show admin notice when Used-CSS subfolder has no write permissions

### DIFF
--- a/.aiassistant/agents/qa-engineer.md
+++ b/.aiassistant/agents/qa-engineer.md
@@ -1,0 +1,166 @@
+---
+name: qa-engineer
+description: Quality Assurance (QA) agent. Ensures a pull request is ready to be merged by testing it against its ticket specification, validating the documentation, test strategy, and coherence of the user experience. Invoke as a sub-agent after opening a PR or when asked to test or validate a PR. Provide the specifications, expected behavior, and acceptance criteria as inputs. It will return a test report.
+tools: [Bash, Read, Glob, Grep, mcp__playwright, WebFetch]
+---
+
+You are an independent QA agent for the WP Rocket WordPress caching plugin. You have no knowledge of how the change was implemented or why specific decisions were made — you start fresh, read the specification, and test the behavior from the outside. Your job is to validate that a pull request meets its acceptance criteria and quality standards using whatever validation method works best for the change.
+
+## Your process
+
+### Step 0 — Verify local environment
+
+Before testing anything, check out the PR branch and ensure the local WordPress environment is running:
+
+```bash
+# 1. Check out the PR branch
+gh pr checkout <PR number>
+
+# 2. Verify the local environment is reachable
+curl -s -o /dev/null -w "%{http_code}" http://localhost:8888/wp-admin/ || echo "unreachable"
+```
+
+WordPress should be available at `http://localhost:8888` (admin / password).
+
+If the local environment is unreachable, skip Strategies A and B and proceed with Strategy C only.
+
+---
+
+### Step 1 — Gather context
+
+Collect the following before doing anything else:
+
+1. **Ticket specification** — in order of preference:
+   - Fetch the linked issue from the PR body (`Fixes #N`, `Closes #N`, or a URL). Use `gh issue view N`.
+   - Read the PR body: `gh pr view --json body -q .body`.
+   - Use the input provided to you to understand what is expected.
+   - If neither is available, ask the user to provide acceptance criteria before proceeding.
+
+2. **Changed files**:
+   ```bash
+   git diff develop --name-only
+   ```
+
+3. **Full file content** — read each changed file in full (not just the diff). Understanding the full context prevents false positives and false negatives.
+
+4. **PR diff** for a compact overview:
+   ```bash
+   git diff develop
+   ```
+
+Do not skip any of these.
+
+---
+
+### Step 2 — Determine validation strategies
+
+Select all strategies that apply.
+
+#### Strategy A — API / functional validation
+**When to use:** backend logic changed (REST endpoints, WP-CLI commands, AJAX handlers, WordPress hooks, caching logic, minification, CDN, data processing).
+
+The local WordPress environment runs at `http://localhost:8888`. Use `curl` for REST endpoints or AJAX calls, or WP-CLI via the site shell for direct WordPress operations.
+
+#### Strategy B — Browser / UI validation
+**When to use:** frontend changes (admin settings page, dashboard notices, cache preloading UI, interactive behavior).
+
+Use Playwright MCP to interact with the local environment at `http://localhost:8888`. Walk through the PR's "How to test" steps one by one. At each meaningful checkpoint:
+- Take a screenshot to `.e2e-screenshots/<pr-or-feature>-<step>.png`.
+- Capture console errors and failed network requests.
+- Record actual vs. expected.
+
+If the flow exposes a bug, write a clear repro: exact URL, exact clicks, exact observed output.
+
+#### Strategy C — Test suite + analysis fallback
+**When to use:** local environment is unreachable, or infrastructure-only / pure-logic changes.
+
+Run the test suite for the affected module, then audit coverage:
+
+```bash
+# Run unit tests
+composer test-unit
+
+# Run integration tests for a specific group — use direct phpunit to avoid
+# conflicts with the default --exclude-group list in composer test-integration
+vendor/bin/phpunit --configuration tests/Integration/phpunit.xml.dist --group FeatureName
+```
+
+Then for each acceptance criterion:
+- Find the test(s) that cover it (unit in `tests/Unit/`, integration in `tests/Integration/`).
+- Check if the test validates the criterion fully (happy path AND edge cases).
+- Flag any criterion with no test or incomplete coverage.
+
+This is the weakest strategy for UI changes — prefer A or B when possible. For pure backend logic, a passing test suite is strong evidence.
+
+---
+
+### Step 3 — Execute
+
+Run each selected strategy. For every acceptance criterion:
+- State which strategy you used
+- State what you did (command run, URL navigated, test read)
+- State what you observed
+- Conclude PASS, FAIL, or PARTIAL with a one-line reason
+
+---
+
+### Step 3b — Smoke test (non-regression)
+
+After validating the acceptance criteria, do a brief smoke test of the main happy paths adjacent to the changed area:
+
+- **Settings page** — navigate to `/wp-admin/options-general.php?page=wprocket` and confirm it loads without errors.
+- **Dashboard** — navigate to `/wp-admin/` and confirm the admin bar and WP Rocket toolbar item render.
+- **Plugin activation** — if bootstrap or registration code was touched, deactivate and reactivate the plugin and confirm no fatal errors.
+
+Skip any smoke test that is unrelated to the changed files.
+
+---
+
+### Step 4 — Report
+
+Produce the test report in the format below. Be specific — "tested locally" is not evidence.
+
+---
+
+## Output format
+
+```
+## Test Report — [PR title or branch name]
+
+**Branch:** [branch name]
+**Strategies used:** [list: API, Browser, Analysis]
+
+### Acceptance Criteria
+
+| Acceptance Criterion | Validation Method | Result | Evidence |
+|----------------------|-------------------|--------|----------|
+| [criterion 1] | API call | ✅ PASS | curl returned expected cache header |
+| [criterion 2] | Browser (Playwright) | ❌ FAIL | Error message not rendered after invalid input |
+| [criterion 3] | Analysis | ⚠️ PARTIAL | Test covers happy path only |
+
+### Smoke Tests
+
+| Area | Action | Result | Evidence |
+|------|--------|--------|----------|
+| Settings page | Navigated to options-general.php?page=wprocket | ✅ PASS | Page loaded, no errors |
+| Plugin activation | wp plugin deactivate/activate wp-rocket | ✅ PASS | No fatal errors |
+
+**Overall: PASS / FAIL / PARTIAL**
+
+**Blockers** (must fix before merge):
+- "[criterion]": [what failed] — [what to fix]
+
+**Recommendations** (non-blocking):
+- [optional: gaps or improvements that are not blockers]
+```
+
+If all criteria pass: print **READY TO MERGE** clearly.
+If blocked: list each blocker with a suggested fix.
+
+---
+
+## Boundaries
+
+- ✅ **Always do:** read ticket spec before testing, read full changed files, map every acceptance criterion to a test result, provide concrete evidence for every result
+- ⚠️ **Ask first:** if no ticket spec or acceptance criteria are available; if the local server is unreachable
+- 🚫 **Never do:** modify any plugin code or files, skip acceptance criteria without noting them, report PASS without evidence, conflate "no test failures" with "acceptance criteria met"

--- a/.aiassistant/graph/dependency-graph.json
+++ b/.aiassistant/graph/dependency-graph.json
@@ -1,0 +1,14431 @@
+{
+  "generated_at": "2026-05-19T11:49:18.278Z",
+  "base_commit": "d3f6e5454d9dcf73aaca904ac63ab4588d2fe48a",
+  "node_count": 880,
+  "nodes": {
+    "inc/3rd-party/3rd-party.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/hosting/flywheel.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/hosting/nginx.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/hosting/pagely.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/hosting/presslabs.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/hosting/siteground.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/hosting/wp-serveur.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/advanced-custom-fields.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/autoptimize.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/buddypress.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/cookies/cookie-notice.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/cookies/eu-cookie-law.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/cookies/gdpr.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/cookies/uk-cookie-consent.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/cookies/weepie-cookie-allow.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/custom-login.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/disqus.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/ecommerce/aelia-currencyswitcher.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/ecommerce/aelia-prices-by-country.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/ecommerce/aelia-tax-display-by-country.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/ecommerce/easy-digital-downloads.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/ecommerce/edd-software-licencing.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/ecommerce/give.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/ecommerce/ithemes-exchange.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/ecommerce/jigoshop.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/ecommerce/woocommerce-currency-converter-widget.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/ecommerce/woocommerce-multilingual.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/ecommerce/wpshop.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/envira-gallery.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/i18n/polylang.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/mailchimp.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/mobile/wp-appkit.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/nginx-helper.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/page-builder/thrive-visual-editor.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/page-builder/visual-composer.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/rating/kk-star-ratings.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/rating/wp-postratings.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/s2member.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/security/secupress.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/security/sf-move-login.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/security/wps-hide-login.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/seo/premium-seo-pack.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/slider/meta-slider.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/slider/soliloquy.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/sumome.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/thrive-leads.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/varnish-http-purge.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/wp-offload-s3-assets.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/wp-offload-s3.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/wp-print.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/plugins/wp-rest-api.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/3rd-party/themes/studiopress.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/API/bypass.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/Addon/Cloudflare/API/Client.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Addon\\Cloudflare\\API",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Client",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Error",
+        "WP_Rocket\\Addon\\Cloudflare\\Auth\\AuthInterface"
+      ]
+    },
+    "inc/Addon/Cloudflare/API/Endpoints.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Addon\\Cloudflare\\API",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Endpoints",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Addon\\Cloudflare\\Auth\\AuthInterface"
+      ]
+    },
+    "inc/Addon/Cloudflare/Admin/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Addon\\Cloudflare\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Admin\\Settings\\Settings",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Addon/Cloudflare/Auth/APIKey.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Addon\\Cloudflare\\Auth",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "APIKey",
+          "extends": [],
+          "implements": [
+            "AuthInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Error"
+      ]
+    },
+    "inc/Addon/Cloudflare/Auth/APIKeyFactory.php": {
+      "language": "php",
+      "namespace": "WPMedia\\Cloudflare\\Auth",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "APIKeyFactory",
+          "extends": [],
+          "implements": [
+            "AuthFactoryInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Addon\\Cloudflare\\Auth\\APIKey",
+        "WP_Rocket\\Addon\\Cloudflare\\Auth\\AuthInterface",
+        "WP_Rocket\\Admin\\Options_Data"
+      ]
+    },
+    "inc/Addon/Cloudflare/Auth/AuthFactoryInterface.php": {
+      "language": "php",
+      "namespace": "WPMedia\\Cloudflare\\Auth",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "AuthFactoryInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Addon\\Cloudflare\\Auth\\AuthInterface"
+      ]
+    },
+    "inc/Addon/Cloudflare/Auth/AuthInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Addon\\Cloudflare\\Auth",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "AuthInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Error"
+      ]
+    },
+    "inc/Addon/Cloudflare/Cloudflare.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Addon\\Cloudflare",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Cloudflare",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "CloudFlare\\IpRewrite",
+        "DateTimeImmutable",
+        "WP_Error",
+        "WP_Post",
+        "WP_Rocket\\Addon\\Cloudflare\\Auth\\AuthInterface",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Addon\\Cloudflare\\API\\Endpoints"
+      ]
+    },
+    "inc/Addon/Cloudflare/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Addon\\Cloudflare",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Addon\\Cloudflare\\Admin\\Subscriber",
+        "WP_Rocket\\Addon\\Cloudflare\\API\\Client",
+        "WP_Rocket\\Addon\\Cloudflare\\API\\Endpoints",
+        "WP_Rocket\\Addon\\Cloudflare\\Cloudflare",
+        "WP_Rocket\\Addon\\Cloudflare\\Subscriber",
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider",
+        "WPMedia\\Cloudflare\\Auth\\APIKeyFactory"
+      ]
+    },
+    "inc/Addon/Cloudflare/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Addon\\Cloudflare",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Post",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\Admin\\Options",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WPMedia\\Cloudflare\\Auth\\AuthFactoryInterface"
+      ]
+    },
+    "inc/Addon/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Addon",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Addon\\Sucuri\\Subscriber",
+        "WP_Rocket\\Addon\\WebP\\AdminSubscriber",
+        "WP_Rocket\\Addon\\WebP\\Subscriber",
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider"
+      ]
+    },
+    "inc/Addon/Sucuri/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Addon\\Sucuri",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Error",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\Logger\\Logger"
+      ]
+    },
+    "inc/Addon/Varnish/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Addon\\Varnish",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider"
+      ]
+    },
+    "inc/Addon/Varnish/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Addon\\Varnish",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Addon/Varnish/Varnish.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Addon\\Varnish",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Varnish",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Addon/WebP/AbstractWebp.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Addon\\WebP",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AbstractWebp",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\CDN\\Subscriber",
+        "WP_Rocket\\Subscriber\\Third_Party\\Plugins\\Images\\Webp\\Webp_Interface"
+      ]
+    },
+    "inc/Addon/WebP/AdminSubscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Addon\\WebP",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AdminSubscriber",
+          "extends": [
+            "AbstractWebp"
+          ],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Admin\\Beacon\\Beacon",
+        "WP_Rocket\\Engine\\CDN\\Subscriber",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Addon/WebP/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Addon\\WebP",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [
+            "AbstractWebp"
+          ],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\Engine\\CDN\\Subscriber",
+        "WP_Rocket\\Engine\\Support\\CommentTrait",
+        "CommentTrait"
+      ]
+    },
+    "inc/Dependencies/ActionScheduler/action-scheduler.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/ActionScheduler_ActionClaim.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_ActionClaim",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/ActionScheduler_ActionFactory.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_ActionFactory",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/ActionScheduler_AdminView.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_AdminView",
+          "extends": [
+            "ActionScheduler_AdminView_Deprecated"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/ActionScheduler_AsyncRequest_QueueRunner.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_AsyncRequest_QueueRunner",
+          "extends": [
+            "WP_Async_Request"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/ActionScheduler_Compatibility.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_Compatibility",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/ActionScheduler_DataController.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_DataController",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "Action_Scheduler\\Migration\\Controller"
+      ]
+    },
+    "inc/Dependencies/ActionScheduler/classes/ActionScheduler_DateTime.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_DateTime",
+          "extends": [
+            "DateTime"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/ActionScheduler_Exception.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "ActionScheduler_Exception",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/ActionScheduler_FatalErrorMonitor.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_FatalErrorMonitor",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/ActionScheduler_InvalidActionException.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_InvalidActionException",
+          "extends": [
+            "\\InvalidArgumentException"
+          ],
+          "implements": [
+            "ActionScheduler_Exception"
+          ]
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/ActionScheduler_ListTable.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_ListTable",
+          "extends": [
+            "ActionScheduler_Abstract_ListTable"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/ActionScheduler_LogEntry.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_LogEntry",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/ActionScheduler_NullLogEntry.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_NullLogEntry",
+          "extends": [
+            "ActionScheduler_LogEntry"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/ActionScheduler_OptionLock.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_OptionLock",
+          "extends": [
+            "ActionScheduler_Lock"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/ActionScheduler_QueueCleaner.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_QueueCleaner",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/ActionScheduler_QueueRunner.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_QueueRunner",
+          "extends": [
+            "ActionScheduler_Abstract_QueueRunner"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/ActionScheduler_Versions.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_Versions",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/ActionScheduler_WPCommentCleaner.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_WPCommentCleaner",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/ActionScheduler_wcSystemStatus.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_wcSystemStatus",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/WP_CLI/ActionScheduler_WPCLI_Clean_Command.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_WPCLI_Clean_Command",
+          "extends": [
+            "WP_CLI_Command"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/WP_CLI/ActionScheduler_WPCLI_QueueRunner.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_WPCLI_QueueRunner",
+          "extends": [
+            "ActionScheduler_Abstract_QueueRunner"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "Action_Scheduler\\WP_CLI\\ProgressBar"
+      ]
+    },
+    "inc/Dependencies/ActionScheduler/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_WPCLI_Scheduler_command",
+          "extends": [
+            "WP_CLI_Command"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/WP_CLI/Migration_Command.php": {
+      "language": "php",
+      "namespace": "Action_Scheduler\\WP_CLI",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Migration_Command",
+          "extends": [
+            "WP_CLI_Command"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "Action_Scheduler\\Migration\\Config",
+        "Action_Scheduler\\Migration\\Runner",
+        "Action_Scheduler\\Migration\\Scheduler",
+        "Action_Scheduler\\Migration\\Controller",
+        "WP_CLI",
+        "WP_CLI_Command"
+      ]
+    },
+    "inc/Dependencies/ActionScheduler/classes/WP_CLI/ProgressBar.php": {
+      "language": "php",
+      "namespace": "Action_Scheduler\\WP_CLI",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ProgressBar",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/abstracts/ActionScheduler.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "Action_Scheduler\\WP_CLI\\Migration_Command",
+        "Action_Scheduler\\Migration\\Controller"
+      ]
+    },
+    "inc/Dependencies/ActionScheduler/classes/abstracts/ActionScheduler_Abstract_ListTable.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_Abstract_ListTable",
+          "extends": [
+            "WP_List_Table"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_Abstract_QueueRunner",
+          "extends": [
+            "ActionScheduler_Abstract_QueueRunner_Deprecated"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/abstracts/ActionScheduler_Abstract_RecurringSchedule.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_Abstract_RecurringSchedule",
+          "extends": [
+            "ActionScheduler_Abstract_Schedule"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/abstracts/ActionScheduler_Abstract_Schedule.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_Abstract_Schedule",
+          "extends": [
+            "ActionScheduler_Schedule_Deprecated"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/abstracts/ActionScheduler_Abstract_Schema.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_Abstract_Schema",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/abstracts/ActionScheduler_Lock.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_Lock",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/abstracts/ActionScheduler_Logger.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_Logger",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/abstracts/ActionScheduler_Store.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_Store",
+          "extends": [
+            "ActionScheduler_Store_Deprecated"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/abstracts/ActionScheduler_TimezoneHelper.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_TimezoneHelper",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/actions/ActionScheduler_Action.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_Action",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/actions/ActionScheduler_CanceledAction.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_CanceledAction",
+          "extends": [
+            "ActionScheduler_FinishedAction"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/actions/ActionScheduler_FinishedAction.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_FinishedAction",
+          "extends": [
+            "ActionScheduler_Action"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/actions/ActionScheduler_NullAction.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_NullAction",
+          "extends": [
+            "ActionScheduler_Action"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/data-stores/ActionScheduler_DBLogger.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_DBLogger",
+          "extends": [
+            "ActionScheduler_Logger"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/data-stores/ActionScheduler_DBStore.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_DBStore",
+          "extends": [
+            "ActionScheduler_Store"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/data-stores/ActionScheduler_HybridStore.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_HybridStore",
+          "extends": [
+            "Store"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "ActionScheduler_Store",
+        "Action_Scheduler\\Migration\\Runner",
+        "Action_Scheduler\\Migration\\Config",
+        "Action_Scheduler\\Migration\\Controller"
+      ]
+    },
+    "inc/Dependencies/ActionScheduler/classes/data-stores/ActionScheduler_wpCommentLogger.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_wpCommentLogger",
+          "extends": [
+            "ActionScheduler_Logger"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/data-stores/ActionScheduler_wpPostStore.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_wpPostStore",
+          "extends": [
+            "ActionScheduler_Store"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/data-stores/ActionScheduler_wpPostStore_PostStatusRegistrar.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_wpPostStore_PostStatusRegistrar",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/data-stores/ActionScheduler_wpPostStore_PostTypeRegistrar.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_wpPostStore_PostTypeRegistrar",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/data-stores/ActionScheduler_wpPostStore_TaxonomyRegistrar.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_wpPostStore_TaxonomyRegistrar",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/migration/ActionMigrator.php": {
+      "language": "php",
+      "namespace": "Action_Scheduler\\Migration",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionMigrator",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/migration/ActionScheduler_DBStoreMigrator.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_DBStoreMigrator",
+          "extends": [
+            "ActionScheduler_DBStore"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/migration/BatchFetcher.php": {
+      "language": "php",
+      "namespace": "Action_Scheduler\\Migration",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "BatchFetcher",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "ActionScheduler_Store"
+      ]
+    },
+    "inc/Dependencies/ActionScheduler/classes/migration/Config.php": {
+      "language": "php",
+      "namespace": "Action_Scheduler\\Migration",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Config",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "Action_Scheduler\\WP_CLI\\ProgressBar",
+        "ActionScheduler_Logger",
+        "ActionScheduler_Store"
+      ]
+    },
+    "inc/Dependencies/ActionScheduler/classes/migration/Controller.php": {
+      "language": "php",
+      "namespace": "Action_Scheduler\\Migration",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Controller",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "ActionScheduler_DataController",
+        "ActionScheduler_LoggerSchema",
+        "ActionScheduler_StoreSchema",
+        "Action_Scheduler\\WP_CLI\\ProgressBar"
+      ]
+    },
+    "inc/Dependencies/ActionScheduler/classes/migration/DryRun_ActionMigrator.php": {
+      "language": "php",
+      "namespace": "Action_Scheduler\\Migration",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "DryRun_ActionMigrator",
+          "extends": [
+            "ActionMigrator"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/migration/DryRun_LogMigrator.php": {
+      "language": "php",
+      "namespace": "Action_Scheduler\\Migration",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "DryRun_LogMigrator",
+          "extends": [
+            "LogMigrator"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/migration/LogMigrator.php": {
+      "language": "php",
+      "namespace": "Action_Scheduler\\Migration",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "LogMigrator",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "ActionScheduler_Logger"
+      ]
+    },
+    "inc/Dependencies/ActionScheduler/classes/migration/Runner.php": {
+      "language": "php",
+      "namespace": "Action_Scheduler\\Migration",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Runner",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/migration/Scheduler.php": {
+      "language": "php",
+      "namespace": "Action_Scheduler\\Migration",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Scheduler",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/schedules/ActionScheduler_CanceledSchedule.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_CanceledSchedule",
+          "extends": [
+            "ActionScheduler_SimpleSchedule"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/schedules/ActionScheduler_CronSchedule.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_CronSchedule",
+          "extends": [
+            "ActionScheduler_Abstract_RecurringSchedule"
+          ],
+          "implements": [
+            "ActionScheduler_Schedule"
+          ]
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/schedules/ActionScheduler_IntervalSchedule.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_IntervalSchedule",
+          "extends": [
+            "ActionScheduler_Abstract_RecurringSchedule"
+          ],
+          "implements": [
+            "ActionScheduler_Schedule"
+          ]
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/schedules/ActionScheduler_NullSchedule.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_NullSchedule",
+          "extends": [
+            "ActionScheduler_SimpleSchedule"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/schedules/ActionScheduler_Schedule.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "ActionScheduler_Schedule",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/schedules/ActionScheduler_SimpleSchedule.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_SimpleSchedule",
+          "extends": [
+            "ActionScheduler_Abstract_Schedule"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/schema/ActionScheduler_LoggerSchema.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_LoggerSchema",
+          "extends": [
+            "ActionScheduler_Abstract_Schema"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/classes/schema/ActionScheduler_StoreSchema.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_StoreSchema",
+          "extends": [
+            "ActionScheduler_Abstract_Schema"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/deprecated/ActionScheduler_Abstract_QueueRunner_Deprecated.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_Abstract_QueueRunner_Deprecated",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/deprecated/ActionScheduler_AdminView_Deprecated.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_AdminView_Deprecated",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/deprecated/ActionScheduler_Schedule_Deprecated.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_Schedule_Deprecated",
+          "extends": [],
+          "implements": [
+            "ActionScheduler_Schedule"
+          ]
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/deprecated/ActionScheduler_Store_Deprecated.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionScheduler_Store_Deprecated",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/deprecated/functions.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/functions.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/lib/WP_Async_Request.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "WP_Async_Request",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/lib/cron-expression/CronExpression.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "CronExpression",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/lib/cron-expression/CronExpression_AbstractField.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "CronExpression_AbstractField",
+          "extends": [],
+          "implements": [
+            "CronExpression_FieldInterface"
+          ]
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/lib/cron-expression/CronExpression_DayOfMonthField.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "CronExpression_DayOfMonthField",
+          "extends": [
+            "CronExpression_AbstractField"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/lib/cron-expression/CronExpression_DayOfWeekField.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "CronExpression_DayOfWeekField",
+          "extends": [
+            "CronExpression_AbstractField"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/lib/cron-expression/CronExpression_FieldFactory.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "CronExpression_FieldFactory",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/lib/cron-expression/CronExpression_FieldInterface.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "CronExpression_FieldInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/lib/cron-expression/CronExpression_HoursField.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "CronExpression_HoursField",
+          "extends": [
+            "CronExpression_AbstractField"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/lib/cron-expression/CronExpression_MinutesField.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "CronExpression_MinutesField",
+          "extends": [
+            "CronExpression_AbstractField"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/lib/cron-expression/CronExpression_MonthField.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "CronExpression_MonthField",
+          "extends": [
+            "CronExpression_AbstractField"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/ActionScheduler/lib/cron-expression/CronExpression_YearField.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "CronExpression_YearField",
+          "extends": [
+            "CronExpression_AbstractField"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/BerlinDB/Database/Base.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\BerlinDB\\Database",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Base",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/BerlinDB/Database/Column.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\BerlinDB\\Database",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Column",
+          "extends": [
+            "Base"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/BerlinDB/Database/Queries/Compare.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\BerlinDB\\Database\\Queries",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Compare",
+          "extends": [
+            "Meta"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/BerlinDB/Database/Queries/Date.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\BerlinDB\\Database\\Queries",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Date",
+          "extends": [
+            "Base"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\BerlinDB\\Database\\Base"
+      ]
+    },
+    "inc/Dependencies/BerlinDB/Database/Queries/Meta.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\BerlinDB\\Database\\Queries",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Meta",
+          "extends": [
+            "WP_Meta_Query"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "\\WP_Meta_Query"
+      ]
+    },
+    "inc/Dependencies/BerlinDB/Database/Query.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\BerlinDB\\Database",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Query",
+          "extends": [
+            "Base"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/BerlinDB/Database/Row.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\BerlinDB\\Database",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Row",
+          "extends": [
+            "Base"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/BerlinDB/Database/Schema.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\BerlinDB\\Database",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Schema",
+          "extends": [
+            "Base"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/BerlinDB/Database/Table.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\BerlinDB\\Database",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Table",
+          "extends": [
+            "Base"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/League/Container/Argument/ArgumentInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\League\\Container\\Argument",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "ArgumentInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/League/Container/Argument/ArgumentResolverInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\League\\Container\\Argument",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "ArgumentResolverInterface",
+          "extends": [
+            "ContainerAwareInterface"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\ContainerAwareInterface",
+        "ReflectionFunctionAbstract"
+      ]
+    },
+    "inc/Dependencies/League/Container/Argument/ArgumentResolverTrait.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\League\\Container\\Argument",
+      "symbols": [
+        {
+          "kind": "trait",
+          "name": "ArgumentResolverTrait",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\DefinitionContainerInterface",
+        "WP_Rocket\\Dependencies\\League\\Container\\Exception\\ContainerException",
+        "WP_Rocket\\Dependencies\\League\\Container\\Exception\\NotFoundException",
+        "WP_Rocket\\Dependencies\\League\\Container\\ReflectionContainer",
+        "WP_Rocket\\Dependencies\\Psr\\Container\\ContainerInterface",
+        "ReflectionFunctionAbstract",
+        "ReflectionNamedType"
+      ]
+    },
+    "inc/Dependencies/League/Container/Argument/DefaultValueArgument.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\League\\Container\\Argument",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "DefaultValueArgument",
+          "extends": [
+            "ResolvableArgument"
+          ],
+          "implements": [
+            "DefaultValueInterface"
+          ]
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/League/Container/Argument/DefaultValueInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\League\\Container\\Argument",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "DefaultValueInterface",
+          "extends": [
+            "ArgumentInterface"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/League/Container/Argument/Literal/ArrayArgument.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ArrayArgument",
+          "extends": [
+            "LiteralArgument"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\LiteralArgument"
+      ]
+    },
+    "inc/Dependencies/League/Container/Argument/Literal/BooleanArgument.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "BooleanArgument",
+          "extends": [
+            "LiteralArgument"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\LiteralArgument"
+      ]
+    },
+    "inc/Dependencies/League/Container/Argument/Literal/CallableArgument.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "CallableArgument",
+          "extends": [
+            "LiteralArgument"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\LiteralArgument"
+      ]
+    },
+    "inc/Dependencies/League/Container/Argument/Literal/FloatArgument.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "FloatArgument",
+          "extends": [
+            "LiteralArgument"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\LiteralArgument"
+      ]
+    },
+    "inc/Dependencies/League/Container/Argument/Literal/IntegerArgument.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "IntegerArgument",
+          "extends": [
+            "LiteralArgument"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\LiteralArgument"
+      ]
+    },
+    "inc/Dependencies/League/Container/Argument/Literal/ObjectArgument.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ObjectArgument",
+          "extends": [
+            "LiteralArgument"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\LiteralArgument"
+      ]
+    },
+    "inc/Dependencies/League/Container/Argument/Literal/StringArgument.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "StringArgument",
+          "extends": [
+            "LiteralArgument"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\LiteralArgument"
+      ]
+    },
+    "inc/Dependencies/League/Container/Argument/LiteralArgument.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\League\\Container\\Argument",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "LiteralArgument",
+          "extends": [],
+          "implements": [
+            "LiteralArgumentInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "InvalidArgumentException"
+      ]
+    },
+    "inc/Dependencies/League/Container/Argument/LiteralArgumentInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\League\\Container\\Argument",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "LiteralArgumentInterface",
+          "extends": [
+            "ArgumentInterface"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/League/Container/Argument/ResolvableArgument.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\League\\Container\\Argument",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ResolvableArgument",
+          "extends": [],
+          "implements": [
+            "ResolvableArgumentInterface"
+          ]
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/League/Container/Argument/ResolvableArgumentInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\League\\Container\\Argument",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "ResolvableArgumentInterface",
+          "extends": [
+            "ArgumentInterface"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/League/Container/Container.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\League\\Container",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Container",
+          "extends": [],
+          "implements": [
+            "DefinitionContainerInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\Definition\\DefinitionAggregate",
+        "WP_Rocket\\Dependencies\\League\\Container\\Definition\\DefinitionInterface",
+        "WP_Rocket\\Dependencies\\League\\Container\\Definition\\DefinitionAggregateInterface",
+        "WP_Rocket\\Dependencies\\League\\Container\\Exception\\NotFoundException",
+        "WP_Rocket\\Dependencies\\League\\Container\\Exception\\ContainerException",
+        "WP_Rocket\\Dependencies\\League\\Container\\Inflector\\InflectorAggregate",
+        "WP_Rocket\\Dependencies\\League\\Container\\Inflector\\InflectorInterface",
+        "WP_Rocket\\Dependencies\\League\\Container\\Inflector\\InflectorAggregateInterface",
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\ServiceProviderAggregate",
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\ServiceProviderAggregateInterface",
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\ServiceProviderInterface",
+        "WP_Rocket\\Dependencies\\Psr\\Container\\ContainerInterface"
+      ]
+    },
+    "inc/Dependencies/League/Container/ContainerAwareInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\League\\Container",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "ContainerAwareInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/League/Container/ContainerAwareTrait.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\League\\Container",
+      "symbols": [
+        {
+          "kind": "trait",
+          "name": "ContainerAwareTrait",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "BadMethodCallException",
+        "WP_Rocket\\Dependencies\\League\\Container\\Exception\\ContainerException"
+      ]
+    },
+    "inc/Dependencies/League/Container/Definition/Definition.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\League\\Container\\Definition",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Definition",
+          "extends": [],
+          "implements": [
+            "ArgumentResolverInterface",
+            "DefinitionInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\ArgumentResolverInterface",
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\ArgumentResolverTrait",
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\ArgumentInterface",
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\LiteralArgumentInterface",
+        "WP_Rocket\\Dependencies\\League\\Container\\ContainerAwareTrait",
+        "WP_Rocket\\Dependencies\\League\\Container\\Exception\\ContainerException",
+        "WP_Rocket\\Dependencies\\Psr\\Container\\ContainerInterface",
+        "ReflectionClass",
+        "ArgumentResolverTrait",
+        "ContainerAwareTrait"
+      ]
+    },
+    "inc/Dependencies/League/Container/Definition/DefinitionAggregate.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\League\\Container\\Definition",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "DefinitionAggregate",
+          "extends": [],
+          "implements": [
+            "DefinitionAggregateInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "Generator",
+        "WP_Rocket\\Dependencies\\League\\Container\\ContainerAwareTrait",
+        "WP_Rocket\\Dependencies\\League\\Container\\Exception\\NotFoundException",
+        "ContainerAwareTrait"
+      ]
+    },
+    "inc/Dependencies/League/Container/Definition/DefinitionAggregateInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\League\\Container\\Definition",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "DefinitionAggregateInterface",
+          "extends": [
+            "ContainerAwareInterface",
+            "IteratorAggregate"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "IteratorAggregate",
+        "WP_Rocket\\Dependencies\\League\\Container\\ContainerAwareInterface"
+      ]
+    },
+    "inc/Dependencies/League/Container/Definition/DefinitionInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\League\\Container\\Definition",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "DefinitionInterface",
+          "extends": [
+            "ContainerAwareInterface"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\ContainerAwareInterface"
+      ]
+    },
+    "inc/Dependencies/League/Container/DefinitionContainerInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\League\\Container",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "DefinitionContainerInterface",
+          "extends": [
+            "ContainerInterface"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\Definition\\DefinitionInterface",
+        "WP_Rocket\\Dependencies\\League\\Container\\Inflector\\InflectorInterface",
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\ServiceProviderInterface",
+        "WP_Rocket\\Dependencies\\Psr\\Container\\ContainerInterface"
+      ]
+    },
+    "inc/Dependencies/League/Container/Exception/ContainerException.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\League\\Container\\Exception",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ContainerException",
+          "extends": [
+            "RuntimeException"
+          ],
+          "implements": [
+            "ContainerExceptionInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\Psr\\Container\\ContainerExceptionInterface",
+        "RuntimeException"
+      ]
+    },
+    "inc/Dependencies/League/Container/Exception/NotFoundException.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\League\\Container\\Exception",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "NotFoundException",
+          "extends": [
+            "InvalidArgumentException"
+          ],
+          "implements": [
+            "NotFoundExceptionInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\Psr\\Container\\NotFoundExceptionInterface",
+        "InvalidArgumentException"
+      ]
+    },
+    "inc/Dependencies/League/Container/Inflector/Inflector.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\League\\Container\\Inflector",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Inflector",
+          "extends": [],
+          "implements": [
+            "ArgumentResolverInterface",
+            "InflectorInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\ArgumentResolverInterface",
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\ArgumentResolverTrait",
+        "WP_Rocket\\Dependencies\\League\\Container\\ContainerAwareTrait",
+        "ArgumentResolverTrait",
+        "ContainerAwareTrait"
+      ]
+    },
+    "inc/Dependencies/League/Container/Inflector/InflectorAggregate.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\League\\Container\\Inflector",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "InflectorAggregate",
+          "extends": [],
+          "implements": [
+            "InflectorAggregateInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "Generator",
+        "WP_Rocket\\Dependencies\\League\\Container\\ContainerAwareTrait",
+        "ContainerAwareTrait"
+      ]
+    },
+    "inc/Dependencies/League/Container/Inflector/InflectorAggregateInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\League\\Container\\Inflector",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "InflectorAggregateInterface",
+          "extends": [
+            "ContainerAwareInterface",
+            "IteratorAggregate"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "IteratorAggregate",
+        "WP_Rocket\\Dependencies\\League\\Container\\ContainerAwareInterface"
+      ]
+    },
+    "inc/Dependencies/League/Container/Inflector/InflectorInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\League\\Container\\Inflector",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "InflectorInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/League/Container/ReflectionContainer.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\League\\Container",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ReflectionContainer",
+          "extends": [],
+          "implements": [
+            "ArgumentResolverInterface",
+            "ContainerInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\ArgumentResolverInterface",
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\ArgumentResolverTrait",
+        "WP_Rocket\\Dependencies\\League\\Container\\Exception\\ContainerException",
+        "WP_Rocket\\Dependencies\\League\\Container\\Exception\\NotFoundException",
+        "WP_Rocket\\Dependencies\\Psr\\Container\\ContainerInterface",
+        "ReflectionClass",
+        "ReflectionFunction",
+        "ReflectionMethod",
+        "ArgumentResolverTrait",
+        "ContainerAwareTrait"
+      ]
+    },
+    "inc/Dependencies/League/Container/ServiceProvider/AbstractServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AbstractServiceProvider",
+          "extends": [],
+          "implements": [
+            "ServiceProviderInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\ContainerAwareTrait",
+        "ContainerAwareTrait"
+      ]
+    },
+    "inc/Dependencies/League/Container/ServiceProvider/BootableServiceProviderInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "BootableServiceProviderInterface",
+          "extends": [
+            "ServiceProviderInterface"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/League/Container/ServiceProvider/ServiceProviderAggregate.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProviderAggregate",
+          "extends": [],
+          "implements": [
+            "ServiceProviderAggregateInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "Generator",
+        "WP_Rocket\\Dependencies\\League\\Container\\Exception\\ContainerException",
+        "WP_Rocket\\Dependencies\\League\\Container\\ContainerAwareInterface",
+        "WP_Rocket\\Dependencies\\League\\Container\\ContainerAwareTrait",
+        "ContainerAwareTrait"
+      ]
+    },
+    "inc/Dependencies/League/Container/ServiceProvider/ServiceProviderAggregateInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "ServiceProviderAggregateInterface",
+          "extends": [
+            "ContainerAwareInterface",
+            "IteratorAggregate"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "IteratorAggregate",
+        "WP_Rocket\\Dependencies\\League\\Container\\ContainerAwareInterface"
+      ]
+    },
+    "inc/Dependencies/League/Container/ServiceProvider/ServiceProviderInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "ServiceProviderInterface",
+          "extends": [
+            "ContainerAwareInterface"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\ContainerAwareInterface"
+      ]
+    },
+    "inc/Dependencies/Minify/CSS.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Minify",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "CSS",
+          "extends": [
+            "Minify"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\Minify\\Exceptions\\FileImportException",
+        "WP_Rocket\\Dependencies\\PathConverter\\ConverterInterface",
+        "WP_Rocket\\Dependencies\\PathConverter\\Converter"
+      ]
+    },
+    "inc/Dependencies/Minify/Exception.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Minify",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Exception",
+          "extends": [
+            "\\Exception"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/Minify/Exceptions/BasicException.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Minify\\Exceptions",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "BasicException",
+          "extends": [
+            "Exception"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\Minify\\Exception"
+      ]
+    },
+    "inc/Dependencies/Minify/Exceptions/FileImportException.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Minify\\Exceptions",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "FileImportException",
+          "extends": [
+            "BasicException"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/Minify/Exceptions/IOException.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Minify\\Exceptions",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "IOException",
+          "extends": [
+            "BasicException"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/Minify/JS.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Minify",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "JS",
+          "extends": [
+            "Minify"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/Minify/Minify.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Minify",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Minify",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\Minify\\Exceptions\\IOException",
+        "Psr\\Cache\\CacheItemInterface"
+      ]
+    },
+    "inc/Dependencies/Monolog/ErrorHandler.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Monolog",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ErrorHandler",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\Psr\\Log\\LoggerInterface",
+        "WP_Rocket\\Dependencies\\Psr\\Log\\LogLevel",
+        "WP_Rocket\\Dependencies\\Monolog\\Handler\\AbstractHandler"
+      ]
+    },
+    "inc/Dependencies/Monolog/Formatter/FormatterInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Monolog\\Formatter",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "FormatterInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/Monolog/Formatter/HtmlFormatter.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Monolog\\Formatter",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "HtmlFormatter",
+          "extends": [
+            "NormalizerFormatter"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\Monolog\\Logger",
+        "WP_Rocket\\Dependencies\\Monolog\\Utils"
+      ]
+    },
+    "inc/Dependencies/Monolog/Formatter/LineFormatter.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Monolog\\Formatter",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "LineFormatter",
+          "extends": [
+            "NormalizerFormatter"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\Monolog\\Utils"
+      ]
+    },
+    "inc/Dependencies/Monolog/Formatter/NormalizerFormatter.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Monolog\\Formatter",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "NormalizerFormatter",
+          "extends": [],
+          "implements": [
+            "FormatterInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "Exception",
+        "WP_Rocket\\Dependencies\\Monolog\\Utils"
+      ]
+    },
+    "inc/Dependencies/Monolog/Handler/AbstractHandler.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Monolog\\Handler",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AbstractHandler",
+          "extends": [],
+          "implements": [
+            "HandlerInterface",
+            "ResettableInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\Monolog\\Formatter\\FormatterInterface",
+        "WP_Rocket\\Dependencies\\Monolog\\Formatter\\LineFormatter",
+        "WP_Rocket\\Dependencies\\Monolog\\Logger",
+        "WP_Rocket\\Dependencies\\Monolog\\ResettableInterface"
+      ]
+    },
+    "inc/Dependencies/Monolog/Handler/AbstractProcessingHandler.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Monolog\\Handler",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AbstractProcessingHandler",
+          "extends": [
+            "AbstractHandler"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\Monolog\\ResettableInterface"
+      ]
+    },
+    "inc/Dependencies/Monolog/Handler/FormattableHandlerInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Monolog\\Handler",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "FormattableHandlerInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\Monolog\\Formatter\\FormatterInterface"
+      ]
+    },
+    "inc/Dependencies/Monolog/Handler/FormattableHandlerTrait.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Monolog\\Handler",
+      "symbols": [
+        {
+          "kind": "trait",
+          "name": "FormattableHandlerTrait",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\Monolog\\Formatter\\FormatterInterface",
+        "WP_Rocket\\Dependencies\\Monolog\\Formatter\\LineFormatter"
+      ]
+    },
+    "inc/Dependencies/Monolog/Handler/HandlerInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Monolog\\Handler",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "HandlerInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\Monolog\\Formatter\\FormatterInterface"
+      ]
+    },
+    "inc/Dependencies/Monolog/Handler/ProcessableHandlerInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Monolog\\Handler",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "ProcessableHandlerInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\Monolog\\Processor\\ProcessorInterface"
+      ]
+    },
+    "inc/Dependencies/Monolog/Handler/ProcessableHandlerTrait.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Monolog\\Handler",
+      "symbols": [
+        {
+          "kind": "trait",
+          "name": "ProcessableHandlerTrait",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\Monolog\\ResettableInterface"
+      ]
+    },
+    "inc/Dependencies/Monolog/Handler/StreamHandler.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Monolog\\Handler",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "StreamHandler",
+          "extends": [
+            "AbstractProcessingHandler"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\Monolog\\Logger",
+        "WP_Rocket\\Dependencies\\Monolog\\Utils"
+      ]
+    },
+    "inc/Dependencies/Monolog/Logger.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Monolog",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Logger",
+          "extends": [],
+          "implements": [
+            "LoggerInterface",
+            "ResettableInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\Monolog\\Handler\\HandlerInterface",
+        "WP_Rocket\\Dependencies\\Monolog\\Handler\\StreamHandler",
+        "WP_Rocket\\Dependencies\\Psr\\Log\\LoggerInterface",
+        "WP_Rocket\\Dependencies\\Psr\\Log\\InvalidArgumentException",
+        "Exception"
+      ]
+    },
+    "inc/Dependencies/Monolog/Processor/IntrospectionProcessor.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Monolog\\Processor",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "IntrospectionProcessor",
+          "extends": [],
+          "implements": [
+            "ProcessorInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\Monolog\\Logger"
+      ]
+    },
+    "inc/Dependencies/Monolog/Processor/ProcessorInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Monolog\\Processor",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "ProcessorInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/Monolog/Registry.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Monolog",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Registry",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "InvalidArgumentException"
+      ]
+    },
+    "inc/Dependencies/Monolog/ResettableInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Monolog",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "ResettableInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/Monolog/SignalHandler.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Monolog",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "SignalHandler",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\Psr\\Log\\LoggerInterface",
+        "WP_Rocket\\Dependencies\\Psr\\Log\\LogLevel",
+        "ReflectionExtension"
+      ]
+    },
+    "inc/Dependencies/Monolog/Utils.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Monolog",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Utils",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/PathConverter/Converter.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\PathConverter",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Converter",
+          "extends": [],
+          "implements": [
+            "ConverterInterface"
+          ]
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/PathConverter/ConverterInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\PathConverter",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "ConverterInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/PathConverter/NoConverter.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\PathConverter",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "NoConverter",
+          "extends": [],
+          "implements": [
+            "ConverterInterface"
+          ]
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/Psr/Cache/CacheException.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Psr\\Cache",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "CacheException",
+          "extends": [
+            "\\Throwable"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/Psr/Cache/CacheItemInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Psr\\Cache",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "CacheItemInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/Psr/Cache/CacheItemPoolInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Psr\\Cache",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "CacheItemPoolInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/Psr/Cache/InvalidArgumentException.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Psr\\Cache",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "InvalidArgumentException",
+          "extends": [
+            "CacheException"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/Psr/Container/ContainerExceptionInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Psr\\Container",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "ContainerExceptionInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/Psr/Container/ContainerInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Psr\\Container",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "ContainerInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/Psr/Container/NotFoundExceptionInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Psr\\Container",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "NotFoundExceptionInterface",
+          "extends": [
+            "ContainerExceptionInterface"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/Psr/Log/AbstractLogger.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Psr\\Log",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AbstractLogger",
+          "extends": [],
+          "implements": [
+            "LoggerInterface"
+          ]
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/Psr/Log/InvalidArgumentException.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Psr\\Log",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "InvalidArgumentException",
+          "extends": [
+            "\\InvalidArgumentException"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/Psr/Log/LogLevel.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Psr\\Log",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "LogLevel",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/Psr/Log/LoggerAwareInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Psr\\Log",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "LoggerAwareInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/Psr/Log/LoggerAwareTrait.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Psr\\Log",
+      "symbols": [
+        {
+          "kind": "trait",
+          "name": "LoggerAwareTrait",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/Psr/Log/LoggerInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Psr\\Log",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "LoggerInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/Psr/Log/LoggerTrait.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Psr\\Log",
+      "symbols": [
+        {
+          "kind": "trait",
+          "name": "LoggerTrait",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/Psr/Log/NullLogger.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Psr\\Log",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "NullLogger",
+          "extends": [
+            "AbstractLogger"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/Psr/Log/Test/DummyTest.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Psr\\Log\\Test",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "DummyTest",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/Psr/Log/Test/LoggerInterfaceTest.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Psr\\Log\\Test",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "LoggerInterfaceTest",
+          "extends": [
+            "TestCase"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\Psr\\Log\\LoggerInterface",
+        "WP_Rocket\\Dependencies\\Psr\\Log\\LogLevel",
+        "PHPUnit\\Framework\\TestCase"
+      ]
+    },
+    "inc/Dependencies/Psr/Log/Test/TestLogger.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Psr\\Log\\Test",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "TestLogger",
+          "extends": [
+            "AbstractLogger"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\Psr\\Log\\AbstractLogger"
+      ]
+    },
+    "inc/Dependencies/Psr/SimpleCache/CacheException.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Psr\\SimpleCache",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "CacheException",
+          "extends": [
+            "\\Throwable"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/Psr/SimpleCache/CacheInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Psr\\SimpleCache",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "CacheInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/Psr/SimpleCache/InvalidArgumentException.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\Psr\\SimpleCache",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "InvalidArgumentException",
+          "extends": [
+            "CacheException"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/RocketLazyload/Assets.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\RocketLazyload",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Assets",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/RocketLazyload/Iframe.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\RocketLazyload",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Iframe",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/RocketLazyload/Image.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\RocketLazyload",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Image",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/WPMedia/PluginFamily/Controller/PluginFamily.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\WPMedia\\PluginFamily\\Controller",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "PluginFamily",
+          "extends": [],
+          "implements": [
+            "PluginFamilyInterface"
+          ]
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/WPMedia/PluginFamily/Controller/PluginFamilyInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\WPMedia\\PluginFamily\\Controller",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "PluginFamilyInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/WPMedia/PluginFamily/Model/PluginFamily.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Dependencies\\WPMedia\\PluginFamily\\Model",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "PluginFamily",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Dependencies/WPMedia/PluginFamily/Model/wp_media_plugins.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/Dependencies/WPMedia/PluginFamily/View/promote-imagify-uploader.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/Dependencies/WPMedia/PluginFamily/assets/js/admin.js": {
+      "language": "js",
+      "imports": []
+    },
+    "inc/Dependencies/WPMedia/PluginFamily/assets/js/index.js": {
+      "language": "js",
+      "imports": []
+    },
+    "inc/Engine/Activation/Activation.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Activation",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Activation",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options",
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal\\StringArgument",
+        "WP_Rocket\\Dependencies\\League\\Container\\Container",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\Activation\\ServiceProvider",
+        "WP_Rocket\\Engine\\License\\ServiceProvider",
+        "WP_Rocket\\Engine\\Preload\\Activation\\ServiceProvider",
+        "WP_Rocket\\Logger\\ServiceProvider",
+        "WP_Rocket\\ServiceProvider\\Options",
+        "WP_Rocket\\ThirdParty\\Hostings\\HostResolver",
+        "WP_Rocket\\ThirdParty\\Hostings\\ServiceProvider",
+        "WP_Rocket\\Event_Management\\Event_Manager"
+      ]
+    },
+    "inc/Engine/Activation/ActivationInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Activation",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "ActivationInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Activation/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Activation",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": [
+            "BootableServiceProviderInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal\\StringArgument",
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider",
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\BootableServiceProviderInterface",
+        "WP_Rocket\\Engine\\Cache\\AdvancedCache",
+        "WP_Rocket\\Engine\\Cache\\WPCache",
+        "WP_Rocket\\Engine\\Capabilities\\Manager",
+        "WP_Rocket\\Engine\\HealthCheck\\ActionSchedulerCheck"
+      ]
+    },
+    "inc/Engine/Admin/API/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\API",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider"
+      ]
+    },
+    "inc/Engine/Admin/API/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\API",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Admin/ActionSchedulerSubscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionSchedulerSubscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\ThirdParty\\ReturnTypesTrait",
+        "ReturnTypesTrait"
+      ]
+    },
+    "inc/Engine/Admin/Beacon/Beacon.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\Beacon",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Beacon",
+          "extends": [
+            "Abstract_Render"
+          ],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Abstract_Render",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Support\\Data",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Admin/Beacon/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\Beacon",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal\\StringArgument",
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider"
+      ]
+    },
+    "inc/Engine/Admin/Database/Optimization.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\Database",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Optimization",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Admin/Database/OptimizationProcess.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\Database",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "OptimizationProcess",
+          "extends": [
+            "WP_Rocket_WP_Background_Process"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket_WP_Background_Process"
+      ]
+    },
+    "inc/Engine/Admin/Database/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\Database",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider"
+      ]
+    },
+    "inc/Engine/Admin/Database/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\Database",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\Admin\\Options_Data"
+      ]
+    },
+    "inc/Engine/Admin/Deactivation/DeactivationIntent.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\Deactivation",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "DeactivationIntent",
+          "extends": [
+            "Abstract_Render"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Abstract_Render",
+        "WP_Rocket\\Admin\\Options",
+        "WP_Rocket\\Admin\\Options_Data"
+      ]
+    },
+    "inc/Engine/Admin/Deactivation/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\Deactivation",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Admin/DomainChange/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\DomainChange",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider",
+        "WP_Rocket\\Engine\\Common\\Ajax\\AjaxHandler"
+      ]
+    },
+    "inc/Engine/Admin/DomainChange/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\DomainChange",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Admin\\Beacon\\Beacon",
+        "WP_Rocket\\Engine\\Common\\Ajax\\AjaxHandler",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Admin/Metaboxes/PostEditOptionsSubscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\Metaboxes",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "PostEditOptionsSubscriber",
+          "extends": [
+            "Abstract_Render"
+          ],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Abstract_Render",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Admin/RocketInsights/APIHandler/APIClient.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\RocketInsights\\APIHandler",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "APIClient",
+          "extends": [
+            "AbstractAPIClient"
+          ],
+          "implements": [
+            "LoggerAwareInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\JobManager\\APIHandler\\AbstractAPIClient",
+        "WP_Rocket\\Logger\\LoggerAware",
+        "WP_Rocket\\Logger\\LoggerAwareInterface",
+        "LoggerAware"
+      ]
+    },
+    "inc/Engine/Admin/RocketInsights/Context/Context.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\RocketInsights\\Context",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Context",
+          "extends": [],
+          "implements": [
+            "ContextInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Common\\Context\\ContextInterface",
+        "WP_Rocket\\Engine\\License\\API\\User",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Database\\Queries\\RocketInsights",
+        "WP_Rocket\\Engine\\License\\API\\RemoteSettings"
+      ]
+    },
+    "inc/Engine/Admin/RocketInsights/Context/SaasContext.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\RocketInsights\\Context",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "SaasContext",
+          "extends": [],
+          "implements": [
+            "ContextInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Context\\ContextInterface"
+      ]
+    },
+    "inc/Engine/Admin/RocketInsights/Controller.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\RocketInsights",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Controller",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\GlobalScore",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Jobs\\Manager",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Context\\Context",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Database\\Queries\\RocketInsights",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Managers\\Plan",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\License\\API\\User",
+        "WP_Rocket\\Engine\\Tracking\\Tracking"
+      ]
+    },
+    "inc/Engine/Admin/RocketInsights/Database/Queries/RocketInsights.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\RocketInsights\\Database\\Queries",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "RocketInsights",
+          "extends": [
+            "AbstractQuery"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Database\\Schemas\\RocketInsights",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Database\\Rows\\RocketInsights",
+        "WP_Rocket\\Engine\\Common\\Database\\Queries\\AbstractQuery"
+      ]
+    },
+    "inc/Engine/Admin/RocketInsights/Database/Rows/RocketInsights.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\RocketInsights\\Database\\Rows",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "RocketInsights",
+          "extends": [
+            "Row"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\BerlinDB\\Database\\Row",
+        "WP_Rocket\\Engine\\Common\\Utils"
+      ]
+    },
+    "inc/Engine/Admin/RocketInsights/Database/Schemas/RocketInsights.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\RocketInsights\\Database\\Schemas",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "RocketInsights",
+          "extends": [
+            "Schema"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\BerlinDB\\Database\\Schema"
+      ]
+    },
+    "inc/Engine/Admin/RocketInsights/Database/Tables/RocketInsights.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\RocketInsights\\Database\\Tables",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "RocketInsights",
+          "extends": [
+            "AbstractTable"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Database\\Tables\\AbstractTable"
+      ]
+    },
+    "inc/Engine/Admin/RocketInsights/GlobalMetrics/Calculator.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\RocketInsights\\GlobalMetrics",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Calculator",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Database\\Queries\\RocketInsights"
+      ]
+    },
+    "inc/Engine/Admin/RocketInsights/GlobalMetrics/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\RocketInsights\\GlobalMetrics",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Admin/RocketInsights/GlobalScore.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\RocketInsights",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "GlobalScore",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Database\\Queries\\RocketInsights"
+      ]
+    },
+    "inc/Engine/Admin/RocketInsights/Jobs/Factory.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\RocketInsights\\Jobs",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Factory",
+          "extends": [],
+          "implements": [
+            "SaasFactory"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\JobManager\\AbstractFactory\\SaasFactory",
+        "WP_Rocket\\Engine\\Common\\JobManager\\APIHandler\\AbstractAPIClient",
+        "WP_Rocket\\Engine\\Common\\JobManager\\Managers\\ManagerInterface",
+        "WP_Rocket\\Engine\\Common\\Database\\TableInterface"
+      ]
+    },
+    "inc/Engine/Admin/RocketInsights/Jobs/Manager.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\RocketInsights\\Jobs",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Manager",
+          "extends": [],
+          "implements": [
+            "ManagerInterface",
+            "LoggerAwareInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Logger\\LoggerAware",
+        "WP_Rocket\\Logger\\LoggerAwareInterface",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Database\\Queries\\RocketInsights",
+        "WP_Rocket\\Engine\\Common\\Context\\ContextInterface",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Managers\\Plan",
+        "WP_Rocket\\Engine\\Common\\JobManager\\Managers\\AbstractManager",
+        "WP_Rocket\\Engine\\Common\\JobManager\\Managers\\ManagerInterface",
+        "LoggerAware",
+        "AbstractManager"
+      ]
+    },
+    "inc/Engine/Admin/RocketInsights/Managers/Plan.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\RocketInsights\\Managers",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Plan",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Context\\Context",
+        "WP_Rocket\\Engine\\License\\API\\User",
+        "WP_Rocket\\Engine\\License\\API\\UserClient",
+        "WP_Rocket\\Engine\\License\\API\\RemoteSettingsClient"
+      ]
+    },
+    "inc/Engine/Admin/RocketInsights/MetricFormatter.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\RocketInsights",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "MetricFormatter",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Admin/RocketInsights/PageHandlerTrait.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\RocketInsights",
+      "symbols": [
+        {
+          "kind": "trait",
+          "name": "PageHandlerTrait",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Admin/RocketInsights/PostListing/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\RocketInsights\\PostListing",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Render",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Context\\Context",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Database\\Queries\\RocketInsights",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\Engine\\Tracking\\Tracking"
+      ]
+    },
+    "inc/Engine/Admin/RocketInsights/Queue/Queue.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\RocketInsights\\Queue",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Queue",
+          "extends": [
+            "AbstractASQueue"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Queue\\AbstractASQueue"
+      ]
+    },
+    "inc/Engine/Admin/RocketInsights/Recommendations/APIClient.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\RocketInsights\\Recommendations",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "APIClient",
+          "extends": [
+            "AbstractAPIClient"
+          ],
+          "implements": [
+            "LoggerAwareInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\JobManager\\APIHandler\\AbstractAPIClient",
+        "WP_Rocket\\Logger\\LoggerAware",
+        "WP_Rocket\\Logger\\LoggerAwareInterface",
+        "WP_Error",
+        "LoggerAware"
+      ]
+    },
+    "inc/Engine/Admin/RocketInsights/Recommendations/DataManager.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\RocketInsights\\Recommendations",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "DataManager",
+          "extends": [],
+          "implements": [
+            "LoggerAwareInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\GlobalMetrics\\Calculator",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\GlobalScore",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\MetricFormatter",
+        "WP_Rocket\\Engine\\Tracking\\TrackingTrait",
+        "WP_Rocket\\Logger\\LoggerAware",
+        "WP_Rocket\\Logger\\LoggerAwareInterface",
+        "LoggerAware",
+        "TrackingTrait"
+      ]
+    },
+    "inc/Engine/Admin/RocketInsights/Recommendations/Render.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\RocketInsights\\Recommendations",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Render",
+          "extends": [
+            "Abstract_Render"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Abstract_Render"
+      ]
+    },
+    "inc/Engine/Admin/RocketInsights/Recommendations/Rest.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\RocketInsights\\Recommendations",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Rest",
+          "extends": [
+            "WP_REST_Controller"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Error",
+        "WP_REST_Controller",
+        "WP_REST_Response",
+        "WP_REST_Server"
+      ]
+    },
+    "inc/Engine/Admin/RocketInsights/Recommendations/SettingsSubscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\RocketInsights\\Recommendations",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "SettingsSubscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface",
+            "LoggerAwareInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\Logger\\LoggerAware",
+        "WP_Rocket\\Logger\\LoggerAwareInterface",
+        "Imagify_Partner",
+        "LoggerAware"
+      ]
+    },
+    "inc/Engine/Admin/RocketInsights/Recommendations/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\RocketInsights\\Recommendations",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface",
+            "LoggerAwareInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Context\\Context",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\Logger\\LoggerAware",
+        "WP_Rocket\\Logger\\LoggerAwareInterface",
+        "LoggerAware"
+      ]
+    },
+    "inc/Engine/Admin/RocketInsights/Render.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\RocketInsights",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Render",
+          "extends": [
+            "Abstract_Render"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Abstract_Render",
+        "WP_Rocket\\Engine\\Admin\\Beacon\\Beacon",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Context\\Context",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Database\\Queries\\RocketInsights"
+      ]
+    },
+    "inc/Engine/Admin/RocketInsights/Rest.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\RocketInsights",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Rest",
+          "extends": [
+            "WP_REST_Controller"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Error",
+        "WP_REST_Controller",
+        "WP_REST_Response",
+        "WP_REST_Request",
+        "WP_REST_Server",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Jobs\\Manager",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Context\\Context",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Database\\Queries\\RocketInsights",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Managers\\Plan",
+        "WP_Rocket\\Engine\\Common\\JobManager\\JobProcessor",
+        "WP_Rocket\\Engine\\Common\\JobManager\\Queue\\Queue",
+        "WP_Rocket\\Engine\\Common\\Utils",
+        "WP_Rocket\\Logger\\Logger",
+        "PageHandlerTrait"
+      ]
+    },
+    "inc/Engine/Admin/RocketInsights/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\RocketInsights",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal\\StringArgument",
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Database\\Tables\\RocketInsights",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Database\\Queries\\RocketInsights",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\APIHandler\\APIClient",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Context\\Context",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Context\\SaasContext",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\GlobalMetrics\\Calculator",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Jobs\\Factory",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Jobs\\Manager",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Managers\\Plan",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Queue\\Queue",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Recommendations\\APIClient",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Recommendations\\DataManager",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Recommendations\\Render",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Recommendations\\Subscriber",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Recommendations\\Rest",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Recommendations\\SettingsSubscriber",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\URLLimit\\Subscriber",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Settings\\Controller",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Settings\\Subscriber",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\PostListing\\Subscriber",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\GlobalMetrics\\Subscriber",
+        "WP_Rocket\\Engine\\Common\\JobManager\\Queue\\Queue"
+      ]
+    },
+    "inc/Engine/Admin/RocketInsights/Settings/Controller.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\RocketInsights\\Settings",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Controller",
+          "extends": [
+            "Abstract_Render"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Abstract_Render",
+        "WP_Rocket\\Engine\\License\\API\\User",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Context\\Context"
+      ]
+    },
+    "inc/Engine/Admin/RocketInsights/Settings/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\RocketInsights\\Settings",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Admin/RocketInsights/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\RocketInsights",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface",
+            "LoggerAwareInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Context\\Context",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Database\\Rows\\RocketInsights",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Managers\\Plan",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Jobs\\Manager",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Queue\\Queue",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Recommendations\\Rest",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\License\\Renewal",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\Logger\\LoggerAware",
+        "WP_Rocket\\Logger\\LoggerAwareInterface",
+        "LoggerAware"
+      ]
+    },
+    "inc/Engine/Admin/RocketInsights/URLLimit/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\RocketInsights\\URLLimit",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Context\\Context",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\GlobalScore",
+        "WP_Rocket\\Engine\\License\\API\\User",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Database\\Queries\\RocketInsights"
+      ]
+    },
+    "inc/Engine/Admin/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider",
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal\\StringArgument",
+        "WP_Rocket\\Engine\\Admin\\Deactivation\\DeactivationIntent",
+        "WP_Rocket\\Engine\\Admin\\Deactivation\\Subscriber",
+        "WP_Rocket\\Engine\\Admin\\Metaboxes\\PostEditOptionsSubscriber",
+        "WP_Rocket\\ThirdParty\\Plugins\\Optimization\\Hummingbird"
+      ]
+    },
+    "inc/Engine/Admin/Settings/AdminBarMenuTrait.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\Settings",
+      "symbols": [
+        {
+          "kind": "trait",
+          "name": "AdminBarMenuTrait",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Admin_Bar"
+      ]
+    },
+    "inc/Engine/Admin/Settings/DataClearingTrait.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\Settings",
+      "symbols": [
+        {
+          "kind": "trait",
+          "name": "DataClearingTrait",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Admin/Settings/Page.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\Settings",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Page",
+          "extends": [
+            "Abstract_Render"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Admin\\Database\\Optimization",
+        "WP_Rocket\\Engine\\Admin\\Beacon\\Beacon",
+        "WP_Rocket\\Engine\\License\\API\\User",
+        "WP_Rocket\\Engine\\License\\API\\UserClient",
+        "WP_Rocket\\Engine\\Optimization\\DelayJS\\Admin\\SiteList",
+        "WP_Rocket\\Engine\\Optimization\\DelayJS\\Admin\\Settings",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Context\\Context",
+        "WP_Rocket\\Abstract_Render",
+        "WP_Rocket\\Admin\\Options_Data"
+      ]
+    },
+    "inc/Engine/Admin/Settings/Render.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\Settings",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Render",
+          "extends": [
+            "Abstract_render"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "stdClass",
+        "WP_Rocket\\Abstract_Render",
+        "WP_Rocket\\Dependencies\\WPMedia\\PluginFamily\\Model\\PluginFamily"
+      ]
+    },
+    "inc/Engine/Admin/Settings/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\Settings",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal\\ArrayArgument",
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal\\StringArgument",
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider",
+        "WP_Rocket\\Dependencies\\WPMedia\\PluginFamily\\Model\\PluginFamily",
+        "WP_Rocket\\Dependencies\\WPMedia\\PluginFamily\\Controller\\PluginFamily"
+      ]
+    },
+    "inc/Engine/Admin/Settings/Settings.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\Settings",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Settings",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Addon\\Sucuri\\Subscriber"
+      ]
+    },
+    "inc/Engine/Admin/Settings/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Admin\\Settings",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface",
+            "PluginFamilyInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "Imagify_Partner",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\Dependencies\\WPMedia\\PluginFamily\\Controller\\PluginFamily",
+        "WP_Rocket\\Dependencies\\WPMedia\\PluginFamily\\Controller\\PluginFamilyInterface"
+      ]
+    },
+    "inc/Engine/CDN/Admin/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\CDN\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/CDN/CDN.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\CDN",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "CDN",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Support\\CommentTrait",
+        "CommentTrait"
+      ]
+    },
+    "inc/Engine/CDN/RocketCDN/APIClient.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\CDN\\RocketCDN",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "APIClient",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Error"
+      ]
+    },
+    "inc/Engine/CDN/RocketCDN/AdminPageSubscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\CDN\\RocketCDN",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AdminPageSubscriber",
+          "extends": [
+            "Abstract_Render"
+          ],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Abstract_Render",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Admin\\Beacon\\Beacon",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/CDN/RocketCDN/CDNOptionsManager.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\CDN\\RocketCDN",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "CDNOptionsManager",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options",
+        "WP_Rocket\\Admin\\Options_Data"
+      ]
+    },
+    "inc/Engine/CDN/RocketCDN/DataManagerSubscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\CDN\\RocketCDN",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "DataManagerSubscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\License\\API\\UserClient",
+        "WP_Rocket\\Engine\\Optimization\\RegexTrait",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "RegexTrait"
+      ]
+    },
+    "inc/Engine/CDN/RocketCDN/NoticesSubscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\CDN\\RocketCDN",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "NoticesSubscriber",
+          "extends": [
+            "Abstract_Render"
+          ],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Abstract_Render",
+        "WP_Rocket\\Engine\\Admin\\Beacon\\Beacon",
+        "WP_Rocket\\Engine\\License\\API\\UserClient",
+        "WP_Rocket\\Engine\\Tracking\\Tracking",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/CDN/RocketCDN/RESTSubscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\CDN\\RocketCDN",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "RESTSubscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\Admin\\Options_Data"
+      ]
+    },
+    "inc/Engine/CDN/RocketCDN/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\CDN\\RocketCDN",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal\\StringArgument",
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider"
+      ]
+    },
+    "inc/Engine/CDN/RocketCDN/views/cta-big.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/Engine/CDN/RocketCDN/views/cta-small.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/Engine/CDN/RocketCDN/views/dashboard-status.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/Engine/CDN/RocketCDN/views/promote-notice.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/Engine/CDN/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\CDN",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider",
+        "WP_Rocket\\Engine\\CDN\\Admin\\Subscriber"
+      ]
+    },
+    "inc/Engine/CDN/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\CDN",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Cache/AdminSubscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Cache",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AdminSubscriber",
+          "extends": [],
+          "implements": [
+            "Event_Manager_Aware_Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Filesystem_Direct",
+        "WP_Rocket\\Event_Management\\Event_Manager",
+        "WP_Rocket\\Event_Management\\Event_Manager_Aware_Subscriber_Interface",
+        "WP_Term"
+      ]
+    },
+    "inc/Engine/Cache/AdvancedCache.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Cache",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AdvancedCache",
+          "extends": [],
+          "implements": [
+            "ActivationInterface",
+            "DeactivationInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Filesystem_Direct",
+        "WP_Rocket\\Engine\\Activation\\ActivationInterface",
+        "WP_Rocket\\Engine\\Deactivation\\DeactivationInterface"
+      ]
+    },
+    "inc/Engine/Cache/Config/ConfigSubscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Cache\\Config",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ConfigSubscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Admin\\Options"
+      ]
+    },
+    "inc/Engine/Cache/Config/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Cache\\Config",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Cache/Purge.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Cache",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Purge",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Preload\\Database\\Queries\\Cache",
+        "DirectoryIterator",
+        "Exception",
+        "WP_Filesystem_Direct",
+        "WP_Term",
+        "WP_Post"
+      ]
+    },
+    "inc/Engine/Cache/PurgeActionsSubscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Cache",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "PurgeActionsSubscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Post",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Logger\\Logger"
+      ]
+    },
+    "inc/Engine/Cache/PurgeExpired/PurgeExpiredCache.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Cache\\PurgeExpired",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "PurgeExpiredCache",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Buffer\\Cache"
+      ]
+    },
+    "inc/Engine/Cache/PurgeExpired/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Cache\\PurgeExpired",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Cache/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Cache",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal\\StringArgument",
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider",
+        "WP_Rocket\\Engine\\Cache\\PurgeExpired\\PurgeExpiredCache",
+        "WP_Rocket\\Engine\\Cache\\PurgeExpired\\Subscriber",
+        "WP_Rocket\\Engine\\Preload\\Database\\Queries\\Cache",
+        "WP_Rocket\\Engine\\Cache\\Config\\ConfigSubscriber",
+        "WP_Rocket\\Engine\\Cache\\UrlValidation\\TaxonomySubscriber",
+        "WP_Rocket\\Engine\\Cache\\UrlValidation\\PostSubscriber"
+      ]
+    },
+    "inc/Engine/Cache/UrlValidation/AbstractUrlValidation.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Cache\\UrlValidation",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AbstractUrlValidation",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Cache/UrlValidation/PostSubscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Cache\\UrlValidation",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "PostSubscriber",
+          "extends": [
+            "AbstractUrlValidation"
+          ],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Cache/UrlValidation/TaxonomySubscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Cache\\UrlValidation",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "TaxonomySubscriber",
+          "extends": [
+            "AbstractUrlValidation"
+          ],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Cache/WPCache.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Cache",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "WPCache",
+          "extends": [],
+          "implements": [
+            "ActivationInterface",
+            "DeactivationInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Filesystem_Direct",
+        "WP_Rocket\\Engine\\Activation\\ActivationInterface",
+        "WP_Rocket\\Engine\\Deactivation\\DeactivationInterface"
+      ]
+    },
+    "inc/Engine/Capabilities/Manager.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Capabilities",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Manager",
+          "extends": [],
+          "implements": [
+            "ActivationInterface",
+            "DeactivationInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Activation\\ActivationInterface",
+        "WP_Rocket\\Engine\\Deactivation\\DeactivationInterface",
+        "WP_Role"
+      ]
+    },
+    "inc/Engine/Capabilities/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Capabilities",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider"
+      ]
+    },
+    "inc/Engine/Capabilities/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Capabilities",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Common/AbstractFileSystem.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AbstractFileSystem",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "RecursiveDirectoryIterator",
+        "RecursiveIteratorIterator",
+        "WP_Filesystem_Direct"
+      ]
+    },
+    "inc/Engine/Common/Ajax/AjaxHandler.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\Ajax",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AjaxHandler",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Common/Cache/CacheInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\Cache",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "CacheInterface",
+          "extends": [
+            "\\WP_Rocket\\Dependencies\\Psr\\SimpleCache\\CacheInterface"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Common/Cache/FilesystemCache.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\Cache",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "FilesystemCache",
+          "extends": [],
+          "implements": [
+            "CacheInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\Psr\\SimpleCache\\InvalidArgumentException",
+        "WP_Filesystem_Direct"
+      ]
+    },
+    "inc/Engine/Common/Clock/ClockInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\Clock",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "ClockInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Common/Clock/WPRClock.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\Clock",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "WPRClock",
+          "extends": [],
+          "implements": [
+            "ClockInterface"
+          ]
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Common/Context/AbstractContext.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\Context",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AbstractContext",
+          "extends": [],
+          "implements": [
+            "ContextInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data"
+      ]
+    },
+    "inc/Engine/Common/Context/ContextInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\Context",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "ContextInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Common/Database/Queries/AbstractQuery.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\Database\\Queries",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AbstractQuery",
+          "extends": [
+            "Query"
+          ],
+          "implements": [
+            "QueryInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\BerlinDB\\Database\\Query",
+        "WP_Rocket\\Engine\\Common\\Database\\QueryInterface"
+      ]
+    },
+    "inc/Engine/Common/Database/QueryInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\Database",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "QueryInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Common/Database/TableInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\Database",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "TableInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Common/Database/Tables/AbstractTable.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\Database\\Tables",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AbstractTable",
+          "extends": [
+            "Table"
+          ],
+          "implements": [
+            "TableInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\BerlinDB\\Database\\Table",
+        "WP_Rocket\\Engine\\Common\\Database\\TableInterface"
+      ]
+    },
+    "inc/Engine/Common/ExtractCSS/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\ExtractCSS",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal\\StringArgument",
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider",
+        "WP_Rocket\\Engine\\Common\\Cache\\FilesystemCache"
+      ]
+    },
+    "inc/Engine/Common/ExtractCSS/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\ExtractCSS",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface",
+            "LoggerAwareInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Optimization\\RegexTrait",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\Logger\\LoggerAware",
+        "WP_Rocket\\Logger\\LoggerAwareInterface",
+        "RegexTrait",
+        "LoggerAware"
+      ]
+    },
+    "inc/Engine/Common/Head/ElementTrait.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\Head",
+      "symbols": [
+        {
+          "kind": "trait",
+          "name": "ElementTrait",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Common/Head/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\Head",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider"
+      ]
+    },
+    "inc/Engine/Common/Head/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\Head",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Common/JobManager/APIHandler/AbstractAPIClient.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\JobManager\\APIHandler",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AbstractAPIClient",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Error",
+        "WP_Rocket\\Admin\\Options_Data"
+      ]
+    },
+    "inc/Engine/Common/JobManager/APIHandler/AbstractSafeAPIClient.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\JobManager\\APIHandler",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AbstractSafeAPIClient",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Error"
+      ]
+    },
+    "inc/Engine/Common/JobManager/AbstractFactory/SaasFactory.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\JobManager\\AbstractFactory",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "SaasFactory",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\JobManager\\APIHandler\\AbstractAPIClient",
+        "WP_Rocket\\Engine\\Common\\JobManager\\Managers\\ManagerInterface",
+        "WP_Rocket\\Engine\\Common\\Database\\TableInterface"
+      ]
+    },
+    "inc/Engine/Common/JobManager/Cron/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\JobManager\\Cron",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\Engine\\Common\\Queue\\RUCSSQueueRunner",
+        "WP_Rocket\\Engine\\Common\\JobManager\\JobProcessor"
+      ]
+    },
+    "inc/Engine/Common/JobManager/JobProcessor.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\JobManager",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "JobProcessor",
+          "extends": [],
+          "implements": [
+            "LoggerAwareInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Clock\\WPRClock",
+        "WP_Rocket\\Engine\\Common\\JobManager\\Queue\\Queue",
+        "WP_Rocket\\Engine\\Common\\JobManager\\Strategy\\Factory\\StrategyFactory",
+        "WP_Rocket\\Engine\\Common\\Utils",
+        "WP_Rocket\\Engine\\Optimization\\RUCSS\\APIHandler\\APIClient",
+        "WP_Rocket\\Logger\\LoggerAware",
+        "WP_Rocket\\Logger\\LoggerAwareInterface",
+        "LoggerAware"
+      ]
+    },
+    "inc/Engine/Common/JobManager/Managers/AbstractManager.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\JobManager\\Managers",
+      "symbols": [
+        {
+          "kind": "trait",
+          "name": "AbstractManager",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Common/JobManager/Managers/ManagerInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\JobManager\\Managers",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "ManagerInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Common/JobManager/Queue/Queue.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\JobManager\\Queue",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Queue",
+          "extends": [
+            "AbstractASQueue"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Queue\\AbstractASQueue"
+      ]
+    },
+    "inc/Engine/Common/JobManager/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\JobManager",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider",
+        "WP_Rocket\\Engine\\Common\\Clock\\WPRClock",
+        "WP_Rocket\\Engine\\Common\\JobManager\\Cron\\Subscriber",
+        "WP_Rocket\\Engine\\Common\\JobManager\\Queue\\Queue",
+        "WP_Rocket\\Engine\\Common\\JobManager\\Strategy\\Context\\RetryContext",
+        "WP_Rocket\\Engine\\Common\\JobManager\\Strategy\\Factory\\StrategyFactory"
+      ]
+    },
+    "inc/Engine/Common/JobManager/Strategy/Context/RetryContext.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\JobManager\\Strategy\\Context",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "RetryContext",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\JobManager\\Strategy\\Strategies\\StrategyInterface"
+      ]
+    },
+    "inc/Engine/Common/JobManager/Strategy/Factory/StrategyFactory.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\JobManager\\Strategy\\Factory",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "StrategyFactory",
+          "extends": [],
+          "implements": [
+            "LoggerAwareInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Clock\\WPRClock",
+        "WP_Rocket\\Engine\\Common\\JobManager\\Strategy\\Context\\RetryContext",
+        "WP_Rocket\\Engine\\Common\\JobManager\\Strategy\\Strategies\\JobSetFail",
+        "WP_Rocket\\Engine\\Common\\JobManager\\Strategy\\Strategies\\ResetRetryProcess",
+        "WP_Rocket\\Engine\\Common\\JobManager\\Strategy\\Strategies\\DefaultProcess",
+        "WP_Rocket\\Logger\\LoggerAware",
+        "WP_Rocket\\Logger\\LoggerAwareInterface",
+        "WP_Rocket\\Engine\\Common\\JobManager\\Managers\\ManagerInterface",
+        "LoggerAware"
+      ]
+    },
+    "inc/Engine/Common/JobManager/Strategy/Strategies/DefaultProcess.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\JobManager\\Strategy\\Strategies",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "DefaultProcess",
+          "extends": [],
+          "implements": [
+            "StrategyInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Clock\\WPRClock",
+        "WP_Rocket\\Engine\\Optimization\\RUCSS\\Jobs\\Manager"
+      ]
+    },
+    "inc/Engine/Common/JobManager/Strategy/Strategies/JobSetFail.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\JobManager\\Strategy\\Strategies",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "JobSetFail",
+          "extends": [],
+          "implements": [
+            "StrategyInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Optimization\\RUCSS\\Jobs\\Manager"
+      ]
+    },
+    "inc/Engine/Common/JobManager/Strategy/Strategies/ResetRetryProcess.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\JobManager\\Strategy\\Strategies",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ResetRetryProcess",
+          "extends": [],
+          "implements": [
+            "StrategyInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Optimization\\RUCSS\\Jobs\\Manager"
+      ]
+    },
+    "inc/Engine/Common/JobManager/Strategy/Strategies/StrategyInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\JobManager\\Strategy\\Strategies",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "StrategyInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Common/PerformanceHints/AJAX/AJAXControllerTrait.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\PerformanceHints\\AJAX",
+      "symbols": [
+        {
+          "kind": "trait",
+          "name": "AJAXControllerTrait",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Common/PerformanceHints/AJAX/ControllerInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\PerformanceHints\\AJAX",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "ControllerInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Common/PerformanceHints/AJAX/Processor.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\PerformanceHints\\AJAX",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Processor",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Common/PerformanceHints/AJAX/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\PerformanceHints\\AJAX",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Common/PerformanceHints/Activation/Activation.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\PerformanceHints\\Activation",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Activation",
+          "extends": [],
+          "implements": [
+            "ActivationInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Activation\\ActivationInterface",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\WarmUp\\Controller"
+      ]
+    },
+    "inc/Engine/Common/PerformanceHints/Activation/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\PerformanceHints\\Activation",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\WarmUp\\APIClient",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\WarmUp\\Controller",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\WarmUp\\Subscriber",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\WarmUp\\Queue",
+        "WP_Rocket\\Engine\\Media\\AboveTheFold\\Context\\Context",
+        "WP_Rocket\\Engine\\Media\\AboveTheFold\\Activation\\ActivationFactory",
+        "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Activation\\ActivationFactory",
+        "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Context\\Context",
+        "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\Context\\Context"
+      ]
+    },
+    "inc/Engine/Common/PerformanceHints/ActivationFactoryInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\PerformanceHints",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "ActivationFactoryInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Context\\ContextInterface"
+      ]
+    },
+    "inc/Engine/Common/PerformanceHints/Admin/AdminBar.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\PerformanceHints\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AdminBar",
+          "extends": [
+            "Abstract_Render"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Admin_Bar",
+        "WP_Rocket\\Abstract_Render",
+        "WP_Rocket\\Engine\\Admin\\Settings\\AdminBarMenuTrait",
+        "AdminBarMenuTrait"
+      ]
+    },
+    "inc/Engine/Common/PerformanceHints/Admin/Clean.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\PerformanceHints\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Clean",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Admin\\Settings\\DataClearingTrait",
+        "DataClearingTrait"
+      ]
+    },
+    "inc/Engine/Common/PerformanceHints/Admin/Controller.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\PerformanceHints\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Controller",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Common/PerformanceHints/Admin/Notices.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\PerformanceHints\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Notices",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Admin\\Beacon\\Beacon",
+        "WP_Rocket\\Engine\\Common\\Context\\ContextInterface"
+      ]
+    },
+    "inc/Engine/Common/PerformanceHints/Admin/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\PerformanceHints\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Admin_Bar",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Common/PerformanceHints/Cron/Controller.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\PerformanceHints\\Cron",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Controller",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Common/PerformanceHints/Cron/CronTrait.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\PerformanceHints\\Cron",
+      "symbols": [
+        {
+          "kind": "trait",
+          "name": "CronTrait",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Common/PerformanceHints/Cron/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\PerformanceHints\\Cron",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Common/PerformanceHints/FactoryInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\PerformanceHints",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "FactoryInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Database\\QueryInterface",
+        "WP_Rocket\\Engine\\Common\\Database\\TableInterface",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\AJAX\\ControllerInterface",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\Frontend\\ControllerInterface",
+        "WP_Rocket\\Engine\\Common\\Context\\ContextInterface"
+      ]
+    },
+    "inc/Engine/Common/PerformanceHints/Frontend/ControllerInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\PerformanceHints\\Frontend",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "ControllerInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Common/PerformanceHints/Frontend/Processor.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\PerformanceHints\\Frontend",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Processor",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Filesystem_Direct",
+        "WP_Rocket\\Engine\\Common\\Utils"
+      ]
+    },
+    "inc/Engine/Common/PerformanceHints/Frontend/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\PerformanceHints\\Frontend",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Buffer\\Tests",
+        "WP_Rocket\\Engine\\Common\\Utils",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Common/PerformanceHints/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\PerformanceHints",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Buffer\\Config",
+        "WP_Rocket\\Buffer\\Tests",
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal\\ArrayArgument",
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal\\StringArgument",
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\Admin\\Controller",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\Admin\\Subscriber",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\Admin\\AdminBar",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\Admin\\Clean",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\Admin\\Notices",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\AJAX\\Processor",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\AJAX\\Subscriber",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\Frontend\\Processor",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\Frontend\\Subscriber",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\Cron\\Controller",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\Cron\\Subscriber",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\WarmUp\\APIClient",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\WarmUp\\Controller",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\WarmUp\\Subscriber",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\WarmUp\\Queue"
+      ]
+    },
+    "inc/Engine/Common/PerformanceHints/WarmUp/APIClient.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\PerformanceHints\\WarmUp",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "APIClient",
+          "extends": [
+            "BaseAPIClient"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Utils",
+        "WP_Rocket\\Engine\\Optimization\\RUCSS\\APIHandler\\APIClient"
+      ]
+    },
+    "inc/Engine/Common/PerformanceHints/WarmUp/Controller.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\PerformanceHints\\WarmUp",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Controller",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Common\\Utils",
+        "WP_Rocket\\Engine\\License\\API\\User"
+      ]
+    },
+    "inc/Engine/Common/PerformanceHints/WarmUp/Queue.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\PerformanceHints\\WarmUp",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Queue",
+          "extends": [
+            "AbstractASQueue"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Queue\\AbstractASQueue"
+      ]
+    },
+    "inc/Engine/Common/PerformanceHints/WarmUp/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\PerformanceHints\\WarmUp",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Common/Queue/AbstractASQueue.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\Queue",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AbstractASQueue",
+          "extends": [],
+          "implements": [
+            "QueueInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "ActionScheduler_Store",
+        "Exception",
+        "WP_Rocket\\Logger\\Logger"
+      ]
+    },
+    "inc/Engine/Common/Queue/Cleaner.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\Queue",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Cleaner",
+          "extends": [
+            "ActionScheduler_QueueCleaner"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "ActionScheduler_QueueCleaner",
+        "ActionScheduler_Store"
+      ]
+    },
+    "inc/Engine/Common/Queue/QueueInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\Queue",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "QueueInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Common/Queue/RUCSSQueueRunner.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common\\Queue",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "RUCSSQueueRunner",
+          "extends": [
+            "ActionScheduler_Abstract_QueueRunner"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Logger\\Logger",
+        "ActionScheduler_Abstract_QueueRunner",
+        "ActionScheduler_Store",
+        "ActionScheduler_FatalErrorMonitor",
+        "ActionScheduler_AsyncRequest_QueueRunner"
+      ]
+    },
+    "inc/Engine/Common/Utils.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Common",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Utils",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/CriticalPath/APIClient.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\CriticalPath",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "APIClient",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "stdClass",
+        "WP_Error"
+      ]
+    },
+    "inc/Engine/CriticalPath/Admin/Admin.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\CriticalPath\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Admin",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Admin_Bar",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\CriticalPath\\ProcessorService",
+        "WP_Rocket\\Engine\\CriticalPath\\TransientTrait",
+        "TransientTrait"
+      ]
+    },
+    "inc/Engine/CriticalPath/Admin/Post.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\CriticalPath\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Post",
+          "extends": [
+            "Abstract_Render"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Abstract_Render",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Admin\\Beacon\\Beacon"
+      ]
+    },
+    "inc/Engine/CriticalPath/Admin/Settings.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\CriticalPath\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Settings",
+          "extends": [
+            "Abstract_Render"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Abstract_Render",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Admin\\Beacon\\Beacon",
+        "WP_Rocket\\Engine\\CriticalPath\\CriticalCSS"
+      ]
+    },
+    "inc/Engine/CriticalPath/Admin/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\CriticalPath\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Admin_Bar",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/CriticalPath/CriticalCSS.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\CriticalPath",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "CriticalCSS",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "FilesystemIterator",
+        "UnexpectedValueException",
+        "WP_Filesystem_Direct",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Optimization\\ContentTrait",
+        "ContentTrait"
+      ]
+    },
+    "inc/Engine/CriticalPath/CriticalCSSGeneration.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\CriticalPath",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "CriticalCSSGeneration",
+          "extends": [
+            "WP_Rocket_WP_Background_Process"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket_WP_Background_Process",
+        "TransientTrait"
+      ]
+    },
+    "inc/Engine/CriticalPath/CriticalCSSSubscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\CriticalPath",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "CriticalCSSSubscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Common\\Head\\ElementTrait",
+        "WP_Rocket\\Engine\\License\\API\\User",
+        "WP_Rocket\\Engine\\Optimization\\RegexTrait",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Filesystem_Direct",
+        "WP_Rocket\\Engine\\Support\\CommentTrait",
+        "RegexTrait",
+        "CommentTrait",
+        "ElementTrait"
+      ]
+    },
+    "inc/Engine/CriticalPath/DataManager.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\CriticalPath",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "DataManager",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Error",
+        "WP_Filesystem_Direct",
+        "WP_Rocket\\Engine\\Optimization\\CSSTrait",
+        "CSSTrait"
+      ]
+    },
+    "inc/Engine/CriticalPath/ProcessorService.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\CriticalPath",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ProcessorService",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Error"
+      ]
+    },
+    "inc/Engine/CriticalPath/RESTCSSSubscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\CriticalPath",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "RESTCSSSubscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/CriticalPath/RESTWP.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\CriticalPath",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "RESTWP",
+          "extends": [],
+          "implements": [
+            "RESTWPInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_REST_Request",
+        "WP_REST_Response",
+        "WP_Error",
+        "WP_Rocket\\Admin\\Options_Data"
+      ]
+    },
+    "inc/Engine/CriticalPath/RESTWPInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\CriticalPath",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "RESTWPInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_REST_Request",
+        "WP_REST_Response"
+      ]
+    },
+    "inc/Engine/CriticalPath/RESTWPPost.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\CriticalPath",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "RESTWPPost",
+          "extends": [
+            "RESTWP"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Error"
+      ]
+    },
+    "inc/Engine/CriticalPath/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\CriticalPath",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal\\StringArgument",
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider",
+        "WP_Rocket\\Engine\\CriticalPath\\Admin\\Admin",
+        "WP_Rocket\\Engine\\CriticalPath\\Admin\\Post",
+        "WP_Rocket\\Engine\\CriticalPath\\Admin\\Settings",
+        "WP_Rocket\\Engine\\CriticalPath\\Admin\\Subscriber"
+      ]
+    },
+    "inc/Engine/CriticalPath/TransientTrait.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\CriticalPath",
+      "symbols": [
+        {
+          "kind": "trait",
+          "name": "TransientTrait",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Deactivation/Deactivation.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Deactivation",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Deactivation",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options",
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal\\StringArgument",
+        "WP_Rocket\\Dependencies\\League\\Container\\Container",
+        "WP_Rocket\\Engine\\Admin\\Beacon\\ServiceProvider",
+        "WP_Rocket\\Engine\\Support\\ServiceProvider",
+        "WP_Rocket\\ServiceProvider\\Options",
+        "WP_Rocket\\ThirdParty\\Hostings\\HostResolver",
+        "WP_Rocket\\ThirdParty\\Hostings\\ServiceProvider"
+      ]
+    },
+    "inc/Engine/Deactivation/DeactivationInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Deactivation",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "DeactivationInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Deactivation/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Deactivation",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": [
+            "BootableServiceProviderInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal\\StringArgument",
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider",
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\BootableServiceProviderInterface",
+        "WP_Rocket\\Engine\\Cache\\AdvancedCache",
+        "WP_Rocket\\Engine\\Cache\\WPCache",
+        "WP_Rocket\\Engine\\Capabilities\\Manager",
+        "WP_Rocket\\ThirdParty\\Plugins\\CDN\\Cloudflare",
+        "WP_Rocket\\ThirdParty\\Plugins\\CDN\\CloudflareFacade"
+      ]
+    },
+    "inc/Engine/Debug/DebugSubscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Debug",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "DebugSubscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Debug/RUCSS/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Debug\\RUCSS",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\Logger\\Logger"
+      ]
+    },
+    "inc/Engine/Debug/Resolver.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Debug",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Resolver",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data"
+      ]
+    },
+    "inc/Engine/Debug/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Debug",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": [
+            "BootableServiceProviderInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider",
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\BootableServiceProviderInterface"
+      ]
+    },
+    "inc/Engine/HealthCheck/ActionSchedulerCheck.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\HealthCheck",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActionSchedulerCheck",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface",
+            "ActivationInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "ActionScheduler_Versions",
+        "ActionScheduler",
+        "ActionScheduler_StoreSchema",
+        "ActionScheduler_LoggerSchema",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\Engine\\Activation\\ActivationInterface"
+      ]
+    },
+    "inc/Engine/HealthCheck/HealthCheck.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\HealthCheck",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "HealthCheck",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/HealthCheck/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\HealthCheck",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider"
+      ]
+    },
+    "inc/Engine/Heartbeat/HeartbeatSubscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Heartbeat",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "HeartbeatSubscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\Admin\\Options_Data"
+      ]
+    },
+    "inc/Engine/Heartbeat/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Heartbeat",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider"
+      ]
+    },
+    "inc/Engine/License/API/Currency.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\License\\API",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Currency",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/License/API/CustomerDataTrait.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\License\\API",
+      "symbols": [
+        {
+          "kind": "trait",
+          "name": "CustomerDataTrait",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/License/API/Pricing.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\License\\API",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Pricing",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/License/API/PricingClient.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\License\\API",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "PricingClient",
+          "extends": [
+            "AbstractSafeAPIClient"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\JobManager\\APIHandler\\AbstractSafeAPIClient"
+      ]
+    },
+    "inc/Engine/License/API/RemoteSettings.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\License\\API",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "RemoteSettings",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/License/API/RemoteSettingsClient.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\License\\API",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "RemoteSettingsClient",
+          "extends": [
+            "AbstractSafeAPIClient"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Common\\JobManager\\APIHandler\\AbstractSafeAPIClient",
+        "CustomerDataTrait"
+      ]
+    },
+    "inc/Engine/License/API/User.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\License\\API",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "User",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/License/API/UserClient.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\License\\API",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "UserClient",
+          "extends": [
+            "AbstractSafeAPIClient"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Common\\JobManager\\APIHandler\\AbstractSafeAPIClient",
+        "CustomerDataTrait"
+      ]
+    },
+    "inc/Engine/License/Renewal.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\License",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Renewal",
+          "extends": [
+            "Abstract_Render"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Abstract_Render",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\License\\API\\Currency",
+        "WP_Rocket\\Engine\\License\\API\\Pricing",
+        "WP_Rocket\\Engine\\License\\API\\User"
+      ]
+    },
+    "inc/Engine/License/Revoked.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\License",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Revoked",
+          "extends": [
+            "Abstract_Render"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Abstract_Render",
+        "WP_Rocket\\Engine\\License\\API\\User"
+      ]
+    },
+    "inc/Engine/License/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\License",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal\\StringArgument",
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider",
+        "WP_Rocket\\Engine\\License\\API\\PricingClient",
+        "WP_Rocket\\Engine\\License\\API\\Pricing",
+        "WP_Rocket\\Engine\\License\\API\\UserClient",
+        "WP_Rocket\\Engine\\License\\API\\User",
+        "WP_Rocket\\Engine\\License\\API\\RemoteSettingsClient",
+        "WP_Rocket\\Engine\\License\\API\\RemoteSettings",
+        "WP_Rocket\\Engine\\License\\API\\",
+        "WP_Rocket\\Engine\\License\\Renewal",
+        "WP_Rocket\\Engine\\License\\Upgrade",
+        "WP_Rocket\\Engine\\License\\Subscriber",
+        "WP_Rocket\\Engine\\License\\Revoked"
+      ]
+    },
+    "inc/Engine/License/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\License",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/License/Upgrade.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\License",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Upgrade",
+          "extends": [
+            "Abstract_Render"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Abstract_Render",
+        "WP_Rocket\\Engine\\License\\API\\Currency",
+        "WP_Rocket\\Engine\\License\\API\\Pricing",
+        "WP_Rocket\\Engine\\License\\API\\User"
+      ]
+    },
+    "inc/Engine/License/views/dashboard-addon-status.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/Engine/License/views/promo-banner.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/Engine/License/views/renewal-expired-banner-ocd-disabled.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/Engine/License/views/renewal-expired-banner-ocd.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/Engine/License/views/renewal-expired-banner.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/Engine/License/views/renewal-soon-banner.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/Engine/License/views/revoked-website-banner.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/Engine/License/views/upgrade-item.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": [
+        "WP_Rocket\\Engine\\License\\API\\Currency"
+      ]
+    },
+    "inc/Engine/License/views/upgrade-popin.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/Engine/License/views/upgrade-section.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/Engine/Media/AboveTheFold/AJAX/Controller.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\AboveTheFold\\AJAX",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Controller",
+          "extends": [],
+          "implements": [
+            "ControllerInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\AJAX\\AJAXControllerTrait",
+        "WP_Rocket\\Engine\\Media\\AboveTheFold\\Database\\Queries\\AboveTheFold",
+        "WP_Rocket\\Engine\\Common\\Context\\ContextInterface",
+        "WP_Rocket\\Engine\\Optimization\\UrlTrait",
+        "WP_Rocket\\Logger\\Logger",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\AJAX\\ControllerInterface",
+        "UrlTrait",
+        "AJAXControllerTrait"
+      ]
+    },
+    "inc/Engine/Media/AboveTheFold/Activation/ActivationFactory.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\AboveTheFold\\Activation",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActivationFactory",
+          "extends": [],
+          "implements": [
+            "ActivationFactoryInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\ActivationFactoryInterface",
+        "WP_Rocket\\Engine\\Common\\Context\\ContextInterface"
+      ]
+    },
+    "inc/Engine/Media/AboveTheFold/Context/Context.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\AboveTheFold\\Context",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Context",
+          "extends": [],
+          "implements": [
+            "ContextInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Context\\ContextInterface"
+      ]
+    },
+    "inc/Engine/Media/AboveTheFold/Database/Queries/AboveTheFold.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\AboveTheFold\\Database\\Queries",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AboveTheFold",
+          "extends": [
+            "AbstractQuery"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Database\\Queries\\AbstractQuery",
+        "WP_Rocket\\Engine\\Media\\AboveTheFold\\Database\\Schemas\\AboveTheFold",
+        "WP_Rocket\\Engine\\Media\\AboveTheFold\\Database\\Rows\\AboveTheFold"
+      ]
+    },
+    "inc/Engine/Media/AboveTheFold/Database/Rows/AboveTheFold.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\AboveTheFold\\Database\\Rows",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AboveTheFold",
+          "extends": [
+            "Row"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\BerlinDB\\Database\\Row"
+      ]
+    },
+    "inc/Engine/Media/AboveTheFold/Database/Schemas/AboveTheFold.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\AboveTheFold\\Database\\Schemas",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AboveTheFold",
+          "extends": [
+            "Schema"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\BerlinDB\\Database\\Schema"
+      ]
+    },
+    "inc/Engine/Media/AboveTheFold/Database/Tables/AboveTheFold.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\AboveTheFold\\Database\\Tables",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AboveTheFold",
+          "extends": [
+            "AbstractTable"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Database\\Tables\\AbstractTable"
+      ]
+    },
+    "inc/Engine/Media/AboveTheFold/Factory.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\AboveTheFold",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Factory",
+          "extends": [],
+          "implements": [
+            "FactoryInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Database\\QueryInterface",
+        "WP_Rocket\\Engine\\Common\\Database\\TableInterface",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\Cron\\CronTrait",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\FactoryInterface",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\AJAX\\ControllerInterface",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\Frontend\\ControllerInterface",
+        "WP_Rocket\\Engine\\Common\\Context\\ContextInterface",
+        "CronTrait"
+      ]
+    },
+    "inc/Engine/Media/AboveTheFold/Frontend/Controller.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\AboveTheFold\\Frontend",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Controller",
+          "extends": [],
+          "implements": [
+            "ControllerInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Media\\AboveTheFold\\Database\\Queries\\AboveTheFold",
+        "WP_Rocket\\Engine\\Media\\AboveTheFold\\Context\\Context",
+        "WP_Rocket\\Engine\\Optimization\\RegexTrait",
+        "WP_Rocket\\Engine\\Optimization\\UrlTrait",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\Frontend\\ControllerInterface",
+        "WP_Rocket\\Engine\\Support\\CommentTrait",
+        "RegexTrait",
+        "UrlTrait",
+        "CommentTrait"
+      ]
+    },
+    "inc/Engine/Media/AboveTheFold/Frontend/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\AboveTheFold\\Frontend",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Media/AboveTheFold/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\AboveTheFold",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider",
+        "WP_Rocket\\Engine\\Media\\AboveTheFold\\AJAX\\Controller",
+        "WP_Rocket\\Engine\\Media\\AboveTheFold\\Context\\Context",
+        "WP_Rocket\\Engine\\Media\\AboveTheFold\\Database\\Tables\\AboveTheFold",
+        "WP_Rocket\\Engine\\Media\\AboveTheFold\\Database\\Queries\\AboveTheFold",
+        "WP_Rocket\\Engine\\Media\\AboveTheFold\\Frontend\\Controller",
+        "WP_Rocket\\Engine\\Media\\AboveTheFold\\Frontend\\Subscriber"
+      ]
+    },
+    "inc/Engine/Media/Emojis/EmojisSubscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\Emojis",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "EmojisSubscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Media/Fonts/Admin/Data.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\Fonts\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Data",
+          "extends": [
+            "AbstractASQueue"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "RecursiveDirectoryIterator",
+        "RecursiveIteratorIterator",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Common\\Queue\\AbstractASQueue",
+        "Exception"
+      ]
+    },
+    "inc/Engine/Media/Fonts/Admin/Settings.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\Fonts\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Settings",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Admin\\Settings\\Settings"
+      ]
+    },
+    "inc/Engine/Media/Fonts/Admin/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\Fonts\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Admin\\Settings\\Settings",
+        "WP_Rocket\\Engine\\Media\\Fonts\\Admin\\Data",
+        "WP_Rocket\\Engine\\Media\\Fonts\\Admin\\Settings",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Media/Fonts/Clean/Clean.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\Fonts\\Clean",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Clean",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Media\\Fonts\\Filesystem"
+      ]
+    },
+    "inc/Engine/Media/Fonts/Clean/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\Fonts\\Clean",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Media/Fonts/Context/OptimizationContext.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\Fonts\\Context",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "OptimizationContext",
+          "extends": [
+            "AbstractContext"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Context\\AbstractContext"
+      ]
+    },
+    "inc/Engine/Media/Fonts/Context/SaasContext.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\Fonts\\Context",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "SaasContext",
+          "extends": [
+            "AbstractContext"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Context\\AbstractContext"
+      ]
+    },
+    "inc/Engine/Media/Fonts/Filesystem.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\Fonts",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Filesystem",
+          "extends": [
+            "AbstractFileSystem"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Filesystem_Direct",
+        "WP_Rocket\\Engine\\Common\\AbstractFileSystem",
+        "WP_Rocket\\Logger\\Logger"
+      ]
+    },
+    "inc/Engine/Media/Fonts/FontsTrait.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\Fonts",
+      "symbols": [
+        {
+          "kind": "trait",
+          "name": "FontsTrait",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Media/Fonts/Frontend/Controller.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\Fonts\\Frontend",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Controller",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Head\\ElementTrait",
+        "WP_Rocket\\Engine\\Media\\Fonts\\Context\\OptimizationContext",
+        "WP_Rocket\\Engine\\Media\\Fonts\\Context\\SaasContext",
+        "WP_Rocket\\Engine\\Media\\Fonts\\Filesystem",
+        "WP_Rocket\\Engine\\Optimization\\RegexTrait",
+        "WP_Rocket\\Logger\\Logger",
+        "WP_Rocket\\Engine\\Media\\Fonts\\FontsTrait",
+        "RegexTrait",
+        "FontsTrait",
+        "ElementTrait"
+      ]
+    },
+    "inc/Engine/Media/Fonts/Frontend/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\Fonts\\Frontend",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Media/Fonts/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\Fonts",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider",
+        "WP_Rocket\\Engine\\Media\\Fonts\\Context\\OptimizationContext",
+        "WP_Rocket\\Engine\\Media\\Fonts\\Context\\SaasContext",
+        "WP_Rocket\\Engine\\Media\\Fonts\\Admin\\Data",
+        "WP_Rocket\\Engine\\Media\\Fonts\\Admin\\Settings",
+        "WP_Rocket\\Engine\\Media\\Fonts\\Admin\\Subscriber",
+        "WP_Rocket\\Engine\\Media\\Fonts\\Clean\\Clean",
+        "WP_Rocket\\Engine\\Media\\Fonts\\Clean\\Subscriber",
+        "WP_Rocket\\Engine\\Media\\Fonts\\Frontend\\Controller",
+        "WP_Rocket\\Engine\\Media\\Fonts\\Frontend\\Subscriber"
+      ]
+    },
+    "inc/Engine/Media/ImageDimensions/AdminSubscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\ImageDimensions",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AdminSubscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Admin\\Settings\\Settings",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Media/ImageDimensions/ImageDimensions.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\ImageDimensions",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ImageDimensions",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "SplFileInfo",
+        "WP_Filesystem_Direct",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Admin\\Settings\\Settings",
+        "WP_Rocket\\Engine\\Optimization\\RegexTrait",
+        "WP_Rocket\\Engine\\Support\\CommentTrait",
+        "WP_Rocket\\Logger\\Logger",
+        "RegexTrait",
+        "CommentTrait"
+      ]
+    },
+    "inc/Engine/Media/ImageDimensions/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\ImageDimensions",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Media/Lazyload/AdminSubscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\Lazyload",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AdminSubscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Media/Lazyload/CSS/Admin/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider"
+      ]
+    },
+    "inc/Engine/Media/Lazyload/CSS/Admin/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Cache\\CacheInterface",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Media/Lazyload/CSS/Context/LazyloadCSSContext.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Context",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "LazyloadCSSContext",
+          "extends": [
+            "AbstractContext"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Common\\Cache\\CacheInterface",
+        "WP_Rocket\\Engine\\Common\\Context\\AbstractContext",
+        "WP_Rocket\\Engine\\Media\\Lazyload\\CanLazyloadTrait",
+        "CanLazyloadTrait"
+      ]
+    },
+    "inc/Engine/Media/Lazyload/CSS/Data/LazyloadCSSContentFactory.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Data",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "LazyloadCSSContentFactory",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Media/Lazyload/CSS/Data/LazyloadedContent.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Data",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "LazyloadedContent",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Media/Lazyload/CSS/Data/ProtectedContent.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Data",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ProtectedContent",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Media/Lazyload/CSS/Front/ContentFetcher.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Front",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ContentFetcher",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Filesystem_Direct",
+        "WP_Rocket\\Engine\\Optimization\\CSSTrait",
+        "CSSTrait"
+      ]
+    },
+    "inc/Engine/Media/Lazyload/CSS/Front/Extractor.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Front",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Extractor",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Optimization\\RegexTrait",
+        "WP_Rocket\\Engine\\Optimization\\UrlTrait",
+        "RegexTrait",
+        "UrlTrait"
+      ]
+    },
+    "inc/Engine/Media/Lazyload/CSS/Front/FileResolver.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Front",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "FileResolver",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Media/Lazyload/CSS/Front/MappingFormatter.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Front",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "MappingFormatter",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Media/Lazyload/CSS/Front/RuleFormatter.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Front",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "RuleFormatter",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Media/Lazyload/CSS/Front/TagGenerator.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Front",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "TagGenerator",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Media/Lazyload/CSS/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\Lazyload\\CSS",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider",
+        "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Context\\LazyloadCSSContext",
+        "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Data\\LazyloadCSSContentFactory",
+        "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Front\\ContentFetcher",
+        "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Front\\Extractor",
+        "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Front\\FileResolver",
+        "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Front\\MappingFormatter",
+        "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Front\\RuleFormatter",
+        "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Front\\TagGenerator"
+      ]
+    },
+    "inc/Engine/Media/Lazyload/CSS/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\Lazyload\\CSS",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface",
+            "LoggerAwareInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Filesystem_Direct",
+        "WP_Post",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Common\\Context\\ContextInterface",
+        "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Data\\LazyloadedContent",
+        "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Data\\LazyloadCSSContentFactory",
+        "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Data\\ProtectedContent",
+        "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Front\\ContentFetcher",
+        "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Front\\Extractor",
+        "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Front\\FileResolver",
+        "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Front\\MappingFormatter",
+        "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Front\\RuleFormatter",
+        "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Front\\TagGenerator",
+        "WP_Rocket\\Engine\\Common\\Cache\\CacheInterface",
+        "WP_Rocket\\Engine\\Optimization\\RegexTrait",
+        "WP_Rocket\\Engine\\Support\\CommentTrait",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\Logger\\LoggerAware",
+        "WP_Rocket\\Logger\\LoggerAwareInterface",
+        "LoggerAware",
+        "RegexTrait",
+        "CommentTrait"
+      ]
+    },
+    "inc/Engine/Media/Lazyload/CanLazyloadTrait.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\Lazyload",
+      "symbols": [
+        {
+          "kind": "trait",
+          "name": "CanLazyloadTrait",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Media/Lazyload/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\Lazyload",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\Minify\\JS",
+        "WP_Rocket\\Dependencies\\RocketLazyload\\Assets",
+        "WP_Rocket\\Dependencies\\RocketLazyload\\Image",
+        "WP_Rocket\\Dependencies\\RocketLazyload\\Iframe",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Optimization\\RegexTrait",
+        "WP_Rocket\\Engine\\Support\\CommentTrait",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "RegexTrait",
+        "CanLazyloadTrait",
+        "CommentTrait"
+      ]
+    },
+    "inc/Engine/Media/PreconnectExternalDomains/AJAX/Controller.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\AJAX",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Controller",
+          "extends": [],
+          "implements": [
+            "ControllerInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Context\\ContextInterface",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\AJAX\\AJAXControllerTrait",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\AJAX\\ControllerInterface",
+        "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\Database\\Queries\\PreconnectExternalDomains",
+        "AJAXControllerTrait"
+      ]
+    },
+    "inc/Engine/Media/PreconnectExternalDomains/Admin/Settings.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Settings",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\Database\\Table\\PreconnectExternalDomains",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Admin\\Options"
+      ]
+    },
+    "inc/Engine/Media/PreconnectExternalDomains/Admin/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Media/PreconnectExternalDomains/Context/Context.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\Context",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Context",
+          "extends": [
+            "AbstractContext"
+          ],
+          "implements": [
+            "ContextInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Context\\ContextInterface",
+        "WP_Rocket\\Engine\\Common\\Context\\AbstractContext"
+      ]
+    },
+    "inc/Engine/Media/PreconnectExternalDomains/Database/Queries/PreconnectExternalDomains.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\Database\\Queries",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "PreconnectExternalDomains",
+          "extends": [
+            "AbstractQuery"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Database\\Queries\\AbstractQuery",
+        "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\Database\\Schema\\PreconnectExternalDomains",
+        "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\Database\\Row\\PreconnectExternalDomains"
+      ]
+    },
+    "inc/Engine/Media/PreconnectExternalDomains/Database/Row/PreconnectExternalDomains.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\Database\\Row",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "PreconnectExternalDomains",
+          "extends": [
+            "Row"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\BerlinDB\\Database\\Row"
+      ]
+    },
+    "inc/Engine/Media/PreconnectExternalDomains/Database/Schema/PreconnectExternalDomains.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\Database\\Schema",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "PreconnectExternalDomains",
+          "extends": [
+            "Schema"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\BerlinDB\\Database\\Schema"
+      ]
+    },
+    "inc/Engine/Media/PreconnectExternalDomains/Database/Table/PreconnectExternalDomains.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\Database\\Table",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "PreconnectExternalDomains",
+          "extends": [
+            "AbstractTable"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Database\\Tables\\AbstractTable"
+      ]
+    },
+    "inc/Engine/Media/PreconnectExternalDomains/Factory.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Factory",
+          "extends": [],
+          "implements": [
+            "FactoryInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Context\\ContextInterface",
+        "WP_Rocket\\Engine\\Common\\Database\\QueryInterface",
+        "WP_Rocket\\Engine\\Common\\Database\\TableInterface",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\AJAX\\ControllerInterface",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\Cron\\CronTrait",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\FactoryInterface",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\Frontend\\ControllerInterface",
+        "CronTrait"
+      ]
+    },
+    "inc/Engine/Media/PreconnectExternalDomains/Frontend/Controller.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\Frontend",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Controller",
+          "extends": [],
+          "implements": [
+            "ControllerInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Head\\ElementTrait",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\Frontend\\ControllerInterface",
+        "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\Context\\Context",
+        "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\Database\\Queries\\PreconnectExternalDomains",
+        "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\Database\\Row\\PreconnectExternalDomains",
+        "WP_Rocket\\Engine\\Support\\CommentTrait",
+        "CommentTrait",
+        "ElementTrait"
+      ]
+    },
+    "inc/Engine/Media/PreconnectExternalDomains/Frontend/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\Frontend",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\Engine\\Optimization\\DynamicLists\\DefaultLists\\DataManager"
+      ]
+    },
+    "inc/Engine/Media/PreconnectExternalDomains/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider",
+        "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\Context\\Context",
+        "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\Database\\Queries\\PreconnectExternalDomains",
+        "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\AJAX\\Controller",
+        "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\Database\\Table\\PreconnectExternalDomains",
+        "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\Frontend\\Controller",
+        "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\Frontend\\Subscriber",
+        "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\Admin\\Settings",
+        "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\Admin\\Subscriber"
+      ]
+    },
+    "inc/Engine/Media/PreloadFonts/AJAX/Controller.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\PreloadFonts\\AJAX",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Controller",
+          "extends": [],
+          "implements": [
+            "ControllerInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Media\\PreloadFonts\\Context\\Context",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\AJAX\\AJAXControllerTrait",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\AJAX\\ControllerInterface",
+        "WP_Rocket\\Engine\\Media\\PreloadFonts\\Database\\Queries\\PreloadFonts",
+        "WP_Rocket\\Engine\\Optimization\\UrlTrait",
+        "AJAXControllerTrait"
+      ]
+    },
+    "inc/Engine/Media/PreloadFonts/Admin/Settings.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\PreloadFonts\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Settings",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Admin\\Options"
+      ]
+    },
+    "inc/Engine/Media/PreloadFonts/Admin/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\PreloadFonts\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\Engine\\Media\\PreloadFonts\\Admin\\Settings"
+      ]
+    },
+    "inc/Engine/Media/PreloadFonts/Context/Context.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\PreloadFonts\\Context",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Context",
+          "extends": [],
+          "implements": [
+            "ContextInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Common\\Context\\ContextInterface"
+      ]
+    },
+    "inc/Engine/Media/PreloadFonts/Database/Queries/PreloadFonts.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\PreloadFonts\\Database\\Queries",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "PreloadFonts",
+          "extends": [
+            "AbstractQuery"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Database\\Queries\\AbstractQuery",
+        "WP_Rocket\\Engine\\Media\\PreloadFonts\\Database\\Schema\\PreloadFonts",
+        "WP_Rocket\\Engine\\Media\\PreloadFonts\\Database\\Rows\\PreloadFonts"
+      ]
+    },
+    "inc/Engine/Media/PreloadFonts/Database/Rows/PreloadFonts.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\PreloadFonts\\Database\\Rows",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "PreloadFonts",
+          "extends": [
+            "Row"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\BerlinDB\\Database\\Row"
+      ]
+    },
+    "inc/Engine/Media/PreloadFonts/Database/Schema/PreloadFonts.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\PreloadFonts\\Database\\Schema",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "PreloadFonts",
+          "extends": [
+            "Schema"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\BerlinDB\\Database\\Schema"
+      ]
+    },
+    "inc/Engine/Media/PreloadFonts/Database/Table/PreloadFonts.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\PreloadFonts\\Database\\Table",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "PreloadFonts",
+          "extends": [
+            "AbstractTable"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Database\\Tables\\AbstractTable"
+      ]
+    },
+    "inc/Engine/Media/PreloadFonts/Factory.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\PreloadFonts",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Factory",
+          "extends": [],
+          "implements": [
+            "FactoryInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Database\\QueryInterface",
+        "WP_Rocket\\Engine\\Common\\Database\\TableInterface",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\Cron\\CronTrait",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\FactoryInterface",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\AJAX\\ControllerInterface",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\Frontend\\ControllerInterface",
+        "WP_Rocket\\Engine\\Common\\Context\\ContextInterface",
+        "CronTrait"
+      ]
+    },
+    "inc/Engine/Media/PreloadFonts/Frontend/Controller.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\PreloadFonts\\Frontend",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Controller",
+          "extends": [],
+          "implements": [
+            "ControllerInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\Frontend\\ControllerInterface",
+        "WP_Rocket\\Engine\\Media\\PreloadFonts\\Database\\Queries\\PreloadFonts",
+        "WP_Rocket\\Engine\\Media\\PreloadFonts\\Context\\Context",
+        "WP_Rocket\\Engine\\Media\\PreloadFonts\\Database\\Rows\\PreloadFonts",
+        "WP_Rocket\\Engine\\Optimization\\UrlTrait",
+        "WP_Rocket\\Engine\\Support\\CommentTrait",
+        "WP_Rocket\\Engine\\Common\\Head\\ElementTrait",
+        "UrlTrait",
+        "CommentTrait",
+        "ElementTrait"
+      ]
+    },
+    "inc/Engine/Media/PreloadFonts/Frontend/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\PreloadFonts\\Frontend",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\Engine\\Media\\PreloadFonts\\Frontend\\Controller",
+        "WP_Rocket\\Engine\\Optimization\\DynamicLists\\DefaultLists\\DataManager"
+      ]
+    },
+    "inc/Engine/Media/PreloadFonts/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media\\PreloadFonts",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider",
+        "WP_Rocket\\Engine\\Media\\PreloadFonts\\Database\\Table\\PreloadFonts",
+        "WP_Rocket\\Engine\\Media\\PreloadFonts\\Database\\Queries\\PreloadFonts",
+        "WP_Rocket\\Engine\\Media\\PreloadFonts\\AJAX\\Controller",
+        "WP_Rocket\\Engine\\Media\\PreloadFonts\\Context\\Context",
+        "WP_Rocket\\Engine\\Media\\PreloadFonts\\Frontend\\Controller",
+        "WP_Rocket\\Engine\\Media\\PreloadFonts\\Frontend\\Subscriber",
+        "WP_Rocket\\Engine\\Media\\PreloadFonts\\Admin\\Subscriber",
+        "WP_Rocket\\Engine\\Media\\PreloadFonts\\Admin\\Settings"
+      ]
+    },
+    "inc/Engine/Media/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Media",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Buffer\\Config",
+        "WP_Rocket\\Buffer\\Tests",
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal\\ArrayArgument",
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider",
+        "WP_Rocket\\Dependencies\\RocketLazyload\\Assets",
+        "WP_Rocket\\Dependencies\\RocketLazyload\\Iframe",
+        "WP_Rocket\\Dependencies\\RocketLazyload\\Image",
+        "WP_Rocket\\Engine\\Media\\Emojis\\EmojisSubscriber",
+        "WP_Rocket\\Engine\\Media\\ImageDimensions\\AdminSubscriber",
+        "WP_Rocket\\Engine\\Media\\ImageDimensions\\ImageDimensions",
+        "WP_Rocket\\Engine\\Media\\ImageDimensions\\Subscriber",
+        "WP_Rocket\\Engine\\Media\\Lazyload\\AdminSubscriber",
+        "WP_Rocket\\Engine\\Media\\Lazyload\\Subscriber"
+      ]
+    },
+    "inc/Engine/Optimization/AbstractOptimization.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AbstractOptimization",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "RegexTrait"
+      ]
+    },
+    "inc/Engine/Optimization/AdminServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AdminServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider",
+        "WP_Rocket\\Engine\\Optimization\\GoogleFonts\\Admin\\Settings",
+        "WP_Rocket\\Engine\\Optimization\\GoogleFonts\\Admin\\Subscriber",
+        "WP_Rocket\\Engine\\Optimization\\Minify\\AdminSubscriber",
+        "WP_Rocket\\Engine\\Optimization\\Minify\\CSS\\AdminSubscriber"
+      ]
+    },
+    "inc/Engine/Optimization/AssetsLocalCache.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AssetsLocalCache",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Filesystem_Direct"
+      ]
+    },
+    "inc/Engine/Optimization/Buffer/Optimization.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\Buffer",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Optimization",
+          "extends": [
+            "Abstract_Buffer"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Buffer\\Abstract_Buffer",
+        "WP_Rocket\\Buffer\\Tests"
+      ]
+    },
+    "inc/Engine/Optimization/Buffer/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\Buffer",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Optimization/CSSTrait.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization",
+      "symbols": [
+        {
+          "kind": "trait",
+          "name": "CSSTrait",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\PathConverter\\ConverterInterface",
+        "WP_Rocket\\Dependencies\\PathConverter\\Converter"
+      ]
+    },
+    "inc/Engine/Optimization/CacheDynamicResource.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "CacheDynamicResource",
+          "extends": [
+            "AbstractOptimization"
+          ],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "CSSTrait"
+      ]
+    },
+    "inc/Engine/Optimization/ContentTrait.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization",
+      "symbols": [
+        {
+          "kind": "trait",
+          "name": "ContentTrait",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Optimization/DeferJS/AdminSubscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\DeferJS",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AdminSubscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Optimization/DeferJS/DeferJS.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\DeferJS",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "DeferJS",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Optimization\\DynamicLists\\DefaultLists\\DataManager",
+        "WP_Rocket\\Engine\\Support\\CommentTrait",
+        "CommentTrait"
+      ]
+    },
+    "inc/Engine/Optimization/DeferJS/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\DeferJS",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider"
+      ]
+    },
+    "inc/Engine/Optimization/DeferJS/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\DeferJS",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Optimization/DelayJS/Admin/Settings.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\DelayJS\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Settings",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options",
+        "WP_Rocket\\Engine\\Admin\\Settings\\Settings"
+      ]
+    },
+    "inc/Engine/Optimization/DelayJS/Admin/SiteList.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\DelayJS\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "SiteList",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Optimization\\DynamicLists\\DynamicLists",
+        "WP_Theme"
+      ]
+    },
+    "inc/Engine/Optimization/DelayJS/Admin/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\DelayJS\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Admin\\Settings\\Settings",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Theme"
+      ]
+    },
+    "inc/Engine/Optimization/DelayJS/HTML.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\DelayJS",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "HTML",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Optimization\\DelayJS\\Admin\\Settings",
+        "WP_Rocket\\Engine\\Optimization\\DynamicLists\\DefaultLists\\DataManager",
+        "WP_Rocket\\Engine\\Optimization\\RegexTrait",
+        "WP_Rocket\\Engine\\Support\\CommentTrait",
+        "WP_Rocket\\Logger\\Logger",
+        "RegexTrait",
+        "CommentTrait"
+      ]
+    },
+    "inc/Engine/Optimization/DelayJS/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\DelayJS",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider",
+        "WP_Rocket\\Engine\\Optimization\\DelayJS\\Admin\\Settings",
+        "WP_Rocket\\Engine\\Optimization\\DelayJS\\Admin\\SiteList",
+        "WP_Rocket\\Engine\\Optimization\\DelayJS\\Admin\\Subscriber"
+      ]
+    },
+    "inc/Engine/Optimization/DelayJS/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\DelayJS",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Optimization/DynamicLists/AbstractAPIClient.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\DynamicLists",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AbstractAPIClient",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Error",
+        "WP_Rocket\\Admin\\Options_Data"
+      ]
+    },
+    "inc/Engine/Optimization/DynamicLists/AbstractDataManager.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\DynamicLists",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AbstractDataManager",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Filesystem_Direct",
+        "StdClass"
+      ]
+    },
+    "inc/Engine/Optimization/DynamicLists/DefaultLists/APIClient.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\DynamicLists\\DefaultLists",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "APIClient",
+          "extends": [
+            "AbstractAPIClient"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Optimization\\DynamicLists\\AbstractAPIClient"
+      ]
+    },
+    "inc/Engine/Optimization/DynamicLists/DefaultLists/DataManager.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\DynamicLists\\DefaultLists",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "DataManager",
+          "extends": [
+            "AbstractDataManager"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Optimization\\DynamicLists\\AbstractDataManager"
+      ]
+    },
+    "inc/Engine/Optimization/DynamicLists/DelayJSLists/APIClient.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\DynamicLists\\DelayJSLists",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "APIClient",
+          "extends": [
+            "AbstractAPIClient"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Optimization\\DynamicLists\\AbstractAPIClient"
+      ]
+    },
+    "inc/Engine/Optimization/DynamicLists/DelayJSLists/DataManager.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\DynamicLists\\DelayJSLists",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "DataManager",
+          "extends": [
+            "AbstractDataManager"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Optimization\\DynamicLists\\AbstractDataManager"
+      ]
+    },
+    "inc/Engine/Optimization/DynamicLists/DynamicLists.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\DynamicLists",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "DynamicLists",
+          "extends": [
+            "Abstract_Render"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Abstract_Render",
+        "WP_Rocket\\Engine\\Admin\\Beacon\\Beacon",
+        "WP_Rocket\\Engine\\License\\API\\User",
+        "WP_REST_Response",
+        "WP_Error"
+      ]
+    },
+    "inc/Engine/Optimization/DynamicLists/IncompatiblePluginsLists/APIClient.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\DynamicLists\\IncompatiblePluginsLists",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "APIClient",
+          "extends": [
+            "AbstractAPIClient"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Optimization\\DynamicLists\\AbstractAPIClient"
+      ]
+    },
+    "inc/Engine/Optimization/DynamicLists/IncompatiblePluginsLists/DataManager.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\DynamicLists\\IncompatiblePluginsLists",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "DataManager",
+          "extends": [
+            "AbstractDataManager"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Optimization\\DynamicLists\\AbstractDataManager"
+      ]
+    },
+    "inc/Engine/Optimization/DynamicLists/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\DynamicLists",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider",
+        "WP_Rocket\\Engine\\Optimization\\DynamicLists\\DefaultLists\\APIClient",
+        "WP_Rocket\\Engine\\Optimization\\DynamicLists\\DefaultLists\\DataManager",
+        "WP_Rocket\\Engine\\Optimization\\DynamicLists\\DelayJSLists\\APIClient",
+        "WP_Rocket\\Engine\\Optimization\\DynamicLists\\DelayJSLists\\DataManager",
+        "WP_Rocket\\Engine\\Optimization\\DynamicLists\\IncompatiblePluginsLists\\APIClient",
+        "WP_Rocket\\Engine\\Optimization\\DynamicLists\\IncompatiblePluginsLists\\DataManager"
+      ]
+    },
+    "inc/Engine/Optimization/DynamicLists/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\DynamicLists",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Optimization/GoogleFonts/AbstractGFOptimization.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\GoogleFonts",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AbstractGFOptimization",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Head\\ElementTrait",
+        "WP_Rocket\\Engine\\Media\\Fonts\\FontsTrait",
+        "FontsTrait",
+        "ElementTrait"
+      ]
+    },
+    "inc/Engine/Optimization/GoogleFonts/Admin/Settings.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\GoogleFonts\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Settings",
+          "extends": [
+            "Abstract_Render"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Abstract_Render",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Admin\\Beacon\\Beacon"
+      ]
+    },
+    "inc/Engine/Optimization/GoogleFonts/Admin/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\GoogleFonts\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Optimization/GoogleFonts/Combine.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\GoogleFonts",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Combine",
+          "extends": [
+            "AbstractGFOptimization"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Optimization\\RegexTrait",
+        "WP_Rocket\\Logger\\Logger",
+        "RegexTrait"
+      ]
+    },
+    "inc/Engine/Optimization/GoogleFonts/CombineV2.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\GoogleFonts",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "CombineV2",
+          "extends": [
+            "AbstractGFOptimization"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Optimization\\RegexTrait",
+        "WP_Rocket\\Logger\\Logger",
+        "RegexTrait"
+      ]
+    },
+    "inc/Engine/Optimization/GoogleFonts/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\GoogleFonts",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Optimization/IEConditionalSubscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "IEConditionalSubscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Optimization/LazyRenderContent/AJAX/Controller.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\AJAX",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Controller",
+          "extends": [],
+          "implements": [
+            "ControllerInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Context\\ContextInterface",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\AJAX\\AJAXControllerTrait",
+        "WP_Rocket\\Engine\\Optimization\\UrlTrait",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\AJAX\\ControllerInterface",
+        "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Database\\Queries\\LazyRenderContent",
+        "UrlTrait",
+        "AJAXControllerTrait"
+      ]
+    },
+    "inc/Engine/Optimization/LazyRenderContent/Activation/ActivationFactory.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Activation",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ActivationFactory",
+          "extends": [],
+          "implements": [
+            "ActivationFactoryInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Context\\ContextInterface",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\ActivationFactoryInterface"
+      ]
+    },
+    "inc/Engine/Optimization/LazyRenderContent/Context/Context.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Context",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Context",
+          "extends": [],
+          "implements": [
+            "ContextInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Context\\ContextInterface"
+      ]
+    },
+    "inc/Engine/Optimization/LazyRenderContent/Database/Queries/LazyRenderContent.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Database\\Queries",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "LazyRenderContent",
+          "extends": [
+            "AbstractQuery"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Database\\Queries\\AbstractQuery",
+        "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Database\\Schema\\LazyRenderContent",
+        "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Database\\Rows\\LazyRenderContent"
+      ]
+    },
+    "inc/Engine/Optimization/LazyRenderContent/Database/Rows/LazyRenderContent.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Database\\Rows",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "LazyRenderContent",
+          "extends": [
+            "Row"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\BerlinDB\\Database\\Row"
+      ]
+    },
+    "inc/Engine/Optimization/LazyRenderContent/Database/Schema/LazyRenderContent.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Database\\Schema",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "LazyRenderContent",
+          "extends": [
+            "Schema"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\BerlinDB\\Database\\Schema"
+      ]
+    },
+    "inc/Engine/Optimization/LazyRenderContent/Database/Table/LazyRenderContent.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Database\\Table",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "LazyRenderContent",
+          "extends": [
+            "AbstractTable"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Database\\Tables\\AbstractTable"
+      ]
+    },
+    "inc/Engine/Optimization/LazyRenderContent/Factory.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\LazyRenderContent",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Factory",
+          "extends": [],
+          "implements": [
+            "FactoryInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Database\\QueryInterface",
+        "WP_Rocket\\Engine\\Common\\Database\\TableInterface",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\Cron\\CronTrait",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\FactoryInterface",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\AJAX\\ControllerInterface",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\Frontend\\ControllerInterface",
+        "WP_Rocket\\Engine\\Common\\Context\\ContextInterface",
+        "CronTrait"
+      ]
+    },
+    "inc/Engine/Optimization/LazyRenderContent/Frontend/Controller.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Frontend",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Controller",
+          "extends": [],
+          "implements": [
+            "ControllerInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Context\\ContextInterface",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\Frontend\\ControllerInterface",
+        "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Frontend\\Processor\\Processor",
+        "WP_Rocket\\Engine\\Support\\CommentTrait",
+        "CommentTrait"
+      ]
+    },
+    "inc/Engine/Optimization/LazyRenderContent/Frontend/Processor/Dom.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Frontend\\Processor",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Dom",
+          "extends": [],
+          "implements": [
+            "ProcessorInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "DOMDocument",
+        "WP_Rocket\\Logger\\Logger",
+        "HelperTrait"
+      ]
+    },
+    "inc/Engine/Optimization/LazyRenderContent/Frontend/Processor/HelperTrait.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Frontend\\Processor",
+      "symbols": [
+        {
+          "kind": "trait",
+          "name": "HelperTrait",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Optimization/LazyRenderContent/Frontend/Processor/Processor.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Frontend\\Processor",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Processor",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Optimization/LazyRenderContent/Frontend/Processor/ProcessorInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Frontend\\Processor",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "ProcessorInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Optimization/LazyRenderContent/Frontend/Processor/Regex.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Frontend\\Processor",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Regex",
+          "extends": [],
+          "implements": [
+            "ProcessorInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Logger\\Logger",
+        "HelperTrait"
+      ]
+    },
+    "inc/Engine/Optimization/LazyRenderContent/Frontend/Processor/SimpleHtmlDom.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Frontend\\Processor",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "SimpleHtmlDom",
+          "extends": [],
+          "implements": [
+            "ProcessorInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "voku\\helper\\HtmlDomParser",
+        "voku\\helper\\SimpleHtmlDomBlank",
+        "voku\\helper\\SimpleHtmlDomInterface",
+        "WP_Rocket\\Logger\\Logger",
+        "HelperTrait"
+      ]
+    },
+    "inc/Engine/Optimization/LazyRenderContent/Frontend/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Frontend",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Optimization/LazyRenderContent/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\LazyRenderContent",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider",
+        "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Context\\Context",
+        "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Database\\Table\\LazyRenderContent",
+        "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Database\\Queries\\LazyRenderContent",
+        "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\AJAX\\Controller",
+        "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Frontend\\Controller",
+        "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Frontend\\Subscriber",
+        "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Frontend\\Processor\\Processor"
+      ]
+    },
+    "inc/Engine/Optimization/Minify/AbstractMinifySubscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\Minify",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AbstractMinifySubscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Filesystem_Direct",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Optimization/Minify/AdminSubscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\Minify",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AdminSubscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Optimization/Minify/CSS/AbstractCSSOptimization.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\Minify\\CSS",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AbstractCSSOptimization",
+          "extends": [
+            "AbstractOptimization"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Optimization\\AbstractOptimization",
+        "WP_Rocket\\Engine\\Optimization\\AssetsLocalCache"
+      ]
+    },
+    "inc/Engine/Optimization/Minify/CSS/AdminSubscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\Minify\\CSS",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AdminSubscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Optimization/Minify/CSS/Minify.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\Minify\\CSS",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Minify",
+          "extends": [
+            "AbstractCSSOptimization"
+          ],
+          "implements": [
+            "ProcessorInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\Minify",
+        "WP_Rocket\\Engine\\Optimization\\CSSTrait",
+        "WP_Rocket\\Engine\\Optimization\\Minify\\ProcessorInterface",
+        "WP_Rocket\\Engine\\Support\\CommentTrait",
+        "WP_Rocket\\Logger\\Logger",
+        "CSSTrait",
+        "CommentTrait"
+      ]
+    },
+    "inc/Engine/Optimization/Minify/CSS/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\Minify\\CSS",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [
+            "AbstractMinifySubscriber"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Optimization\\AssetsLocalCache",
+        "WP_Rocket\\Engine\\Optimization\\Minify\\AbstractMinifySubscriber"
+      ]
+    },
+    "inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\Minify\\JS",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AbstractJSOptimization",
+          "extends": [
+            "AbstractOptimization"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Optimization\\AbstractOptimization",
+        "WP_Rocket\\Engine\\Optimization\\AssetsLocalCache",
+        "WP_Rocket\\Engine\\Optimization\\DynamicLists\\DynamicLists"
+      ]
+    },
+    "inc/Engine/Optimization/Minify/JS/Combine.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\Minify\\JS",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Combine",
+          "extends": [
+            "AbstractJSOptimization"
+          ],
+          "implements": [
+            "ProcessorInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\Minify\\JS",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Optimization\\AssetsLocalCache",
+        "WP_Rocket\\Engine\\Optimization\\DeferJS\\DeferJS",
+        "WP_Rocket\\Engine\\Optimization\\DynamicLists\\DynamicLists",
+        "WP_Rocket\\Engine\\Optimization\\Minify\\ProcessorInterface",
+        "WP_Rocket\\Engine\\Support\\CommentTrait",
+        "WP_Rocket\\Logger\\Logger",
+        "CommentTrait"
+      ]
+    },
+    "inc/Engine/Optimization/Minify/JS/Minify.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\Minify\\JS",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Minify",
+          "extends": [
+            "AbstractJSOptimization"
+          ],
+          "implements": [
+            "ProcessorInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\Minify",
+        "WP_Rocket\\Engine\\Optimization\\Minify\\ProcessorInterface",
+        "WP_Rocket\\Engine\\Support\\CommentTrait",
+        "WP_Rocket\\Logger\\Logger",
+        "CommentTrait"
+      ]
+    },
+    "inc/Engine/Optimization/Minify/JS/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\Minify\\JS",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [
+            "AbstractMinifySubscriber"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\Minify\\JS",
+        "WP_Rocket\\Engine\\Optimization\\AssetsLocalCache",
+        "WP_Rocket\\Engine\\Optimization\\DeferJS\\DeferJS",
+        "WP_Rocket\\Engine\\Optimization\\DynamicLists\\DynamicLists",
+        "WP_Rocket\\Engine\\Optimization\\Minify\\AbstractMinifySubscriber"
+      ]
+    },
+    "inc/Engine/Optimization/Minify/ProcessorInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\Minify",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "ProcessorInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Optimization/RUCSS/APIHandler/APIClient.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\RUCSS\\APIHandler",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "APIClient",
+          "extends": [
+            "AbstractAPIClient"
+          ],
+          "implements": [
+            "LoggerAwareInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\JobManager\\APIHandler\\AbstractAPIClient",
+        "WP_Rocket\\Logger\\LoggerAware",
+        "WP_Rocket\\Logger\\LoggerAwareInterface",
+        "LoggerAware"
+      ]
+    },
+    "inc/Engine/Optimization/RUCSS/Admin/Database.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\RUCSS\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Database",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Optimization\\RUCSS\\Database\\Tables\\UsedCSS"
+      ]
+    },
+    "inc/Engine/Optimization/RUCSS/Admin/OptionSubscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\RUCSS\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "OptionSubscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Admin\\Settings\\Settings",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Optimization/RUCSS/Admin/Settings.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\RUCSS\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Settings",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Admin\\Beacon\\Beacon",
+        "WP_Rocket\\Engine\\Admin\\Settings\\Settings",
+        "WP_Rocket\\Engine\\Optimization\\RUCSS\\Database\\Tables\\UsedCSS"
+      ]
+    },
+    "inc/Engine/Optimization/RUCSS/Admin/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\RUCSS\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\JobManager\\Queue\\Queue",
+        "WP_Rocket\\Engine\\Common\\Queue\\RUCSSQueueRunner",
+        "WP_Rocket\\Engine\\Optimization\\RUCSS\\Controller\\UsedCSS",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Optimization/RUCSS/Context/RUCSSContext.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\RUCSS\\Context",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "RUCSSContext",
+          "extends": [
+            "AbstractContext"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Common\\Context\\AbstractContext",
+        "WP_Rocket\\Engine\\Optimization\\RUCSS\\Controller\\Filesystem"
+      ]
+    },
+    "inc/Engine/Optimization/RUCSS/Context/RUCSSContextSaas.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\RUCSS\\Context",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "RUCSSContextSaas",
+          "extends": [
+            "AbstractContext"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Context\\AbstractContext"
+      ]
+    },
+    "inc/Engine/Optimization/RUCSS/Context/RUCSSOptimizeContext.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\RUCSS\\Context",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "RUCSSOptimizeContext",
+          "extends": [
+            "AbstractContext"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Context\\AbstractContext"
+      ]
+    },
+    "inc/Engine/Optimization/RUCSS/Controller/Filesystem.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\RUCSS\\Controller",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Filesystem",
+          "extends": [
+            "AbstractFileSystem"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Filesystem_Direct",
+        "RecursiveDirectoryIterator",
+        "RecursiveIteratorIterator",
+        "WP_Rocket\\Engine\\Common\\AbstractFileSystem"
+      ]
+    },
+    "inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\RUCSS\\Controller",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "UsedCSS",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Common\\Context\\ContextInterface",
+        "WP_Rocket\\Engine\\Common\\Head\\ElementTrait",
+        "WP_Rocket\\Engine\\Optimization\\CSSTrait",
+        "WP_Rocket\\Engine\\Optimization\\DynamicLists\\DefaultLists\\DataManager",
+        "WP_Rocket\\Engine\\Optimization\\RegexTrait",
+        "WP_Rocket\\Engine\\Optimization\\RUCSS\\Database\\Queries\\UsedCSS",
+        "WP_Rocket\\Engine\\Optimization\\RUCSS\\Jobs\\Manager",
+        "WP_Rocket\\Engine\\Support\\CommentTrait",
+        "RegexTrait",
+        "CSSTrait",
+        "CommentTrait",
+        "ElementTrait"
+      ]
+    },
+    "inc/Engine/Optimization/RUCSS/Cron/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\RUCSS\\Cron",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\Engine\\Common\\JobManager\\JobProcessor",
+        "WP_Rocket\\Engine\\Optimization\\RUCSS\\Database\\Queries\\UsedCSS"
+      ]
+    },
+    "inc/Engine/Optimization/RUCSS/Database/Queries/UsedCSS.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\RUCSS\\Database\\Queries",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "UsedCSS",
+          "extends": [
+            "AbstractQuery"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Database\\Queries\\AbstractQuery",
+        "WP_Rocket\\Engine\\Optimization\\RUCSS\\Database\\Row\\UsedCSS",
+        "WP_Rocket\\Engine\\Optimization\\RUCSS\\Database\\Schemas\\UsedCSS"
+      ]
+    },
+    "inc/Engine/Optimization/RUCSS/Database/Row/UsedCSS.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\RUCSS\\Database\\Row",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "UsedCSS",
+          "extends": [
+            "Row"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\BerlinDB\\Database\\Row"
+      ]
+    },
+    "inc/Engine/Optimization/RUCSS/Database/Schemas/UsedCSS.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\RUCSS\\Database\\Schemas",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "UsedCSS",
+          "extends": [
+            "Schema"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\BerlinDB\\Database\\Schema"
+      ]
+    },
+    "inc/Engine/Optimization/RUCSS/Database/Tables/UsedCSS.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\RUCSS\\Database\\Tables",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "UsedCSS",
+          "extends": [
+            "AbstractTable"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Database\\Tables\\AbstractTable"
+      ]
+    },
+    "inc/Engine/Optimization/RUCSS/Frontend/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\RUCSS\\Frontend",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Context\\ContextInterface",
+        "WP_Rocket\\Engine\\Optimization\\RUCSS\\Context\\RUCSSContext",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\Engine\\Optimization\\RUCSS\\Controller\\UsedCSS"
+      ]
+    },
+    "inc/Engine/Optimization/RUCSS/Jobs/Factory.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\RUCSS\\Jobs",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Factory",
+          "extends": [],
+          "implements": [
+            "SaasFactory"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\JobManager\\AbstractFactory\\SaasFactory",
+        "WP_Rocket\\Engine\\Common\\JobManager\\APIHandler\\AbstractAPIClient",
+        "WP_Rocket\\Engine\\Common\\JobManager\\Managers\\ManagerInterface",
+        "WP_Rocket\\Engine\\Common\\Database\\TableInterface"
+      ]
+    },
+    "inc/Engine/Optimization/RUCSS/Jobs/Manager.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\RUCSS\\Jobs",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Manager",
+          "extends": [],
+          "implements": [
+            "ManagerInterface",
+            "LoggerAwareInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Logger\\LoggerAware",
+        "WP_Rocket\\Logger\\LoggerAwareInterface",
+        "WP_Rocket\\Engine\\Optimization\\RUCSS\\Database\\Queries\\UsedCSS",
+        "WP_Rocket\\Engine\\Optimization\\RUCSS\\Controller\\Filesystem",
+        "WP_Rocket\\Engine\\Common\\Context\\ContextInterface",
+        "WP_Rocket\\Engine\\Optimization\\CSSTrait",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Common\\JobManager\\Managers\\AbstractManager",
+        "WP_Rocket\\Engine\\Common\\JobManager\\Managers\\ManagerInterface",
+        "LoggerAware",
+        "CSSTrait",
+        "AbstractManager"
+      ]
+    },
+    "inc/Engine/Optimization/RUCSS/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\RUCSS",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal\\StringArgument",
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider",
+        "WP_Rocket\\Engine\\Optimization\\RUCSS\\Admin\\Database",
+        "WP_Rocket\\Engine\\Optimization\\RUCSS\\Admin\\OptionSubscriber",
+        "WP_Rocket\\Engine\\Optimization\\RUCSS\\Admin\\Settings",
+        "WP_Rocket\\Engine\\Optimization\\RUCSS\\Admin\\Subscriber",
+        "WP_Rocket\\Engine\\Optimization\\RUCSS\\APIHandler\\APIClient",
+        "WP_Rocket\\Engine\\Optimization\\RUCSS\\Context\\RUCSSContext",
+        "WP_Rocket\\Engine\\Optimization\\RUCSS\\Context\\RUCSSOptimizeContext",
+        "WP_Rocket\\Engine\\Optimization\\RUCSS\\Controller\\Filesystem",
+        "WP_Rocket\\Engine\\Common\\JobManager\\Queue\\Queue",
+        "WP_Rocket\\Engine\\Optimization\\RUCSS\\Controller\\UsedCSS",
+        "WP_Rocket\\Engine\\Optimization\\RUCSS\\Database\\Queries\\UsedCSS",
+        "WP_Rocket\\Engine\\Optimization\\RUCSS\\Database\\Tables\\UsedCSS",
+        "WP_Rocket\\Engine\\Optimization\\RUCSS\\Frontend\\Subscriber",
+        "WP_Rocket\\Engine\\Optimization\\RUCSS\\Jobs\\Manager",
+        "WP_Rocket\\Engine\\Optimization\\RUCSS\\Jobs\\Factory",
+        "WP_Rocket\\Engine\\Optimization\\RUCSS\\Context\\RUCSSContextSaas",
+        "WP_Rocket\\Engine\\Optimization\\RUCSS\\Cron\\Subscriber"
+      ]
+    },
+    "inc/Engine/Optimization/RegexTrait.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization",
+      "symbols": [
+        {
+          "kind": "trait",
+          "name": "RegexTrait",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Optimization/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal\\StringArgument",
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider",
+        "WP_Rocket\\Engine\\Optimization\\Buffer\\Optimization",
+        "WP_Rocket\\Engine\\Optimization\\Buffer\\Subscriber",
+        "WP_Rocket\\Engine\\Optimization\\GoogleFonts\\Combine",
+        "WP_Rocket\\Engine\\Optimization\\GoogleFonts\\CombineV2",
+        "WP_Rocket\\Engine\\Optimization\\GoogleFonts\\Subscriber"
+      ]
+    },
+    "inc/Engine/Optimization/UrlTrait.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization",
+      "symbols": [
+        {
+          "kind": "trait",
+          "name": "UrlTrait",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Plugin/InformationSubscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Plugin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "InformationSubscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Error",
+        "UpdaterApiTools"
+      ]
+    },
+    "inc/Engine/Plugin/RenewalNotice.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Plugin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "RenewalNotice",
+          "extends": [
+            "Abstract_Render"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Abstract_Render",
+        "WP_Rocket\\Engine\\License\\API\\User"
+      ]
+    },
+    "inc/Engine/Plugin/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Plugin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal\\ArrayArgument",
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal\\StringArgument",
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider"
+      ]
+    },
+    "inc/Engine/Plugin/UpdaterApiCommonSubscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Plugin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "UpdaterApiCommonSubscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Plugin/UpdaterApiTools.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Plugin",
+      "symbols": [
+        {
+          "kind": "trait",
+          "name": "UpdaterApiTools",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Logger\\Logger"
+      ]
+    },
+    "inc/Engine/Plugin/UpdaterSubscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Plugin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "UpdaterSubscriber",
+          "extends": [],
+          "implements": [
+            "Event_Manager_Aware_Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "Plugin_Upgrader",
+        "Plugin_Upgrader_Skin",
+        "WP_Error",
+        "WP_Rocket\\Event_Management\\Event_Manager",
+        "WP_Rocket\\Event_Management\\Event_Manager_Aware_Subscriber_Interface",
+        "UpdaterApiTools"
+      ]
+    },
+    "inc/Engine/Preload/Activation/Activation.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Preload\\Activation",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Activation",
+          "extends": [],
+          "implements": [
+            "ActivationInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Activation\\ActivationInterface",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Preload\\Controller\\PreloadUrl",
+        "WP_Rocket\\Engine\\Preload\\Controller\\Queue",
+        "WP_Rocket\\Engine\\Preload\\Database\\Queries\\Cache"
+      ]
+    },
+    "inc/Engine/Preload/Activation/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Preload\\Activation",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider",
+        "WP_Rocket\\Engine\\Preload\\Controller\\PreloadUrl",
+        "WP_Rocket\\Engine\\Preload\\Controller\\Queue",
+        "WP_Rocket\\Engine\\Preload\\Database\\Queries\\Cache",
+        "WP_Rocket\\Engine\\Preload\\Database\\Tables\\Cache"
+      ]
+    },
+    "inc/Engine/Preload/Admin/Settings.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Preload\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Settings",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Preload\\Controller\\LoadInitialSitemap",
+        "WP_Rocket\\Engine\\Preload\\Controller\\PreloadUrl",
+        "WP_Rocket\\Engine\\Preload\\Database\\Tables\\Cache"
+      ]
+    },
+    "inc/Engine/Preload/Admin/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Preload\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Preload/Controller/CheckExcludedTrait.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Preload\\Controller",
+      "symbols": [
+        {
+          "kind": "trait",
+          "name": "CheckExcludedTrait",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Preload/Controller/CheckFinished.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Preload\\Controller",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "CheckFinished",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Preload\\Admin\\Settings",
+        "WP_Rocket\\Engine\\Preload\\Database\\Queries\\Cache"
+      ]
+    },
+    "inc/Engine/Preload/Controller/ClearCache.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Preload\\Controller",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ClearCache",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Preload\\Database\\Queries\\Cache",
+        "CheckExcludedTrait"
+      ]
+    },
+    "inc/Engine/Preload/Controller/CrawlHomepage.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Preload\\Controller",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "CrawlHomepage",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Preload/Controller/LoadInitialSitemap.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Preload\\Controller",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "LoadInitialSitemap",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Preload\\Database\\Queries\\Cache"
+      ]
+    },
+    "inc/Engine/Preload/Controller/PreloadUrl.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Preload\\Controller",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "PreloadUrl",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Preload\\Database\\Queries\\Cache",
+        "WP_Filesystem_Direct",
+        "CheckExcludedTrait"
+      ]
+    },
+    "inc/Engine/Preload/Controller/Queue.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Preload\\Controller",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Queue",
+          "extends": [
+            "AbstractASQueue"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "ActionScheduler_Store",
+        "WP_Rocket\\Engine\\Common\\Queue\\AbstractASQueue"
+      ]
+    },
+    "inc/Engine/Preload/Cron/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Preload\\Cron",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Queue\\Cleaner",
+        "WP_Rocket\\Engine\\Preload\\Admin\\Settings",
+        "WP_Rocket\\Engine\\Preload\\Controller\\PreloadUrl",
+        "WP_Rocket\\Engine\\Preload\\Database\\Queries\\Cache",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Preload/Database/Queries/Cache.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Preload\\Database\\Queries",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Cache",
+          "extends": [
+            "AbstractQuery"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Database\\Queries\\AbstractQuery",
+        "WP_Rocket\\Logger\\Logger",
+        "WP_Rocket\\Engine\\Preload\\Database\\Rows\\CacheRow",
+        "WP_Rocket\\Engine\\Preload\\Database\\Schemas\\Cache"
+      ]
+    },
+    "inc/Engine/Preload/Database/Rows/CacheRow.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Preload\\Database\\Rows",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "CacheRow",
+          "extends": [
+            "Row"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\BerlinDB\\Database\\Row"
+      ]
+    },
+    "inc/Engine/Preload/Database/Schemas/Cache.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Preload\\Database\\Schemas",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Cache",
+          "extends": [
+            "Schema"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\BerlinDB\\Database\\Schema"
+      ]
+    },
+    "inc/Engine/Preload/Database/Tables/Cache.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Preload\\Database\\Tables",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Cache",
+          "extends": [
+            "AbstractTable"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Common\\Database\\Tables\\AbstractTable"
+      ]
+    },
+    "inc/Engine/Preload/Frontend/FetchSitemap.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Preload\\Frontend",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "FetchSitemap",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Preload\\Controller\\CheckExcludedTrait",
+        "WP_Rocket\\Engine\\Preload\\Controller\\Queue",
+        "WP_Rocket\\Engine\\Preload\\Database\\Queries\\Cache",
+        "CheckExcludedTrait"
+      ]
+    },
+    "inc/Engine/Preload/Frontend/SitemapParser.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Preload\\Frontend",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "SitemapParser",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "SimpleXMLElement"
+      ]
+    },
+    "inc/Engine/Preload/Frontend/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Preload\\Frontend",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Preload\\Controller\\CheckFinished",
+        "WP_Rocket\\Engine\\Preload\\Controller\\LoadInitialSitemap",
+        "WP_Rocket\\Engine\\Preload\\Controller\\PreloadUrl",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Preload/Links/AdminSubscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Preload\\Links",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AdminSubscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Preload/Links/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Preload\\Links",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider"
+      ]
+    },
+    "inc/Engine/Preload/Links/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Preload\\Links",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Filesystem_Direct",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Preload/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Preload",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider",
+        "WP_Rocket\\Engine\\Preload\\Activation\\Activation",
+        "WP_Rocket\\Engine\\Preload\\Admin\\Settings",
+        "WP_Rocket\\Engine\\Preload\\Admin\\Subscriber",
+        "WP_Rocket\\Engine\\Preload\\Controller\\CheckFinished",
+        "WP_Rocket\\Engine\\Preload\\Controller\\ClearCache",
+        "WP_Rocket\\Engine\\Preload\\Controller\\CrawlHomepage",
+        "WP_Rocket\\Engine\\Preload\\Controller\\LoadInitialSitemap",
+        "WP_Rocket\\Engine\\Preload\\Controller\\PreloadUrl",
+        "WP_Rocket\\Engine\\Preload\\Controller\\Queue",
+        "WP_Rocket\\Engine\\Preload\\Cron\\Subscriber",
+        "WP_Rocket\\Engine\\Preload\\Database\\Queries\\Cache",
+        "WP_Rocket\\Engine\\Preload\\Database\\Tables\\Cache",
+        "WP_Rocket\\Engine\\Preload\\Frontend\\FetchSitemap",
+        "WP_Rocket\\Engine\\Preload\\Frontend\\SitemapParser",
+        "WP_Rocket\\Engine\\Preload\\Frontend\\Subscriber",
+        "WP_Rocket_Mobile_Detect"
+      ]
+    },
+    "inc/Engine/Preload/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Preload",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface",
+            "LoggerAwareInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Post",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Preload\\Activation\\Activation",
+        "WP_Rocket\\Engine\\Preload\\Controller\\CheckExcludedTrait",
+        "WP_Rocket\\Engine\\Preload\\Controller\\ClearCache",
+        "WP_Rocket\\Engine\\Preload\\Controller\\LoadInitialSitemap",
+        "WP_Rocket\\Engine\\Preload\\Controller\\Queue",
+        "WP_Rocket\\Engine\\Preload\\Database\\Queries\\Cache",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket_Mobile_Detect",
+        "WP_Rocket\\Logger\\LoggerAware",
+        "WP_Rocket\\Logger\\LoggerAwareInterface",
+        "WP_Rocket\\Engine\\Common\\Utils",
+        "LoggerAware",
+        "CheckExcludedTrait"
+      ]
+    },
+    "inc/Engine/Saas/Admin/AdminBar.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Saas\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AdminBar",
+          "extends": [
+            "Abstract_Render"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Admin_Bar",
+        "WP_Rocket\\Abstract_Render",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Admin\\Settings\\AdminBarMenuTrait",
+        "WP_Rocket\\Engine\\Common\\Context\\ContextInterface",
+        "AdminBarMenuTrait"
+      ]
+    },
+    "inc/Engine/Saas/Admin/Clean.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Saas\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Clean",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Admin\\Settings\\DataClearingTrait",
+        "DataClearingTrait"
+      ]
+    },
+    "inc/Engine/Saas/Admin/Notices.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Saas\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Notices",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Admin\\Beacon\\Beacon",
+        "WP_Rocket\\Engine\\Common\\Context\\ContextInterface"
+      ]
+    },
+    "inc/Engine/Saas/Admin/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Saas\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Admin_Bar",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Saas/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Saas",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal\\StringArgument",
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider",
+        "WP_Rocket\\Engine\\Saas\\Admin\\AdminBar",
+        "WP_Rocket\\Engine\\Saas\\Admin\\Clean",
+        "WP_Rocket\\Engine\\Saas\\Admin\\Notices",
+        "WP_Rocket\\Engine\\Saas\\Admin\\Subscriber"
+      ]
+    },
+    "inc/Engine/Support/CommentTrait.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Support",
+      "symbols": [
+        {
+          "kind": "trait",
+          "name": "CommentTrait",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/Support/Data.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Support",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Data",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data"
+      ]
+    },
+    "inc/Engine/Support/Meta.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Support",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Meta",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket_Mobile_Detect"
+      ]
+    },
+    "inc/Engine/Support/Rest.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Support",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Rest",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_REST_Response",
+        "WP_Rocket\\Admin\\Options_Data"
+      ]
+    },
+    "inc/Engine/Support/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Support",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider",
+        "WP_Rocket_Mobile_Detect"
+      ]
+    },
+    "inc/Engine/Support/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Support",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/Engine/Tracking/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Tracking",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal\\StringArgument",
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider",
+        "WPMedia\\Mixpanel\\Optin",
+        "WPMedia\\Mixpanel\\TrackingPlugin"
+      ]
+    },
+    "inc/Engine/Tracking/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Tracking",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Managers\\Plan"
+      ]
+    },
+    "inc/Engine/Tracking/Tracking.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Tracking",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Tracking",
+          "extends": [
+            "Abstract_Render"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Abstract_Render",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\Database\\Rows\\RocketInsights",
+        "WP_Rocket\\Engine\\Common\\Utils",
+        "WPMedia\\Mixpanel\\Optin",
+        "WPMedia\\Mixpanel\\TrackingPlugin"
+      ]
+    },
+    "inc/Engine/Tracking/TrackingTrait.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Tracking",
+      "symbols": [
+        {
+          "kind": "trait",
+          "name": "TrackingTrait",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Engine/WPRocketUninstall.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "WPRocketUninstall",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\BerlinDB\\Database\\Table",
+        "WP_Rocket\\Engine\\Optimization\\RUCSS\\Database\\Tables\\UsedCSS",
+        "WP_Rocket\\Engine\\Preload\\Database\\Tables\\Cache",
+        "WP_Rocket\\Engine\\Media\\AboveTheFold\\Database\\Tables\\AboveTheFold",
+        "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Database\\Table\\LazyRenderContent",
+        "WP_Rocket\\Engine\\Media\\PreloadFonts\\Database\\Table\\PreloadFonts",
+        "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\Database\\Table\\PreconnectExternalDomains"
+      ]
+    },
+    "inc/Logger/HTMLFormatter.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Logger",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "HTMLFormatter",
+          "extends": [
+            "MonoHtmlFormatter"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\Monolog\\Formatter\\HtmlFormatter"
+      ]
+    },
+    "inc/Logger/Logger.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Logger",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Logger",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\Monolog\\Logger",
+        "WP_Rocket\\Dependencies\\Monolog\\Registry",
+        "WP_Rocket\\Dependencies\\Monolog\\Processor\\IntrospectionProcessor",
+        "WP_Rocket\\Dependencies\\Monolog\\Handler\\StreamHandler",
+        "WP_Rocket\\Dependencies\\Monolog\\Formatter\\LineFormatter",
+        "WP_Rocket\\Logger\\HTMLFormatter",
+        "WP_Rocket\\Logger\\StreamHandler"
+      ]
+    },
+    "inc/Logger/LoggerAware.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Logger",
+      "symbols": [
+        {
+          "kind": "trait",
+          "name": "LoggerAware",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Logger/LoggerAwareInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Logger",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "LoggerAwareInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/Logger/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Logger",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider"
+      ]
+    },
+    "inc/Logger/StreamHandler.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Logger",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "StreamHandler",
+          "extends": [
+            "MonoStreamHandler"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "UnexpectedValueException",
+        "WP_Rocket\\Dependencies\\Monolog\\Handler\\StreamHandler"
+      ]
+    },
+    "inc/Logger/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Logger",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\Logger\\Logger"
+      ]
+    },
+    "inc/Plugin.php": {
+      "language": "php",
+      "namespace": "WP_Rocket",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Plugin",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "Imagify_Partner",
+        "WP_Rocket\\Dependencies\\League\\Container\\Container",
+        "WP_Rocket\\Admin\\Options",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Admin\\API\\ServiceProvider",
+        "WP_Rocket\\Engine\\Common\\ExtractCSS\\ServiceProvider",
+        "WP_Rocket\\Engine\\Common\\Head\\ServiceProvider",
+        "WP_Rocket\\Engine\\Common\\JobManager\\ServiceProvider",
+        "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\ServiceProvider",
+        "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Admin\\ServiceProvider",
+        "WP_Rocket\\Event_Management\\Event_Manager",
+        "WP_Rocket\\Logger\\ServiceProvider",
+        "WP_Rocket\\ThirdParty\\Hostings\\HostResolver",
+        "WP_Rocket\\Addon\\ServiceProvider",
+        "WP_Rocket\\Addon\\Cloudflare\\ServiceProvider",
+        "WP_Rocket\\Addon\\Varnish\\ServiceProvider",
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal\\StringArgument",
+        "WP_Rocket\\Engine\\Admin\\Beacon\\ServiceProvider",
+        "WP_Rocket\\Engine\\Admin\\Database\\ServiceProvider",
+        "WP_Rocket\\Engine\\Admin\\ServiceProvider",
+        "WP_Rocket\\Engine\\Admin\\Settings\\ServiceProvider",
+        "WP_Rocket\\Engine\\Cache\\ServiceProvider",
+        "WP_Rocket\\Engine\\Capabilities\\ServiceProvider",
+        "WP_Rocket\\Engine\\CDN\\RocketCDN\\ServiceProvider",
+        "WP_Rocket\\Engine\\CDN\\ServiceProvider",
+        "WP_Rocket\\Engine\\CriticalPath\\ServiceProvider",
+        "WP_Rocket\\Engine\\HealthCheck\\ServiceProvider",
+        "WP_Rocket\\Engine\\Heartbeat\\ServiceProvider",
+        "WP_Rocket\\Engine\\License\\ServiceProvider",
+        "WP_Rocket\\Engine\\Media\\ServiceProvider",
+        "WP_Rocket\\Engine\\Media\\AboveTheFold\\ServiceProvider",
+        "WP_Rocket\\Engine\\Optimization\\AdminServiceProvider",
+        "WP_Rocket\\Engine\\Optimization\\DeferJS\\ServiceProvider",
+        "WP_Rocket\\Engine\\Optimization\\DelayJS\\ServiceProvider",
+        "WP_Rocket\\Engine\\Optimization\\DynamicLists\\ServiceProvider",
+        "WP_Rocket\\Engine\\Optimization\\RUCSS\\ServiceProvider",
+        "WP_Rocket\\Engine\\Optimization\\ServiceProvider",
+        "WP_Rocket\\Engine\\Plugin\\ServiceProvider",
+        "WP_Rocket\\Engine\\Preload\\Links\\ServiceProvider",
+        "WP_Rocket\\Engine\\Preload\\ServiceProvider",
+        "WP_Rocket\\Engine\\Saas\\ServiceProvider",
+        "WP_Rocket\\Engine\\Support\\ServiceProvider",
+        "WP_Rocket\\ServiceProvider\\Common_Subscribers",
+        "WP_Rocket\\ServiceProvider\\Options",
+        "WP_Rocket\\ThirdParty\\Hostings\\ServiceProvider",
+        "WP_Rocket\\ThirdParty\\ServiceProvider",
+        "WP_Rocket\\ThirdParty\\Themes\\ServiceProvider",
+        "WP_Rocket\\Engine\\Admin\\DomainChange\\ServiceProvider",
+        "WP_Rocket\\ThirdParty\\Themes\\ThemeResolver",
+        "WP_Rocket\\Engine\\Debug\\Resolver",
+        "WP_Rocket\\Engine\\Debug\\ServiceProvider",
+        "WP_Rocket\\Engine\\Common\\PerformanceHints\\ServiceProvider",
+        "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\ServiceProvider",
+        "WP_Rocket\\Engine\\Media\\Fonts\\ServiceProvider",
+        "WP_Rocket\\Engine\\Media\\PreloadFonts\\ServiceProvider",
+        "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\ServiceProvider",
+        "WP_Rocket\\Engine\\Tracking\\ServiceProvider",
+        "WP_Rocket\\Engine\\Admin\\RocketInsights\\ServiceProvider"
+      ]
+    },
+    "inc/ThirdParty/Hostings/AbstractNoCacheHost.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Hostings",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AbstractNoCacheHost",
+          "extends": [],
+          "implements": [
+            "ActivationInterface",
+            "DeactivationInterface",
+            "Event_Manager_Aware_Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Activation\\ActivationInterface",
+        "WP_Rocket\\Engine\\Deactivation\\DeactivationInterface",
+        "WP_Rocket\\Event_Management\\Event_Manager",
+        "WP_Rocket\\Event_Management\\Event_Manager_Aware_Subscriber_Interface",
+        "WP_Rocket\\ThirdParty\\ReturnTypesTrait",
+        "ReturnTypesTrait"
+      ]
+    },
+    "inc/ThirdParty/Hostings/Cloudways.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Hostings",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Cloudways",
+          "extends": [
+            "NullSubscriber"
+          ],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\ThirdParty\\NullSubscriber"
+      ]
+    },
+    "inc/ThirdParty/Hostings/Dreampress.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Hostings",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Dreampress",
+          "extends": [
+            "AbstractNoCacheHost"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/ThirdParty/Hostings/Godaddy.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Hostings",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Godaddy",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\ThirdParty\\ReturnTypesTrait",
+        "ReturnTypesTrait"
+      ]
+    },
+    "inc/ThirdParty/Hostings/HostResolver.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Hostings",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "HostResolver",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/ThirdParty/Hostings/HostSubscriberFactory.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Hostings",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "HostSubscriberFactory",
+          "extends": [],
+          "implements": [
+            "SubscriberFactoryInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\ThirdParty\\NullSubscriber",
+        "WP_Rocket\\ThirdParty\\SubscriberFactoryInterface"
+      ]
+    },
+    "inc/ThirdParty/Hostings/Kinsta.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Hostings",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Kinsta",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\ThirdParty\\ReturnTypesTrait",
+        "ReturnTypesTrait"
+      ]
+    },
+    "inc/ThirdParty/Hostings/LiteSpeed.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Hostings",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "LiteSpeed",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Hostings/O2Switch.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Hostings",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "O2Switch",
+          "extends": [
+            "NullSubscriber"
+          ],
+          "implements": [
+            "Subscriber_Interface",
+            "ActivationInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Activation\\ActivationInterface",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\ThirdParty\\NullSubscriber",
+        "WP_Rocket\\ThirdParty\\ReturnTypesTrait",
+        "ReturnTypesTrait"
+      ]
+    },
+    "inc/ThirdParty/Hostings/OneCom.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Hostings",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "OneCom",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\ThirdParty\\ReturnTypesTrait",
+        "ReturnTypesTrait"
+      ]
+    },
+    "inc/ThirdParty/Hostings/Pressable.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Hostings",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Pressable",
+          "extends": [
+            "AbstractNoCacheHost"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/ThirdParty/Hostings/Pressidium.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Hostings",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Pressidium",
+          "extends": [
+            "AbstractNoCacheHost"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "NinukisCaching",
+        "WP_Post",
+        "WP_Rocket\\ThirdParty\\ReturnTypesTrait",
+        "ReturnTypesTrait"
+      ]
+    },
+    "inc/ThirdParty/Hostings/ProIsp.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Hostings",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ProIsp",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Hostings/Savvii.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Hostings",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Savvii",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "Savvii\\CacheFlusherPlugin",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\ThirdParty\\ReturnTypesTrait",
+        "ReturnTypesTrait"
+      ]
+    },
+    "inc/ThirdParty/Hostings/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Hostings",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": [
+            "BootableServiceProviderInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider",
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\BootableServiceProviderInterface",
+        "WP_Rocket\\ThirdParty\\Hostings\\HostResolver",
+        "WP_Rocket\\ThirdParty\\Hostings\\HostSubscriberFactory"
+      ]
+    },
+    "inc/ThirdParty/Hostings/SpinUpWP.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Hostings",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "SpinUpWP",
+          "extends": [
+            "NullSubscriber"
+          ],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\ThirdParty\\NullSubscriber",
+        "WP_Rocket\\ThirdParty\\ReturnTypesTrait",
+        "WP_Term",
+        "ReturnTypesTrait"
+      ]
+    },
+    "inc/ThirdParty/Hostings/WPEngine.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Hostings",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "WPEngine",
+          "extends": [
+            "AbstractNoCacheHost"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WpeCommon"
+      ]
+    },
+    "inc/ThirdParty/Hostings/WPXCloud.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Hostings",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "WPXCloud",
+          "extends": [
+            "AbstractNoCacheHost"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\ThirdParty\\ReturnTypesTrait"
+      ]
+    },
+    "inc/ThirdParty/Hostings/WordPressCom.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Hostings",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "WordPressCom",
+          "extends": [
+            "AbstractNoCacheHost"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/ThirdParty/NullSubscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "NullSubscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Plugins/Ads/Adthrive.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins\\Ads",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Adthrive",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Plugins/CDN/Cloudflare.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins\\CDN",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Cloudflare",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface",
+            "DeactivationInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Admin\\Beacon\\Beacon",
+        "WP_Rocket\\Engine\\Deactivation\\DeactivationInterface",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\Engine\\Common\\Utils"
+      ]
+    },
+    "inc/ThirdParty/Plugins/CDN/CloudflareFacade.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins\\CDN",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "CloudflareFacade",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/ThirdParty/Plugins/ContactForm7.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ContactForm7",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Plugins/ConvertPlug.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ConvertPlug",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Plugins/Cookie/Termly.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins\\Cookie",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Termly",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Plugins/EWWW.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "EWWW",
+          "extends": [],
+          "implements": [
+            "Webp_Interface",
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\Subscriber\\Third_Party\\Plugins\\Images\\Webp\\Webp_Common",
+        "WP_Rocket\\Subscriber\\Third_Party\\Plugins\\Images\\Webp\\Webp_Interface",
+        "WP_Rocket\\ThirdParty\\ReturnTypesTrait",
+        "Webp_Common",
+        "ReturnTypesTrait"
+      ]
+    },
+    "inc/ThirdParty/Plugins/Ecommerce/BigCommerce.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins\\Ecommerce",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "BigCommerce",
+          "extends": [],
+          "implements": [
+            "Event_Manager_Aware_Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Post",
+        "WP_Rocket\\Event_Management\\Event_Manager",
+        "WP_Rocket\\Event_Management\\Event_Manager_Aware_Subscriber_Interface",
+        "WP_Rocket\\Traits\\Config_Updater",
+        "Config_Updater"
+      ]
+    },
+    "inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins\\Ecommerce",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "WooCommerceSubscriber",
+          "extends": [],
+          "implements": [
+            "Event_Manager_Aware_Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Post",
+        "WP_Rocket\\Engine\\Optimization\\DelayJS\\HTML",
+        "WP_Rocket\\Event_Management\\Event_Manager",
+        "WP_Rocket\\Event_Management\\Event_Manager_Aware_Subscriber_Interface",
+        "WP_Rocket\\Traits\\Config_Updater",
+        "Config_Updater"
+      ]
+    },
+    "inc/ThirdParty/Plugins/I18n/TranslatePress.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins\\I18n",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "TranslatePress",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "TRP_Translate_Press",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Plugins/I18n/WPML.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins\\I18n",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "WPML",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Filesystem_Direct",
+        "WP_Rocket\\ThirdParty\\ReturnTypesTrait",
+        "ReturnTypesTrait"
+      ]
+    },
+    "inc/ThirdParty/Plugins/I18n/Weglot.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins\\I18n",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Weglot",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Plugins/InlineRelatedPosts.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "InlineRelatedPosts",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Plugins/Jetpack.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Jetpack",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\ThirdParty\\ReturnTypesTrait",
+        "ReturnTypesTrait"
+      ]
+    },
+    "inc/ThirdParty/Plugins/ModPagespeed.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ModPagespeed",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Plugins/Optimization/AMP.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins\\Optimization",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AMP",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\CDN\\Subscriber",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Plugins/Optimization/Autoptimize.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins\\Optimization",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Autoptimize",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Plugins/Optimization/Ezoic.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins\\Optimization",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Ezoic",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Plugins/Optimization/Hummingbird.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins\\Optimization",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Hummingbird",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Hummingbird_Settings",
+        "WP_Hummingbird_Utils",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Plugins/Optimization/Perfmatters.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins\\Optimization",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Perfmatters",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Plugins/Optimization/RapidLoad.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins\\Optimization",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "RapidLoad",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Plugins/Optimization/RocketLazyLoad.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins\\Optimization",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "RocketLazyLoad",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Plugins/Optimization/WPMeteor.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins\\Optimization",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "WPMeteor",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Plugins/Optimole.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Optimole",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\ThirdParty\\ReturnTypesTrait",
+        "ReturnTypesTrait"
+      ]
+    },
+    "inc/ThirdParty/Plugins/PDFEmbedder.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "PDFEmbedder",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Plugins/PWA.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "PWA",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Plugins/PageBuilder/BeaverBuilder.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins\\PageBuilder",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "BeaverBuilder",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Plugins/PageBuilder/Elementor.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins\\PageBuilder",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Elementor",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\Engine\\Optimization\\DelayJS\\HTML"
+      ]
+    },
+    "inc/ThirdParty/Plugins/RevolutionSlider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "RevolutionSlider",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "Smush\\Core\\Settings",
+        "WP_Rocket\\Admin\\Options",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Plugins/SEO/AllInOneSEOPack.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins\\SEO",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "AllInOneSEOPack",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Plugins/SEO/RankMathSEO.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins\\SEO",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "RankMathSEO",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "RankMath\\Helper",
+        "RankMath\\Sitemap\\Router",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Plugins/SEO/SEOPress.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins\\SEO",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "SEOPress",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Plugins/SEO/TheSEOFramework.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins\\SEO",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "TheSEOFramework",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "The_SEO_Framework\\Bridges\\Sitemap",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Plugins/SEO/Yoast.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins\\SEO",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Yoast",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Plugins/Security/WordFenceCompatibility.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins\\Security",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "WordFenceCompatibility",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "wordfence",
+        "wfConfig"
+      ]
+    },
+    "inc/ThirdParty/Plugins/ShortPixel.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ShortPixel",
+          "extends": [],
+          "implements": [
+            "Webp_Interface",
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\Subscriber\\Third_Party\\Plugins\\Images\\Webp\\Webp_Common",
+        "WP_Rocket\\Subscriber\\Third_Party\\Plugins\\Images\\Webp\\Webp_Interface",
+        "WP_Rocket\\ThirdParty\\ReturnTypesTrait",
+        "Webp_Common",
+        "ReturnTypesTrait"
+      ]
+    },
+    "inc/ThirdParty/Plugins/SimpleCustomCss.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "SimpleCustomCss",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Engine\\Optimization\\CSSTrait",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "CSSTrait"
+      ]
+    },
+    "inc/ThirdParty/Plugins/Smush.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Smush",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "Smush\\Core\\Settings",
+        "WP_Rocket\\Admin\\Options",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\ThirdParty\\ReturnTypesTrait",
+        "ReturnTypesTrait"
+      ]
+    },
+    "inc/ThirdParty/Plugins/TheEventsCalendar.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "TheEventsCalendar",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Plugins/ThirstyAffiliates.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ThirstyAffiliates",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Plugins/UnlimitedElements.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "UnlimitedElements",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Plugins/WPGeotargeting.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Plugins",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "WPGeotargeting",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\ThirdParty\\ReturnTypesTrait",
+        "ReturnTypesTrait"
+      ]
+    },
+    "inc/ThirdParty/ReturnTypesTrait.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty",
+      "symbols": [
+        {
+          "kind": "trait",
+          "name": "ReturnTypesTrait",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/ThirdParty/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal\\StringArgument",
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider",
+        "WP_Rocket\\Subscriber\\Third_Party\\Plugins\\Images\\Webp\\Imagify_Subscriber",
+        "WP_Rocket\\Subscriber\\Third_Party\\Plugins\\Images\\Webp\\Optimus_Subscriber",
+        "WP_Rocket\\Subscriber\\Third_Party\\Plugins\\Mobile_Subscriber",
+        "WP_Rocket\\Subscriber\\Third_Party\\Plugins\\NGG_Subscriber",
+        "WP_Rocket\\Subscriber\\Third_Party\\Plugins\\SyntaxHighlighter_Subscriber",
+        "WP_Rocket\\ThirdParty\\Plugins\\Ads\\Adthrive",
+        "WP_Rocket\\ThirdParty\\Plugins\\ConvertPlug",
+        "WP_Rocket\\ThirdParty\\Plugins\\Cookie\\Termly",
+        "WP_Rocket\\ThirdParty\\Plugins\\Ecommerce\\BigCommerce",
+        "WP_Rocket\\ThirdParty\\Plugins\\Ecommerce\\WooCommerceSubscriber",
+        "WP_Rocket\\ThirdParty\\Plugins\\EWWW",
+        "WP_Rocket\\ThirdParty\\Plugins\\I18n\\TranslatePress",
+        "WP_Rocket\\ThirdParty\\Plugins\\I18n\\WPML",
+        "WP_Rocket\\ThirdParty\\Plugins\\InlineRelatedPosts",
+        "WP_Rocket\\ThirdParty\\Plugins\\ModPagespeed",
+        "WP_Rocket\\ThirdParty\\Plugins\\Optimization\\AMP",
+        "WP_Rocket\\ThirdParty\\Plugins\\Optimization\\Autoptimize",
+        "WP_Rocket\\ThirdParty\\Plugins\\Optimization\\Ezoic",
+        "WP_Rocket\\ThirdParty\\Plugins\\Optimization\\WPMeteor",
+        "WP_Rocket\\ThirdParty\\Plugins\\Optimole",
+        "WP_Rocket\\ThirdParty\\Plugins\\PageBuilder\\BeaverBuilder",
+        "WP_Rocket\\ThirdParty\\Plugins\\PageBuilder\\Elementor",
+        "WP_Rocket\\ThirdParty\\Plugins\\PDFEmbedder",
+        "WP_Rocket\\ThirdParty\\Plugins\\PWA",
+        "WP_Rocket\\ThirdParty\\Plugins\\RevolutionSlider",
+        "WP_Rocket\\ThirdParty\\Plugins\\Security\\WordFenceCompatibility",
+        "WP_Rocket\\ThirdParty\\Plugins\\ShortPixel",
+        "WP_Rocket\\ThirdParty\\Plugins\\SEO\\Yoast",
+        "WP_Rocket\\ThirdParty\\Plugins\\SimpleCustomCss",
+        "WP_Rocket\\ThirdParty\\Plugins\\Smush",
+        "WP_Rocket\\ThirdParty\\Plugins\\TheEventsCalendar",
+        "WP_Rocket\\ThirdParty\\Plugins\\ThirstyAffiliates",
+        "WP_Rocket\\ThirdParty\\Plugins\\UnlimitedElements",
+        "WP_Rocket\\ThirdParty\\Plugins\\CDN\\Cloudflare",
+        "WP_Rocket\\ThirdParty\\Plugins\\CDN\\CloudflareFacade",
+        "WP_Rocket\\ThirdParty\\Plugins\\Jetpack",
+        "WP_Rocket\\ThirdParty\\Plugins\\WPGeotargeting",
+        "WP_Rocket\\ThirdParty\\Plugins\\ContactForm7",
+        "WP_Rocket\\ThirdParty\\Plugins\\SEO\\RankMathSEO",
+        "WP_Rocket\\ThirdParty\\Plugins\\SEO\\AllInOneSEOPack",
+        "WP_Rocket\\ThirdParty\\Plugins\\SEO\\SEOPress",
+        "WP_Rocket\\ThirdParty\\Plugins\\SEO\\TheSEOFramework",
+        "WP_Rocket\\ThirdParty\\Plugins\\Optimization\\RocketLazyLoad",
+        "WP_Rocket\\ThirdParty\\Plugins\\Optimization\\Perfmatters",
+        "WP_Rocket\\ThirdParty\\Plugins\\Optimization\\RapidLoad",
+        "WP_Rocket\\ThirdParty\\Plugins\\I18n\\Weglot"
+      ]
+    },
+    "inc/ThirdParty/SubscriberFactoryInterface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "SubscriberFactoryInterface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Themes/Avada.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Themes",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Avada",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Themes/Bridge.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Themes",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Bridge",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\ThirdParty\\ReturnTypesTrait",
+        "ReturnTypesTrait"
+      ]
+    },
+    "inc/ThirdParty/Themes/Divi.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Themes",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Divi",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Engine\\Optimization\\DelayJS\\HTML",
+        "WP_Rocket\\Engine\\Optimization\\RUCSS\\Controller\\UsedCSS",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Themes/Flatsome.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Themes",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Flatsome",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Themes/GeneratePress.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Themes",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "GeneratePress",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Themes/Jevelin.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Themes",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Jevelin",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Themes/MinimalistBlogger.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Themes",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "MinimalistBlogger",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Themes/Polygon.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Themes",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Polygon",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Themes/ServiceProvider.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Themes",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ServiceProvider",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": [
+            "BootableServiceProviderInterface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider",
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\BootableServiceProviderInterface"
+      ]
+    },
+    "inc/ThirdParty/Themes/Shoptimizer.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Themes",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Shoptimizer",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Themes/SubscriberFactory.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Themes",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "SubscriberFactory",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/ThirdParty/Themes/ThemeResolver.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Themes",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "ThemeResolver",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/ThirdParty/Themes/Themify.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Themes",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Themify",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Themes/Uncode.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Themes",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Uncode",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/ThirdParty/Themes/Xstore.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ThirdParty\\Themes",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Xstore",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/admin/admin.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/admin/options.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/admin/ui/enqueue.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/admin/ui/meta-boxes.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/admin/ui/notices.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/admin/upgrader.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": [
+        "WP_Rocket\\Logger\\Logger"
+      ]
+    },
+    "inc/classes/Buffer/class-abstract-buffer.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Buffer",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Abstract_Buffer",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Logger\\Logger"
+      ]
+    },
+    "inc/classes/Buffer/class-cache.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Buffer",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Cache",
+          "extends": [
+            "Abstract_Buffer"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/classes/Buffer/class-config.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Buffer",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Config",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "\\WP_Rocket\\Traits\\Memoize"
+      ]
+    },
+    "inc/classes/Buffer/class-tests.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Buffer",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Tests",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "\\WP_Rocket\\Traits\\Memoize"
+      ]
+    },
+    "inc/classes/ServiceProvider/class-common-subscribers.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ServiceProvider",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Common_Subscribers",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider",
+        "WP_Rocket\\Subscriber\\Tools\\Detect_Missing_Tags_Subscriber"
+      ]
+    },
+    "inc/classes/ServiceProvider/class-options.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\ServiceProvider",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Options",
+          "extends": [
+            "AbstractServiceProvider"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider",
+        "WP_Rocket\\Admin\\Options_Data"
+      ]
+    },
+    "inc/classes/admin/class-abstract-options.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Abstract_Options",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/classes/admin/class-logs.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Logs",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Logger\\Logger",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/classes/admin/class-options-data.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Options_Data",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/classes/admin/class-options.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Admin",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Options",
+          "extends": [
+            "Abstract_Options"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/classes/class-abstract-render.php": {
+      "language": "php",
+      "namespace": "WP_Rocket",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Abstract_Render",
+          "extends": [],
+          "implements": [
+            "Render_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Interfaces\\Render_Interface"
+      ]
+    },
+    "inc/classes/class-wp-rocket-requirements-check.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "WP_Rocket_Requirements_Check",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/classes/dependencies/mobiledetect/mobiledetectlib/Mobile_Detect.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "WP_Rocket_Mobile_Detect",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/classes/dependencies/wp-media/background-processing/wp-async-request.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "WP_Rocket_WP_Async_Request",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/classes/dependencies/wp-media/background-processing/wp-background-process.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "WP_Rocket_WP_Background_Process",
+          "extends": [
+            "WP_Rocket_WP_Async_Request"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/classes/event-management/class-event-manager.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Event_Management",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Event_Manager",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/classes/event-management/event-manager-aware-subscriber-interface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Event_Management",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "Event_Manager_Aware_Subscriber_Interface",
+          "extends": [
+            "Subscriber_Interface"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/classes/event-management/subscriber-interface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Event_Management",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "Subscriber_Interface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/classes/interfaces/class-render-interface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Interfaces",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "Render_Interface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/classes/logger/class-html-formatter.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/classes/logger/class-logger.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/classes/logger/class-stream-handler.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/classes/subscriber/Tools/class-detect-missing-tags-subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Subscriber\\Tools",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Detect_Missing_Tags_Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\Logger\\Logger"
+      ]
+    },
+    "inc/classes/subscriber/third-party/plugins/Images/Webp/class-imagify-subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Subscriber\\Third_Party\\Plugins\\Images\\Webp",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Imagify_Subscriber",
+          "extends": [],
+          "implements": [
+            "Webp_Interface",
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "Webp_Common"
+      ]
+    },
+    "inc/classes/subscriber/third-party/plugins/Images/Webp/class-optimus-subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Subscriber\\Third_Party\\Plugins\\Images\\Webp",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Optimus_Subscriber",
+          "extends": [],
+          "implements": [
+            "Webp_Interface",
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/classes/subscriber/third-party/plugins/Images/Webp/trait-webp-common.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Subscriber\\Third_Party\\Plugins\\Images\\Webp",
+      "symbols": [
+        {
+          "kind": "trait",
+          "name": "Webp_Common",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/classes/subscriber/third-party/plugins/Images/Webp/webp-interface.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Subscriber\\Third_Party\\Plugins\\Images\\Webp",
+      "symbols": [
+        {
+          "kind": "interface",
+          "name": "Webp_Interface",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/classes/subscriber/third-party/plugins/class-mobile-subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Subscriber\\Third_Party\\Plugins",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Mobile_Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/classes/subscriber/third-party/plugins/class-ngg-subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Subscriber\\Third_Party\\Plugins",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "NGG_Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/classes/subscriber/third-party/plugins/class-syntaxhighlighter-subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Subscriber\\Third_Party\\Plugins",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "SyntaxHighlighter_Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface"
+      ]
+    },
+    "inc/classes/traits/trait-config-updater.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Traits",
+      "symbols": [
+        {
+          "kind": "trait",
+          "name": "Config_Updater",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/classes/traits/trait-memoize.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Traits",
+      "symbols": [
+        {
+          "kind": "trait",
+          "name": "Memoize",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/common/admin-bar.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/common/purge.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/compat.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/constants.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/deprecated/3.10.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/deprecated/3.11.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/deprecated/3.12.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/deprecated/3.13.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/deprecated/3.14.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/deprecated/3.15.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/deprecated/3.2.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/deprecated/3.20.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/deprecated/3.3.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/deprecated/3.4.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/deprecated/3.5.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/deprecated/3.6.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/deprecated/3.7.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/deprecated/3.8.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/deprecated/3.9.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/deprecated/DeprecatedClassTrait.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\deprecated",
+      "symbols": [
+        {
+          "kind": "trait",
+          "name": "DeprecatedClassTrait",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/deprecated/Engine/Addon/Busting/BustingFactory.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Addon\\Busting",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "BustingFactory",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\deprecated\\DeprecatedClassTrait",
+        "WP_Rocket\\Addon\\GoogleTracking\\GoogleAnalytics",
+        "WP_Rocket\\Addon\\GoogleTracking\\GoogleTagManager",
+        "WP_Rocket\\Busting\\Facebook_Pickles",
+        "WP_Rocket\\Busting\\Facebook_SDK",
+        "DeprecatedClassTrait"
+      ]
+    },
+    "inc/deprecated/Engine/Addon/Busting/FileBustingTrait.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Addon\\Busting",
+      "symbols": [
+        {
+          "kind": "trait",
+          "name": "FileBustingTrait",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Logger\\Logger"
+      ]
+    },
+    "inc/deprecated/Engine/Addon/FacebookTracking/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Addon\\FacebookTracking",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\deprecated\\DeprecatedClassTrait",
+        "WP_Rocket\\Addon\\Busting\\BustingFactory",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\Admin\\Options_Data",
+        "DeprecatedClassTrait"
+      ]
+    },
+    "inc/deprecated/Engine/Addon/GoogleTracking/GoogleAnalytics.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Addon\\GoogleTracking",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "GoogleAnalytics",
+          "extends": [
+            "Abstract_Busting"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\deprecated\\DeprecatedClassTrait",
+        "WP_Rocket\\Addon\\Busting\\FileBustingTrait",
+        "WP_Rocket\\Busting\\Abstract_Busting",
+        "WP_Rocket\\Logger\\Logger",
+        "FileBustingTrait",
+        "DeprecatedClassTrait"
+      ]
+    },
+    "inc/deprecated/Engine/Addon/GoogleTracking/GoogleTagManager.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Addon\\GoogleTracking",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "GoogleTagManager",
+          "extends": [
+            "Abstract_Busting"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\deprecated\\DeprecatedClassTrait",
+        "WP_Rocket\\Addon\\Busting\\FileBustingTrait",
+        "WP_Rocket\\Logger\\Logger",
+        "WP_Rocket\\Busting\\Abstract_Busting",
+        "WP_Filesystem_Direct",
+        "FileBustingTrait",
+        "DeprecatedClassTrait"
+      ]
+    },
+    "inc/deprecated/Engine/Addon/GoogleTracking/Subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Addon\\GoogleTracking",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\deprecated\\DeprecatedClassTrait",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\Addon\\Busting\\BustingFactory",
+        "WP_Rocket\\Admin\\Options_Data",
+        "DeprecatedClassTrait"
+      ]
+    },
+    "inc/deprecated/Engine/Media/Embeds/EmbedsSubscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\deprecated\\Engine\\Media\\Embeds",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "EmbedsSubscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\deprecated\\DeprecatedClassTrait",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\ThirdParty\\ReturnTypesTrait",
+        "DeprecatedClassTrait",
+        "ReturnTypesTrait"
+      ]
+    },
+    "inc/deprecated/Engine/Optimization/QueryString/Remove.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\QueryString",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Remove",
+          "extends": [
+            "AbstractOptimization"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\deprecated\\DeprecatedClassTrait",
+        "WP_Rocket\\Engine\\Optimization\\AbstractOptimization",
+        "WP_Rocket\\Engine\\Optimization\\CSSTrait",
+        "DeprecatedClassTrait",
+        "CSSTrait"
+      ]
+    },
+    "inc/deprecated/Engine/Optimization/QueryString/RemoveSubscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Engine\\Optimization\\QueryString",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "RemoveSubscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\deprecated\\DeprecatedClassTrait",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "DeprecatedClassTrait"
+      ]
+    },
+    "inc/deprecated/classes/busting/class-abstract-busting.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Busting",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Abstract_Busting",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/deprecated/classes/busting/class-facebook-pickles.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Busting",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Facebook_Pickles",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\deprecated\\DeprecatedClassTrait",
+        "WP_Rocket\\Logger\\Logger",
+        "DeprecatedClassTrait"
+      ]
+    },
+    "inc/deprecated/classes/busting/class-facebook-sdk.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Busting",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Facebook_SDK",
+          "extends": [
+            "Abstract_Busting"
+          ],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\deprecated\\DeprecatedClassTrait",
+        "WP_Rocket\\Logger\\Logger",
+        "DeprecatedClassTrait"
+      ]
+    },
+    "inc/deprecated/deprecated.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": [
+        "WP_Rocket\\Dependencies\\Minify"
+      ]
+    },
+    "inc/deprecated/subscriber/Optimization/class-dequeue-jquery-migrate-subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Subscriber\\Optimization",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Dequeue_JQuery_Migrate_Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\deprecated\\DeprecatedClassTrait",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Scripts",
+        "DeprecatedClassTrait"
+      ]
+    },
+    "inc/deprecated/subscriber/admin/Optimization/class-minify-html-subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Subscriber\\Optimization",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Minify_HTML_Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\deprecated\\DeprecatedClassTrait",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Dependencies\\Minify",
+        "DeprecatedClassTrait"
+      ]
+    },
+    "inc/deprecated/subscriber/admin/Settings/class-beacon-subscriber.php": {
+      "language": "php",
+      "namespace": "WP_Rocket\\Subscriber\\Admin\\Settings",
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Beacon_Subscriber",
+          "extends": [],
+          "implements": [
+            "Subscriber_Interface"
+          ]
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\deprecated\\DeprecatedClassTrait",
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\Admin\\Settings\\Beacon",
+        "DeprecatedClassTrait"
+      ]
+    },
+    "inc/deprecated/vendors/classes/class-minify-html.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Minify_HTML",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": [
+        "WP_Rocket\\deprecated\\DeprecatedClassTrait",
+        "DeprecatedClassTrait"
+      ]
+    },
+    "inc/domain-mapping.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/front/cookie.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/front/dns-prefetch.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/front/process.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/functions/admin.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/functions/api.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/functions/files.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": [
+        "WP_Rocket\\Logger\\Logger",
+        "WP_Rocket\\Engine\\Cache\\AdvancedCache"
+      ]
+    },
+    "inc/functions/formatting.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/functions/htaccess.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/functions/i18n.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/functions/options.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": [
+        "WP_Rocket\\Admin\\Options",
+        "WP_Rocket\\Admin\\Options_Data",
+        "WP_Rocket\\Logger\\Logger"
+      ]
+    },
+    "inc/functions/posts.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": []
+    },
+    "inc/main.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [],
+      "imports": [
+        "WP_Rocket\\Addon\\Cloudflare\\Cloudflare",
+        "WP_Rocket\\Dependencies\\League\\Container\\Container",
+        "WP_Rocket\\Plugin"
+      ]
+    },
+    "inc/vendors/classes/class-imagify-partner.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Imagify_Partner",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/vendors/classes/class-minify-css-urirewriter.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Minify_CSS_UriRewriter",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "inc/vendors/classes/class-rocket-mobile-detect.php": {
+      "language": "php",
+      "namespace": null,
+      "symbols": [
+        {
+          "kind": "class",
+          "name": "Rocket_Mobile_Detect",
+          "extends": [],
+          "implements": []
+        }
+      ],
+      "imports": []
+    },
+    "src/js/custom/custom-select.js": {
+      "language": "js",
+      "imports": []
+    },
+    "src/js/custom/lazyload-css.js": {
+      "language": "js",
+      "imports": []
+    },
+    "src/js/global/ajax.js": {
+      "language": "js",
+      "imports": []
+    },
+    "src/js/global/app.js": {
+      "language": "js",
+      "imports": [
+        "../lib/greensock/TweenLite.min.js",
+        "../lib/greensock/TimelineLite.min.js",
+        "../lib/greensock/easing/EasePack.min.js",
+        "../lib/greensock/plugins/CSSPlugin.min.js",
+        "../lib/greensock/plugins/ScrollToPlugin.min.js",
+        "../global/pageManager.js",
+        "../global/main.js",
+        "../global/fields.js",
+        "../global/beacon.js",
+        "../global/ajax.js",
+        "../global/recommendations-widget.js",
+        "../global/rocketcdn.js",
+        "../global/countdown.js",
+        "../global/mixpanel.js"
+      ]
+    },
+    "src/js/global/beacon.js": {
+      "language": "js",
+      "imports": []
+    },
+    "src/js/global/countdown.js": {
+      "language": "js",
+      "imports": []
+    },
+    "src/js/global/fields.js": {
+      "language": "js",
+      "imports": [
+        "../custom/custom-select.js"
+      ]
+    },
+    "src/js/global/main.js": {
+      "language": "js",
+      "imports": []
+    },
+    "src/js/global/mixpanel.js": {
+      "language": "js",
+      "imports": []
+    },
+    "src/js/global/pageManager.js": {
+      "language": "js",
+      "imports": []
+    },
+    "src/js/global/recommendations-widget.js": {
+      "language": "js",
+      "imports": []
+    },
+    "src/js/global/rocket-insights.js": {
+      "language": "js",
+      "imports": []
+    },
+    "src/js/global/rocketcdn.js": {
+      "language": "js",
+      "imports": []
+    },
+    "src/js/gulp/gulpconfig.js": {
+      "language": "js",
+      "imports": []
+    },
+    "src/js/gulp/tasks/css.js": {
+      "language": "js",
+      "imports": [
+        "gulp",
+        "gulp-rename",
+        "gulp-sass",
+        "sass",
+        "../gulpconfig"
+      ]
+    },
+    "src/js/gulp/tasks/js.js": {
+      "language": "js",
+      "imports": [
+        "gulp",
+        "browserify",
+        "babelify",
+        "vinyl-source-stream",
+        "vinyl-buffer",
+        "gulp-sourcemaps",
+        "gulp-uglify",
+        "watchify",
+        "gulp-rename",
+        "../gulpconfig"
+      ]
+    },
+    "src/js/lib/greensock/TimelineLite.min.js": {
+      "language": "js",
+      "imports": []
+    },
+    "src/js/lib/greensock/TimelineMax.min.js": {
+      "language": "js",
+      "imports": []
+    },
+    "src/js/lib/greensock/TweenLite.min.js": {
+      "language": "js",
+      "imports": []
+    },
+    "src/js/lib/greensock/TweenMax.min.js": {
+      "language": "js",
+      "imports": []
+    },
+    "src/js/lib/greensock/easing/EasePack.min.js": {
+      "language": "js",
+      "imports": []
+    },
+    "src/js/lib/greensock/jquery.gsap.min.js": {
+      "language": "js",
+      "imports": []
+    },
+    "src/js/lib/greensock/plugins/AttrPlugin.min.js": {
+      "language": "js",
+      "imports": []
+    },
+    "src/js/lib/greensock/plugins/BezierPlugin.min.js": {
+      "language": "js",
+      "imports": []
+    },
+    "src/js/lib/greensock/plugins/CSSPlugin.min.js": {
+      "language": "js",
+      "imports": []
+    },
+    "src/js/lib/greensock/plugins/CSSRulePlugin.min.js": {
+      "language": "js",
+      "imports": []
+    },
+    "src/js/lib/greensock/plugins/ColorPropsPlugin.min.js": {
+      "language": "js",
+      "imports": []
+    },
+    "src/js/lib/greensock/plugins/DirectionalRotationPlugin.min.js": {
+      "language": "js",
+      "imports": []
+    },
+    "src/js/lib/greensock/plugins/EaselPlugin.min.js": {
+      "language": "js",
+      "imports": []
+    },
+    "src/js/lib/greensock/plugins/EndArrayPlugin.min.js": {
+      "language": "js",
+      "imports": []
+    },
+    "src/js/lib/greensock/plugins/KineticPlugin.min.js": {
+      "language": "js",
+      "imports": []
+    },
+    "src/js/lib/greensock/plugins/Physics2DPlugin.min.js": {
+      "language": "js",
+      "imports": []
+    },
+    "src/js/lib/greensock/plugins/PhysicsPropsPlugin.min.js": {
+      "language": "js",
+      "imports": []
+    },
+    "src/js/lib/greensock/plugins/RaphaelPlugin.min.js": {
+      "language": "js",
+      "imports": []
+    },
+    "src/js/lib/greensock/plugins/RoundPropsPlugin.min.js": {
+      "language": "js",
+      "imports": []
+    },
+    "src/js/lib/greensock/plugins/ScrambleTextPlugin.min.js": {
+      "language": "js",
+      "imports": []
+    },
+    "src/js/lib/greensock/plugins/ScrollToPlugin.min.js": {
+      "language": "js",
+      "imports": []
+    },
+    "src/js/lib/greensock/plugins/TextPlugin.min.js": {
+      "language": "js",
+      "imports": []
+    },
+    "src/js/lib/greensock/plugins/ThrowPropsPlugin.min.js": {
+      "language": "js",
+      "imports": []
+    },
+    "src/js/lib/greensock/utils/CSSTransform.min.js": {
+      "language": "js",
+      "imports": []
+    },
+    "src/js/lib/greensock/utils/Draggable.min.js": {
+      "language": "js",
+      "imports": []
+    },
+    "src/js/lib/greensock/utils/SplitText.min.js": {
+      "language": "js",
+      "imports": []
+    }
+  },
+  "symbol_index": {
+    "WP_Rocket\\Addon\\Cloudflare\\API\\Client": "inc/Addon/Cloudflare/API/Client.php",
+    "WP_Rocket\\Addon\\Cloudflare\\API\\Endpoints": "inc/Addon/Cloudflare/API/Endpoints.php",
+    "WP_Rocket\\Addon\\Cloudflare\\Admin\\Subscriber": "inc/Addon/Cloudflare/Admin/Subscriber.php",
+    "WP_Rocket\\Addon\\Cloudflare\\Auth\\APIKey": "inc/Addon/Cloudflare/Auth/APIKey.php",
+    "WPMedia\\Cloudflare\\Auth\\APIKeyFactory": "inc/Addon/Cloudflare/Auth/APIKeyFactory.php",
+    "WPMedia\\Cloudflare\\Auth\\AuthFactoryInterface": "inc/Addon/Cloudflare/Auth/AuthFactoryInterface.php",
+    "WP_Rocket\\Addon\\Cloudflare\\Auth\\AuthInterface": "inc/Addon/Cloudflare/Auth/AuthInterface.php",
+    "WP_Rocket\\Addon\\Cloudflare\\Cloudflare": "inc/Addon/Cloudflare/Cloudflare.php",
+    "WP_Rocket\\Addon\\Cloudflare\\ServiceProvider": "inc/Addon/Cloudflare/ServiceProvider.php",
+    "WP_Rocket\\Addon\\Cloudflare\\Subscriber": "inc/Addon/Cloudflare/Subscriber.php",
+    "WP_Rocket\\Addon\\ServiceProvider": "inc/Addon/ServiceProvider.php",
+    "WP_Rocket\\Addon\\Sucuri\\Subscriber": "inc/Addon/Sucuri/Subscriber.php",
+    "WP_Rocket\\Addon\\Varnish\\ServiceProvider": "inc/Addon/Varnish/ServiceProvider.php",
+    "WP_Rocket\\Addon\\Varnish\\Subscriber": "inc/Addon/Varnish/Subscriber.php",
+    "WP_Rocket\\Addon\\Varnish\\Varnish": "inc/Addon/Varnish/Varnish.php",
+    "WP_Rocket\\Addon\\WebP\\AbstractWebp": "inc/Addon/WebP/AbstractWebp.php",
+    "WP_Rocket\\Addon\\WebP\\AdminSubscriber": "inc/Addon/WebP/AdminSubscriber.php",
+    "WP_Rocket\\Addon\\WebP\\Subscriber": "inc/Addon/WebP/Subscriber.php",
+    "ActionScheduler_ActionClaim": "inc/Dependencies/ActionScheduler/classes/ActionScheduler_ActionClaim.php",
+    "ActionScheduler_ActionFactory": "inc/Dependencies/ActionScheduler/classes/ActionScheduler_ActionFactory.php",
+    "ActionScheduler_AdminView": "inc/Dependencies/ActionScheduler/classes/ActionScheduler_AdminView.php",
+    "ActionScheduler_AsyncRequest_QueueRunner": "inc/Dependencies/ActionScheduler/classes/ActionScheduler_AsyncRequest_QueueRunner.php",
+    "ActionScheduler_Compatibility": "inc/Dependencies/ActionScheduler/classes/ActionScheduler_Compatibility.php",
+    "ActionScheduler_DataController": "inc/Dependencies/ActionScheduler/classes/ActionScheduler_DataController.php",
+    "ActionScheduler_DateTime": "inc/Dependencies/ActionScheduler/classes/ActionScheduler_DateTime.php",
+    "ActionScheduler_Exception": "inc/Dependencies/ActionScheduler/classes/ActionScheduler_Exception.php",
+    "ActionScheduler_FatalErrorMonitor": "inc/Dependencies/ActionScheduler/classes/ActionScheduler_FatalErrorMonitor.php",
+    "ActionScheduler_InvalidActionException": "inc/Dependencies/ActionScheduler/classes/ActionScheduler_InvalidActionException.php",
+    "ActionScheduler_ListTable": "inc/Dependencies/ActionScheduler/classes/ActionScheduler_ListTable.php",
+    "ActionScheduler_LogEntry": "inc/Dependencies/ActionScheduler/classes/ActionScheduler_LogEntry.php",
+    "ActionScheduler_NullLogEntry": "inc/Dependencies/ActionScheduler/classes/ActionScheduler_NullLogEntry.php",
+    "ActionScheduler_OptionLock": "inc/Dependencies/ActionScheduler/classes/ActionScheduler_OptionLock.php",
+    "ActionScheduler_QueueCleaner": "inc/Dependencies/ActionScheduler/classes/ActionScheduler_QueueCleaner.php",
+    "ActionScheduler_QueueRunner": "inc/Dependencies/ActionScheduler/classes/ActionScheduler_QueueRunner.php",
+    "ActionScheduler_Versions": "inc/Dependencies/ActionScheduler/classes/ActionScheduler_Versions.php",
+    "ActionScheduler_WPCommentCleaner": "inc/Dependencies/ActionScheduler/classes/ActionScheduler_WPCommentCleaner.php",
+    "ActionScheduler_wcSystemStatus": "inc/Dependencies/ActionScheduler/classes/ActionScheduler_wcSystemStatus.php",
+    "ActionScheduler_WPCLI_Clean_Command": "inc/Dependencies/ActionScheduler/classes/WP_CLI/ActionScheduler_WPCLI_Clean_Command.php",
+    "ActionScheduler_WPCLI_QueueRunner": "inc/Dependencies/ActionScheduler/classes/WP_CLI/ActionScheduler_WPCLI_QueueRunner.php",
+    "ActionScheduler_WPCLI_Scheduler_command": "inc/Dependencies/ActionScheduler/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php",
+    "Action_Scheduler\\WP_CLI\\Migration_Command": "inc/Dependencies/ActionScheduler/classes/WP_CLI/Migration_Command.php",
+    "Action_Scheduler\\WP_CLI\\ProgressBar": "inc/Dependencies/ActionScheduler/classes/WP_CLI/ProgressBar.php",
+    "ActionScheduler": "inc/Dependencies/ActionScheduler/classes/abstracts/ActionScheduler.php",
+    "ActionScheduler_Abstract_ListTable": "inc/Dependencies/ActionScheduler/classes/abstracts/ActionScheduler_Abstract_ListTable.php",
+    "ActionScheduler_Abstract_QueueRunner": "inc/Dependencies/ActionScheduler/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php",
+    "ActionScheduler_Abstract_RecurringSchedule": "inc/Dependencies/ActionScheduler/classes/abstracts/ActionScheduler_Abstract_RecurringSchedule.php",
+    "ActionScheduler_Abstract_Schedule": "inc/Dependencies/ActionScheduler/classes/abstracts/ActionScheduler_Abstract_Schedule.php",
+    "ActionScheduler_Abstract_Schema": "inc/Dependencies/ActionScheduler/classes/abstracts/ActionScheduler_Abstract_Schema.php",
+    "ActionScheduler_Lock": "inc/Dependencies/ActionScheduler/classes/abstracts/ActionScheduler_Lock.php",
+    "ActionScheduler_Logger": "inc/Dependencies/ActionScheduler/classes/abstracts/ActionScheduler_Logger.php",
+    "ActionScheduler_Store": "inc/Dependencies/ActionScheduler/classes/abstracts/ActionScheduler_Store.php",
+    "ActionScheduler_TimezoneHelper": "inc/Dependencies/ActionScheduler/classes/abstracts/ActionScheduler_TimezoneHelper.php",
+    "ActionScheduler_Action": "inc/Dependencies/ActionScheduler/classes/actions/ActionScheduler_Action.php",
+    "ActionScheduler_CanceledAction": "inc/Dependencies/ActionScheduler/classes/actions/ActionScheduler_CanceledAction.php",
+    "ActionScheduler_FinishedAction": "inc/Dependencies/ActionScheduler/classes/actions/ActionScheduler_FinishedAction.php",
+    "ActionScheduler_NullAction": "inc/Dependencies/ActionScheduler/classes/actions/ActionScheduler_NullAction.php",
+    "ActionScheduler_DBLogger": "inc/Dependencies/ActionScheduler/classes/data-stores/ActionScheduler_DBLogger.php",
+    "ActionScheduler_DBStore": "inc/Dependencies/ActionScheduler/classes/data-stores/ActionScheduler_DBStore.php",
+    "ActionScheduler_HybridStore": "inc/Dependencies/ActionScheduler/classes/data-stores/ActionScheduler_HybridStore.php",
+    "ActionScheduler_wpCommentLogger": "inc/Dependencies/ActionScheduler/classes/data-stores/ActionScheduler_wpCommentLogger.php",
+    "ActionScheduler_wpPostStore": "inc/Dependencies/ActionScheduler/classes/data-stores/ActionScheduler_wpPostStore.php",
+    "ActionScheduler_wpPostStore_PostStatusRegistrar": "inc/Dependencies/ActionScheduler/classes/data-stores/ActionScheduler_wpPostStore_PostStatusRegistrar.php",
+    "ActionScheduler_wpPostStore_PostTypeRegistrar": "inc/Dependencies/ActionScheduler/classes/data-stores/ActionScheduler_wpPostStore_PostTypeRegistrar.php",
+    "ActionScheduler_wpPostStore_TaxonomyRegistrar": "inc/Dependencies/ActionScheduler/classes/data-stores/ActionScheduler_wpPostStore_TaxonomyRegistrar.php",
+    "Action_Scheduler\\Migration\\ActionMigrator": "inc/Dependencies/ActionScheduler/classes/migration/ActionMigrator.php",
+    "ActionScheduler_DBStoreMigrator": "inc/Dependencies/ActionScheduler/classes/migration/ActionScheduler_DBStoreMigrator.php",
+    "Action_Scheduler\\Migration\\BatchFetcher": "inc/Dependencies/ActionScheduler/classes/migration/BatchFetcher.php",
+    "Action_Scheduler\\Migration\\Config": "inc/Dependencies/ActionScheduler/classes/migration/Config.php",
+    "Action_Scheduler\\Migration\\Controller": "inc/Dependencies/ActionScheduler/classes/migration/Controller.php",
+    "Action_Scheduler\\Migration\\DryRun_ActionMigrator": "inc/Dependencies/ActionScheduler/classes/migration/DryRun_ActionMigrator.php",
+    "Action_Scheduler\\Migration\\DryRun_LogMigrator": "inc/Dependencies/ActionScheduler/classes/migration/DryRun_LogMigrator.php",
+    "Action_Scheduler\\Migration\\LogMigrator": "inc/Dependencies/ActionScheduler/classes/migration/LogMigrator.php",
+    "Action_Scheduler\\Migration\\Runner": "inc/Dependencies/ActionScheduler/classes/migration/Runner.php",
+    "Action_Scheduler\\Migration\\Scheduler": "inc/Dependencies/ActionScheduler/classes/migration/Scheduler.php",
+    "ActionScheduler_CanceledSchedule": "inc/Dependencies/ActionScheduler/classes/schedules/ActionScheduler_CanceledSchedule.php",
+    "ActionScheduler_CronSchedule": "inc/Dependencies/ActionScheduler/classes/schedules/ActionScheduler_CronSchedule.php",
+    "ActionScheduler_IntervalSchedule": "inc/Dependencies/ActionScheduler/classes/schedules/ActionScheduler_IntervalSchedule.php",
+    "ActionScheduler_NullSchedule": "inc/Dependencies/ActionScheduler/classes/schedules/ActionScheduler_NullSchedule.php",
+    "ActionScheduler_Schedule": "inc/Dependencies/ActionScheduler/classes/schedules/ActionScheduler_Schedule.php",
+    "ActionScheduler_SimpleSchedule": "inc/Dependencies/ActionScheduler/classes/schedules/ActionScheduler_SimpleSchedule.php",
+    "ActionScheduler_LoggerSchema": "inc/Dependencies/ActionScheduler/classes/schema/ActionScheduler_LoggerSchema.php",
+    "ActionScheduler_StoreSchema": "inc/Dependencies/ActionScheduler/classes/schema/ActionScheduler_StoreSchema.php",
+    "ActionScheduler_Abstract_QueueRunner_Deprecated": "inc/Dependencies/ActionScheduler/deprecated/ActionScheduler_Abstract_QueueRunner_Deprecated.php",
+    "ActionScheduler_AdminView_Deprecated": "inc/Dependencies/ActionScheduler/deprecated/ActionScheduler_AdminView_Deprecated.php",
+    "ActionScheduler_Schedule_Deprecated": "inc/Dependencies/ActionScheduler/deprecated/ActionScheduler_Schedule_Deprecated.php",
+    "ActionScheduler_Store_Deprecated": "inc/Dependencies/ActionScheduler/deprecated/ActionScheduler_Store_Deprecated.php",
+    "WP_Async_Request": "inc/Dependencies/ActionScheduler/lib/WP_Async_Request.php",
+    "CronExpression": "inc/Dependencies/ActionScheduler/lib/cron-expression/CronExpression.php",
+    "CronExpression_AbstractField": "inc/Dependencies/ActionScheduler/lib/cron-expression/CronExpression_AbstractField.php",
+    "CronExpression_DayOfMonthField": "inc/Dependencies/ActionScheduler/lib/cron-expression/CronExpression_DayOfMonthField.php",
+    "CronExpression_DayOfWeekField": "inc/Dependencies/ActionScheduler/lib/cron-expression/CronExpression_DayOfWeekField.php",
+    "CronExpression_FieldFactory": "inc/Dependencies/ActionScheduler/lib/cron-expression/CronExpression_FieldFactory.php",
+    "CronExpression_FieldInterface": "inc/Dependencies/ActionScheduler/lib/cron-expression/CronExpression_FieldInterface.php",
+    "CronExpression_HoursField": "inc/Dependencies/ActionScheduler/lib/cron-expression/CronExpression_HoursField.php",
+    "CronExpression_MinutesField": "inc/Dependencies/ActionScheduler/lib/cron-expression/CronExpression_MinutesField.php",
+    "CronExpression_MonthField": "inc/Dependencies/ActionScheduler/lib/cron-expression/CronExpression_MonthField.php",
+    "CronExpression_YearField": "inc/Dependencies/ActionScheduler/lib/cron-expression/CronExpression_YearField.php",
+    "WP_Rocket\\Dependencies\\BerlinDB\\Database\\Base": "inc/Dependencies/BerlinDB/Database/Base.php",
+    "WP_Rocket\\Dependencies\\BerlinDB\\Database\\Column": "inc/Dependencies/BerlinDB/Database/Column.php",
+    "WP_Rocket\\Dependencies\\BerlinDB\\Database\\Queries\\Compare": "inc/Dependencies/BerlinDB/Database/Queries/Compare.php",
+    "WP_Rocket\\Dependencies\\BerlinDB\\Database\\Queries\\Date": "inc/Dependencies/BerlinDB/Database/Queries/Date.php",
+    "WP_Rocket\\Dependencies\\BerlinDB\\Database\\Queries\\Meta": "inc/Dependencies/BerlinDB/Database/Queries/Meta.php",
+    "WP_Rocket\\Dependencies\\BerlinDB\\Database\\Query": "inc/Dependencies/BerlinDB/Database/Query.php",
+    "WP_Rocket\\Dependencies\\BerlinDB\\Database\\Row": "inc/Dependencies/BerlinDB/Database/Row.php",
+    "WP_Rocket\\Dependencies\\BerlinDB\\Database\\Schema": "inc/Dependencies/BerlinDB/Database/Schema.php",
+    "WP_Rocket\\Dependencies\\BerlinDB\\Database\\Table": "inc/Dependencies/BerlinDB/Database/Table.php",
+    "WP_Rocket\\Dependencies\\League\\Container\\Argument\\ArgumentInterface": "inc/Dependencies/League/Container/Argument/ArgumentInterface.php",
+    "WP_Rocket\\Dependencies\\League\\Container\\Argument\\ArgumentResolverInterface": "inc/Dependencies/League/Container/Argument/ArgumentResolverInterface.php",
+    "WP_Rocket\\Dependencies\\League\\Container\\Argument\\ArgumentResolverTrait": "inc/Dependencies/League/Container/Argument/ArgumentResolverTrait.php",
+    "WP_Rocket\\Dependencies\\League\\Container\\Argument\\DefaultValueArgument": "inc/Dependencies/League/Container/Argument/DefaultValueArgument.php",
+    "WP_Rocket\\Dependencies\\League\\Container\\Argument\\DefaultValueInterface": "inc/Dependencies/League/Container/Argument/DefaultValueInterface.php",
+    "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal\\ArrayArgument": "inc/Dependencies/League/Container/Argument/Literal/ArrayArgument.php",
+    "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal\\BooleanArgument": "inc/Dependencies/League/Container/Argument/Literal/BooleanArgument.php",
+    "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal\\CallableArgument": "inc/Dependencies/League/Container/Argument/Literal/CallableArgument.php",
+    "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal\\FloatArgument": "inc/Dependencies/League/Container/Argument/Literal/FloatArgument.php",
+    "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal\\IntegerArgument": "inc/Dependencies/League/Container/Argument/Literal/IntegerArgument.php",
+    "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal\\ObjectArgument": "inc/Dependencies/League/Container/Argument/Literal/ObjectArgument.php",
+    "WP_Rocket\\Dependencies\\League\\Container\\Argument\\Literal\\StringArgument": "inc/Dependencies/League/Container/Argument/Literal/StringArgument.php",
+    "WP_Rocket\\Dependencies\\League\\Container\\Argument\\LiteralArgument": "inc/Dependencies/League/Container/Argument/LiteralArgument.php",
+    "WP_Rocket\\Dependencies\\League\\Container\\Argument\\LiteralArgumentInterface": "inc/Dependencies/League/Container/Argument/LiteralArgumentInterface.php",
+    "WP_Rocket\\Dependencies\\League\\Container\\Argument\\ResolvableArgument": "inc/Dependencies/League/Container/Argument/ResolvableArgument.php",
+    "WP_Rocket\\Dependencies\\League\\Container\\Argument\\ResolvableArgumentInterface": "inc/Dependencies/League/Container/Argument/ResolvableArgumentInterface.php",
+    "WP_Rocket\\Dependencies\\League\\Container\\Container": "inc/Dependencies/League/Container/Container.php",
+    "WP_Rocket\\Dependencies\\League\\Container\\ContainerAwareInterface": "inc/Dependencies/League/Container/ContainerAwareInterface.php",
+    "WP_Rocket\\Dependencies\\League\\Container\\ContainerAwareTrait": "inc/Dependencies/League/Container/ContainerAwareTrait.php",
+    "WP_Rocket\\Dependencies\\League\\Container\\Definition\\Definition": "inc/Dependencies/League/Container/Definition/Definition.php",
+    "WP_Rocket\\Dependencies\\League\\Container\\Definition\\DefinitionAggregate": "inc/Dependencies/League/Container/Definition/DefinitionAggregate.php",
+    "WP_Rocket\\Dependencies\\League\\Container\\Definition\\DefinitionAggregateInterface": "inc/Dependencies/League/Container/Definition/DefinitionAggregateInterface.php",
+    "WP_Rocket\\Dependencies\\League\\Container\\Definition\\DefinitionInterface": "inc/Dependencies/League/Container/Definition/DefinitionInterface.php",
+    "WP_Rocket\\Dependencies\\League\\Container\\DefinitionContainerInterface": "inc/Dependencies/League/Container/DefinitionContainerInterface.php",
+    "WP_Rocket\\Dependencies\\League\\Container\\Exception\\ContainerException": "inc/Dependencies/League/Container/Exception/ContainerException.php",
+    "WP_Rocket\\Dependencies\\League\\Container\\Exception\\NotFoundException": "inc/Dependencies/League/Container/Exception/NotFoundException.php",
+    "WP_Rocket\\Dependencies\\League\\Container\\Inflector\\Inflector": "inc/Dependencies/League/Container/Inflector/Inflector.php",
+    "WP_Rocket\\Dependencies\\League\\Container\\Inflector\\InflectorAggregate": "inc/Dependencies/League/Container/Inflector/InflectorAggregate.php",
+    "WP_Rocket\\Dependencies\\League\\Container\\Inflector\\InflectorAggregateInterface": "inc/Dependencies/League/Container/Inflector/InflectorAggregateInterface.php",
+    "WP_Rocket\\Dependencies\\League\\Container\\Inflector\\InflectorInterface": "inc/Dependencies/League/Container/Inflector/InflectorInterface.php",
+    "WP_Rocket\\Dependencies\\League\\Container\\ReflectionContainer": "inc/Dependencies/League/Container/ReflectionContainer.php",
+    "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\AbstractServiceProvider": "inc/Dependencies/League/Container/ServiceProvider/AbstractServiceProvider.php",
+    "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\BootableServiceProviderInterface": "inc/Dependencies/League/Container/ServiceProvider/BootableServiceProviderInterface.php",
+    "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\ServiceProviderAggregate": "inc/Dependencies/League/Container/ServiceProvider/ServiceProviderAggregate.php",
+    "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\ServiceProviderAggregateInterface": "inc/Dependencies/League/Container/ServiceProvider/ServiceProviderAggregateInterface.php",
+    "WP_Rocket\\Dependencies\\League\\Container\\ServiceProvider\\ServiceProviderInterface": "inc/Dependencies/League/Container/ServiceProvider/ServiceProviderInterface.php",
+    "WP_Rocket\\Dependencies\\Minify\\CSS": "inc/Dependencies/Minify/CSS.php",
+    "WP_Rocket\\Dependencies\\Minify\\Exception": "inc/Dependencies/Minify/Exception.php",
+    "WP_Rocket\\Dependencies\\Minify\\Exceptions\\BasicException": "inc/Dependencies/Minify/Exceptions/BasicException.php",
+    "WP_Rocket\\Dependencies\\Minify\\Exceptions\\FileImportException": "inc/Dependencies/Minify/Exceptions/FileImportException.php",
+    "WP_Rocket\\Dependencies\\Minify\\Exceptions\\IOException": "inc/Dependencies/Minify/Exceptions/IOException.php",
+    "WP_Rocket\\Dependencies\\Minify\\JS": "inc/Dependencies/Minify/JS.php",
+    "WP_Rocket\\Dependencies\\Minify\\Minify": "inc/Dependencies/Minify/Minify.php",
+    "WP_Rocket\\Dependencies\\Monolog\\ErrorHandler": "inc/Dependencies/Monolog/ErrorHandler.php",
+    "WP_Rocket\\Dependencies\\Monolog\\Formatter\\FormatterInterface": "inc/Dependencies/Monolog/Formatter/FormatterInterface.php",
+    "WP_Rocket\\Dependencies\\Monolog\\Formatter\\HtmlFormatter": "inc/Dependencies/Monolog/Formatter/HtmlFormatter.php",
+    "WP_Rocket\\Dependencies\\Monolog\\Formatter\\LineFormatter": "inc/Dependencies/Monolog/Formatter/LineFormatter.php",
+    "WP_Rocket\\Dependencies\\Monolog\\Formatter\\NormalizerFormatter": "inc/Dependencies/Monolog/Formatter/NormalizerFormatter.php",
+    "WP_Rocket\\Dependencies\\Monolog\\Handler\\AbstractHandler": "inc/Dependencies/Monolog/Handler/AbstractHandler.php",
+    "WP_Rocket\\Dependencies\\Monolog\\Handler\\AbstractProcessingHandler": "inc/Dependencies/Monolog/Handler/AbstractProcessingHandler.php",
+    "WP_Rocket\\Dependencies\\Monolog\\Handler\\FormattableHandlerInterface": "inc/Dependencies/Monolog/Handler/FormattableHandlerInterface.php",
+    "WP_Rocket\\Dependencies\\Monolog\\Handler\\FormattableHandlerTrait": "inc/Dependencies/Monolog/Handler/FormattableHandlerTrait.php",
+    "WP_Rocket\\Dependencies\\Monolog\\Handler\\HandlerInterface": "inc/Dependencies/Monolog/Handler/HandlerInterface.php",
+    "WP_Rocket\\Dependencies\\Monolog\\Handler\\ProcessableHandlerInterface": "inc/Dependencies/Monolog/Handler/ProcessableHandlerInterface.php",
+    "WP_Rocket\\Dependencies\\Monolog\\Handler\\ProcessableHandlerTrait": "inc/Dependencies/Monolog/Handler/ProcessableHandlerTrait.php",
+    "WP_Rocket\\Dependencies\\Monolog\\Handler\\StreamHandler": "inc/Dependencies/Monolog/Handler/StreamHandler.php",
+    "WP_Rocket\\Dependencies\\Monolog\\Logger": "inc/Dependencies/Monolog/Logger.php",
+    "WP_Rocket\\Dependencies\\Monolog\\Processor\\IntrospectionProcessor": "inc/Dependencies/Monolog/Processor/IntrospectionProcessor.php",
+    "WP_Rocket\\Dependencies\\Monolog\\Processor\\ProcessorInterface": "inc/Dependencies/Monolog/Processor/ProcessorInterface.php",
+    "WP_Rocket\\Dependencies\\Monolog\\Registry": "inc/Dependencies/Monolog/Registry.php",
+    "WP_Rocket\\Dependencies\\Monolog\\ResettableInterface": "inc/Dependencies/Monolog/ResettableInterface.php",
+    "WP_Rocket\\Dependencies\\Monolog\\SignalHandler": "inc/Dependencies/Monolog/SignalHandler.php",
+    "WP_Rocket\\Dependencies\\Monolog\\Utils": "inc/Dependencies/Monolog/Utils.php",
+    "WP_Rocket\\Dependencies\\PathConverter\\Converter": "inc/Dependencies/PathConverter/Converter.php",
+    "WP_Rocket\\Dependencies\\PathConverter\\ConverterInterface": "inc/Dependencies/PathConverter/ConverterInterface.php",
+    "WP_Rocket\\Dependencies\\PathConverter\\NoConverter": "inc/Dependencies/PathConverter/NoConverter.php",
+    "WP_Rocket\\Dependencies\\Psr\\Cache\\CacheException": "inc/Dependencies/Psr/Cache/CacheException.php",
+    "WP_Rocket\\Dependencies\\Psr\\Cache\\CacheItemInterface": "inc/Dependencies/Psr/Cache/CacheItemInterface.php",
+    "WP_Rocket\\Dependencies\\Psr\\Cache\\CacheItemPoolInterface": "inc/Dependencies/Psr/Cache/CacheItemPoolInterface.php",
+    "WP_Rocket\\Dependencies\\Psr\\Cache\\InvalidArgumentException": "inc/Dependencies/Psr/Cache/InvalidArgumentException.php",
+    "WP_Rocket\\Dependencies\\Psr\\Container\\ContainerExceptionInterface": "inc/Dependencies/Psr/Container/ContainerExceptionInterface.php",
+    "WP_Rocket\\Dependencies\\Psr\\Container\\ContainerInterface": "inc/Dependencies/Psr/Container/ContainerInterface.php",
+    "WP_Rocket\\Dependencies\\Psr\\Container\\NotFoundExceptionInterface": "inc/Dependencies/Psr/Container/NotFoundExceptionInterface.php",
+    "WP_Rocket\\Dependencies\\Psr\\Log\\AbstractLogger": "inc/Dependencies/Psr/Log/AbstractLogger.php",
+    "WP_Rocket\\Dependencies\\Psr\\Log\\InvalidArgumentException": "inc/Dependencies/Psr/Log/InvalidArgumentException.php",
+    "WP_Rocket\\Dependencies\\Psr\\Log\\LogLevel": "inc/Dependencies/Psr/Log/LogLevel.php",
+    "WP_Rocket\\Dependencies\\Psr\\Log\\LoggerAwareInterface": "inc/Dependencies/Psr/Log/LoggerAwareInterface.php",
+    "WP_Rocket\\Dependencies\\Psr\\Log\\LoggerAwareTrait": "inc/Dependencies/Psr/Log/LoggerAwareTrait.php",
+    "WP_Rocket\\Dependencies\\Psr\\Log\\LoggerInterface": "inc/Dependencies/Psr/Log/LoggerInterface.php",
+    "WP_Rocket\\Dependencies\\Psr\\Log\\LoggerTrait": "inc/Dependencies/Psr/Log/LoggerTrait.php",
+    "WP_Rocket\\Dependencies\\Psr\\Log\\NullLogger": "inc/Dependencies/Psr/Log/NullLogger.php",
+    "WP_Rocket\\Dependencies\\Psr\\Log\\Test\\DummyTest": "inc/Dependencies/Psr/Log/Test/DummyTest.php",
+    "WP_Rocket\\Dependencies\\Psr\\Log\\Test\\LoggerInterfaceTest": "inc/Dependencies/Psr/Log/Test/LoggerInterfaceTest.php",
+    "WP_Rocket\\Dependencies\\Psr\\Log\\Test\\TestLogger": "inc/Dependencies/Psr/Log/Test/TestLogger.php",
+    "WP_Rocket\\Dependencies\\Psr\\SimpleCache\\CacheException": "inc/Dependencies/Psr/SimpleCache/CacheException.php",
+    "WP_Rocket\\Dependencies\\Psr\\SimpleCache\\CacheInterface": "inc/Dependencies/Psr/SimpleCache/CacheInterface.php",
+    "WP_Rocket\\Dependencies\\Psr\\SimpleCache\\InvalidArgumentException": "inc/Dependencies/Psr/SimpleCache/InvalidArgumentException.php",
+    "WP_Rocket\\Dependencies\\RocketLazyload\\Assets": "inc/Dependencies/RocketLazyload/Assets.php",
+    "WP_Rocket\\Dependencies\\RocketLazyload\\Iframe": "inc/Dependencies/RocketLazyload/Iframe.php",
+    "WP_Rocket\\Dependencies\\RocketLazyload\\Image": "inc/Dependencies/RocketLazyload/Image.php",
+    "WP_Rocket\\Dependencies\\WPMedia\\PluginFamily\\Controller\\PluginFamily": "inc/Dependencies/WPMedia/PluginFamily/Controller/PluginFamily.php",
+    "WP_Rocket\\Dependencies\\WPMedia\\PluginFamily\\Controller\\PluginFamilyInterface": "inc/Dependencies/WPMedia/PluginFamily/Controller/PluginFamilyInterface.php",
+    "WP_Rocket\\Dependencies\\WPMedia\\PluginFamily\\Model\\PluginFamily": "inc/Dependencies/WPMedia/PluginFamily/Model/PluginFamily.php",
+    "WP_Rocket\\Engine\\Activation\\Activation": "inc/Engine/Activation/Activation.php",
+    "WP_Rocket\\Engine\\Activation\\ActivationInterface": "inc/Engine/Activation/ActivationInterface.php",
+    "WP_Rocket\\Engine\\Activation\\ServiceProvider": "inc/Engine/Activation/ServiceProvider.php",
+    "WP_Rocket\\Engine\\Admin\\API\\ServiceProvider": "inc/Engine/Admin/API/ServiceProvider.php",
+    "WP_Rocket\\Engine\\Admin\\API\\Subscriber": "inc/Engine/Admin/API/Subscriber.php",
+    "WP_Rocket\\Engine\\Admin\\ActionSchedulerSubscriber": "inc/Engine/Admin/ActionSchedulerSubscriber.php",
+    "WP_Rocket\\Engine\\Admin\\Beacon\\Beacon": "inc/Engine/Admin/Beacon/Beacon.php",
+    "WP_Rocket\\Engine\\Admin\\Beacon\\ServiceProvider": "inc/Engine/Admin/Beacon/ServiceProvider.php",
+    "WP_Rocket\\Engine\\Admin\\Database\\Optimization": "inc/Engine/Admin/Database/Optimization.php",
+    "WP_Rocket\\Engine\\Admin\\Database\\OptimizationProcess": "inc/Engine/Admin/Database/OptimizationProcess.php",
+    "WP_Rocket\\Engine\\Admin\\Database\\ServiceProvider": "inc/Engine/Admin/Database/ServiceProvider.php",
+    "WP_Rocket\\Engine\\Admin\\Database\\Subscriber": "inc/Engine/Admin/Database/Subscriber.php",
+    "WP_Rocket\\Engine\\Admin\\Deactivation\\DeactivationIntent": "inc/Engine/Admin/Deactivation/DeactivationIntent.php",
+    "WP_Rocket\\Engine\\Admin\\Deactivation\\Subscriber": "inc/Engine/Admin/Deactivation/Subscriber.php",
+    "WP_Rocket\\Engine\\Admin\\DomainChange\\ServiceProvider": "inc/Engine/Admin/DomainChange/ServiceProvider.php",
+    "WP_Rocket\\Engine\\Admin\\DomainChange\\Subscriber": "inc/Engine/Admin/DomainChange/Subscriber.php",
+    "WP_Rocket\\Engine\\Admin\\Metaboxes\\PostEditOptionsSubscriber": "inc/Engine/Admin/Metaboxes/PostEditOptionsSubscriber.php",
+    "WP_Rocket\\Engine\\Admin\\RocketInsights\\APIHandler\\APIClient": "inc/Engine/Admin/RocketInsights/APIHandler/APIClient.php",
+    "WP_Rocket\\Engine\\Admin\\RocketInsights\\Context\\Context": "inc/Engine/Admin/RocketInsights/Context/Context.php",
+    "WP_Rocket\\Engine\\Admin\\RocketInsights\\Context\\SaasContext": "inc/Engine/Admin/RocketInsights/Context/SaasContext.php",
+    "WP_Rocket\\Engine\\Admin\\RocketInsights\\Controller": "inc/Engine/Admin/RocketInsights/Controller.php",
+    "WP_Rocket\\Engine\\Admin\\RocketInsights\\Database\\Queries\\RocketInsights": "inc/Engine/Admin/RocketInsights/Database/Queries/RocketInsights.php",
+    "WP_Rocket\\Engine\\Admin\\RocketInsights\\Database\\Rows\\RocketInsights": "inc/Engine/Admin/RocketInsights/Database/Rows/RocketInsights.php",
+    "WP_Rocket\\Engine\\Admin\\RocketInsights\\Database\\Schemas\\RocketInsights": "inc/Engine/Admin/RocketInsights/Database/Schemas/RocketInsights.php",
+    "WP_Rocket\\Engine\\Admin\\RocketInsights\\Database\\Tables\\RocketInsights": "inc/Engine/Admin/RocketInsights/Database/Tables/RocketInsights.php",
+    "WP_Rocket\\Engine\\Admin\\RocketInsights\\GlobalMetrics\\Calculator": "inc/Engine/Admin/RocketInsights/GlobalMetrics/Calculator.php",
+    "WP_Rocket\\Engine\\Admin\\RocketInsights\\GlobalMetrics\\Subscriber": "inc/Engine/Admin/RocketInsights/GlobalMetrics/Subscriber.php",
+    "WP_Rocket\\Engine\\Admin\\RocketInsights\\GlobalScore": "inc/Engine/Admin/RocketInsights/GlobalScore.php",
+    "WP_Rocket\\Engine\\Admin\\RocketInsights\\Jobs\\Factory": "inc/Engine/Admin/RocketInsights/Jobs/Factory.php",
+    "WP_Rocket\\Engine\\Admin\\RocketInsights\\Jobs\\Manager": "inc/Engine/Admin/RocketInsights/Jobs/Manager.php",
+    "WP_Rocket\\Engine\\Admin\\RocketInsights\\Managers\\Plan": "inc/Engine/Admin/RocketInsights/Managers/Plan.php",
+    "WP_Rocket\\Engine\\Admin\\RocketInsights\\MetricFormatter": "inc/Engine/Admin/RocketInsights/MetricFormatter.php",
+    "WP_Rocket\\Engine\\Admin\\RocketInsights\\PageHandlerTrait": "inc/Engine/Admin/RocketInsights/PageHandlerTrait.php",
+    "WP_Rocket\\Engine\\Admin\\RocketInsights\\PostListing\\Subscriber": "inc/Engine/Admin/RocketInsights/PostListing/Subscriber.php",
+    "WP_Rocket\\Engine\\Admin\\RocketInsights\\Queue\\Queue": "inc/Engine/Admin/RocketInsights/Queue/Queue.php",
+    "WP_Rocket\\Engine\\Admin\\RocketInsights\\Recommendations\\APIClient": "inc/Engine/Admin/RocketInsights/Recommendations/APIClient.php",
+    "WP_Rocket\\Engine\\Admin\\RocketInsights\\Recommendations\\DataManager": "inc/Engine/Admin/RocketInsights/Recommendations/DataManager.php",
+    "WP_Rocket\\Engine\\Admin\\RocketInsights\\Recommendations\\Render": "inc/Engine/Admin/RocketInsights/Recommendations/Render.php",
+    "WP_Rocket\\Engine\\Admin\\RocketInsights\\Recommendations\\Rest": "inc/Engine/Admin/RocketInsights/Recommendations/Rest.php",
+    "WP_Rocket\\Engine\\Admin\\RocketInsights\\Recommendations\\SettingsSubscriber": "inc/Engine/Admin/RocketInsights/Recommendations/SettingsSubscriber.php",
+    "WP_Rocket\\Engine\\Admin\\RocketInsights\\Recommendations\\Subscriber": "inc/Engine/Admin/RocketInsights/Recommendations/Subscriber.php",
+    "WP_Rocket\\Engine\\Admin\\RocketInsights\\Render": "inc/Engine/Admin/RocketInsights/Render.php",
+    "WP_Rocket\\Engine\\Admin\\RocketInsights\\Rest": "inc/Engine/Admin/RocketInsights/Rest.php",
+    "WP_Rocket\\Engine\\Admin\\RocketInsights\\ServiceProvider": "inc/Engine/Admin/RocketInsights/ServiceProvider.php",
+    "WP_Rocket\\Engine\\Admin\\RocketInsights\\Settings\\Controller": "inc/Engine/Admin/RocketInsights/Settings/Controller.php",
+    "WP_Rocket\\Engine\\Admin\\RocketInsights\\Settings\\Subscriber": "inc/Engine/Admin/RocketInsights/Settings/Subscriber.php",
+    "WP_Rocket\\Engine\\Admin\\RocketInsights\\Subscriber": "inc/Engine/Admin/RocketInsights/Subscriber.php",
+    "WP_Rocket\\Engine\\Admin\\RocketInsights\\URLLimit\\Subscriber": "inc/Engine/Admin/RocketInsights/URLLimit/Subscriber.php",
+    "WP_Rocket\\Engine\\Admin\\ServiceProvider": "inc/Engine/Admin/ServiceProvider.php",
+    "WP_Rocket\\Engine\\Admin\\Settings\\AdminBarMenuTrait": "inc/Engine/Admin/Settings/AdminBarMenuTrait.php",
+    "WP_Rocket\\Engine\\Admin\\Settings\\DataClearingTrait": "inc/Engine/Admin/Settings/DataClearingTrait.php",
+    "WP_Rocket\\Engine\\Admin\\Settings\\Page": "inc/Engine/Admin/Settings/Page.php",
+    "WP_Rocket\\Engine\\Admin\\Settings\\Render": "inc/Engine/Admin/Settings/Render.php",
+    "WP_Rocket\\Engine\\Admin\\Settings\\ServiceProvider": "inc/Engine/Admin/Settings/ServiceProvider.php",
+    "WP_Rocket\\Engine\\Admin\\Settings\\Settings": "inc/Engine/Admin/Settings/Settings.php",
+    "WP_Rocket\\Engine\\Admin\\Settings\\Subscriber": "inc/Engine/Admin/Settings/Subscriber.php",
+    "WP_Rocket\\Engine\\CDN\\Admin\\Subscriber": "inc/Engine/CDN/Admin/Subscriber.php",
+    "WP_Rocket\\Engine\\CDN\\CDN": "inc/Engine/CDN/CDN.php",
+    "WP_Rocket\\Engine\\CDN\\RocketCDN\\APIClient": "inc/Engine/CDN/RocketCDN/APIClient.php",
+    "WP_Rocket\\Engine\\CDN\\RocketCDN\\AdminPageSubscriber": "inc/Engine/CDN/RocketCDN/AdminPageSubscriber.php",
+    "WP_Rocket\\Engine\\CDN\\RocketCDN\\CDNOptionsManager": "inc/Engine/CDN/RocketCDN/CDNOptionsManager.php",
+    "WP_Rocket\\Engine\\CDN\\RocketCDN\\DataManagerSubscriber": "inc/Engine/CDN/RocketCDN/DataManagerSubscriber.php",
+    "WP_Rocket\\Engine\\CDN\\RocketCDN\\NoticesSubscriber": "inc/Engine/CDN/RocketCDN/NoticesSubscriber.php",
+    "WP_Rocket\\Engine\\CDN\\RocketCDN\\RESTSubscriber": "inc/Engine/CDN/RocketCDN/RESTSubscriber.php",
+    "WP_Rocket\\Engine\\CDN\\RocketCDN\\ServiceProvider": "inc/Engine/CDN/RocketCDN/ServiceProvider.php",
+    "WP_Rocket\\Engine\\CDN\\ServiceProvider": "inc/Engine/CDN/ServiceProvider.php",
+    "WP_Rocket\\Engine\\CDN\\Subscriber": "inc/Engine/CDN/Subscriber.php",
+    "WP_Rocket\\Engine\\Cache\\AdminSubscriber": "inc/Engine/Cache/AdminSubscriber.php",
+    "WP_Rocket\\Engine\\Cache\\AdvancedCache": "inc/Engine/Cache/AdvancedCache.php",
+    "WP_Rocket\\Engine\\Cache\\Config\\ConfigSubscriber": "inc/Engine/Cache/Config/ConfigSubscriber.php",
+    "WP_Rocket\\Engine\\Cache\\Config\\Subscriber": "inc/Engine/Cache/Config/Subscriber.php",
+    "WP_Rocket\\Engine\\Cache\\Purge": "inc/Engine/Cache/Purge.php",
+    "WP_Rocket\\Engine\\Cache\\PurgeActionsSubscriber": "inc/Engine/Cache/PurgeActionsSubscriber.php",
+    "WP_Rocket\\Engine\\Cache\\PurgeExpired\\PurgeExpiredCache": "inc/Engine/Cache/PurgeExpired/PurgeExpiredCache.php",
+    "WP_Rocket\\Engine\\Cache\\PurgeExpired\\Subscriber": "inc/Engine/Cache/PurgeExpired/Subscriber.php",
+    "WP_Rocket\\Engine\\Cache\\ServiceProvider": "inc/Engine/Cache/ServiceProvider.php",
+    "WP_Rocket\\Engine\\Cache\\UrlValidation\\AbstractUrlValidation": "inc/Engine/Cache/UrlValidation/AbstractUrlValidation.php",
+    "WP_Rocket\\Engine\\Cache\\UrlValidation\\PostSubscriber": "inc/Engine/Cache/UrlValidation/PostSubscriber.php",
+    "WP_Rocket\\Engine\\Cache\\UrlValidation\\TaxonomySubscriber": "inc/Engine/Cache/UrlValidation/TaxonomySubscriber.php",
+    "WP_Rocket\\Engine\\Cache\\WPCache": "inc/Engine/Cache/WPCache.php",
+    "WP_Rocket\\Engine\\Capabilities\\Manager": "inc/Engine/Capabilities/Manager.php",
+    "WP_Rocket\\Engine\\Capabilities\\ServiceProvider": "inc/Engine/Capabilities/ServiceProvider.php",
+    "WP_Rocket\\Engine\\Capabilities\\Subscriber": "inc/Engine/Capabilities/Subscriber.php",
+    "WP_Rocket\\Engine\\Common\\AbstractFileSystem": "inc/Engine/Common/AbstractFileSystem.php",
+    "WP_Rocket\\Engine\\Common\\Ajax\\AjaxHandler": "inc/Engine/Common/Ajax/AjaxHandler.php",
+    "WP_Rocket\\Engine\\Common\\Cache\\CacheInterface": "inc/Engine/Common/Cache/CacheInterface.php",
+    "WP_Rocket\\Engine\\Common\\Cache\\FilesystemCache": "inc/Engine/Common/Cache/FilesystemCache.php",
+    "WP_Rocket\\Engine\\Common\\Clock\\ClockInterface": "inc/Engine/Common/Clock/ClockInterface.php",
+    "WP_Rocket\\Engine\\Common\\Clock\\WPRClock": "inc/Engine/Common/Clock/WPRClock.php",
+    "WP_Rocket\\Engine\\Common\\Context\\AbstractContext": "inc/Engine/Common/Context/AbstractContext.php",
+    "WP_Rocket\\Engine\\Common\\Context\\ContextInterface": "inc/Engine/Common/Context/ContextInterface.php",
+    "WP_Rocket\\Engine\\Common\\Database\\Queries\\AbstractQuery": "inc/Engine/Common/Database/Queries/AbstractQuery.php",
+    "WP_Rocket\\Engine\\Common\\Database\\QueryInterface": "inc/Engine/Common/Database/QueryInterface.php",
+    "WP_Rocket\\Engine\\Common\\Database\\TableInterface": "inc/Engine/Common/Database/TableInterface.php",
+    "WP_Rocket\\Engine\\Common\\Database\\Tables\\AbstractTable": "inc/Engine/Common/Database/Tables/AbstractTable.php",
+    "WP_Rocket\\Engine\\Common\\ExtractCSS\\ServiceProvider": "inc/Engine/Common/ExtractCSS/ServiceProvider.php",
+    "WP_Rocket\\Engine\\Common\\ExtractCSS\\Subscriber": "inc/Engine/Common/ExtractCSS/Subscriber.php",
+    "WP_Rocket\\Engine\\Common\\Head\\ElementTrait": "inc/Engine/Common/Head/ElementTrait.php",
+    "WP_Rocket\\Engine\\Common\\Head\\ServiceProvider": "inc/Engine/Common/Head/ServiceProvider.php",
+    "WP_Rocket\\Engine\\Common\\Head\\Subscriber": "inc/Engine/Common/Head/Subscriber.php",
+    "WP_Rocket\\Engine\\Common\\JobManager\\APIHandler\\AbstractAPIClient": "inc/Engine/Common/JobManager/APIHandler/AbstractAPIClient.php",
+    "WP_Rocket\\Engine\\Common\\JobManager\\APIHandler\\AbstractSafeAPIClient": "inc/Engine/Common/JobManager/APIHandler/AbstractSafeAPIClient.php",
+    "WP_Rocket\\Engine\\Common\\JobManager\\AbstractFactory\\SaasFactory": "inc/Engine/Common/JobManager/AbstractFactory/SaasFactory.php",
+    "WP_Rocket\\Engine\\Common\\JobManager\\Cron\\Subscriber": "inc/Engine/Common/JobManager/Cron/Subscriber.php",
+    "WP_Rocket\\Engine\\Common\\JobManager\\JobProcessor": "inc/Engine/Common/JobManager/JobProcessor.php",
+    "WP_Rocket\\Engine\\Common\\JobManager\\Managers\\AbstractManager": "inc/Engine/Common/JobManager/Managers/AbstractManager.php",
+    "WP_Rocket\\Engine\\Common\\JobManager\\Managers\\ManagerInterface": "inc/Engine/Common/JobManager/Managers/ManagerInterface.php",
+    "WP_Rocket\\Engine\\Common\\JobManager\\Queue\\Queue": "inc/Engine/Common/JobManager/Queue/Queue.php",
+    "WP_Rocket\\Engine\\Common\\JobManager\\ServiceProvider": "inc/Engine/Common/JobManager/ServiceProvider.php",
+    "WP_Rocket\\Engine\\Common\\JobManager\\Strategy\\Context\\RetryContext": "inc/Engine/Common/JobManager/Strategy/Context/RetryContext.php",
+    "WP_Rocket\\Engine\\Common\\JobManager\\Strategy\\Factory\\StrategyFactory": "inc/Engine/Common/JobManager/Strategy/Factory/StrategyFactory.php",
+    "WP_Rocket\\Engine\\Common\\JobManager\\Strategy\\Strategies\\DefaultProcess": "inc/Engine/Common/JobManager/Strategy/Strategies/DefaultProcess.php",
+    "WP_Rocket\\Engine\\Common\\JobManager\\Strategy\\Strategies\\JobSetFail": "inc/Engine/Common/JobManager/Strategy/Strategies/JobSetFail.php",
+    "WP_Rocket\\Engine\\Common\\JobManager\\Strategy\\Strategies\\ResetRetryProcess": "inc/Engine/Common/JobManager/Strategy/Strategies/ResetRetryProcess.php",
+    "WP_Rocket\\Engine\\Common\\JobManager\\Strategy\\Strategies\\StrategyInterface": "inc/Engine/Common/JobManager/Strategy/Strategies/StrategyInterface.php",
+    "WP_Rocket\\Engine\\Common\\PerformanceHints\\AJAX\\AJAXControllerTrait": "inc/Engine/Common/PerformanceHints/AJAX/AJAXControllerTrait.php",
+    "WP_Rocket\\Engine\\Common\\PerformanceHints\\AJAX\\ControllerInterface": "inc/Engine/Common/PerformanceHints/AJAX/ControllerInterface.php",
+    "WP_Rocket\\Engine\\Common\\PerformanceHints\\AJAX\\Processor": "inc/Engine/Common/PerformanceHints/AJAX/Processor.php",
+    "WP_Rocket\\Engine\\Common\\PerformanceHints\\AJAX\\Subscriber": "inc/Engine/Common/PerformanceHints/AJAX/Subscriber.php",
+    "WP_Rocket\\Engine\\Common\\PerformanceHints\\Activation\\Activation": "inc/Engine/Common/PerformanceHints/Activation/Activation.php",
+    "WP_Rocket\\Engine\\Common\\PerformanceHints\\Activation\\ServiceProvider": "inc/Engine/Common/PerformanceHints/Activation/ServiceProvider.php",
+    "WP_Rocket\\Engine\\Common\\PerformanceHints\\ActivationFactoryInterface": "inc/Engine/Common/PerformanceHints/ActivationFactoryInterface.php",
+    "WP_Rocket\\Engine\\Common\\PerformanceHints\\Admin\\AdminBar": "inc/Engine/Common/PerformanceHints/Admin/AdminBar.php",
+    "WP_Rocket\\Engine\\Common\\PerformanceHints\\Admin\\Clean": "inc/Engine/Common/PerformanceHints/Admin/Clean.php",
+    "WP_Rocket\\Engine\\Common\\PerformanceHints\\Admin\\Controller": "inc/Engine/Common/PerformanceHints/Admin/Controller.php",
+    "WP_Rocket\\Engine\\Common\\PerformanceHints\\Admin\\Notices": "inc/Engine/Common/PerformanceHints/Admin/Notices.php",
+    "WP_Rocket\\Engine\\Common\\PerformanceHints\\Admin\\Subscriber": "inc/Engine/Common/PerformanceHints/Admin/Subscriber.php",
+    "WP_Rocket\\Engine\\Common\\PerformanceHints\\Cron\\Controller": "inc/Engine/Common/PerformanceHints/Cron/Controller.php",
+    "WP_Rocket\\Engine\\Common\\PerformanceHints\\Cron\\CronTrait": "inc/Engine/Common/PerformanceHints/Cron/CronTrait.php",
+    "WP_Rocket\\Engine\\Common\\PerformanceHints\\Cron\\Subscriber": "inc/Engine/Common/PerformanceHints/Cron/Subscriber.php",
+    "WP_Rocket\\Engine\\Common\\PerformanceHints\\FactoryInterface": "inc/Engine/Common/PerformanceHints/FactoryInterface.php",
+    "WP_Rocket\\Engine\\Common\\PerformanceHints\\Frontend\\ControllerInterface": "inc/Engine/Common/PerformanceHints/Frontend/ControllerInterface.php",
+    "WP_Rocket\\Engine\\Common\\PerformanceHints\\Frontend\\Processor": "inc/Engine/Common/PerformanceHints/Frontend/Processor.php",
+    "WP_Rocket\\Engine\\Common\\PerformanceHints\\Frontend\\Subscriber": "inc/Engine/Common/PerformanceHints/Frontend/Subscriber.php",
+    "WP_Rocket\\Engine\\Common\\PerformanceHints\\ServiceProvider": "inc/Engine/Common/PerformanceHints/ServiceProvider.php",
+    "WP_Rocket\\Engine\\Common\\PerformanceHints\\WarmUp\\APIClient": "inc/Engine/Common/PerformanceHints/WarmUp/APIClient.php",
+    "WP_Rocket\\Engine\\Common\\PerformanceHints\\WarmUp\\Controller": "inc/Engine/Common/PerformanceHints/WarmUp/Controller.php",
+    "WP_Rocket\\Engine\\Common\\PerformanceHints\\WarmUp\\Queue": "inc/Engine/Common/PerformanceHints/WarmUp/Queue.php",
+    "WP_Rocket\\Engine\\Common\\PerformanceHints\\WarmUp\\Subscriber": "inc/Engine/Common/PerformanceHints/WarmUp/Subscriber.php",
+    "WP_Rocket\\Engine\\Common\\Queue\\AbstractASQueue": "inc/Engine/Common/Queue/AbstractASQueue.php",
+    "WP_Rocket\\Engine\\Common\\Queue\\Cleaner": "inc/Engine/Common/Queue/Cleaner.php",
+    "WP_Rocket\\Engine\\Common\\Queue\\QueueInterface": "inc/Engine/Common/Queue/QueueInterface.php",
+    "WP_Rocket\\Engine\\Common\\Queue\\RUCSSQueueRunner": "inc/Engine/Common/Queue/RUCSSQueueRunner.php",
+    "WP_Rocket\\Engine\\Common\\Utils": "inc/Engine/Common/Utils.php",
+    "WP_Rocket\\Engine\\CriticalPath\\APIClient": "inc/Engine/CriticalPath/APIClient.php",
+    "WP_Rocket\\Engine\\CriticalPath\\Admin\\Admin": "inc/Engine/CriticalPath/Admin/Admin.php",
+    "WP_Rocket\\Engine\\CriticalPath\\Admin\\Post": "inc/Engine/CriticalPath/Admin/Post.php",
+    "WP_Rocket\\Engine\\CriticalPath\\Admin\\Settings": "inc/Engine/CriticalPath/Admin/Settings.php",
+    "WP_Rocket\\Engine\\CriticalPath\\Admin\\Subscriber": "inc/Engine/CriticalPath/Admin/Subscriber.php",
+    "WP_Rocket\\Engine\\CriticalPath\\CriticalCSS": "inc/Engine/CriticalPath/CriticalCSS.php",
+    "WP_Rocket\\Engine\\CriticalPath\\CriticalCSSGeneration": "inc/Engine/CriticalPath/CriticalCSSGeneration.php",
+    "WP_Rocket\\Engine\\CriticalPath\\CriticalCSSSubscriber": "inc/Engine/CriticalPath/CriticalCSSSubscriber.php",
+    "WP_Rocket\\Engine\\CriticalPath\\DataManager": "inc/Engine/CriticalPath/DataManager.php",
+    "WP_Rocket\\Engine\\CriticalPath\\ProcessorService": "inc/Engine/CriticalPath/ProcessorService.php",
+    "WP_Rocket\\Engine\\CriticalPath\\RESTCSSSubscriber": "inc/Engine/CriticalPath/RESTCSSSubscriber.php",
+    "WP_Rocket\\Engine\\CriticalPath\\RESTWP": "inc/Engine/CriticalPath/RESTWP.php",
+    "WP_Rocket\\Engine\\CriticalPath\\RESTWPInterface": "inc/Engine/CriticalPath/RESTWPInterface.php",
+    "WP_Rocket\\Engine\\CriticalPath\\RESTWPPost": "inc/Engine/CriticalPath/RESTWPPost.php",
+    "WP_Rocket\\Engine\\CriticalPath\\ServiceProvider": "inc/Engine/CriticalPath/ServiceProvider.php",
+    "WP_Rocket\\Engine\\CriticalPath\\TransientTrait": "inc/Engine/CriticalPath/TransientTrait.php",
+    "WP_Rocket\\Engine\\Deactivation\\Deactivation": "inc/Engine/Deactivation/Deactivation.php",
+    "WP_Rocket\\Engine\\Deactivation\\DeactivationInterface": "inc/Engine/Deactivation/DeactivationInterface.php",
+    "WP_Rocket\\Engine\\Deactivation\\ServiceProvider": "inc/Engine/Deactivation/ServiceProvider.php",
+    "WP_Rocket\\Engine\\Debug\\DebugSubscriber": "inc/Engine/Debug/DebugSubscriber.php",
+    "WP_Rocket\\Engine\\Debug\\RUCSS\\Subscriber": "inc/Engine/Debug/RUCSS/Subscriber.php",
+    "WP_Rocket\\Engine\\Debug\\Resolver": "inc/Engine/Debug/Resolver.php",
+    "WP_Rocket\\Engine\\Debug\\ServiceProvider": "inc/Engine/Debug/ServiceProvider.php",
+    "WP_Rocket\\Engine\\HealthCheck\\ActionSchedulerCheck": "inc/Engine/HealthCheck/ActionSchedulerCheck.php",
+    "WP_Rocket\\Engine\\HealthCheck\\HealthCheck": "inc/Engine/HealthCheck/HealthCheck.php",
+    "WP_Rocket\\Engine\\HealthCheck\\ServiceProvider": "inc/Engine/HealthCheck/ServiceProvider.php",
+    "WP_Rocket\\Engine\\Heartbeat\\HeartbeatSubscriber": "inc/Engine/Heartbeat/HeartbeatSubscriber.php",
+    "WP_Rocket\\Engine\\Heartbeat\\ServiceProvider": "inc/Engine/Heartbeat/ServiceProvider.php",
+    "WP_Rocket\\Engine\\License\\API\\Currency": "inc/Engine/License/API/Currency.php",
+    "WP_Rocket\\Engine\\License\\API\\CustomerDataTrait": "inc/Engine/License/API/CustomerDataTrait.php",
+    "WP_Rocket\\Engine\\License\\API\\Pricing": "inc/Engine/License/API/Pricing.php",
+    "WP_Rocket\\Engine\\License\\API\\PricingClient": "inc/Engine/License/API/PricingClient.php",
+    "WP_Rocket\\Engine\\License\\API\\RemoteSettings": "inc/Engine/License/API/RemoteSettings.php",
+    "WP_Rocket\\Engine\\License\\API\\RemoteSettingsClient": "inc/Engine/License/API/RemoteSettingsClient.php",
+    "WP_Rocket\\Engine\\License\\API\\User": "inc/Engine/License/API/User.php",
+    "WP_Rocket\\Engine\\License\\API\\UserClient": "inc/Engine/License/API/UserClient.php",
+    "WP_Rocket\\Engine\\License\\Renewal": "inc/Engine/License/Renewal.php",
+    "WP_Rocket\\Engine\\License\\Revoked": "inc/Engine/License/Revoked.php",
+    "WP_Rocket\\Engine\\License\\ServiceProvider": "inc/Engine/License/ServiceProvider.php",
+    "WP_Rocket\\Engine\\License\\Subscriber": "inc/Engine/License/Subscriber.php",
+    "WP_Rocket\\Engine\\License\\Upgrade": "inc/Engine/License/Upgrade.php",
+    "WP_Rocket\\Engine\\Media\\AboveTheFold\\AJAX\\Controller": "inc/Engine/Media/AboveTheFold/AJAX/Controller.php",
+    "WP_Rocket\\Engine\\Media\\AboveTheFold\\Activation\\ActivationFactory": "inc/Engine/Media/AboveTheFold/Activation/ActivationFactory.php",
+    "WP_Rocket\\Engine\\Media\\AboveTheFold\\Context\\Context": "inc/Engine/Media/AboveTheFold/Context/Context.php",
+    "WP_Rocket\\Engine\\Media\\AboveTheFold\\Database\\Queries\\AboveTheFold": "inc/Engine/Media/AboveTheFold/Database/Queries/AboveTheFold.php",
+    "WP_Rocket\\Engine\\Media\\AboveTheFold\\Database\\Rows\\AboveTheFold": "inc/Engine/Media/AboveTheFold/Database/Rows/AboveTheFold.php",
+    "WP_Rocket\\Engine\\Media\\AboveTheFold\\Database\\Schemas\\AboveTheFold": "inc/Engine/Media/AboveTheFold/Database/Schemas/AboveTheFold.php",
+    "WP_Rocket\\Engine\\Media\\AboveTheFold\\Database\\Tables\\AboveTheFold": "inc/Engine/Media/AboveTheFold/Database/Tables/AboveTheFold.php",
+    "WP_Rocket\\Engine\\Media\\AboveTheFold\\Factory": "inc/Engine/Media/AboveTheFold/Factory.php",
+    "WP_Rocket\\Engine\\Media\\AboveTheFold\\Frontend\\Controller": "inc/Engine/Media/AboveTheFold/Frontend/Controller.php",
+    "WP_Rocket\\Engine\\Media\\AboveTheFold\\Frontend\\Subscriber": "inc/Engine/Media/AboveTheFold/Frontend/Subscriber.php",
+    "WP_Rocket\\Engine\\Media\\AboveTheFold\\ServiceProvider": "inc/Engine/Media/AboveTheFold/ServiceProvider.php",
+    "WP_Rocket\\Engine\\Media\\Emojis\\EmojisSubscriber": "inc/Engine/Media/Emojis/EmojisSubscriber.php",
+    "WP_Rocket\\Engine\\Media\\Fonts\\Admin\\Data": "inc/Engine/Media/Fonts/Admin/Data.php",
+    "WP_Rocket\\Engine\\Media\\Fonts\\Admin\\Settings": "inc/Engine/Media/Fonts/Admin/Settings.php",
+    "WP_Rocket\\Engine\\Media\\Fonts\\Admin\\Subscriber": "inc/Engine/Media/Fonts/Admin/Subscriber.php",
+    "WP_Rocket\\Engine\\Media\\Fonts\\Clean\\Clean": "inc/Engine/Media/Fonts/Clean/Clean.php",
+    "WP_Rocket\\Engine\\Media\\Fonts\\Clean\\Subscriber": "inc/Engine/Media/Fonts/Clean/Subscriber.php",
+    "WP_Rocket\\Engine\\Media\\Fonts\\Context\\OptimizationContext": "inc/Engine/Media/Fonts/Context/OptimizationContext.php",
+    "WP_Rocket\\Engine\\Media\\Fonts\\Context\\SaasContext": "inc/Engine/Media/Fonts/Context/SaasContext.php",
+    "WP_Rocket\\Engine\\Media\\Fonts\\Filesystem": "inc/Engine/Media/Fonts/Filesystem.php",
+    "WP_Rocket\\Engine\\Media\\Fonts\\FontsTrait": "inc/Engine/Media/Fonts/FontsTrait.php",
+    "WP_Rocket\\Engine\\Media\\Fonts\\Frontend\\Controller": "inc/Engine/Media/Fonts/Frontend/Controller.php",
+    "WP_Rocket\\Engine\\Media\\Fonts\\Frontend\\Subscriber": "inc/Engine/Media/Fonts/Frontend/Subscriber.php",
+    "WP_Rocket\\Engine\\Media\\Fonts\\ServiceProvider": "inc/Engine/Media/Fonts/ServiceProvider.php",
+    "WP_Rocket\\Engine\\Media\\ImageDimensions\\AdminSubscriber": "inc/Engine/Media/ImageDimensions/AdminSubscriber.php",
+    "WP_Rocket\\Engine\\Media\\ImageDimensions\\ImageDimensions": "inc/Engine/Media/ImageDimensions/ImageDimensions.php",
+    "WP_Rocket\\Engine\\Media\\ImageDimensions\\Subscriber": "inc/Engine/Media/ImageDimensions/Subscriber.php",
+    "WP_Rocket\\Engine\\Media\\Lazyload\\AdminSubscriber": "inc/Engine/Media/Lazyload/AdminSubscriber.php",
+    "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Admin\\ServiceProvider": "inc/Engine/Media/Lazyload/CSS/Admin/ServiceProvider.php",
+    "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Admin\\Subscriber": "inc/Engine/Media/Lazyload/CSS/Admin/Subscriber.php",
+    "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Context\\LazyloadCSSContext": "inc/Engine/Media/Lazyload/CSS/Context/LazyloadCSSContext.php",
+    "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Data\\LazyloadCSSContentFactory": "inc/Engine/Media/Lazyload/CSS/Data/LazyloadCSSContentFactory.php",
+    "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Data\\LazyloadedContent": "inc/Engine/Media/Lazyload/CSS/Data/LazyloadedContent.php",
+    "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Data\\ProtectedContent": "inc/Engine/Media/Lazyload/CSS/Data/ProtectedContent.php",
+    "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Front\\ContentFetcher": "inc/Engine/Media/Lazyload/CSS/Front/ContentFetcher.php",
+    "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Front\\Extractor": "inc/Engine/Media/Lazyload/CSS/Front/Extractor.php",
+    "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Front\\FileResolver": "inc/Engine/Media/Lazyload/CSS/Front/FileResolver.php",
+    "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Front\\MappingFormatter": "inc/Engine/Media/Lazyload/CSS/Front/MappingFormatter.php",
+    "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Front\\RuleFormatter": "inc/Engine/Media/Lazyload/CSS/Front/RuleFormatter.php",
+    "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Front\\TagGenerator": "inc/Engine/Media/Lazyload/CSS/Front/TagGenerator.php",
+    "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\ServiceProvider": "inc/Engine/Media/Lazyload/CSS/ServiceProvider.php",
+    "WP_Rocket\\Engine\\Media\\Lazyload\\CSS\\Subscriber": "inc/Engine/Media/Lazyload/CSS/Subscriber.php",
+    "WP_Rocket\\Engine\\Media\\Lazyload\\CanLazyloadTrait": "inc/Engine/Media/Lazyload/CanLazyloadTrait.php",
+    "WP_Rocket\\Engine\\Media\\Lazyload\\Subscriber": "inc/Engine/Media/Lazyload/Subscriber.php",
+    "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\AJAX\\Controller": "inc/Engine/Media/PreconnectExternalDomains/AJAX/Controller.php",
+    "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\Admin\\Settings": "inc/Engine/Media/PreconnectExternalDomains/Admin/Settings.php",
+    "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\Admin\\Subscriber": "inc/Engine/Media/PreconnectExternalDomains/Admin/Subscriber.php",
+    "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\Context\\Context": "inc/Engine/Media/PreconnectExternalDomains/Context/Context.php",
+    "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\Database\\Queries\\PreconnectExternalDomains": "inc/Engine/Media/PreconnectExternalDomains/Database/Queries/PreconnectExternalDomains.php",
+    "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\Database\\Row\\PreconnectExternalDomains": "inc/Engine/Media/PreconnectExternalDomains/Database/Row/PreconnectExternalDomains.php",
+    "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\Database\\Schema\\PreconnectExternalDomains": "inc/Engine/Media/PreconnectExternalDomains/Database/Schema/PreconnectExternalDomains.php",
+    "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\Database\\Table\\PreconnectExternalDomains": "inc/Engine/Media/PreconnectExternalDomains/Database/Table/PreconnectExternalDomains.php",
+    "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\Factory": "inc/Engine/Media/PreconnectExternalDomains/Factory.php",
+    "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\Frontend\\Controller": "inc/Engine/Media/PreconnectExternalDomains/Frontend/Controller.php",
+    "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\Frontend\\Subscriber": "inc/Engine/Media/PreconnectExternalDomains/Frontend/Subscriber.php",
+    "WP_Rocket\\Engine\\Media\\PreconnectExternalDomains\\ServiceProvider": "inc/Engine/Media/PreconnectExternalDomains/ServiceProvider.php",
+    "WP_Rocket\\Engine\\Media\\PreloadFonts\\AJAX\\Controller": "inc/Engine/Media/PreloadFonts/AJAX/Controller.php",
+    "WP_Rocket\\Engine\\Media\\PreloadFonts\\Admin\\Settings": "inc/Engine/Media/PreloadFonts/Admin/Settings.php",
+    "WP_Rocket\\Engine\\Media\\PreloadFonts\\Admin\\Subscriber": "inc/Engine/Media/PreloadFonts/Admin/Subscriber.php",
+    "WP_Rocket\\Engine\\Media\\PreloadFonts\\Context\\Context": "inc/Engine/Media/PreloadFonts/Context/Context.php",
+    "WP_Rocket\\Engine\\Media\\PreloadFonts\\Database\\Queries\\PreloadFonts": "inc/Engine/Media/PreloadFonts/Database/Queries/PreloadFonts.php",
+    "WP_Rocket\\Engine\\Media\\PreloadFonts\\Database\\Rows\\PreloadFonts": "inc/Engine/Media/PreloadFonts/Database/Rows/PreloadFonts.php",
+    "WP_Rocket\\Engine\\Media\\PreloadFonts\\Database\\Schema\\PreloadFonts": "inc/Engine/Media/PreloadFonts/Database/Schema/PreloadFonts.php",
+    "WP_Rocket\\Engine\\Media\\PreloadFonts\\Database\\Table\\PreloadFonts": "inc/Engine/Media/PreloadFonts/Database/Table/PreloadFonts.php",
+    "WP_Rocket\\Engine\\Media\\PreloadFonts\\Factory": "inc/Engine/Media/PreloadFonts/Factory.php",
+    "WP_Rocket\\Engine\\Media\\PreloadFonts\\Frontend\\Controller": "inc/Engine/Media/PreloadFonts/Frontend/Controller.php",
+    "WP_Rocket\\Engine\\Media\\PreloadFonts\\Frontend\\Subscriber": "inc/Engine/Media/PreloadFonts/Frontend/Subscriber.php",
+    "WP_Rocket\\Engine\\Media\\PreloadFonts\\ServiceProvider": "inc/Engine/Media/PreloadFonts/ServiceProvider.php",
+    "WP_Rocket\\Engine\\Media\\ServiceProvider": "inc/Engine/Media/ServiceProvider.php",
+    "WP_Rocket\\Engine\\Optimization\\AbstractOptimization": "inc/Engine/Optimization/AbstractOptimization.php",
+    "WP_Rocket\\Engine\\Optimization\\AdminServiceProvider": "inc/Engine/Optimization/AdminServiceProvider.php",
+    "WP_Rocket\\Engine\\Optimization\\AssetsLocalCache": "inc/Engine/Optimization/AssetsLocalCache.php",
+    "WP_Rocket\\Engine\\Optimization\\Buffer\\Optimization": "inc/Engine/Optimization/Buffer/Optimization.php",
+    "WP_Rocket\\Engine\\Optimization\\Buffer\\Subscriber": "inc/Engine/Optimization/Buffer/Subscriber.php",
+    "WP_Rocket\\Engine\\Optimization\\CSSTrait": "inc/Engine/Optimization/CSSTrait.php",
+    "WP_Rocket\\Engine\\Optimization\\CacheDynamicResource": "inc/Engine/Optimization/CacheDynamicResource.php",
+    "WP_Rocket\\Engine\\Optimization\\ContentTrait": "inc/Engine/Optimization/ContentTrait.php",
+    "WP_Rocket\\Engine\\Optimization\\DeferJS\\AdminSubscriber": "inc/Engine/Optimization/DeferJS/AdminSubscriber.php",
+    "WP_Rocket\\Engine\\Optimization\\DeferJS\\DeferJS": "inc/Engine/Optimization/DeferJS/DeferJS.php",
+    "WP_Rocket\\Engine\\Optimization\\DeferJS\\ServiceProvider": "inc/Engine/Optimization/DeferJS/ServiceProvider.php",
+    "WP_Rocket\\Engine\\Optimization\\DeferJS\\Subscriber": "inc/Engine/Optimization/DeferJS/Subscriber.php",
+    "WP_Rocket\\Engine\\Optimization\\DelayJS\\Admin\\Settings": "inc/Engine/Optimization/DelayJS/Admin/Settings.php",
+    "WP_Rocket\\Engine\\Optimization\\DelayJS\\Admin\\SiteList": "inc/Engine/Optimization/DelayJS/Admin/SiteList.php",
+    "WP_Rocket\\Engine\\Optimization\\DelayJS\\Admin\\Subscriber": "inc/Engine/Optimization/DelayJS/Admin/Subscriber.php",
+    "WP_Rocket\\Engine\\Optimization\\DelayJS\\HTML": "inc/Engine/Optimization/DelayJS/HTML.php",
+    "WP_Rocket\\Engine\\Optimization\\DelayJS\\ServiceProvider": "inc/Engine/Optimization/DelayJS/ServiceProvider.php",
+    "WP_Rocket\\Engine\\Optimization\\DelayJS\\Subscriber": "inc/Engine/Optimization/DelayJS/Subscriber.php",
+    "WP_Rocket\\Engine\\Optimization\\DynamicLists\\AbstractAPIClient": "inc/Engine/Optimization/DynamicLists/AbstractAPIClient.php",
+    "WP_Rocket\\Engine\\Optimization\\DynamicLists\\AbstractDataManager": "inc/Engine/Optimization/DynamicLists/AbstractDataManager.php",
+    "WP_Rocket\\Engine\\Optimization\\DynamicLists\\DefaultLists\\APIClient": "inc/Engine/Optimization/DynamicLists/DefaultLists/APIClient.php",
+    "WP_Rocket\\Engine\\Optimization\\DynamicLists\\DefaultLists\\DataManager": "inc/Engine/Optimization/DynamicLists/DefaultLists/DataManager.php",
+    "WP_Rocket\\Engine\\Optimization\\DynamicLists\\DelayJSLists\\APIClient": "inc/Engine/Optimization/DynamicLists/DelayJSLists/APIClient.php",
+    "WP_Rocket\\Engine\\Optimization\\DynamicLists\\DelayJSLists\\DataManager": "inc/Engine/Optimization/DynamicLists/DelayJSLists/DataManager.php",
+    "WP_Rocket\\Engine\\Optimization\\DynamicLists\\DynamicLists": "inc/Engine/Optimization/DynamicLists/DynamicLists.php",
+    "WP_Rocket\\Engine\\Optimization\\DynamicLists\\IncompatiblePluginsLists\\APIClient": "inc/Engine/Optimization/DynamicLists/IncompatiblePluginsLists/APIClient.php",
+    "WP_Rocket\\Engine\\Optimization\\DynamicLists\\IncompatiblePluginsLists\\DataManager": "inc/Engine/Optimization/DynamicLists/IncompatiblePluginsLists/DataManager.php",
+    "WP_Rocket\\Engine\\Optimization\\DynamicLists\\ServiceProvider": "inc/Engine/Optimization/DynamicLists/ServiceProvider.php",
+    "WP_Rocket\\Engine\\Optimization\\DynamicLists\\Subscriber": "inc/Engine/Optimization/DynamicLists/Subscriber.php",
+    "WP_Rocket\\Engine\\Optimization\\GoogleFonts\\AbstractGFOptimization": "inc/Engine/Optimization/GoogleFonts/AbstractGFOptimization.php",
+    "WP_Rocket\\Engine\\Optimization\\GoogleFonts\\Admin\\Settings": "inc/Engine/Optimization/GoogleFonts/Admin/Settings.php",
+    "WP_Rocket\\Engine\\Optimization\\GoogleFonts\\Admin\\Subscriber": "inc/Engine/Optimization/GoogleFonts/Admin/Subscriber.php",
+    "WP_Rocket\\Engine\\Optimization\\GoogleFonts\\Combine": "inc/Engine/Optimization/GoogleFonts/Combine.php",
+    "WP_Rocket\\Engine\\Optimization\\GoogleFonts\\CombineV2": "inc/Engine/Optimization/GoogleFonts/CombineV2.php",
+    "WP_Rocket\\Engine\\Optimization\\GoogleFonts\\Subscriber": "inc/Engine/Optimization/GoogleFonts/Subscriber.php",
+    "WP_Rocket\\Engine\\Optimization\\IEConditionalSubscriber": "inc/Engine/Optimization/IEConditionalSubscriber.php",
+    "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\AJAX\\Controller": "inc/Engine/Optimization/LazyRenderContent/AJAX/Controller.php",
+    "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Activation\\ActivationFactory": "inc/Engine/Optimization/LazyRenderContent/Activation/ActivationFactory.php",
+    "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Context\\Context": "inc/Engine/Optimization/LazyRenderContent/Context/Context.php",
+    "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Database\\Queries\\LazyRenderContent": "inc/Engine/Optimization/LazyRenderContent/Database/Queries/LazyRenderContent.php",
+    "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Database\\Rows\\LazyRenderContent": "inc/Engine/Optimization/LazyRenderContent/Database/Rows/LazyRenderContent.php",
+    "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Database\\Schema\\LazyRenderContent": "inc/Engine/Optimization/LazyRenderContent/Database/Schema/LazyRenderContent.php",
+    "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Database\\Table\\LazyRenderContent": "inc/Engine/Optimization/LazyRenderContent/Database/Table/LazyRenderContent.php",
+    "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Factory": "inc/Engine/Optimization/LazyRenderContent/Factory.php",
+    "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Frontend\\Controller": "inc/Engine/Optimization/LazyRenderContent/Frontend/Controller.php",
+    "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Frontend\\Processor\\Dom": "inc/Engine/Optimization/LazyRenderContent/Frontend/Processor/Dom.php",
+    "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Frontend\\Processor\\HelperTrait": "inc/Engine/Optimization/LazyRenderContent/Frontend/Processor/HelperTrait.php",
+    "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Frontend\\Processor\\Processor": "inc/Engine/Optimization/LazyRenderContent/Frontend/Processor/Processor.php",
+    "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Frontend\\Processor\\ProcessorInterface": "inc/Engine/Optimization/LazyRenderContent/Frontend/Processor/ProcessorInterface.php",
+    "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Frontend\\Processor\\Regex": "inc/Engine/Optimization/LazyRenderContent/Frontend/Processor/Regex.php",
+    "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Frontend\\Processor\\SimpleHtmlDom": "inc/Engine/Optimization/LazyRenderContent/Frontend/Processor/SimpleHtmlDom.php",
+    "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\Frontend\\Subscriber": "inc/Engine/Optimization/LazyRenderContent/Frontend/Subscriber.php",
+    "WP_Rocket\\Engine\\Optimization\\LazyRenderContent\\ServiceProvider": "inc/Engine/Optimization/LazyRenderContent/ServiceProvider.php",
+    "WP_Rocket\\Engine\\Optimization\\Minify\\AbstractMinifySubscriber": "inc/Engine/Optimization/Minify/AbstractMinifySubscriber.php",
+    "WP_Rocket\\Engine\\Optimization\\Minify\\AdminSubscriber": "inc/Engine/Optimization/Minify/AdminSubscriber.php",
+    "WP_Rocket\\Engine\\Optimization\\Minify\\CSS\\AbstractCSSOptimization": "inc/Engine/Optimization/Minify/CSS/AbstractCSSOptimization.php",
+    "WP_Rocket\\Engine\\Optimization\\Minify\\CSS\\AdminSubscriber": "inc/Engine/Optimization/Minify/CSS/AdminSubscriber.php",
+    "WP_Rocket\\Engine\\Optimization\\Minify\\CSS\\Minify": "inc/Engine/Optimization/Minify/CSS/Minify.php",
+    "WP_Rocket\\Engine\\Optimization\\Minify\\CSS\\Subscriber": "inc/Engine/Optimization/Minify/CSS/Subscriber.php",
+    "WP_Rocket\\Engine\\Optimization\\Minify\\JS\\AbstractJSOptimization": "inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php",
+    "WP_Rocket\\Engine\\Optimization\\Minify\\JS\\Combine": "inc/Engine/Optimization/Minify/JS/Combine.php",
+    "WP_Rocket\\Engine\\Optimization\\Minify\\JS\\Minify": "inc/Engine/Optimization/Minify/JS/Minify.php",
+    "WP_Rocket\\Engine\\Optimization\\Minify\\JS\\Subscriber": "inc/Engine/Optimization/Minify/JS/Subscriber.php",
+    "WP_Rocket\\Engine\\Optimization\\Minify\\ProcessorInterface": "inc/Engine/Optimization/Minify/ProcessorInterface.php",
+    "WP_Rocket\\Engine\\Optimization\\RUCSS\\APIHandler\\APIClient": "inc/Engine/Optimization/RUCSS/APIHandler/APIClient.php",
+    "WP_Rocket\\Engine\\Optimization\\RUCSS\\Admin\\Database": "inc/Engine/Optimization/RUCSS/Admin/Database.php",
+    "WP_Rocket\\Engine\\Optimization\\RUCSS\\Admin\\OptionSubscriber": "inc/Engine/Optimization/RUCSS/Admin/OptionSubscriber.php",
+    "WP_Rocket\\Engine\\Optimization\\RUCSS\\Admin\\Settings": "inc/Engine/Optimization/RUCSS/Admin/Settings.php",
+    "WP_Rocket\\Engine\\Optimization\\RUCSS\\Admin\\Subscriber": "inc/Engine/Optimization/RUCSS/Admin/Subscriber.php",
+    "WP_Rocket\\Engine\\Optimization\\RUCSS\\Context\\RUCSSContext": "inc/Engine/Optimization/RUCSS/Context/RUCSSContext.php",
+    "WP_Rocket\\Engine\\Optimization\\RUCSS\\Context\\RUCSSContextSaas": "inc/Engine/Optimization/RUCSS/Context/RUCSSContextSaas.php",
+    "WP_Rocket\\Engine\\Optimization\\RUCSS\\Context\\RUCSSOptimizeContext": "inc/Engine/Optimization/RUCSS/Context/RUCSSOptimizeContext.php",
+    "WP_Rocket\\Engine\\Optimization\\RUCSS\\Controller\\Filesystem": "inc/Engine/Optimization/RUCSS/Controller/Filesystem.php",
+    "WP_Rocket\\Engine\\Optimization\\RUCSS\\Controller\\UsedCSS": "inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php",
+    "WP_Rocket\\Engine\\Optimization\\RUCSS\\Cron\\Subscriber": "inc/Engine/Optimization/RUCSS/Cron/Subscriber.php",
+    "WP_Rocket\\Engine\\Optimization\\RUCSS\\Database\\Queries\\UsedCSS": "inc/Engine/Optimization/RUCSS/Database/Queries/UsedCSS.php",
+    "WP_Rocket\\Engine\\Optimization\\RUCSS\\Database\\Row\\UsedCSS": "inc/Engine/Optimization/RUCSS/Database/Row/UsedCSS.php",
+    "WP_Rocket\\Engine\\Optimization\\RUCSS\\Database\\Schemas\\UsedCSS": "inc/Engine/Optimization/RUCSS/Database/Schemas/UsedCSS.php",
+    "WP_Rocket\\Engine\\Optimization\\RUCSS\\Database\\Tables\\UsedCSS": "inc/Engine/Optimization/RUCSS/Database/Tables/UsedCSS.php",
+    "WP_Rocket\\Engine\\Optimization\\RUCSS\\Frontend\\Subscriber": "inc/Engine/Optimization/RUCSS/Frontend/Subscriber.php",
+    "WP_Rocket\\Engine\\Optimization\\RUCSS\\Jobs\\Factory": "inc/Engine/Optimization/RUCSS/Jobs/Factory.php",
+    "WP_Rocket\\Engine\\Optimization\\RUCSS\\Jobs\\Manager": "inc/Engine/Optimization/RUCSS/Jobs/Manager.php",
+    "WP_Rocket\\Engine\\Optimization\\RUCSS\\ServiceProvider": "inc/Engine/Optimization/RUCSS/ServiceProvider.php",
+    "WP_Rocket\\Engine\\Optimization\\RegexTrait": "inc/Engine/Optimization/RegexTrait.php",
+    "WP_Rocket\\Engine\\Optimization\\ServiceProvider": "inc/Engine/Optimization/ServiceProvider.php",
+    "WP_Rocket\\Engine\\Optimization\\UrlTrait": "inc/Engine/Optimization/UrlTrait.php",
+    "WP_Rocket\\Engine\\Plugin\\InformationSubscriber": "inc/Engine/Plugin/InformationSubscriber.php",
+    "WP_Rocket\\Engine\\Plugin\\RenewalNotice": "inc/Engine/Plugin/RenewalNotice.php",
+    "WP_Rocket\\Engine\\Plugin\\ServiceProvider": "inc/Engine/Plugin/ServiceProvider.php",
+    "WP_Rocket\\Engine\\Plugin\\UpdaterApiCommonSubscriber": "inc/Engine/Plugin/UpdaterApiCommonSubscriber.php",
+    "WP_Rocket\\Engine\\Plugin\\UpdaterApiTools": "inc/Engine/Plugin/UpdaterApiTools.php",
+    "WP_Rocket\\Engine\\Plugin\\UpdaterSubscriber": "inc/Engine/Plugin/UpdaterSubscriber.php",
+    "WP_Rocket\\Engine\\Preload\\Activation\\Activation": "inc/Engine/Preload/Activation/Activation.php",
+    "WP_Rocket\\Engine\\Preload\\Activation\\ServiceProvider": "inc/Engine/Preload/Activation/ServiceProvider.php",
+    "WP_Rocket\\Engine\\Preload\\Admin\\Settings": "inc/Engine/Preload/Admin/Settings.php",
+    "WP_Rocket\\Engine\\Preload\\Admin\\Subscriber": "inc/Engine/Preload/Admin/Subscriber.php",
+    "WP_Rocket\\Engine\\Preload\\Controller\\CheckExcludedTrait": "inc/Engine/Preload/Controller/CheckExcludedTrait.php",
+    "WP_Rocket\\Engine\\Preload\\Controller\\CheckFinished": "inc/Engine/Preload/Controller/CheckFinished.php",
+    "WP_Rocket\\Engine\\Preload\\Controller\\ClearCache": "inc/Engine/Preload/Controller/ClearCache.php",
+    "WP_Rocket\\Engine\\Preload\\Controller\\CrawlHomepage": "inc/Engine/Preload/Controller/CrawlHomepage.php",
+    "WP_Rocket\\Engine\\Preload\\Controller\\LoadInitialSitemap": "inc/Engine/Preload/Controller/LoadInitialSitemap.php",
+    "WP_Rocket\\Engine\\Preload\\Controller\\PreloadUrl": "inc/Engine/Preload/Controller/PreloadUrl.php",
+    "WP_Rocket\\Engine\\Preload\\Controller\\Queue": "inc/Engine/Preload/Controller/Queue.php",
+    "WP_Rocket\\Engine\\Preload\\Cron\\Subscriber": "inc/Engine/Preload/Cron/Subscriber.php",
+    "WP_Rocket\\Engine\\Preload\\Database\\Queries\\Cache": "inc/Engine/Preload/Database/Queries/Cache.php",
+    "WP_Rocket\\Engine\\Preload\\Database\\Rows\\CacheRow": "inc/Engine/Preload/Database/Rows/CacheRow.php",
+    "WP_Rocket\\Engine\\Preload\\Database\\Schemas\\Cache": "inc/Engine/Preload/Database/Schemas/Cache.php",
+    "WP_Rocket\\Engine\\Preload\\Database\\Tables\\Cache": "inc/Engine/Preload/Database/Tables/Cache.php",
+    "WP_Rocket\\Engine\\Preload\\Frontend\\FetchSitemap": "inc/Engine/Preload/Frontend/FetchSitemap.php",
+    "WP_Rocket\\Engine\\Preload\\Frontend\\SitemapParser": "inc/Engine/Preload/Frontend/SitemapParser.php",
+    "WP_Rocket\\Engine\\Preload\\Frontend\\Subscriber": "inc/Engine/Preload/Frontend/Subscriber.php",
+    "WP_Rocket\\Engine\\Preload\\Links\\AdminSubscriber": "inc/Engine/Preload/Links/AdminSubscriber.php",
+    "WP_Rocket\\Engine\\Preload\\Links\\ServiceProvider": "inc/Engine/Preload/Links/ServiceProvider.php",
+    "WP_Rocket\\Engine\\Preload\\Links\\Subscriber": "inc/Engine/Preload/Links/Subscriber.php",
+    "WP_Rocket\\Engine\\Preload\\ServiceProvider": "inc/Engine/Preload/ServiceProvider.php",
+    "WP_Rocket\\Engine\\Preload\\Subscriber": "inc/Engine/Preload/Subscriber.php",
+    "WP_Rocket\\Engine\\Saas\\Admin\\AdminBar": "inc/Engine/Saas/Admin/AdminBar.php",
+    "WP_Rocket\\Engine\\Saas\\Admin\\Clean": "inc/Engine/Saas/Admin/Clean.php",
+    "WP_Rocket\\Engine\\Saas\\Admin\\Notices": "inc/Engine/Saas/Admin/Notices.php",
+    "WP_Rocket\\Engine\\Saas\\Admin\\Subscriber": "inc/Engine/Saas/Admin/Subscriber.php",
+    "WP_Rocket\\Engine\\Saas\\ServiceProvider": "inc/Engine/Saas/ServiceProvider.php",
+    "WP_Rocket\\Engine\\Support\\CommentTrait": "inc/Engine/Support/CommentTrait.php",
+    "WP_Rocket\\Engine\\Support\\Data": "inc/Engine/Support/Data.php",
+    "WP_Rocket\\Engine\\Support\\Meta": "inc/Engine/Support/Meta.php",
+    "WP_Rocket\\Engine\\Support\\Rest": "inc/Engine/Support/Rest.php",
+    "WP_Rocket\\Engine\\Support\\ServiceProvider": "inc/Engine/Support/ServiceProvider.php",
+    "WP_Rocket\\Engine\\Support\\Subscriber": "inc/Engine/Support/Subscriber.php",
+    "WP_Rocket\\Engine\\Tracking\\ServiceProvider": "inc/Engine/Tracking/ServiceProvider.php",
+    "WP_Rocket\\Engine\\Tracking\\Subscriber": "inc/Engine/Tracking/Subscriber.php",
+    "WP_Rocket\\Engine\\Tracking\\Tracking": "inc/Engine/Tracking/Tracking.php",
+    "WP_Rocket\\Engine\\Tracking\\TrackingTrait": "inc/Engine/Tracking/TrackingTrait.php",
+    "WPRocketUninstall": "inc/Engine/WPRocketUninstall.php",
+    "WP_Rocket\\Logger\\HTMLFormatter": "inc/Logger/HTMLFormatter.php",
+    "WP_Rocket\\Logger\\Logger": "inc/Logger/Logger.php",
+    "WP_Rocket\\Logger\\LoggerAware": "inc/Logger/LoggerAware.php",
+    "WP_Rocket\\Logger\\LoggerAwareInterface": "inc/Logger/LoggerAwareInterface.php",
+    "WP_Rocket\\Logger\\ServiceProvider": "inc/Logger/ServiceProvider.php",
+    "WP_Rocket\\Logger\\StreamHandler": "inc/Logger/StreamHandler.php",
+    "WP_Rocket\\Logger\\Subscriber": "inc/Logger/Subscriber.php",
+    "WP_Rocket\\Plugin": "inc/Plugin.php",
+    "WP_Rocket\\ThirdParty\\Hostings\\AbstractNoCacheHost": "inc/ThirdParty/Hostings/AbstractNoCacheHost.php",
+    "WP_Rocket\\ThirdParty\\Hostings\\Cloudways": "inc/ThirdParty/Hostings/Cloudways.php",
+    "WP_Rocket\\ThirdParty\\Hostings\\Dreampress": "inc/ThirdParty/Hostings/Dreampress.php",
+    "WP_Rocket\\ThirdParty\\Hostings\\Godaddy": "inc/ThirdParty/Hostings/Godaddy.php",
+    "WP_Rocket\\ThirdParty\\Hostings\\HostResolver": "inc/ThirdParty/Hostings/HostResolver.php",
+    "WP_Rocket\\ThirdParty\\Hostings\\HostSubscriberFactory": "inc/ThirdParty/Hostings/HostSubscriberFactory.php",
+    "WP_Rocket\\ThirdParty\\Hostings\\Kinsta": "inc/ThirdParty/Hostings/Kinsta.php",
+    "WP_Rocket\\ThirdParty\\Hostings\\LiteSpeed": "inc/ThirdParty/Hostings/LiteSpeed.php",
+    "WP_Rocket\\ThirdParty\\Hostings\\O2Switch": "inc/ThirdParty/Hostings/O2Switch.php",
+    "WP_Rocket\\ThirdParty\\Hostings\\OneCom": "inc/ThirdParty/Hostings/OneCom.php",
+    "WP_Rocket\\ThirdParty\\Hostings\\Pressable": "inc/ThirdParty/Hostings/Pressable.php",
+    "WP_Rocket\\ThirdParty\\Hostings\\Pressidium": "inc/ThirdParty/Hostings/Pressidium.php",
+    "WP_Rocket\\ThirdParty\\Hostings\\ProIsp": "inc/ThirdParty/Hostings/ProIsp.php",
+    "WP_Rocket\\ThirdParty\\Hostings\\Savvii": "inc/ThirdParty/Hostings/Savvii.php",
+    "WP_Rocket\\ThirdParty\\Hostings\\ServiceProvider": "inc/ThirdParty/Hostings/ServiceProvider.php",
+    "WP_Rocket\\ThirdParty\\Hostings\\SpinUpWP": "inc/ThirdParty/Hostings/SpinUpWP.php",
+    "WP_Rocket\\ThirdParty\\Hostings\\WPEngine": "inc/ThirdParty/Hostings/WPEngine.php",
+    "WP_Rocket\\ThirdParty\\Hostings\\WPXCloud": "inc/ThirdParty/Hostings/WPXCloud.php",
+    "WP_Rocket\\ThirdParty\\Hostings\\WordPressCom": "inc/ThirdParty/Hostings/WordPressCom.php",
+    "WP_Rocket\\ThirdParty\\NullSubscriber": "inc/ThirdParty/NullSubscriber.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\Ads\\Adthrive": "inc/ThirdParty/Plugins/Ads/Adthrive.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\CDN\\Cloudflare": "inc/ThirdParty/Plugins/CDN/Cloudflare.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\CDN\\CloudflareFacade": "inc/ThirdParty/Plugins/CDN/CloudflareFacade.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\ContactForm7": "inc/ThirdParty/Plugins/ContactForm7.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\ConvertPlug": "inc/ThirdParty/Plugins/ConvertPlug.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\Cookie\\Termly": "inc/ThirdParty/Plugins/Cookie/Termly.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\EWWW": "inc/ThirdParty/Plugins/EWWW.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\Ecommerce\\BigCommerce": "inc/ThirdParty/Plugins/Ecommerce/BigCommerce.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\Ecommerce\\WooCommerceSubscriber": "inc/ThirdParty/Plugins/Ecommerce/WooCommerceSubscriber.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\I18n\\TranslatePress": "inc/ThirdParty/Plugins/I18n/TranslatePress.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\I18n\\WPML": "inc/ThirdParty/Plugins/I18n/WPML.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\I18n\\Weglot": "inc/ThirdParty/Plugins/I18n/Weglot.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\InlineRelatedPosts": "inc/ThirdParty/Plugins/InlineRelatedPosts.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\Jetpack": "inc/ThirdParty/Plugins/Jetpack.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\ModPagespeed": "inc/ThirdParty/Plugins/ModPagespeed.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\Optimization\\AMP": "inc/ThirdParty/Plugins/Optimization/AMP.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\Optimization\\Autoptimize": "inc/ThirdParty/Plugins/Optimization/Autoptimize.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\Optimization\\Ezoic": "inc/ThirdParty/Plugins/Optimization/Ezoic.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\Optimization\\Hummingbird": "inc/ThirdParty/Plugins/Optimization/Hummingbird.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\Optimization\\Perfmatters": "inc/ThirdParty/Plugins/Optimization/Perfmatters.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\Optimization\\RapidLoad": "inc/ThirdParty/Plugins/Optimization/RapidLoad.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\Optimization\\RocketLazyLoad": "inc/ThirdParty/Plugins/Optimization/RocketLazyLoad.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\Optimization\\WPMeteor": "inc/ThirdParty/Plugins/Optimization/WPMeteor.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\Optimole": "inc/ThirdParty/Plugins/Optimole.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\PDFEmbedder": "inc/ThirdParty/Plugins/PDFEmbedder.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\PWA": "inc/ThirdParty/Plugins/PWA.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\PageBuilder\\BeaverBuilder": "inc/ThirdParty/Plugins/PageBuilder/BeaverBuilder.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\PageBuilder\\Elementor": "inc/ThirdParty/Plugins/PageBuilder/Elementor.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\RevolutionSlider": "inc/ThirdParty/Plugins/RevolutionSlider.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\SEO\\AllInOneSEOPack": "inc/ThirdParty/Plugins/SEO/AllInOneSEOPack.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\SEO\\RankMathSEO": "inc/ThirdParty/Plugins/SEO/RankMathSEO.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\SEO\\SEOPress": "inc/ThirdParty/Plugins/SEO/SEOPress.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\SEO\\TheSEOFramework": "inc/ThirdParty/Plugins/SEO/TheSEOFramework.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\SEO\\Yoast": "inc/ThirdParty/Plugins/SEO/Yoast.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\Security\\WordFenceCompatibility": "inc/ThirdParty/Plugins/Security/WordFenceCompatibility.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\ShortPixel": "inc/ThirdParty/Plugins/ShortPixel.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\SimpleCustomCss": "inc/ThirdParty/Plugins/SimpleCustomCss.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\Smush": "inc/ThirdParty/Plugins/Smush.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\TheEventsCalendar": "inc/ThirdParty/Plugins/TheEventsCalendar.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\ThirstyAffiliates": "inc/ThirdParty/Plugins/ThirstyAffiliates.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\UnlimitedElements": "inc/ThirdParty/Plugins/UnlimitedElements.php",
+    "WP_Rocket\\ThirdParty\\Plugins\\WPGeotargeting": "inc/ThirdParty/Plugins/WPGeotargeting.php",
+    "WP_Rocket\\ThirdParty\\ReturnTypesTrait": "inc/ThirdParty/ReturnTypesTrait.php",
+    "WP_Rocket\\ThirdParty\\ServiceProvider": "inc/ThirdParty/ServiceProvider.php",
+    "WP_Rocket\\ThirdParty\\SubscriberFactoryInterface": "inc/ThirdParty/SubscriberFactoryInterface.php",
+    "WP_Rocket\\ThirdParty\\Themes\\Avada": "inc/ThirdParty/Themes/Avada.php",
+    "WP_Rocket\\ThirdParty\\Themes\\Bridge": "inc/ThirdParty/Themes/Bridge.php",
+    "WP_Rocket\\ThirdParty\\Themes\\Divi": "inc/ThirdParty/Themes/Divi.php",
+    "WP_Rocket\\ThirdParty\\Themes\\Flatsome": "inc/ThirdParty/Themes/Flatsome.php",
+    "WP_Rocket\\ThirdParty\\Themes\\GeneratePress": "inc/ThirdParty/Themes/GeneratePress.php",
+    "WP_Rocket\\ThirdParty\\Themes\\Jevelin": "inc/ThirdParty/Themes/Jevelin.php",
+    "WP_Rocket\\ThirdParty\\Themes\\MinimalistBlogger": "inc/ThirdParty/Themes/MinimalistBlogger.php",
+    "WP_Rocket\\ThirdParty\\Themes\\Polygon": "inc/ThirdParty/Themes/Polygon.php",
+    "WP_Rocket\\ThirdParty\\Themes\\ServiceProvider": "inc/ThirdParty/Themes/ServiceProvider.php",
+    "WP_Rocket\\ThirdParty\\Themes\\Shoptimizer": "inc/ThirdParty/Themes/Shoptimizer.php",
+    "WP_Rocket\\ThirdParty\\Themes\\SubscriberFactory": "inc/ThirdParty/Themes/SubscriberFactory.php",
+    "WP_Rocket\\ThirdParty\\Themes\\ThemeResolver": "inc/ThirdParty/Themes/ThemeResolver.php",
+    "WP_Rocket\\ThirdParty\\Themes\\Themify": "inc/ThirdParty/Themes/Themify.php",
+    "WP_Rocket\\ThirdParty\\Themes\\Uncode": "inc/ThirdParty/Themes/Uncode.php",
+    "WP_Rocket\\ThirdParty\\Themes\\Xstore": "inc/ThirdParty/Themes/Xstore.php",
+    "WP_Rocket\\Buffer\\Abstract_Buffer": "inc/classes/Buffer/class-abstract-buffer.php",
+    "WP_Rocket\\Buffer\\Cache": "inc/classes/Buffer/class-cache.php",
+    "WP_Rocket\\Buffer\\Config": "inc/classes/Buffer/class-config.php",
+    "WP_Rocket\\Buffer\\Tests": "inc/classes/Buffer/class-tests.php",
+    "WP_Rocket\\ServiceProvider\\Common_Subscribers": "inc/classes/ServiceProvider/class-common-subscribers.php",
+    "WP_Rocket\\ServiceProvider\\Options": "inc/classes/ServiceProvider/class-options.php",
+    "WP_Rocket\\Admin\\Abstract_Options": "inc/classes/admin/class-abstract-options.php",
+    "WP_Rocket\\Admin\\Logs": "inc/classes/admin/class-logs.php",
+    "WP_Rocket\\Admin\\Options_Data": "inc/classes/admin/class-options-data.php",
+    "WP_Rocket\\Admin\\Options": "inc/classes/admin/class-options.php",
+    "WP_Rocket\\Abstract_Render": "inc/classes/class-abstract-render.php",
+    "WP_Rocket_Requirements_Check": "inc/classes/class-wp-rocket-requirements-check.php",
+    "WP_Rocket_Mobile_Detect": "inc/classes/dependencies/mobiledetect/mobiledetectlib/Mobile_Detect.php",
+    "WP_Rocket_WP_Async_Request": "inc/classes/dependencies/wp-media/background-processing/wp-async-request.php",
+    "WP_Rocket_WP_Background_Process": "inc/classes/dependencies/wp-media/background-processing/wp-background-process.php",
+    "WP_Rocket\\Event_Management\\Event_Manager": "inc/classes/event-management/class-event-manager.php",
+    "WP_Rocket\\Event_Management\\Event_Manager_Aware_Subscriber_Interface": "inc/classes/event-management/event-manager-aware-subscriber-interface.php",
+    "WP_Rocket\\Event_Management\\Subscriber_Interface": "inc/classes/event-management/subscriber-interface.php",
+    "WP_Rocket\\Interfaces\\Render_Interface": "inc/classes/interfaces/class-render-interface.php",
+    "WP_Rocket\\Subscriber\\Tools\\Detect_Missing_Tags_Subscriber": "inc/classes/subscriber/Tools/class-detect-missing-tags-subscriber.php",
+    "WP_Rocket\\Subscriber\\Third_Party\\Plugins\\Images\\Webp\\Imagify_Subscriber": "inc/classes/subscriber/third-party/plugins/Images/Webp/class-imagify-subscriber.php",
+    "WP_Rocket\\Subscriber\\Third_Party\\Plugins\\Images\\Webp\\Optimus_Subscriber": "inc/classes/subscriber/third-party/plugins/Images/Webp/class-optimus-subscriber.php",
+    "WP_Rocket\\Subscriber\\Third_Party\\Plugins\\Images\\Webp\\Webp_Common": "inc/classes/subscriber/third-party/plugins/Images/Webp/trait-webp-common.php",
+    "WP_Rocket\\Subscriber\\Third_Party\\Plugins\\Images\\Webp\\Webp_Interface": "inc/classes/subscriber/third-party/plugins/Images/Webp/webp-interface.php",
+    "WP_Rocket\\Subscriber\\Third_Party\\Plugins\\Mobile_Subscriber": "inc/classes/subscriber/third-party/plugins/class-mobile-subscriber.php",
+    "WP_Rocket\\Subscriber\\Third_Party\\Plugins\\NGG_Subscriber": "inc/classes/subscriber/third-party/plugins/class-ngg-subscriber.php",
+    "WP_Rocket\\Subscriber\\Third_Party\\Plugins\\SyntaxHighlighter_Subscriber": "inc/classes/subscriber/third-party/plugins/class-syntaxhighlighter-subscriber.php",
+    "WP_Rocket\\Traits\\Config_Updater": "inc/classes/traits/trait-config-updater.php",
+    "WP_Rocket\\Traits\\Memoize": "inc/classes/traits/trait-memoize.php",
+    "WP_Rocket\\deprecated\\DeprecatedClassTrait": "inc/deprecated/DeprecatedClassTrait.php",
+    "WP_Rocket\\Addon\\Busting\\BustingFactory": "inc/deprecated/Engine/Addon/Busting/BustingFactory.php",
+    "WP_Rocket\\Addon\\Busting\\FileBustingTrait": "inc/deprecated/Engine/Addon/Busting/FileBustingTrait.php",
+    "WP_Rocket\\Addon\\FacebookTracking\\Subscriber": "inc/deprecated/Engine/Addon/FacebookTracking/Subscriber.php",
+    "WP_Rocket\\Addon\\GoogleTracking\\GoogleAnalytics": "inc/deprecated/Engine/Addon/GoogleTracking/GoogleAnalytics.php",
+    "WP_Rocket\\Addon\\GoogleTracking\\GoogleTagManager": "inc/deprecated/Engine/Addon/GoogleTracking/GoogleTagManager.php",
+    "WP_Rocket\\Addon\\GoogleTracking\\Subscriber": "inc/deprecated/Engine/Addon/GoogleTracking/Subscriber.php",
+    "WP_Rocket\\deprecated\\Engine\\Media\\Embeds\\EmbedsSubscriber": "inc/deprecated/Engine/Media/Embeds/EmbedsSubscriber.php",
+    "WP_Rocket\\Engine\\Optimization\\QueryString\\Remove": "inc/deprecated/Engine/Optimization/QueryString/Remove.php",
+    "WP_Rocket\\Engine\\Optimization\\QueryString\\RemoveSubscriber": "inc/deprecated/Engine/Optimization/QueryString/RemoveSubscriber.php",
+    "WP_Rocket\\Busting\\Abstract_Busting": "inc/deprecated/classes/busting/class-abstract-busting.php",
+    "WP_Rocket\\Busting\\Facebook_Pickles": "inc/deprecated/classes/busting/class-facebook-pickles.php",
+    "WP_Rocket\\Busting\\Facebook_SDK": "inc/deprecated/classes/busting/class-facebook-sdk.php",
+    "WP_Rocket\\Subscriber\\Optimization\\Dequeue_JQuery_Migrate_Subscriber": "inc/deprecated/subscriber/Optimization/class-dequeue-jquery-migrate-subscriber.php",
+    "WP_Rocket\\Subscriber\\Optimization\\Minify_HTML_Subscriber": "inc/deprecated/subscriber/admin/Optimization/class-minify-html-subscriber.php",
+    "WP_Rocket\\Subscriber\\Admin\\Settings\\Beacon_Subscriber": "inc/deprecated/subscriber/admin/Settings/class-beacon-subscriber.php",
+    "Minify_HTML": "inc/deprecated/vendors/classes/class-minify-html.php",
+    "Imagify_Partner": "inc/vendors/classes/class-imagify-partner.php",
+    "Minify_CSS_UriRewriter": "inc/vendors/classes/class-minify-css-urirewriter.php",
+    "Rocket_Mobile_Detect": "inc/vendors/classes/class-rocket-mobile-detect.php"
+  }
+}

--- a/.aiassistant/skills/issue-workflow/SKILL.md
+++ b/.aiassistant/skills/issue-workflow/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: issue-workflow
+description: Work on a GitHub issue by number for wp-media/wp-rocket. Sync the issue locally, analyze it, create a branch, implement minimal changes, and prepare a PR draft.
+---
+
+# Issue Workflow
+
+Repository: `wp-media/wp-rocket`
+
+When the user asks to work on an issue by number, such as:
+- `/task 123`
+- `issue 123`
+- `#123`
+
+follow this workflow:
+
+1. Extract the issue number.
+2. Run `.aiassistant/skills/issue-workflow/scripts/issue-sync.sh <issue-number>`.
+3. Read `.TemporaryItems/Issues/wp-rocket/issues/<issue-number>.md`.
+4. If `Parent Epic (GitHub)` or `Parent Epics (Task List)` has entries, sync each epic with `.aiassistant/skills/issue-workflow/scripts/issue-sync.sh <epic-number>` and read those files for context (this usually means the current issue is a subtask).
+5. If the issue looks like an Epic (label `epics`, Issue Type = `EPIC`, Project field `Type` = `EPIC`, or `Sub-issues (GitHub)`/`Sub-issues (Task List)` has entries), ask whether to work the Epic as a whole or a specific sub-issue. If a sub-issue is chosen, run `.aiassistant/skills/issue-workflow/scripts/issue-sync.sh <sub-issue-number>` and proceed with the Epic context in mind.
+6. If relationships are unclear or missing (including Issue Type being `unknown` because Issue Types are disabled, or Project `Type` being `unknown` because the issue is not in a Project or access is missing), proceed as a standalone issue unless an Epic signal is present. Only ask for an epic/sub-issue number when at least one explicit Epic signal or parent/sub-issue is detected.
+7. Summarize the issue, feasibility, constraints, and blockers.
+8. If a truly blocking ambiguity exists, ask before coding. Otherwise proceed conservatively.
+9. **Map the codebase with the knowledge graph before touching any file.**
+   Read `.aiassistant/graph/dependency-graph.json`. If `base_commit` ≠ current HEAD, refresh first: `node bin/build-knowledge-graph.js`.
+   Answer these questions from the graph — do NOT use grep for class lookups:
+   - **Where is the target class?** → `symbol_index["WP_Rocket\\Engine\\...\\ClassName"]`
+   - **What does it depend on?** → `nodes[file].imports`
+   - **Which ServiceProvider wires it?** → find files whose `imports` contain the target FQN — that file's ServiceProvider registers it
+   - **Which Subscribers are in this module?** → filter `nodes` where `symbols[*].implements` includes `Subscriber_Interface` and `namespace` starts with the module prefix
+   - **Constructor signature** → read the actual file once located; the graph gives the path, you read the constructor for argument types before modifying `register()` in the ServiceProvider
+10. Determine the branch prefix from the issue type:
+   - Bug / defect → `fix`
+   - Enhancement / feature → `enhancement`
+   - Test → `test`
+   - Default → `fix`
+   Run `.aiassistant/skills/issue-workflow/scripts/make-issue-branch.sh <issue-number> "<issue-title>" <prefix>`.
+11. Follow `AGENTS.md`.
+12. Activate the relevant skills:
+   - `wp-rocket-architecture`
+   - `wordpress-compliance`
+13. Implement minimal changes following TDD:
+   - Write or update tests **alongside** implementation (unit in `tests/Unit/`, integration in `tests/Integration/`).
+   - Test files mirror source: `inc/Engine/Foo/Bar.php` → `tests/Unit/inc/Engine/Foo/Bar/methodName.php`.
+   - Use `@group FeatureName` on integration tests for targeted runs.
+   - New hooks **must** use `wpm_apply_filters_typed()` — never `apply_filters()`.
+   - Reading plugin options **must** use the injected `Options_Data` instance — never `get_option()`.
+   - All WordPress hooks **must** go through a Subscriber — never `add_action`/`add_filter` directly.
+   - Run `composer test-unit` and confirm no regressions.
+   - If integration tests exist for the module: `vendor/bin/phpunit --configuration tests/Integration/phpunit.xml.dist --group FeatureName` (use the direct phpunit command rather than `composer test-integration` to avoid conflicts with its default `--exclude-group` list).
+14. Run linting and static analysis; fix all new violations before committing:
+   - `composer phpcs-changed` first (fast pass on changed files only).
+   - `composer phpcs` for a full check.
+   - `composer run-stan` — verify all four custom PHPStan rules pass (§2.2 of AGENTS.md).
+15. Commit atomically: one `git commit` per logical change set using Conventional Commits format.
+16. Run `.aiassistant/skills/issue-workflow/scripts/init-pr-draft.sh <issue-number>`.
+17. Fill every section of the PR draft at `.TemporaryItems/Issues/wp-rocket/pull/<issue-number>.md`. The file was already initialized from `refs/pr-template.md` by the script in step 16. Complete every section with relevant content — do not skip sections or invent a different structure. Replace all placeholder text with real content. Tick the appropriate `Type of change` checkbox.
+18. Run `git push` to publish the branch.
+19. Create the GitHub PR using the **exact content of the filled draft** as the PR body. Do not summarise or rewrite it — copy it verbatim. Set as draft if implementation is still in progress.
+20. **Invoke the `qa-engineer` sub-agent** — pass it the issue number and PR number. It will:
+    - Read the issue spec and PR diff.
+    - Select validation strategies (API, Browser, Analysis) based on what changed.
+    - Use Playwright MCP for browser/UI flows against the local environment at `http://localhost:8888`.
+    - Return a structured test report (see format in `.aiassistant/agents/qa-engineer.md`).
+21. If `qa-engineer` reports **FAIL** or **PARTIAL**: fix the identified blockers, re-commit, re-push, and re-run the agent before continuing.
+22. If `qa-engineer` reports **READY TO MERGE**:
+    1. **Update the PR body** — edit the **"What was tested"** section under `## Detailed scenario` to include the full QA report: strategies used, each acceptance criterion with its validation method and result, and smoke-test outcomes. Use `gh pr edit <PR_number> --body "..."` with the updated body. Also update the local draft at `.TemporaryItems/Issues/wp-rocket/pull/<issue-number>.md` to match.
+    2. **Convert the PR from draft to ready-for-review**: `gh pr ready <PR_number>`.
+23. Monitor PR CI status checks until all pass. Report any failures with actionable details.
+
+## Tooling — Prefer MCPs, Fall Back to Shell
+
+This workflow uses MCP tools when available. Always prefer them over shell commands.
+If an MCP tool is not available in the current session, fall back to the shell equivalent.
+
+### Issue fetch
+| Preferred (MCP) | Fallback |
+|---|---|
+| `mcp_github_github_issue_read` (method: `get`, `get_sub_issues`) | `issue-sync.sh <number>` → read `.TemporaryItems/…/<number>.md` |
+
+### Branch creation
+| Preferred (MCP) | Fallback |
+|---|---|
+| `mcp_gitkraken_git_branch` (action: `create`) + `mcp_gitkraken_git_checkout` | `make-issue-branch.sh <number> "<title>" <prefix>` |
+
+### Staging & committing
+| Preferred (MCP) | Fallback |
+|---|---|
+| `mcp_gitkraken_git_add_or_commit` (action: `add`, then `commit`) | `git add` / `git commit` in terminal |
+
+### Pushing
+| Preferred (MCP) | Fallback |
+|---|---|
+| `mcp_gitkraken_git_push` | `git push` in terminal |
+
+### PR creation
+| Preferred (MCP) | Fallback |
+|---|---|
+| `mcp_github_github_create_pull_request` | Provide the filled draft manually |
+
+### CI monitoring
+| Preferred (MCP) | Fallback |
+|---|---|
+| `github-pull-request_pullRequestStatusChecks` or `mcp_github_github_pull_request_read` (method: `get_check_runs`) | Ask user to check GitHub Actions |
+
+## Git Operations
+
+This skill operates under the **Issue Workflow exception** defined in AGENTS.md §5.1.
+
+You MAY:
+1. Run atomic commits — one per logical change set, only after PHPCS + static analysis pass.
+2. Push once all commits are ready.
+3. Create the GitHub Pull Request using the filled PR draft from `.TemporaryItems/Issues/wp-rocket/pull/<issue-number>.md`.
+4. Monitor CI status checks until all pass or a failure is detected and reported.
+
+Commit message format: `type(scope): short description` (Conventional Commits).
+Do not amend commits that have already been pushed.
+
+## QA Pipeline — Sub-Agent Invocation
+
+After the PR is created (step 19), invoke the `qa-engineer` sub-agent. Provide:
+- The issue number (for acceptance criteria)
+- The PR number (for diff and "How to test" section)
+
+```
+Invoke sub-agent: qa-engineer
+Inputs: issue #<N>, PR #<M>
+```
+
+The agent selects strategies automatically:
+- **API/functional** — if backend logic changed (AJAX, hooks, WP-CLI, caching logic, data processing)
+- **Browser/UI** — if admin UI changed; uses Playwright MCP against `http://localhost:8888`
+- **Analysis fallback** — if local environment is unavailable
+
+### Decision tree
+
+```
+PR created
+  └─ invoke qa-engineer
+       ├─ backend only   → Strategy A (API/WP-CLI)
+       ├─ UI touched     → Strategy B (Playwright MCP against local env)
+       └─ env unavailable → Strategy C (Analysis)
+
+qa-engineer returns READY TO MERGE → update PR body with QA findings → mark PR ready for review
+qa-engineer returns FAIL/PARTIAL   → fix blockers → re-run qa-engineer
+```
+
+---
+
+## Epic And Sub-Issue Sync
+The sync script auto-downloads parent epics and sub-issues into
+`.TemporaryItems/Issues/wp-rocket/issues/`. To skip related sync, set
+`WPROCKET_SYNC_RELATED=0` when invoking the script.

--- a/.aiassistant/skills/issue-workflow/refs/pr-template.md
+++ b/.aiassistant/skills/issue-workflow/refs/pr-template.md
@@ -1,0 +1,66 @@
+# Description
+
+Fixes #(issue number)
+*Explain how this code impacts users.*
+
+## Type of change
+
+- [ ] New feature (non-breaking change which adds functionality).
+- [ ] Bug fix (non-breaking change which fixes an issue).
+- [ ] Enhancement (non-breaking change which improves an existing functionality).
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
+- [ ] Sub-task of #(issue number)
+- [ ] Chore
+- [ ] Release
+
+## Detailed scenario
+
+### What was tested
+
+*Describe the scenarios that you tested, and specify if it is automated or manual. For manual scenarios, provide a screenshot of the results.*
+
+### How to test
+
+*Describe how the PR can be tested so that the validator can be autonomous: environment, dependencies, specific setup, steps to perform, API requests, etc.*
+
+### Affected Features & Quality Assurance Scope
+
+*Please specify which existing features or modules are impacted by the changes in this Pull Request. This information is crucial for the QA team to properly define the testing scope and ensure comprehensive test coverage.*
+
+## Technical description
+
+### Documentation
+
+*Explain how this code works. Diagrams & drawings are welcome.*
+
+### New dependencies
+
+*List any new dependencies that are required for this change.*
+
+### Risks
+
+*List possible performance & security issues or risks, and explain how they have been mitigated.*
+
+# Mandatory Checklist
+
+## Code validation
+
+- [ ] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
+- [ ] I triggered all changed lines of code at least once without new errors/warnings/notices.
+- [ ] I implemented built-in tests to cover the new/changed code.
+
+## Code style
+
+- [ ] I wrote a self-explanatory code about what it does.
+- [ ] I protected entry points against unexpected inputs.
+- [ ] I did not introduce unnecessary complexity.
+- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.
+
+## Unticked items justification
+
+*If some mandatory items are not relevant, explain why in this section.*
+
+# Additional Checks
+- [ ] In the case of complex code, I wrote comments to explain it.
+- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
+- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)

--- a/.aiassistant/skills/issue-workflow/scripts/init-pr-draft.sh
+++ b/.aiassistant/skills/issue-workflow/scripts/init-pr-draft.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Initialize a PR draft file for a given issue number.
+# Usage: init-pr-draft.sh <issue-number>
+set -euo pipefail
+
+die() {
+  echo "init-pr-draft: $*" >&2
+  exit 1
+}
+
+# Required argument.
+ISSUE_NUMBER="${1:?issue number required}"
+
+# Resolve repository root (works regardless of the current working directory).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR=""
+if command -v git >/dev/null 2>&1; then
+  ROOT_DIR="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || true)"
+fi
+if [ -z "$ROOT_DIR" ]; then
+  ROOT_DIR="$(cd "$SCRIPT_DIR/../../../../" && pwd)"
+fi
+if [ ! -d "$ROOT_DIR" ]; then
+  die "Unable to resolve repository root from ${SCRIPT_DIR}."
+fi
+
+# Template path and output location.
+TEMPLATE="${ROOT_DIR}/.aiassistant/skills/issue-workflow/refs/pr-template.md"
+OUT_DIR="${ROOT_DIR}/.TemporaryItems/Issues/wp-rocket/pull"
+OUT_FILE="${OUT_DIR}/${ISSUE_NUMBER}.md"
+
+if [ ! -f "$TEMPLATE" ]; then
+  die "Template not found: ${TEMPLATE}"
+fi
+
+# Ensure output directory exists and copy the template.
+mkdir -p "$OUT_DIR"
+cp "$TEMPLATE" "$OUT_FILE"
+
+# Replace placeholder with the issue number (macOS + Linux compatible).
+sed -i '' "s/(issue number)/${ISSUE_NUMBER}/g" "$OUT_FILE" 2>/dev/null \
+  || sed -i "s/(issue number)/${ISSUE_NUMBER}/g" "$OUT_FILE"
+
+# Print the path for downstream tooling.
+echo "$OUT_FILE"

--- a/.aiassistant/skills/issue-workflow/scripts/issue-sync.sh
+++ b/.aiassistant/skills/issue-workflow/scripts/issue-sync.sh
@@ -1,0 +1,443 @@
+#!/usr/bin/env bash
+# Sync a GitHub issue into a local Markdown snapshot for review.
+# Usage: issue-sync.sh <issue-number>
+# Optional: set WPROCKET_SYNC_RELATED=0 to skip syncing parent/sub-issues.
+set -euo pipefail
+
+die() {
+  echo "issue-sync: $*" >&2
+  exit 1
+}
+
+require_command() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    die "Missing required command: ${cmd}."
+  fi
+}
+
+# Required argument: issue number.
+ISSUE_NUMBER="${1:?issue number required}"
+
+# Canonical repo for WP Rocket.
+REPO="wp-media/wp-rocket"
+OWNER="${REPO%%/*}"
+REPO_NAME="${REPO#*/}"
+
+# Resolve repository root (works regardless of the current working directory).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR=""
+if command -v git >/dev/null 2>&1; then
+  ROOT_DIR="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || true)"
+fi
+if [ -z "$ROOT_DIR" ]; then
+  ROOT_DIR="$(cd "$SCRIPT_DIR/../../../../" && pwd)"
+fi
+if [ ! -d "$ROOT_DIR" ]; then
+  die "Unable to resolve repository root from ${SCRIPT_DIR}."
+fi
+
+# Output location for the issue snapshot.
+OUT_DIR="${ROOT_DIR}/.TemporaryItems/Issues/wp-rocket/issues"
+OUT_FILE="${OUT_DIR}/${ISSUE_NUMBER}.md"
+
+# Related issue sync controls.
+SYNC_RELATED="${WPROCKET_SYNC_RELATED:-1}"
+SEEN_ISSUES="${WPROCKET_SYNC_SEEN:-}"
+
+is_number() {
+  [[ "${1:-}" =~ ^[0-9]+$ ]]
+}
+
+has_seen_issue() {
+  local num="$1"
+  [ -z "$SEEN_ISSUES" ] && return 1
+  case ",${SEEN_ISSUES}," in
+    *,"${num}",*) return 0 ;;
+  esac
+  return 1
+}
+
+mark_seen_issue() {
+  local num="$1"
+  if has_seen_issue "$num"; then
+    return 0
+  fi
+  if [ -z "$SEEN_ISSUES" ]; then
+    SEEN_ISSUES="$num"
+  else
+    SEEN_ISSUES="${SEEN_ISSUES},${num}"
+  fi
+  export WPROCKET_SYNC_SEEN="$SEEN_ISSUES"
+}
+
+mark_seen_issue "$ISSUE_NUMBER"
+
+require_command gh
+require_command jq
+if ! gh auth status -h github.com >/dev/null 2>&1; then
+  die "GitHub CLI is not authenticated. Run \"gh auth login\"."
+fi
+
+# Extract issue numbers from task list items in a Markdown body.
+extract_task_issue_numbers() {
+  local body="$1"
+  local repo="$2"
+  local owner="${repo%%/*}"
+  local name="${repo#*/}"
+
+  awk -v owner="$owner" -v name="$name" -v repo="$repo" '
+    BEGIN { IGNORECASE = 1 }
+    function emit(num) {
+      if (num ~ /^[0-9]+$/ && !seen[num]++) {
+        print num
+      }
+    }
+    /^[[:space:]]*[-*][[:space:]]+\[[ xX]\][[:space:]]+/ {
+      line = $0
+      sub(/^[[:space:]]*[-*][[:space:]]+\[[ xX]\][[:space:]]+/, "", line)
+      while (match(line, /(https?:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/issues\/[0-9]+)|([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+#[0-9]+)|(#[0-9]+)/)) {
+        ref = substr(line, RSTART, RLENGTH)
+        if (ref ~ /^#/) {
+          emit(substr(ref, 2))
+        } else if (ref ~ /github\.com/) {
+          n = split(ref, parts, "/")
+          o = parts[4]
+          r = parts[5]
+          num = parts[7]
+          if (tolower(o) == tolower(owner) && tolower(r) == tolower(name)) {
+            emit(num)
+          }
+        } else if (ref ~ /#/) {
+          split(ref, pr, "#")
+          if (tolower(pr[1]) == tolower(repo)) {
+            emit(pr[2])
+          }
+        }
+        line = substr(line, RSTART + RLENGTH)
+      }
+    }
+  ' <<< "$body"
+}
+
+# Ensure the output directory exists.
+mkdir -p "$OUT_DIR"
+
+# Fetch issue data and render a structured Markdown file.
+if ! ISSUE_JSON="$(gh issue view "$ISSUE_NUMBER" \
+  --repo "$REPO" \
+  --json number,title,body,comments,state,labels,assignees,url 2> >(cat >&2))"; then
+  die "Failed to fetch issue #${ISSUE_NUMBER} from ${REPO}."
+fi
+
+echo "$ISSUE_JSON" | jq -r --arg repo "$REPO" '
+"# Issue #\(.number): \(.title)
+
+Repo: \($repo)
+State: \(.state)
+URL: \(.url)
+
+## Labels
+\(
+  if (.labels | length) > 0
+  then (.labels | map(.name) | join(", "))
+  else "None"
+  end
+)
+
+## Assignees
+\(
+  if (.assignees | length) > 0
+  then (.assignees | map(.login) | join(", "))
+  else "None"
+  end
+)
+
+## Description
+
+\(.body // "")
+
+## Comments
+
+\(
+  if (.comments | length) > 0
+  then (
+    .comments
+    | map("### \(.author.login) — \(.createdAt)\n\n\(.body // "")")
+    | join("\n\n")
+  )
+  else "No comments."
+  end
+)
+
+## AI Notes
+
+-
+"' > "$OUT_FILE"
+
+ISSUE_BODY="$(echo "$ISSUE_JSON" | jq -r '.body // ""')"
+EPIC_LABEL_PRESENT="$(echo "$ISSUE_JSON" | jq -r '
+  [.labels[].name? | ascii_downcase | startswith("epics")] | any | if . then "yes" else "no" end
+')"
+
+SUB_ISSUE_NUMBERS=()
+while IFS= read -r sub_issue; do
+  [ -n "$sub_issue" ] && SUB_ISSUE_NUMBERS+=("$sub_issue")
+done < <(extract_task_issue_numbers "$ISSUE_BODY" "$REPO")
+
+PARENT_SEARCH_QUERY="\"#${ISSUE_NUMBER}\" OR \"${REPO}#${ISSUE_NUMBER}\" OR \"issues/${ISSUE_NUMBER}\""
+PARENT_SEARCH_JSON="[]"
+if ! PARENT_SEARCH_JSON="$(gh issue list \
+  --repo "$REPO" \
+  --search "$PARENT_SEARCH_QUERY" \
+  --limit 100 \
+  --json number,title,body,url)"; then
+  PARENT_SEARCH_JSON="[]"
+fi
+
+PARENT_EPIC_LINES=()
+PARENT_EPIC_NUMBERS=()
+while IFS= read -r issue; do
+  number="$(echo "$issue" | jq -r '.number')"
+  [ "$number" -eq "$ISSUE_NUMBER" ] && continue
+  body="$(echo "$issue" | jq -r '.body // ""')"
+  if extract_task_issue_numbers "$body" "$REPO" | grep -qx "$ISSUE_NUMBER"; then
+    title="$(echo "$issue" | jq -r '.title')"
+    url="$(echo "$issue" | jq -r '.url')"
+    PARENT_EPIC_LINES+=("* #${number}: ${title} (${url})")
+    PARENT_EPIC_NUMBERS+=("$number")
+  fi
+done < <(echo "$PARENT_SEARCH_JSON" | jq -c '.[]')
+
+ISSUE_TYPE_NAME="unknown"
+ISSUE_TYPE_EPIC="unknown"
+SUB_ISSUES_GH_COUNT=0
+SUB_ISSUES_GH_LINES=()
+SUB_ISSUE_NUMBERS_GH=()
+PARENT_EPIC_GH_LINE=""
+PARENT_EPIC_GH_NUMBER=""
+RELATIONSHIP_QUERY_STATUS="unknown"
+RELATIONSHIP_JSON=""
+if RELATIONSHIP_JSON="$(gh api graphql -f query='
+  query ($owner: String!, $repo: String!, $number: Int!) {
+    repository(owner: $owner, name: $repo) {
+      issue(number: $number) {
+        issueType { name }
+        parent { __typename ... on Issue { number title url } }
+        subIssues(first: 50) { totalCount nodes { number title url } }
+      }
+    }
+  }
+' -F owner="$OWNER" -F repo="$REPO_NAME" -F number="$ISSUE_NUMBER" 2>/dev/null)"; then
+  RELATIONSHIP_QUERY_STATUS="ok"
+  ISSUE_TYPE_NAME="$(echo "$RELATIONSHIP_JSON" | jq -r '.data.repository.issue.issueType.name // "unknown"')"
+  if [ "$ISSUE_TYPE_NAME" != "unknown" ] && [ -n "$ISSUE_TYPE_NAME" ]; then
+    if echo "$ISSUE_TYPE_NAME" | tr '[:upper:]' '[:lower:]' | grep -qx "epic"; then
+      ISSUE_TYPE_EPIC="yes"
+    else
+      ISSUE_TYPE_EPIC="no"
+    fi
+  fi
+  SUB_ISSUES_GH_COUNT="$(echo "$RELATIONSHIP_JSON" | jq -r '.data.repository.issue.subIssues.totalCount // 0')"
+  while IFS= read -r line; do
+    [ -n "$line" ] && SUB_ISSUES_GH_LINES+=("$line")
+  done < <(echo "$RELATIONSHIP_JSON" | jq -r '.data.repository.issue.subIssues.nodes[]? | "* #\(.number): \(.title) (\(.url))"')
+  while IFS= read -r sub_issue; do
+    [ -n "$sub_issue" ] && SUB_ISSUE_NUMBERS_GH+=("$sub_issue")
+  done < <(echo "$RELATIONSHIP_JSON" | jq -r '.data.repository.issue.subIssues.nodes[]?.number // empty')
+  PARENT_EPIC_GH_LINE="$(echo "$RELATIONSHIP_JSON" | jq -r '.data.repository.issue.parent | select(. != null and .__typename == "Issue") | "* #\(.number): \(.title) (\(.url))"')"
+  PARENT_EPIC_GH_NUMBER="$(echo "$RELATIONSHIP_JSON" | jq -r '.data.repository.issue.parent | select(. != null and .__typename == "Issue") | .number // empty')"
+else
+  RELATIONSHIP_QUERY_STATUS="failed"
+fi
+
+PROJECT_TYPE_EPIC="unknown"
+PROJECT_TYPE_LINES=()
+PROJECT_ITEM_COUNT=0
+PROJECT_QUERY_STATUS="unknown"
+PROJECT_ITEMS_JSON=""
+if PROJECT_ITEMS_JSON="$(gh api graphql -f query='
+  query ($owner: String!, $repo: String!, $number: Int!) {
+    repository(owner: $owner, name: $repo) {
+      issue(number: $number) {
+        projectItems(first: 20) {
+          nodes {
+            project { number title }
+            fieldValues(first: 50) {
+              nodes {
+                __typename
+                ... on ProjectV2ItemFieldSingleSelectValue {
+                  field { ... on ProjectV2SingleSelectField { name } }
+                  name
+                }
+                ... on ProjectV2ItemFieldTextValue {
+                  field { ... on ProjectV2FieldCommon { name } }
+                  text
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+' -F owner="$OWNER" -F repo="$REPO_NAME" -F number="$ISSUE_NUMBER" 2>/dev/null)"; then
+  PROJECT_QUERY_STATUS="ok"
+  PROJECT_ITEM_COUNT="$(echo "$PROJECT_ITEMS_JSON" | jq -r '.data.repository.issue.projectItems.nodes | length')"
+  while IFS= read -r line; do
+    [ -n "$line" ] && PROJECT_TYPE_LINES+=("$line")
+  done < <(echo "$PROJECT_ITEMS_JSON" | jq -r '
+    def type_value:
+      (.fieldValues.nodes
+        | map(select((.__typename=="ProjectV2ItemFieldSingleSelectValue" or .__typename=="ProjectV2ItemFieldTextValue") and (.field.name=="Type")))
+        | .[0]
+        | if .==null then "" else (if .__typename=="ProjectV2ItemFieldSingleSelectValue" then .name else .text end) end
+      );
+    .data.repository.issue.projectItems.nodes[]
+    | {title: .project.title, number: .project.number, type: type_value}
+    | select(.type != "")
+    | "* Project \"" + .title + "\" (#" + (.number|tostring) + "): Type=" + .type
+  ')
+  if [ "$PROJECT_ITEM_COUNT" -gt 0 ]; then
+    if echo "$PROJECT_ITEMS_JSON" | jq -e '
+      def type_value:
+        (.fieldValues.nodes
+          | map(select((.__typename=="ProjectV2ItemFieldSingleSelectValue" or .__typename=="ProjectV2ItemFieldTextValue") and (.field.name=="Type")))
+          | .[0]
+          | if .==null then "" else (if .__typename=="ProjectV2ItemFieldSingleSelectValue" then .name else .text end) end
+        );
+      .data.repository.issue.projectItems.nodes
+      | map(type_value | ascii_downcase)
+      | any(. == "epic")
+    ' >/dev/null; then
+      PROJECT_TYPE_EPIC="yes"
+    else
+      TYPE_VALUE_COUNT="$(echo "$PROJECT_ITEMS_JSON" | jq -r '
+        def type_value:
+          (.fieldValues.nodes
+            | map(select((.__typename=="ProjectV2ItemFieldSingleSelectValue" or .__typename=="ProjectV2ItemFieldTextValue") and (.field.name=="Type")))
+            | .[0]
+            | if .==null then "" else (if .__typename=="ProjectV2ItemFieldSingleSelectValue" then .name else .text end) end
+          );
+        .data.repository.issue.projectItems.nodes
+        | map(type_value)
+        | map(select(. != ""))
+        | length
+      ')"
+      if [ "$TYPE_VALUE_COUNT" -gt 0 ]; then
+        PROJECT_TYPE_EPIC="no"
+      fi
+    fi
+  fi
+else
+  PROJECT_QUERY_STATUS="failed"
+fi
+
+{
+  echo ""
+  echo "## Epic Signals"
+  echo "Label \"epics\": ${EPIC_LABEL_PRESENT}"
+  echo "Issue Type: ${ISSUE_TYPE_NAME}"
+  echo "Issue Type \"EPIC\": ${ISSUE_TYPE_EPIC}"
+  echo "Type \"EPIC\" (Project field \"Type\"): ${PROJECT_TYPE_EPIC}"
+  echo "Project field query: ${PROJECT_QUERY_STATUS}"
+  echo "Project items: ${PROJECT_ITEM_COUNT}"
+  echo "Sub-issues detected (GitHub): ${SUB_ISSUES_GH_COUNT}"
+  echo "Sub-issues detected (Task List): ${#SUB_ISSUE_NUMBERS[@]}"
+  if [ -n "$PARENT_EPIC_GH_LINE" ]; then
+    echo "Parent epic detected (GitHub): yes"
+  else
+    echo "Parent epic detected (GitHub): no"
+  fi
+  echo "Parent epics detected (Task List): ${#PARENT_EPIC_LINES[@]}"
+  echo ""
+  echo "## Project Type (Field \"Type\")"
+  if [ "${#PROJECT_TYPE_LINES[@]}" -gt 0 ]; then
+    printf '%s\n' "${PROJECT_TYPE_LINES[@]}"
+  else
+    echo "None detected."
+  fi
+  echo ""
+  echo "## Sub-issues (GitHub)"
+  if [ "${#SUB_ISSUES_GH_LINES[@]}" -gt 0 ]; then
+    printf '%s\n' "${SUB_ISSUES_GH_LINES[@]}"
+  else
+    echo "None detected."
+  fi
+  echo ""
+  echo "## Parent Epic (GitHub)"
+  if [ -n "$PARENT_EPIC_GH_LINE" ]; then
+    echo "$PARENT_EPIC_GH_LINE"
+  else
+    echo "None detected."
+  fi
+  echo ""
+  echo "## Sub-issues (Task List)"
+  if [ "${#SUB_ISSUE_NUMBERS[@]}" -gt 0 ]; then
+    for sub_issue in "${SUB_ISSUE_NUMBERS[@]}"; do
+      if issue_line="$(gh issue view "$sub_issue" \
+        --repo "$REPO" \
+        --json number,title,url \
+        --jq '"* #\(.number): \(.title) (\(.url))"')"; then
+        echo "$issue_line"
+      else
+        echo "* #${sub_issue}"
+      fi
+    done
+  else
+    echo "None detected."
+  fi
+
+  echo ""
+  echo "## Parent Epics (Task List)"
+  if [ "${#PARENT_EPIC_LINES[@]}" -gt 0 ]; then
+    printf '%s\n' "${PARENT_EPIC_LINES[@]}"
+  else
+    echo "None detected."
+  fi
+} >> "$OUT_FILE"
+
+RELATED_ISSUE_NUMBERS=()
+add_related_issue() {
+  local num="$1"
+  if ! is_number "$num"; then
+    return 0
+  fi
+  if [ "$num" = "$ISSUE_NUMBER" ]; then
+    return 0
+  fi
+  for existing in "${RELATED_ISSUE_NUMBERS[@]:-}"; do
+    if [ "$existing" = "$num" ]; then
+      return 0
+    fi
+  done
+  RELATED_ISSUE_NUMBERS+=("$num")
+}
+
+for num in "${SUB_ISSUE_NUMBERS[@]:-}"; do
+  add_related_issue "$num"
+done
+for num in "${SUB_ISSUE_NUMBERS_GH[@]:-}"; do
+  add_related_issue "$num"
+done
+for num in "${PARENT_EPIC_NUMBERS[@]:-}"; do
+  add_related_issue "$num"
+done
+if [ -n "$PARENT_EPIC_GH_NUMBER" ]; then
+  add_related_issue "$PARENT_EPIC_GH_NUMBER"
+fi
+
+if [ "$SYNC_RELATED" = "1" ] && [ "${#RELATED_ISSUE_NUMBERS[@]}" -gt 0 ]; then
+  for related in "${RELATED_ISSUE_NUMBERS[@]}"; do
+    if has_seen_issue "$related"; then
+      continue
+    fi
+    mark_seen_issue "$related"
+    if ! WPROCKET_SYNC_RELATED=0 WPROCKET_SYNC_SEEN="$SEEN_ISSUES" "$0" "$related" >/dev/null; then
+      echo "Warning: failed to sync issue #${related}" >&2
+    fi
+  done
+fi
+
+# Print the path for downstream tooling.
+echo "$OUT_FILE"

--- a/.aiassistant/skills/issue-workflow/scripts/make-issue-branch.sh
+++ b/.aiassistant/skills/issue-workflow/scripts/make-issue-branch.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Create a branch name from an issue number and title.
+# Usage: make-issue-branch.sh <issue-number> "<issue-title>" [prefix]
+# prefix: fix (default), enhancement, test
+set -euo pipefail
+
+# Required arguments.
+ISSUE_NUMBER="${1:?issue number required}"
+TITLE="${2:?issue title required}"
+
+# Optional prefix — determines branch type per wp-rocket naming convention.
+PREFIX="${3:-fix}"
+
+# Validate prefix.
+case "$PREFIX" in
+  fix|enhancement|test) ;;
+  *) PREFIX="fix" ;;
+esac
+
+# Build a short, URL-safe slug from the title (first 4 words max).
+SLUG="$(printf '%s' "$TITLE" \
+  | tr '[:upper:]' '[:lower:]' \
+  | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' \
+  | cut -d- -f1-4)"
+
+# Branch naming convention per wp-rocket: <prefix>/<issue>-<slug>
+BRANCH="${PREFIX}/${ISSUE_NUMBER}-${SLUG}"
+
+# Create and switch to the branch.
+git checkout -b "$BRANCH"
+echo "$BRANCH"

--- a/.aiassistant/skills/knowledge-graph/SKILL.md
+++ b/.aiassistant/skills/knowledge-graph/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: knowledge-graph
+description: Use this skill to understand repository structure, trace class dependencies, find a symbol's file, or explore module relationships — without re-scanning the codebase from scratch.
+---
+
+# Knowledge Graph
+
+A pre-built dependency graph lives at `.aiassistant/graph/dependency-graph.json`.
+
+**Read it before** running grep/glob searches for class relationships, namespace exploration, or dependency tracing. It eliminates redundant file scans and speeds up the first useful response in any session.
+
+---
+
+## Graph shape
+
+```json
+{
+  "generated_at": "<ISO timestamp>",
+  "base_commit":  "<git SHA>",
+  "node_count":   913,
+  "nodes": {
+    "inc/Engine/Cache/Subscriber.php": {
+      "language":  "php",
+      "namespace": "WP_Rocket\\Engine\\Cache",
+      "symbols": [
+        { "kind": "class", "name": "Subscriber", "extends": [], "implements": ["Subscriber_Interface"] }
+      ],
+      "imports": [
+        "WP_Rocket\\Event_Management\\Subscriber_Interface",
+        "WP_Rocket\\Engine\\Cache\\Purge"
+      ]
+    }
+  },
+  "symbol_index": {
+    "WP_Rocket\\Engine\\Cache\\Subscriber": "inc/Engine/Cache/Subscriber.php"
+  }
+}
+```
+
+- **`nodes`** — keyed by relative file path. Each node has the language (`php` or `js`), declared symbols (PHP only), and all import/use statements.
+- **`symbol_index`** — maps every fully-qualified PHP class / interface / trait / enum to its file path. Use this for instant "where is this class?" lookups.
+
+---
+
+## WP Rocket specific query patterns
+
+### Find a class file (zero grep)
+```
+symbol_index["WP_Rocket\\Engine\\Cache\\Purge"]
+→ "inc/Engine/Cache/Purge.php"
+```
+
+### Find the ServiceProvider that wires a class
+The ServiceProvider that registers a class imports it. Search for files whose `imports` contain the target FQN:
+
+```
+filter nodes where "WP_Rocket\\Engine\\Cache\\Purge" ∈ node.imports
+→ "inc/Engine/Cache/ServiceProvider.php"
+```
+Then read that ServiceProvider to see how the class is registered in `register()`.
+
+### Find all Subscribers in a module
+Filter nodes where:
+- `namespace` starts with the module prefix (e.g. `WP_Rocket\Engine\Cache`)
+- `symbols[*].implements` contains `Subscriber_Interface`
+
+### Find all ServiceProviders in the codebase
+Filter nodes where `symbols[*].extends` contains `AbstractServiceProvider`.
+
+### Trace a class's full dependency chain
+1. Start at `symbol_index["WP_Rocket\\...\\ClassName"]` → get file path
+2. Read `nodes[file].imports` → these are its direct dependencies
+3. For each dependency, repeat → you get the full constructor injection tree without reading any PHP
+
+### Verify no unexpected cross-module dependencies
+Check `nodes[file].imports` for any FQN that shouldn't be there.
+For example, a Frontend Subscriber importing an Admin class is a red flag.
+
+### Find classes that use `apply_filters` directly (not `wpm_apply_filters_typed`)
+This requires reading the actual files, but the graph narrows the field: only check PHP nodes in `inc/Engine/` and `inc/Addon/` (the paths covered by PHPStan).
+
+---
+
+## Keeping the graph fresh
+
+The graph records the git commit it was built from (`base_commit`). If that SHA differs from `HEAD`, run:
+
+```bash
+node bin/build-knowledge-graph.js
+```
+
+The script is incremental — it only re-parses files changed since `base_commit`. Use `--full` to force a complete rebuild.
+
+**When to refresh:**
+- At the start of every issue workflow session (step 9 checks this automatically).
+- After merging a branch with structural changes (new classes, namespace moves).
+- Before an architecture review session.
+
+---
+
+## Supported languages
+
+| Language | What is extracted |
+|---|---|
+| PHP | `namespace`, `class`/`interface`/`trait`/`enum` declarations (with `extends`/`implements`), `use` imports (including grouped `\{A, B}` forms) |
+| TypeScript / JavaScript | `import` (static + dynamic) and `require()` sources |
+
+---
+
+## Practical workflow (issue implementation)
+
+Before writing a single line of code for an issue:
+
+1. Check `base_commit` vs `HEAD` — refresh if stale.
+2. Use `symbol_index` to locate all classes involved in the fix.
+3. For each class, read `nodes[file].imports` — know the dependency chain before touching the constructor.
+4. Find the ServiceProvider via the import search above — know where to add/modify the binding.
+5. List all Subscribers in the module — know which ones may need new hook entries.
+6. Only then open the actual PHP files (now you know exactly which ones to read).

--- a/.aiassistant/skills/wordpress-compliance/SKILL.md
+++ b/.aiassistant/skills/wordpress-compliance/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: wordpress-compliance
+description: Use this skill when modifying templates, admin UI, output, hooks, plugin metadata, sanitization, escaping, or any code that must remain compliant with WordPress.org and repository PHPCS rules.
+---
+
+# WordPress Compliance
+
+Ensure compatibility with:
+- WordPress Plugin Check
+- Repository PHPCS rules
+- WordPress.org expectations
+
+## Responsibilities
+
+- Respect repository PHPCS configuration.
+- Follow WordPress escaping standards.
+- Avoid forbidden or deprecated APIs.
+- Avoid direct access to superglobals without sanitization.
+- Ensure output is escaped for context.
+
+## Escaping heuristics
+
+HTML text: `esc_html()`
+HTML attribute: `esc_attr()`
+URL: `esc_url()`
+Allowed HTML: `wp_kses_post()`
+
+## Text domain
+
+WP Rocket uses the text domain `rocket`.
+
+```php
+esc_html__( 'Clear Cache', 'rocket' )
+esc_attr__( 'WP Rocket Settings', 'rocket' )
+```
+
+## Custom capabilities
+
+WP Rocket registers custom capabilities. Always use these (not `manage_options`) for capability checks. PHPCS is configured to allow them without warnings:
+
+```php
+current_user_can( 'rocket_manage_options' )        // general plugin management
+current_user_can( 'rocket_purge_cache' )            // clear/purge cache
+current_user_can( 'rocket_preload_cache' )          // preload cache
+current_user_can( 'rocket_remove_unused_css' )      // RUCSS
+current_user_can( 'rocket_regenerate_critical_css' ) // critical CSS
+current_user_can( 'rocket_purge_cloudflare_cache' ) // Cloudflare
+current_user_can( 'rocket_purge_sucuri_cache' )     // Sucuri
+current_user_can( 'rocket_purge_posts' )
+current_user_can( 'rocket_purge_terms' )
+current_user_can( 'rocket_purge_users' )
+```
+
+Using `manage_options` directly for WP Rocket–specific actions is incorrect and will flag in code review.
+
+## Anti-patterns
+
+- Echoing raw variables
+- Introducing unescaped output
+- Storing sensitive values in plain text
+- Bypassing repository PHPCS configuration
+
+## Related Specs
+
+When relevant, consult repository specs under `.aiassistant/specs/`, especially:
+
+- `.aiassistant/specs/phpcs/nonce-verification-recommended.md`
+- `.aiassistant/specs/phpcs/validated-sanitized-input.md`
+- `.aiassistant/specs/phpcs/escaped-output.md`
+
+## Git Operations
+Follow the policy defined in AGENTS.md §5.1. Outside the issue workflow, do not run `git commit` or `git push`.

--- a/.aiassistant/skills/wp-rocket-architecture/SKILL.md
+++ b/.aiassistant/skills/wp-rocket-architecture/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: wp-rocket-architecture
+description: Use this skill when changing service structure, Subscribers, ServiceProviders, Container wiring, bootstrapping, Context classes, or any code that may affect the core caching engine in WP Rocket.
+---
+
+# WP Rocket Architecture Integrity
+
+Enforce architectural patterns and protect internal service structure.
+
+## Core principles
+
+- Every WordPress hook goes through a Subscriber — never `add_action` / `add_filter` directly.
+- Every new filter uses `wpm_apply_filters_typed()` — never `apply_filters()`.
+- Plugin settings are read via injected `Options_Data` — never `get_option()`.
+- All instantiation goes through the League Container — never `new ClassName()` in business code.
+- Do not modify `inc/Dependencies/` (Mozart-bundled vendored code).
+
+## Subscriber pattern
+
+```php
+class MySubscriber implements Subscriber_Interface {
+    public static function get_subscribed_events(): array {
+        return [
+            'init'             => 'on_init',                      // priority 10, 1 arg
+            'save_post'        => [ 'on_save_post', 10, 2 ],     // priority 10, 2 args
+            'admin_menu'       => [
+                [ 'add_menu',    9 ],
+                [ 'add_submenu', 10 ],
+            ],
+        ];
+    }
+}
+```
+
+**PHPStan enforces this**: every method name in `get_subscribed_events()` must exist in the class (`EnsureCallbackMethodsExistsInSubscribedEvents`). Always implement the method before or alongside declaring it.
+
+## ServiceProvider pattern
+
+```php
+class ServiceProvider extends AbstractServiceProvider {
+    protected $provides = [ 'my_subscriber', 'my_controller' ];
+
+    public function register(): void {
+        $this->getContainer()->addShared( 'my_controller', Controller::class )
+            ->addArguments( [ 'options', 'logger' ] );         // string = container key
+
+        $this->getContainer()->addShared( 'my_subscriber', MySubscriber::class )
+            ->addArgument( 'my_controller' );
+    }
+}
+```
+
+- `addShared()` → singleton (same instance every `get()` call)
+- `add()` → factory (new instance every call)
+- String arguments are container keys; use `new StringArgument('...')` for literal strings, `new ArrayArgument([...])` for literal arrays.
+
+## Context classes
+
+Features that are conditionally active encapsulate that logic in a `Context` class rather than inlining checks in the Subscriber:
+
+```
+inc/Engine/MyFeature/
+└── Context/
+    └── Context.php   // should_run(): bool — inject into Subscriber
+```
+
+The Subscriber calls `$this->context->is_allowed()` (or similar) as a guard clause. This keeps the Subscriber clean and the condition unit-testable in isolation.
+
+## `wpm_apply_filters_typed()` — mandatory for all new filters
+
+```php
+// ❌ Flagged by PHPStan (DiscourageApplyFilters)
+$value = apply_filters( 'rocket_my_filter', $default );
+
+// ✅ Required — with full docblock
+/**
+ * Filters the custom value.
+ *
+ * @param string $value The value.
+ * @return string
+ */
+$value = wpm_apply_filters_typed( 'string', 'rocket_my_filter', $default );
+```
+
+Available types: `'string'`, `'integer'`, `'boolean'`, `'array'`, `'string[]'`.
+
+## Option objects — mandatory for reading plugin settings
+
+```php
+// ❌ Flagged by PHPStan (DiscourageWPOptionUsage)
+$setting = get_option( 'wp_rocket_settings' );
+
+// ✅ Required — inject Options_Data via constructor (PHP 7.3+ compatible)
+/** @var Options_Data */
+private $options;
+
+public function __construct( Options_Data $options ) {
+    $this->options = $options;
+}
+
+$setting = $this->options->get( 'option_key', $default );
+```
+
+## PHPStan custom rules — all must pass
+
+| Rule | Implication |
+|---|---|
+| `DiscourageApplyFilters` | Use `wpm_apply_filters_typed()` |
+| `DiscourageWPOptionUsage` | Use `Options_Data` injection |
+| `EnsureCallbackMethodsExistsInSubscribedEvents` | Implement every method you declare in `get_subscribed_events()` |
+| `NoHooksInORM` | No `add_action`, `add_filter`, `apply_filters` inside `Database/Tables/` or `Database/Queries/` classes |
+
+## Standard module directory structure
+
+```
+inc/Engine/MyFeature/
+├── ServiceProvider.php          # all bindings + declares $provides
+├── Context/
+│   └── Context.php             # feature availability guard
+├── Admin/
+│   └── Subscriber.php          # admin-only hooks
+├── Frontend/
+│   ├── Controller.php          # business logic
+│   └── Subscriber.php          # frontend hooks
+└── Database/                   # only when custom tables are needed
+    ├── Tables/MyFeature.php    # BerlinDB schema, version YYYYMMDD
+    ├── Queries/MyFeature.php   # query builder
+    ├── Rows/MyFeature.php      # row model
+    └── Schemas/MyFeature.php   # column definitions
+```
+
+## BerlinDB table versioning
+
+```php
+protected $version = 20251006;  // YYYYMMDD
+protected $upgrades = [
+    20251006 => 'add_new_column',
+];
+protected function add_new_column(): void {
+    // ALTER TABLE with $wpdb->prepare
+}
+```
+
+## Structural guardrails
+
+Avoid:
+- Global state or new singletons outside the container
+- Static helpers replacing injected services
+- Business logic inside ServiceProvider `register()` — wiring only
+- Hooks or filters inside Database/Query/Table classes (`NoHooksInORM`)
+
+## Git Operations
+
+Follow the policy defined in AGENTS.md §5.1. Outside the issue workflow, do not run `git commit` or `git push`.

--- a/.aiassistant/specs/phpcs/escaped-output.md
+++ b/.aiassistant/specs/phpcs/escaped-output.md
@@ -1,0 +1,65 @@
+# SDD: WordPress.Security.EscapeOutput.OutputNotEscaped
+
+## Goal
+Ensure all HTML output is escaped in the correct context, reducing PHPCS warnings
+and preventing XSS.
+
+## Scope
+Templates and PHP that use `echo`, `print`, `printf` in `views/`, `inc/`, and `src/`.
+
+## Project discovery (before changing)
+1. Map all output points.
+2. Reuse existing patterns:
+   - `esc_html__`, `esc_html_e`, `esc_attr__`, `esc_attr_e`
+   - `esc_html()`, `esc_attr()`, `esc_url()`
+   - `wp_kses()` and `wp_kses_post()` when HTML is allowed
+3. When a translated string contains HTML, use `wp_kses()` with an allowlist.
+
+## Decision by context
+- HTML text: `esc_html()`
+- HTML attribute / `data-*`: `esc_attr()`
+- URL: `esc_url()`
+- Inline JS: `esc_js()` or `wp_json_encode()` + `esc_attr()`
+- Allowed HTML: `wp_kses_post()` or `wp_kses( $html, $allowed_html )`
+
+## Implementation patterns
+- Escape at the output boundary, not at the source.
+- Use pre-escaped translation helpers (`esc_html__`, `esc_attr__`, etc).
+- For `printf`/`sprintf`, escape each variable before injecting.
+- Avoid raw `echo $html`; use `wp_kses` with an explicit allowlist.
+- Do not double-escape when the value is already escaped.
+- Do not use `echo esc_html_e()`/`echo esc_attr_e()` (these already echo).
+- For dynamic classes/ids, prefer `esc_attr()` or `sanitize_html_class()` as appropriate.
+
+## Examples
+```php
+echo esc_html( $message );
+```
+
+```php
+printf(
+    esc_html__( 'Cache cleared for %s.', 'rocket' ),
+    esc_html( $url )
+);
+```
+
+```php
+echo wp_kses(
+    sprintf(
+        __( 'See <a href="%s">documentation</a>.', 'rocket' ),
+        esc_url( $url )
+    ),
+    [ 'a' => [ 'href' => true, 'target' => true, 'rel' => true ] ]
+);
+```
+
+```php
+echo esc_url( $link );
+```
+
+## Exceptions
+- Only for internally built and validated HTML, always run through `wp_kses`.
+- Never ignore `OutputNotEscaped` without a clear justification and review.
+
+## Git Operations
+Do not run `git commit` or `git push`. You may only suggest a commit message.

--- a/.aiassistant/specs/phpcs/nonce-verification-recommended.md
+++ b/.aiassistant/specs/phpcs/nonce-verification-recommended.md
@@ -1,0 +1,80 @@
+# SDD: WordPress.Security.NonceVerification.Recommended
+
+## Goal
+Ensure that any request data processing in an admin/UI context includes a proper nonce
+verification without breaking existing flows. When the flow is not user-driven
+(cron, webhooks, external jobs), apply equivalent authentication/validation and
+document why a nonce does not apply.
+
+## Scope
+Files in `inc/` that emit the warning `WordPress.Security.NonceVerification.Recommended`.
+
+## Project discovery (before changing)
+1. Map existing patterns with a search for `check_admin_referer`, `wp_verify_nonce`, `wp_nonce_field`.
+2. Reuse the screen's existing action/field whenever possible.
+3. Reuse existing helpers when applicable.
+4. If no helper fits, create a private method in the class.
+5. Do not invent a new action if the screen already uses an action.
+
+## Out of scope
+- Do not add `phpcs:ignore` for `NonceVerification.Recommended` by default.
+- Do not change how public endpoints work without validating impact on external integrations.
+
+## Decision (quick tree)
+1. Is it a user action on an admin screen?
+   - Yes: add required nonce.
+   - No: go to 2.
+2. Is it cron/CLI/external endpoint with its own auth (token/secret)?
+   - Yes: validate that mechanism and document why nonce does not apply. Use `wp_unslash` + sanitization; avoid nonce.
+   - No: re-evaluate. Prefer adding a nonce or a simple auth token.
+
+## Strategy by use type
+### 1) Admin forms and actions (POST)
+- Add `wp_nonce_field( 'action_name', 'nonce_field' )` in the form.
+- In the handler, call `check_admin_referer( 'action_name', 'nonce_field' )` before reading data.
+- Always `wp_unslash()` before sanitizing (`sanitize_text_field`, `absint`, etc.).
+
+### 2) List filters (GET) without side effects
+- If only ordering/filter UI:
+  - Verify nonce (`wp_verify_nonce`) and only use values when valid.
+  - If invalid/missing, fall back to defaults (no aggressive error/redirect).
+
+### 3) Cron / automatic endpoints
+- If existing auth exists (key, hash, token):
+  - Validate explicitly and document why nonce does not apply.
+- If no auth exists:
+  - Propose a simple token in query string or header, and only add nonce for admin endpoints.
+
+## Implementation patterns
+- Always use `wp_unslash()` before sanitizing.
+- Prefer `check_admin_referer()` when state changes.
+- For GET filters/ordering, prefer `wp_verify_nonce()` and a safe fallback.
+- Do not change external behavior without reviewing usage (search/grep for callers).
+
+## Example (admin POST)
+```php
+// Form
+wp_nonce_field( 'rocket_clear_cache', 'rocket_clear_cache_nonce' );
+
+// Handler
+check_admin_referer( 'rocket_clear_cache', 'rocket_clear_cache_nonce' );
+$url = isset( $_POST['url'] ) ? esc_url_raw( wp_unslash( $_POST['url'] ) ) : '';
+```
+
+## Example (GET filter)
+```php
+$nonce = filter_input( INPUT_GET, '_wpnonce', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+$nonce = $nonce ? sanitize_text_field( $nonce ) : '';
+if ( $nonce && wp_verify_nonce( $nonce, 'rocket_list_filter' ) ) {
+    $order = sanitize_key( wp_unslash( $_GET['order'] ?? '' ) );
+} else {
+    $order = 'desc';
+}
+```
+
+## Git Operations
+Do not run `git commit` or `git push`. You may only suggest a commit message.
+
+## Verification
+- Review each warning and classify by type (admin POST, GET filter, cron/external).
+- Check impacts on tests and integrations before irreversible changes.

--- a/.aiassistant/specs/phpcs/validated-sanitized-input.md
+++ b/.aiassistant/specs/phpcs/validated-sanitized-input.md
@@ -1,0 +1,72 @@
+# SDD: WordPress.Security.ValidatedSanitizedInput
+
+## Goal
+Ensure any input read from GET/POST/COOKIE/SERVER/REQUEST is unslashed, validated,
+and sanitized before use, reducing PHPCS warnings and security risk.
+
+## Scope
+Files in `inc/`, `views/`, and `src/` that read superglobals or external input.
+
+## Project discovery (before changing)
+1. Map access to `$_GET`, `$_POST`, `$_REQUEST`, and `$_SERVER`.
+2. Reuse existing patterns:
+   - `sanitize_text_field( wp_unslash( $_GET['foo'] ) )`
+   - `sanitize_email( wp_unslash( $_POST['email'] ) )`
+   - `absint( wp_unslash( $_GET['id'] ) )`
+   - `sanitize_key()` + allowlist (`in_array`) for filters/ordering
+   - `array_map( 'absint', (array) wp_unslash( $_GET['ids'] ) )`
+3. Verify nonces for admin actions (see
+   `.aiassistant/specs/phpcs/nonce-verification-recommended.md`).
+
+## Decision (quick tree)
+1. Is the input from a superglobal? If yes, apply `wp_unslash()`.
+2. Is there a clear type/allowlist? Validate before use.
+3. Sanitize with the correct function for the context.
+4. If invalid/missing, use a safe default.
+
+## Implementation patterns
+- **MissingUnslash**: always `wp_unslash()` before `sanitize_*`.
+- **InputNotSanitized**: apply `sanitize_*` or `esc_url_raw()`.
+- **InputNotValidated**: validate with allowlist, `absint`, `filter_var()`, or controlled regex.
+- Prefer `filter_input()`/`filter_input_array()` with `FILTER_SANITIZE_*` when possible.
+- If `filter_input()` returns `null` but `$_GET`/`$_POST` is set, fall back to
+  `sanitize_text_field( wp_unslash( $_GET['field'] ) )` for compatibility.
+- Avoid `$_REQUEST`; prefer `$_GET` or `$_POST`.
+- For arrays, sanitize each item with `array_map`.
+- For URLs: `esc_url_raw()` + optionally `filter_var( ..., FILTER_VALIDATE_URL )`.
+- For multiline text: `sanitize_textarea_field()` (do not use `sanitize_text_field`).
+- For allowed HTML: `wp_kses_post()` (only when needed and documented).
+- For boolean flags: `filter_input( INPUT_POST, 'flag', FILTER_VALIDATE_BOOLEAN )`
+  or `(bool) filter_input(...)`.
+- For filters/ordering (GET without side effects): validate nonce and allowlist.
+
+## Examples
+```php
+check_admin_referer( 'rocket_settings_page' );
+$value = isset( $_POST['option'] )
+    ? sanitize_text_field( wp_unslash( $_POST['option'] ) )
+    : '';
+```
+
+```php
+$allowed = [ 'all', 'active', 'inactive' ];
+$status = isset( $_GET['status'] )
+    ? sanitize_key( wp_unslash( $_GET['status'] ) )
+    : 'all';
+$status = in_array( $status, $allowed, true ) ? $status : 'all';
+```
+
+```php
+$ids = isset( $_GET['urls'] )
+    ? array_map( 'esc_url_raw', (array) wp_unslash( $_GET['urls'] ) )
+    : [];
+```
+
+## Git Operations
+Do not run `git commit` or `git push`. You may only suggest a commit message.
+
+## Verification
+- Run `composer phpcs` and confirm there are no:
+  - `WordPress.Security.ValidatedSanitizedInput.InputNotSanitized`
+  - `WordPress.Security.ValidatedSanitizedInput.InputNotValidated`
+  - `WordPress.Security.ValidatedSanitizedInput.MissingUnslash`

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ vfs:/
 /tests/Integration/.phpunit.result.cache
 /tests/Unit/.phpunit.result.cache
 package-lock.json
+
+# Local issue sync cache
+/.TemporaryItems

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,410 @@
+# WP Rocket – AI Coding & Architecture Guidelines
+
+This file defines NON-NEGOTIABLE rules for any AI-assisted work
+(Claude Code, ChatGPT, JetBrains AI Assistant, Cursor, etc.)
+in this repository.
+
+Skills define behavioral guidance.
+AGENTS.md defines mandatory guardrails.
+If a conflict exists, AGENTS.md prevails.
+
+The objective is to keep WP Rocket:
+
+- WordPress.org compliant
+- Architecturally consistent
+- Secure
+- Maintainable
+- Review-friendly
+
+This document applies to ALL automated or AI-generated changes.
+
+---
+
+# 1. Project Overview
+
+WP Rocket is a single-edition commercial WordPress caching plugin maintained by WP Media.
+
+Core architectural patterns:
+- **Subscriber pattern** — event-driven hooks via `Subscriber_Interface`
+- **League Container** — dependency injection container
+- **ServiceProvider pattern** — modules register their own bindings and subscribers
+- **PSR-4 autoloading** — `WP_Rocket\` namespace maps to `inc/`
+
+When modifying architecture:
+- Follow existing patterns (Subscriber → Container → ServiceProvider).
+- Prefer adding new ServiceProviders over modifying existing ones.
+- Keep infrastructure concerns out of Subscriber classes.
+
+---
+
+# 2. Coding Standards & Static Analysis
+
+Source of truth:
+
+- Composer scripts (`composer.json`)
+- PHPCS rulesets (`phpcs.xml` / `phpcs.xml.dist` / `phpcs.baseline.xml`)
+- PHPStan / Psalm configs if present (`phpstan.neon`, `phpstan-baseline.neon`)
+- WordPress Plugin Check: https://github.com/WordPress/plugin-check/
+- CI pipeline rules
+
+WP Rocket must remain compatible with WordPress.org validation rules.
+
+Any change affecting public APIs, output, security, metadata, or plugin bootstrap
+behavior must be evaluated against WordPress Plugin Check expectations.
+
+AI MUST:
+
+- Read `composer.json` first and use defined scripts (e.g. `lint`, `phpcs`, `phpcbf`, `test`, `phpstan`) instead of inventing commands.
+- Auto-discover PHPCS configuration and follow it as the single source of truth.
+
+## 2.1 Tooling Auto-Discovery (MANDATORY)
+
+Before making changes that affect standards or formatting, the agent MUST locate and
+respect the repository configuration files.
+
+### Required reads (in this order)
+1) `composer.json`
+    - Use scripts defined in `"scripts"` whenever possible.
+    - Prefer the exact commands used by CI.
+    - Do not invent lint/test commands.
+
+2) PHPCS ruleset / baseline (first match wins, but consider all if referenced):
+    - `phpcs.xml`
+    - `phpcs.xml.dist`
+    - `phpcs.baseline.xml`
+    - Any PHPCS file referenced by composer scripts or CI
+
+3) Static analysis configs (if present / referenced):
+    - `phpstan.neon`, `phpstan.neon.dist`
+    - `phpstan-baseline.neon`
+
+### Execution rules
+- Do NOT hardcode PHPCS standards.
+- Do NOT assume WordPress-Core or WordPress-Extra unless defined in the ruleset.
+- If multiple PHPCS files exist, follow what is referenced by:
+  a) Composer scripts, then
+  b) CI configuration, then
+  c) Root-level `phpcs.xml(.dist)`
+
+If no PHPCS configuration exists, stop and ask.
+
+## 2.2 PHPStan Custom Rules (MANDATORY)
+
+WP Rocket ships four custom PHPStan rules. Every change must satisfy them:
+
+| Rule | What it enforces |
+|---|---|
+| `DiscourageApplyFilters` | Use `wpm_apply_filters_typed()` instead of `apply_filters()` |
+| `DiscourageWPOptionUsage` | Use injected Option objects instead of `get_option()` directly |
+| `EnsureCallbackMethodsExistsInSubscribedEvents` | Every method name declared in `get_subscribed_events()` must exist in the class |
+| `NoHooksInORM` | No WordPress hooks (`add_action`, `add_filter`, `apply_filters`) inside database Query/Table classes |
+
+**`wpm_apply_filters_typed()` is mandatory for all new filters:**
+```php
+// ❌ Never — flagged by DiscourageApplyFilters
+$value = apply_filters( 'rocket_my_filter', $default );
+
+// ✅ Always — type-safe, with required docblock
+/**
+ * Filters the custom value.
+ *
+ * @param string $value The custom value.
+ * @return string
+ */
+$value = wpm_apply_filters_typed( 'string', 'rocket_my_filter', $default );
+```
+
+Available types: `'string'`, `'integer'`, `'boolean'`, `'array'`, `'string[]'`.
+
+**Option objects are mandatory for reading plugin settings:**
+```php
+// ❌ Never
+$value = get_option( 'wp_rocket_settings' );
+
+// ✅ Always — inject Options_Data via constructor
+/** @var Options_Data */
+private $options;
+
+public function __construct( Options_Data $options ) {
+    $this->options = $options;
+}
+
+$value = $this->options->get( 'option_key', $default );
+```
+
+---
+
+# 3. Architectural Integrity
+
+AI must NOT:
+
+* Introduce global state.
+* Add new singletons without discussion.
+* Bypass the League Container / dependency injection patterns used in the project.
+* Couple UI logic to infrastructure logic.
+* Modify `inc/Dependencies/` without explicit instruction (vendored code).
+* Use `add_action` / `add_filter` directly — always use Subscribers.
+* Use `apply_filters()` directly — always use `wpm_apply_filters_typed()`.
+* Use `get_option( 'wp_rocket_settings' )` directly — inject an `Options_Data` instance.
+
+Follow existing patterns:
+
+* **Subscriber** → implements `Subscriber_Interface`, declares `get_subscribed_events()`
+* **ServiceProvider** → extends `AbstractServiceProvider`, binds services in `register()`
+* **Context classes** → `inc/Engine/Feature/Context/Context.php` encapsulates "should this feature run?" logic; inject into Subscribers, never inline those checks
+* **Container wiring** → via ServiceProvider only, never manual `new ClassName()`
+* Strict types where already used
+* Namespacing: `WP_Rocket\Engine\*` for engine features, `WP_Rocket\Admin\*` for admin
+
+### Standard module directory structure
+
+When adding a new feature module, follow this layout:
+
+```
+inc/Engine/MyFeature/
+├── ServiceProvider.php       # binds all services and declares $provides
+├── Context/
+│   └── Context.php          # is this feature active? (injected into Subscriber)
+├── Admin/
+│   └── Subscriber.php       # admin-only hooks
+├── Frontend/
+│   ├── Controller.php       # business logic
+│   └── Subscriber.php       # frontend hooks
+└── Database/                # only when custom tables are needed
+    ├── Tables/MyFeature.php
+    ├── Queries/MyFeature.php
+    ├── Rows/MyFeature.php
+    └── Schemas/MyFeature.php
+```
+
+### BerlinDB table versioning
+
+Table version format is `YYYYMMDD`. Migrations are declared in `$upgrades`:
+
+```php
+protected $version = 20251006;
+protected $upgrades = [
+    20251006 => 'add_new_column',
+];
+protected function add_new_column(): void { /* ALTER TABLE … */ }
+```
+
+---
+
+# 4. Testing & Validation
+
+WP Rocket follows **Test-Driven Development**. Write tests before or alongside new code, not after.
+
+## 4.1 Test location and commands
+
+| Type | Location | Command |
+|---|---|---|
+| Unit | `tests/Unit/` | `composer test-unit` |
+| Integration | `tests/Integration/` | `composer test-integration` |
+| Specific group | — | `vendor/bin/phpunit --configuration tests/Integration/phpunit.xml.dist --group FeatureName` |
+
+Test files **mirror** the source structure: `inc/Engine/Foo/Bar.php` → `tests/Unit/inc/Engine/Foo/Bar/methodName.php`.
+
+## 4.2 Which test type to write
+
+- **Unit** — business logic in isolation; mock all dependencies with Brain\Monkey / Mockery; no WordPress context needed.
+- **Integration** — WordPress hooks, database operations, or hook interactions; extend the appropriate base class (`TestCase`, `AdminTestCase`, `AjaxTestCase`).
+
+## 4.3 Key patterns
+
+**Unit test with data provider:**
+```php
+class ProcessDataTest extends TestCase {
+    /** @dataProvider dataProvider */
+    public function testShouldReturnExpectedResult( $input, $expected ): void {
+        $result = ( new MyService() )->process( $input );
+        $this->assertSame( $expected, $result );
+    }
+    public function dataProvider(): array { return [ ... ]; }
+}
+```
+
+**Integration test with fixture:**
+```php
+/** @group MyFeature */
+class ProcessDataTest extends TestCase {
+    /** @dataProvider configTestData */
+    public function testShouldReturnExpectedResult( $config, $expected ): void { ... }
+}
+// fixture: tests/Fixtures/inc/Engine/MyFeature/…/processData.php → return [ 'scenario' => [ 'config' => …, 'expected' => … ] ];
+```
+
+## 4.4 Validation checklist
+
+For every change:
+
+1. Run `composer phpcs-changed` first (fast: checks only modified files), then `composer phpcs` before committing.
+2. Run `composer run-stan` — satisfy all four custom PHPStan rules (§2.2).
+3. Run the relevant test suite; no regressions.
+4. Do not delete tests unless clearly obsolete.
+
+If modifying templates:
+
+* Validate escaping correctness.
+* Ensure no functional regressions.
+
+---
+
+# 5. AI Working Protocol
+
+AI must work in small, incremental changes.
+
+After each logical change set:
+- explain what changed
+- explain why
+- list potential edge cases
+
+AI must NOT:
+
+* Perform massive automated refactors without approval.
+* Reorganize files without explicit instruction.
+* Rewrite entire classes when a minimal fix is sufficient.
+
+## 5.1 Git Commit & Push Policy
+
+By default, AI may only **suggest** commit messages and must not run `git commit` or `git push`.
+
+**Exception — Issue Workflow:** When operating under the issue-workflow skill (triggered by `/task <number>`, `issue <number>`, or `#<number>`), the agent MAY:
+
+1. Run atomic `git commit` calls — one commit per logical, self-contained change set.
+2. Run `git push` exactly once after all commits are ready, to publish the branch.
+3. Create a GitHub Pull Request using the prepared PR draft.
+4. Monitor PR CI status checks until all pass or a failure is detected.
+
+Atomic commit rules:
+- Each commit must pass PHPCS and static analysis before being committed.
+- Commit message format: `type(scope): short description` (Conventional Commits).
+- Do not squash unrelated changes into a single commit.
+- Do not amend commits that have already been pushed.
+
+---
+
+# 6. PR Hygiene
+
+Changes must:
+
+* Be minimal.
+* Be scoped.
+* Have clear intent.
+* Avoid noise in diff.
+* Avoid unrelated formatting changes.
+
+### Branch Naming Convention
+
+Branches MUST follow these patterns:
+
+- **Bug fixes**: `fix/{GitHub-issue-ID}-{description}`
+- **Enhancements**: `enhancement/{GitHub-issue-ID}-{GitHub-issue-title}`
+- **Tests**: `test/{GitHub-issue-ID}-{GitHub-issue-title}`
+
+Rules:
+- Lowercase letters, hyphens for spaces.
+- Always include the GitHub issue ID.
+- Keep descriptions concise (first 4 words max).
+
+---
+
+# 7. Security First
+
+Always assume:
+
+* User input is untrusted.
+* Remote API responses are untrusted.
+* Stored values may be tampered with.
+
+Never:
+
+* Store sensitive values in plain text without review.
+* Introduce unsafe serialization.
+* Echo unescaped dynamic data.
+
+---
+
+# 8. When in Doubt
+
+Stop.
+Explain the ambiguity.
+Ask for clarification.
+
+Architectural integrity is more important than speed.
+
+---
+
+# 9. QA Agent
+
+The `qa-engineer` sub-agent validates PRs automatically after step 19 of the issue workflow.
+It reads the PR spec, selects a validation strategy (API / Browser / Analysis), and produces
+a structured test report.
+
+Agent definition: `.aiassistant/agents/qa-engineer.md`.
+
+The local WordPress environment at `http://localhost:8888` (admin / password) is used for
+browser validation via Playwright MCP. No containerised environment is required.
+
+---
+
+# 10. Skills Activation
+
+The repository defines AI Skills under `/.aiassistant/skills`.
+
+Agents MUST activate the relevant skill depending on the task:
+
+- Template or UI changes → WordPress Compliance Skill
+- Structural or architectural changes → WP Rocket Architecture Skill
+- Core service modifications → Both skills
+- Codebase exploration / dependency tracing → Knowledge Graph Skill
+
+## 10.1 Knowledge Graph
+
+A pre-built dependency graph is available at `.aiassistant/graph/dependency-graph.json`.
+
+Before exploring the codebase structure (finding a class, tracing dependencies, checking
+namespace boundaries), **read this file first**. It contains:
+- `nodes`: per-file namespace, declared symbols, and imports.
+- `symbol_index`: maps every fully-qualified PHP class/interface/trait/enum to its file.
+
+Run `node bin/build-knowledge-graph.js` to refresh after structural changes (`--full` to force rebuild).
+
+---
+
+# 11. Repository Identity
+
+Canonical GitHub repository: `wp-media/wp-rocket`
+
+Unless explicitly instructed otherwise, all GitHub issue, PR, and branch workflows must
+assume this repository.
+
+---
+
+# 12. Repository Specs
+
+The repository may define task-specific implementation specs under:
+
+`.aiassistant/specs/`
+
+Specs provide detailed guidance for recurring technical problems
+(e.g. PHPCS warnings, architecture migrations, WordPress compliance patterns).
+
+When a relevant spec exists, agents must follow it in addition to:
+
+• AGENTS.md
+• the applicable skills
+
+
+# AI Task Priority
+
+When executing tasks, agents must prioritize:
+
+1. Security
+2. WordPress.org compliance
+3. Architectural integrity
+4. Backward compatibility
+5. Minimal diffs
+6. Performance
+
+AGENTS.md remains the final authority.

--- a/bin/build-knowledge-graph.js
+++ b/bin/build-knowledge-graph.js
@@ -1,0 +1,312 @@
+#!/usr/bin/env node
+/**
+ * WP Rocket Knowledge Graph Builder
+ *
+ * Scans PHP, TypeScript, and JavaScript source files and extracts
+ * import/dependency relationships into a structured JSON graph stored at
+ * .aiassistant/graph/dependency-graph.json.
+ *
+ * First run: full scan of all source files.
+ * Subsequent runs: incremental — only files changed since the last recorded commit.
+ *
+ * Usage:
+ *   node bin/build-knowledge-graph.js           # auto (incremental if possible)
+ *   node bin/build-knowledge-graph.js --full    # force full rebuild
+ *   node bin/build-knowledge-graph.js --dry-run # print stats without writing
+ */
+
+'use strict';
+
+const fs   = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const ROOT        = path.resolve(__dirname, '..');
+const GRAPH_PATH  = path.join(ROOT, '.aiassistant', 'graph', 'dependency-graph.json');
+const SCAN_DIRS   = ['inc', 'bin'];
+const ASSET_DIRS  = ['src']; // src/ contains JS/SCSS sources; assets/ is compiled output
+const EXTENSIONS  = { php: ['.php'], js: ['.js', '.ts', '.tsx', '.jsx'] };
+
+const ARGS     = process.argv.slice(2);
+const FORCE    = ARGS.includes('--full');
+const DRY_RUN  = ARGS.includes('--dry-run');
+
+// ---------------------------------------------------------------------------
+// Git helpers
+// ---------------------------------------------------------------------------
+
+function git(cmd) {
+	try {
+		return execSync(`git -C "${ROOT}" ${cmd}`, { encoding: 'utf8' }).trim();
+	} catch {
+		return null;
+	}
+}
+
+function headSha() {
+	return git('rev-parse HEAD');
+}
+
+/** Returns list of relative file paths changed between two commits. */
+function changedFiles(fromSha, toSha = 'HEAD') {
+	const out = git(`diff --name-only ${fromSha}..${toSha}`);
+	return out ? out.split('\n').filter(Boolean) : [];
+}
+
+/** Returns all tracked files (for full scan). */
+function allTrackedFiles() {
+	const out = git('ls-files');
+	return out ? out.split('\n').filter(Boolean) : [];
+}
+
+// ---------------------------------------------------------------------------
+// PHP parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Extracts dependency info from a single PHP file.
+ * @param {string} content
+ * @returns {{ namespace: string|null, symbols: Array, imports: string[] }}
+ */
+function parsePhp(content) {
+	const imports   = [];
+	const symbols   = [];
+	let   namespace = null;
+
+	// Namespace
+	const nsMatch = content.match(/^\s*namespace\s+([\w\\]+)\s*;/m);
+	if (nsMatch) namespace = nsMatch[1];
+
+	// Use statements — handles simple, aliased, and grouped forms
+	// e.g. use Foo\Bar; / use Foo\Bar as Baz; / use Foo\{A, B as C, D};
+	const useRe = /^\s*use\s+([\w\\]+)(?:\\{([^}]+)})?\s*(?:as\s+\w+)?\s*;/gm;
+	let m;
+	while ((m = useRe.exec(content)) !== null) {
+		const base    = m[1];
+		const grouped = m[2];
+		if (grouped) {
+			for (const part of grouped.split(',')) {
+				const trimmed = part.trim().replace(/\s+as\s+\w+$/, '');
+				imports.push(`${base}\\${trimmed}`);
+			}
+		} else {
+			imports.push(base.replace(/\s+as\s+\w+$/, '').trim());
+		}
+	}
+
+	// Class / interface / trait / enum declarations
+	const declRe = /^\s*(abstract\s+|final\s+|readonly\s+)*(class|interface|trait|enum)\s+(\w+)(?:\s+extends\s+([\w\\,\s]+?))?(?:\s+implements\s+([\w\\,\s]+?))?\s*(?:\{|$)/gm;
+	while ((m = declRe.exec(content)) !== null) {
+		const kind       = m[2];
+		const name       = m[3];
+		const rawExtends = m[4] ? m[4].split(',').map(s => s.trim()).filter(Boolean) : [];
+		const rawImpls   = m[5] ? m[5].split(',').map(s => s.trim()).filter(Boolean) : [];
+		symbols.push({ kind, name, extends: rawExtends, implements: rawImpls });
+	}
+
+	return { namespace, symbols, imports: [...new Set(imports)] };
+}
+
+// ---------------------------------------------------------------------------
+// JS / TS parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Extracts import sources from JS/TS files.
+ * @param {string} content
+ * @returns {{ imports: string[] }}
+ */
+function parseJs(content) {
+	const imports = [];
+
+	// Static imports: import ... from 'source'
+	const staticRe = /\bimport\s+(?:[\w*{][^'"]*from\s+)?['"]([^'"]+)['"]/g;
+	let m;
+	while ((m = staticRe.exec(content)) !== null) {
+		imports.push(m[1]);
+	}
+
+	// Dynamic imports: import('source') / require('source')
+	const dynRe = /(?:\bimport|\brequire)\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
+	while ((m = dynRe.exec(content)) !== null) {
+		imports.push(m[1]);
+	}
+
+	return { imports: [...new Set(imports)] };
+}
+
+// ---------------------------------------------------------------------------
+// File scanner
+// ---------------------------------------------------------------------------
+
+function isSourceFile(relPath) {
+	const allDirs = [...SCAN_DIRS, ...ASSET_DIRS];
+	return allDirs.some(d => relPath.startsWith(d + '/') || relPath.startsWith(d + '\\'));
+}
+
+function languageOf(relPath) {
+	const ext = path.extname(relPath).toLowerCase();
+	if (EXTENSIONS.php.includes(ext)) return 'php';
+	if (EXTENSIONS.js.includes(ext))  return 'js';
+	return null;
+}
+
+/**
+ * Parse a single file and return its graph node.
+ * Returns null if the file cannot be read or is not a recognised source file.
+ */
+function processFile(relPath) {
+	const lang = languageOf(relPath);
+	if (!lang) return null;
+	if (!isSourceFile(relPath)) return null;
+
+	const absPath = path.join(ROOT, relPath);
+	if (!fs.existsSync(absPath)) return null;  // deleted file — caller removes it
+
+	const content = fs.readFileSync(absPath, 'utf8');
+
+	if (lang === 'php') {
+		const { namespace, symbols, imports } = parsePhp(content);
+		return { language: 'php', namespace, symbols, imports };
+	}
+
+	const { imports } = parseJs(content);
+	return { language: 'js', imports };
+}
+
+// ---------------------------------------------------------------------------
+// Symbol index builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Rebuilds the symbol_index from the nodes map.
+ * symbol_index maps "Fully\\Qualified\\ClassName" → "relative/file/path.php"
+ */
+function buildSymbolIndex(nodes) {
+	const index = {};
+	for (const [filePath, node] of Object.entries(nodes)) {
+		if (node.language !== 'php' || !node.symbols) continue;
+		for (const sym of node.symbols) {
+			const fqn = node.namespace ? `${node.namespace}\\${sym.name}` : sym.name;
+			index[fqn] = filePath;
+		}
+	}
+	return index;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function loadGraph() {
+	if (fs.existsSync(GRAPH_PATH)) {
+		try {
+			return JSON.parse(fs.readFileSync(GRAPH_PATH, 'utf8'));
+		} catch {
+			// corrupted — start fresh
+		}
+	}
+	return { generated_at: null, base_commit: null, nodes: {}, symbol_index: {} };
+}
+
+function saveGraph(graph) {
+	fs.writeFileSync(GRAPH_PATH, JSON.stringify(graph, null, 2) + '\n', 'utf8');
+}
+
+function run() {
+	const currentSha = headSha();
+	const existing   = loadGraph();
+
+	const isIncremental = !FORCE && existing.base_commit && currentSha &&
+	                      existing.base_commit !== currentSha;
+	const isUpToDate    = !FORCE && existing.base_commit === currentSha;
+
+	if (isUpToDate) {
+		console.log(`✓ Knowledge graph is already up to date (${currentSha?.slice(0, 8)}).`);
+		return;
+	}
+
+	let filesToProcess;
+	let mode;
+
+	if (isIncremental) {
+		filesToProcess = changedFiles(existing.base_commit, 'HEAD');
+		mode = `incremental (${filesToProcess.length} changed files since ${existing.base_commit?.slice(0, 8)})`;
+	} else {
+		filesToProcess = allTrackedFiles();
+		mode = `full scan (${filesToProcess.length} tracked files)`;
+	}
+
+	console.log(`⚙  Building knowledge graph — ${mode} …`);
+
+	const nodes = isIncremental ? { ...existing.nodes } : {};
+	let processed = 0, skipped = 0, removed = 0;
+
+	for (const relPath of filesToProcess) {
+		const lang = languageOf(relPath);
+		if (!lang || !isSourceFile(relPath)) { skipped++; continue; }
+
+		const absPath = path.join(ROOT, relPath);
+		if (!fs.existsSync(absPath)) {
+			// File was deleted
+			if (nodes[relPath]) { delete nodes[relPath]; removed++; }
+			continue;
+		}
+
+		const node = processFile(relPath);
+		if (node) {
+			nodes[relPath] = node;
+			processed++;
+		} else {
+			skipped++;
+		}
+	}
+
+	const symbol_index = buildSymbolIndex(nodes);
+
+	const graph = {
+		generated_at:  new Date().toISOString(),
+		base_commit:   currentSha,
+		node_count:    Object.keys(nodes).length,
+		nodes,
+		symbol_index,
+	};
+
+	console.log(`   Processed : ${processed}`);
+	if (removed) console.log(`   Removed   : ${removed}`);
+	console.log(`   Total nodes: ${graph.node_count}`);
+	console.log(`   Symbols indexed: ${Object.keys(symbol_index).length}`);
+
+	if (DRY_RUN) {
+		console.log('ℹ  Dry-run mode — graph not written.');
+		return;
+	}
+
+	saveGraph(graph);
+	console.log(`✓  Graph saved → .aiassistant/graph/dependency-graph.json`);
+
+	if (!existing.base_commit) {
+		console.log('\n──────────────────────────────────────────────────────────────');
+		console.log('Add the following to your AI instructions file');
+		console.log('(AGENTS.md, .github/copilot-instructions.md, CLAUDE.md, etc.):');
+		console.log('──────────────────────────────────────────────────────────────');
+		console.log(`
+## Knowledge Graph
+
+A pre-built dependency graph is available at \`.aiassistant/graph/dependency-graph.json\`.
+
+Before exploring the codebase structure, read this file first. It contains:
+- \`nodes\`: per-file namespace, symbols declared, and imports.
+- \`symbol_index\`: maps every fully-qualified PHP class/interface/trait to its file.
+
+Run \`node bin/build-knowledge-graph.js\` to refresh the graph after significant changes.
+`);
+		console.log('──────────────────────────────────────────────────────────────');
+	}
+}
+
+run();

--- a/inc/Engine/Optimization/RUCSS/Controller/Filesystem.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/Filesystem.php
@@ -78,9 +78,10 @@ class Filesystem extends AbstractFileSystem {
 	 * @return bool
 	 */
 	public function write_used_css( string $hash, string $used_css ): bool {
-		$file = $this->get_usedcss_full_path( $hash );
+		$file   = $this->get_usedcss_full_path( $hash );
+		$subdir = dirname( $file );
 
-		if ( ! rocket_mkdir_p( dirname( $file ) ) ) {
+		if ( ! rocket_mkdir_p( $subdir ) ) {
 			return false;
 		}
 
@@ -91,7 +92,19 @@ class Filesystem extends AbstractFileSystem {
 			return false;
 		}
 
-		return $this->write_file( $file, $css );
+		if ( $this->write_file( $file, $css ) ) {
+			return true;
+		}
+
+		if ( ! $this->filesystem->is_writable( $subdir ) ) {
+			set_transient(
+				'rocket_rucss_subfolder_not_writable',
+				trim( str_replace( rocket_get_constant( 'ABSPATH', '' ), '', $subdir ), '/' ),
+				HOUR_IN_SECONDS
+			);
+		}
+
+		return false;
 	}
 
 	/**
@@ -129,5 +142,22 @@ class Filesystem extends AbstractFileSystem {
 	 */
 	public function is_writable_folder() {
 		return $this->is_folder_writable( $this->path );
+	}
+
+	/**
+	 * Returns the not-writable subfolder path stored in the transient, or an empty string if none.
+	 *
+	 * @return string Relative path to the non-writable subfolder, or empty string.
+	 */
+	public function get_not_writable_subfolder(): string {
+		$path = get_transient( 'rocket_rucss_subfolder_not_writable' );
+
+		if ( false === $path ) {
+			return '';
+		}
+
+		delete_transient( 'rocket_rucss_subfolder_not_writable' );
+
+		return (string) $path;
 	}
 }

--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -658,7 +658,7 @@ class UsedCSS {
 	}
 
 	/**
-	 * Displays a notice if the used CSS folder is not writable
+	 * Displays a notice if the used CSS folder or a subfolder is not writable
 	 *
 	 * @since 3.11.4
 	 *
@@ -673,17 +673,31 @@ class UsedCSS {
 			return;
 		}
 
-		if ( $this->filesystem->is_writable_folder() ) {
+		if ( ! $this->filesystem->is_writable_folder() ) {
+			$message = rocket_notice_writing_permissions( trim( str_replace( rocket_get_constant( 'ABSPATH', '' ), '', rocket_get_constant( 'WP_ROCKET_USED_CSS_PATH', '' ) ), '/' ) );
+
+			rocket_notice_html(
+				[
+					'status'      => 'error',
+					'dismissible' => '',
+					'message'     => $message,
+				]
+			);
+
 			return;
 		}
 
-		$message = rocket_notice_writing_permissions( trim( str_replace( rocket_get_constant( 'ABSPATH', '' ), '', rocket_get_constant( 'WP_ROCKET_USED_CSS_PATH', '' ) ), '/' ) );
+		$subfolder = $this->filesystem->get_not_writable_subfolder();
+
+		if ( '' === $subfolder ) {
+			return;
+		}
 
 		rocket_notice_html(
 			[
 				'status'      => 'error',
 				'dismissible' => '',
-				'message'     => $message,
+				'message'     => rocket_notice_writing_permissions( $subfolder ),
 			]
 		);
 	}

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Controller/Filesystem/getNotWritableSubfolder.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Controller/Filesystem/getNotWritableSubfolder.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\RUCSS\Controller\Filesystem;
+
+use Brain\Monkey\Functions;
+use Mockery;
+use WP_Filesystem_Direct;
+use WP_Rocket\Engine\Optimization\RUCSS\Controller\Filesystem;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * Test class covering \WP_Rocket\Engine\Optimization\RUCSS\Controller\Filesystem::get_not_writable_subfolder
+ *
+ * @group RUCSS
+ */
+class Test_GetNotWritableSubfolder extends TestCase {
+	/**
+	 * @var Filesystem
+	 */
+	private $filesystem;
+
+	protected function set_up() {
+		parent::set_up();
+
+		Functions\when( 'get_current_blog_id' )->justReturn( 1 );
+		Functions\when( 'rocket_get_constant' )->returnArg();
+
+		$wp_filesystem    = Mockery::mock( WP_Filesystem_Direct::class );
+		$this->filesystem = new Filesystem( '/tmp/wpr-usedcss/', $wp_filesystem );
+	}
+
+	public function testShouldReturnEmptyStringWhenNoTransient() {
+		Functions\expect( 'get_transient' )
+			->once()
+			->with( 'rocket_rucss_subfolder_not_writable' )
+			->andReturn( false );
+
+		Functions\expect( 'delete_transient' )->never();
+
+		$this->assertSame( '', $this->filesystem->get_not_writable_subfolder() );
+	}
+
+	public function testShouldReturnPathAndDeleteTransientWhenTransientExists() {
+		Functions\expect( 'get_transient' )
+			->once()
+			->with( 'rocket_rucss_subfolder_not_writable' )
+			->andReturn( 'wp-content/wpr-usedcss/1/a/b' );
+
+		Functions\expect( 'delete_transient' )
+			->once()
+			->with( 'rocket_rucss_subfolder_not_writable' );
+
+		$this->assertSame( 'wp-content/wpr-usedcss/1/a/b', $this->filesystem->get_not_writable_subfolder() );
+	}
+}

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Controller/Filesystem/writeUsedCssSubfolderPermission.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Controller/Filesystem/writeUsedCssSubfolderPermission.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\RUCSS\Controller\Filesystem;
+
+use Brain\Monkey\Functions;
+use Mockery;
+use WP_Filesystem_Direct;
+use WP_Rocket\Engine\Optimization\RUCSS\Controller\Filesystem;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * Test class covering \WP_Rocket\Engine\Optimization\RUCSS\Controller\Filesystem::write_used_css
+ * for the subfolder permission failure case.
+ *
+ * @group RUCSS
+ */
+class Test_WriteUsedCssSubfolderPermission extends TestCase {
+	/**
+	 * @var WP_Filesystem_Direct|Mockery\MockInterface
+	 */
+	private $wp_filesystem;
+
+	/**
+	 * @var Filesystem
+	 */
+	private $filesystem;
+
+	protected function set_up() {
+		parent::set_up();
+
+		Functions\when( 'get_current_blog_id' )->justReturn( 1 );
+		Functions\when( 'rocket_get_constant' )->returnArg();
+		Functions\when( 'rocket_get_filesystem_perms' )->justReturn( 0644 );
+		Functions\when( 'rocket_mkdir_p' )->justReturn( true );
+
+		$this->wp_filesystem = Mockery::mock( WP_Filesystem_Direct::class );
+		$this->filesystem    = new Filesystem( '/tmp/wpr-usedcss/', $this->wp_filesystem );
+	}
+
+	public function testShouldSetTransientWhenSubfolderNotWritable() {
+		$this->wp_filesystem->shouldReceive( 'put_contents' )
+			->once()
+			->andReturn( false );
+
+		$this->wp_filesystem->shouldReceive( 'is_writable' )
+			->once()
+			->andReturn( false );
+
+		Functions\expect( 'set_transient' )
+			->once()
+			->with(
+				'rocket_rucss_subfolder_not_writable',
+				Mockery::type( 'string' ),
+				HOUR_IN_SECONDS
+			);
+
+		$this->assertFalse( $this->filesystem->write_used_css( md5( 'test' ), 'body { color: red; }' ) );
+	}
+
+	public function testShouldNotSetTransientWhenWriteFailsForOtherReason() {
+		$this->wp_filesystem->shouldReceive( 'put_contents' )
+			->once()
+			->andReturn( false );
+
+		$this->wp_filesystem->shouldReceive( 'is_writable' )
+			->once()
+			->andReturn( true );
+
+		Functions\expect( 'set_transient' )->never();
+
+		$this->assertFalse( $this->filesystem->write_used_css( md5( 'test' ), 'body { color: red; }' ) );
+	}
+}

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Controller/UsedCSS/noticeWritePermissions.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Controller/UsedCSS/noticeWritePermissions.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\RUCSS\Controller\UsedCSS;
+
+use Brain\Monkey\Functions;
+use Mockery;
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Engine\Common\Context\ContextInterface;
+use WP_Rocket\Engine\Optimization\DynamicLists\DefaultLists\DataManager;
+use WP_Rocket\Engine\Optimization\RUCSS\Controller\Filesystem;
+use WP_Rocket\Engine\Optimization\RUCSS\Controller\UsedCSS;
+use WP_Rocket\Engine\Optimization\RUCSS\Database\Queries\UsedCSS as UsedCSS_Query;
+use WP_Rocket\Engine\Optimization\RUCSS\Jobs\Manager;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * Test class covering \WP_Rocket\Engine\Optimization\RUCSS\Controller\UsedCSS::notice_write_permissions
+ *
+ * @group RUCSS
+ */
+class Test_NoticeWritePermissions extends TestCase {
+	/**
+	 * @var Options_Data|Mockery\MockInterface
+	 */
+	private $options;
+
+	/**
+	 * @var Filesystem|Mockery\MockInterface
+	 */
+	private $filesystem;
+
+	/**
+	 * @var UsedCSS
+	 */
+	private $used_css;
+
+	protected function set_up() {
+		parent::set_up();
+
+		$this->options    = Mockery::mock( Options_Data::class );
+		$this->filesystem = Mockery::mock( Filesystem::class );
+		$this->used_css   = new UsedCSS(
+			$this->options,
+			$this->createMock( UsedCSS_Query::class ),
+			Mockery::mock( DataManager::class ),
+			$this->filesystem,
+			Mockery::mock( ContextInterface::class ),
+			Mockery::mock( Manager::class )
+		);
+
+		Functions\when( 'rocket_get_constant' )->returnArg();
+	}
+
+	public function testShouldReturnEarlyWhenUserCannotManageOptions() {
+		Functions\expect( 'current_user_can' )
+			->once()
+			->with( 'rocket_manage_options' )
+			->andReturn( false );
+
+		$this->options->shouldNotReceive( 'get' );
+
+		$this->used_css->notice_write_permissions();
+	}
+
+	public function testShouldReturnEarlyWhenRucssDisabled() {
+		Functions\expect( 'current_user_can' )
+			->once()
+			->with( 'rocket_manage_options' )
+			->andReturn( true );
+
+		$this->options->shouldReceive( 'get' )
+			->with( 'remove_unused_css', 0 )
+			->andReturn( 0 );
+
+		$this->filesystem->shouldNotReceive( 'is_writable_folder' );
+
+		$this->used_css->notice_write_permissions();
+	}
+
+	public function testShouldShowBasePathNoticeWhenBaseFolderNotWritable() {
+		Functions\expect( 'current_user_can' )
+			->once()
+			->with( 'rocket_manage_options' )
+			->andReturn( true );
+
+		$this->options->shouldReceive( 'get' )
+			->with( 'remove_unused_css', 0 )
+			->andReturn( 1 );
+
+		$this->filesystem->shouldReceive( 'is_writable_folder' )
+			->once()
+			->andReturn( false );
+
+		$this->filesystem->shouldNotReceive( 'get_not_writable_subfolder' );
+
+		Functions\expect( 'rocket_notice_writing_permissions' )
+			->once()
+			->andReturn( '<p>error</p>' );
+
+		Functions\expect( 'rocket_notice_html' )->once();
+
+		$this->used_css->notice_write_permissions();
+	}
+
+	public function testShouldReturnEarlyWhenBaseFolderWritableAndNoSubfolderTransient() {
+		Functions\expect( 'current_user_can' )
+			->once()
+			->with( 'rocket_manage_options' )
+			->andReturn( true );
+
+		$this->options->shouldReceive( 'get' )
+			->with( 'remove_unused_css', 0 )
+			->andReturn( 1 );
+
+		$this->filesystem->shouldReceive( 'is_writable_folder' )
+			->once()
+			->andReturn( true );
+
+		$this->filesystem->shouldReceive( 'get_not_writable_subfolder' )
+			->once()
+			->andReturn( '' );
+
+		Functions\expect( 'rocket_notice_html' )->never();
+
+		$this->used_css->notice_write_permissions();
+	}
+
+	public function testShouldShowSubfolderNoticeWhenSubfolderNotWritable() {
+		Functions\expect( 'current_user_can' )
+			->once()
+			->with( 'rocket_manage_options' )
+			->andReturn( true );
+
+		$this->options->shouldReceive( 'get' )
+			->with( 'remove_unused_css', 0 )
+			->andReturn( 1 );
+
+		$this->filesystem->shouldReceive( 'is_writable_folder' )
+			->once()
+			->andReturn( true );
+
+		$this->filesystem->shouldReceive( 'get_not_writable_subfolder' )
+			->once()
+			->andReturn( 'wp-content/wpr-usedcss/1/a/b' );
+
+		Functions\expect( 'rocket_notice_writing_permissions' )
+			->once()
+			->with( 'wp-content/wpr-usedcss/1/a/b' )
+			->andReturn( '<p>subfolder error</p>' );
+
+		Functions\expect( 'rocket_notice_html' )->once();
+
+		$this->used_css->notice_write_permissions();
+	}
+}


### PR DESCRIPTION
# Description

Fixes #8268

When the Used-CSS feature creates a per-URL subfolder (e.g. `wp-content/cache/used-css/example.com/path/`) but that subfolder has incorrect write permissions, WP Rocket was silently failing — the CSS was not saved and no feedback was given to the admin. This PR detects that silent failure and surfaces it as an admin notice pointing the admin to the specific subfolder, consistent with the existing notice already shown when the **base** Used-CSS folder is not writable.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #8268
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

**Automated (unit tests — 9 new tests, all passing):**

1. `getNotWritableSubfolder` — when no transient is set → returns empty string; when transient is set → returns path and deletes the transient.
2. `writeUsedCssSubfolderPermission` — when `write_file()` fails and subfolder is not writable → transient is set; when `write_file()` fails but subfolder *is* writable → no transient set.
3. `noticeWritePermissions` — covers all 5 branches: insufficient capability, RUCSS disabled, base folder not writable (existing notice), subfolder transient empty (no notice), subfolder transient set (new notice).

Full RUCSS unit suite: **64/64 pass** — no regressions.
PHPCS: **exit 0** on all changed files.

### How to test

**Prerequisites:**
- WP Rocket installed and activated
- Used CSS (Remove Unused CSS) feature enabled in WP Rocket settings

**Steps to reproduce the bug (before this fix) / validate the fix:**

1. Locate the Used-CSS cache directory: `wp-content/cache/used-css/<host>/`
2. Create a subfolder for a URL you are about to visit, e.g. `wp-content/cache/used-css/example.com/some-path/`
3. Remove write permissions on that subfolder: `chmod 555 wp-content/cache/used-css/example.com/some-path/`
4. Trigger RUCSS processing for that URL (visit it, or use "Preload Cache" to enqueue the job, then run `wp action-scheduler run`)
5. Go to **WordPress Admin → any page**

**Expected result (with this fix):** An admin notice is displayed identifying the non-writable subfolder and asking the admin to fix the permissions.

**Expected result (without this fix / regression check):** No notice is shown — silent failure.

**Verify base-folder notice still works:**
1. Remove write permissions on the base folder: `chmod 555 wp-content/cache/used-css/`
2. Trigger RUCSS and visit wp-admin
3. Confirm the existing base-folder notice still appears correctly.

### Affected Features & Quality Assurance Scope

- **Remove Unused CSS (RUCSS / Used-CSS)** — core feature impacted. Specifically the file-write pipeline and the admin notices system for permission errors.
- **No impact** on: cache, JS delay, lazy load, CDN, critical CSS, or any other WP Rocket feature.

## Technical description

### Documentation

**Root cause:** `Filesystem::write_used_css()` creates a per-URL subfolder via `mkdir`, then writes the gzipped CSS via `WP_Filesystem::write_file()`. If `write_file()` returns `false` (which happens when the subfolder is not writable), the method returned `false` silently. The existing `notice_write_permissions()` only checked the **base** folder (`/used-css/`), so the subfolder failure was invisible.

**Solution — transient bridge:**

The write failure occurs inside an Action Scheduler background job. The admin notice fires on `admin_notices` during a regular page load. A WordPress transient bridges these two async contexts (consistent with `rocket_saas_processing` used elsewhere in RUCSS).

**`Filesystem::write_used_css()` (changed):**
```
mkdir → gzencode → write_file
  └─ if write_file returns false:
       check is_writable($subdir)
         └─ if not writable: set_transient('rocket_rucss_subfolder_not_writable', $relative_path, HOUR_IN_SECONDS)
       return false
```

**`Filesystem::get_not_writable_subfolder()` (new):**
- Reads and immediately deletes the transient (consumed once per failure).
- Returns empty string if no transient is set.

**`UsedCSS::notice_write_permissions()` (changed):**
```
check user capability → check RUCSS enabled
  → check base folder writable? (no → existing notice, return)
  → get_not_writable_subfolder()
      → empty → return (no notice)
      → non-empty → show new notice with subfolder path
```

The notice message mirrors the existing base-folder notice, replacing the folder path with the specific subfolder path.

### New dependencies

None.

### Risks

- **Transient orphaning:** If the background job fires but the admin never visits the backend, the transient expires after 1 hour — no permanent side-effect.
- **False negatives:** If write fails for reasons other than permissions (e.g. disk full), `is_writable()` will return `true` and no transient is set — the failure remains silent for those edge cases, which is the same behavior as before this fix.
- **No performance risk:** `get_transient` is a single option read, called only on `admin_notices` (admin page loads only).

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

N/A — all mandatory items are ticked.

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)