### PR TITLE
Enhancement: sync analytics_enabled import/export with Mixpanel opt-in

### DIFF
--- a/inc/admin/admin.php
+++ b/inc/admin/admin.php
@@ -374,6 +374,36 @@ function rocket_analytics_optin() {
 add_action( 'admin_post_rocket_analytics_optin', 'rocket_analytics_optin' );
 
 /**
+ * Imports legacy analytics option into Mixpanel opt-in option.
+ *
+ * @param array $settings Imported settings.
+ * @return array
+ */
+function rocket_import_analytics_preference( array $settings ): array {
+	if ( ! array_key_exists( 'analytics_enabled', $settings ) ) {
+		return $settings;
+	}
+
+	$new_optin     = 1 === (int) $settings['analytics_enabled'] ? 1 : 0;
+	$current_optin = (int) get_option( 'rocket_mixpanel_optin', 0 );
+
+	if ( $new_optin !== $current_optin ) {
+		update_option( 'rocket_mixpanel_optin', $new_optin );
+
+		/**
+		 * Fires when the Mixpanel opt-in status changes.
+		 *
+		 * @param bool $status The opt-in status.
+		 */
+		do_action( 'rocket_mixpanel_optin_changed', 1 === $new_optin );
+	}
+
+	unset( $settings['analytics_enabled'] );
+
+	return $settings;
+}
+
+/**
  * Handle WP Rocket settings import.
  *
  * @since 3.10 disable async_css if both async_css and remove_unused_css are enabled
@@ -437,6 +467,7 @@ function rocket_handle_settings_import() {
 		$options_api        = new WP_Rocket\Admin\Options( 'wp_rocket_' );
 		$current_options    = $options_api->get( 'settings', [] );
 		$regenerate_configs = false;
+		$settings           = rocket_import_analytics_preference( $settings );
 
 		$settings['consumer_key']     = $current_options['consumer_key'];
 		$settings['consumer_email']   = $current_options['consumer_email'];

--- a/inc/functions/options.php
+++ b/inc/functions/options.php
@@ -31,7 +31,15 @@ function rocket_export_options() {
 	$site_name = get_rocket_parse_url( get_home_url() );
 	$site_name = $site_name['host'] . $site_name['path'];
 	$filename  = sprintf( 'wp-rocket-settings-%s-%s-%s.json', $site_name, date( 'Y-m-d' ), uniqid() ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
-	return [ $filename, wp_json_encode( get_option( WP_ROCKET_SLUG ), JSON_PRETTY_PRINT ) ]; // do not use get_rocket_option() here.
+	$settings  = get_option( WP_ROCKET_SLUG ); // do not use get_rocket_option() here.
+
+	if ( ! is_array( $settings ) ) {
+		$settings = [];
+	}
+
+	$settings['analytics_enabled'] = (int) get_option( 'rocket_mixpanel_optin', 0 );
+
+	return [ $filename, wp_json_encode( $settings, JSON_PRETTY_PRINT ) ];
 }
 
 /**

--- a/tests/Unit/inc/admin/rocketImportAnalyticsPreference.php
+++ b/tests/Unit/inc/admin/rocketImportAnalyticsPreference.php
@@ -13,12 +13,18 @@ use WP_Rocket\Tests\Unit\TestCase;
  */
 class Test_RocketImportAnalyticsPreference extends TestCase {
 	/**
-	 * Load tested functions file.
+	 * Load tested file and bootstrap expected constants/functions.
 	 *
 	 * @return void
 	 */
-	public static function setUpBeforeClass(): void {
-		parent::setUpBeforeClass();
+	protected function setUp(): void {
+		parent::setUp();
+
+		if ( ! defined( 'WP_ROCKET_FILE' ) ) {
+			define( 'WP_ROCKET_FILE', '/tmp/wp-rocket/wp-rocket.php' );
+		}
+
+		Functions\when( 'plugin_basename' )->justReturn( 'wp-rocket/wp-rocket.php' );
 
 		require_once WP_ROCKET_PLUGIN_ROOT . 'inc/admin/admin.php';
 	}
@@ -37,6 +43,7 @@ class Test_RocketImportAnalyticsPreference extends TestCase {
 		Functions\expect( 'update_option' )->never();
 		Functions\expect( 'do_action' )->never();
 
+		// @phpstan-ignore-next-line
 		$this->assertSame( $settings, rocket_import_analytics_preference( $settings ) );
 	}
 
@@ -70,6 +77,7 @@ class Test_RocketImportAnalyticsPreference extends TestCase {
 			Functions\expect( 'do_action' )->never();
 		}
 
+		// @phpstan-ignore-next-line
 		$result = rocket_import_analytics_preference( $settings );
 
 		$this->assertArrayNotHasKey( 'analytics_enabled', $result );

--- a/tests/Unit/inc/admin/rocketImportAnalyticsPreference.php
+++ b/tests/Unit/inc/admin/rocketImportAnalyticsPreference.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\admin;
+
+use Brain\Monkey\Functions;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * Test class covering ::rocket_import_analytics_preference
+ *
+ * @group admin
+ * @group Options
+ */
+class Test_RocketImportAnalyticsPreference extends TestCase {
+	/**
+	 * Load tested functions file.
+	 *
+	 * @return void
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
+		require_once WP_ROCKET_PLUGIN_ROOT . 'inc/admin/admin.php';
+	}
+
+	/**
+	 * Checks settings remain unchanged when legacy key is missing.
+	 *
+	 * @return void
+	 */
+	public function testShouldReturnSettingsUnchangedWhenLegacyOptionMissing() {
+		$settings = [
+			'cache_mobile' => 1,
+		];
+
+		Functions\expect( 'get_option' )->never();
+		Functions\expect( 'update_option' )->never();
+		Functions\expect( 'do_action' )->never();
+
+		$this->assertSame( $settings, rocket_import_analytics_preference( $settings ) );
+	}
+
+	/**
+	 * Checks legacy analytics option syncs Mixpanel opt-in value.
+	 *
+	 * @dataProvider analyticsImportProvider
+	 *
+	 * @param array $settings      Imported settings payload.
+	 * @param int   $current_optin Current Mixpanel opt-in value.
+	 * @param bool  $should_update Whether update_option() should be called.
+	 * @param int   $expected_optin Expected Mixpanel opt-in value.
+	 *
+	 * @return void
+	 */
+	public function testShouldSyncMixpanelOptinFromLegacySetting( array $settings, int $current_optin, bool $should_update, int $expected_optin ) {
+		Functions\expect( 'get_option' )
+			->once()
+			->with( 'rocket_mixpanel_optin', 0 )
+			->andReturn( $current_optin );
+
+		if ( $should_update ) {
+			Functions\expect( 'update_option' )
+				->once()
+				->with( 'rocket_mixpanel_optin', $expected_optin );
+			Functions\expect( 'do_action' )
+				->once()
+				->with( 'rocket_mixpanel_optin_changed', 1 === $expected_optin );
+		} else {
+			Functions\expect( 'update_option' )->never();
+			Functions\expect( 'do_action' )->never();
+		}
+
+		$result = rocket_import_analytics_preference( $settings );
+
+		$this->assertArrayNotHasKey( 'analytics_enabled', $result );
+	}
+
+	/**
+	 * Provides scenarios for legacy analytics import handling.
+	 *
+	 * @return array
+	 */
+	public function analyticsImportProvider(): array {
+		return [
+			'should enable optin from legacy option'    => [
+				'settings'       => [
+					'analytics_enabled' => 1,
+				],
+				'current_optin'  => 0,
+				'should_update'  => true,
+				'expected_optin' => 1,
+			],
+			'should disable optin from legacy option'   => [
+				'settings'       => [
+					'analytics_enabled' => 0,
+				],
+				'current_optin'  => 1,
+				'should_update'  => true,
+				'expected_optin' => 0,
+			],
+			'should not update when value is unchanged' => [
+				'settings'       => [
+					'analytics_enabled' => 1,
+				],
+				'current_optin'  => 1,
+				'should_update'  => false,
+				'expected_optin' => 1,
+			],
+		];
+	}
+}

--- a/tests/Unit/inc/functions/rocketExportOptions.php
+++ b/tests/Unit/inc/functions/rocketExportOptions.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\functions;
+
+use Brain\Monkey\Functions;
+use WPMedia\PHPUnit\Unit\TestCase;
+
+/**
+ * Test class covering ::rocket_export_options
+ *
+ * @group Functions
+ * @group Options
+ */
+class Test_RocketExportOptions extends TestCase {
+	/**
+	 * Load tested functions file.
+	 *
+	 * @return void
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
+		if ( ! defined( 'WP_ROCKET_SLUG' ) ) {
+			define( 'WP_ROCKET_SLUG', 'wp_rocket_settings' );
+		}
+
+		require_once WP_ROCKET_PLUGIN_ROOT . 'inc/functions/options.php';
+	}
+
+	/**
+	 * Checks export payload when Mixpanel opt-in is enabled.
+	 *
+	 * @return void
+	 */
+	public function testShouldExportAnalyticsOptinWhenEnabled() {
+		Functions\expect( 'get_home_url' )
+			->once()
+			->andReturn( 'https://example.org' );
+		Functions\expect( 'get_rocket_parse_url' )
+			->once()
+			->with( 'https://example.org' )
+			->andReturn(
+				[
+					'host' => 'example.org',
+					'path' => '',
+				]
+			);
+		Functions\expect( 'get_option' )
+			->once()
+			->with( 'wp_rocket_settings' )
+			->andReturn(
+				[
+					'cache_mobile' => 1,
+				]
+			);
+		Functions\expect( 'get_option' )
+			->once()
+			->with( 'rocket_mixpanel_optin', 0 )
+			->andReturn( 1 );
+		Functions\expect( 'wp_json_encode' )
+			->once()
+			->with(
+				[
+					'cache_mobile'      => 1,
+					'analytics_enabled' => 1,
+				],
+				JSON_PRETTY_PRINT
+			)
+			->andReturn( '{"cache_mobile":1,"analytics_enabled":1}' );
+
+		$result = rocket_export_options();
+
+		$this->assertStringStartsWith( 'wp-rocket-settings-example.org-', $result[0] );
+		$this->assertStringEndsWith( '.json', $result[0] );
+		$this->assertSame( '{"cache_mobile":1,"analytics_enabled":1}', $result[1] );
+	}
+
+	/**
+	 * Checks export payload when stored settings are not a valid array.
+	 *
+	 * @return void
+	 */
+	public function testShouldExportAnalyticsOptinWhenSettingsAreInvalid() {
+		Functions\expect( 'get_home_url' )
+			->once()
+			->andReturn( 'https://example.org' );
+		Functions\expect( 'get_rocket_parse_url' )
+			->once()
+			->with( 'https://example.org' )
+			->andReturn(
+				[
+					'host' => 'example.org',
+					'path' => '',
+				]
+			);
+		Functions\expect( 'get_option' )
+			->once()
+			->with( 'wp_rocket_settings' )
+			->andReturn( false );
+		Functions\expect( 'get_option' )
+			->once()
+			->with( 'rocket_mixpanel_optin', 0 )
+			->andReturn( 0 );
+		Functions\expect( 'wp_json_encode' )
+			->once()
+			->with(
+				[
+					'analytics_enabled' => 0,
+				],
+				JSON_PRETTY_PRINT
+			)
+			->andReturn( '{"analytics_enabled":0}' );
+
+		$result = rocket_export_options();
+
+		$this->assertStringStartsWith( 'wp-rocket-settings-example.org-', $result[0] );
+		$this->assertStringEndsWith( '.json', $result[0] );
+		$this->assertSame( '{"analytics_enabled":0}', $result[1] );
+	}
+}


### PR DESCRIPTION
# Description

Fixes #8033
This change makes exported settings consistently include the current analytics preference and makes imports correctly apply that preference to the current Mixpanel opt-in mechanism, including disabling opt-in when importing `analytics_enabled: 0`.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #8033
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

Automated:
- Unit test for `rocket_export_options()` to validate export payload always includes `analytics_enabled` and mirrors `rocket_mixpanel_optin`.
- Unit test for `rocket_import_analytics_preference()` to validate legacy `analytics_enabled` import updates `rocket_mixpanel_optin` for both enable and disable scenarios.
- PHPCS run on changed files.

### How to test

1. Checkout branch `enhancement/8033-inconsistent-handling-of-analytics`.
2. Run unit tests:
   - `vendor/bin/phpunit --configuration tests/Unit/phpunit.xml.dist tests/Unit/inc/functions/rocketExportOptions.php tests/Unit/inc/admin/rocketImportAnalyticsPreference.php`
3. Run PHPCS:
   - `vendor/bin/phpcs --basepath=. inc/functions/options.php inc/admin/admin.php tests/Unit/inc/functions/rocketExportOptions.php tests/Unit/inc/admin/rocketImportAnalyticsPreference.php`
4. Manual behavior check:
   - Ensure `rocket_mixpanel_optin` is `1`, export settings, and verify exported JSON contains `"analytics_enabled": 1`.
   - Ensure `rocket_mixpanel_optin` is `1`, import JSON with `"analytics_enabled": 0`, and verify `rocket_mixpanel_optin` becomes `0`.

### Affected Features & Quality Assurance Scope

- Settings export (`rocket_export_options`) payload content.
- Settings import (`rocket_handle_settings_import`) behavior for legacy analytics field.
- Mixpanel opt-in synchronization from imported legacy setting.

## Technical description

### Documentation

- `rocket_export_options()` now normalizes settings to an array and injects `analytics_enabled` from `rocket_mixpanel_optin` before JSON encoding.
- New helper `rocket_import_analytics_preference()` in `inc/admin/admin.php`:
  - Reads legacy `analytics_enabled` from imported settings when present.
  - Synchronizes `rocket_mixpanel_optin` to `0|1` accordingly.
  - Fires `rocket_mixpanel_optin_changed` only when value changes.
  - Removes legacy `analytics_enabled` from imported WP Rocket settings payload.
- `rocket_handle_settings_import()` now calls this helper before persisting settings.

### New dependencies

No new dependencies.

### Risks

- Risk: Legacy imports without `analytics_enabled` should keep current opt-in unchanged.
  - Mitigation: Helper is no-op when key is absent.
- Risk: Event consumers of `rocket_mixpanel_optin_changed` receive updates for disable path too.
  - Mitigation: Hook payload is boolean and dispatched only on actual change.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

No unticked mandatory items.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
