### PR TITLE
Fix/8364: RocketCDN Free CNAME displaying in 'Other CDN' tab

### DIFF
--- a/inc/Engine/CDN/RocketCDN/FrontendSubscriber.php
+++ b/inc/Engine/CDN/RocketCDN/FrontendSubscriber.php
@@ -57,7 +57,6 @@ class FrontendSubscriber implements Subscriber_Interface {
 		return [
 			'pre_get_rocket_option_cdn_cnames' => [ 'set_cdn_cnames', 9 ],
 			'pre_get_rocket_option_cdn_zone'   => [ 'set_cdn_zone', 9 ],
-			'rocket_field_cdn_cnames'          => 'remove_rocketcdn_cnames',
 		];
 	}
 
@@ -97,26 +96,6 @@ class FrontendSubscriber implements Subscriber_Interface {
 		}
 
 		return [ 'all' ];
-	}
-
-	/**
-	 * Remove RocketCDN URL from the list of CNAMEs in 'Other CDN' settings field.
-	 *
-	 * Filters out the RocketCDN URL from the provided list of CNAMEs
-	 * to prevent it from being displayed in 'Other CDN' settings field.
-	 *
-	 * @param array $cnames List of CNAME URLs to filter.
-	 * @return array Filtered array of CNAMEs with RocketCDN URL removed.
-	 */
-	public function remove_rocketcdn_cnames( $cnames ) {
-		// Remove RocketCDN URL from the list of CNAMEs to display in the 'Other CDN' settings field.
-		$rocketcdn_url = $this->subscription_controller->get_rocketcdn_url();
-
-		if ( empty( $rocketcdn_url ) ) {
-			return $cnames;
-		}
-
-		return array_diff( $cnames, [ $rocketcdn_url ] );
 	}
 
 	/**

--- a/inc/Engine/CDN/RocketCDN/FrontendSubscriber.php
+++ b/inc/Engine/CDN/RocketCDN/FrontendSubscriber.php
@@ -57,6 +57,7 @@ class FrontendSubscriber implements Subscriber_Interface {
 		return [
 			'pre_get_rocket_option_cdn_cnames' => [ 'set_cdn_cnames', 9 ],
 			'pre_get_rocket_option_cdn_zone'   => [ 'set_cdn_zone', 9 ],
+			'rocket_field_cdn_cnames'          => 'remove_rocketcdn_cnames',
 		];
 	}
 
@@ -96,6 +97,26 @@ class FrontendSubscriber implements Subscriber_Interface {
 		}
 
 		return [ 'all' ];
+	}
+
+	/**
+	 * Remove RocketCDN URL from the list of CNAMEs in 'Other CDN' settings field.
+	 *
+	 * Filters out the RocketCDN URL from the provided list of CNAMEs
+	 * to prevent it from being displayed in 'Other CDN' settings field.
+	 *
+	 * @param array $cnames List of CNAME URLs to filter.
+	 * @return array Filtered array of CNAMEs with RocketCDN URL removed.
+	 */
+	public function remove_rocketcdn_cnames( $cnames ) {
+		// Remove RocketCDN URL from the list of CNAMEs to display in the 'Other CDN' settings field.
+		$rocketcdn_url = $this->subscription_controller->get_rocketcdn_url();
+
+		if ( empty( $rocketcdn_url ) ) {
+			return $cnames;
+		}
+
+		return array_diff( $cnames, [ $rocketcdn_url ] );
 	}
 
 	/**

--- a/views/settings/fields/cnames.php
+++ b/views/settings/fields/cnames.php
@@ -9,7 +9,7 @@ defined( 'ABSPATH' ) || exit;
 
 $rocket_options = get_option( rocket_get_constant( 'WP_ROCKET_SLUG' ) );
 
-$rocket_cnames = $rocket_options['cdn_cnames'] ?? []; 
+$rocket_cnames      = $rocket_options['cdn_cnames'] ?? [];
 $rocket_cnames_zone = $rocket_options['cdn_zone'] ?? [];
 /**
  * Filters the fields to be disabled for the CDN section.

--- a/views/settings/fields/cnames.php
+++ b/views/settings/fields/cnames.php
@@ -7,15 +7,10 @@
 
 defined( 'ABSPATH' ) || exit;
 
-/**
- * Filters the CDN CNAME URLs displayed in the settings field.
- *
- * @since 3.22
- *
- * @param array $cdn_cnames Array of CDN CNAME URLs.
- */
-$rocket_cnames      = wpm_apply_filters_typed( 'array', 'rocket_field_cdn_cnames', get_rocket_option( 'cdn_cnames' ) ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
-$rocket_cnames_zone = get_rocket_option( 'cdn_zone' );
+$rocket_options = get_option( rocket_get_constant( 'WP_ROCKET_SLUG' ) );
+
+$rocket_cnames = $rocket_options['cdn_cnames'] ?? []; 
+$rocket_cnames_zone = $rocket_options['cdn_zone'] ?? [];
 /**
  * Filters the fields to be disabled for the CDN section.
  *
@@ -55,7 +50,7 @@ $rocket_disable_input_alt = wpm_apply_filters_typed( 'boolean', 'rocket_disable_
 							 *
 							 * @param bool $allow true to add the option, false otherwise.
 							 */
-							if ( apply_filters( 'rocket_allow_cdn_images', true ) ) :
+							if ( wpm_apply_filters_typed( 'boolean', 'rocket_allow_cdn_images', true ) ) :
 								?>
 								<option value="images" <?php selected( $rocket_cnames_zone[ $key ], 'images' ); ?>><?php esc_html_e( 'For Images', 'rocket' ); ?></option>
 							<?php endif; ?>
@@ -88,7 +83,7 @@ $rocket_disable_input_alt = wpm_apply_filters_typed( 'boolean', 'rocket_disable_
 					 *
 					 * @param bool $allow true to add the option, false otherwise.
 					 */
-					if ( apply_filters( 'rocket_allow_cdn_images', true ) ) :
+					if ( wpm_apply_filters_typed( 'boolean', 'rocket_allow_cdn_images', true ) ) :
 						?>
 					<option value="images"><?php esc_html_e( 'For Images', 'rocket' ); ?></option>
 					<?php endif; ?>
@@ -117,7 +112,7 @@ $rocket_disable_input_alt = wpm_apply_filters_typed( 'boolean', 'rocket_disable_
 					 *
 					 * @param bool $allow true to add the option, false otherwise.
 					 */
-					if ( apply_filters( 'rocket_allow_cdn_images', true ) ) :
+					if ( wpm_apply_filters_typed( 'boolean', 'rocket_allow_cdn_images', true ) ) :
 						?>
 					<option value="images"><?php esc_html_e( 'For Images', 'rocket' ); ?></option>
 					<?php endif; ?>

--- a/views/settings/fields/cnames.php
+++ b/views/settings/fields/cnames.php
@@ -7,7 +7,14 @@
 
 defined( 'ABSPATH' ) || exit;
 
-$rocket_cnames      = get_rocket_option( 'cdn_cnames' );
+/**
+ * Filters the CDN CNAME URLs displayed in the settings field.
+ *
+ * @since 3.22
+ *
+ * @param array $cdn_cnames Array of CDN CNAME URLs.
+ */
+$rocket_cnames      = wpm_apply_filters_typed( 'array', 'rocket_field_cdn_cnames', get_rocket_option( 'cdn_cnames' ) ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
 $rocket_cnames_zone = get_rocket_option( 'cdn_zone' );
 /**
  * Filters the fields to be disabled for the CDN section.
@@ -16,7 +23,7 @@ $rocket_cnames_zone = get_rocket_option( 'cdn_zone' );
  *
  * @param bool $alter Input should be altered.
  */
-$rocket_disable_input_alt = apply_filters( 'rocket_disable_cdn_option_change', false );
+$rocket_disable_input_alt = wpm_apply_filters_typed( 'boolean', 'rocket_disable_cdn_option_change', false );
 ?>
 <div class="wpr-field <?php echo $rocket_disable_input_alt ? 'wpr-isDisabled' : ''; ?>">
 	<div class="wpr-field-description-label">


### PR DESCRIPTION
# Description

Fixes #8364 
Fixes issue with RocketCDN CNAME being added to CNAMES list in 'Other CDN' section.

## Type of change

- [x] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

Refer to [issue](https://github.com/wp-media/wp-rocket/issues/8364)

### How to test

Refer to [issue](https://github.com/wp-media/wp-rocket/issues/8364)

### Affected Features & Quality Assurance Scope

CNAMES field

## Technical description

### Documentation

- Use WP get_option to get cdn_cnames directly on the view instead of WPR options class.
- This is intentional so when RocketCDN is enabled, The filtered cdn_cnames option is not applied to the view. 

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

Not applicable to the changes in this PR

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
