### PR TITLE
RocketCDN cancellation and refund states

### DIFF
--- a/inc/Engine/CDN/Context.php
+++ b/inc/Engine/CDN/Context.php
@@ -103,7 +103,7 @@ class Context {
 	 * @return string
 	 */
 	private function rocketcdn_resolver(): string {
-		if ( ! $this->subscription_controller->has_active_subscription() ) {
+		if ( ! $this->subscription_controller->has_active_subscription() && $this->subscription_controller->is_cancelled_outside_grace_period() ) {
 			return self::ROCKETCDN_TYPE;
 		}
 

--- a/inc/Engine/CDN/Render/Controller.php
+++ b/inc/Engine/CDN/Render/Controller.php
@@ -479,7 +479,7 @@ class Controller extends Abstract_Render {
 		$stored['tracking'] = $is_forced;
 		update_option( self::FORCED_PAUSE_TRACKING_OPTION, $stored, false );
 
-		//Clear whole cache.
+		// Clear whole cache.
 		$this->cache->clear_all_cache();
 
 		/**
@@ -561,7 +561,7 @@ class Controller extends Abstract_Render {
 				$stored['persistent'] = true;
 				update_option( self::FORCED_PAUSE_TRACKING_OPTION, $stored, false );
 
-				//Clear whole cache.
+				// Clear whole cache.
 				$this->cache->clear_all_cache();
 			}
 
@@ -679,7 +679,7 @@ class Controller extends Abstract_Render {
 		$stored['persistent'] = false;
 		update_option( self::FORCED_PAUSE_TRACKING_OPTION, $stored, false );
 
-		//Clear whole cache.
+		// Clear whole cache.
 		$this->cache->clear_all_cache();
 
 		// Bail out if there are no add pages in the free plan — no need to auto create, allow normal flow.

--- a/inc/Engine/CDN/Render/Controller.php
+++ b/inc/Engine/CDN/Render/Controller.php
@@ -655,6 +655,10 @@ class Controller extends Abstract_Render {
 			return;
 		}
 
+		if ( $this->subscription_controller->is_license_invalid() ) {
+			return;
+		}
+
 		// Update the forced pause tracking option to indicate the forced pause has been resolved.
 		$stored['persistent'] = false;
 		update_option( self::FORCED_PAUSE_TRACKING_OPTION, $stored, false );
@@ -890,6 +894,10 @@ class Controller extends Abstract_Render {
 	 */
 	private function is_forced_paused(): bool {
 		if ( $this->subscription_controller->is_in_grace_period() ) {
+			return true;
+		}
+
+		if ( $this->subscription_controller->is_cancelled_outside_grace_period() && $this->subscription_controller->is_license_invalid() ) {
 			return true;
 		}
 

--- a/inc/Engine/CDN/Render/Controller.php
+++ b/inc/Engine/CDN/Render/Controller.php
@@ -113,6 +113,7 @@ class Controller extends Abstract_Render {
 		$this->cdn_query               = $cdn_query;
 		$this->subscription_controller = $subscription_controller;
 		$this->user                    = $user;
+		$this->cache                   = $cache;
 	}
 
 	/**
@@ -643,7 +644,7 @@ class Controller extends Abstract_Render {
 		$texts['status_text']        = $texts['active_status_text'];
 
 		if ( $this->subscription_controller->is_in_grace_period() ) {
-			$texts['paused_details'] = __( 'RocketCDN is currently paused because your licence was cancelled, you need to wait up to two days before resuming.', 'rocket' );
+			$texts['paused_details'] = __( 'RocketCDN is currently paused because your RocketCDN subscription was cancelled. Please wait up to two days before resuming.', 'rocket' );
 			$texts['class']         .= ' wpr-cdn-status--expired';
 		}
 

--- a/inc/Engine/CDN/Render/Controller.php
+++ b/inc/Engine/CDN/Render/Controller.php
@@ -650,8 +650,8 @@ class Controller extends Abstract_Render {
 			return;
 		}
 
-		// Bail out if the subscription is still within the cancellation grace period — too early to auto-resume.
-		if ( ! $this->subscription_controller->is_cancelled_outside_grace_period() ) {
+		// Bail out if the subscription is paid and is still within the cancellation grace period — too early to auto-resume.
+		if ( $this->subscription_controller->is_paid() && $this->subscription_controller->is_in_grace_period() ) {
 			return;
 		}
 
@@ -893,10 +893,17 @@ class Controller extends Abstract_Render {
 	 * @return bool True if the CDN should be force-paused, false otherwise.
 	 */
 	private function is_forced_paused(): bool {
-		if ( $this->subscription_controller->is_in_grace_period() ) {
+		// Force paused if paid plan cancelled but in grace period.
+		if ( $this->subscription_controller->is_paid() && $this->subscription_controller->is_in_grace_period() ) {
 			return true;
 		}
 
+		// Force paused if free plan with an invalid WP Rocket licence.
+		if ( $this->subscription_controller->is_free() && $this->subscription_controller->is_license_invalid() ) {
+			return true;
+		}
+
+		// Force paused if subscription cancelled beyond the grace period and WP Rocket licence is invalid.
 		if ( $this->subscription_controller->is_cancelled_outside_grace_period() && $this->subscription_controller->is_license_invalid() ) {
 			return true;
 		}

--- a/inc/Engine/CDN/Render/Controller.php
+++ b/inc/Engine/CDN/Render/Controller.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace WP_Rocket\Engine\CDN\Render;
 
 use WP_Rocket\Abstract_Render;
+use WP_Rocket\Engine\CDN\Cache;
 use WP_Rocket\Engine\CDN\Context;
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\CDN\RocketCDN\SubscriptionController;
@@ -76,6 +77,13 @@ class Controller extends Abstract_Render {
 	private $user;
 
 	/**
+	 * Cache instance
+	 *
+	 * @var Cache
+	 */
+	private $cache;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param Beacon                 $beacon        Beacon instance.
@@ -85,6 +93,7 @@ class Controller extends Abstract_Render {
 	 * @param RocketCDNQuery         $cdn_query RocketCDNQuery instance.
 	 * @param SubscriptionController $subscription_controller RocketCDN Subscription controller instance.
 	 * @param User                   $user          User instance.
+	 * @param Cache                  $cache Cache instance.
 	 */
 	public function __construct(
 		Beacon $beacon,
@@ -93,7 +102,8 @@ class Controller extends Abstract_Render {
 		Options_Data $options,
 		RocketCDNQuery $cdn_query,
 		SubscriptionController $subscription_controller,
-		User $user
+		User $user,
+		Cache $cache
 	) {
 		parent::__construct( $template_path );
 
@@ -469,6 +479,9 @@ class Controller extends Abstract_Render {
 		$stored['tracking'] = $is_forced;
 		update_option( self::FORCED_PAUSE_TRACKING_OPTION, $stored, false );
 
+		//Clear whole cache.
+		$this->cache->clear_all_cache();
+
 		/**
 		 * Fires when the CDN state changes between paused and active.
 		 *
@@ -547,6 +560,9 @@ class Controller extends Abstract_Render {
 			if ( empty( $stored['persistent'] ) ) {
 				$stored['persistent'] = true;
 				update_option( self::FORCED_PAUSE_TRACKING_OPTION, $stored, false );
+
+				//Clear whole cache.
+				$this->cache->clear_all_cache();
 			}
 
 			return false;
@@ -662,6 +678,9 @@ class Controller extends Abstract_Render {
 		// Update the forced pause tracking option to indicate the forced pause has been resolved.
 		$stored['persistent'] = false;
 		update_option( self::FORCED_PAUSE_TRACKING_OPTION, $stored, false );
+
+		//Clear whole cache.
+		$this->cache->clear_all_cache();
 
 		// Bail out if there are no add pages in the free plan — no need to auto create, allow normal flow.
 		if ( empty( $this->get_items() ) ) {

--- a/inc/Engine/CDN/Render/Controller.php
+++ b/inc/Engine/CDN/Render/Controller.php
@@ -730,7 +730,12 @@ class Controller extends Abstract_Render {
 
 		$class = '';
 
-		if ( $this->subscription_controller->has_inactive_subscription() || $this->subscription_controller->is_license_invalid() ) {
+		if ( $this->subscription_controller->is_in_grace_period() ) {
+			$class         .= ' wpr-cdn-status--expired';
+			$paused_details = __( 'RocketCDN is currently paused because your licence was cancelled, you need to wait up to two days before resuming.', 'rocket' );
+		}
+
+		if ( $this->subscription_controller->is_license_invalid() ) {
 			$class         .= ' wpr-cdn-status--expired';
 			$paused_details = __( 'RocketCDN is currently paused because your WPRocket licence has expired.', 'rocket' );
 		}
@@ -762,6 +767,14 @@ class Controller extends Abstract_Render {
 	 * @return bool
 	 */
 	private function is_cdn_paused(): bool {
-		return ! (bool) $this->options->get( 'cdn' );
+		return $this->is_forced_paused() || ! (bool) $this->options->get( 'cdn' );
+	}
+
+	private function is_forced_paused(): bool {
+		if ( $this->subscription_controller->is_paid() && $this->subscription_controller->is_in_grace_period() ) {
+			return true;
+		}
+
+		return false;
 	}
 }

--- a/inc/Engine/CDN/Render/Controller.php
+++ b/inc/Engine/CDN/Render/Controller.php
@@ -457,37 +457,30 @@ class Controller extends Abstract_Render {
 		if ( 'settings_page_wprocket' !== $screen->id || ! current_user_can( 'rocket_manage_options' ) ) {
 			return;
 		}
-		$is_forced  = ( $this->subscription_controller->has_inactive_subscription() || $this->subscription_controller->is_license_invalid() );
-		$stored     = get_option( self::FORCED_PAUSE_TRACKING_OPTION, false );
-		$was_forced = (bool) $stored;
+		$is_forced  = $this->is_forced_paused();
+		$stored     = $this->get_forced_pause_tracking();
+		$was_forced = (bool) ( $stored['tracking'] ?? false );
 
-		if ( $is_forced && ! $was_forced ) {
-			update_option( self::FORCED_PAUSE_TRACKING_OPTION, true, false );
-
-			/**
-			 * Fires when the CDN state is changed to paused due to an inactive or invalid subscription.
-			 *
-			 * @param string $new_state The new state of the CDN, e.g. 'paused'.
-			 * @param string $reason The reason for the state change, e.g. 'wpr_forced_pause'.
-			 * @since 3.22
-			 */
-			do_action( 'rocket_rocketcdn_cdn_state_changed', 'paused', 'wpr_forced_pause' );
-
+		// Bail out when state hasn't changed to avoid unnecessary option updates and tracking events.
+		if ( $is_forced === $was_forced ) {
 			return;
 		}
 
-		if ( ! $is_forced && $was_forced ) {
-			update_option( self::FORCED_PAUSE_TRACKING_OPTION, false, false );
+		$stored['tracking'] = $is_forced;
+		update_option( self::FORCED_PAUSE_TRACKING_OPTION, $stored, false );
 
-			/**
-			 * Fires when the CDN state is changed to active.
-			 *
-			 * @param string $new_state The new state of the CDN, e.g. 'active'.
-			 * @param string $reason The reason for the state change, e.g. 'wpr_forced_resume'.
-			 * @since 3.22
-			 */
-			do_action( 'rocket_rocketcdn_cdn_state_changed', 'active', 'wpr_forced_resume' );
-		}
+		/**
+		 * Fires when the CDN state changes between paused and active.
+		 *
+		 * @param string $new_state The new state of the CDN: 'paused' or 'active'.
+		 * @param string $reason    'wpr_forced_pause' when pausing, 'wpr_forced_resume' when resuming.
+		 * @since 3.22
+		 */
+		do_action(
+			'rocket_rocketcdn_cdn_state_changed',
+			$is_forced ? 'paused' : 'active',
+			$is_forced ? 'wpr_forced_pause' : 'wpr_forced_resume'
+		);
 	}
 
 	/**
@@ -547,13 +540,15 @@ class Controller extends Abstract_Render {
 			return $cdn;
 		}
 
-		// If subscription is free and licence is not valid, forced pause cdn.
-		if ( $this->subscription_controller->is_free() && $this->subscription_controller->is_license_invalid() ) {
-			return false;
-		}
+		if ( $this->is_forced_paused() ) {
+			$stored = $this->get_forced_pause_tracking();
 
-		$transient = $this->subscription_controller->get_rocketcdn_status();
-		if ( false !== $transient && $this->subscription_controller->has_inactive_subscription() ) {
+			// Prevent unnecessary DB write on every request.
+			if ( empty( $stored['persistent'] ) ) {
+				$stored['persistent'] = true;
+				update_option( self::FORCED_PAUSE_TRACKING_OPTION, $stored, false );
+			}
+
 			return false;
 		}
 
@@ -574,6 +569,119 @@ class Controller extends Abstract_Render {
 			|| $this->is_cdn_paused()
 			|| $this->should_display_licence_expired_notice()
 			|| ! $this->subscription_controller->has_active_subscription();
+	}
+
+	/**
+	 * Filters status indicator texts for the free RocketCDN tier.
+	 *
+	 * Hooked to {@see 'rocket_rocketcdn_status_indicator_texts'} at priority 10.
+	 * Activates the status text once pages have been added, and surfaces an
+	 * expiry notice when the WP Rocket licence is invalid.
+	 *
+	 * @param array $texts                   Text strings for the status indicator.
+	 * @param int   $pages_count             Number of pages using RocketCDN.
+	 * @param bool  $is_subscription_loading Whether the subscription is loading.
+	 * @param bool  $free                    Whether this is for the free version.
+	 *
+	 * @return array
+	 */
+	public function get_free_status_indicator_texts( array $texts, int $pages_count, bool $is_subscription_loading, bool $free ): array {
+		if ( ! $free ) {
+			return $texts;
+		}
+
+		if ( $pages_count > 0 ) {
+			$texts['status_text'] = $texts['active_status_text'];
+			$texts['details']     = __( 'Serving files from 10 edge locations. Covering up to 3 pages.', 'rocket' );
+		}
+
+		if ( $this->subscription_controller->is_license_invalid() ) {
+			$texts['class']         .= ' wpr-cdn-status--expired';
+			$texts['paused_details'] = __( 'RocketCDN is currently paused because your WPRocket licence has expired.', 'rocket' );
+		}
+
+		return $texts;
+	}
+
+	/**
+	 * Filters status indicator texts for the paid RocketCDN tier.
+	 *
+	 * Hooked to {@see 'rocket_rocketcdn_status_indicator_texts'} at priority 10.
+	 * Activates the paid status text and surfaces a cancellation notice during
+	 * the grace period.
+	 *
+	 * @param array $texts                   Text strings for the status indicator.
+	 * @param int   $pages_count             Number of pages using RocketCDN.
+	 * @param bool  $is_subscription_loading Whether the subscription is loading.
+	 * @param bool  $free                    Whether this is for the free version.
+	 *
+	 * @return array
+	 */
+	public function get_paid_status_indicator_texts( array $texts, int $pages_count, bool $is_subscription_loading, bool $free ): array {
+		if ( $free ) {
+			return $texts;
+		}
+
+		$texts['details']            = __( 'Serving files from 100+ edge locations', 'rocket' );
+		$texts['active_status_text'] = __( 'RocketCDN is active on your website', 'rocket' );
+		$texts['status_text']        = $texts['active_status_text'];
+
+		if ( $this->subscription_controller->is_in_grace_period() ) {
+			$texts['paused_details'] = __( 'RocketCDN is currently paused because your licence was cancelled, you need to wait up to two days before resuming.', 'rocket' );
+			$texts['class']         .= ' wpr-cdn-status--expired';
+		}
+
+		return $texts;
+	}
+
+	/**
+	 * Auto-creates a RocketCDN Free subscription when a previously forced-paused state is resolved.
+	 *
+	 * @since 3.22.0.2
+	 *
+	 * @return void
+	 */
+	public function maybe_auto_create_rocketcdn_free_subscription() {
+		$stored           = $this->get_forced_pause_tracking();
+		$was_forced_pause = (bool) ( $stored['persistent'] ?? false );
+
+		// Bail out if there was never a forced paused state to avoid unnecessary subscription creation on new accounts.
+		if ( ! $was_forced_pause ) {
+			return;
+		}
+
+		// Bail out if the subscription is still within the cancellation grace period — too early to auto-resume.
+		if ( ! $this->subscription_controller->is_cancelled_outside_grace_period() ) {
+			return;
+		}
+
+		// Update the forced pause tracking option to indicate the forced pause has been resolved.
+		$stored['persistent'] = false;
+		update_option( self::FORCED_PAUSE_TRACKING_OPTION, $stored, false );
+
+		// Bail out if there are no add pages in the free plan — no need to auto create, allow normal flow.
+		if ( empty( $this->get_items() ) ) {
+			return;
+		}
+
+		// Auto-create a new subscription to resume free RocketCDN service.
+		$this->subscription_controller->create_subscription();
+	}
+
+	/**
+	 * Reads the forced pause tracking option, migrating the legacy bool format to the current array format.
+	 *
+	 * @return array
+	 */
+	private function get_forced_pause_tracking(): array {
+		$stored = get_option( self::FORCED_PAUSE_TRACKING_OPTION, [] );
+
+		// Migrate legacy bool value: the option used to be stored as a plain bool.
+		if ( is_bool( $stored ) ) {
+			return [ 'tracking' => $stored ];
+		}
+
+		return (array) $stored;
 	}
 
 	/**
@@ -696,64 +804,67 @@ class Controller extends Abstract_Render {
 	 *     @type bool   $hide_pause_btn         Whether to hide the pause button.
 	 * }
 	 */
-	private function get_status_indicator_data( int $pages_count, bool $is_subscription_loading, bool $free = true ) {
-		$paused_status_text = __( 'RocketCDN is paused', 'rocket' );
-		$active_status_text = __( 'RocketCDN is active', 'rocket' );
-		$paused_details     = __( 'RocketCDN is currently paused. Click Resume CDN to re-enable content delivery.', 'rocket' );
+	private function get_status_indicator_data( int $pages_count, bool $is_subscription_loading, bool $free = true ): array {
+		$texts = [
+			'paused_status_text' => __( 'RocketCDN is paused', 'rocket' ),
+			'active_status_text' => __( 'RocketCDN is active', 'rocket' ),
+			'paused_details'     => __( 'RocketCDN is currently paused. Click Resume CDN to re-enable content delivery.', 'rocket' ),
+			'status_text'        => '',
+			'details'            => sprintf(
+			// translators: %1$s = opening <strong> tag, %2$s = closing </strong> tag.
+				__( '%1$sStart with your homepage and add up to 2 more key pages.%2$s Includes unlimited traffic across 10 edge locations.', 'rocket' ),
+				'<strong>',
+				'</strong>'
+			),
+			'class'              => '',
+		];
 
-		$status_text = '';
-		$details     = sprintf(
-		// translators: %1$s = opening <strong> tag, %2$s = closing </strong> tag.
-			__( '%1$sStart with your homepage and add up to 2 more key pages.%2$s Includes unlimited traffic across 10 edge locations.', 'rocket' ),
-			'<strong>',
-			'</strong>'
-		);
+		/**
+		 * Filters the status indicator text strings for RocketCDN.
+		 *
+		 * Free- and paid-tier callbacks are registered by default to apply
+		 * tier-specific overrides. Additional callbacks may be added to
+		 * customise the indicator for custom subscription states.
+		 *
+		 * @param array $texts                   {
+		 *     Text strings and CSS modifier class for the status indicator.
+		 *
+		 *     @type string $paused_status_text Text displayed when CDN is paused.
+		 *     @type string $active_status_text Text displayed when CDN is active.
+		 *     @type string $paused_details     Details shown while CDN is paused.
+		 *     @type string $status_text        Currently-shown status text (empty = inactive state).
+		 *     @type string $details            Currently-shown details text.
+		 *     @type string $class              CSS modifier class(es) for the indicator element.
+		 * }
+		 * @param int   $pages_count             Number of pages currently using RocketCDN.
+		 * @param bool  $is_subscription_loading Whether the subscription is currently being processed.
+		 * @param bool  $free                    Whether this is for the free version of RocketCDN.
+		 *
+		 * @since 3.22.0.2
+		 */
+		$texts = (array) apply_filters( 'rocket_rocketcdn_status_indicator_texts', $texts, $pages_count, $is_subscription_loading, $free );
 
-		if ( $pages_count > 0 ) {
-			$status_text = $active_status_text;
-			$details     = __( 'Serving files from 10 edge locations. Covering up to 3 pages.', 'rocket' );
-		}
-
-		if ( ! $free ) {
-			$details            = __( 'Serving files from 100+ edge locations', 'rocket' );
-			$active_status_text = __( 'RocketCDN is active on your website', 'rocket' );
-			$status_text        = $active_status_text;
-		}
-
-		// Update status indicator details when subscription is processing.
 		if ( $is_subscription_loading ) {
-			$status_text = __( 'Creating your subscription...', 'rocket' );
-			$details     = __( 'Please wait, RocketCDN will be ready and active shortly.', 'rocket' );
+			$texts['status_text'] = __( 'Creating your subscription...', 'rocket' );
+			$texts['details']     = __( 'Please wait, RocketCDN will be ready and active shortly.', 'rocket' );
 		}
 
 		$is_paused = $this->is_cdn_paused();
 
-		$class = '';
-
-		if ( $this->subscription_controller->is_in_grace_period() ) {
-			$class         .= ' wpr-cdn-status--expired';
-			$paused_details = __( 'RocketCDN is currently paused because your licence was cancelled, you need to wait up to two days before resuming.', 'rocket' );
-		}
-
-		if ( $this->subscription_controller->is_license_invalid() ) {
-			$class         .= ' wpr-cdn-status--expired';
-			$paused_details = __( 'RocketCDN is currently paused because your WPRocket licence has expired.', 'rocket' );
-		}
-
 		if ( $is_paused ) {
-			$status_text = $paused_status_text;
-			$details     = $paused_details;
-			$class      .= ' wpr-cdn-status--paused';
+			$texts['status_text'] = $texts['paused_status_text'];
+			$texts['details']     = $texts['paused_details'];
+			$texts['class']      .= ' wpr-cdn-status--paused';
 		}
 
 		return [
-			'class'                   => $class,
+			'class'                   => $texts['class'],
 			'is_active'               => true,
-			'status_text'             => $status_text,
-			'details'                 => $details,
-			'active_status_text'      => $active_status_text,
-			'paused_status_text'      => $paused_status_text,
-			'paused_details'          => $paused_details,
+			'status_text'             => $texts['status_text'],
+			'details'                 => $texts['details'],
+			'active_status_text'      => $texts['active_status_text'],
+			'paused_status_text'      => $texts['paused_status_text'],
+			'paused_details'          => $texts['paused_details'],
 			'is_paused'               => $is_paused,
 			'pages_count'             => $pages_count,
 			'is_subscription_loading' => $is_subscription_loading,
@@ -767,11 +878,18 @@ class Controller extends Abstract_Render {
 	 * @return bool
 	 */
 	private function is_cdn_paused(): bool {
-		return $this->is_forced_paused() || ! (bool) $this->options->get( 'cdn' );
+		return ! (bool) $this->options->get( 'cdn' );
 	}
 
+	/**
+	 * Determines whether the CDN should be force-paused due to an inactive or invalid subscription state.
+	 *
+	 * @since 3.22
+	 *
+	 * @return bool True if the CDN should be force-paused, false otherwise.
+	 */
 	private function is_forced_paused(): bool {
-		if ( $this->subscription_controller->is_paid() && $this->subscription_controller->is_in_grace_period() ) {
+		if ( $this->subscription_controller->is_in_grace_period() ) {
 			return true;
 		}
 

--- a/inc/Engine/CDN/Render/Controller.php
+++ b/inc/Engine/CDN/Render/Controller.php
@@ -918,6 +918,10 @@ class Controller extends Abstract_Render {
 			return true;
 		}
 
+		if ( $this->subscription_controller->is_paid() && $this->subscription_controller->is_cancelled_outside_grace_period() ) {
+			return true;
+		}
+
 		// Force paused if free plan with an invalid WP Rocket licence.
 		if ( $this->subscription_controller->is_free() && $this->subscription_controller->is_license_invalid() ) {
 			return true;

--- a/inc/Engine/CDN/Render/Controller.php
+++ b/inc/Engine/CDN/Render/Controller.php
@@ -846,7 +846,7 @@ class Controller extends Abstract_Render {
 		 *
 		 * @since 3.22.0.2
 		 */
-		$texts = (array) apply_filters( 'rocket_rocketcdn_status_indicator_texts', $texts, $pages_count, $is_subscription_loading, $free );
+		$texts = wpm_apply_filters_typed( 'array', 'rocket_rocketcdn_status_indicator_texts', $texts, $pages_count, $is_subscription_loading, $free );
 
 		if ( $is_subscription_loading ) {
 			$texts['status_text'] = __( 'Creating your subscription...', 'rocket' );

--- a/inc/Engine/CDN/Render/Controller.php
+++ b/inc/Engine/CDN/Render/Controller.php
@@ -659,11 +659,8 @@ class Controller extends Abstract_Render {
 	 * @return void
 	 */
 	public function maybe_auto_create_rocketcdn_free_subscription() {
-		$stored           = $this->get_forced_pause_tracking();
-		$was_forced_pause = (bool) ( $stored['persistent'] ?? false );
-
-		// Bail out if there was never a forced paused state to avoid unnecessary subscription creation on new accounts.
-		if ( ! $was_forced_pause ) {
+		// Bail out if customer is outside the grace period to avoid unnecessary subscription creation on new accounts.
+		if ( ! $this->subscription_controller->is_cancelled_outside_grace_period() ) {
 			return;
 		}
 
@@ -677,6 +674,7 @@ class Controller extends Abstract_Render {
 		}
 
 		// Update the forced pause tracking option to indicate the forced pause has been resolved.
+		$stored               = $this->get_forced_pause_tracking();
 		$stored['persistent'] = false;
 		update_option( self::FORCED_PAUSE_TRACKING_OPTION, $stored, false );
 

--- a/inc/Engine/CDN/Render/Subscriber.php
+++ b/inc/Engine/CDN/Render/Subscriber.php
@@ -51,6 +51,11 @@ class Subscriber implements Subscriber_Interface {
 			'rocket_cdn_tab_badge'                    => 'maybe_hide_cdn_tab_badge',
 			'pre_get_rocket_option_cdn'               => 'maybe_pause_cdn_for_inactive_subscription',
 			'rocket_cdn_free_before_status_indicator' => [ 'render_expired_wpr_licence_notice', 9 ],
+			'rocket_rocketcdn_status_indicator_texts' => [
+				[ 'get_free_status_indicator_texts', 10, 4 ],
+				[ 'get_paid_status_indicator_texts', 10, 4 ],
+			],
+			'admin_init'                              => 'maybe_auto_create_rocketcdn_free_subscription',
 		];
 	}
 
@@ -211,5 +216,44 @@ class Subscriber implements Subscriber_Interface {
 	 */
 	public function render_expired_wpr_licence_notice(): void {
 		$this->controller->render_expired_wpr_licence_notice();
+	}
+
+	/**
+	 * Filters status indicator texts for the free RocketCDN tier.
+	 *
+	 * @param array $texts                   Text strings for the status indicator.
+	 * @param int   $pages_count             Number of pages using RocketCDN.
+	 * @param bool  $is_subscription_loading Whether the subscription is loading.
+	 * @param bool  $free                    Whether this is for the free version.
+	 *
+	 * @return array
+	 */
+	public function get_free_status_indicator_texts( array $texts, int $pages_count, bool $is_subscription_loading, bool $free ): array {
+		return $this->controller->get_free_status_indicator_texts( $texts, $pages_count, $is_subscription_loading, $free );
+	}
+
+	/**
+	 * Filters status indicator texts for the paid RocketCDN tier.
+	 *
+	 * @param array $texts                   Text strings for the status indicator.
+	 * @param int   $pages_count             Number of pages using RocketCDN.
+	 * @param bool  $is_subscription_loading Whether the subscription is loading.
+	 * @param bool  $free                    Whether this is for the free version.
+	 *
+	 * @return array
+	 */
+	public function get_paid_status_indicator_texts( array $texts, int $pages_count, bool $is_subscription_loading, bool $free ): array {
+		return $this->controller->get_paid_status_indicator_texts( $texts, $pages_count, $is_subscription_loading, $free );
+	}
+
+	/**
+	 * Auto-creates a RocketCDN Free subscription when a previously forced-paused state is resolved.
+	 *
+	 * @since 3.22.0.2
+	 *
+	 * @return void
+	 */
+	public function maybe_auto_create_rocketcdn_free_subscription(): void {
+		$this->controller->maybe_auto_create_rocketcdn_free_subscription();
 	}
 }

--- a/inc/Engine/CDN/RocketCDN/APIClient.php
+++ b/inc/Engine/CDN/RocketCDN/APIClient.php
@@ -46,6 +46,7 @@ class APIClient {
 			'plan_type'                     => 'free',
 			'plan_page_limit'               => 0,
 			'website_id'                    => 0,
+			'status_code'                   => 500,
 		];
 
 		$token = get_option( 'rocketcdn_user_token' );
@@ -72,8 +73,11 @@ class APIClient {
 			$args
 		);
 
-		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			$this->set_status_transient( $default, 3 * MINUTE_IN_SECONDS );
+		$status_code            = wp_remote_retrieve_response_code( $response );
+		$default['status_code'] = $status_code;
+
+		if ( 200 !== $status_code ) {
+			$this->set_status_transient( $default, 404 !== $status_code ? 3 * MINUTE_IN_SECONDS : DAY_IN_SECONDS );
 
 			return $default;
 		}
@@ -103,6 +107,7 @@ class APIClient {
 			'plan_type'                     => $data['plan_type'] ?? 'free',
 			'plan_page_limit'               => $data['plan_page_limit'] ?? 0,
 			'website_id'                    => $data['website_id'] ?? 0,
+			'status_code'                   => $data['status_code'] ?? 0,
 		];
 
 		$this->set_status_transient( $final_data, DAY_IN_SECONDS );

--- a/inc/Engine/CDN/RocketCDN/APIClient.php
+++ b/inc/Engine/CDN/RocketCDN/APIClient.php
@@ -107,7 +107,7 @@ class APIClient {
 			'plan_type'                     => $data['plan_type'] ?? 'free',
 			'plan_page_limit'               => $data['plan_page_limit'] ?? 0,
 			'website_id'                    => $data['website_id'] ?? 0,
-			'status_code'                   => $data['status_code'] ?? 0,
+			'status_code'                   => $status_code,
 		];
 
 		$this->set_status_transient( $final_data, DAY_IN_SECONDS );

--- a/inc/Engine/CDN/RocketCDN/APIHandler/CheckStatusAPIClient.php
+++ b/inc/Engine/CDN/RocketCDN/APIHandler/CheckStatusAPIClient.php
@@ -56,7 +56,19 @@ class CheckStatusAPIClient extends AbstractSafeAPIClient {
 	 * @return array|false
 	 */
 	public function check() {
-		$response = $this->send_get_request( [], true );
+		$token = get_option( 'rocketcdn_user_token' );
+
+		if ( empty( $token ) ) {
+			return false;
+		}
+
+		$args = [
+			'headers' => [
+				'Authorization' => 'Token ' . $token,
+			],
+		];
+
+		$response = $this->send_get_request( $args, true );
 
 		if ( is_wp_error( $response ) ) {
 			return false;

--- a/inc/Engine/CDN/RocketCDN/APIHandler/WebsiteSearch.php
+++ b/inc/Engine/CDN/RocketCDN/APIHandler/WebsiteSearch.php
@@ -1,0 +1,94 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Engine\CDN\RocketCDN\APIHandler;
+
+use WP_Rocket\Engine\CDN\RocketCDN\APIClient;
+use WP_Rocket\Engine\Common\JobManager\APIHandler\AbstractSafeAPIClient;
+use WP_Rocket\Engine\License\API\User;
+
+/**
+ * Class to Interact with the RocketCDN API - website search.
+ */
+class WebsiteSearch extends AbstractSafeAPIClient {
+
+	private $site_url;
+
+	/**
+	 * Set site_url.
+	 *
+	 * @param string $site_url Site url.
+	 * @return void
+	 */
+	public function set_site_url( string $site_url ): void {
+		$this->site_url = $site_url;
+	}
+
+	/**
+	 * Get the transient key for making this API Client calls.
+	 *
+	 * @return string The transient key.
+	 */
+	protected function get_transient_key() {
+		return 'rocket_cdn_website_search';
+	}
+
+	/**
+	 * Get the API URL for website search.
+	 *
+	 * @return string The API URL.
+	 */
+	protected function get_api_url() {
+		if ( empty( $this->site_url ) ) {
+			return '';
+		}
+		return sprintf( '%1$swebsite/search/?url=%2$s/', APIClient::ROCKETCDN_API, $this->site_url );
+	}
+
+	/**
+	 * Check RocketCDN free account creation status.
+	 *
+	 * @return array|false
+	 */
+	public function find() {
+		$cached = get_transient( $this->get_transient_key() );
+		if ( false !== $cached ) {
+			return $cached;
+		}
+
+		$token = get_option( 'rocketcdn_user_token' );
+
+		if ( empty( $token ) ) {
+			return false;
+		}
+
+		$args = [
+			'headers' => [
+				'Authorization' => 'Token ' . $token,
+			],
+		];
+
+		$response = $this->send_get_request( $args, true );
+
+		$status_code = wp_remote_retrieve_response_code( $response );
+		if ( is_wp_error( $response ) || 200 !== $status_code ) {
+			return false;
+		}
+
+		$response = wp_remote_retrieve_body( $response );
+		if ( empty( $response ) ) {
+			return false;
+		}
+
+		$response = json_decode( $response, true );
+		$final    = [
+			'subscription_status' => $response['subscription_status'],
+			'plan_type'           => $response['subscription_plan_type'],
+			'status_code'         => $status_code,
+			'website_status'      => $response['status'],
+		];
+		set_transient( $this->get_transient_key(), $final, HOUR_IN_SECONDS );
+
+		return $final;
+	}
+}

--- a/inc/Engine/CDN/RocketCDN/APIHandler/WebsiteSearch.php
+++ b/inc/Engine/CDN/RocketCDN/APIHandler/WebsiteSearch.php
@@ -47,7 +47,11 @@ class WebsiteSearch extends AbstractSafeAPIClient {
 		if ( empty( $this->site_url ) ) {
 			return '';
 		}
-		return sprintf( '%1$swebsite/search/?url=%2$s/', APIClient::ROCKETCDN_API, $this->site_url );
+		return add_query_arg(
+			'url',
+			untrailingslashit( $this->site_url ),
+			APIClient::ROCKETCDN_API . 'website/search/'
+		);
 	}
 
 	/**
@@ -86,11 +90,15 @@ class WebsiteSearch extends AbstractSafeAPIClient {
 		}
 
 		$response = json_decode( $response, true );
+		if ( ! is_array( $response ) ) {
+			return false;
+		}
+
 		$final    = [
 			'subscription_status' => $response['subscription_status'],
 			'plan_type'           => $response['subscription_plan_type'],
 			'status_code'         => $status_code,
-			'website_status'      => $response['status'],
+			'website_status'      => $response['status'] ?? '',
 		];
 		set_transient( $this->get_transient_key(), $final, HOUR_IN_SECONDS );
 

--- a/inc/Engine/CDN/RocketCDN/APIHandler/WebsiteSearch.php
+++ b/inc/Engine/CDN/RocketCDN/APIHandler/WebsiteSearch.php
@@ -79,8 +79,7 @@ class WebsiteSearch extends AbstractSafeAPIClient {
 
 		$response = $this->send_get_request( $args, true );
 
-		$status_code = wp_remote_retrieve_response_code( $response );
-		if ( is_wp_error( $response ) || 200 !== $status_code ) {
+		if ( is_wp_error( $response ) ) {
 			return false;
 		}
 
@@ -95,13 +94,21 @@ class WebsiteSearch extends AbstractSafeAPIClient {
 		}
 
 		$final = [
-			'subscription_status' => $response['subscription_status'],
-			'plan_type'           => $response['subscription_plan_type'],
-			'status_code'         => $status_code,
+			'subscription_status' => $response['subscription_status'] ?? 'cancelled',
+			'plan_type'           => $response['subscription_plan_type'] ?? 'free',
+			'status_code'         => wp_remote_retrieve_response_code( $response ),
 			'website_status'      => $response['status'] ?? '',
 		];
 		set_transient( $this->get_transient_key(), $final, HOUR_IN_SECONDS );
 
 		return $final;
+	}
+
+	protected function valid_response_code( $response ) {
+		return in_array( wp_remote_retrieve_response_code( $response ), [ 200, 404 ], true );
+	}
+
+	protected function valid_response_body( $response ) {
+		return ! empty( wp_remote_retrieve_body( $response ) );
 	}
 }

--- a/inc/Engine/CDN/RocketCDN/APIHandler/WebsiteSearch.php
+++ b/inc/Engine/CDN/RocketCDN/APIHandler/WebsiteSearch.php
@@ -94,7 +94,7 @@ class WebsiteSearch extends AbstractSafeAPIClient {
 			return false;
 		}
 
-		$final    = [
+		$final = [
 			'subscription_status' => $response['subscription_status'],
 			'plan_type'           => $response['subscription_plan_type'],
 			'status_code'         => $status_code,

--- a/inc/Engine/CDN/RocketCDN/APIHandler/WebsiteSearch.php
+++ b/inc/Engine/CDN/RocketCDN/APIHandler/WebsiteSearch.php
@@ -12,6 +12,11 @@ use WP_Rocket\Engine\License\API\User;
  */
 class WebsiteSearch extends AbstractSafeAPIClient {
 
+	/**
+	 * The site URL to search for in the RocketCDN API.
+	 *
+	 * @var string
+	 */
 	private $site_url;
 
 	/**

--- a/inc/Engine/CDN/RocketCDN/APIHandler/WebsiteSearch.php
+++ b/inc/Engine/CDN/RocketCDN/APIHandler/WebsiteSearch.php
@@ -104,10 +104,22 @@ class WebsiteSearch extends AbstractSafeAPIClient {
 		return $final;
 	}
 
+	/**
+	 * Validate response code.
+	 *
+	 * @param array $response Response object.
+	 * @return bool
+	 */
 	protected function valid_response_code( $response ) {
 		return in_array( wp_remote_retrieve_response_code( $response ), [ 200, 404 ], true );
 	}
 
+	/**
+	 * Validate response body.
+	 *
+	 * @param array $response Response object.
+	 * @return bool
+	 */
 	protected function valid_response_body( $response ) {
 		return ! empty( wp_remote_retrieve_body( $response ) );
 	}

--- a/inc/Engine/CDN/RocketCDN/CDNOptionsManager.php
+++ b/inc/Engine/CDN/RocketCDN/CDNOptionsManager.php
@@ -108,5 +108,6 @@ class CDNOptionsManager {
 	 */
 	public function flush_subscription_cache() {
 		delete_transient( 'rocketcdn_status' );
+		delete_transient( 'rocket_cdn_website_search' );
 	}
 }

--- a/inc/Engine/CDN/RocketCDN/DataManagerSubscriber.php
+++ b/inc/Engine/CDN/RocketCDN/DataManagerSubscriber.php
@@ -3,6 +3,7 @@ namespace WP_Rocket\Engine\CDN\RocketCDN;
 
 use WP_Rocket\Admin\Options;
 use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Engine\CDN\Context;
 use WP_Rocket\Engine\License\API\UserClient;
 use WP_Rocket\Engine\Optimization\RegexTrait;
 use WP_Rocket\Event_Management\Subscriber_Interface;
@@ -99,6 +100,7 @@ class DataManagerSubscriber implements Subscriber_Interface {
 			'wp_rocket_upgrade'                      => [
 				[ 'refresh_cdn_cname', 10, 2 ],
 				[ 'refresh_subscription_details_with_update', 10, 2 ],
+				[ 'maybe_set_rocketcdn_as_cdn_type_on_upgrade', 12, 2 ],
 			],
 			'set_transient_wp_rocket_customer_data'  => 'maybe_refresh_rocketcdn_details',
 		];
@@ -585,5 +587,29 @@ class DataManagerSubscriber implements Subscriber_Interface {
 		}
 
 		$this->cdn_options->flush_subscription_cache();
+	}
+
+	/**
+	 * Sets cdn_type to rocketcdn when upgrading from a version affected by the grace period bug.
+	 *
+	 * @since 3.22.0.2
+	 *
+	 * @param string $new_version New plugin version.
+	 * @param string $old_version Previously installed plugin version.
+	 *
+	 * @return void
+	 */
+	public function maybe_set_rocketcdn_as_cdn_type_on_upgrade( string $new_version, string $old_version ) {
+		if ( version_compare( $old_version, '3.22.0.2', '>=' ) ) {
+			return;
+		}
+
+		if ( ! $this->subscription_controller->is_in_grace_period() ) {
+			return;
+		}
+
+		$current_options             = $this->options_api->get( 'settings', [] );
+		$current_options['cdn_type'] = Context::ROCKETCDN_TYPE;
+		$this->options_api->set( 'settings', $current_options );
 	}
 }

--- a/inc/Engine/CDN/RocketCDN/DataManagerSubscriber.php
+++ b/inc/Engine/CDN/RocketCDN/DataManagerSubscriber.php
@@ -556,14 +556,14 @@ class DataManagerSubscriber implements Subscriber_Interface {
 	}
 
 	/**
-	 * Refresh subscription details with update to v3.22.
+	 * Refresh subscription details with update to v3.22.0.2.
 	 *
 	 * @param string $new_version Plugin new version.
 	 * @param string $old_version Plugin old version.
 	 * @return void
 	 */
 	public function refresh_subscription_details_with_update( $new_version, $old_version ) {
-		if ( version_compare( $old_version, '3.22', '>=' ) ) {
+		if ( version_compare( $old_version, '3.22.0.2', '>=' ) ) {
 			return;
 		}
 

--- a/inc/Engine/CDN/RocketCDN/Rest.php
+++ b/inc/Engine/CDN/RocketCDN/Rest.php
@@ -239,14 +239,6 @@ class Rest extends WP_REST_Controller {
 			);
 		}
 
-		if ( $this->subscription_controller->has_inactive_subscription() ) {
-			return new WP_Error(
-				'rocketcdn_no_active_subscription',
-				__( 'You do not have an active RocketCDN subscription.', 'rocket' ),
-				[ 'status' => 403 ]
-			);
-		}
-
 		if ( $this->is_limit_reached() ) {
 			return new WP_Error(
 				'rocketcdn_page_limit_reached',

--- a/inc/Engine/CDN/RocketCDN/ServiceProvider.php
+++ b/inc/Engine/CDN/RocketCDN/ServiceProvider.php
@@ -7,6 +7,7 @@ use WP_Rocket\Dependencies\League\Container\Argument\Literal\StringArgument;
 use WP_Rocket\Dependencies\League\Container\ServiceProvider\AbstractServiceProvider;
 use WP_Rocket\Engine\CDN\RocketCDN\APIHandler\CheckStatusAPIClient;
 use WP_Rocket\Engine\CDN\RocketCDN\APIHandler\CreateAPIClient;
+use WP_Rocket\Engine\CDN\RocketCDN\APIHandler\WebsiteSearch;
 use WP_Rocket\Engine\CDN\RocketCDN\Database\Queries\RocketCDN as RocketCDNQuery;
 use WP_Rocket\Engine\CDN\RocketCDN\Database\Tables\RocketCDN as RocketCDNTable;
 
@@ -34,6 +35,7 @@ class ServiceProvider extends AbstractServiceProvider {
 		'rocketcdn_create_api_client',
 		'rocketcdn_queue',
 		'rocketcdn_check_status_api_client',
+		'rocketcdn_website_search_api_client',
 	];
 
 	/**
@@ -126,6 +128,7 @@ class ServiceProvider extends AbstractServiceProvider {
 		$this->getContainer()->add( 'rocketcdn_queue', Queue::class );
 		$this->getContainer()->add( 'rocketcdn_create_api_client', CreateAPIClient::class )->addArgument( 'user' );
 		$this->getContainer()->add( 'rocketcdn_check_status_api_client', CheckStatusAPIClient::class );
+		$this->getContainer()->add( 'rocketcdn_website_search_api_client', WebsiteSearch::class );
 		$this->getContainer()->add( 'rocketcdn_subscription_controller', SubscriptionController::class )
 			->addArguments(
 				[
@@ -135,6 +138,7 @@ class ServiceProvider extends AbstractServiceProvider {
 					'rocketcdn_queue',
 					'rocketcdn_check_status_api_client',
 					'user',
+					'rocketcdn_website_search_api_client',
 				]
 				);
 

--- a/inc/Engine/CDN/RocketCDN/SubscriptionController.php
+++ b/inc/Engine/CDN/RocketCDN/SubscriptionController.php
@@ -6,6 +6,7 @@ namespace WP_Rocket\Engine\CDN\RocketCDN;
 use WP_Error;
 use WP_Rocket\Engine\CDN\RocketCDN\APIHandler\CheckStatusAPIClient;
 use WP_Rocket\Engine\CDN\RocketCDN\APIHandler\CreateAPIClient;
+use WP_Rocket\Engine\CDN\RocketCDN\APIHandler\WebsiteSearch;
 use WP_Rocket\Engine\License\API\User;
 use WP_Rocket\Logger\LoggerAware;
 use WP_Rocket\Logger\LoggerAwareInterface;
@@ -69,6 +70,8 @@ class SubscriptionController implements LoggerAwareInterface {
 	 */
 	private $subscription;
 
+	private $website_search_api_client;
+
 	/**
 	 * Constructor.
 	 *
@@ -79,13 +82,22 @@ class SubscriptionController implements LoggerAwareInterface {
 	 * @param CheckStatusAPIClient $check_status_api_client Check Status API Client instance.
 	 * @param User                 $user  License User instance.
 	 */
-	public function __construct( APIClient $api_client, CreateAPIClient $create_api_client, CDNOptionsManager $options_manager, Queue $queue, CheckStatusAPIClient $check_status_api_client, User $user ) {
-		$this->api_client              = $api_client;
-		$this->create_api_client       = $create_api_client;
-		$this->options_manager         = $options_manager;
-		$this->queue                   = $queue;
-		$this->check_status_api_client = $check_status_api_client;
-		$this->user                    = $user;
+	public function __construct(
+		APIClient $api_client,
+		CreateAPIClient $create_api_client,
+		CDNOptionsManager $options_manager,
+		Queue $queue,
+		CheckStatusAPIClient $check_status_api_client,
+		User $user,
+		WebsiteSearch $website_search_api_client
+	) {
+		$this->api_client                = $api_client;
+		$this->create_api_client         = $create_api_client;
+		$this->options_manager           = $options_manager;
+		$this->queue                     = $queue;
+		$this->check_status_api_client   = $check_status_api_client;
+		$this->user                      = $user;
+		$this->website_search_api_client = $website_search_api_client;
 	}
 
 	/**
@@ -103,6 +115,14 @@ class SubscriptionController implements LoggerAwareInterface {
 		}
 
 		$this->subscription = $this->api_client->get_subscription_data();
+		if ( 404 === $this->subscription['status_code'] ) {
+			$this->website_search_api_client->set_site_url( home_url() );
+			$website = $this->website_search_api_client->find();
+			if ( ! empty( $website ) ) {
+				$this->subscription = array_merge( $this->subscription, $website );
+			}
+		}
+
 		return $this->subscription;
 	}
 
@@ -353,5 +373,23 @@ class SubscriptionController implements LoggerAwareInterface {
 	 */
 	public function get_rocketcdn_status() {
 		return get_transient( 'rocketcdn_status' );
+	}
+
+	public function is_cancelled(): bool {
+		$subscription = $this->get_subscription_data();
+		return ! empty( $subscription['subscription_status'] ) && 'cancelled' === $subscription['subscription_status'];
+	}
+
+	public function is_website_pending_deletion(): bool {
+		$subscription = $this->get_subscription_data();
+		return ! empty( $subscription['website_status'] ) && 'pending_deletion' === $subscription['website_status'];
+	}
+
+	public function is_in_grace_period(): bool {
+		return $this->is_cancelled() && $this->is_website_pending_deletion();
+	}
+
+	public function is_cancelled_outside_grace_period(): bool {
+		return $this->is_cancelled() && ! $this->is_website_pending_deletion();
 	}
 }

--- a/inc/Engine/CDN/RocketCDN/SubscriptionController.php
+++ b/inc/Engine/CDN/RocketCDN/SubscriptionController.php
@@ -70,6 +70,11 @@ class SubscriptionController implements LoggerAwareInterface {
 	 */
 	private $subscription;
 
+	/**
+	 * Website Search API Client instance.
+	 *
+	 * @var WebsiteSearch
+	 */
 	private $website_search_api_client;
 
 	/**
@@ -81,6 +86,7 @@ class SubscriptionController implements LoggerAwareInterface {
 	 * @param Queue                $queue Queue instance.
 	 * @param CheckStatusAPIClient $check_status_api_client Check Status API Client instance.
 	 * @param User                 $user  License User instance.
+	 * @param WebsiteSearch        $website_search_api_client Website Search API Client instance.
 	 */
 	public function __construct(
 		APIClient $api_client,
@@ -375,20 +381,54 @@ class SubscriptionController implements LoggerAwareInterface {
 		return get_transient( 'rocketcdn_status' );
 	}
 
+	/**
+	 * Checks whether the subscription has been cancelled or refunded.
+	 *
+	 * @since 3.22.0.2
+	 *
+	 * @return bool True if the subscription status is 'cancelled' or 'refunded', false otherwise.
+	 */
 	public function is_cancelled(): bool {
 		$subscription = $this->get_subscription_data();
 		return ! empty( $subscription['subscription_status'] ) && in_array( $subscription['subscription_status'], [ 'cancelled', 'refunded' ], true );
 	}
 
+	/**
+	 * Checks whether the website is pending deletion on the RocketCDN side.
+	 *
+	 * @since 3.22.0.2
+	 *
+	 * @return bool True if the website status is 'pending_deletion', false otherwise.
+	 */
 	public function is_website_pending_deletion(): bool {
 		$subscription = $this->get_subscription_data();
 		return ! empty( $subscription['website_status'] ) && 'pending_deletion' === $subscription['website_status'];
 	}
 
+	/**
+	 * Checks whether the subscription is within the cancellation grace period.
+	 *
+	 * The grace period is active when the subscription is cancelled but the website
+	 * is still pending deletion, meaning it has not yet been fully removed.
+	 *
+	 * @since 3.22.0.2
+	 *
+	 * @return bool True if the subscription is cancelled and the website is pending deletion, false otherwise.
+	 */
 	public function is_in_grace_period(): bool {
 		return $this->is_cancelled() && $this->is_website_pending_deletion();
 	}
 
+	/**
+	 * Checks whether the subscription is cancelled and the grace period has elapsed.
+	 *
+	 * Returns true when the subscription is cancelled and the website is no longer
+	 * pending deletion, indicating the grace period has fully passed.
+	 *
+	 * @since 3.22.0.2
+	 *
+	 * @return bool True if cancelled and outside the grace period, false otherwise.
+	 */
 	public function is_cancelled_outside_grace_period(): bool {
 		return $this->is_cancelled() && ! $this->is_website_pending_deletion();
 	}

--- a/inc/Engine/CDN/RocketCDN/SubscriptionController.php
+++ b/inc/Engine/CDN/RocketCDN/SubscriptionController.php
@@ -121,7 +121,7 @@ class SubscriptionController implements LoggerAwareInterface {
 		}
 
 		$this->subscription = $this->api_client->get_subscription_data();
-		if ( 404 === $this->subscription['status_code'] ) {
+		if ( 404 === ( $this->subscription['status_code'] ?? null ) ) {
 			$this->website_search_api_client->set_site_url( home_url() );
 			$website = $this->website_search_api_client->find();
 			if ( ! empty( $website ) ) {

--- a/inc/Engine/CDN/RocketCDN/SubscriptionController.php
+++ b/inc/Engine/CDN/RocketCDN/SubscriptionController.php
@@ -377,7 +377,7 @@ class SubscriptionController implements LoggerAwareInterface {
 
 	public function is_cancelled(): bool {
 		$subscription = $this->get_subscription_data();
-		return ! empty( $subscription['subscription_status'] ) && 'cancelled' === $subscription['subscription_status'];
+		return ! empty( $subscription['subscription_status'] ) && in_array( $subscription['subscription_status'], [ 'cancelled', 'refunded' ] );
 	}
 
 	public function is_website_pending_deletion(): bool {

--- a/inc/Engine/CDN/RocketCDN/SubscriptionController.php
+++ b/inc/Engine/CDN/RocketCDN/SubscriptionController.php
@@ -377,7 +377,7 @@ class SubscriptionController implements LoggerAwareInterface {
 
 	public function is_cancelled(): bool {
 		$subscription = $this->get_subscription_data();
-		return ! empty( $subscription['subscription_status'] ) && in_array( $subscription['subscription_status'], [ 'cancelled', 'refunded' ] );
+		return ! empty( $subscription['subscription_status'] ) && in_array( $subscription['subscription_status'], [ 'cancelled', 'refunded' ], true );
 	}
 
 	public function is_website_pending_deletion(): bool {

--- a/inc/Engine/CDN/ServiceProvider.php
+++ b/inc/Engine/CDN/ServiceProvider.php
@@ -128,6 +128,7 @@ class ServiceProvider extends AbstractServiceProvider {
 					'rocketcdn_query',
 					'rocketcdn_subscription_controller',
 					'user',
+					'cache_controller',
 				]
 			);
 

--- a/inc/Engine/Common/JobManager/APIHandler/AbstractSafeAPIClient.php
+++ b/inc/Engine/Common/JobManager/APIHandler/AbstractSafeAPIClient.php
@@ -82,10 +82,14 @@ abstract class AbstractSafeAPIClient {
 			return $response;
 		}
 
-		$body = wp_remote_retrieve_body( $response );
-		if ( empty( $body ) || ( ! empty( $response['response']['code'] ) && ! in_array( $response['response']['code'], [ 200, 202 ], true ) ) ) {
+		if ( ! $this->valid_response_code( $response ) ) {
 			$this->set_timeout_transients( $previous_expiration );
-			return new WP_Error( 500, 'Not valid response.' );
+			return new WP_Error( 500, 'Not valid response code.' );
+		}
+
+		if ( ! $this->valid_response_body( $response ) ) {
+			$this->set_timeout_transients( $previous_expiration );
+			return new WP_Error( 500, 'Not valid response body.' );
 		}
 
 		$this->delete_timeout_transients();
@@ -152,5 +156,13 @@ abstract class AbstractSafeAPIClient {
 		}
 
 		return new WP_Error( 400, 'Not valid request type.' );
+	}
+
+	protected function valid_response_code( $response ) {
+		return empty( $response['response']['code'] ) || in_array( $response['response']['code'], [ 200, 202 ], true );
+	}
+
+	protected function valid_response_body( $response) {
+		return ! empty( wp_remote_retrieve_body( $response ) );
 	}
 }

--- a/inc/Engine/Common/JobManager/APIHandler/AbstractSafeAPIClient.php
+++ b/inc/Engine/Common/JobManager/APIHandler/AbstractSafeAPIClient.php
@@ -158,11 +158,23 @@ abstract class AbstractSafeAPIClient {
 		return new WP_Error( 400, 'Not valid request type.' );
 	}
 
+	/**
+	 * Validate response code.
+	 *
+	 * @param array $response Response object.
+	 * @return bool
+	 */
 	protected function valid_response_code( $response ) {
 		return empty( $response['response']['code'] ) || in_array( $response['response']['code'], [ 200, 202 ], true );
 	}
 
-	protected function valid_response_body( $response) {
+	/**
+	 * Validate response body.
+	 *
+	 * @param array $response Response object.
+	 * @return bool
+	 */
+	protected function valid_response_body( $response ) {
 		return ! empty( wp_remote_retrieve_body( $response ) );
 	}
 }

--- a/inc/Engine/WPRocketUninstall.php
+++ b/inc/Engine/WPRocketUninstall.php
@@ -96,6 +96,7 @@ class WPRocketUninstall {
 		'wpr_global_score_data',
 		'wp_rocket_log_file_size_check',
 		'wpr_ri_recommendations',
+		'rocket_cdn_website_search',
 	];
 
 	/**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -97,6 +97,11 @@ parameters:
 
 		-
 			message: "#^Usage of get_option\\(\\) is discouraged\\. Use the Option object instead\\.$#"
+			count: 1
+			path: inc/Engine/CDN/RocketCDN/APIHandler/WebsiteSearch.php
+
+		-
+			message: "#^Usage of get_option\\(\\) is discouraged\\. Use the Option object instead\\.$#"
 			count: 3
 			path: inc/Engine/CDN/RocketCDN/APIClient.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -167,7 +167,7 @@ parameters:
 
 		-
 			message: "#^Usage of update_option\\(\\) is discouraged\\. Use the Option object instead\\.$#"
-			count: 2
+			count: 3
 			path: inc/Engine/CDN/Render/Controller.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -864,6 +864,16 @@ parameters:
 			message: "#^Usage of update_option\\(\\) is discouraged\\. Use the Option object instead\\.$#"
 			count: 2
 			path: tests/Integration/inc/Engine/CDN/RocketCDN/DataManagerSubscriber/maybeRetryActivation.php
+		
+		-
+			message: "#^Usage of get_option\\(\\) is discouraged\\. Use the Option object instead\\.$#"
+			count: 2
+			path: tests/Integration/inc/Engine/CDN/RocketCDN/DataManagerSubscriber/maybeSetRocketcdnAsCdnTypeOnUpgrade.php
+		
+		-
+			message: "#^Usage of update_option\\(\\) is discouraged\\. Use the Option object instead\\.$#"
+			count: 1
+			path: tests/Integration/inc/Engine/CDN/RocketCDN/DataManagerSubscriber/maybeSetRocketcdnAsCdnTypeOnUpgrade.php
 
 		-
 			message: "#^Usage of delete_option\\(\\) is discouraged\\. Use the Option object instead\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -98,12 +98,27 @@ parameters:
 		-
 			message: "#^Usage of get_option\\(\\) is discouraged\\. Use the Option object instead\\.$#"
 			count: 1
-			path: inc/Engine/CDN/RocketCDN/APIHandler/WebsiteSearch.php
+			path: inc/Engine/CDN/Render/Controller.php
+
+		-
+			message: "#^Usage of update_option\\(\\) is discouraged\\. Use the Option object instead\\.$#"
+			count: 3
+			path: inc/Engine/CDN/Render/Controller.php
 
 		-
 			message: "#^Usage of get_option\\(\\) is discouraged\\. Use the Option object instead\\.$#"
 			count: 3
 			path: inc/Engine/CDN/RocketCDN/APIClient.php
+
+		-
+			message: "#^Usage of get_option\\(\\) is discouraged\\. Use the Option object instead\\.$#"
+			count: 1
+			path: inc/Engine/CDN/RocketCDN/APIHandler/CheckStatusAPIClient.php
+
+		-
+			message: "#^Usage of get_option\\(\\) is discouraged\\. Use the Option object instead\\.$#"
+			count: 1
+			path: inc/Engine/CDN/RocketCDN/APIHandler/WebsiteSearch.php
 
 		-
 			message: "#^Usage of apply_filters\\(\\) is discouraged\\. Use wpm_apply_filters_typed\\(\\) instead\\.$#"
@@ -152,7 +167,7 @@ parameters:
 
 		-
 			message: "#^Usage of apply_filters\\(\\) is discouraged\\. Use wpm_apply_filters_typed\\(\\) instead\\.$#"
-			count: 2
+			count: 1
 			path: inc/Engine/CDN/RocketCDN/NoticesSubscriber.php
 
 		-
@@ -164,16 +179,6 @@ parameters:
 			message: "#^Usage of apply_filters\\(\\) is discouraged\\. Use wpm_apply_filters_typed\\(\\) instead\\.$#"
 			count: 1
 			path: inc/Engine/CDN/Subscriber.php
-
-		-
-			message: "#^Usage of get_option\\(\\) is discouraged\\. Use the Option object instead\\.$#"
-			count: 1
-			path: inc/Engine/CDN/Render/Controller.php
-
-		-
-			message: "#^Usage of update_option\\(\\) is discouraged\\. Use the Option object instead\\.$#"
-			count: 3
-			path: inc/Engine/CDN/Render/Controller.php
 
 		-
 			message: "#^Usage of apply_filters\\(\\) is discouraged\\. Use wpm_apply_filters_typed\\(\\) instead\\.$#"
@@ -864,12 +869,12 @@ parameters:
 			message: "#^Usage of update_option\\(\\) is discouraged\\. Use the Option object instead\\.$#"
 			count: 2
 			path: tests/Integration/inc/Engine/CDN/RocketCDN/DataManagerSubscriber/maybeRetryActivation.php
-		
+
 		-
 			message: "#^Usage of get_option\\(\\) is discouraged\\. Use the Option object instead\\.$#"
 			count: 2
 			path: tests/Integration/inc/Engine/CDN/RocketCDN/DataManagerSubscriber/maybeSetRocketcdnAsCdnTypeOnUpgrade.php
-		
+
 		-
 			message: "#^Usage of update_option\\(\\) is discouraged\\. Use the Option object instead\\.$#"
 			count: 1
@@ -886,11 +891,6 @@ parameters:
 			path: tests/Integration/inc/Engine/CDN/RocketCDN/NoticesSubscriber/activationFailedNotice.php
 
 		-
-			message: "#^Usage of update_option\\(\\) is discouraged\\. Use the Option object instead\\.$#"
-			count: 1
-			path: tests/Integration/inc/Engine/CDN/RocketCDN/NoticesSubscriber/displayRocketcdnCta.php
-
-		-
 			message: "#^Usage of get_option\\(\\) is discouraged\\. Use the Option object instead\\.$#"
 			count: 2
 			path: tests/Integration/inc/Engine/CDN/RocketCDN/RESTSubscriber/disable.php
@@ -904,7 +904,7 @@ parameters:
 			message: "#^Usage of get_option\\(\\) is discouraged\\. Use the Option object instead\\.$#"
 			count: 2
 			path: tests/Integration/inc/Engine/CDN/RocketCDN/RESTSubscriber/enable.php
-		
+
 		-
 			message: "#^Usage of update_option\\(\\) is discouraged\\. Use the Option object instead\\.$#"
 			count: 1

--- a/tests/Fixtures/inc/Engine/CDN/Context/getDriver.php
+++ b/tests/Fixtures/inc/Engine/CDN/Context/getDriver.php
@@ -31,8 +31,9 @@ return [
 	],
 	'testShouldReturnRocketcdnWhenNoActiveSubscription' => [
 		'config'   => [
-			'cdn_type'                => 'rocketcdn',
-			'has_active_subscription' => false,
+			'cdn_type'                          => 'rocketcdn',
+			'has_active_subscription'           => false,
+			'is_cancelled_outside_grace_period' => true,
 		],
 		'expected' => 'rocketcdn',
 	],

--- a/tests/Fixtures/inc/Engine/CDN/Render/Controller/addRocketcdnFreeSection.php
+++ b/tests/Fixtures/inc/Engine/CDN/Render/Controller/addRocketcdnFreeSection.php
@@ -1,0 +1,28 @@
+<?php
+
+return [
+	'testShouldSetLimitReachedFalseWhenNoPagesAdded' => [
+		'config'   => [
+			'page_count' => 0,
+		],
+		'expected' => false,
+	],
+	'testShouldSetLimitReachedFalseWhenUnderLimit'   => [
+		'config'   => [
+			'page_count' => 2,
+		],
+		'expected' => false,
+	],
+	'testShouldSetLimitReachedTrueWhenAtLimit'       => [
+		'config'   => [
+			'page_count' => 3,
+		],
+		'expected' => true,
+	],
+	'testShouldSetLimitReachedTrueWhenOverLimit'     => [
+		'config'   => [
+			'page_count' => 4,
+		],
+		'expected' => true,
+	],
+];

--- a/tests/Fixtures/inc/Engine/CDN/RocketCDN/DataManagerSubscriber/maybeSetRocketcdnAsCdnTypeOnUpgrade.php
+++ b/tests/Fixtures/inc/Engine/CDN/RocketCDN/DataManagerSubscriber/maybeSetRocketcdnAsCdnTypeOnUpgrade.php
@@ -1,0 +1,62 @@
+<?php
+
+return [
+	'test_data' => [
+		'testShouldBailWhenOldVersionIsEqualTo3_22_0_2'     => [
+			'config'   => [
+				'new_version'      => '3.22.0.2',
+				'old_version'      => '3.22.0.2',
+				'settings'         => [ 'cdn_type' => 'byocdn' ],
+				'rocketcdn_status' => [
+					'subscription_status' => 'cancelled',
+					'website_status'      => 'pending_deletion',
+				],
+			],
+			'expected' => [
+				'cdn_type' => 'byocdn',
+			],
+		],
+		'testShouldBailWhenOldVersionIsGreaterThan3_22_0_2' => [
+			'config'   => [
+				'new_version'      => '3.22.1',
+				'old_version'      => '3.22.1',
+				'settings'         => [ 'cdn_type' => 'byocdn' ],
+				'rocketcdn_status' => [
+					'subscription_status' => 'cancelled',
+					'website_status'      => 'pending_deletion',
+				],
+			],
+			'expected' => [
+				'cdn_type' => 'byocdn',
+			],
+		],
+		'testShouldBailWhenNotInGracePeriod'                => [
+			'config'   => [
+				'new_version'      => '3.22.0.2',
+				'old_version'      => '3.22.0.1',
+				'settings'         => [ 'cdn_type' => 'byocdn' ],
+				'rocketcdn_status' => [
+					'subscription_status' => 'running',
+					'website_status'      => 'active',
+				],
+			],
+			'expected' => [
+				'cdn_type' => 'byocdn',
+			],
+		],
+		'testShouldSetRocketcdnWhenInGracePeriod'           => [
+			'config'   => [
+				'new_version'      => '3.22.0.2',
+				'old_version'      => '3.22.0.1',
+				'settings'         => [ 'cdn_type' => 'byocdn' ],
+				'rocketcdn_status' => [
+					'subscription_status' => 'cancelled',
+					'website_status'      => 'pending_deletion',
+				],
+			],
+			'expected' => [
+				'cdn_type' => 'rocketcdn',
+			],
+		],
+	],
+];

--- a/tests/Integration/inc/Engine/CDN/RocketCDN/DataManagerSubscriber/maybeSetRocketcdnAsCdnTypeOnUpgrade.php
+++ b/tests/Integration/inc/Engine/CDN/RocketCDN/DataManagerSubscriber/maybeSetRocketcdnAsCdnTypeOnUpgrade.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\CDN\RocketCDN\DataManagerSubscriber;
+
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * Test class covering \WP_Rocket\Engine\CDN\RocketCDN\DataManagerSubscriber::maybe_set_rocketcdn_as_cdn_type_on_upgrade
+ *
+ * @group CDN
+ * @group RocketCDN
+ * @group AdminOnly
+ */
+class Test_MaybeSetRocketcdnAsCdnTypeOnUpgrade extends TestCase {
+
+	protected static $transients = [
+		'rocketcdn_status' => null,
+	];
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->unregisterAllCallbacksExcept( 'wp_rocket_upgrade', 'maybe_set_rocketcdn_as_cdn_type_on_upgrade', 12 );
+	}
+
+	public function tear_down(): void {
+		delete_transient( 'rocketcdn_status' );
+		$this->restoreWpHook( 'wp_rocket_upgrade' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldDoAsExpected( array $config, array $expected ): void {
+		if ( isset( $config['settings'] ) ) {
+			$current = get_option( 'wp_rocket_settings', [] );
+			update_option( 'wp_rocket_settings', array_merge( $current, $config['settings'] ) );
+		}
+
+		if ( isset( $config['rocketcdn_status'] ) ) {
+			set_transient( 'rocketcdn_status', $config['rocketcdn_status'] );
+		}
+
+		do_action( 'wp_rocket_upgrade', $config['new_version'], $config['old_version'] );
+
+		$settings = get_option( 'wp_rocket_settings', [] );
+		$this->assertSame( $expected['cdn_type'], $settings['cdn_type'] ?? '' );
+	}
+}

--- a/tests/Unit/inc/Engine/CDN/Context/getDriver.php
+++ b/tests/Unit/inc/Engine/CDN/Context/getDriver.php
@@ -46,7 +46,12 @@ class Test_GetDriver extends TestCase {
 			->andReturn( $config['has_active_subscription'] ?? false );
 
 		if ( 'rocketcdn' === $cdn_type ) {
-			if ( ! empty( $config['has_active_subscription'] ) ) {
+			if ( ! ( $config['has_active_subscription'] ?? false ) ) {
+				$this->subscription_controller->shouldReceive( 'is_cancelled_outside_grace_period' )
+					->andReturn( $config['is_cancelled_outside_grace_period'] ?? false );
+			}
+
+			if ( ( $config['has_active_subscription'] ?? false ) || ! ( $config['is_cancelled_outside_grace_period'] ?? false ) ) {
 				$this->subscription_controller->shouldReceive( 'is_paid' )
 					->andReturn( $config['is_paid'] ?? false );
 			}

--- a/tests/Unit/inc/Engine/CDN/Render/Controller/addRocketcdnFreeSection.php
+++ b/tests/Unit/inc/Engine/CDN/Render/Controller/addRocketcdnFreeSection.php
@@ -123,7 +123,7 @@ class Test_AddRocketcdnFreeSection extends TestCase {
 					'id'  => 'beacon-id',
 					'url' => 'https://example.com',
 				]
-				);
+			);
 
 		$this->subscription_controller->shouldReceive( 'is_subscription_creation_loading' )
 			->andReturn( false );
@@ -146,7 +146,7 @@ class Test_AddRocketcdnFreeSection extends TestCase {
 				'url'   => 'http://example.org/',
 				'title' => 'Page',
 			]
-			);
+		);
 
 		$this->cdn_query->method( 'query' )
 			->willReturn( $pages );

--- a/tests/Unit/inc/Engine/CDN/Render/Controller/addRocketcdnFreeSection.php
+++ b/tests/Unit/inc/Engine/CDN/Render/Controller/addRocketcdnFreeSection.php
@@ -5,6 +5,7 @@ namespace WP_Rocket\Tests\Unit\inc\Engine\CDN\Render\Controller;
 
 use Mockery;
 use WP_Rocket\Engine\Admin\Beacon\Beacon;
+use WP_Rocket\Engine\CDN\Cache;
 use WP_Rocket\Engine\CDN\Context;
 use WP_Rocket\Engine\CDN\Render\Controller;
 use WP_Rocket\Engine\CDN\RocketCDN\Database\Queries\RocketCDN as RocketCDNQuery;
@@ -65,6 +66,13 @@ class Test_AddRocketcdnFreeSection extends TestCase {
 	private $user;
 
 	/**
+	 * Cache mock instance.
+	 *
+	 * @var Mockery\MockInterface|Cache
+	 */
+	private $cache;
+
+	/**
 	 * Sets up the test fixture.
 	 *
 	 * @return void
@@ -80,6 +88,7 @@ class Test_AddRocketcdnFreeSection extends TestCase {
 		$this->cdn_query               = $this->createMock( RocketCDNQuery::class );
 		$this->subscription_controller = Mockery::mock( SubscriptionController::class );
 		$this->user                    = Mockery::mock( User::class );
+		$this->cache                    = Mockery::mock( Cache::class );
 	}
 
 	/**
@@ -95,7 +104,8 @@ class Test_AddRocketcdnFreeSection extends TestCase {
 			$this->options,
 			$this->cdn_query,
 			$this->subscription_controller,
-			$this->user
+			$this->user,
+			$this->cache
 		);
 	}
 

--- a/tests/Unit/inc/Engine/CDN/Render/Controller/addRocketcdnFreeSection.php
+++ b/tests/Unit/inc/Engine/CDN/Render/Controller/addRocketcdnFreeSection.php
@@ -1,0 +1,162 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\CDN\Render\Controller;
+
+use Mockery;
+use WP_Rocket\Engine\Admin\Beacon\Beacon;
+use WP_Rocket\Engine\CDN\Context;
+use WP_Rocket\Engine\CDN\Render\Controller;
+use WP_Rocket\Engine\CDN\RocketCDN\Database\Queries\RocketCDN as RocketCDNQuery;
+use WP_Rocket\Engine\CDN\RocketCDN\SubscriptionController;
+use WP_Rocket\Engine\License\API\User;
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * Test class covering \WP_Rocket\Engine\CDN\Render\Controller::add_rocketcdn_free_section
+ *
+ * @covers \WP_Rocket\Engine\CDN\Render\Controller::add_rocketcdn_free_section
+ * @group  CDN
+ * @group  RocketCDN
+ */
+class Test_AddRocketcdnFreeSection extends TestCase {
+
+	/**
+	 * Beacon mock instance.
+	 *
+	 * @var Mockery\MockInterface|Beacon
+	 */
+	private $beacon;
+
+	/**
+	 * CDN Context mock instance.
+	 *
+	 * @var Mockery\MockInterface|Context
+	 */
+	private $context;
+
+	/**
+	 * Options_Data mock instance.
+	 *
+	 * @var Mockery\MockInterface|Options_Data
+	 */
+	private $options;
+
+	/**
+	 * RocketCDNQuery mock instance.
+	 *
+	 * @var \PHPUnit\Framework\MockObject\MockObject|RocketCDNQuery
+	 */
+	private $cdn_query;
+
+	/**
+	 * SubscriptionController mock instance.
+	 *
+	 * @var Mockery\MockInterface|SubscriptionController
+	 */
+	private $subscription_controller;
+
+	/**
+	 * User mock instance.
+	 *
+	 * @var Mockery\MockInterface|User
+	 */
+	private $user;
+
+	/**
+	 * Sets up the test fixture.
+	 *
+	 * @return void
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->stubTranslationFunctions();
+
+		$this->beacon                  = Mockery::mock( Beacon::class );
+		$this->context                 = Mockery::mock( Context::class );
+		$this->options                 = Mockery::mock( Options_Data::class );
+		$this->cdn_query               = $this->createMock( RocketCDNQuery::class );
+		$this->subscription_controller = Mockery::mock( SubscriptionController::class );
+		$this->user                    = Mockery::mock( User::class );
+	}
+
+	/**
+	 * Creates a Controller instance under test.
+	 *
+	 * @return Controller
+	 */
+	private function get_controller(): Controller {
+		return new Controller(
+			$this->beacon,
+			'',
+			$this->context,
+			$this->options,
+			$this->cdn_query,
+			$this->subscription_controller,
+			$this->user
+		);
+	}
+
+	/**
+	 * Tests that add_rocketcdn_free_section sets limit_reached correctly.
+	 *
+	 * @dataProvider configTestData
+	 *
+	 * @param array $config   Test configuration.
+	 * @param bool  $expected Expected value of limit_reached.
+	 *
+	 * @return void
+	 */
+	public function testShouldSetLimitReachedCorrectly( array $config, bool $expected ): void {
+		$this->context->shouldReceive( 'get_driver' )
+			->andReturn( Context::ROCKETCDN_TYPE );
+
+		$this->context->shouldReceive( 'get_free_page_limit' )
+			->andReturn( 3 );
+
+		$this->beacon->shouldReceive( 'get_suggest' )
+			->with( 'rocketcdn_free' )
+			->andReturn(
+				[
+					'id'  => 'beacon-id',
+					'url' => 'https://example.com',
+				]
+				);
+
+		$this->subscription_controller->shouldReceive( 'is_subscription_creation_loading' )
+			->andReturn( false );
+
+		$this->subscription_controller->shouldReceive( 'has_inactive_subscription' )
+			->andReturn( false );
+
+		$this->subscription_controller->shouldReceive( 'is_license_invalid' )
+			->andReturn( false );
+
+		$this->options->shouldReceive( 'get' )
+			->with( 'cdn' )
+			->andReturn( true );
+
+		$pages = array_fill(
+			0,
+			$config['page_count'],
+			(object) [
+				'id'    => 1,
+				'url'   => 'http://example.org/',
+				'title' => 'Page',
+			]
+			);
+
+		$this->cdn_query->method( 'query' )
+			->willReturn( $pages );
+
+		$controller = $this->get_controller();
+		$sections   = $controller->add_rocketcdn_free_section( [] );
+
+		$this->assertArrayHasKey( 'rocketcdn_free_section', $sections );
+		$this->assertArrayHasKey( 'cta_data', $sections['rocketcdn_free_section'] );
+		$this->assertArrayHasKey( 'limit_reached', $sections['rocketcdn_free_section']['cta_data'] );
+		$this->assertSame( $expected, $sections['rocketcdn_free_section']['cta_data']['limit_reached'] );
+	}
+}

--- a/tests/Unit/inc/Engine/CDN/Render/Controller/maybeHideCdnTabBadge.php
+++ b/tests/Unit/inc/Engine/CDN/Render/Controller/maybeHideCdnTabBadge.php
@@ -6,6 +6,7 @@ namespace WP_Rocket\Tests\Unit\inc\Engine\CDN\Render\Controller;
 use Mockery;
 use PHPUnit\Framework\MockObject\MockObject;
 use WP_Rocket\Engine\Admin\Beacon\Beacon;
+use WP_Rocket\Engine\CDN\Cache;
 use WP_Rocket\Engine\CDN\Context;
 use WP_Rocket\Engine\CDN\Render\Controller;
 use WP_Rocket\Engine\CDN\RocketCDN\Database\Queries\RocketCDN as RocketCDNQuery;
@@ -51,6 +52,7 @@ class Test_MaybeHideCdnTabBadge extends TestCase {
 		$cdn_query                     = $this->createMock( RocketCDNQuery::class );
 		$this->subscription_controller = Mockery::mock( SubscriptionController::class );
 		$user                          = Mockery::mock( User::class );
+		$cache                         = Mockery::mock( Cache::class );
 
 		$this->controller = new Controller(
 			$beacon,
@@ -59,7 +61,8 @@ class Test_MaybeHideCdnTabBadge extends TestCase {
 			$options,
 			$cdn_query,
 			$this->subscription_controller,
-			$user
+			$user,
+			$cache
 		);
 	}
 


### PR DESCRIPTION
# Description

Fixes #8493

Check the issue for more context, but in this PR we introduced another layer of the API, if the subscription/status endpoint returns 404 we can get the website details from website/search endpoint and there we can find website status and real subscription status so we can know if the subscription is cancelled or not and it's inside the grace period or not.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

**Free**

• Free subscription cancelled because WPR license expired.
◦ Free subscription is force paused.
• WPR license renewed during grace period or after grace period..
◦ With no pages in free table, user works through the normal flow of adding first page to create subscription.
◦ With pages in free table, free subscription is automatically created..

**Paid**

• Paid subscription cancelled or refunded, enters int grace period..
◦ Paid subscription is force paused.
• Grace period elapses with WPR license valid.
◦ Free subscription UI is displayed.
◦ With no pages in free table, user works through the normal flow of adding first page to create subscription.
◦ With pages in free table, free subscription is automatically created..
• Grace period elapses with WPR license expired.
◦ Free subscription UI is displayed.
◦ Free subscription is force paused..

**For the update scenarios:**

1. user is on 3.21.3 with paid rocketcdn subscription => Cancel subscription => Update to the PR version => he should have the free version normal behavior.
2. User is on 3.21.3 with paid rocketcdn subscription =>cancel subscription => update to 3.22 => you should be in forced pause state => update to PR => Should be resumed with free interface.

### How to test

Mentioned above

### Affected Features & Quality Assurance Scope

RocketCDN

## Technical description

### Documentation

Everything is mentioned in the issue.

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

*If some mandatory items are not relevant, explain why in this section.*

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
