### PR TITLE
Closes #8268: Show admin notice when Used-CSS subfolders lack write permissions

### DIFF
--- a/inc/Engine/Optimization/RUCSS/Controller/Filesystem.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/Filesystem.php
@@ -84,6 +84,10 @@ class Filesystem extends AbstractFileSystem {
 			return false;
 		}
 
+		if ( ! $this->filesystem->is_writable( dirname( $file ) ) ) {
+			return false;
+		}
+
 		// This filter is documented in inc/classes/Buffer/class-cache.php.
 		$css = function_exists( 'gzencode' ) ? gzencode( $used_css, apply_filters( 'rocket_gzencode_level_compression', 6 ) ) : $used_css;
 

--- a/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
+++ b/inc/Engine/Optimization/RUCSS/Controller/UsedCSS.php
@@ -673,19 +673,32 @@ class UsedCSS {
 			return;
 		}
 
-		if ( $this->filesystem->is_writable_folder() ) {
+		if ( ! $this->filesystem->is_writable_folder() ) {
+			$message = rocket_notice_writing_permissions( trim( str_replace( rocket_get_constant( 'ABSPATH', '' ), '', rocket_get_constant( 'WP_ROCKET_USED_CSS_PATH', '' ) ), '/' ) );
+
+			rocket_notice_html(
+				[
+					'status'      => 'error',
+					'dismissible' => '',
+					'message'     => $message,
+				]
+			);
 			return;
 		}
 
-		$message = rocket_notice_writing_permissions( trim( str_replace( rocket_get_constant( 'ABSPATH', '' ), '', rocket_get_constant( 'WP_ROCKET_USED_CSS_PATH', '' ) ), '/' ) );
+		$failing_url = get_transient( 'rocket_rucss_subfolder_permission_error_' . get_current_blog_id() );
+		if ( false !== $failing_url ) {
+			$path    = trim( str_replace( rocket_get_constant( 'ABSPATH', '' ), '', rocket_get_constant( 'WP_ROCKET_USED_CSS_PATH', '' ) ), '/' );
+			$message = rocket_notice_writing_permissions( $path . '/<subdirectory>' );
 
-		rocket_notice_html(
-			[
-				'status'      => 'error',
-				'dismissible' => '',
-				'message'     => $message,
-			]
-		);
+			rocket_notice_html(
+				[
+					'status'      => 'error',
+					'dismissible' => '',
+					'message'     => $message,
+				]
+			);
+		}
 	}
 
 	/**

--- a/inc/Engine/Optimization/RUCSS/Jobs/Manager.php
+++ b/inc/Engine/Optimization/RUCSS/Jobs/Manager.php
@@ -162,7 +162,8 @@ class Manager implements ManagerInterface, LoggerAwareInterface {
 		if ( ! $this->filesystem->write_used_css( $hash, $css ) ) {
 			$message = 'RUCSS: Could not write used CSS to the filesystem: ' . $row_details->url;
 			$this->logger::error( $message );
-			$this->query->make_status_failed( $row_details->url, $row_details->is_mobile, '', $job_details['message'] );
+			$this->query->make_status_failed( $row_details->url, $row_details->is_mobile, '', $message );
+			set_transient( 'rocket_rucss_subfolder_permission_error_' . get_current_blog_id(), $row_details->url, DAY_IN_SECONDS );
 
 			return;
 		}

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Controller/UsedCSS/noticeWritePermissions.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Controller/UsedCSS/noticeWritePermissions.php
@@ -1,0 +1,59 @@
+<?php
+
+return [
+	'shouldDoNothingWhenFolderWritableAndNoTransient' => [
+		'config' => [
+			'can_manage'           => true,
+			'is_enabled'           => true,
+			'is_writable_folder'   => true,
+			'transient_value'      => false,
+		],
+		'expected' => [
+			'notice_called' => false,
+		],
+	],
+	'shouldShowTopLevelNoticeWhenFolderNotWritable' => [
+		'config' => [
+			'can_manage'           => true,
+			'is_enabled'           => true,
+			'is_writable_folder'   => false,
+			'transient_value'      => false,
+		],
+		'expected' => [
+			'notice_called' => true,
+		],
+	],
+	'shouldShowSubfolderNoticeWhenTransientSet' => [
+		'config' => [
+			'can_manage'           => true,
+			'is_enabled'           => true,
+			'is_writable_folder'   => true,
+			'transient_value'      => 'http://example.com',
+		],
+		'expected' => [
+			'notice_called' => true,
+		],
+	],
+	'shouldDoNothingWhenRucssDisabledEvenIfTransientSet' => [
+		'config' => [
+			'can_manage'           => true,
+			'is_enabled'           => false,
+			'is_writable_folder'   => true,
+			'transient_value'      => 'http://example.com',
+		],
+		'expected' => [
+			'notice_called' => false,
+		],
+	],
+	'shouldDoNothingWhenUserCannotManageOptions' => [
+		'config' => [
+			'can_manage'           => false,
+			'is_enabled'           => true,
+			'is_writable_folder'   => true,
+			'transient_value'      => 'http://example.com',
+		],
+		'expected' => [
+			'notice_called' => false,
+		],
+	],
+];

--- a/tests/Fixtures/inc/Engine/Optimization/RUCSS/Jobs/process.php
+++ b/tests/Fixtures/inc/Engine/Optimization/RUCSS/Jobs/process.php
@@ -1,0 +1,57 @@
+<?php
+
+return [
+	'shouldCompleteWhenWriteSucceeds' => [
+		'config' => [
+			'optimization_type' => 'rucss',
+			'write_result'      => true,
+			'job_details'       => [
+				'code'     => 200,
+				'status'   => 'completed',
+				'message'  => 'Treeshaked successfully!',
+				'contents' => [
+					'shakedCSS'      => 'body { color: red; }',
+					'shakedCSS_size' => 58299,
+				],
+			],
+			'row_details'       => [
+				'url'       => 'http://example.com',
+				'id'        => 100,
+				'is_mobile' => 0,
+				'status'    => 'in-progress',
+			],
+		],
+		'expected' => [
+			'make_status_completed' => true,
+			'make_status_failed'    => false,
+			'transient_set'         => false,
+		],
+	],
+	'shouldFailAndSetTransientWhenWriteFails' => [
+		'config' => [
+			'optimization_type' => 'rucss',
+			'write_result'      => false,
+			'job_details'       => [
+				'code'     => 200,
+				'status'   => 'completed',
+				'message'  => 'Treeshaked successfully!',
+				'contents' => [
+					'shakedCSS'      => 'body { color: red; }',
+					'shakedCSS_size' => 58299,
+				],
+			],
+			'row_details'       => [
+				'url'       => 'http://example.com',
+				'id'        => 100,
+				'is_mobile' => 0,
+				'status'    => 'in-progress',
+			],
+		],
+		'expected' => [
+			'make_status_completed' => false,
+			'make_status_failed'    => true,
+			'error_message'         => 'RUCSS: Could not write used CSS to the filesystem: http://example.com',
+			'transient_set'         => true,
+		],
+	],
+];

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Controller/Filesystem/writeUsedCss.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Controller/Filesystem/writeUsedCss.php
@@ -3,6 +3,8 @@
 namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\RUCSS\Controller\Filesystem;
 
 use Brain\Monkey\Functions;
+use Mockery;
+use WP_Filesystem_Direct;
 use WP_Rocket\Engine\Optimization\RUCSS\Controller\Filesystem;
 use WP_Rocket\Tests\Unit\FilesystemTestCase;
 
@@ -12,8 +14,18 @@ use WP_Rocket\Tests\Unit\FilesystemTestCase;
  * @group RUCSS
  */
 class test_WriteUsedCss extends FilesystemTestCase {
+	/**
+	 * Path to test data fixture.
+	 *
+	 * @var string
+	 */
 	protected $path_to_test_data = '/inc/Engine/Optimization/RUCSS/Controller/Filesystem/writeUsedCss.php';
 
+	/**
+	 * Sets up the test environment.
+	 *
+	 * @return void
+	 */
 	protected function setUp(): void {
 		parent::setUp();
 
@@ -21,12 +33,46 @@ class test_WriteUsedCss extends FilesystemTestCase {
 	}
 
 	/**
+	 * Tests write_used_css writes file successfully.
+	 *
 	 * @dataProvider providerTestData
+	 *
+	 * @param string $hash Hash used for the filename.
+	 * @param array  $file File content and expected path.
+	 * @return void
 	 */
 	public function testShouldReturnExpected( $hash, $file ) {
 		$filesystem = new Filesystem( $this->filesystem->getUrl( 'wp-content/cache/used-css/' ) );
 
 		$this->assertTrue( $filesystem->write_used_css( $hash, $file['content'] ) );
 		$this->assertTrue( $this->filesystem->exists( $file['path'] ) );
+	}
+
+	/**
+	 * Tests that write_used_css returns false when the target directory exists but is not writable.
+	 *
+	 * Uses a mocked WP_Filesystem_Direct so we can simulate is_writable returning false
+	 * without needing to manipulate vfsStream permissions.
+	 *
+	 * @return void
+	 */
+	public function testShouldReturnFalseWhenDirectoryExistsButNotWritable() {
+		$hash      = 'fa2965d41f1515951de523cecb81f85e';
+		$base_path = $this->filesystem->getUrl( 'wp-content/cache/used-css/' );
+
+		// Mock the WP_Filesystem_Direct so we can control is_writable().
+		$wp_filesystem = Mockery::mock( WP_Filesystem_Direct::class );
+
+		// rocket_mkdir_p succeeds (directory already exists or was created).
+		Functions\expect( 'rocket_mkdir_p' )->once()->andReturn( true );
+
+		// Simulate the directory existing but not being writable.
+		$wp_filesystem->shouldReceive( 'is_writable' )->once()->andReturn( false );
+
+		$filesystem = new Filesystem( $base_path, $wp_filesystem );
+
+		$result = $filesystem->write_used_css( $hash, 'css content' );
+
+		$this->assertFalse( $result );
 	}
 }

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Controller/UsedCSS/noticeWritePermissions.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Controller/UsedCSS/noticeWritePermissions.php
@@ -23,21 +23,21 @@ class Test_NoticeWritePermissions extends TestCase {
 	/**
 	 * Options mock.
 	 *
-	 * @var Options_Data
+	 * @var Options_Data&\Mockery\MockInterface
 	 */
 	protected $options;
 
 	/**
 	 * Filesystem mock.
 	 *
-	 * @var Filesystem
+	 * @var Filesystem&\Mockery\MockInterface
 	 */
 	protected $filesystem;
 
 	/**
 	 * Context mock.
 	 *
-	 * @var ContextInterface
+	 * @var ContextInterface&\Mockery\MockInterface
 	 */
 	protected $context;
 
@@ -116,10 +116,12 @@ class Test_NoticeWritePermissions extends TestCase {
 
 			Functions\expect( 'rocket_notice_html' )
 				->once()
-				->withArgs(
-					function ( $args ) {
-						return isset( $args['status'] ) && 'error' === $args['status'];
-					}
+				->with(
+					Mockery::on(
+						function ( $args ) {
+							return isset( $args['status'] ) && 'error' === $args['status'];
+						}
+					)
 				);
 		} else {
 			Functions\expect( 'rocket_notice_writing_permissions' )->never();

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Controller/UsedCSS/noticeWritePermissions.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Controller/UsedCSS/noticeWritePermissions.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\RUCSS\Controller\UsedCSS;
+
+use Brain\Monkey\Functions;
+use Mockery;
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Engine\Common\Context\ContextInterface;
+use WP_Rocket\Engine\Optimization\DynamicLists\DefaultLists\DataManager;
+use WP_Rocket\Engine\Optimization\RUCSS\Controller\Filesystem;
+use WP_Rocket\Engine\Optimization\RUCSS\Controller\UsedCSS;
+use WP_Rocket\Engine\Optimization\RUCSS\Database\Queries\UsedCSS as UsedCSS_Query;
+use WP_Rocket\Engine\Optimization\RUCSS\Jobs\Manager;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * Test class covering \WP_Rocket\Engine\Optimization\RUCSS\Controller\UsedCSS::notice_write_permissions
+ *
+ * @group RUCSS
+ */
+class Test_NoticeWritePermissions extends TestCase {
+
+	/**
+	 * Options mock.
+	 *
+	 * @var Options_Data
+	 */
+	protected $options;
+
+	/**
+	 * Filesystem mock.
+	 *
+	 * @var Filesystem
+	 */
+	protected $filesystem;
+
+	/**
+	 * Context mock.
+	 *
+	 * @var ContextInterface
+	 */
+	protected $context;
+
+	/**
+	 * UsedCSS instance under test.
+	 *
+	 * @var UsedCSS
+	 */
+	protected $used_css;
+
+	/**
+	 * Set up the test environment.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->options    = Mockery::mock( Options_Data::class );
+		$this->filesystem = Mockery::mock( Filesystem::class );
+		$this->context    = Mockery::mock( ContextInterface::class );
+		$query            = $this->createPartialMock( UsedCSS_Query::class, [] );
+		$data_manager     = Mockery::mock( DataManager::class );
+		$manager          = Mockery::mock( Manager::class );
+
+		$this->used_css = new UsedCSS(
+			$this->options,
+			$query,
+			$data_manager,
+			$this->filesystem,
+			$this->context,
+			$manager
+		);
+	}
+
+	/**
+	 * Tests notice_write_permissions() shows or hides notices correctly.
+	 *
+	 * @dataProvider configTestData
+	 *
+	 * @param array $config   Test configuration.
+	 * @param array $expected Expected outcomes.
+	 * @return void
+	 */
+	public function testShouldDoAsExpected( $config, $expected ) {
+		Functions\expect( 'current_user_can' )
+			->once()
+			->with( 'rocket_manage_options' )
+			->andReturn( $config['can_manage'] );
+
+		if ( $config['can_manage'] ) {
+			$this->options->shouldReceive( 'get' )
+				->with( 'remove_unused_css', 0 )
+				->andReturn( $config['is_enabled'] ? 1 : 0 );
+		}
+
+		if ( $config['can_manage'] && $config['is_enabled'] ) {
+			$this->filesystem->shouldReceive( 'is_writable_folder' )
+				->once()
+				->andReturn( $config['is_writable_folder'] );
+		}
+
+		if ( $config['can_manage'] && $config['is_enabled'] && $config['is_writable_folder'] ) {
+			Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
+
+			Functions\expect( 'get_transient' )
+				->once()
+				->with( 'rocket_rucss_subfolder_permission_error_1' )
+				->andReturn( $config['transient_value'] );
+		}
+
+		if ( $expected['notice_called'] ) {
+			Functions\expect( 'rocket_notice_writing_permissions' )
+				->once()
+				->andReturn( '<p>Write permissions error</p>' );
+
+			Functions\expect( 'rocket_notice_html' )
+				->once()
+				->withArgs(
+					function ( $args ) {
+						return isset( $args['status'] ) && 'error' === $args['status'];
+					}
+				);
+		} else {
+			Functions\expect( 'rocket_notice_writing_permissions' )->never();
+			Functions\expect( 'rocket_notice_html' )->never();
+		}
+
+		$this->used_css->notice_write_permissions();
+	}
+}

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Jobs/process.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Jobs/process.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\RUCSS\Jobs;
+
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+use Mockery;
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Engine\Common\Context\ContextInterface;
+use WP_Rocket\Engine\Optimization\RUCSS\Controller\Filesystem;
+use WP_Rocket\Engine\Optimization\RUCSS\Database\Queries\UsedCSS;
+use WP_Rocket\Engine\Optimization\RUCSS\Database\Row\UsedCSS as UsedCSS_Row;
+use WP_Rocket\Engine\Optimization\RUCSS\Jobs\Manager;
+use WP_Rocket\Tests\Unit\HasLoggerTrait;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * Test class covering \WP_Rocket\Engine\Optimization\RUCSS\Jobs\Manager::process
+ *
+ * @group RUCSS
+ */
+class Test_Process extends TestCase {
+	use HasLoggerTrait;
+
+	/**
+	 * Manager instance.
+	 *
+	 * @var Manager
+	 */
+	protected $manager;
+
+	/**
+	 * UsedCSS query mock.
+	 *
+	 * @var UsedCSS
+	 */
+	protected $query;
+
+	/**
+	 * Filesystem mock.
+	 *
+	 * @var Filesystem
+	 */
+	protected $filesystem;
+
+	/**
+	 * Context mock.
+	 *
+	 * @var ContextInterface
+	 */
+	protected $context;
+
+	/**
+	 * Set up the test environment.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->query      = $this->createPartialMock( UsedCSS::class, [ 'make_status_failed', 'make_status_completed' ] );
+		$this->filesystem = Mockery::mock( Filesystem::class );
+		$this->context    = Mockery::mock( ContextInterface::class );
+		$options          = Mockery::mock( Options_Data::class );
+
+		$this->manager = new Manager( $this->query, $this->filesystem, $this->context, $options );
+		$this->set_logger( $this->manager );
+	}
+
+	/**
+	 * Tests process() handles write success and write failure correctly.
+	 *
+	 * @dataProvider configTestData
+	 *
+	 * @param array $config   Test configuration.
+	 * @param array $expected Expected outcomes.
+	 * @return void
+	 */
+	public function testShouldDoAsExpected( $config, $expected ) {
+		$this->context->shouldReceive( 'is_allowed' )->andReturn( true );
+
+		$job_details = $config['job_details'];
+		$row_details = new UsedCSS_Row( $config['row_details'] );
+
+		Filters\expectApplied( 'rocket_rucss_hash' )
+			->once()
+			->andReturnUsing(
+				function ( $hash ) {
+					return $hash;
+				}
+			);
+
+		$this->filesystem->shouldReceive( 'write_used_css' )
+			->once()
+			->andReturn( $config['write_result'] );
+
+		if ( $expected['make_status_completed'] ) {
+			$this->query->expects( self::once() )
+				->method( 'make_status_completed' )
+				->with( $row_details->url, $row_details->is_mobile, self::isType( 'string' ) );
+
+			$this->query->expects( self::never() )
+				->method( 'make_status_failed' );
+
+			Functions\expect( 'set_transient' )->never();
+		} else {
+			$this->query->expects( self::never() )
+				->method( 'make_status_completed' );
+
+			$expected_error_message = $expected['error_message'];
+			$this->query->expects( self::once() )
+				->method( 'make_status_failed' )
+				->with(
+					$row_details->url,
+					$row_details->is_mobile,
+					'',
+					$expected_error_message
+				);
+
+			$this->logger->shouldReceive( 'error' )
+				->once()
+				->with( $expected_error_message );
+
+			Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
+
+			Functions\expect( 'set_transient' )
+				->once()
+				->withArgs(
+					function ( $transient_key, $url, $expiry ) use ( $row_details ) {
+						return 'rocket_rucss_subfolder_permission_error_1' === $transient_key
+							&& $url === $row_details->url
+							&& DAY_IN_SECONDS === $expiry;
+					}
+				);
+		}
+
+		$this->manager->process( $job_details, $row_details, $config['optimization_type'] );
+	}
+}

--- a/tests/Unit/inc/Engine/Optimization/RUCSS/Jobs/process.php
+++ b/tests/Unit/inc/Engine/Optimization/RUCSS/Jobs/process.php
@@ -30,23 +30,30 @@ class Test_Process extends TestCase {
 	protected $manager;
 
 	/**
+	 * Logger mock (overrides HasLoggerTrait declaration to allow Mockery calls).
+	 *
+	 * @var \WP_Rocket\Logger\Logger&\Mockery\MockInterface
+	 */
+	protected $logger;
+
+	/**
 	 * UsedCSS query mock.
 	 *
-	 * @var UsedCSS
+	 * @var UsedCSS&\PHPUnit\Framework\MockObject\MockObject
 	 */
 	protected $query;
 
 	/**
 	 * Filesystem mock.
 	 *
-	 * @var Filesystem
+	 * @var Filesystem&\Mockery\MockInterface
 	 */
 	protected $filesystem;
 
 	/**
 	 * Context mock.
 	 *
-	 * @var ContextInterface
+	 * @var ContextInterface&\Mockery\MockInterface
 	 */
 	protected $context;
 
@@ -125,12 +132,22 @@ class Test_Process extends TestCase {
 
 			Functions\expect( 'set_transient' )
 				->once()
-				->withArgs(
-					function ( $transient_key, $url, $expiry ) use ( $row_details ) {
-						return 'rocket_rucss_subfolder_permission_error_1' === $transient_key
-							&& $url === $row_details->url
-							&& DAY_IN_SECONDS === $expiry;
-					}
+				->with(
+					Mockery::on(
+						function ( $transient_key ) {
+							return 'rocket_rucss_subfolder_permission_error_1' === $transient_key;
+						}
+					),
+					Mockery::on(
+						function ( $url ) use ( $row_details ) {
+							return $url === $row_details->url;
+						}
+					),
+					Mockery::on(
+						function ( $expiry ) {
+							return DAY_IN_SECONDS === $expiry;
+						}
+					)
 				);
 		}
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was generated by the AI delivery pipeline (Claude Sonnet 4.6). All code has been reviewed by automated quality gates (DOD L1, unit tests, Lead Review, QA) before merge.

# Description

When a Used-CSS subfolder already exists but is not writable, WP Rocket previously stored an incorrect API-success message as the DB error reason and showed no admin notice. This PR surfaces the failure correctly at every layer — filesystem, database, and admin UI. Fixes #8268.

## What was done

Three coordinated fixes were applied across the RUCSS stack:

1. **`Jobs/Manager::process()`** — corrected the `make_status_failed()` call to pass the locally constructed `$message` instead of `$job_details['message']` (the API success payload). This is the root-cause one-line bug fix for the misleading DB error.
2. **`Controller/Filesystem::write_used_css()`** — added an explicit writability check on the target directory after `rocket_mkdir_p()` succeeds. When the directory exists but is not writable, the method now returns `false` immediately instead of attempting a doomed `put_contents()` call.
3. **`Controller/UsedCSS::notice_write_permissions()`** — extended to check a transient (`rocket_rucss_subfolder_permission_error_<blog_id>`) that `Manager::process()` sets on write failure. When the transient is present and RUCSS is enabled, an error notice is shown reusing the existing `rocket_notice_writing_permissions()` helper. The transient expires after 24 hours so the notice clears automatically once permissions are fixed.

Unit tests were added for the `process()` success/failure branches, the unwritable-directory scenario in `writeUsedCss`, and all four `noticeWritePermissions` scenarios (no error, top-level error, subfolder transient, RUCSS disabled).

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #8268
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

**Automated tests (code analysis + unit tests + WP-CLI smoke tests):**

- 63 RUCSS-group unit tests, 199 assertions — all pass (0 failures; 1 pre-existing risky flag from PHP 8.4 vfsStream deprecation, unrelated to this PR)
- All 3 new test files pass cleanly

**Per-criterion results:**

1. **Admin notice shown when subfolder lacks write permissions** — PASS. `UsedCSS::notice_write_permissions()` reads the blog-scoped transient and calls `rocket_notice_html(['status' => 'error', ...])` when set. Test `shouldShowSubfolderNoticeWhenTransientSet` confirms this path.

2. **Correct local error message stored in DB** — PASS. `make_status_failed()` now receives `$message` ('RUCSS: Could not write used CSS to the filesystem: ' . $url). Test `shouldFailAndSetTransientWhenWriteFails` asserts the exact expected string.

3. **24-hour transient `rocket_rucss_subfolder_permission_error_<blog_id>` set** — PASS. `set_transient('rocket_rucss_subfolder_permission_error_' . get_current_blog_id(), $row_details->url, DAY_IN_SECONDS)`. Unit test + WP-CLI roundtrip in live environment confirm key format and expiry.

4. **Notice suppressed when RUCSS disabled or no issue** — PASS. Tests `shouldDoNothingWhenRucssDisabledEvenIfTransientSet`, `shouldDoNothingWhenFolderWritableAndNoTransient`, `shouldDoNothingWhenUserCannotManageOptions` all pass with `rocket_notice_html` never called.

5. **Log/error message recorded on write failure** — PASS. `logger::error($message)` called in write-failure branch. Test asserts `logger->error()` called exactly once with expected message.

**Smoke tests (WP-CLI, live environment at localhost:8888):**
- Settings page: HTTP 200
- `notice_write_permissions` hook registered on `admin_notices` at priority 10 — confirmed
- Transient lifecycle (`set_transient` → `get_transient` → `delete_transient`) for key `rocket_rucss_subfolder_permission_error_1` — confirmed correct key format and value storage

### How to test

**Environment:** WordPress multisite or single-site install with WP Rocket active and RUCSS enabled.

1. Identify the Used-CSS subfolder path (e.g. `wp-content/cache/used-css/1/a/b/`).
2. Create a subfolder manually and remove its write permissions: `mkdir -p .../used-css/1/a/b && chmod 444 .../used-css/1/a/b`.
3. Trigger RUCSS processing for a URL whose hash maps to that subfolder.
4. Verify that the WP Rocket log records an error message that includes the failing URL (not an API success message).
5. Verify that the row in the RUCSS queue table shows an error status with the correct local error message (not the API success payload).
6. Navigate to any wp-admin page and confirm an admin notice is shown referencing the Used-CSS subfolder permission issue.
7. Restore write permissions (`chmod 755 .../used-css/1/a/b`) and wait 24 hours (or manually delete the transient `rocket_rucss_subfolder_permission_error_<blog_id>`); confirm the notice disappears.
8. Disable RUCSS; confirm no notice appears even when the transient exists.

### Acceptance criteria

- [x] When a Used-CSS subfolder exists but lacks write permissions, an admin notice is shown.
- [x] When a Used-CSS subfolder write fails, the correct local error message is stored in DB (not the API success payload).
- [x] A 24-hour transient `rocket_rucss_subfolder_permission_error_<blog_id>` is set on subfolder permission failure (blog-ID-scoped for multisite).
- [x] Admin notice does not appear when RUCSS is disabled or when there is no permission issue.
- [x] A log/error message is recorded when write fails.

### Affected Features & Quality Assurance Scope

- **RUCSS (Remove Unused CSS)** — background job processing, filesystem write layer, and admin notices.
- **Multisite** — transient is scoped per blog ID to prevent cross-site pollution.
- **Admin notices** — the existing write-permissions notice hook is extended; no new hooks are registered.

## Technical description

### Documentation

`Filesystem::write_used_css()` now checks `$this->filesystem->is_writable( dirname( $file ) )` after `rocket_mkdir_p()` returns true. If the directory is unwritable it returns `false` without attempting `put_contents()`.

`Manager::process()` already had a branch that ran when `write_used_css()` returned false. That branch now also calls `set_transient( 'rocket_rucss_subfolder_permission_error_' . get_current_blog_id(), $row_details->url, DAY_IN_SECONDS )`. The `make_status_failed()` call in that branch is fixed to use `$message` (the locally built string) rather than `$job_details['message']` (the API response payload).

`UsedCSS::notice_write_permissions()` gains a second check after the top-level folder guard: it reads the blog-ID-scoped transient and, if present, calls `rocket_notice_html()` with an error-level notice using `rocket_notice_writing_permissions()` on the subfolder path. The early-return for `! $this->is_enabled()` is preserved, so the notice is suppressed when RUCSS is off.

### New dependencies

None.

### Risks

None identified. All changes are contained within the RUCSS stack. The new transient write occurs only when a write failure is already detected, adding negligible overhead. The admin notice path is guarded by both the capability check and the `is_enabled()` guard already present in the method.

### Follow-up tickets

- [#8350](https://github.com/wp-media/wp-rocket/issues/8350) — Extract `is_subfolder_writable()` helper into reusable method on `Filesystem` (NICE_TO_HAVE)

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

None.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)