### PR TITLE
Closes #908: restore Other CDN tab selection after upgrade to 3.22

### DIFF
--- a/inc/Engine/CDN/Subscriber.php
+++ b/inc/Engine/CDN/Subscriber.php
@@ -485,10 +485,8 @@ class Subscriber implements Subscriber_Interface {
 			return;
 		}
 		$cdn_type = 'rocketcdn';
-		// Check if cdn was enabled in previous version and default to byocdn.
+		// Check if a CNAME is saved and no RocketCDN subscription, then default to byocdn.
 		if (
-			$this->options->get( 'cdn', 0 )
-			&&
 			! $this->subscription_controller->has_active_subscription()
 			&&
 			! empty( $this->options->get( 'cdn_cnames', [] ) )

--- a/tests/Fixtures/inc/Engine/CDN/Subscriber/upgradeCDN.php
+++ b/tests/Fixtures/inc/Engine/CDN/Subscriber/upgradeCDN.php
@@ -1,16 +1,16 @@
 <?php
 return [
-	'shouldSetByocdnWhenLegacyCdnIsEnabled' => [
-		'config' => [
-			'new_version' => '3.22.0',
-			'old_version' => '3.21.1',
-			'cdn_enabled' => 1,
-			'current_options' => [
+	'shouldSetByocdnWhenLegacyCdnIsEnabled'             => [
+		'config'   => [
+			'new_version'             => '3.22.0',
+			'old_version'             => '3.21.1',
+			'cdn_enabled'             => 1,
+			'current_options'         => [
 				'cdn' => 1,
 			],
 			'has_active_subscription' => false,
-			'cdn_cnames' => [
-				'https://cdnexample.org/'
+			'cdn_cnames'              => [
+				'https://cdnexample.org/',
 			],
 		],
 		'expected' => [
@@ -22,29 +22,47 @@ return [
 			],
 		],
 	],
-	'shouldSetRocketcdnWhenCdnIsNotEnabled' => [
-		'config' => [
-			'new_version' => '3.22.0',
-			'old_version' => '3.21.1',
-			'cdn_enabled' => 0,
-			'current_options' => [],
+	'shouldSetRocketcdnWhenCdnIsNotEnabled'             => [
+		'config'   => [
+			'new_version'             => '3.22.0',
+			'old_version'             => '3.21.1',
+			'cdn_enabled'             => 0,
+			'current_options'         => [],
 			'has_active_subscription' => false,
 		],
 		'expected' => [
 			'should_update' => true,
 			'cdn_type'      => 'rocketcdn',
 			'options'       => [
-				'cdn'	  => 1,
+				'cdn'      => 1,
 				'cdn_type' => 'rocketcdn',
 			],
 		],
 	],
+	'shouldSetByocdnWhenCdnDisabledButCnameExists'      => [
+		'config'   => [
+			'new_version'             => '3.22.0',
+			'old_version'             => '3.21.1',
+			'cdn_enabled'             => 0,
+			'current_options'         => [ 'cdn' => 0 ],
+			'has_active_subscription' => false,
+			'cdn_cnames'              => [ 'https://cdnexample.org/' ],
+		],
+		'expected' => [
+			'should_update' => true,
+			'cdn_type'      => 'byocdn',
+			'options'       => [
+				'cdn'      => 1,
+				'cdn_type' => 'byocdn',
+			],
+		],
+	],
 	'shouldSetRocketcdnWhenHavingrocketcdnSubscription' => [
-		'config' => [
-			'new_version' => '3.22.0',
-			'old_version' => '3.21.1',
-			'cdn_enabled' => 1,
-			'current_options' => [
+		'config'   => [
+			'new_version'             => '3.22.0',
+			'old_version'             => '3.21.1',
+			'cdn_enabled'             => 1,
+			'current_options'         => [
 				'cdn' => 1,
 			],
 			'has_active_subscription' => true,
@@ -53,7 +71,7 @@ return [
 			'should_update' => true,
 			'cdn_type'      => 'rocketcdn',
 			'options'       => [
-				'cdn'	  => 1,
+				'cdn'      => 1,
 				'cdn_type' => 'rocketcdn',
 			],
 		],

--- a/tests/Unit/inc/Engine/CDN/Subscriber/upgradeCDN.php
+++ b/tests/Unit/inc/Engine/CDN/Subscriber/upgradeCDN.php
@@ -15,25 +15,26 @@ use WP_Rocket\Engine\CDN\Subscriber;
 
 /**
  * Test class covering \WP_Rocket\Engine\CDN\Subscriber::on_update_add_cdn_type_option
+ *
  * @group  CDN
  */
 class Test_UpgradeCDN extends TestCase {
-    private $cdn;
+	private $cdn;
 	private $options;
 
 	private $options_api;
 	private $subscriber;
 	private $subscription_controller;
 
-    public function setUp() : void {
+	public function setUp(): void {
 		parent::setUp();
 
-        $this->cdn         = Mockery::mock( CDN::class );
-		$this->options     = Mockery::mock( Options_Data::class );
-	    $this->options_api = Mockery::mock( Options::class );
+		$this->cdn                     = Mockery::mock( CDN::class );
+		$this->options                 = Mockery::mock( Options_Data::class );
+		$this->options_api             = Mockery::mock( Options::class );
 		$this->subscription_controller = Mockery::mock( SubscriptionController::class );
 
-		$this->subscriber  = new Subscriber(
+		$this->subscriber = new Subscriber(
 			$this->options,
 			$this->cdn,
 			$this->options_api,
@@ -41,38 +42,32 @@ class Test_UpgradeCDN extends TestCase {
 			Mockery::mock( Cache::class ),
 			$this->createMock( RocketCDN::class )
 		);
-    }
+	}
 
 
-    /**
+	/**
 	 * @dataProvider configTestData
 	 */
-    public function testShouldSetExpectedCdnType( array $config, array $expected ) {
-	    $this->options
-		    ->expects()
-		    ->get( 'cdn', 0 )
-		    ->andReturn( $config['cdn_enabled'] );
+	public function testShouldSetExpectedCdnType( array $config, array $expected ) {
+		Functions\when( 'rocket_get_constant' )
+			->alias(
+					function ( $constant ) {
+						if ( 'WP_ROCKET_SLUG' === $constant ) {
+								return 'wp_rocket_settings';
+						}
+						return null;
+					}
+				);
 
-	    Functions\when( 'rocket_get_constant' )
-		    ->alias( function( $constant ) {
-			    if ( 'WP_ROCKET_SLUG' === $constant ) {
-				    return 'wp_rocket_settings';
-			    }
-			    return null;
-		    } );
+		$this->subscription_controller->expects()->has_active_subscription()
+			->andReturn( $config['has_active_subscription'] ?? false );
 
-		if ( $config['cdn_enabled'] ) {
-			$this->subscription_controller->expects()->has_active_subscription()
-				->andReturn( $config['has_active_subscription'] ?? false );
-
-			if ( ! $config['has_active_subscription'] ) {
-				$this->options
-					->expects()
-					->get( 'cdn_cnames', [] )
-					->andReturn( $config['cdn_cnames'] ?? [] );
-			}
+		if ( ! ( $config['has_active_subscription'] ?? false ) ) {
+			$this->options
+				->expects()
+				->get( 'cdn_cnames', [] )
+				->andReturn( $config['cdn_cnames'] ?? [] );
 		}
-
 
 		$this->options_api
 			->expects()
@@ -83,6 +78,6 @@ class Test_UpgradeCDN extends TestCase {
 			->expects()
 			->set( 'settings', $expected['options'] );
 
-        $this->subscriber->on_update_add_cdn_type_option( $config['new_version'], $config['old_version'] );
-    }
+		$this->subscriber->on_update_add_cdn_type_option( $config['new_version'], $config['old_version'] );
+	}
 }


### PR DESCRIPTION
> [!NOTE]
> This PR was generated by the AI delivery pipeline (orchestrator · Claude Sonnet 4.6). It has been reviewed for correctness by automated DOD, unit tests, and e2e smoke tests. A human reviewer should validate the fix logic and any edge cases before merging.

# Description

When upgrading WP Rocket from 3.21.x to 3.22, users with "Other CDN" configured and a saved CNAME see the "RocketCDN" tab selected by default instead of "Other CDN". This fix restores the correct tab selection by removing an overly strict guard in the upgrade migration. Fixes #908

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #908
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

**Strategy: Code Analysis + Unit Tests**

1. **Code analysis (PASS):** Confirmed `$this->options->get('cdn', 0)` guard removed from `on_update_add_cdn_type_option` in `inc/Engine/CDN/Subscriber.php`. Revised condition now sets `cdn_type=byocdn` when: no active RocketCDN subscription AND `cdn_cnames` not empty — regardless of CDN toggle state.

2. **Unit tests (PASS):** 4/4 tests pass including new scenario `shouldSetByocdnWhenCdnDisabledButCnameExists` (cdn=0, cnames=['https://cdnexample.org/'], no subscription → cdn_type=byocdn).

3. **Edge case verified:** When `cdn_cnames` is empty + no subscription → stays `rocketcdn` (correct — no CNAME means no Other CDN intent).

4. **Smoke test (PASS):** Settings page returns HTTP 200, `cdn_type` hidden field renders correctly, no PHP fatal errors.

Full QA report: https://github.com/wp-media/wp-rocket/pull/8405#issuecomment-4613655003

### How to test

1. Set up a test WP Rocket 3.21.x installation with "Other CDN" enabled and a custom CNAME saved (e.g., `https://cdnexample.org/`)
2. Update to WP Rocket 3.22
3. Navigate to the CDN settings page
4. Verify the "Other CDN" tab is selected by default
5. Verify the saved CNAME value is preserved and displayed correctly

### Affected Features & Quality Assurance Scope

- CDN settings UI and tab selection
- Upgrade migration from 3.21.x to 3.22
- BYOCDN (Bring Your Own CDN) functionality
- RocketCDN tab rendering

## Technical description

### Root Cause

The upgrade migration method `on_update_add_cdn_type_option` in `WP_Rocket\Engine\CDN\Subscriber` required both `cdn = 1` (CDN enabled) AND a saved CNAME to set `cdn_type = 'byocdn'`. However, the presence of a CNAME is the authoritative signal that a user configured "Other CDN", regardless of the CDN toggle state. When `cdn = 0` but `cdn_cnames` was not empty, the migration incorrectly defaulted to `cdn_type = 'rocketcdn'`, causing the wrong tab to be selected.

### Fix Implementation

Removed the `$this->options->get('cdn', 0)` guard from the migration condition in `on_update_add_cdn_type_option`. The revised condition now sets `cdn_type = 'byocdn'` if:
- No active RocketCDN subscription exists AND
- A CNAME is configured (`cdn_cnames` not empty)

**Files changed:**
- `inc/Engine/CDN/Subscriber.php` - Updated migration logic to remove the CDN toggle guard
- `tests/Fixtures/inc/Engine/CDN/Subscriber/upgradeCDN.php` - Added test case for `cdn = 0` with saved CNAME
- `tests/Unit/inc/Engine/CDN/Subscriber/upgradeCDN.php` - Updated test setup to cover the new scenario

### Documentation

No public API change. `on_update_add_cdn_type_option` is an internal migration method — no new hooks, options, or REST routes.

### New dependencies

None.

### Risks

Low. The change narrows the `rocketcdn` default, making it more permissive toward `byocdn`. The only new case is users who have a CNAME saved but CDN disabled: they now correctly get `cdn_type = 'byocdn'` instead of the incorrect `cdn_type = 'rocketcdn'`. This is the intended behavior.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

Unit tests cover the changed logic. No new user-facing messages or entry points were added.

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)

# Follow-up tickets

None.