### PR TITLE
fix: do not show shared data summary notice after analytics consent

### DIFF
--- a/inc/Engine/Tracking/Tracking.php
+++ b/inc/Engine/Tracking/Tracking.php
@@ -152,8 +152,6 @@ class Tracking extends Abstract_Render {
 			$this->optin->enable();
 			// Update the legacy option to prevent the notice from being displayed again after the opt-in is enabled.
 			update_option( 'rocket_analytics_notice_displayed', 1 );
-			// Set the thank-you transient to display the thank-you notice after the opt-in is enabled.
-			set_transient( 'rocket_analytics_optin', 1 );
 			wp_send_json_success( 'Opt-in enabled.' );
 		} elseif ( '0' === $value ) {
 			$this->optin->disable();

--- a/inc/admin/admin.php
+++ b/inc/admin/admin.php
@@ -360,7 +360,6 @@ function rocket_analytics_optin() {
 
 	if ( isset( $_GET['value'] ) && 'yes' === $_GET['value'] ) {
 		update_option( 'rocket_mixpanel_optin', 1 );
-		set_transient( 'rocket_analytics_optin', 1 );
 
 		/**
 		 * Fires when the Mixpanel opt-in status changes to enabled.

--- a/inc/admin/options.php
+++ b/inc/admin/options.php
@@ -62,9 +62,6 @@ function rocket_after_save_options( $oldvalue, $value ) {
 	// Update config file.
 	rocket_generate_config_file();
 
-	if ( isset( $oldvalue['analytics_enabled'], $value['analytics_enabled'] ) && $oldvalue['analytics_enabled'] !== $value['analytics_enabled'] && 1 === (int) $value['analytics_enabled'] ) {
-		set_transient( 'rocket_analytics_optin', 1 );
-	}
 	// If it's different, clean the domain.
 	if ( rocket_create_options_hash( $value ) !== rocket_create_options_hash( $oldvalue ) ) {
 		// Purge all cache files.

--- a/inc/admin/ui/notices.php
+++ b/inc/admin/ui/notices.php
@@ -548,53 +548,6 @@ function rocket_analytics_optin_notice() {
 }
 add_action( 'admin_notices', 'rocket_analytics_optin_notice' );
 
-/**
- * Displays a notice after analytics opt-in
- *
- * @since 2.11
- * @author Remy Perona
- */
-function rocket_analytics_optin_thankyou_notice() {
-	$screen = get_current_screen();
-
-	if ( ! current_user_can( 'rocket_manage_options' ) ) {
-		return;
-	}
-
-	if ( 'settings_page_wprocket' !== $screen->id ) {
-		return;
-	}
-
-	$analytics_optin = get_transient( 'rocket_analytics_optin' );
-
-	if ( ! $analytics_optin ) {
-		return;
-	}
-
-	$thankyou_message = sprintf(
-		// Opening <p> provided by rocket_notice_html().
-		'<strong>%s</strong></p>',
-		__( 'Thank you!', 'rocket' )
-	);
-
-	$thankyou_message .= sprintf(
-		'<p>%1$s</p><div>%2$s</div>',
-		__( 'WP Rocket now collects these metrics from your website:', 'rocket' ),
-		rocket_data_collection_preview_table()
-	);
-
-	// Closing </p> provided by rocket_notice_html().
-	$thankyou_message .= '<p>';
-
-	rocket_notice_html(
-		[
-			'message' => $thankyou_message,
-		]
-	);
-
-	delete_transient( 'rocket_analytics_optin' );
-}
-add_action( 'admin_notices', 'rocket_analytics_optin_thankyou_notice' );
 
 /**
  * Displays a notice after clearing the cache

--- a/tests/Fixtures/inc/admin/rocketAfterSaveOptions.php
+++ b/tests/Fixtures/inc/admin/rocketAfterSaveOptions.php
@@ -235,7 +235,6 @@ return [
 					$htaccess['end'],
 				],
 				'rocket_generate_config_file' => '<?php $var = "Some contents.";',
-				'set_transient'               => '1',
 			],
 		],
 

--- a/tests/Integration/inc/admin/rocketAfterSaveOptions.php
+++ b/tests/Integration/inc/admin/rocketAfterSaveOptions.php
@@ -26,9 +26,7 @@ class Test_RocketAfterSaveOptions extends FilesystemTestCase {
 	protected $path_to_test_data = '/inc/admin/rocketAfterSaveOptions.php';
 
 	protected static $use_settings_trait = true;
-	protected static $transients         = [
-		'rocket_analytics_optin' => null,
-	];
+	protected static $transients = [];
 
 	private $is_apache;
 	private $expected;
@@ -119,7 +117,6 @@ class Test_RocketAfterSaveOptions extends FilesystemTestCase {
 		$this->rocket_generate_advanced_cache_file();
 		$this->flush_rocket_htaccess();
 		$this->rocket_generate_config_file();
-		$this->set_transient();
 	}
 
 	public function return_true() {
@@ -238,11 +235,4 @@ class Test_RocketAfterSaveOptions extends FilesystemTestCase {
 		}
 	}
 
-	private function set_transient() {
-		if ( isset( $this->expected['set_transient'] ) ) {
-			$this->assertEquals( '1', get_transient( 'rocket_analytics_optin' ) );
-		} else {
-			Functions\expect( 'set_transient' )->with( 'rocket_analytics_optin', 1 )->never();
-		}
-	}
 }

--- a/tests/Unit/inc/Engine/Tracking/Tracking/AjaxToggleOptinTest.php
+++ b/tests/Unit/inc/Engine/Tracking/Tracking/AjaxToggleOptinTest.php
@@ -95,17 +95,10 @@ class AjaxToggleOptinTest extends TestCase {
 				Functions\expect( 'update_option' )
 					->once()
 					->with( 'rocket_analytics_notice_displayed', 1 );
-
-				Functions\expect( 'set_transient' )
-					->once()
-					->with( 'rocket_analytics_optin', 1 );
 				break;
 
 			case 'Opt-in disabled.':
 				Functions\expect( 'update_option' )
-					->never();
-
-				Functions\expect( 'set_transient' )
 					->never();
 				break;
 		}

--- a/tests/Unit/inc/admin/rocketAfterSaveOptions.php
+++ b/tests/Unit/inc/admin/rocketAfterSaveOptions.php
@@ -45,7 +45,6 @@ class Test_RocketAfterSaveOptions extends FilesystemTestCase {
 		$this->flush_rocket_htaccess();
 		$this->rocket_generate_advanced_cache_file();
 		$this->rocket_generate_config_file();
-		$this->set_transient();
 
 		// Run it.
 		rocket_after_save_options( $this->config['settings'], $settings );
@@ -93,11 +92,4 @@ class Test_RocketAfterSaveOptions extends FilesystemTestCase {
 		}
 	}
 
-	private function set_transient() {
-		if ( isset( $this->expected['set_transient'] ) ) {
-			Functions\expect( 'set_transient' )->with( 'rocket_analytics_optin', 1 )->andReturnNull();
-		} else {
-			Functions\expect( 'set_transient' )->with( 'rocket_analytics_optin', 1 )->never();
-		}
-	}
 }


### PR DESCRIPTION


## Summary

- Removes the `rocket_analytics_optin_thankyou_notice()` function and its `admin_notices` hook that displayed "Thank you! WP Rocket now collects these metrics..." after the user enabled analytics.
- Removes all three `set_transient( 'rocket_analytics_optin', 1 )` calls (settings save, legacy admin handler, AJAX toggle handler) since the transient's only consumer was the removed notice.
- Updates unit, integration, and fixture test files to reflect that `set_transient` for this transient is no longer called.

## Test plan

- [ ] Enable analytics via the settings page toggle — verify no shared-data summary notice appears after saving.
- [ ] Enable analytics via the old consent banner ("Yes, allow") — verify no notice appears after redirect.
- [ ] Disable and re-enable analytics — verify the banner still appears/disappears correctly, only the post-consent notice is gone.
- [ ] Run unit tests: `tests/Unit/inc/admin/rocketAfterSaveOptions.php` and `tests/Unit/inc/Engine/Tracking/Tracking/AjaxToggleOptinTest.php`.
- [ ] Run integration tests: `tests/Integration/inc/admin/rocketAfterSaveOptions.php`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)