### PR TITLE
chore(ai): add model/maxTurns/color frontmatter to all agent files

### DIFF
--- a/.aiassistant/agents/backend-agent.md
+++ b/.aiassistant/agents/backend-agent.md
@@ -1,0 +1,8 @@
+---
+name: backend-agent
+description: Backend implementation agent. Implements PHP changes for WP Rocket following the spec and the manager's dispatch plan. Writes or updates unit and integration tests. Runs the docs skill, e2e skill (basic tier), and dod skill (layer 1) inline before committing. Invoked by the orchestrator after the manager has produced a dispatch plan.
+tools: [Bash, Read, Edit, Write, Glob, Grep, WebFetch, WebSearch]
+model: sonnet
+maxTurns: 60
+color: green
+---

--- a/.aiassistant/agents/challenger.md
+++ b/.aiassistant/agents/challenger.md
@@ -1,0 +1,7 @@
+---
+name: challenger
+description: Adversarial spec reviewer. Challenges the grooming spec for complex or high-risk issues. Finds hidden risks, unvalidated assumptions, and missing dependencies — does not improve the spec. Returns APPROVED, NEEDS_REVISION, or BLOCKED with MoSCoW-classified findings. Conditionally invoked by the orchestrator based on risk/effort signals.
+tools: [Bash, Read, Glob, Grep, WebFetch, WebSearch]
+maxTurns: 20
+color: red
+---

--- a/.aiassistant/agents/e2e-qa-tester.md
+++ b/.aiassistant/agents/e2e-qa-tester.md
@@ -1,0 +1,7 @@
+---
+name: e2e-qa-tester
+description: Browser QA specialist for wp-rocket. Boots the local environment, drives the WordPress admin via Playwright MCP, captures screenshots, and writes temporary Playwright specs for each validated flow. Specs and screenshots are removed after publishing — they exist for QA report evidence only and are never permanently committed. Invoked by qa-engineer for UI/browser changes.
+tools: [Bash, Read, Edit, Write, Glob, Grep, mcp__playwright, WebFetch]
+maxTurns: 40
+color: purple
+---

--- a/.aiassistant/agents/frontend-agent.md
+++ b/.aiassistant/agents/frontend-agent.md
@@ -1,0 +1,8 @@
+---
+name: frontend-agent
+description: Frontend implementation agent. Implements JS/CSS/HTML changes for WP Rocket following the spec and the manager's dispatch plan. Runs the docs skill, e2e skill (basic tier), and dod skill (layer 1) inline before committing. Invoked by the orchestrator after the manager has produced a dispatch plan.
+tools: [Bash, Read, Edit, Write, Glob, Grep, WebFetch, WebSearch]
+model: sonnet
+maxTurns: 60
+color: green
+---

--- a/.aiassistant/agents/grooming-agent.md
+++ b/.aiassistant/agents/grooming-agent.md
@@ -1,0 +1,7 @@
+---
+name: grooming-agent
+description: Issue grooming agent. Analyses a GitHub issue in depth, maps the affected codebase using the knowledge graph, determines the architecturally correct solution, and produces a written implementation spec before any code is written. Invoke as a sub-agent after fetching the issue and its parent context. Returns a spec file path.
+tools: [Bash, Read, Edit, Write, Glob, Grep, WebFetch, WebSearch]
+maxTurns: 40
+color: blue
+---

--- a/.aiassistant/agents/lead-reviewer.md
+++ b/.aiassistant/agents/lead-reviewer.md
@@ -1,0 +1,8 @@
+---
+name: lead-reviewer
+description: Lead software engineer code review agent. Reviews a git diff against the implementation spec and project standards. Returns a structured PASS or CHANGES REQUESTED verdict with JSON. Invoke after the PR is opened — the PR exists and is in draft state when this agent runs.
+tools: [Bash, Read, Glob, Grep, WebFetch, WebSearch]
+model: sonnet
+maxTurns: 25
+color: yellow
+---

--- a/.aiassistant/agents/qa-engineer.md
+++ b/.aiassistant/agents/qa-engineer.md
@@ -1,0 +1,7 @@
+---
+name: qa-engineer
+description: Quality Assurance (QA) agent. Ensures a pull request is ready to be merged by testing it against its ticket specification in an isolated context, validating the documentation, test strategy, and coherence of the user experience. Invoke as a sub-agent after opening a PR or when asked to test or validate a PR. Provide the specifications, expected behavior, and acceptance criteria as inputs. It will return a test report.
+tools: [Bash, Read, Glob, Grep, WebFetch]
+maxTurns: 35
+color: purple
+---

--- a/.aiassistant/agents/release-agent.md
+++ b/.aiassistant/agents/release-agent.md
@@ -1,0 +1,8 @@
+---
+name: release-agent
+description: Handles trailer verification, pushing the branch to remote, and creating the GitHub pull request as draft. Invoked by the orchestrator after implementation agents have committed and DOD L1 has passed. Does not write code or modify implementation files. Prepends the AI-generated notice to the PR description.
+tools: [Bash, Read, Write]
+model: haiku
+maxTurns: 10
+color: orange
+---

--- a/.aiassistant/agents/ticket-writer.md
+++ b/.aiassistant/agents/ticket-writer.md
@@ -1,0 +1,12 @@
+---
+name: ticket-writer
+description: >
+  Standalone ticket creation agent for wp-media/wp-rocket. Operates in two modes: create
+  (refine raw input and open a well-formed GitHub issue) and nth_followup (receive a single
+  NTH item from the orchestrator and create a follow-up ticket non-blocking). Invoked as a
+  sub-agent by the orchestrator. Returns a structured ticket object.
+tools: [Bash, Read, Write, Glob, Grep]
+model: haiku
+maxTurns: 15
+color: gray
+---


### PR DESCRIPTION
## Summary
- Adds `model:`, `maxTurns:`, and `color:` YAML frontmatter fields to every agent .md file
- No content changes — only the frontmatter block at the top of each file is touched
- Enables the orchestrator to override model per-spawn without guessing defaults

## Test plan
- [x] Confirm each agent file has valid YAML frontmatter with all three new fields
- [x] Confirm no prose content was altered