### PR TITLE
Closes #916 Pausing CDN is reverted when clicking "Save Changes"

### DIFF
--- a/inc/Engine/CDN/Render/Controller.php
+++ b/inc/Engine/CDN/Render/Controller.php
@@ -661,7 +661,7 @@ class Controller extends Abstract_Render {
 		$transient = $this->subscription_controller->get_rocketcdn_status();
 
 		return false !== $transient
-			? ! $this->subscription_controller->has_active_subscription()
-			: ! (bool) $this->options->get( 'cdn' );
+			? ! $this->options->get( 'cdn' )
+			: ! $this->subscription_controller->has_active_subscription();
 	}
 }


### PR DESCRIPTION
# Description

Fixes wp-media/rocket-cdn#916

*Explain how this code impacts users.*

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested
Tried pausing the feature and save immediately and vice versa

### How to test
Follow the steps as highlighted in the issue

### Affected Features & Quality Assurance Scope
n/a

## Technical description

### Documentation
update the logic for pause state.

### New dependencies
n/a

### Risks
n/a

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification
minor js update, no test.

