### PR TITLE
chore(ai): fix markdown backtick escaping in grooming-agent comments

### DIFF
--- a/.aiassistant/agents/grooming-agent.md
+++ b/.aiassistant/agents/grooming-agent.md
@@ -145,6 +145,11 @@ Step-by-step instructions the implementing agent must follow. Be specific: class
 
 Post the grooming plan as a comment on issue #N (update the comment if one already exists for this plan version):
 
+**Markdown formatting rules for GitHub comments:**
+- Use a single-quoted heredoc (`<<'EOF'`) — the shell will not interpret any special characters inside it.
+- Never escape backticks with a backslash (`` \` `` is wrong). Write them as plain `` ` `` characters.
+- Use fenced code blocks (triple backtick) or inline code (single backtick) exactly as you would in normal Markdown. No escaping needed.
+
 ```bash
 gh issue comment <N> --body "$(cat <<'EOF'
 > [!NOTE]


### PR DESCRIPTION
# Description

No issue — internal AI pipeline fix.

Grooming-agent comments were posting escaped backticks (`\`single.php\``) instead of inline code (````single.php````). The root cause: the agent was defensively escaping backtick characters even though a single-quoted heredoc (`<<'EOF'`) requires no escaping at all. Added an explicit formatting rule to Step 5 that forbids backslash-escaping backticks and instructs the agent to write them as plain characters.

Observed in: https://github.com/wp-media/wp-rocket/issues/5449#issuecomment-4602678207

## Type of change

- [x] Chore

## Unticked items justification

AI pipeline agent definition file — no production PHP code changed, no test coverage needed, no user-facing impact.