### PR TITLE
Fix preload font external domain path filtering

### DIFF
--- a/inc/Engine/Media/PreloadFonts/AJAX/Controller.php
+++ b/inc/Engine/Media/PreloadFonts/AJAX/Controller.php
@@ -155,22 +155,24 @@ class Controller implements ControllerInterface {
 	 * @return array Filtered array of fonts, excluding those specified in the exclusion list.
 	 */
 	private function filter_fonts( array $fonts, array $exclusions ): array {
-		if ( empty( $exclusions ) ) {
-			return $fonts;
-		}
-
 		/**
 		 * Create a single regex pattern from all exclusions.
 		 * Use a different delimiter (#) to avoid issues with URLs containing slashes.
 		 */
-		$pattern    = '#(' . implode( '|', array_map( 'preg_quote', $exclusions ) ) . ')#i';
+		$pattern    = empty( $exclusions ) ? '' : '#(' . implode( '|', array_map( 'preg_quote', $exclusions ) ) . ')#i';
 		$extensions = $this->context->get_extensions();
 
 		// Filter out fonts that match the pattern.
 		$filtered_fonts = array_filter(
 			$fonts,
 			function ( $font ) use ( $pattern, $exclusions, $extensions ) {
-				if ( ! in_array( pathinfo( $font, PATHINFO_EXTENSION ), $extensions, true ) ) {
+				$path = wp_parse_url( $font, PHP_URL_PATH ) ?: $font;
+
+				if ( ! in_array( pathinfo( $path, PATHINFO_EXTENSION ), $extensions, true ) ) {
+					return false;
+				}
+
+				if ( $this->is_external_domain_path( $font ) ) {
 					return false;
 				}
 
@@ -180,10 +182,27 @@ class Controller implements ControllerInterface {
 				}
 
 				// Check for substring match using regex.
-				return ! preg_match( $pattern, $font );
+				return empty( $pattern ) || ! preg_match( $pattern, $font );
 			}
 		);
 
 		return array_values( $filtered_fonts );
+	}
+
+	/**
+	 * Checks if a font is a scheme-less external domain path.
+	 *
+	 * @param string $font Font URL or path.
+	 *
+	 * @return bool
+	 */
+	private function is_external_domain_path( string $font ): bool {
+		if ( wp_parse_url( $font, PHP_URL_SCHEME ) ) {
+			return false;
+		}
+
+		$first_path_segment = strtok( ltrim( $font, '/' ), '/' );
+
+		return is_string( $first_path_segment ) && str_contains( $first_path_segment, '.' );
 	}
 }

--- a/tests/Fixtures/inc/Engine/Media/PreloadFonts/AJAX/Controller/addData.php
+++ b/tests/Fixtures/inc/Engine/Media/PreloadFonts/AJAX/Controller/addData.php
@@ -10,6 +10,8 @@ return [
 				'preload_fonts' => [
 					'https://fonts.gstatic.com/s/raleway/v34/1Ptug8zYS_SKggPNyC0IT4ttDfA.woff2',
 					'https://fonts.googleapis.com/css?family=Roboto',
+					'fonts.gstatic.com/s/poppins/v13/pxiByp8kv8JHgFVrLGT9Z1xlFQ.woff2',
+					'/fonts.gstatic.com/s/poppins/v13/pxiByp8kv8JHgFVrLGT9Z1xlFQ.woff2',
 				]
 			]),
 		],
@@ -21,7 +23,6 @@ return [
 				'fonts' => json_encode(
 					[
 						'https://fonts.gstatic.com/s/raleway/v34/1Ptug8zYS_SKggPNyC0IT4ttDfA.woff2',
-						'https://fonts.googleapis.com/css?family=Roboto',
 					],
 				),
 				'last_accessed'  => '2025-02-02 00:00:00',
@@ -37,7 +38,6 @@ return [
 				'fonts' => json_encode(
 					[
 						'https://fonts.gstatic.com/s/raleway/v34/1Ptug8zYS_SKggPNyC0IT4ttDfA.woff2',
-						'https://fonts.googleapis.com/css?family=Roboto',
 					],
 				),
 				'created_at'     => '2025-02-02 00:00:00',
@@ -138,7 +138,6 @@ return [
 				'fonts' => json_encode(
 					[
 						'https://fonts.gstatic.com/s/raleway/v34/1Ptug8zYS_SKggPNyC0IT4ttDfA.woff2',
-						'https://fonts.googleapis.com/css?family=Roboto',
 					],
 				),
 				'last_accessed'  => '2025-02-02 00:00:00',
@@ -169,7 +168,6 @@ return [
 				'fonts' => json_encode(
 					[
 						'https://fonts.gstatic.com/s/raleway/v34/1Ptug8zYS_SKggPNyC0IT4ttDfA.woff2',
-						'https://fonts.googleapis.com/css?family=Roboto',
 					],
 				),
 				'last_accessed'  => '2025-02-02 00:00:00',
@@ -185,7 +183,6 @@ return [
 				'fonts' => json_encode(
 					[
 						'https://fonts.gstatic.com/s/raleway/v34/1Ptug8zYS_SKggPNyC0IT4ttDfA.woff2',
-						'https://fonts.googleapis.com/css?family=Roboto',
 					],
 				),
 				'created_at'     => '2025-02-02 00:00:00',


### PR DESCRIPTION
## Summary

- Fixes #3276
- Keeps Preload Fonts from saving scheme-less external-domain paths such as `fonts.gstatic.com/...woff2`
- Also rejects root-prefixed external-domain paths such as `/fonts.gstatic.com/...woff2` before they can be output as same-origin preload links
- Ensures extension validation runs even when there are no preload-font exclusions configured

## Testing

- `vendor/bin/phpunit --testsuite unit --colors=always --configuration tests/Unit/phpunit.xml.dist tests/Unit/inc/Engine/Media/PreloadFonts/AJAX/Controller/addData.php`
- `vendor/bin/phpcs --basepath=. inc/Engine/Media/PreloadFonts/AJAX/Controller.php`
- `git diff --check`

Note: running PHPCS on the fixture file reports existing fixture-formatting issues across the data provider, so I kept this PR focused on the behavior change and validated the touched production file separately.
