### PR TITLE
Add MCP ability execution tracking (Part of #8489)

### DIFF
--- a/inc/Engine/Abilities/Options/GetOptions.php
+++ b/inc/Engine/Abilities/Options/GetOptions.php
@@ -5,8 +5,11 @@ namespace WP_Rocket\Engine\Abilities\Options;
 
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\Abilities\AbilitiesInterface;
+use WP_Rocket\Engine\Tracking\TrackingTrait;
 
 class GetOptions implements AbilitiesInterface {
+	use TrackingTrait;
+
 	/**
 	 * Options data instance.
 	 *
@@ -407,6 +410,7 @@ class GetOptions implements AbilitiesInterface {
 	 * @return array
 	 */
 	public function execute(): array {
+		$this->track_event( 'MCP Ability Executed', [ 'ability' => 'wp-rocket/get-options' ] );
 		$denylist = [
 			'cache_mobile',
 			'do_caching_mobile_files',

--- a/inc/Engine/Abilities/Options/SetOption.php
+++ b/inc/Engine/Abilities/Options/SetOption.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 namespace WP_Rocket\Engine\Abilities\Options;
 
 use WP_Rocket\Engine\Abilities\AbilitiesInterface;
+use WP_Rocket\Engine\Tracking\TrackingTrait;
 
 class SetOption implements AbilitiesInterface {
+	use TrackingTrait;
+
 	/**
 	 * Options that accept boolean values (0 or 1).
 	 */
@@ -229,6 +232,7 @@ class SetOption implements AbilitiesInterface {
 	 * @return array Response with success status and option values.
 	 */
 	public function execute( $input = null ): array {
+		$this->track_event( 'MCP Ability Executed', [ 'ability' => 'wp-rocket/set-option' ] );
 		$option_name  = $input['option_name'];
 		$option_value = $input['option_value'];
 		$update_mode  = $input['update_mode'] ?? 'update';

--- a/inc/Engine/Admin/RocketInsights/Abilities/AddPageInsights.php
+++ b/inc/Engine/Admin/RocketInsights/Abilities/AddPageInsights.php
@@ -16,10 +16,12 @@ use WP_Rocket\Engine\Common\{
 	JobManager\Queue\Queue,
 	Utils
 };
+use WP_Rocket\Engine\Tracking\TrackingTrait;
 use WP_Rocket\Logger\Logger;
 
 class AddPageInsights implements AbilitiesInterface {
 	use PageHandlerTrait;
+	use TrackingTrait;
 
 	/**
 	 * Context instance providing necessary dependencies and configuration.
@@ -153,6 +155,7 @@ class AddPageInsights implements AbilitiesInterface {
 	 * @return array
 	 */
 	public function execute( $input = null ): array {
+		$this->track_event( 'MCP Ability Executed', [ 'ability' => 'wp-rocket/add-page-insights' ] );
 		$payload = $this->get_url_validation_payload( $input['url'] );
 
 		if ( $payload['error'] ) {

--- a/inc/Engine/Admin/RocketInsights/Abilities/GetInsightsScore.php
+++ b/inc/Engine/Admin/RocketInsights/Abilities/GetInsightsScore.php
@@ -6,8 +6,11 @@ namespace WP_Rocket\Engine\Admin\RocketInsights\Abilities;
 use WP_Rocket\Engine\Abilities\AbilitiesInterface;
 use WP_Rocket\Engine\Admin\RocketInsights\Database\Queries\RocketInsights as Query;
 use WP_Rocket\Engine\Admin\RocketInsights\GlobalScore;
+use WP_Rocket\Engine\Tracking\TrackingTrait;
 
 class GetInsightsScore implements AbilitiesInterface {
+	use TrackingTrait;
+
 	/**
 	 * Rocket Insights Query instance.
 	 *
@@ -162,6 +165,7 @@ class GetInsightsScore implements AbilitiesInterface {
 	 * @return array
 	 */
 	public function execute( $input = null ) {
+		$this->track_event( 'MCP Ability Executed', [ 'ability' => 'wp-rocket/get-insights-scores' ] );
 		$global_score = $this->global_score->get_global_score_data();
 		$results      = [];
 

--- a/inc/Engine/Admin/RocketInsights/Abilities/GetPageInsightsScore.php
+++ b/inc/Engine/Admin/RocketInsights/Abilities/GetPageInsightsScore.php
@@ -6,8 +6,11 @@ namespace WP_Rocket\Engine\Admin\RocketInsights\Abilities;
 use WP_Rocket\Engine\Abilities\AbilitiesInterface;
 use WP_Rocket\Engine\Admin\RocketInsights\Database\Queries\RocketInsights as Query;
 use WP_Rocket\Engine\Admin\RocketInsights\Managers\Plan;
+use WP_Rocket\Engine\Tracking\TrackingTrait;
 
 class GetPageInsightsScore implements AbilitiesInterface {
+	use TrackingTrait;
+
 	/**
 	 * Rocket Insights Query instance.
 	 *
@@ -135,6 +138,7 @@ class GetPageInsightsScore implements AbilitiesInterface {
 	 * @return array
 	 */
 	public function execute( $input = null ): array {
+		$this->track_event( 'MCP Ability Executed', [ 'ability' => 'wp-rocket/get-page-insights-score' ] );
 		$url  = rocket_add_url_protocol( $input['url'] );
 		$url  = untrailingslashit( $url );
 		$rows = $this->query->get_rows_by_url( $url );

--- a/inc/Engine/Admin/RocketInsights/Abilities/GetRecommendations.php
+++ b/inc/Engine/Admin/RocketInsights/Abilities/GetRecommendations.php
@@ -5,8 +5,10 @@ namespace WP_Rocket\Engine\Admin\RocketInsights\Abilities;
 
 use WP_Rocket\Engine\Abilities\AbilitiesInterface;
 use WP_Rocket\Engine\Admin\RocketInsights\Recommendations\DataManager;
+use WP_Rocket\Engine\Tracking\TrackingTrait;
 
 class GetRecommendations implements AbilitiesInterface {
+	use TrackingTrait;
 
 	/**
 	 * Option slugs that are both tracked by Rocket Insights (DataManager::TRACKED_OPTIONS)
@@ -140,6 +142,7 @@ class GetRecommendations implements AbilitiesInterface {
 	 * @return array
 	 */
 	public function execute( $input = null ): array {
+		$this->track_event( 'MCP Ability Executed', [ 'ability' => 'wp-rocket/get-recommendations' ] );
 		$data = $this->data_manager->get_recommendations();
 
 		if ( false === $data ) {

--- a/inc/Engine/Admin/RocketInsights/Abilities/RemovePageInsights.php
+++ b/inc/Engine/Admin/RocketInsights/Abilities/RemovePageInsights.php
@@ -8,8 +8,11 @@ use WP_Rocket\Engine\Admin\RocketInsights\{
 	Context\Context,
 	Database\Queries\RocketInsights as Query
 };
+use WP_Rocket\Engine\Tracking\TrackingTrait;
 
 class RemovePageInsights implements AbilitiesInterface {
+	use TrackingTrait;
+
 	/**
 	 * Context instance providing necessary dependencies and configuration.
 	 *
@@ -107,6 +110,7 @@ class RemovePageInsights implements AbilitiesInterface {
 	 * @return array
 	 */
 	public function execute( $input = null ): array {
+		$this->track_event( 'MCP Ability Executed', [ 'ability' => 'wp-rocket/remove-page-insights' ] );
 		if ( ! $this->context->is_allowed() ) {
 			return [
 				'success' => false,

--- a/inc/Engine/Admin/RocketInsights/Abilities/RetestPageInsights.php
+++ b/inc/Engine/Admin/RocketInsights/Abilities/RetestPageInsights.php
@@ -12,9 +12,11 @@ use WP_Rocket\Engine\Common\{
 	JobManager\JobProcessor,
 	JobManager\Queue\Queue
 };
+use WP_Rocket\Engine\Tracking\TrackingTrait;
 use WP_Rocket\Logger\Logger;
 
 class RetestPageInsights implements AbilitiesInterface {
+	use TrackingTrait;
 
 	/**
 	 * Context instance providing necessary dependencies and configuration.
@@ -137,6 +139,7 @@ class RetestPageInsights implements AbilitiesInterface {
 	 * @return array
 	 */
 	public function execute( $input = null ): array {
+		$this->track_event( 'MCP Ability Executed', [ 'ability' => 'wp-rocket/retest-page-insights' ] );
 		// Guard: local environments do not support performance monitoring.
 		if ( 'local' === wp_get_environment_type() ) {
 			return [


### PR DESCRIPTION
> [!NOTE]
> This pull request was generated by the AI delivery pipeline (orchestrator · Claude Opus 4.8).

Refs #8489

# Description

Adds data tracking to validate usage of MCP abilities. Each of the 8 MCP abilities now emits a `MCP Ability Executed` event from its `execute()` method, carrying the current ability name, so the product team can measure MCP adoption and per-ability usage.

This PR implements **only the ability-execution tracking slice** of #8489. The other parts of the issue (`MCP Abilities Pinged` via `tools/list`, and the `changed_through` property on the `Option Changed` event) remain out of scope and are intentionally not addressed here — hence `Refs` rather than `Closes`.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

Acceptance criteria:

- [x] Given an MCP ability's `execute()` runs, When it executes, Then a `MCP Ability Executed` event is emitted via `TrackingTrait::track_event()`.
- [x] Given the event is emitted, Then it carries `event_data` `ability => <current ability name>` (the `wp-rocket/<slug>` used in `wp_register_ability()`).
- [x] Given the MCP abilities surface, Then all 8 registered abilities are covered (RocketInsights ×6 + Options ×2).

### What was tested

- The new `MCP Ability Executed` event fires from each of the 8 MCP abilities' `execute()` with the correct `ability` slug.
- Each tracked slug matches that ability's `wp_register_ability()` registration verbatim (verified 1:1).
- Static checks all pass: `php -l` (8/8), PHPCS (8/8), PHPStan (`[OK] No errors`).

Per the ticket's explicit instruction, no unit or integration tests were added for this change.

### How to test

1. On a non-local WordPress install with an MCP client connected to the WP Rocket MCP endpoint, invoke an ability — e.g. `wp-rocket/get-options`.
2. Confirm a `MCP Ability Executed` event is emitted with `event_data` `ability = wp-rocket/get-options`. Observe it via Mixpanel, or locally via a temporary listener: `add_action( 'rocket_mixpanel_track_event', function ( $name, $data ) { error_log( $name . ' ' . wp_json_encode( $data ) ); }, 10, 2 );`.
3. Invoke a second ability (e.g. `wp-rocket/get-recommendations`) and confirm the event fires again with the slug updated accordingly.

### Affected Features & Quality Assurance Scope

- MCP abilities — RocketInsights (`add-page-insights`, `get-insights-scores`, `get-page-insights-score`, `get-recommendations`, `remove-page-insights`, `retest-page-insights`) and Options (`get-options`, `set-option`).
- Data tracking only — no change to the abilities' behavior, inputs, outputs, or permissions.
- Backwards compatibility — no breaking changes; the `rocket_mixpanel_track_event` action already existed.

## Technical description

### How it works

Each of the 8 ability classes now:

1. Imports and uses the existing `WP_Rocket\Engine\Tracking\TrackingTrait`.
2. Calls `$this->track_event( 'MCP Ability Executed', [ 'ability' => 'wp-rocket/<slug>' ] )` as the first statement of `execute()`, so the event fires whenever the ability runs.

`track_event()` fires the pre-existing `rocket_mixpanel_track_event` action. The `<slug>` literal in each call is copied verbatim from that file's own `wp_register_ability()` registration, so the tracked name can never drift from the registered name without a reviewer seeing both lines in the same file. No new files, traits, abstractions, or ServiceProvider changes were introduced.

### Documentation

No developer-facing documentation changes are required. This is internal instrumentation; the `rocket_mixpanel_track_event` action it relies on already exists and is unchanged.

### New dependencies

None.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit and actionable.

## Unticked items justification

Unit/integration tests were intentionally skipped per the ticket's explicit "skip tests / keep it simple" instruction. The change is a minimal, mechanical, additive instrumentation call with no branching logic.

# Additional Checks

- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
