### PR TITLE
Close #899 Hero banner from WPR Dashboard is replaced with the old banner once RocketCDN Free is activated

### DIFF
--- a/inc/Engine/Admin/Settings/Page.php
+++ b/inc/Engine/Admin/Settings/Page.php
@@ -3,6 +3,7 @@ namespace WP_Rocket\Engine\Admin\Settings;
 
 use WP_Rocket\Engine\Admin\Database\Optimization;
 use WP_Rocket\Engine\Admin\Beacon\Beacon;
+use WP_Rocket\Engine\CDN\RocketCDN\SubscriptionController;
 use WP_Rocket\Engine\License\API\User;
 use WP_Rocket\Engine\License\API\UserClient;
 use WP_Rocket\Engine\Optimization\DelayJS\Admin\SiteList;
@@ -110,20 +111,27 @@ class Page extends Abstract_Render {
 	private $ri_context;
 
 	/**
+	 * Subscription controller instance.
+	 *
+	 * @var SubscriptionController
+	 */
+	private $subscription_controller;
+
+	/**
 	 * Creates an instance of the Page object.
 	 *
+	 * @param array                  $args        Array of required arguments to add the admin page.
+	 * @param Settings               $settings    Instance of Settings class.
+	 * @param Render                 $render      Render instance.
+	 * @param Beacon                 $beacon      Beacon instance.
+	 * @param Optimization           $optimize    Database optimization instance.
+	 * @param UserClient             $user_client User client instance.
+	 * @param SiteList               $delayjs_sitelist User client instance.
+	 * @param string                 $template_path Path to views.
+	 * @param Options_Data           $options       WP Rocket options instance.
+	 * @param Context                $ri_context   Rocket Insights context instance.
+	 * @param SubscriptionController $subscription_controller Subscription controller instance.
 	 * @since 3.0
-	 *
-	 * @param array        $args        Array of required arguments to add the admin page.
-	 * @param Settings     $settings    Instance of Settings class.
-	 * @param Render       $render      Render instance.
-	 * @param Beacon       $beacon      Beacon instance.
-	 * @param Optimization $optimize    Database optimization instance.
-	 * @param UserClient   $user_client User client instance.
-	 * @param SiteList     $delayjs_sitelist User client instance.
-	 * @param string       $template_path Path to views.
-	 * @param Options_Data $options       WP Rocket options instance.
-	 * @param Context      $ri_context   Rocket Insights context instance.
 	 */
 	public function __construct(
 		array $args,
@@ -135,7 +143,8 @@ class Page extends Abstract_Render {
 		SiteList $delayjs_sitelist,
 		$template_path,
 		Options_Data $options,
-		Context $ri_context
+		Context $ri_context,
+		SubscriptionController $subscription_controller
 	) {
 		parent::__construct( $template_path );
 		$args = array_merge(
@@ -147,17 +156,18 @@ class Page extends Abstract_Render {
 			$args
 		);
 
-		$this->slug             = $args['slug'];
-		$this->title            = $args['title'];
-		$this->capability       = $args['capability'];
-		$this->settings         = $settings;
-		$this->render           = $render;
-		$this->beacon           = $beacon;
-		$this->optimize         = $optimize;
-		$this->user_client      = $user_client;
-		$this->delayjs_sitelist = $delayjs_sitelist;
-		$this->options          = $options;
-		$this->ri_context       = $ri_context;
+		$this->slug                    = $args['slug'];
+		$this->title                   = $args['title'];
+		$this->capability              = $args['capability'];
+		$this->settings                = $settings;
+		$this->render                  = $render;
+		$this->beacon                  = $beacon;
+		$this->optimize                = $optimize;
+		$this->user_client             = $user_client;
+		$this->delayjs_sitelist        = $delayjs_sitelist;
+		$this->options                 = $options;
+		$this->ri_context              = $ri_context;
+		$this->subscription_controller = $subscription_controller;
 	}
 
 	/**
@@ -450,6 +460,7 @@ class Page extends Abstract_Render {
 				'faq'                     => $this->beacon->get_suggest( 'faq' ),
 				'customer_data'           => $this->customer_data(),
 				'rocket_insights_enabled' => $this->ri_context->is_allowed(),
+				'is_rocketcdn_paid_user'  => $this->subscription_controller->is_paid(),
 			]
 		);
 	}

--- a/inc/Engine/Admin/Settings/ServiceProvider.php
+++ b/inc/Engine/Admin/Settings/ServiceProvider.php
@@ -74,6 +74,7 @@ class ServiceProvider extends AbstractServiceProvider {
 					'template_path',
 					'options',
 					'ri_context',
+					'rocketcdn_subscription_controller',
 				]
 			);
 		$this->getContainer()->addShared( 'settings_page_subscriber', Subscriber::class )

--- a/tests/Unit/inc/Engine/Admin/Settings/Page/asyncWistiaScript.php
+++ b/tests/Unit/inc/Engine/Admin/Settings/Page/asyncWistiaScript.php
@@ -8,6 +8,7 @@ use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\Admin\Database\Optimization;
 use WP_Rocket\Engine\Admin\Beacon\Beacon;
 use WP_Rocket\Engine\Admin\Settings\{Page, Render, Settings};
+use WP_Rocket\Engine\CDN\RocketCDN\SubscriptionController;
 use WP_Rocket\Engine\License\API\UserClient;
 use WP_Rocket\Engine\Optimization\DelayJS\Admin\SiteList;
 use WP_Rocket\Engine\Admin\RocketInsights\Context\Context;
@@ -42,7 +43,8 @@ class TestAsyncWistiaScript extends TestCase {
 			Mockery::mock( SiteList::class ),
 			$template_path,
 			Mockery::mock( Options_Data::class ),
-			Mockery::mock( Context::class )
+			Mockery::mock( Context::class ),
+			Mockery::mock( SubscriptionController::class )
 		);
 
         $this->assertSame(

--- a/tests/Unit/inc/Engine/Admin/Settings/Page/enableMobileCache.php
+++ b/tests/Unit/inc/Engine/Admin/Settings/Page/enableMobileCache.php
@@ -9,6 +9,7 @@ use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\Admin\Database\Optimization;
 use WP_Rocket\Engine\Admin\Beacon\Beacon;
 use WP_Rocket\Engine\Admin\Settings\{Page, Render, Settings};
+use WP_Rocket\Engine\CDN\RocketCDN\SubscriptionController;
 use WP_Rocket\Engine\License\API\UserClient;
 use WP_Rocket\Engine\Optimization\DelayJS\Admin\SiteList;
 use WP_Rocket\Engine\Admin\RocketInsights\Context\Context;
@@ -47,7 +48,8 @@ class TestEnableMobileCache extends TestCase {
 			Mockery::mock( SiteList::class ),
 			$template_path,
 			$this->options,
-			Mockery::mock( Context::class )
+			Mockery::mock( Context::class ),
+			Mockery::mock( SubscriptionController::class )
 		);
 
 		Functions\when( 'check_ajax_referer' )->justReturn( true );

--- a/tests/Unit/inc/Engine/Admin/Settings/Page/enableSeparateCacheFilesMobile.php
+++ b/tests/Unit/inc/Engine/Admin/Settings/Page/enableSeparateCacheFilesMobile.php
@@ -9,6 +9,7 @@ use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\Admin\Database\Optimization;
 use WP_Rocket\Engine\Admin\Beacon\Beacon;
 use WP_Rocket\Engine\Admin\Settings\{Page, Render, Settings};
+use WP_Rocket\Engine\CDN\RocketCDN\SubscriptionController;
 use WP_Rocket\Engine\License\API\UserClient;
 use WP_Rocket\Engine\Optimization\DelayJS\Admin\SiteList;
 use WP_Rocket\Engine\Admin\RocketInsights\Context\Context;
@@ -47,7 +48,8 @@ class TestEnableSeparateCacheFilesMobile extends TestCase {
 			Mockery::mock( SiteList::class ),
 			$template_path,
 			$this->options,
-			Mockery::mock( Context::class )
+			Mockery::mock( Context::class ),
+			Mockery::mock( SubscriptionController::class )
 		);
 	}
 

--- a/tests/Unit/inc/Engine/Admin/Settings/Page/enqueueRocketScripts.php
+++ b/tests/Unit/inc/Engine/Admin/Settings/Page/enqueueRocketScripts.php
@@ -9,6 +9,7 @@ use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\Admin\Database\Optimization;
 use WP_Rocket\Engine\Admin\Beacon\Beacon;
 use WP_Rocket\Engine\Admin\Settings\{Page, Render, Settings};
+use WP_Rocket\Engine\CDN\RocketCDN\SubscriptionController;
 use WP_Rocket\Engine\License\API\UserClient;
 use WP_Rocket\Engine\Optimization\DelayJS\Admin\SiteList;
 use WP_Rocket\Engine\Admin\RocketInsights\Context\Context;
@@ -43,7 +44,8 @@ class TestEnqueueRocketScripts extends TestCase {
 			Mockery::mock( SiteList::class ),
 			$template_path,
 			Mockery::mock( Options_Data::class ),
-			Mockery::mock( Context::class )
+			Mockery::mock( Context::class ),
+			Mockery::mock( SubscriptionController::class )
 		);
 
 		if ( true === $expected ) {

--- a/views/settings/page-sections/dashboard.php
+++ b/views/settings/page-sections/dashboard.php
@@ -26,8 +26,9 @@ $rocket_manual_preload   = (bool) get_rocket_option( 'manual_preload', false );
 $rocket_boxes            = get_user_meta( get_current_user_id(), 'rocket_boxes', true );
 $rocket_cdn_token        = get_option( 'rocketcdn_user_token', '' );
 $rocket_box_is_dismissed = in_array( 'rocket_activation_notice', (array) $rocket_boxes, true );
+$rocketcdn_paid_plan     = ! empty( $rocket_cdn_token ) && $data['is_rocketcdn_paid_user'];
 
-if ( ! empty( $rocket_cdn_token ) ) {
+if ( $rocketcdn_paid_plan ) {
 	$rocket_hero_title       = __( 'Congratulations!', 'rocket' );
 	$rocket_title            = __( 'WP Rocket is now activated and already working for you.', 'rocket' )
 		. '<br>'


### PR DESCRIPTION
# Description

Fixes wp-media/rocket-cdn#899



## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested
Tested with free user with the rocketcdn activated and banner remain the same. 

### How to test
Compile this branch, install and activate the rocketcdn banner check the hero banner afterwards it shouldn't change the content.

### Affected Features & Quality Assurance Scope
n/a

## Technical description

### Documentation
N/A

### New dependencies

N/A

### Risks
What should we do with user who upgrade from free to paid, should we still display the banner or not.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification
No tests needed for the ui
