### PR TITLE
Closes #8487: 'Other CDN' tab is automatically re-enabled if CDN CNAME was present in previous version despite CDN option being disabled

### DIFF
--- a/inc/Engine/CDN/Subscriber.php
+++ b/inc/Engine/CDN/Subscriber.php
@@ -3,9 +3,12 @@ namespace WP_Rocket\Engine\CDN;
 
 use WP_Rocket\Admin\Options;
 use WP_Rocket\Admin\Options_Data;
-use WP_Rocket\Engine\CDN\Drivers\DriverInterface;
-use WP_Rocket\Engine\CDN\RocketCDN\Database\Queries\RocketCDN as RocketCDNQuery;
-use WP_Rocket\Engine\CDN\RocketCDN\SubscriptionController;
+use WP_Rocket\Engine\CDN\{
+	Context,
+	Drivers\DriverInterface,
+	RocketCDN\Database\Queries\RocketCDN as RocketCDNQuery,
+	RocketCDN\SubscriptionController
+};
 use WP_Rocket\Engine\Common\Utils;
 use WP_Rocket\Engine\Optimization\UrlTrait;
 use WP_Rocket\Event_Management\Subscriber_Interface;
@@ -488,7 +491,7 @@ class Subscriber implements Subscriber_Interface {
 		if (
 			! $has_active_subscription
 			&&
-			! empty( $this->options->get( 'cdn_cnames', [] ) )
+			! empty( $this->options->get( 'cdn_cnames', [] ) ) && $this->options->get( 'cdn' )
 		) {
 			$cdn_type = 'byocdn';
 		}

--- a/inc/Engine/CDN/Subscriber.php
+++ b/inc/Engine/CDN/Subscriber.php
@@ -4,7 +4,6 @@ namespace WP_Rocket\Engine\CDN;
 use WP_Rocket\Admin\Options;
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\CDN\{
-	Context,
 	Drivers\DriverInterface,
 	RocketCDN\Database\Queries\RocketCDN as RocketCDNQuery,
 	RocketCDN\SubscriptionController
@@ -487,11 +486,11 @@ class Subscriber implements Subscriber_Interface {
 
 		$has_active_subscription = $this->subscription_controller->has_active_subscription();
 		$cdn_type                = 'rocketcdn';
-		// Check if a CNAME is saved and no RocketCDN subscription, then default to byocdn.
+		// Check if a CNAME is saved, cdn is enabled, and no RocketCDN subscription, then default to byocdn.
 		if (
 			! $has_active_subscription
 			&&
-			! empty( $this->options->get( 'cdn_cnames', [] ) ) && $this->options->get( 'cdn' )
+			! empty( $this->options->get( 'cdn_cnames', [] ) ) && $this->is_cdn_enabled()
 		) {
 			$cdn_type = 'byocdn';
 		}

--- a/tests/Fixtures/inc/Engine/CDN/Subscriber/upgradeCDN.php
+++ b/tests/Fixtures/inc/Engine/CDN/Subscriber/upgradeCDN.php
@@ -39,7 +39,7 @@ return [
 			],
 		],
 	],
-	'shouldSetByocdnWhenCdnDisabledButCnameExists'      => [
+	'shouldSetRocketcdnWhenCdnDisabledButCnameExists'      => [
 		'config'   => [
 			'new_version'             => '3.22.0',
 			'old_version'             => '3.21.1',
@@ -50,10 +50,10 @@ return [
 		],
 		'expected' => [
 			'should_update' => true,
-			'cdn_type'      => 'byocdn',
+			'cdn_type'      => 'rocketcdn',
 			'options'       => [
 				'cdn'      => 1,
-				'cdn_type' => 'byocdn',
+				'cdn_type' => 'rocketcdn',
 			],
 		],
 	],
@@ -61,17 +61,14 @@ return [
 		'config'   => [
 			'new_version'             => '3.22.0',
 			'old_version'             => '3.21.1',
-			'cdn_enabled'             => 1,
-			'current_options'         => [
-				'cdn' => 1,
-			],
+			'cdn_enabled'             => 0,
+			'current_options'         => [],
 			'has_active_subscription' => true,
 		],
 		'expected' => [
 			'should_update' => true,
 			'cdn_type'      => 'rocketcdn',
 			'options'       => [
-				'cdn'      => 1,
 				'cdn_type' => 'rocketcdn',
 			],
 		],

--- a/tests/Unit/inc/Engine/CDN/Subscriber/upgradeCDN.php
+++ b/tests/Unit/inc/Engine/CDN/Subscriber/upgradeCDN.php
@@ -69,6 +69,13 @@ class Test_UpgradeCDN extends TestCase {
 				->andReturn( $config['cdn_cnames'] ?? [] );
 		}
 
+		if ( ! ( $config['has_active_subscription'] ?? false ) && ! empty( $config['cdn_cnames'] ?? [] ) ) {
+			$this->options
+				->expects()
+				->get( 'cdn' )
+				->andReturn( $config['cdn_enabled'] );
+		}
+
 		$this->options_api
 			->expects()
 			->get( 'settings', [] )

--- a/tests/Unit/inc/Engine/CDN/Subscriber/upgradeCDN.php
+++ b/tests/Unit/inc/Engine/CDN/Subscriber/upgradeCDN.php
@@ -72,7 +72,7 @@ class Test_UpgradeCDN extends TestCase {
 		if ( ! ( $config['has_active_subscription'] ?? false ) && ! empty( $config['cdn_cnames'] ?? [] ) ) {
 			$this->options
 				->expects()
-				->get( 'cdn' )
+				->get( 'cdn', 0 )
 				->andReturn( $config['cdn_enabled'] );
 		}
 


### PR DESCRIPTION
# Description

Fixes
*Explain how this code impacts users.*

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested
Fixes issue with 'Other CDN' being activated when update from version < 3.22

### How to test

- Install version < 3.22
- Leave CDN disabled
- Add CNAME
- Save changes
- Update to PR branch
- RocketCDN tab is selected

### Affected Features & Quality Assurance Scope

CDN

## Technical description

### Documentation

- Add an extra check to the condition for cdn option
- if cdn option is enabled and cname is not empty in previous version
- Set cdn_type to byocdn
- Else, leave as default - RocketCDN

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

Not applicable to the changes in this PR.

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
