### PR TITLE
chore(ai): lift maxTurns caps on pipeline agents

### DIFF
--- a/.claude/agents/backend-agent.md
+++ b/.claude/agents/backend-agent.md
@@ -3,7 +3,7 @@ name: backend-agent
 description: Backend implementation agent. Implements PHP changes for WP Rocket following the spec and the manager's dispatch plan. Writes or updates unit and integration tests. Runs the docs skill and dod skill (layer 1) inline before committing. Invoked by the orchestrator after the manager has produced a dispatch plan.
 tools: [Bash, Read, Edit, Write, Glob, Grep, WebFetch, WebSearch]
 model: sonnet
-maxTurns: 60
+maxTurns: 100
 color: green
 ---
 

--- a/.claude/agents/frontend-agent.md
+++ b/.claude/agents/frontend-agent.md
@@ -3,7 +3,7 @@ name: frontend-agent
 description: Frontend implementation agent. Implements JS/CSS/HTML changes for WP Rocket following the spec and the manager's dispatch plan. Runs the docs skill and dod skill (layer 1) inline before committing. Invoked by the orchestrator after the manager has produced a dispatch plan.
 tools: [Bash, Read, Edit, Write, Glob, Grep, WebFetch, WebSearch]
 model: sonnet
-maxTurns: 60
+maxTurns: 100
 color: green
 ---
 

--- a/.claude/agents/lead-reviewer.md
+++ b/.claude/agents/lead-reviewer.md
@@ -3,7 +3,7 @@ name: lead-reviewer
 description: Lead software engineer code review agent. Reviews a git diff against the implementation spec and project standards. Returns a structured PASS or CHANGES REQUESTED verdict with JSON. Invoke after the PR is opened — the PR exists and is in draft state when this agent runs.
 tools: [Bash, Read, Glob, Grep, WebFetch, WebSearch]
 model: sonnet
-maxTurns: 25
+maxTurns: 40
 color: yellow
 ---
 

--- a/.claude/agents/release-agent.md
+++ b/.claude/agents/release-agent.md
@@ -3,7 +3,7 @@ name: release-agent
 description: Handles trailer verification, pushing the branch to remote, and creating the GitHub pull request as draft. Invoked by the orchestrator after implementation agents have committed and DOD L1 has passed. Does not write code or modify implementation files. Prepends the AI-generated notice to the PR description.
 tools: [Bash, Read, Write]
 model: haiku
-maxTurns: 10
+maxTurns: 20
 color: orange
 ---
 


### PR DESCRIPTION
# Description

No linked issue — originated from pipeline-run feedback in Slack (Rémi / Mathieu).

The `maxTurns` caps introduced in #8509 were truncating several issue-workflow agents mid-run. After a live run, `release-agent`, `lead-reviewer` and `backend-agent` all stopped early because their caps were tight relative to the task's sequential floor. This PR raises the tight caps to give headroom for the moment.

No product or runtime impact — this only touches the `.claude/agents/*` frontmatter that configures the AI delivery pipeline.

- `release-agent`: 10 → 20
- `lead-reviewer`: 25 → 40
- `backend-agent`: 60 → 100
- `frontend-agent`: 60 → 100 (kept in sync with `backend-agent`)

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [x] Chore
- [ ] Release

## Detailed scenario

### What was tested

Config-only change to agent frontmatter. Verified each of the four files carries the new `maxTurns` value and that the diff is limited to those four lines. Confirmed no orchestrator or skill file references these values (they live only in agent frontmatter), so nothing else needs to stay in sync.

### How to test

Inspect the frontmatter of `.claude/agents/{release-agent,lead-reviewer,backend-agent,frontend-agent}.md` and confirm the new caps. No build or runtime steps are involved.

### Affected Features & Quality Assurance Scope

AI issue-workflow pipeline only (grooming → implementation → review → release agents). No WP Rocket product code and no end-user-facing behaviour is affected.

## Technical description

### Documentation

`maxTurns` is the per-agent turn ceiling enforced by the Claude Code harness. It only bites when an agent would otherwise truncate mid-task — a higher cap does not slow down or cost more on runs that finish early, since the agent stops as soon as its work is done. The caps added in #8509 were set too low for the agents with a long sequential floor (e.g. `release-agent`'s irreducible `gh` sequence) or many sequential reads (`lead-reviewer`).

### New dependencies

None.

### Risks

A higher ceiling means a genuinely stuck or looping agent can burn more turns before being killed. This is mitigated by the agents' own loop protection (dod layer-1 self-correction caps at 3 attempts) and the orchestrator's loop counters. The underlying turn-waste (per-file-at-a-time reads, separate `gh` calls, and attempts to run the un-runnable local test suite in worktrees) is the better long-term fix and is tracked separately as a later enhancement.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

Built-in tests are not applicable — the change is limited to AI-agent configuration (markdown frontmatter), which is not executable product code.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
