### PR TITLE
Fixed issue with expired banner showing before adding a a page

### DIFF
--- a/inc/Engine/CDN/Render/Controller.php
+++ b/inc/Engine/CDN/Render/Controller.php
@@ -495,6 +495,10 @@ class Controller extends Abstract_Render {
 	 * @return bool True when the subscription can be used.
 	 */
 	private function has_active_valid_subscription(): bool {
+		if ( $this->subscription_controller->is_free() ) {
+			return ! $this->subscription_controller->is_license_invalid();
+		}
+
 		return $this->subscription_controller->has_active_subscription()
 			&& ! $this->subscription_controller->is_license_invalid();
 	}


### PR DESCRIPTION
# Description
Fixed issue with expired banner showing for free user with active licence.

Fixes n/a

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested
Installed the plugin with a valid account, you shouldn't see any expired banner/message.

### How to test
Check the comment here https://group-onecom.slack.com/archives/C0A74GB3CQ5/p1780467595999849

### Affected Features & Quality Assurance Scope
n/a

## Technical description

### Documentation
Modify logic for subscription.

### New dependencies
n/a

### Risks
n/a

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification
No test
