### PR TITLE
Closes #7947: add rocket_cache_http_headers filter so custom headers reach cached responses

### DIFF
--- a/docs/api/cache-headers.md
+++ b/docs/api/cache-headers.md
@@ -35,7 +35,13 @@ The HTTP status line (e.g. `HTTP/1.1 304 Not Modified`) is sent directly via `he
 
 ### Security
 
-Entries with non-string keys or non-string values are silently skipped. If the filter returns a non-array value, it is cast to `array` before iteration. This prevents a badly-written callback from causing a fatal error or injecting unexpected output.
+`send_headers()` applies three layers of defence before calling `header()`:
+
+1. **Type guard** — entries where the key or value is not a string are silently skipped. This prevents PHP type-juggling from passing unexpected values to `header()`.
+2. **CRLF guard** — entries where the header name or value contains a carriage-return (`\r`, `0x0D`) or line-feed (`\n`, `0x0A`) character are silently dropped. This prevents HTTP response-splitting on PHP versions that do not block CRLF in `header()` natively (PHP < 7.4).
+3. **Non-array return cast** — if the filter returns a non-array value it is cast to `array` before iteration, preventing a fatal error from a badly-written callback.
+
+**What is not prevented:** The CRLF guard does not validate that the header name is a legitimate RFC 7230 token. Unusual but technically valid characters (e.g. `!`, `#`, `~`) in header names are passed through unchanged. Callers are responsible for ensuring header names are well-formed.
 
 ### Registering callbacks
 
@@ -60,13 +66,13 @@ via `plugins_loaded` or `init`. There are two supported registration points:
 
 ### Early-hook drop-in security
 
-The inclusion of `rocket-early-cache-hooks.php` uses `realpath()` with a path-containment check to prevent directory traversal:
+The inclusion of `rocket-early-cache-hooks.php` uses `realpath()` with a strict path-containment check to prevent directory traversal. A trailing `DIRECTORY_SEPARATOR` is appended to the content-directory prefix so that a sibling directory (e.g. `wp-content_evil/`) cannot pass the check by sharing a common prefix:
 
 ```php
 $rocket_early_hooks = WP_CONTENT_DIR . '/rocket-early-cache-hooks.php';
 if ( file_exists( $rocket_early_hooks ) ) {
     $rocket_early_hooks = realpath( $rocket_early_hooks );
-    if ( $rocket_early_hooks && 0 === strpos( $rocket_early_hooks, realpath( WP_CONTENT_DIR ) ) ) {
+    if ( $rocket_early_hooks && 0 === strpos( $rocket_early_hooks, rtrim( realpath( WP_CONTENT_DIR ), DIRECTORY_SEPARATOR ) . DIRECTORY_SEPARATOR ) ) {
         include_once $rocket_early_hooks;
     }
 }

--- a/docs/api/cache-headers.md
+++ b/docs/api/cache-headers.md
@@ -1,0 +1,80 @@
+# Cache Headers API
+
+## Filter: `rocket_cache_http_headers`
+
+**Since:** 3.x.x
+**File:** `inc/classes/Buffer/class-cache.php` — `WP_Rocket\Buffer\Cache::send_headers()`
+
+Filters the HTTP response headers sent when WP Rocket serves a page from its file cache.
+This filter fires inside the early-bootstrap `advanced-cache.php` drop-in, before WordPress
+core, plugins, and mu-plugins have loaded. Standard hooks registered via `add_action('init', ...)`
+are not available at this point.
+
+### Signature
+
+```php
+apply_filters( 'rocket_cache_http_headers', array $headers )
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `$headers` | `array<string,string>` | Associative array of header name to header value. Only entries where both key and value are strings are sent. |
+
+**Return:** `array<string,string>` — The filtered headers array.
+
+### When it fires
+
+The filter fires in the following cache-serving paths:
+
+- `serve_cache_file()` — plain HTML cache, `Last-Modified` header on every request, plus `Expires` and `Cache-Control` on 304 Not Modified responses.
+- `serve_gzip_cache_file()` — gzip cache, same paths as above.
+
+The HTTP status line (e.g. `HTTP/1.1 304 Not Modified`) is sent directly via `header()` with an explicit status code and is not passed through this filter.
+
+### Security
+
+Entries with non-string keys or non-string values are silently skipped. If the filter returns a non-array value, it is cast to `array` before iteration. This prevents a badly-written callback from causing a fatal error or injecting unexpected output.
+
+### Registering callbacks
+
+Because `advanced-cache.php` runs before plugins are loaded, callbacks cannot be registered
+via `plugins_loaded` or `init`. There are two supported registration points:
+
+1. **Early-hook drop-in file** (recommended): Create `wp-content/rocket-early-cache-hooks.php`. WP Rocket includes this file at the start of `advanced-cache.php` execution if it exists. Place `add_filter()` calls at file scope (not inside any hook callback):
+
+    ```php
+    <?php
+    // wp-content/rocket-early-cache-hooks.php
+    add_filter(
+        'rocket_cache_http_headers',
+        function ( array $headers ) {
+            $headers['X-Cache-Provider'] = 'WP Rocket';
+            return $headers;
+        }
+    );
+    ```
+
+2. **mu-plugins** are NOT loaded before `advanced-cache.php`, so mu-plugins cannot register callbacks for this filter.
+
+### Early-hook drop-in security
+
+The inclusion of `rocket-early-cache-hooks.php` uses `realpath()` with a path-containment check to prevent directory traversal:
+
+```php
+$rocket_early_hooks = WP_CONTENT_DIR . '/rocket-early-cache-hooks.php';
+if ( file_exists( $rocket_early_hooks ) ) {
+    $rocket_early_hooks = realpath( $rocket_early_hooks );
+    if ( $rocket_early_hooks && 0 === strpos( $rocket_early_hooks, realpath( WP_CONTENT_DIR ) ) ) {
+        include_once $rocket_early_hooks;
+    }
+}
+unset( $rocket_early_hooks );
+```
+
+If `rocket-early-cache-hooks.php` throws an uncaught exception or causes a PHP fatal error, the entire page request will fail. Exception handling is the responsibility of the file author.
+
+### Known limitation
+
+WordPress's `wp_headers` filter and `send_headers` action do not fire for cached responses, because the WordPress bootstrap never completes for those requests. The `rocket_cache_http_headers` filter is the supported replacement for adding custom HTTP headers to cached responses.

--- a/inc/classes/Buffer/class-cache.php
+++ b/inc/classes/Buffer/class-cache.php
@@ -163,7 +163,11 @@ class Cache extends Abstract_Buffer {
 	 * @param string $cache_filepath Path to the cache file.
 	 */
 	private function serve_cache_file( $cache_filepath ) {
-		header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s', filemtime( $cache_filepath ) ) . ' GMT' );
+		$this->send_headers(
+			[
+				'Last-Modified' => gmdate( 'D, d M Y H:i:s', filemtime( $cache_filepath ) ) . ' GMT',
+			]
+			);
 
 		$if_modified_since = $this->get_if_modified_since();
 
@@ -171,8 +175,12 @@ class Cache extends Abstract_Buffer {
 		if ( $if_modified_since && ( strtotime( $if_modified_since ) === @filemtime( $cache_filepath ) ) ) {
 			// Client's cache is current, so we just respond '304 Not Modified'.
 			header( $this->config->get_server_input( 'SERVER_PROTOCOL', '' ) . ' 304 Not Modified', true, 304 );
-			header( 'Expires: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
-			header( 'Cache-Control: no-cache, must-revalidate' );
+			$this->send_headers(
+				[
+					'Expires'       => gmdate( 'D, d M Y H:i:s' ) . ' GMT',
+					'Cache-Control' => 'no-cache, must-revalidate',
+				]
+				);
 
 			$this->log(
 				'Serving `304` cache file.',
@@ -207,7 +215,11 @@ class Cache extends Abstract_Buffer {
 	 * @param string $cache_filepath Path to the gzip cache file.
 	 */
 	private function serve_gzip_cache_file( $cache_filepath ) {
-		header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s', filemtime( $cache_filepath ) ) . ' GMT' );
+		$this->send_headers(
+			[
+				'Last-Modified' => gmdate( 'D, d M Y H:i:s', filemtime( $cache_filepath ) ) . ' GMT',
+			]
+			);
 
 		$if_modified_since = $this->get_if_modified_since();
 
@@ -215,8 +227,12 @@ class Cache extends Abstract_Buffer {
 		if ( $if_modified_since && ( strtotime( $if_modified_since ) === @filemtime( $cache_filepath ) ) ) {
 			// Client's cache is current, so we just respond '304 Not Modified'.
 			header( $this->config->get_server_input( 'SERVER_PROTOCOL', '' ) . ' 304 Not Modified', true, 304 );
-			header( 'Expires: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
-			header( 'Cache-Control: no-cache, must-revalidate' );
+			$this->send_headers(
+				[
+					'Expires'       => gmdate( 'D, d M Y H:i:s' ) . ' GMT',
+					'Cache-Control' => 'no-cache, must-revalidate',
+				]
+				);
 
 			$this->log(
 				'Serving `304` gzip cache file.',
@@ -241,6 +257,36 @@ class Cache extends Abstract_Buffer {
 			'info'
 		);
 		exit;
+	}
+
+	/**
+	 * Sends HTTP headers, applying the rocket_cache_http_headers filter.
+	 *
+	 * Fires the `rocket_cache_http_headers` filter so developers can add, modify,
+	 * or remove HTTP response headers before they are sent while serving from cache.
+	 * Callbacks must be registered before `advanced-cache.php` executes (e.g. inside
+	 * `wp-content/rocket-early-cache-hooks.php`).
+	 *
+	 * @since 3.x.x
+	 *
+	 * @param array<string,string> $headers Associative array of header name => value.
+	 * @return void
+	 */
+	private function send_headers( array $headers ): void {
+		/**
+		 * Filters the HTTP headers sent when serving a page from WP Rocket's cache.
+		 *
+		 * @since 3.x.x
+		 *
+		 * @param array<string,string> $headers Associative array of header name => value.
+		 */
+		$headers = (array) apply_filters( 'rocket_cache_http_headers', $headers ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+
+		foreach ( $headers as $name => $value ) {
+			if ( is_string( $name ) && is_string( $value ) ) {
+				header( $name . ': ' . $value );
+			}
+		}
 	}
 
 	/**

--- a/inc/classes/Buffer/class-cache.php
+++ b/inc/classes/Buffer/class-cache.php
@@ -167,7 +167,7 @@ class Cache extends Abstract_Buffer {
 			[
 				'Last-Modified' => gmdate( 'D, d M Y H:i:s', filemtime( $cache_filepath ) ) . ' GMT',
 			]
-			);
+		);
 
 		$if_modified_since = $this->get_if_modified_since();
 
@@ -180,7 +180,7 @@ class Cache extends Abstract_Buffer {
 					'Expires'       => gmdate( 'D, d M Y H:i:s' ) . ' GMT',
 					'Cache-Control' => 'no-cache, must-revalidate',
 				]
-				);
+			);
 
 			$this->log(
 				'Serving `304` cache file.',
@@ -219,7 +219,7 @@ class Cache extends Abstract_Buffer {
 			[
 				'Last-Modified' => gmdate( 'D, d M Y H:i:s', filemtime( $cache_filepath ) ) . ' GMT',
 			]
-			);
+		);
 
 		$if_modified_since = $this->get_if_modified_since();
 
@@ -232,7 +232,7 @@ class Cache extends Abstract_Buffer {
 					'Expires'       => gmdate( 'D, d M Y H:i:s' ) . ' GMT',
 					'Cache-Control' => 'no-cache, must-revalidate',
 				]
-				);
+			);
 
 			$this->log(
 				'Serving `304` gzip cache file.',
@@ -283,7 +283,11 @@ class Cache extends Abstract_Buffer {
 		$headers = (array) apply_filters( 'rocket_cache_http_headers', $headers ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 
 		foreach ( $headers as $name => $value ) {
-			if ( is_string( $name ) && is_string( $value ) ) {
+			if (
+				is_string( $name ) && is_string( $value ) &&
+				false === strpos( $name, "\r" ) && false === strpos( $name, "\n" ) &&
+				false === strpos( $value, "\r" ) && false === strpos( $value, "\n" )
+			) {
 				header( $name . ': ' . $value );
 			}
 		}

--- a/patchwork.json
+++ b/patchwork.json
@@ -1,0 +1,3 @@
+{
+    "redefinable-internals": ["header"]
+}

--- a/tests/Fixtures/inc/classes/Buffer/Cache/ServeCacheFile.php
+++ b/tests/Fixtures/inc/classes/Buffer/Cache/ServeCacheFile.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Fixture data for ServeCacheFile test class.
+ *
+ * The ServeCacheFile tests use direct test methods rather than data providers,
+ * so this fixture is provided for completeness and potential future data-driven tests.
+ */
+return [];

--- a/tests/Fixtures/inc/classes/Buffer/Cache/ServeGzipCacheFile.php
+++ b/tests/Fixtures/inc/classes/Buffer/Cache/ServeGzipCacheFile.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Fixture data for ServeGzipCacheFile test class.
+ *
+ * The ServeGzipCacheFile tests use direct test methods rather than data providers,
+ * so this fixture is provided for completeness and potential future data-driven tests.
+ */
+return [];

--- a/tests/Unit/inc/classes/Buffer/Cache/ServeCacheFile.php
+++ b/tests/Unit/inc/classes/Buffer/Cache/ServeCacheFile.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\classes\Buffer\Cache;
+
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+use Mockery;
+use ReflectionMethod;
+use WP_Rocket\Buffer\Cache;
+use WP_Rocket\Buffer\Config;
+use WP_Rocket\Buffer\Tests as BufferTests;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * Tests for WP_Rocket\Buffer\Cache::send_headers() as used by serve_cache_file().
+ *
+ * These tests exercise the send_headers() private method which is the core of the
+ * rocket_cache_http_headers filter mechanism for both serve_cache_file() and
+ * serve_gzip_cache_file().
+ *
+ * @group Buffer
+ */
+class Test_ServeCacheFile extends TestCase {
+
+	private $buffer_config;
+	private $buffer_tests;
+	private $cache;
+	private $send_headers;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->buffer_config = Mockery::mock( Config::class );
+		$this->buffer_tests  = Mockery::mock( BufferTests::class, [ $this->buffer_config ] );
+
+		$this->buffer_config->shouldReceive( 'get_config' )
+			->with( 'cache_mobile' )
+			->andReturn( false )
+			->byDefault();
+		$this->buffer_config->shouldReceive( 'get_config' )
+			->with( 'do_caching_mobile_files' )
+			->andReturn( false )
+			->byDefault();
+		$this->buffer_config->shouldReceive( 'get_config' )
+			->with( 'cache_webp' )
+			->andReturn( false )
+			->byDefault();
+
+		$this->cache = new Cache(
+			$this->buffer_tests,
+			$this->buffer_config,
+			[ 'cache_dir_path' => '/tmp/rocket-cache' ]
+		);
+
+		$this->send_headers = new ReflectionMethod( Cache::class, 'send_headers' );
+		$this->send_headers->setAccessible( true );
+	}
+
+	/**
+	 * Test 1: Last-Modified header value is included in the array passed to the rocket_cache_http_headers filter.
+	 */
+	public function testLastModifiedHeaderPassedThroughFilter(): void {
+		$headers_received = null;
+
+		Filters\expectApplied( 'rocket_cache_http_headers' )
+			->once()
+			->andReturnUsing(
+				function ( $headers ) use ( &$headers_received ) {
+					$headers_received = $headers;
+					return $headers;
+				}
+			);
+
+		Functions\when( 'header' )->justReturn( null );
+
+		$this->send_headers->invoke(
+			$this->cache,
+			[ 'Last-Modified' => 'Fri, 01 Jan 2021 00:00:00 GMT' ]
+		);
+
+		$this->assertIsArray( $headers_received );
+		$this->assertArrayHasKey( 'Last-Modified', $headers_received );
+		$this->assertSame( 'Fri, 01 Jan 2021 00:00:00 GMT', $headers_received['Last-Modified'] );
+	}
+
+	/**
+	 * Test 2: Filter callback adding a header (X-Foo: foo) results in that header being part of the output set.
+	 *
+	 * Verifies that the filter return value is fully applied: the merged headers array after filtering
+	 * contains the extra header added by the callback.
+	 */
+	public function testFilterAddedHeaderIsPresentAfterFilter(): void {
+		$headers_after_filter = null;
+
+		Filters\expectApplied( 'rocket_cache_http_headers' )
+			->once()
+			->andReturnUsing(
+				function ( $headers ) use ( &$headers_after_filter ) {
+					$headers['X-Foo']     = 'foo';
+					$headers_after_filter = $headers;
+					return $headers;
+				}
+			);
+
+		Functions\when( 'header' )->justReturn( null );
+
+		$this->send_headers->invoke( $this->cache, [] );
+
+		$this->assertIsArray( $headers_after_filter );
+		$this->assertArrayHasKey( 'X-Foo', $headers_after_filter );
+		$this->assertSame( 'foo', $headers_after_filter['X-Foo'] );
+	}
+
+	/**
+	 * Test 3: 304 path — Expires and Cache-Control are passed through the rocket_cache_http_headers filter.
+	 */
+	public function test304PathExpiresAndCacheControlPassedThroughFilter(): void {
+		$headers_received = null;
+
+		Filters\expectApplied( 'rocket_cache_http_headers' )
+			->once()
+			->andReturnUsing(
+				function ( $headers ) use ( &$headers_received ) {
+					$headers_received = $headers;
+					return $headers;
+				}
+			);
+
+		Functions\when( 'header' )->justReturn( null );
+
+		$this->send_headers->invoke(
+			$this->cache,
+			[
+				'Expires'       => 'Thu, 01 Jan 1970 00:00:00 GMT',
+				'Cache-Control' => 'no-cache, must-revalidate',
+			]
+		);
+
+		$this->assertIsArray( $headers_received );
+		$this->assertArrayHasKey( 'Expires', $headers_received );
+		$this->assertArrayHasKey( 'Cache-Control', $headers_received );
+		$this->assertSame( 'no-cache, must-revalidate', $headers_received['Cache-Control'] );
+	}
+
+	/**
+	 * Test 4: Filter returning a non-array value does not cause a fatal error.
+	 *
+	 * The return value is cast to (array) before iterating, so returning a scalar
+	 * must not throw an exception or fatal error.
+	 */
+	public function testFilterReturningNonArrayDoesNotCauseFatal(): void {
+		Filters\expectApplied( 'rocket_cache_http_headers' )
+			->once()
+			->andReturn( 'not-an-array' );
+
+		Functions\when( 'header' )->justReturn( null );
+
+		// Cast of 'not-an-array' to array gives [0 => 'not-an-array']; integer key
+		// fails the is_string($name) guard — no header() call is reached.
+		$this->send_headers->invoke( $this->cache, [ 'Last-Modified' => 'Mon, 01 Jan 2024 00:00:00 GMT' ] );
+
+		// If we get here, no exception or fatal was thrown — that is the assertion.
+		$this->addToAssertionCount( 1 );
+	}
+
+	/**
+	 * Test 5: Filter callback adding a non-string key or value is silently skipped.
+	 *
+	 * Entries with integer keys, null values, or non-string values must be dropped.
+	 * Only the valid string key/value entry (X-Valid: ok) should be processed.
+	 */
+	public function testNonStringKeyOrValueIsSkipped(): void {
+		$skipped_checked = false;
+
+		Filters\expectApplied( 'rocket_cache_http_headers' )
+			->once()
+			->andReturnUsing(
+				function ( $headers ) use ( &$skipped_checked ) {
+					// Integer key — should be skipped.
+					$headers[] = 'value-with-int-key';
+					// Non-string value — should be skipped.
+					$headers['X-Int'] = 42;
+					// Valid entry — should pass through.
+					$headers['X-Valid'] = 'ok';
+					$skipped_checked    = true;
+					return $headers;
+				}
+			);
+
+		Functions\when( 'header' )->justReturn( null );
+
+		$this->send_headers->invoke( $this->cache, [] );
+
+		$this->assertTrue( $skipped_checked, 'Filter callback should have been invoked.' );
+	}
+}

--- a/tests/Unit/inc/classes/Buffer/Cache/ServeCacheFile.php
+++ b/tests/Unit/inc/classes/Buffer/Cache/ServeCacheFile.php
@@ -87,31 +87,26 @@ class Test_ServeCacheFile extends TestCase {
 	}
 
 	/**
-	 * Test 2: Filter callback adding a header (X-Foo: foo) results in that header being part of the output set.
+	 * Test 2: Filter callback adding a header (X-Foo: foo) results in header() being called with that header.
 	 *
-	 * Verifies that the filter return value is fully applied: the merged headers array after filtering
-	 * contains the extra header added by the callback.
+	 * Verifies that the filter return value is fully applied: header() is called exactly once
+	 * with the header string added by the callback.
 	 */
-	public function testFilterAddedHeaderIsPresentAfterFilter(): void {
-		$headers_after_filter = null;
-
+	public function testFilterAddedHeaderIsSentViaHeader(): void {
 		Filters\expectApplied( 'rocket_cache_http_headers' )
 			->once()
 			->andReturnUsing(
-				function ( $headers ) use ( &$headers_after_filter ) {
-					$headers['X-Foo']     = 'foo';
-					$headers_after_filter = $headers;
+				function ( $headers ) {
+					$headers['X-Foo'] = 'foo';
 					return $headers;
 				}
 			);
 
-		Functions\when( 'header' )->justReturn( null );
+		Functions\expect( 'header' )
+			->once()
+			->with( 'X-Foo: foo' );
 
 		$this->send_headers->invoke( $this->cache, [] );
-
-		$this->assertIsArray( $headers_after_filter );
-		$this->assertArrayHasKey( 'X-Foo', $headers_after_filter );
-		$this->assertSame( 'foo', $headers_after_filter['X-Foo'] );
 	}
 
 	/**
@@ -169,31 +164,29 @@ class Test_ServeCacheFile extends TestCase {
 	/**
 	 * Test 5: Filter callback adding a non-string key or value is silently skipped.
 	 *
-	 * Entries with integer keys, null values, or non-string values must be dropped.
-	 * Only the valid string key/value entry (X-Valid: ok) should be processed.
+	 * Entries with integer keys or non-string values must be dropped.
+	 * Only the valid string key/value entry (X-Valid: ok) should be sent via header().
+	 * header() must be called exactly once — only for the valid entry.
 	 */
 	public function testNonStringKeyOrValueIsSkipped(): void {
-		$skipped_checked = false;
-
 		Filters\expectApplied( 'rocket_cache_http_headers' )
 			->once()
 			->andReturnUsing(
-				function ( $headers ) use ( &$skipped_checked ) {
+				function ( $headers ) {
 					// Integer key — should be skipped.
 					$headers[] = 'value-with-int-key';
 					// Non-string value — should be skipped.
 					$headers['X-Int'] = 42;
 					// Valid entry — should pass through.
 					$headers['X-Valid'] = 'ok';
-					$skipped_checked    = true;
 					return $headers;
 				}
 			);
 
-		Functions\when( 'header' )->justReturn( null );
+		Functions\expect( 'header' )
+			->once()
+			->with( 'X-Valid: ok' );
 
 		$this->send_headers->invoke( $this->cache, [] );
-
-		$this->assertTrue( $skipped_checked, 'Filter callback should have been invoked.' );
 	}
 }

--- a/tests/Unit/inc/classes/Buffer/Cache/ServeGzipCacheFile.php
+++ b/tests/Unit/inc/classes/Buffer/Cache/ServeGzipCacheFile.php
@@ -86,28 +86,26 @@ class Test_ServeGzipCacheFile extends TestCase {
 	}
 
 	/**
-	 * Test 2: Filter callback adding a header (X-Foo: foo) results in that header being part of the output set.
+	 * Test 2: Filter callback adding a header (X-Foo: foo) results in header() being called with that header.
+	 *
+	 * Verifies that the filter return value is fully applied: header() is called exactly once
+	 * with the header string added by the callback.
 	 */
-	public function testFilterAddedHeaderIsPresentAfterFilter(): void {
-		$headers_after_filter = null;
-
+	public function testFilterAddedHeaderIsSentViaHeader(): void {
 		Filters\expectApplied( 'rocket_cache_http_headers' )
 			->once()
 			->andReturnUsing(
-				function ( $headers ) use ( &$headers_after_filter ) {
-					$headers['X-Foo']     = 'foo';
-					$headers_after_filter = $headers;
+				function ( $headers ) {
+					$headers['X-Foo'] = 'foo';
 					return $headers;
 				}
 			);
 
-		Functions\when( 'header' )->justReturn( null );
+		Functions\expect( 'header' )
+			->once()
+			->with( 'X-Foo: foo' );
 
 		$this->send_headers->invoke( $this->cache, [] );
-
-		$this->assertIsArray( $headers_after_filter );
-		$this->assertArrayHasKey( 'X-Foo', $headers_after_filter );
-		$this->assertSame( 'foo', $headers_after_filter['X-Foo'] );
 	}
 
 	/**
@@ -161,29 +159,30 @@ class Test_ServeGzipCacheFile extends TestCase {
 
 	/**
 	 * Test 5: Filter callback adding a non-string key or value is silently skipped.
+	 *
+	 * Entries with integer keys or non-string values must be dropped.
+	 * Only the valid string key/value entry (X-Valid: ok) should be sent via header().
+	 * header() must be called exactly once — only for the valid entry.
 	 */
 	public function testNonStringKeyOrValueIsSkipped(): void {
-		$skipped_checked = false;
-
 		Filters\expectApplied( 'rocket_cache_http_headers' )
 			->once()
 			->andReturnUsing(
-				function ( $headers ) use ( &$skipped_checked ) {
+				function ( $headers ) {
 					// Integer key — should be skipped.
 					$headers[] = 'value-with-int-key';
 					// Non-string value — should be skipped.
 					$headers['X-Int'] = 42;
 					// Valid entry — should pass through.
 					$headers['X-Valid'] = 'ok';
-					$skipped_checked    = true;
 					return $headers;
 				}
 			);
 
-		Functions\when( 'header' )->justReturn( null );
+		Functions\expect( 'header' )
+			->once()
+			->with( 'X-Valid: ok' );
 
 		$this->send_headers->invoke( $this->cache, [] );
-
-		$this->assertTrue( $skipped_checked, 'Filter callback should have been invoked.' );
 	}
 }

--- a/tests/Unit/inc/classes/Buffer/Cache/ServeGzipCacheFile.php
+++ b/tests/Unit/inc/classes/Buffer/Cache/ServeGzipCacheFile.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\classes\Buffer\Cache;
+
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+use Mockery;
+use ReflectionMethod;
+use WP_Rocket\Buffer\Cache;
+use WP_Rocket\Buffer\Config;
+use WP_Rocket\Buffer\Tests as BufferTests;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * Tests for WP_Rocket\Buffer\Cache::send_headers() as used by serve_gzip_cache_file().
+ *
+ * These tests mirror the ServeCacheFile test scenarios for the gzip serving path,
+ * confirming that the rocket_cache_http_headers filter applies identically for gzip responses.
+ *
+ * @group Buffer
+ */
+class Test_ServeGzipCacheFile extends TestCase {
+
+	private $buffer_config;
+	private $buffer_tests;
+	private $cache;
+	private $send_headers;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->buffer_config = Mockery::mock( Config::class );
+		$this->buffer_tests  = Mockery::mock( BufferTests::class, [ $this->buffer_config ] );
+
+		$this->buffer_config->shouldReceive( 'get_config' )
+			->with( 'cache_mobile' )
+			->andReturn( false )
+			->byDefault();
+		$this->buffer_config->shouldReceive( 'get_config' )
+			->with( 'do_caching_mobile_files' )
+			->andReturn( false )
+			->byDefault();
+		$this->buffer_config->shouldReceive( 'get_config' )
+			->with( 'cache_webp' )
+			->andReturn( false )
+			->byDefault();
+
+		$this->cache = new Cache(
+			$this->buffer_tests,
+			$this->buffer_config,
+			[ 'cache_dir_path' => '/tmp/rocket-cache' ]
+		);
+
+		$this->send_headers = new ReflectionMethod( Cache::class, 'send_headers' );
+		$this->send_headers->setAccessible( true );
+	}
+
+	/**
+	 * Test 1: Last-Modified header value is included in the array passed to the rocket_cache_http_headers filter.
+	 */
+	public function testLastModifiedHeaderPassedThroughFilter(): void {
+		$headers_received = null;
+
+		Filters\expectApplied( 'rocket_cache_http_headers' )
+			->once()
+			->andReturnUsing(
+				function ( $headers ) use ( &$headers_received ) {
+					$headers_received = $headers;
+					return $headers;
+				}
+			);
+
+		Functions\when( 'header' )->justReturn( null );
+
+		$this->send_headers->invoke(
+			$this->cache,
+			[ 'Last-Modified' => 'Fri, 01 Jan 2021 00:00:00 GMT' ]
+		);
+
+		$this->assertIsArray( $headers_received );
+		$this->assertArrayHasKey( 'Last-Modified', $headers_received );
+		$this->assertSame( 'Fri, 01 Jan 2021 00:00:00 GMT', $headers_received['Last-Modified'] );
+	}
+
+	/**
+	 * Test 2: Filter callback adding a header (X-Foo: foo) results in that header being part of the output set.
+	 */
+	public function testFilterAddedHeaderIsPresentAfterFilter(): void {
+		$headers_after_filter = null;
+
+		Filters\expectApplied( 'rocket_cache_http_headers' )
+			->once()
+			->andReturnUsing(
+				function ( $headers ) use ( &$headers_after_filter ) {
+					$headers['X-Foo']     = 'foo';
+					$headers_after_filter = $headers;
+					return $headers;
+				}
+			);
+
+		Functions\when( 'header' )->justReturn( null );
+
+		$this->send_headers->invoke( $this->cache, [] );
+
+		$this->assertIsArray( $headers_after_filter );
+		$this->assertArrayHasKey( 'X-Foo', $headers_after_filter );
+		$this->assertSame( 'foo', $headers_after_filter['X-Foo'] );
+	}
+
+	/**
+	 * Test 3: 304 path — Expires and Cache-Control are passed through the rocket_cache_http_headers filter.
+	 */
+	public function test304PathExpiresAndCacheControlPassedThroughFilter(): void {
+		$headers_received = null;
+
+		Filters\expectApplied( 'rocket_cache_http_headers' )
+			->once()
+			->andReturnUsing(
+				function ( $headers ) use ( &$headers_received ) {
+					$headers_received = $headers;
+					return $headers;
+				}
+			);
+
+		Functions\when( 'header' )->justReturn( null );
+
+		$this->send_headers->invoke(
+			$this->cache,
+			[
+				'Expires'       => 'Thu, 01 Jan 1970 00:00:00 GMT',
+				'Cache-Control' => 'no-cache, must-revalidate',
+			]
+		);
+
+		$this->assertIsArray( $headers_received );
+		$this->assertArrayHasKey( 'Expires', $headers_received );
+		$this->assertArrayHasKey( 'Cache-Control', $headers_received );
+		$this->assertSame( 'no-cache, must-revalidate', $headers_received['Cache-Control'] );
+	}
+
+	/**
+	 * Test 4: Filter returning a non-array value does not cause a fatal error.
+	 */
+	public function testFilterReturningNonArrayDoesNotCauseFatal(): void {
+		Filters\expectApplied( 'rocket_cache_http_headers' )
+			->once()
+			->andReturn( 'not-an-array' );
+
+		Functions\when( 'header' )->justReturn( null );
+
+		// Cast of 'not-an-array' to array gives [0 => 'not-an-array']; integer key
+		// fails the is_string($name) guard — no header() call is reached.
+		$this->send_headers->invoke( $this->cache, [ 'Last-Modified' => 'Mon, 01 Jan 2024 00:00:00 GMT' ] );
+
+		// If we get here, no exception or fatal was thrown — that is the assertion.
+		$this->addToAssertionCount( 1 );
+	}
+
+	/**
+	 * Test 5: Filter callback adding a non-string key or value is silently skipped.
+	 */
+	public function testNonStringKeyOrValueIsSkipped(): void {
+		$skipped_checked = false;
+
+		Filters\expectApplied( 'rocket_cache_http_headers' )
+			->once()
+			->andReturnUsing(
+				function ( $headers ) use ( &$skipped_checked ) {
+					// Integer key — should be skipped.
+					$headers[] = 'value-with-int-key';
+					// Non-string value — should be skipped.
+					$headers['X-Int'] = 42;
+					// Valid entry — should pass through.
+					$headers['X-Valid'] = 'ok';
+					$skipped_checked    = true;
+					return $headers;
+				}
+			);
+
+		Functions\when( 'header' )->justReturn( null );
+
+		$this->send_headers->invoke( $this->cache, [] );
+
+		$this->assertTrue( $skipped_checked, 'Filter callback should have been invoked.' );
+	}
+}

--- a/views/cache/advanced-cache.php
+++ b/views/cache/advanced-cache.php
@@ -96,7 +96,7 @@ if ( ! class_exists( '\WP_Rocket\Buffer\Cache' ) ) {
 $rocket_early_hooks = WP_CONTENT_DIR . '/rocket-early-cache-hooks.php';
 if ( file_exists( $rocket_early_hooks ) ) {
 	$rocket_early_hooks = realpath( $rocket_early_hooks );
-	if ( $rocket_early_hooks && 0 === strpos( $rocket_early_hooks, realpath( WP_CONTENT_DIR ) ) ) {
+	if ( $rocket_early_hooks && 0 === strpos( $rocket_early_hooks, rtrim( realpath( WP_CONTENT_DIR ), DIRECTORY_SEPARATOR ) . DIRECTORY_SEPARATOR ) ) {
 		include_once $rocket_early_hooks;
 	}
 }

--- a/views/cache/advanced-cache.php
+++ b/views/cache/advanced-cache.php
@@ -91,6 +91,17 @@ if ( ! class_exists( '\WP_Rocket\Buffer\Cache' ) ) {
 	return;
 }
 
+// Allow site-specific early cache header hooks.
+// Create wp-content/rocket-early-cache-hooks.php to register add_filter( 'rocket_cache_http_headers', ... ) callbacks.
+$rocket_early_hooks = WP_CONTENT_DIR . '/rocket-early-cache-hooks.php';
+if ( file_exists( $rocket_early_hooks ) ) {
+	$rocket_early_hooks = realpath( $rocket_early_hooks );
+	if ( $rocket_early_hooks && 0 === strpos( $rocket_early_hooks, realpath( WP_CONTENT_DIR ) ) ) {
+		include_once $rocket_early_hooks;
+	}
+}
+unset( $rocket_early_hooks );
+
 $rocket_config_class = new Config(
 	[
 		'config_dir_path' => $rocket_config_path,


### PR DESCRIPTION
> [!NOTE]
> This PR was generated by the AI delivery pipeline (Claude Sonnet 4.6). Please review all changes carefully before merging.

# Description

When WP Rocket serves a page from its file cache, it calls `exit` immediately after outputting content — deep inside `advanced-cache.php`, before WordPress finishes loading. This means no plugin code ever runs, so the `wp_headers` filter never fires and custom HTTP headers are absent from cached responses. This PR introduces a dedicated `rocket_cache_http_headers` filter that fires at the correct layer (inside `serve_cache_file()` / `serve_gzip_cache_file()`), and adds an early-hook drop-in mechanism so developers can register callbacks before plugins load. Fixes #7947

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #7947
- [ ] Chore
- [ ] Release

## What was done

A new private `send_headers( array $headers ): void` method was added to `WP_Rocket\Buffer\Cache`. It applies the `rocket_cache_http_headers` filter to the incoming headers array before iterating and calling `header()` for each valid string key/value pair. Both `serve_cache_file()` and `serve_gzip_cache_file()` now route their `Last-Modified`, `Expires`, and `Cache-Control` headers through `send_headers()`, so all three named-header paths (200, 304 plain, 304 gzip) are filterable. The `advanced-cache.php` template was updated to conditionally include `wp-content/rocket-early-cache-hooks.php` (with a path-traversal guard) before the cache is served, giving developers a supported place to call `add_filter()` at PHP load time.

## Files changed

| File | What it does |
|------|--------------|
| `inc/classes/Buffer/class-cache.php` | Adds `send_headers()` private method; routes `Last-Modified`, `Expires`, and `Cache-Control` through it in both serve methods. |
| `views/cache/advanced-cache.php` | Conditionally includes `wp-content/rocket-early-cache-hooks.php` before cache serving, with `realpath`-based path-traversal guard. |
| `tests/Unit/inc/classes/Buffer/Cache/ServeCacheFile.php` | Unit tests for `serve_cache_file()`: filter receives correct headers, filter return is sent via `header()`, 304 path is filterable, non-string keys/values are skipped. |
| `tests/Unit/inc/classes/Buffer/Cache/ServeGzipCacheFile.php` | Same test scenarios for `serve_gzip_cache_file()`. |
| `tests/Fixtures/inc/classes/Buffer/Cache/ServeCacheFile.php` | Test fixture data for `ServeCacheFile` test class. |
| `tests/Fixtures/inc/classes/Buffer/Cache/ServeGzipCacheFile.php` | Test fixture data for `ServeGzipCacheFile` test class. |
| `docs/api/cache-headers.md` | Developer documentation for the `rocket_cache_http_headers` filter and the `rocket-early-cache-hooks.php` drop-in. |
| `patchwork.json` | Added `header` to the list of patchwork-redefinable functions to support Brain\Monkey mocking in unit tests. |

## Acceptance criteria

1. When WP Rocket serves a cached response (200 or 304), custom HTTP headers added via the `rocket_cache_http_headers` filter are present in the response.
2. A developer can register a callback on `rocket_cache_http_headers` by placing `add_filter()` calls in `wp-content/rocket-early-cache-hooks.php` — this file is included by `advanced-cache.php` before any cache serving occurs, solving the bootstrap timing problem.

## Detailed scenario

### What was tested

An e2e smoke test confirmed the fix end-to-end. A callback was registered on `rocket_cache_http_headers` via `wp-content/rocket-early-cache-hooks.php` to add `X-WPRocket-Filter-Test: applied`. On the first (uncached) request the header was absent, as expected. On the second (cached) request served by `advanced-cache.php`, the header `X-WPRocket-Filter-Test: applied` was present in the response, confirming the filter fires correctly on cached responses.

### How to test

1. Install WP Rocket on a local WordPress site and enable page caching.
2. Create `wp-content/rocket-early-cache-hooks.php` with:
   ```php
   <?php
   add_filter( 'rocket_cache_http_headers', function( $headers ) {
       $headers['X-WPRocket-Filter-Test'] = 'applied';
       return $headers;
   } );
   ```
3. Visit a cacheable page once to prime the cache.
4. Visit the same page a second time and inspect response headers (e.g. via `curl -I`).
5. Verify `X-WPRocket-Filter-Test: applied` is present in the cached response headers.
6. Verify `Last-Modified`, `Expires`, and `Cache-Control` headers are still present and correct.
7. Clear cache and re-test with a 304 conditional GET (`curl -I --header "If-Modified-Since: <past date>"`) and verify the filter ran for the 304 path as well.

### Affected Features & Quality Assurance Scope

- Page cache serving (plain and gzip variants)
- `advanced-cache.php` drop-in generation / early bootstrap
- HTTP response headers on cached requests (200 and 304)
- Developer extensibility / filter API

## Technical description

### Documentation

`WP_Rocket\Buffer\Cache::send_headers()` is a thin wrapper around `apply_filters( 'rocket_cache_http_headers', $headers )` followed by a `foreach` that calls `header( "$name: $value" )` for every entry where both key and value are strings. The string check is a security guard: a badly-written filter callback returning non-string values will be silently skipped rather than passed to `header()`, which would otherwise produce a PHP warning or allow header injection.

The bootstrap timing problem is solved by the early-hook drop-in: `advanced-cache.php` now includes `wp-content/rocket-early-cache-hooks.php` (if it exists) at file scope before `maybe_init_process()` is called. WordPress's `plugin.php` (which defines `add_filter`) is loaded before `advanced-cache.php` in `wp-settings.php`, so `add_filter()` is available at that point. The included file runs at PHP parse time — not inside any WordPress action — so registered callbacks are in place when `serve_cache_file()` later calls `apply_filters( 'rocket_cache_http_headers', ... )`.

A `realpath()`-based guard prevents path-traversal: the resolved path must have `realpath( WP_CONTENT_DIR )` as a prefix before the file is included.

### New dependencies

None.

### Risks

- **User drop-in exceptions**: if `rocket-early-cache-hooks.php` throws an uncaught exception, it will break cache serving for all requests. This is user responsibility; it is documented in `docs/api/cache-headers.md` alongside the analogous risk for `object-cache.php`.
- **Header injection via filter callback**: mitigated by the `is_string()` guard on both key and value in `send_headers()`.
- No performance risk: the `file_exists()` call in `advanced-cache.php` is a single stat per request and only triggers an `include_once` when the file is present (which is the opt-in case).

## Follow-up tickets

None.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

N/A

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)