### PR TITLE
Fixes #8487 'Other CDN' cname is shown on frontend if no rocketcdn subscription

### DIFF
--- a/inc/Engine/CDN/RocketCDN/FrontendSubscriber.php
+++ b/inc/Engine/CDN/RocketCDN/FrontendSubscriber.php
@@ -74,13 +74,13 @@ class FrontendSubscriber implements Subscriber_Interface {
 			return $this->handle_admin_cname( $cnames );
 		}
 
-		if( ! $this->context->is_rocketcdn() ) {
+		if ( ! $this->context->is_rocketcdn() ) {
 			return $cnames;
 		}
 
 		$cdn_url = $this->get_rocketcdn_url();
 
-		return empty( $cdn_url) ? [] : [ $cdn_url ];
+		return empty( $cdn_url ) ? [] : [ $cdn_url ];
 	}
 
 	/**

--- a/inc/Engine/CDN/RocketCDN/FrontendSubscriber.php
+++ b/inc/Engine/CDN/RocketCDN/FrontendSubscriber.php
@@ -67,19 +67,20 @@ class FrontendSubscriber implements Subscriber_Interface {
 	 *
 	 * @param mixed $cnames The current filter value.
 	 *
-	 * @return mixed The CDN CNAME array if RocketCDN is active, or the original value.
+	 * @return mixed The CDN CNAME array if RocketCDN is active, or the original value for BYOCDN, or empty otherwise.
 	 */
 	public function set_cdn_cnames( $cnames ) {
 		if ( is_admin() ) {
 			return $this->handle_admin_cname( $cnames );
 		}
 
-		$cdn_url = $this->get_rocketcdn_url();
-		if ( empty( $cdn_url ) ) {
+		if( ! $this->context->is_rocketcdn() ) {
 			return $cnames;
 		}
 
-		return [ $cdn_url ];
+		$cdn_url = $this->get_rocketcdn_url();
+
+		return empty( $cdn_url) ? [] : [ $cdn_url ];
 	}
 
 	/**

--- a/tests/Fixtures/inc/Engine/CDN/RocketCDN/FrontendSubscriber/setCdnCnames.php
+++ b/tests/Fixtures/inc/Engine/CDN/RocketCDN/FrontendSubscriber/setCdnCnames.php
@@ -10,24 +10,24 @@ return [
 		],
 	],
 
-	'shouldReturnOriginalValueWhenNoActiveSubscription' => [
+	'shouldReturnEmptyCnamesWhenNoActiveSubscription' => [
 		'config'   => [
 			'cdn_type'          => 'rocketcdn',
 			'has_active_subscription' => false,
 		],
 		'expected' => [
-			'cdn_cnames' => null,
+			'cdn_cnames' => [],
 		],
 	],
 
-	'shouldReturnOriginalValueWhenSubscriptionRunningButNoCdnUrl' => [
+	'shouldReturnEmptyCnamesWhenSubscriptionRunningButNoCdnUrl' => [
 		'config'   => [
 			'cdn_type'          => 'rocketcdn',
 			'has_active_subscription' => true,
 			'cdn_url' => '',
 		],
 		'expected' => [
-			'cdn_cnames' => null,
+			'cdn_cnames' => [],
 		],
 	],
 

--- a/tests/Fixtures/inc/functions/getRocketOption.php
+++ b/tests/Fixtures/inc/functions/getRocketOption.php
@@ -25,7 +25,7 @@ return [
 		[
 			'option'   => 'cdn_cnames',
 			'default'  => [],
-			'expected' => [ 'https://rocketcdn.me' ],
+			'expected' => [],
 		],
 		[
 			'option'   => 'cdn_zone',


### PR DESCRIPTION
# Description
Fixed issue with Other cname appearing in frontend when there's no rocketcdn subscription.

Fixes n/a


## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested
Follow through the steps in #8487 and check the frontend

### How to test

- In previous versions before 3.22, add your CNAME, but disable the CDN option.
- Update to WP Rocket Version 3.22
- Go to content delivery tab and you'll see that 'Other cdn' active
- Switch back to Rocketcdn(don't add any page to rocketcdn)
- Go to the frontend and other cdn name is applied


### Affected Features & Quality Assurance Scope
n/a

## Technical description

### Documentation
n/a

### New dependencies
n/a

### Risks
n/a

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification
n/a