### PR TITLE
Closes #8198: skip data-rocket-location-hash for logged-in users when User Cache is enabled

### DIFF
--- a/inc/Engine/Common/PerformanceHints/Activation/ServiceProvider.php
+++ b/inc/Engine/Common/PerformanceHints/Activation/ServiceProvider.php
@@ -61,7 +61,8 @@ class ServiceProvider extends AbstractServiceProvider {
 				]
 			);
 
-		$this->getContainer()->add( 'lrc_context', LRCContext::class );
+		$this->getContainer()->add( 'lrc_context', LRCContext::class )
+			->addArgument( 'options' );
 
 		$this->getContainer()->addShared( 'lrc_activation_factory', LRCActivationFactory::class )
 			->addArguments(

--- a/inc/Engine/Optimization/LazyRenderContent/Context/Context.php
+++ b/inc/Engine/Optimization/LazyRenderContent/Context/Context.php
@@ -3,9 +3,26 @@ declare(strict_types=1);
 
 namespace WP_Rocket\Engine\Optimization\LazyRenderContent\Context;
 
+use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\Common\Context\ContextInterface;
 
 class Context implements ContextInterface {
+	/**
+	 * Plugin options.
+	 *
+	 * @var Options_Data
+	 */
+	private $options;
+
+	/**
+	 * Context constructor.
+	 *
+	 * @param Options_Data $options Plugin options.
+	 */
+	public function __construct( Options_Data $options ) {
+		$this->options = $options;
+	}
+
 	/**
 	 * Determine if the action is allowed.
 	 *
@@ -14,6 +31,10 @@ class Context implements ContextInterface {
 	 */
 	public function is_allowed( array $data = [] ): bool {
 		if ( get_option( 'wp_rocket_no_licence' ) ) {
+			return false;
+		}
+
+		if ( is_user_logged_in() && $this->options->get( 'cache_logged_user', 0 ) ) {
 			return false;
 		}
 

--- a/inc/Engine/Optimization/LazyRenderContent/ServiceProvider.php
+++ b/inc/Engine/Optimization/LazyRenderContent/ServiceProvider.php
@@ -49,7 +49,8 @@ class ServiceProvider extends AbstractServiceProvider {
 	 * @return void
 	 */
 	public function register(): void {
-		$this->getContainer()->add( 'lrc_context', Context::class );
+		$this->getContainer()->add( 'lrc_context', Context::class )
+			->addArgument( 'options' );
 		$this->getContainer()->addShared( 'lrc_table', LRCTable::class );
 		$this->getContainer()->add( 'lrc_query', LRCQuery::class );
 

--- a/tests/Fixtures/inc/Engine/Optimization/LazyRenderContent/Context/Context/isAllowed.php
+++ b/tests/Fixtures/inc/Engine/Optimization/LazyRenderContent/Context/Context/isAllowed.php
@@ -3,22 +3,55 @@
 return [
 	'testShouldReturnFalseWhenNoLicense' => [
 		'config'   => [
-			'licence' => true,
-			'filter'  => true,
+			'licence'           => true,
+			'filter'            => true,
+			'is_logged_in'      => false,
+			'cache_logged_user' => 0,
 		],
 		'expected' => false,
 	],
 	'testShouldReturnFalseWhenFilterFalse' => [
 		'config'   => [
-			'licence' => false,
-			'filter'  => false,
+			'licence'           => false,
+			'filter'            => false,
+			'is_logged_in'      => false,
+			'cache_logged_user' => 0,
 		],
 		'expected' => false,
 	],
 	'testShouldReturnTrueWhenLicenseAndFilterTrue' => [
 		'config'   => [
-			'licence' => false,
-			'filter'  => true,
+			'licence'           => false,
+			'filter'            => true,
+			'is_logged_in'      => false,
+			'cache_logged_user' => 0,
+		],
+		'expected' => true,
+	],
+	'testShouldReturnFalseWhenLoggedInAndUserCacheEnabled' => [
+		'config'   => [
+			'licence'           => false,
+			'filter'            => true,
+			'is_logged_in'      => true,
+			'cache_logged_user' => 1,
+		],
+		'expected' => false,
+	],
+	'testShouldReturnTrueWhenLoggedInButUserCacheDisabled' => [
+		'config'   => [
+			'licence'           => false,
+			'filter'            => true,
+			'is_logged_in'      => true,
+			'cache_logged_user' => 0,
+		],
+		'expected' => true,
+	],
+	'testShouldReturnTrueWhenNotLoggedInAndUserCacheEnabled' => [
+		'config'   => [
+			'licence'           => false,
+			'filter'            => true,
+			'is_logged_in'      => false,
+			'cache_logged_user' => 1,
 		],
 		'expected' => true,
 	],

--- a/tests/Fixtures/inc/Engine/Optimization/LazyRenderContent/Frontend/Subscriber/add_hashes_when_allowed.php
+++ b/tests/Fixtures/inc/Engine/Optimization/LazyRenderContent/Frontend/Subscriber/add_hashes_when_allowed.php
@@ -4,7 +4,9 @@ return [
 	'test_data' => [
 		'shouldNotAddHashesWhenNotAllowed' => [
 			'config' => [
-				'filter' => false,
+				'filter'            => false,
+				'logged_in'         => false,
+				'cache_logged_user' => 0,
 				'row' => [
 					'url' => 'http://example.org/',
 					'is_mobile' => 0,
@@ -26,7 +28,9 @@ return [
 		],
 		'shouldAddHashes' => [
 			'config' => [
-				'filter' => true,
+				'filter'            => true,
+				'logged_in'         => false,
+				'cache_logged_user' => 0,
 				'row' => [
 					'url' => 'http://example.org/',
 					'is_mobile' => 0,
@@ -44,6 +48,30 @@ return [
 			],
 			'expected' => [
 				'html' => file_get_contents( WP_ROCKET_TESTS_FIXTURES_DIR . '/inc/Engine/Optimization/LazyRenderContent/Frontend/Subscriber/html/expected.php' ),
+			],
+		],
+		'shouldNotAddHashesWhenLoggedInAndUserCacheEnabled' => [
+			'config' => [
+				'filter'            => true,
+				'logged_in'         => true,
+				'cache_logged_user' => 1,
+				'row' => [
+					'url' => 'http://example.org/',
+					'is_mobile' => 0,
+					'below_the_fold' => json_encode(
+						[
+							'93548b90aa8f4989f7198144479055dc',
+							'7b16eca0652d4703f83ba63e304f2030',
+							'737184bbad8e65d0172a89cc68a46107',
+							'8a4ef50742cf3456f9db6425e16930dc',
+						]
+					),
+					'status' => 'completed',
+				],
+				'html' => file_get_contents( WP_ROCKET_TESTS_FIXTURES_DIR . '/inc/Engine/Optimization/LazyRenderContent/Frontend/Subscriber/html/original.php' ),
+			],
+			'expected' => [
+				'html' => file_get_contents( WP_ROCKET_TESTS_FIXTURES_DIR . '/inc/Engine/Optimization/LazyRenderContent/Frontend/Subscriber/html/original.php' ),
 			],
 		],
 	],

--- a/tests/Integration/inc/Engine/Optimization/LazyRenderContent/Frontend/Subscriber/add_hashes_when_allowed.php
+++ b/tests/Integration/inc/Engine/Optimization/LazyRenderContent/Frontend/Subscriber/add_hashes_when_allowed.php
@@ -11,6 +11,7 @@ use WP_Rocket\Tests\Integration\TestCase;
  */
 class Test_AddHashesWhenAllowed extends TestCase {
 	private $filter;
+	private $cache_logged_user = 0;
 
 	public static function set_up_before_class() {
 		parent::set_up_before_class();
@@ -34,6 +35,8 @@ class Test_AddHashesWhenAllowed extends TestCase {
 	public function tear_down() {
 		$this->restoreWpHook( 'rocket_buffer' );
 		remove_filter( 'rocket_lrc_optimization', '__return_false' );
+		remove_filter( 'pre_get_rocket_option_cache_logged_user', [ $this, 'returnCacheLoggedUser' ] );
+		wp_set_current_user( 0 );
 
 		parent::tear_down();
 	}
@@ -42,9 +45,15 @@ class Test_AddHashesWhenAllowed extends TestCase {
 	 * @dataProvider configTestData
 	 */
 	public function testShouldReturnExpected( $config, $expected ) {
-		$this->filter = $config['filter'];
+		$this->filter            = $config['filter'];
+		$this->cache_logged_user = $config['cache_logged_user'] ?? 0;
 
+		add_filter( 'pre_get_rocket_option_cache_logged_user', [ $this, 'returnCacheLoggedUser' ] );
 		add_filter( 'rocket_lrc_optimization', [ $this, 'returnFilter' ] );
+
+		if ( ! empty( $config['logged_in'] ) ) {
+			wp_set_current_user( 1 );
+		}
 
 		self::addLrc( $config['row'] );
 
@@ -58,5 +67,9 @@ class Test_AddHashesWhenAllowed extends TestCase {
 
 	public function returnFilter() {
 		return $this->filter;
+	}
+
+	public function returnCacheLoggedUser() {
+		return $this->cache_logged_user;
 	}
 }

--- a/tests/Unit/inc/Engine/Optimization/LazyRenderContent/Context/Context/isAllowed.php
+++ b/tests/Unit/inc/Engine/Optimization/LazyRenderContent/Context/Context/isAllowed.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\LazyRenderContent\Context\Context;
 
 use Brain\Monkey\{Filters, Functions};
+use Mockery;
+use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\Optimization\LazyRenderContent\Context\Context;
 use WP_Rocket\Tests\Unit\TestCase;
 
@@ -11,25 +13,33 @@ use WP_Rocket\Tests\Unit\TestCase;
  * @group LRC
  */
 class TestIsAllowed extends TestCase {
-	private $context;
-
-	public function set_up() {
-		parent::set_up();
-
-		$this->context = new Context();
-	}
-
 	/**
 	 * @dataProvider configTestData
 	 */
 	public function testShouldReturnExpected( $config, $expected ) {
+		$cache_logged_user = $config['cache_logged_user'] ?? 0;
+
+		$options = Mockery::mock( Options_Data::class );
+		$options->shouldReceive( 'get' )
+			->with( 'cache_logged_user', 0 )
+			->andReturn( $cache_logged_user );
+
+		$context = new Context( $options );
+
 		Functions\when( 'get_option' )->justReturn( $config['licence'] );
-		Filters\expectApplied( 'rocket_lrc_optimization' )
-			->andReturn( $config['filter'] );
+		Functions\when( 'is_user_logged_in' )->justReturn( $config['is_logged_in'] ?? false );
+
+		$reaches_filter = ! $config['licence']
+			&& ! ( ( $config['is_logged_in'] ?? false ) && $cache_logged_user );
+
+		if ( $reaches_filter ) {
+			Filters\expectApplied( 'rocket_lrc_optimization' )
+				->andReturn( $config['filter'] );
+		}
 
 		$this->assertSame(
 			$expected,
-			$this->context->is_allowed()
+			$context->is_allowed()
 		);
 	}
 }


### PR DESCRIPTION
> [!NOTE]
> 🤖 This pull request was generated by the AI delivery pipeline (orchestrator-team · Claude Sonnet 4.6). All code was reviewed by a lead-reviewer teammate in real time before commit.

# Description

Fixes #8198

When User Cache (`cache_logged_user`) is enabled, the Beacon-based Automatic Lazy Rendering feature should not apply to logged-in users — cached pages are per-user and the optimization is meaningless in that context. However, `Context::is_allowed()` in `LRC\Context` was missing the guard, so `data-rocket-location-hash` attributes were added to HTML elements regardless of user login state.

This fix adds the `is_user_logged_in() && cache_logged_user` check directly to `Context::is_allowed()` (the correct layer — every consumer of this context inherits the fix), and injects `Options_Data` via constructor to read the plugin option properly (also resolves a pre-existing §2.2 violation).

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

- **Unit (automated):** 6 `Context::is_allowed()` assertions pass — 3 new scenarios (logged-in + cache=1 → false, logged-in + cache=0 → true, not-logged-in + cache=1 → true) and 3 pre-existing scenarios unchanged.\n- **Integration (written, not executed):** New scenario written for `add_hashes_when_allowed` — logged-in user + `cache_logged_user=1` → HTML returned unchanged (no `data-rocket-location-hash` attributes). Could not execute — MySQL test DB unavailable in local env.
- **e2e smoke (manual via WP-CLI):** On live dev env (`localhost:8888`): set `cache_logged_user=1`, called `Context::is_allowed()` with `wp_set_current_user(1)` → returns `false`. With anonymous user → returns `true`. Both scenarios confirmed PASS.
- **Real-time review:** All 7 changed files reviewed by lead-reviewer teammate before commit — PASS, no blockers found.

### How to test

1. Enable **User Cache** (WP Rocket → Cache → Enable caching for logged-in WordPress users).
2. Log in to the WordPress site as any user.
3. Visit a front-end page and inspect the HTML source.
4. Verify: no `data-rocket-location-hash` attributes appear on any element.
5. Log out and revisit the same page.
6. Verify: `data-rocket-location-hash` attributes are present (optimization applies for anonymous users).
7. Disable User Cache. Log in again.
8. Verify: `data-rocket-location-hash` attributes are present (optimization applies when User Cache is off).

### Affected Features & Quality Assurance Scope

- **Lazy Render Content (LRC) / Automatic Lazy Rendering** — the fix is in `LRC\Context\Context::is_allowed()`, which gates the entire LRC feature. Scope: all LRC consumers (hash injection Subscriber, AJAX controller, beacon data).
- **User Cache** — the fix interacts with the `cache_logged_user` option. Existing User Cache behavior is unchanged.
- **Beacon-based features** — no regression expected; the guard only activates when both User Cache is enabled AND the user is logged in.

## Technical description

### Documentation

No new public hooks, REST routes, AJAX actions, or option keys introduced. The `rocket_lrc_optimization` filter pre-existed and is unchanged; it is now bypassed when the user-cache guard returns early (intentional — the feature is categorically disabled in this case). No doc update required.

### New dependencies

None. `Options_Data` was already a container-bound service (`options` key); this change injects it into `Context` via constructor, following the established AGENTS.md §2.2 pattern.

### Risks

- **Two ServiceProviders** register `lrc_context` — both were updated (`LRC\ServiceProvider` and `PerformanceHints\Activation\ServiceProvider`). Risk of missing one is mitigated by the spec explicitly calling both out.
- **Activation-time eager call** — `PerformanceHints\Activation\ServiceProvider` calls `is_allowed()` synchronously at activation. `is_user_logged_in()` is always false at activation time, so the guard is inert there — no regression.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Untitled items justification

Integration tests were written but could not be executed — MySQL test DB requires `bin/install-wp-tests.sh` setup not present in this environment. Unit tests and WP-CLI e2e smoke cover the behavior change.

## Follow-up tickets

None
