### PR TITLE
Closes #895: Plugin: CDN free is applied to assets in other pages

### DIFF
--- a/inc/Engine/CDN/Subscriber.php
+++ b/inc/Engine/CDN/Subscriber.php
@@ -142,6 +142,10 @@ class Subscriber implements Subscriber_Interface {
 	 * @return string
 	 */
 	public function rewrite_css_properties( $content ) {
+		if ( ! $this->cdn_driver_should_rewrite_url() ) {
+			return $content;
+		}
+
 		/**
 		 * Filters the application of the CDN on CSS properties
 		 *
@@ -226,6 +230,10 @@ class Subscriber implements Subscriber_Interface {
 	 * @return string
 	 */
 	public function add_cdn_url( $url, $original_url = '' ) {
+		if ( ! $this->is_allowed() ) {
+			return $url;
+		}
+
 		if ( ! empty( $original_url ) ) {
 			if ( $this->cdn->is_excluded( $original_url ) ) {
 				return $url;
@@ -372,7 +380,7 @@ class Subscriber implements Subscriber_Interface {
 			return false;
 		}
 
-		if ( $this->driver && ! $this->driver->should_rewrite_url( $this->get_current_url() ) ) {
+		if ( ! $this->cdn_driver_should_rewrite_url() ) {
 			return false;
 		}
 
@@ -455,5 +463,20 @@ class Subscriber implements Subscriber_Interface {
 		$current_options['cdn']      = 1;
 
 		$this->options_api->set( 'settings', $current_options );
+	}
+
+	/**
+	 * Determines if the CDN driver should rewrite the current URL.
+	 *
+	 * Checks if a CDN driver is set and whether it allows rewriting of the current URL.
+	 *
+	 * @return bool True if the URL should be rewritten by the CDN driver, false otherwise.
+	 */
+	private function cdn_driver_should_rewrite_url(): bool {
+		if ( $this->driver && ! $this->driver->should_rewrite_url( $this->get_current_url() ) ) {
+			return false;
+		}
+
+		return true;
 	}
 }


### PR DESCRIPTION
# Description

Fixes https://github.com/wp-media/rocket-cdn/issues/895
Fixes issue with asset url being re-written for other pages outside the free cdn defined pages when minify css/js is enabled.

## Type of change

- [x] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

Refer to [issue](https://github.com/wp-media/rocket-cdn/issues/895)

### How to test

Refer to [issue](https://github.com/wp-media/rocket-cdn/issues/895) and also enable minify css/js

### Affected Features & Quality Assurance Scope

- CDN
- RUCSS + ROCKETCDN
- Minify Js/CSS + ROCKETCDN

## Technical description

### Documentation

In `WP_Rocket\Engine\CDN\Subscriber`
- Created a new method (`cdn_driver_should_rewrite_url`) to assert if driver should allow rewriting of url
- Used new method in `is_allowed` & `rewrite_css_properties` method with a conditional to bail out when false.
- Added a conditional with `is_allowed` to `add_cdn_url` to bail out when not allowed.

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

Not applicable to changes in this PR & also did not need to updated test.

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
