### PR TITLE
Remove dismiss button from analytics consent notice

### DIFF
--- a/inc/admin/ui/notices.php
+++ b/inc/admin/ui/notices.php
@@ -539,10 +539,12 @@ function rocket_analytics_optin_notice() {
 	);
 
 	// Status should be as neutral as possible; nothing has happened yet.
+	// Remove the native dismiss (X) button so the user must make an explicit accept/refuse decision.
 	rocket_notice_html(
 		[
-			'status'  => 'info',
-			'message' => $analytics_notice,
+			'status'      => 'info',
+			'dismissible' => '',
+			'message'     => $analytics_notice,
 		]
 	);
 }

--- a/inc/admin/ui/notices.php
+++ b/inc/admin/ui/notices.php
@@ -660,17 +660,16 @@ function rocket_clear_cache_notice() {
 }
 add_action( 'admin_notices', 'rocket_clear_cache_notice' );
 
-if ( ! function_exists( 'rocket_notice_html' ) ) :
-	/**
-	 * Outputs notice HTML
-	 *
-	 * @since 2.11
-	 * @author Remy Perona
-	 *
-	 * @param array $args An array of arguments used to determine the notice output.
-	 * @return void
-	 */
-	function rocket_notice_html( $args ) {
+/**
+ * Outputs notice HTML
+ *
+ * @since 2.11
+ * @author Remy Perona
+ *
+ * @param array $args An array of arguments used to determine the notice output.
+ * @return void
+ */
+function rocket_notice_html( $args ) {
 		$defaults = [
 			'status'                 => 'success',
 			'dismissible'            => 'is-dismissible',
@@ -779,43 +778,40 @@ if ( ! function_exists( 'rocket_notice_html' ) ) :
 		</p>
 		<?php endif; ?>
 	</div>
-			<?php
-	}
-endif;
+	<?php
+}
 
-if ( ! function_exists( 'rocket_notice_writing_permissions' ) ) :
-	/**
-	 * Outputs formatted notice about issues with writing permissions
-	 *
-	 * @since  2.11
-	 * @author Caspar Hübinger
-	 *
-	 * @param  string $file File or folder name.
-	 * @return string       Message HTML
-	 */
-	function rocket_notice_writing_permissions( $file ) {
+/**
+ * Outputs formatted notice about issues with writing permissions
+ *
+ * @since  2.11
+ * @author Caspar Hübinger
+ *
+ * @param  string $file File or folder name.
+ * @return string       Message HTML
+ */
+function rocket_notice_writing_permissions( $file ) {
 
-		$message = sprintf(
+	$message = sprintf(
 		// translators: %s = plugin name.
 		__( '%s cannot configure itself due to missing writing permissions.', 'rocket' ),
 		'<strong>' . WP_ROCKET_PLUGIN_NAME . '</strong>'
-		);
+	);
 
-		$message .= '<br>' . sprintf(
-			/* translators: %s = file/folder name */
-			__( 'Affected file/folder: %s', 'rocket' ),
-			'<code>' . $file . '</code>'
-		);
+	$message .= '<br>' . sprintf(
+		/* translators: %s = file/folder name */
+		__( 'Affected file/folder: %s', 'rocket' ),
+		'<code>' . $file . '</code>'
+	);
 
-		$message .= '<br>' . sprintf(
-			/* translators: This is a doc title! %1$s = opening link; %2$s = closing link */
-			__( 'Troubleshoot: %1$sHow to make system files writeable%2$s', 'rocket' ),
-			/* translators: Documentation exists in EN, DE, FR, ES, IT; use loaclised URL if applicable */
-			'<a href="' . __( 'https://docs.wp-rocket.me/article/626-how-to-make-system-files-htaccess-wp-config-writeable/?utm_source=wp_plugin&utm_medium=wp_rocket', 'rocket' ) . '" target="_blank">',
-			'</a>'
-		);
+	$message .= '<br>' . sprintf(
+		/* translators: This is a doc title! %1$s = opening link; %2$s = closing link */
+		__( 'Troubleshoot: %1$sHow to make system files writeable%2$s', 'rocket' ),
+		/* translators: Documentation exists in EN, DE, FR, ES, IT; use loaclised URL if applicable */
+		'<a href="' . __( 'https://docs.wp-rocket.me/article/626-how-to-make-system-files-htaccess-wp-config-writeable/?utm_source=wp_plugin&utm_medium=wp_rocket', 'rocket' ) . '" target="_blank">',
+		'</a>'
+	);
 
-		return $message;
-	}
-endif;
+	return $message;
+}
 

--- a/inc/admin/ui/notices.php
+++ b/inc/admin/ui/notices.php
@@ -660,102 +660,103 @@ function rocket_clear_cache_notice() {
 }
 add_action( 'admin_notices', 'rocket_clear_cache_notice' );
 
-/**
- * Outputs notice HTML
- *
- * @since 2.11
- * @author Remy Perona
- *
- * @param array $args An array of arguments used to determine the notice output.
- * @return void
- */
-function rocket_notice_html( $args ) {
-	$defaults = [
-		'status'                 => 'success',
-		'dismissible'            => 'is-dismissible',
-		'message'                => '',
-		'action'                 => '',
-		'dismiss_button'         => false,
-		'dismiss_button_message' => __( 'Dismiss this notice', 'rocket' ),
-		'readonly_content'       => '',
-		'id'                     => '',
-		'class_prefix'           => '',
-	];
-
-	$args = wp_parse_args( $args, $defaults );
-
-	switch ( $args['action'] ) {
-		case 'clear_cache':
-			$args['action'] = '<a class="wp-core-ui button" href="' . wp_nonce_url( admin_url( 'admin-post.php?action=purge_cache&type=all' ), 'purge_cache_all' ) . '">' . __( 'Clear cache', 'rocket' ) . '</a>';
-			break;
-		case 'clear_used_css':
-			$params = [
-				'action' => 'rocket_clean_saas',
-			];
-
-			if ( ! empty( $_SERVER['REQUEST_URI'] ) ) {
-				$referer_url                = filter_var( wp_unslash( $_SERVER['REQUEST_URI'] ), FILTER_SANITIZE_URL );
-				$params['_wp_http_referer'] = rawurlencode( $referer_url );
-			}
-			$args['action'] = '<a class="wp-core-ui button" href="' . add_query_arg( $params, wp_nonce_url( admin_url( 'admin-post.php' ), $params['action'] ) ) . '">' . __( 'Clear Used CSS', 'rocket' ) . '</a>';
-			break;
-		case 'stop_preload':
-			$args['action'] = '<a class="wp-core-ui button" href="' . wp_nonce_url( admin_url( 'admin-post.php?action=rocket_stop_preload&type=all' ), 'rocket_stop_preload' ) . '">' . __( 'Stop Preload', 'rocket' ) . '</a>';
-			break;
-		case 'switch_to_rucss':
-			$params         = [
-				'action' => 'switch_to_rucss',
-			];
-			$args['action'] = '<a class="wp-core-ui button" href="' . add_query_arg( $params, wp_nonce_url( admin_url( 'admin-post.php' ), 'rucss_switch' ) ) . '">' . __( 'Turn on Remove Unused CSS', 'rocket' ) . '</a>';
-			break;
-		case 'enable_separate_mobile_cache':
-			$params         = [
-				'action' => 'rocket_enable_separate_mobile_cache',
-			];
-			$args['action'] = '<a class="wp-core-ui button" href="' . add_query_arg( $params, wp_nonce_url( admin_url( 'admin-post.php' ), 'rocket_enable_separate_mobile_cache' ) ) . '">' . __( 'Enable “Separate Cache Files for Mobile Devices” now', 'rocket' ) . '</a>';
-			break;
-		case 'force_deactivation':
-			/**
-			 * Allow a "force deactivation" link to be printed, use at your own risks
-			 *
-			 * @since 2.0.0
-			 *
-			 * @param bool $permit_force_deactivation true will print the link.
-			 */
-			$permit_force_deactivation = apply_filters( 'rocket_permit_force_deactivation', true );
-
-			// We add a link to permit "force deactivation", use at your own risks.
-			if ( $permit_force_deactivation ) {
-				global $status, $page, $s;
-				$plugin_file  = 'wp-rocket/wp-rocket.php';
-				$rocket_nonce = wp_create_nonce( 'force_deactivation' );
-
-				$args['action'] = '<a href="' . wp_nonce_url( 'plugins.php?action=deactivate&amp;rocket_nonce=' . $rocket_nonce . '&amp;plugin=' . $plugin_file . '&amp;plugin_status=' . $status . '&amp;paged=' . $page . '&amp;s=' . $s, 'deactivate-plugin_' . $plugin_file ) . '">' . __( 'Force deactivation ', 'rocket' ) . '</a>';
-			}
-			break;
-		case 'rocket_insights_page':
-			$args['action'] = '<a class="button button-primary" href="' . admin_url( 'options-general.php?page=' . WP_ROCKET_PLUGIN_SLUG . '&rocket_source=notice_insights_promotion_notice#rocket_insights' ) . '">' . __( 'Run the test now!', 'rocket' ) . '</a>';
-			break;
-	}
+if ( ! function_exists( 'rocket_notice_html' ) ) :
 	/**
-	 * Notice arguments.
+	 * Outputs notice HTML
 	 *
-	 * @param array $args arguments from the notice.
-	 * @return array
+	 * @since 2.11
+	 * @author Remy Perona
+	 *
+	 * @param array $args An array of arguments used to determine the notice output.
+	 * @return void
 	 */
-	$filtered_args = apply_filters( 'rocket_notice_args', $args );
+	function rocket_notice_html( $args ) {
+		$defaults = [
+			'status'                 => 'success',
+			'dismissible'            => 'is-dismissible',
+			'message'                => '',
+			'action'                 => '',
+			'dismiss_button'         => false,
+			'dismiss_button_message' => __( 'Dismiss this notice', 'rocket' ),
+			'readonly_content'       => '',
+			'id'                     => '',
+			'class_prefix'           => '',
+		];
 
-	if ( is_array( $filtered_args ) ) {
-		$args = wp_parse_args( $filtered_args, $defaults );
-	}
+		$args = wp_parse_args( $args, $defaults );
 
-	$notice_id = '';
+		switch ( $args['action'] ) {
+			case 'clear_cache':
+				$args['action'] = '<a class="wp-core-ui button" href="' . wp_nonce_url( admin_url( 'admin-post.php?action=purge_cache&type=all' ), 'purge_cache_all' ) . '">' . __( 'Clear cache', 'rocket' ) . '</a>';
+				break;
+			case 'clear_used_css':
+				$params = [
+					'action' => 'rocket_clean_saas',
+				];
 
-	if ( ! empty( $args['id'] ) ) {
-		$notice_id = ' id="' . esc_attr( $args['id'] ) . '"';
-	}
+				if ( ! empty( $_SERVER['REQUEST_URI'] ) ) {
+					$referer_url                = filter_var( wp_unslash( $_SERVER['REQUEST_URI'] ), FILTER_SANITIZE_URL );
+					$params['_wp_http_referer'] = rawurlencode( $referer_url );
+				}
+				$args['action'] = '<a class="wp-core-ui button" href="' . add_query_arg( $params, wp_nonce_url( admin_url( 'admin-post.php' ), $params['action'] ) ) . '">' . __( 'Clear Used CSS', 'rocket' ) . '</a>';
+				break;
+			case 'stop_preload':
+				$args['action'] = '<a class="wp-core-ui button" href="' . wp_nonce_url( admin_url( 'admin-post.php?action=rocket_stop_preload&type=all' ), 'rocket_stop_preload' ) . '">' . __( 'Stop Preload', 'rocket' ) . '</a>';
+				break;
+			case 'switch_to_rucss':
+				$params         = [
+					'action' => 'switch_to_rucss',
+				];
+				$args['action'] = '<a class="wp-core-ui button" href="' . add_query_arg( $params, wp_nonce_url( admin_url( 'admin-post.php' ), 'rucss_switch' ) ) . '">' . __( 'Turn on Remove Unused CSS', 'rocket' ) . '</a>';
+				break;
+			case 'enable_separate_mobile_cache':
+				$params         = [
+					'action' => 'rocket_enable_separate_mobile_cache',
+				];
+				$args['action'] = '<a class="wp-core-ui button" href="' . add_query_arg( $params, wp_nonce_url( admin_url( 'admin-post.php' ), 'rocket_enable_separate_mobile_cache' ) ) . '">' . __( 'Enable “Separate Cache Files for Mobile Devices” now', 'rocket' ) . '</a>';
+				break;
+			case 'force_deactivation':
+				/**
+				 * Allow a "force deactivation" link to be printed, use at your own risks
+				 *
+				 * @since 2.0.0
+				 *
+				 * @param bool $permit_force_deactivation true will print the link.
+				 */
+				$permit_force_deactivation = apply_filters( 'rocket_permit_force_deactivation', true );
 
-	?>
+				// We add a link to permit "force deactivation", use at your own risks.
+				if ( $permit_force_deactivation ) {
+					global $status, $page, $s;
+					$plugin_file  = 'wp-rocket/wp-rocket.php';
+					$rocket_nonce = wp_create_nonce( 'force_deactivation' );
+
+					$args['action'] = '<a href="' . wp_nonce_url( 'plugins.php?action=deactivate&amp;rocket_nonce=' . $rocket_nonce . '&amp;plugin=' . $plugin_file . '&amp;plugin_status=' . $status . '&amp;paged=' . $page . '&amp;s=' . $s, 'deactivate-plugin_' . $plugin_file ) . '">' . __( 'Force deactivation ', 'rocket' ) . '</a>';
+				}
+				break;
+			case 'rocket_insights_page':
+				$args['action'] = '<a class="button button-primary" href="' . admin_url( 'options-general.php?page=' . WP_ROCKET_PLUGIN_SLUG . '&rocket_source=notice_insights_promotion_notice#rocket_insights' ) . '">' . __( 'Run the test now!', 'rocket' ) . '</a>';
+				break;
+		}
+		/**
+		 * Notice arguments.
+		 *
+		 * @param array $args arguments from the notice.
+		 * @return array
+		 */
+		$filtered_args = apply_filters( 'rocket_notice_args', $args );
+
+		if ( is_array( $filtered_args ) ) {
+			$args = wp_parse_args( $filtered_args, $defaults );
+		}
+
+		$notice_id = '';
+
+		if ( ! empty( $args['id'] ) ) {
+			$notice_id = ' id="' . esc_attr( $args['id'] ) . '"';
+		}
+
+		?>
 	<div class="<?php echo esc_attr( $args['class_prefix'] ); ?>notice notice-<?php echo esc_attr( $args['status'] ); ?> <?php echo esc_attr( $args['dismissible'] ); ?>"<?php echo $notice_id; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 		<?php
 			$tag = 0 !== strpos( $args['message'], '<p' ) && 0 !== strpos( $args['message'], '<ul' );
@@ -767,7 +768,7 @@ function rocket_notice_html( $args ) {
 			<br><textarea readonly="readonly" id="rules" name="rules" class="large-text readonly" rows="6"><?php echo esc_textarea( $args['readonly_content'] ); ?></textarea>
 		</p>
 			<?php
-		endif;
+			endif;
 		if ( $args['action'] || $args['dismiss_button'] ) :
 			?>
 		<p>
@@ -778,40 +779,43 @@ function rocket_notice_html( $args ) {
 		</p>
 		<?php endif; ?>
 	</div>
-	<?php
-}
+			<?php
+	}
+endif;
 
-/**
- * Outputs formatted notice about issues with writing permissions
- *
- * @since  2.11
- * @author Caspar Hübinger
- *
- * @param  string $file File or folder name.
- * @return string       Message HTML
- */
-function rocket_notice_writing_permissions( $file ) {
+if ( ! function_exists( 'rocket_notice_writing_permissions' ) ) :
+	/**
+	 * Outputs formatted notice about issues with writing permissions
+	 *
+	 * @since  2.11
+	 * @author Caspar Hübinger
+	 *
+	 * @param  string $file File or folder name.
+	 * @return string       Message HTML
+	 */
+	function rocket_notice_writing_permissions( $file ) {
 
-	$message = sprintf(
+		$message = sprintf(
 		// translators: %s = plugin name.
 		__( '%s cannot configure itself due to missing writing permissions.', 'rocket' ),
 		'<strong>' . WP_ROCKET_PLUGIN_NAME . '</strong>'
-	);
+		);
 
-	$message .= '<br>' . sprintf(
-		/* translators: %s = file/folder name */
-		__( 'Affected file/folder: %s', 'rocket' ),
-		'<code>' . $file . '</code>'
-	);
+		$message .= '<br>' . sprintf(
+			/* translators: %s = file/folder name */
+			__( 'Affected file/folder: %s', 'rocket' ),
+			'<code>' . $file . '</code>'
+		);
 
-	$message .= '<br>' . sprintf(
-		/* translators: This is a doc title! %1$s = opening link; %2$s = closing link */
-		__( 'Troubleshoot: %1$sHow to make system files writeable%2$s', 'rocket' ),
-		/* translators: Documentation exists in EN, DE, FR, ES, IT; use loaclised URL if applicable */
-		'<a href="' . __( 'https://docs.wp-rocket.me/article/626-how-to-make-system-files-htaccess-wp-config-writeable/?utm_source=wp_plugin&utm_medium=wp_rocket', 'rocket' ) . '" target="_blank">',
-		'</a>'
-	);
+		$message .= '<br>' . sprintf(
+			/* translators: This is a doc title! %1$s = opening link; %2$s = closing link */
+			__( 'Troubleshoot: %1$sHow to make system files writeable%2$s', 'rocket' ),
+			/* translators: Documentation exists in EN, DE, FR, ES, IT; use loaclised URL if applicable */
+			'<a href="' . __( 'https://docs.wp-rocket.me/article/626-how-to-make-system-files-htaccess-wp-config-writeable/?utm_source=wp_plugin&utm_medium=wp_rocket', 'rocket' ) . '" target="_blank">',
+			'</a>'
+		);
 
-	return $message;
-}
+		return $message;
+	}
+endif;
 

--- a/tests/Unit/inc/admin/ui/rocketAnalyticsOptinNotice.php
+++ b/tests/Unit/inc/admin/ui/rocketAnalyticsOptinNotice.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\admin\ui;
+
+use Brain\Monkey\Functions;
+use Mockery;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * Test class covering ::rocket_analytics_optin_notice
+ *
+ * @covers ::rocket_analytics_optin_notice
+ * @group  admin
+ * @group  Notices
+ */
+class Test_RocketAnalyticsOptinNotice extends TestCase {
+
+	/**
+	 * Sets up the test fixture.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		require_once WP_ROCKET_PLUGIN_ROOT . 'inc/admin/ui/notices.php';
+	}
+
+	/**
+	 * Mocks all WordPress functions needed to reach rocket_notice_html.
+	 *
+	 * @return void
+	 */
+	private function setUpHappyPathMocks(): void {
+		$screen     = new \stdClass();
+		$screen->id = 'settings_page_wprocket';
+
+		Functions\when( 'get_current_screen' )->justReturn( $screen );
+		Functions\when( 'current_user_can' )->justReturn( true );
+		Functions\when( 'get_option' )->justReturn( false );
+		Functions\when( '__' )->returnArg( 1 );
+		Functions\when( 'esc_html__' )->returnArg( 1 );
+		Functions\when( 'rocket_data_collection_preview_table' )->justReturn( '<table></table>' );
+		Functions\when( 'admin_url' )->justReturn( 'http://example.com/wp-admin/admin-post.php' );
+		Functions\when( 'wp_nonce_url' )->justReturn( 'http://example.com/wp-admin/admin-post.php?_wpnonce=abc123' );
+	}
+
+	/**
+	 * Tests that rocket_notice_html is called with dismissible set to an empty string
+	 * when all conditions are met.
+	 *
+	 * @return void
+	 */
+	public function testShouldCallNoticeHtmlWithEmptyDismissible(): void {
+		$this->setUpHappyPathMocks();
+
+		Functions\expect( 'rocket_notice_html' )
+			->once()
+			->with(
+				Mockery::on(
+					function ( $args ) {
+						return isset( $args['dismissible'] ) && '' === $args['dismissible'];
+					}
+				)
+			)
+			->andReturnNull();
+
+		rocket_analytics_optin_notice();
+	}
+
+	/**
+	 * Tests that rocket_notice_html is never called when the user lacks the required capability.
+	 *
+	 * @return void
+	 */
+	public function testShouldNotDisplayWhenUserLacksCapability(): void {
+		$screen     = new \stdClass();
+		$screen->id = 'settings_page_wprocket';
+
+		Functions\when( 'get_current_screen' )->justReturn( $screen );
+		Functions\when( 'current_user_can' )->justReturn( false );
+
+		Functions\expect( 'rocket_notice_html' )->never();
+
+		rocket_analytics_optin_notice();
+	}
+
+	/**
+	 * Tests that rocket_notice_html is never called when the current screen is not the WP Rocket settings page.
+	 *
+	 * @return void
+	 */
+	public function testShouldNotDisplayWhenNotOnRocketSettingsPage(): void {
+		$screen     = new \stdClass();
+		$screen->id = 'dashboard';
+
+		Functions\when( 'get_current_screen' )->justReturn( $screen );
+		Functions\when( 'current_user_can' )->justReturn( true );
+
+		Functions\expect( 'rocket_notice_html' )->never();
+
+		rocket_analytics_optin_notice();
+	}
+
+	/**
+	 * Tests that rocket_notice_html is never called when the notice has already been displayed.
+	 *
+	 * @return void
+	 */
+	public function testShouldNotDisplayWhenNoticeAlreadyDisplayed(): void {
+		$screen     = new \stdClass();
+		$screen->id = 'settings_page_wprocket';
+
+		Functions\when( 'get_current_screen' )->justReturn( $screen );
+		Functions\when( 'current_user_can' )->justReturn( true );
+		Functions\when( 'get_option' )->alias(
+			function ( $option ) {
+				if ( 'rocket_analytics_notice_displayed' === $option ) {
+					return 1;
+				}
+				return false;
+			}
+		);
+
+		Functions\expect( 'rocket_notice_html' )->never();
+
+		rocket_analytics_optin_notice();
+	}
+
+	/**
+	 * Tests that rocket_notice_html is never called when the user has already opted in to analytics.
+	 *
+	 * @return void
+	 */
+	public function testShouldNotDisplayWhenUserAlreadyOptedIn(): void {
+		$screen     = new \stdClass();
+		$screen->id = 'settings_page_wprocket';
+
+		Functions\when( 'get_current_screen' )->justReturn( $screen );
+		Functions\when( 'current_user_can' )->justReturn( true );
+		Functions\when( 'get_option' )->alias(
+			function ( $option ) {
+				if ( 'rocket_mixpanel_optin' === $option ) {
+					return 'yes';
+				}
+				return false;
+			}
+		);
+
+		Functions\expect( 'rocket_notice_html' )->never();
+
+		rocket_analytics_optin_notice();
+	}
+}

--- a/tests/Unit/inc/admin/ui/rocketAnalyticsOptinNotice.php
+++ b/tests/Unit/inc/admin/ui/rocketAnalyticsOptinNotice.php
@@ -12,6 +12,8 @@ use WP_Rocket\Tests\Unit\TestCase;
  * @covers ::rocket_analytics_optin_notice
  * @group  admin
  * @group  Notices
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
  */
 class Test_RocketAnalyticsOptinNotice extends TestCase {
 


### PR DESCRIPTION
# Description

Fixes #8048

The analytics data-collection consent notice could previously be closed with the native WordPress X button without the user recording a Yes/No preference. Because no option is written on close, the notice keeps re-appearing on every page load, causing confusion.

This change removes the X button so the user must make an explicit decision through the **Yes, allow** or **No, thanks** action buttons.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

### What was tested

1. **Automated** — 5 unit tests covering:
   - Notice renders without the `is-dismissible` class (`rocket_notice_html` called with `'dismissible' => ''`)
   - Guard clause: notice suppressed when user lacks `rocket_manage_options` capability
   - Guard clause: notice suppressed when not on WP Rocket settings page
   - Guard clause: notice suppressed when `rocket_analytics_notice_displayed` option equals 1
   - Guard clause: notice suppressed when `rocket_mixpanel_optin` is truthy

2. **Manual** — navigate to the WP Rocket settings page before making an analytics decision and verify the X button is absent.

### How to test

1. Install WP Rocket on a fresh site (or clear `rocket_analytics_notice_displayed` and `rocket_mixpanel_optin` options).
2. Navigate to **Settings → WP Rocket**.
3. The analytics consent banner appears — verify there is **no X close button** in the top-right corner.
4. Click **Yes, allow** or **No, thanks** — banner disappears and does not reappear.

### Affected Features & Quality Assurance Scope

- Analytics / data-collection consent banner displayed on the WP Rocket settings page

## Technical description

### Documentation

`rocket_notice_html()` accepts a `dismissible` key used as a CSS class on the notice `<div>`. The default `'is-dismissible'` tells WordPress core's `common.js` to inject a native X close button. Passing `''` suppresses that button.

**Single change in `inc/admin/ui/notices.php`:**

Before: `rocket_notice_html( [ 'status' => 'info', 'message' => $analytics_notice ] );`

After: `rocket_notice_html( [ 'status' => 'info', 'dismissible' => '', 'message' => $analytics_notice ] );`

### New dependencies

None.

### Risks

A third-party plugin hooking into the `rocket_notice_args` filter could re-add `is-dismissible`, but this was already possible before and is not a regression.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

N/A

# Additional Checks

- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.)
- [ ] I added error handling logic when using functions that could throw errors.

---
> This PR was prepared with AI assistance (GitHub Copilot / Claude Sonnet 4.6). All code, tests, and descriptions have been reviewed for correctness.
