### PR TITLE
Closes #8487: 'Other CDN' tab is automatically re-enabled if CDN CNAM…

### DIFF
--- a/inc/Engine/CDN/RocketCDN/FrontendSubscriber.php
+++ b/inc/Engine/CDN/RocketCDN/FrontendSubscriber.php
@@ -67,19 +67,20 @@ class FrontendSubscriber implements Subscriber_Interface {
 	 *
 	 * @param mixed $cnames The current filter value.
 	 *
-	 * @return mixed The CDN CNAME array if RocketCDN is active, or the original value.
+	 * @return mixed The CDN CNAME array if RocketCDN is active, or the original value for BYOCDN, or empty otherwise.
 	 */
 	public function set_cdn_cnames( $cnames ) {
 		if ( is_admin() ) {
 			return $this->handle_admin_cname( $cnames );
 		}
 
-		$cdn_url = $this->get_rocketcdn_url();
-		if ( empty( $cdn_url ) ) {
+		if ( ! $this->context->is_rocketcdn() ) {
 			return $cnames;
 		}
 
-		return [ $cdn_url ];
+		$cdn_url = $this->get_rocketcdn_url();
+
+		return empty( $cdn_url ) ? [] : [ $cdn_url ];
 	}
 
 	/**

--- a/inc/Engine/CDN/Subscriber.php
+++ b/inc/Engine/CDN/Subscriber.php
@@ -3,9 +3,11 @@ namespace WP_Rocket\Engine\CDN;
 
 use WP_Rocket\Admin\Options;
 use WP_Rocket\Admin\Options_Data;
-use WP_Rocket\Engine\CDN\Drivers\DriverInterface;
-use WP_Rocket\Engine\CDN\RocketCDN\Database\Queries\RocketCDN as RocketCDNQuery;
-use WP_Rocket\Engine\CDN\RocketCDN\SubscriptionController;
+use WP_Rocket\Engine\CDN\{
+	Drivers\DriverInterface,
+	RocketCDN\Database\Queries\RocketCDN as RocketCDNQuery,
+	RocketCDN\SubscriptionController
+};
 use WP_Rocket\Engine\Common\Utils;
 use WP_Rocket\Engine\Optimization\UrlTrait;
 use WP_Rocket\Event_Management\Subscriber_Interface;
@@ -484,11 +486,11 @@ class Subscriber implements Subscriber_Interface {
 
 		$has_active_subscription = $this->subscription_controller->has_active_subscription();
 		$cdn_type                = 'rocketcdn';
-		// Check if a CNAME is saved and no RocketCDN subscription, then default to byocdn.
+		// Check if a CNAME is saved, cdn is enabled, and no RocketCDN subscription, then default to byocdn.
 		if (
 			! $has_active_subscription
 			&&
-			! empty( $this->options->get( 'cdn_cnames', [] ) )
+			! empty( $this->options->get( 'cdn_cnames', [] ) ) && $this->is_cdn_enabled()
 		) {
 			$cdn_type = 'byocdn';
 		}

--- a/inc/Engine/CDN/Subscriber.php
+++ b/inc/Engine/CDN/Subscriber.php
@@ -480,7 +480,7 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	public function on_update_add_cdn_type_option( string $new_version, string $old_version ) {
 		// Bail early.
-		if ( version_compare( $old_version, '3.22.0', '>=' ) ) {
+		if ( version_compare( $old_version, '3.22', '>=' ) ) {
 			return;
 		}
 

--- a/tests/Fixtures/inc/Engine/CDN/RocketCDN/FrontendSubscriber/setCdnCnames.php
+++ b/tests/Fixtures/inc/Engine/CDN/RocketCDN/FrontendSubscriber/setCdnCnames.php
@@ -10,24 +10,24 @@ return [
 		],
 	],
 
-	'shouldReturnOriginalValueWhenNoActiveSubscription' => [
+	'shouldReturnEmptyCnamesWhenNoActiveSubscription' => [
 		'config'   => [
 			'cdn_type'          => 'rocketcdn',
 			'has_active_subscription' => false,
 		],
 		'expected' => [
-			'cdn_cnames' => null,
+			'cdn_cnames' => [],
 		],
 	],
 
-	'shouldReturnOriginalValueWhenSubscriptionRunningButNoCdnUrl' => [
+	'shouldReturnEmptyCnamesWhenSubscriptionRunningButNoCdnUrl' => [
 		'config'   => [
 			'cdn_type'          => 'rocketcdn',
 			'has_active_subscription' => true,
 			'cdn_url' => '',
 		],
 		'expected' => [
-			'cdn_cnames' => null,
+			'cdn_cnames' => [],
 		],
 	],
 

--- a/tests/Fixtures/inc/Engine/CDN/Subscriber/upgradeCDN.php
+++ b/tests/Fixtures/inc/Engine/CDN/Subscriber/upgradeCDN.php
@@ -39,7 +39,7 @@ return [
 			],
 		],
 	],
-	'shouldSetByocdnWhenCdnDisabledButCnameExists'      => [
+	'shouldSetRocketcdnWhenCdnDisabledButCnameExists'      => [
 		'config'   => [
 			'new_version'             => '3.22.0',
 			'old_version'             => '3.21.1',
@@ -50,10 +50,10 @@ return [
 		],
 		'expected' => [
 			'should_update' => true,
-			'cdn_type'      => 'byocdn',
+			'cdn_type'      => 'rocketcdn',
 			'options'       => [
 				'cdn'      => 1,
-				'cdn_type' => 'byocdn',
+				'cdn_type' => 'rocketcdn',
 			],
 		],
 	],
@@ -61,17 +61,14 @@ return [
 		'config'   => [
 			'new_version'             => '3.22.0',
 			'old_version'             => '3.21.1',
-			'cdn_enabled'             => 1,
-			'current_options'         => [
-				'cdn' => 1,
-			],
+			'cdn_enabled'             => 0,
+			'current_options'         => [],
 			'has_active_subscription' => true,
 		],
 		'expected' => [
 			'should_update' => true,
 			'cdn_type'      => 'rocketcdn',
 			'options'       => [
-				'cdn'      => 1,
 				'cdn_type' => 'rocketcdn',
 			],
 		],

--- a/tests/Fixtures/inc/functions/getRocketOption.php
+++ b/tests/Fixtures/inc/functions/getRocketOption.php
@@ -25,7 +25,7 @@ return [
 		[
 			'option'   => 'cdn_cnames',
 			'default'  => [],
-			'expected' => [ 'https://rocketcdn.me' ],
+			'expected' => [],
 		],
 		[
 			'option'   => 'cdn_zone',

--- a/tests/Unit/inc/Engine/CDN/Subscriber/upgradeCDN.php
+++ b/tests/Unit/inc/Engine/CDN/Subscriber/upgradeCDN.php
@@ -69,6 +69,13 @@ class Test_UpgradeCDN extends TestCase {
 				->andReturn( $config['cdn_cnames'] ?? [] );
 		}
 
+		if ( ! ( $config['has_active_subscription'] ?? false ) && ! empty( $config['cdn_cnames'] ?? [] ) ) {
+			$this->options
+				->expects()
+				->get( 'cdn', 0 )
+				->andReturn( $config['cdn_enabled'] );
+		}
+
 		$this->options_api
 			->expects()
 			->get( 'settings', [] )

--- a/wp-rocket.php
+++ b/wp-rocket.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Rocket
  * Plugin URI: https://wp-rocket.me
  * Description: The best WordPress performance plugin.
- * Version: 3.22.0.1
+ * Version: 3.22.0.2
  * Requires at least: 5.8
  * Requires PHP: 7.3
  * Code Name: Iego
@@ -20,7 +20,7 @@
 defined( 'ABSPATH' ) || exit;
 
 // Rocket defines.
-define( 'WP_ROCKET_VERSION',               '3.22.0.1' );
+define( 'WP_ROCKET_VERSION',               '3.22.0.2' );
 define( 'WP_ROCKET_WP_VERSION',            '5.8' );
 define( 'WP_ROCKET_WP_VERSION_TESTED',     '6.3.1' );
 define( 'WP_ROCKET_PHP_VERSION',           '7.3' );


### PR DESCRIPTION
# Description

Fixes #8487 
- Fixed issue with 'Other CDN' being active if cdn option was disabled when update from version < 3.22.
- Fixed issue with Other cname appearing in frontend when there's no rocketcdn subscription.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested
Fixes issue with 'Other CDN' being activated when update from version < 3.22

### How to test

- Install version < 3.22
- Leave CDN disabled
- Add CNAME
- Save changes
- Update to PR branch
- RocketCDN tab is now automatically selected
- Visit frontend
- No CNAME is applied

### Affected Features & Quality Assurance Scope

CDN

## Technical description

### Documentation

- Add an extra check to the condition for cdn option
- if cdn option is enabled and cname is not empty in previous version
- Set cdn_type to byocdn
- Else, leave as default - RocketCDN

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

Not applicable to the changes in this PR.

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
