### PR TITLE
chore(ai): remove tasks.json — dispatch context inline, status from return JSON

### DIFF
--- a/.aiassistant/agents/backend-agent.md
+++ b/.aiassistant/agents/backend-agent.md
@@ -9,8 +9,7 @@ You are a senior PHP developer implementing a backend change for WP Rocket. Foll
 You receive:
 - The issue number
 - The spec path (`.TemporaryItems/Issues/wp-rocket/issues/<N>-spec.md`)
-- The dispatch plan (which files you are responsible for and any constraints)
-- The tasks.json path (`.TemporaryItems/Issues/wp-rocket/issue-<N>/tasks.json`)
+- The dispatch plan (which files you are responsible for, your `file_scope`, and any constraints)
 - `CURRENT_MODEL` — use this in `Co-Authored-By` commit trailers and the `co_authored_by` return field
 
 ## Your process
@@ -19,12 +18,10 @@ You receive:
 
 1. Read `AGENTS.md` at the repo root in full. Section 13 (Session Learnings) takes
    precedence over any assumption in the spec or skill files.
-2. Read `tasks.json`. Locate your task (`owner: "backend-agent"`). Confirm your
-   `file_scope` — treat it as the primary scope, not a hard lock. You may touch additional
-   files required by the implementation (e.g., a ServiceProvider wiring you discover
-   mid-work). Report any additions in `notes` on return rather than touching them silently.
-3. Write your lock: create `.TemporaryItems/Issues/wp-rocket/issue-<N>/locks/backend-<task-id>.lock`
-   (empty file). This signals file ownership to any concurrently running agent.
+2. Your `file_scope` is provided inline in the dispatch plan — treat it as the primary
+   scope, not a hard lock. You may touch additional files required by the implementation
+   (e.g., a ServiceProvider wiring you discover mid-work). Report any additions in `notes`
+   on return rather than touching them silently.
 
 ---
 
@@ -145,14 +142,7 @@ Do not push. The `release-agent` handles push and PR creation after both impleme
 
 ### Step 5 — Finalize and return
 
-Before returning:
-
-1. Update your task entry in `tasks.json`: set `status: "completed"` and `completed_at` to
-   the current ISO timestamp.
-2. Remove your lock file: `.TemporaryItems/Issues/wp-rocket/issue-<N>/locks/backend-<task-id>.lock`
-
-Then return the following JSON object to the orchestrator. The orchestrator reads this from
-`result_path` in `tasks.json` — write it there, then also return it inline.
+Return the following JSON object directly to the orchestrator.
 
 ```json
 {
@@ -161,11 +151,6 @@ Then return the following JSON object to the orchestrator. The orchestrator read
   "files_changed": ["list of PHP + docs files modified"],
   "tests_passing": true,
   "test_output": "one-line summary, e.g. '42 tests, 0 failures'",
-  "e2e_smoke": {
-    "status": "PASS|FAIL|SKIP",
-    "scenarios_tested": ["Primary happy path: cache header returned on /sample-page"],
-    "details": "curl http://localhost:8888/ returned X-Rocket-Cached: 1"
-  },
   "docs": {
     "status": "DONE|SKIP",
     "files_updated": ["docs/api/<file>.md"],

--- a/.aiassistant/agents/frontend-agent.md
+++ b/.aiassistant/agents/frontend-agent.md
@@ -9,8 +9,7 @@ You are a senior frontend developer implementing a frontend change for WP Rocket
 You receive:
 - The issue number
 - The spec path (`.TemporaryItems/Issues/wp-rocket/issues/<N>-spec.md`)
-- The dispatch plan (which files you are responsible for and any constraints)
-- The tasks.json path (`.TemporaryItems/Issues/wp-rocket/issue-<N>/tasks.json`)
+- The dispatch plan (which files you are responsible for, your `file_scope`, and any constraints)
 - `CURRENT_MODEL` — use this in `Co-Authored-By` commit trailers and the `co_authored_by` return field
 
 ## Your process
@@ -19,10 +18,8 @@ You receive:
 
 1. Read `AGENTS.md` at the repo root in full. Section 13 (Session Learnings) takes
    precedence over any assumption in the spec or skill files.
-2. Read `tasks.json`. Locate your task (`owner: "frontend-agent"`). Confirm your
-   `file_scope` — you may only touch files listed there.
-3. Write your lock: create `.TemporaryItems/Issues/wp-rocket/issue-<N>/locks/frontend-<task-id>.lock`
-   (empty file).
+2. Your `file_scope` is provided inline in the dispatch plan — you may only touch files
+   listed there.
 
 ---
 
@@ -133,14 +130,7 @@ Do not push. The `release-agent` handles push and PR creation after both impleme
 
 ### Step 5 — Finalize and return
 
-Before returning:
-
-1. Update your task entry in `tasks.json`: set `status: "completed"` and `completed_at` to
-   the current ISO timestamp.
-2. Remove your lock file: `.TemporaryItems/Issues/wp-rocket/issue-<N>/locks/frontend-<task-id>.lock`
-
-Then return the following JSON object to the orchestrator. The orchestrator reads this from
-`result_path` in `tasks.json` — write it there, then also return it inline.
+Return the following JSON object directly to the orchestrator.
 
 ```json
 {
@@ -149,11 +139,6 @@ Then return the following JSON object to the orchestrator. The orchestrator read
   "files_changed": ["list of JS/CSS/HTML + docs files modified"],
   "tests_passing": true,
   "test_output": "e.g. 'lint: PASS, build: PASS' or 'lint not configured'",
-  "e2e_smoke": {
-    "status": "PASS|FAIL|SKIP",
-    "scenarios_tested": ["Settings page renders the new toggle without console errors"],
-    "details": "Navigated to /wp-admin/options-general.php?page=wprocket, confirmed toggle present and clickable"
-  },
   "docs": {
     "status": "DONE|SKIP",
     "files_updated": [],

--- a/.aiassistant/skills/orchestrator/SKILL.md
+++ b/.aiassistant/skills/orchestrator/SKILL.md
@@ -112,10 +112,7 @@ Maintain in your context tracking:
 - Escalation reason if stopped
 - Calibration mode chosen
 
-**Synthesis rule:** Read routing-relevant fields from each agent's `result_path` (in
-`tasks.json`) rather than holding full agent JSONs in this context. This keeps the
-orchestrator context lean across long pipeline runs. Full JSONs are written to the HTML log
-from the contract files.
+**Synthesis rule:** Read routing-relevant fields directly from each agent's return JSON. This keeps the orchestrator context lean across long pipeline runs. Write full return JSONs to the HTML log — do not accumulate them in orchestrator context.
 
 ---
 
@@ -127,53 +124,10 @@ Each pipeline run creates an isolated working directory for coordination artifac
 
 ```
 issue-<N>/
-├── tasks.json               # shared task ledger — read/written by all agents
-├── contracts/
-│   ├── backend-api.json     # written by backend-agent (Step 3c): hooks, option_keys, rest_endpoints
-│   ├── backend-result.json  # written by backend-agent (Step 5): full implementation result
-│   └── frontend-result.json # written by frontend-agent on completion
-└── locks/
-    └── <agent>-<task-id>.lock  # file ownership — removed when agent finishes
-```
-
-### `tasks.json` structure
-
-```json
-{
-  "run_id": "issue-<N>-<unix-timestamp>",
-  "issue_id": "<N>",
-  "branch": "<branch-name>",
-  "base_branch": "origin/develop",
-  "worktrees": {},
-  "tasks": [
-    {
-      "id": "impl-backend",
-      "type": "implementation",
-      "owner": "backend-agent",
-      "status": "pending | in-progress | completed | blocked",
-      "depends_on": [],
-      "file_scope": ["inc/Engine/...", "tests/Unit/..."],
-      "worktree": null,
-      "result_path": ".TemporaryItems/Issues/wp-rocket/issue-<N>/contracts/backend-result.json",
-      "started_at": null,
-      "completed_at": null,
-      "blocked_reason": null
-    },
-    {
-      "id": "impl-frontend",
-      "type": "implementation",
-      "owner": "frontend-agent",
-      "status": "pending | in-progress | completed | blocked",
-      "depends_on": [],
-      "file_scope": ["assets/src/...", "views/..."],
-      "worktree": null,
-      "result_path": ".TemporaryItems/Issues/wp-rocket/issue-<N>/contracts/frontend-result.json",
-      "started_at": null,
-      "completed_at": null,
-      "blocked_reason": null
-    }
-  ]
-}
+└── contracts/
+    ├── backend-api.json     # written by backend-agent (Step 3c): hooks, option_keys, rest_endpoints
+    ├── backend-result.json  # written by backend-agent (Step 5): full implementation result
+    └── frontend-result.json # written by frontend-agent on completion
 ```
 
 ### Backend API contract
@@ -181,7 +135,7 @@ issue-<N>/
 Two separate files, two separate purposes:
 
 - **`contracts/backend-api.json`** — API surface only (`hooks`, `option_keys`, `rest_endpoints`, `ajax_actions`). Written by backend-agent in Step 3c, before committing. The orchestrator reads this to share the actual API surface with frontend-agent.
-- **`contracts/backend-result.json`** — Full implementation result (`ticket_id`, `branch`, `files_changed`, `dod_layer1`, etc.). Written by backend-agent in Step 5. The orchestrator reads this for routing decisions. `result_path` in `tasks.json` points here.
+- **`backend_api` (return JSON field)** — API surface (`hooks`, `option_keys`, `rest_endpoints`, `ajax_actions`). Returned by backend-agent in its JSON. The orchestrator extracts it and passes it explicitly in the frontend-agent dispatch plan (sequential mode only).
 
 **Sequential mode:** when backend finishes before frontend starts, the orchestrator reads `backend-api.json`, extracts `hooks`, `option_keys`, and `rest_endpoints`, and includes them explicitly in the frontend agent's dispatch plan. The frontend agent never reads the file itself.
 
@@ -477,23 +431,22 @@ Log AGENT event.
 
 ### Step 4b — Task graph initialization
 
-Create the run directory and write the initial `tasks.json`:
+Create the run directory:
 
 ```bash
 mkdir -p .TemporaryItems/Issues/wp-rocket/issue-<N>/contracts
-mkdir -p .TemporaryItems/Issues/wp-rocket/issue-<N>/locks
 ```
 
-Populate `file_scope` for each task from `grooming.development_steps[*].files`:
+Derive `file_scope` for each domain from `grooming.development_steps[*].files`:
 - **backend scope**: `.php` files in `inc/`, `src/`, `tests/`
 - **frontend scope**: `.js`, `.css`, `.twig`, `.html` files in `assets/`, `views/`
 
 If a file appears in both (e.g., a ServiceProvider registering both PHP services and JS
 localizations), assign it to the domain owning the majority of changes; note the shared
-file in `blocked_reason` for the other task so it doesn't touch it.
+file as a constraint in that domain's dispatch plan so the other agent does not touch it.
 
-**Parallel eligibility:** scopes are disjoint when no single file path appears in both
-`impl-backend.file_scope` and `impl-frontend.file_scope`.
+**Parallel eligibility:** scopes are disjoint when no single file path appears in both the
+backend scope and the frontend scope.
 
 Log a ROUTING DECISION event: "Task graph initialized — N backend files, M frontend files,
 parallel: YES | NO" (with explicit reason if NO: overlapping files).
@@ -505,42 +458,33 @@ parallel: YES | NO" (with explicit reason if NO: overlapping files).
 Each agent runs the `docs` skill, `e2e` skill (basic tier), and `dod` skill (layer 1)
 inline before committing, then commits atomically.
 
-Before spawning, mark each in-scope task `in-progress` in `tasks.json` and record
-`started_at`. If scopes are disjoint, create git worktrees:
+If scopes are disjoint, create git worktrees:
 
 ```bash
 git worktree add .TemporaryItems/Issues/wp-rocket/issue-<N>/worktrees/backend <branch>
 git worktree add .TemporaryItems/Issues/wp-rocket/issue-<N>/worktrees/frontend <branch>
 ```
 
-Update each task's `worktree` field in `tasks.json`.
-
 **05a/b — Parallel** (scopes disjoint):
 > Spawn `backend-agent` and `frontend-agent` simultaneously.
-> Each agent receives: issue #N, spec path, dispatch plan, their task entry from `tasks.json`
-> (including `file_scope` and `worktree` path).
+> Each agent receives: issue #N, spec path, dispatch plan, `file_scope` (inline), and `worktree` path.
 >
 > The orchestrator is the coordination hub — agents do not communicate with each other.
-> Backend writes `contracts/backend-api.json` (API surface) and `contracts/backend-result.json` (full result) on completion.
-> When backend completes, orchestrator reads `backend-api.json`, logs the API surface to the HTML log,
-> and updates `tasks.json`. Routing decisions use `backend-result.json` (via `result_path`).
-> Frontend reads `contracts/backend-api.json` opportunistically if it exists — this is
-> orchestrator-managed shared state, not direct agent-to-agent communication.
+> Backend returns `backend_api` (hooks, option_keys, rest_endpoints) in its return JSON on completion.
+> When backend completes, orchestrator extracts `backend_api` from the return JSON, logs the API surface to the HTML log,
+> and passes it explicitly in the frontend-agent dispatch plan.
+> Frontend receives it from the orchestrator — no file read involved.
 >
-> Orchestrator proceeds when both tasks show `completed` in `tasks.json`
-> (or either shows `blocked`).
+> Orchestrator proceeds when it receives return JSON from both agents
+> (or either returns a blocked/error state).
 
 **05a/b — Sequential fallback** (scopes overlap):
 > Invoke `backend-agent` first (if in scope), then `frontend-agent` (if in scope).
 > Max 3 attempts each. Hard stop after 3 — escalate.
 
-**Synthesis:** Read `tests_passing`, `dod_layer1.overall`, `e2e_smoke.status`, and
-`files_changed` from each agent's `result_path` in `tasks.json`. Full implementation
-JSONs go to the HTML log directly from contract files — do not accumulate them in
-orchestrator context.
+**Synthesis:** Read `tests_passing`, `dod_layer1.overall`, and `files_changed` directly from each agent's return JSON. Write full return JSONs to the HTML log — do not accumulate them in orchestrator context.
 
-Log AGENT events after each with `docs` status, `e2e_smoke` status, DOD L1 summary, and
-commit SHA.
+Log AGENT events after each with `docs` status, DOD L1 summary, and commit SHA.
 
 ---
 
@@ -696,12 +640,11 @@ Final summary template:
 | L | 30 min |
 | XL | 45 min |
 
-If any agent's task remains `in-progress` past its timeout:
-1. Mark it `blocked` in `tasks.json` with `blocked_reason: "timeout"`.
+If any agent has not returned past its timeout:
+1. Note it as timed-out in orchestrator context.
 2. Remove any worktree created for it: `git worktree remove <path>`.
 3. Log an ESCALATION event — do not silently retry with the same scope.
-4. Offer the human two options: (a) re-spawn with a narrower `file_scope` (split the task
-   entry in `tasks.json`), or (b) hand off to manual implementation.
+4. Offer the human two options: (a) re-spawn with a narrower `file_scope` (passed inline in the dispatch plan), or (b) hand off to manual implementation.
 
 Reassign rather than retry when the same agent has failed 3 times with the same error —
 that pattern signals a spec ambiguity, not a transient failure.


### PR DESCRIPTION
# Description

Remove `tasks.json` from the AI delivery pipeline entirely.

`tasks.json` was a shared coordination ledger written by the orchestrator at branch creation time and read by `backend-agent` and `frontend-agent` at startup. It stored `file_scope`, `status`, `worktree` paths, and `result_path` pointers for each task. With session recovery removed in a prior change and agents now returning results directly as JSON to the orchestrator, the file is vestigial:

- `file_scope` is now passed inline in each agent's dispatch plan — no file read required.
- Agent status (`pending → in-progress → completed`) is determined from the return JSON the orchestrator receives, not from polling a shared file.
- Lock files (`.TemporaryItems/.../locks/<agent>-<task-id>.lock`) signalled file ownership to concurrently running agents, but lock coordination belongs to the orchestrator, not to the agents themselves.

The run directory (`.TemporaryItems/Issues/wp-rocket/issue-<N>/`) and its `contracts/` subdirectory are preserved — backend-api.json and the result contracts still live there.

## Type of change

- [x] Chore

## Detailed scenario

### What was tested

No runnable test harness exists for AI workflow files. Verified manually by grepping all `.aiassistant` markdown files for `tasks.json`, `task-id`, `task_id`, and `locks/` — zero matches after this change.

### How to test

Run a pipeline from scratch and confirm no `tasks.json` file is created under `.TemporaryItems/Issues/wp-rocket/issue-<N>/`. The orchestrator should pass `file_scope` inline in each agent's dispatch plan and route from the return JSON alone.

```bash
grep -rn "tasks\.json\|task-id\|locks/" .aiassistant --include="*.md"
# expected: no output
```

### Affected Features & Quality Assurance Scope

- Orchestrator skill (`.aiassistant/skills/orchestrator/SKILL.md`)
- Backend implementation agent (`.aiassistant/agents/backend-agent.md`)
- Frontend implementation agent (`.aiassistant/agents/frontend-agent.md`)

## Technical description

### Documentation

Three files changed:

**`orchestrator/SKILL.md`** — removed the `tasks.json` directory tree entry and `locks/` subtree, removed the full `tasks.json` JSON schema section, removed the "Create run directory and write initial tasks.json" step (mkdir for contracts/ is kept), removed "mark task in-progress in tasks.json" and "update worktree field in tasks.json" instructions, updated agent dispatch note to reflect that `file_scope` and `worktree` path are passed inline, updated the parallel-completion condition from "both tasks show completed in tasks.json" to "orchestrator receives return JSON from both agents", and updated the WIP-limits timeout action from "mark blocked in tasks.json" to "note in orchestrator context".

**`backend-agent.md`** — removed `tasks.json` path from the inputs list, replaced Step 0's tasks.json read + lock-file write with a note that `file_scope` arrives inline in the dispatch plan, removed Step 5's tasks.json status update and lock-file removal, simplified Step 5 to a direct JSON return.

**`frontend-agent.md`** — same pattern as backend-agent.md.

### New dependencies

None.

### Risks

None. The orchestrator already has all the information it needs in context from return values. No runtime behavior changes — this is workflow documentation only.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

**Built-in tests:** these are AI workflow instruction files (Markdown). There is no test harness for agent skill files — correctness is validated by reading the output of pipeline runs.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.)
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)