### PR TITLE
Fix: Remove unnecessary cache clear from RocketCDN free subscription auto-create

### DIFF
--- a/inc/Engine/CDN/Render/Controller.php
+++ b/inc/Engine/CDN/Render/Controller.php
@@ -678,13 +678,13 @@ class Controller extends Abstract_Render {
 		$stored['persistent'] = false;
 		update_option( self::FORCED_PAUSE_TRACKING_OPTION, $stored, false );
 
-		// Clear whole cache.
-		$this->cache->clear_all_cache();
-
 		// Bail out if there are no add pages in the free plan — no need to auto create, allow normal flow.
 		if ( empty( $this->get_items() ) ) {
 			return;
 		}
+
+		// Clear whole cache.
+		$this->cache->clear_all_cache();
 
 		// Auto-create a new subscription to resume free RocketCDN service.
 		$this->subscription_controller->create_subscription();

--- a/inc/Engine/CDN/Render/Controller.php
+++ b/inc/Engine/CDN/Render/Controller.php
@@ -683,9 +683,6 @@ class Controller extends Abstract_Render {
 			return;
 		}
 
-		// Clear whole cache.
-		$this->cache->clear_all_cache();
-
 		// Auto-create a new subscription to resume free RocketCDN service.
 		$this->subscription_controller->create_subscription();
 	}


### PR DESCRIPTION
# Description

Fixes #8551

`maybe_auto_create_rocketcdn_free_subscription()` runs on every `admin_init`. It was calling `clear_all_cache()` before `create_subscription()`, which triggered a full preload-cache table update (`UPDATE wpr_rocket_cache SET status = 'pending' WHERE 1 = 1`) on every admin page load for any site whose subscription was cancelled outside the grace period. On busy sites this caused lock-wait-timeout DB errors and made the WP admin barely accessible.

The fix removes `clear_all_cache()` entirely from this flow. The cache clear is not needed here: `create_subscription()` handles resuming free CDN delivery on its own, and there is no requirement to invalidate the local cache at this point.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

- **Manual — subscription cancelled outside grace period, free pages present**: Before fix: `clear_all_cache()` fired on every admin page load, causing DB lock-wait errors. After fix: `create_subscription()` is called directly with no cache wipe, admin remains responsive.
- **Manual — subscription active / in grace period**: Existing early-return guards still prevent the method body from running (unchanged behaviour).
- **Manual — no free RocketCDN pages (`get_items()` empty)**: Early return is hit before reaching `create_subscription()` — unchanged behaviour.

### How to test

**Setup:**
1. Install WP Rocket 3.22.0.2+ on a test site.
2. Simulate a forced-pause tracking state: set `FORCED_PAUSE_TRACKING_OPTION` so `is_cancelled_outside_grace_period()` returns `true`, `is_paid()` returns `false`, `is_license_invalid()` returns `false`.
3. Ensure `get_items()` returns at least one item (free RocketCDN pages present).

**Steps:**
1. Navigate to any WP admin page (e.g., Dashboard).
2. Watch the slow-query log or run: `SHOW PROCESSLIST` during the request.

**Expected (after fix):**
- No `UPDATE wpr_rocket_cache SET status = 'pending' WHERE 1 = 1` query is executed.
- `create_subscription()` is still called — free CDN subscription resumes as expected.
- Admin remains responsive with no DB lock errors.

**Regression check:**
1. Repeat with `get_items()` returning empty → method returns early, `create_subscription()` is not called (same as before).
2. Repeat with subscription active → early return at line 663 (same as before).

### Affected Features & Quality Assurance Scope

- **RocketCDN Free subscription auto-create flow** (`CDN > Render > Controller::maybe_auto_create_rocketcdn_free_subscription`)
- **WP admin performance** — no longer triggers a full preload-cache table update on admin page loads
- **Cache behaviour** — local cache is no longer cleared during this flow; free CDN delivery resumes via `create_subscription()` alone

## Technical description

### Documentation

`maybe_auto_create_rocketcdn_free_subscription()` is hooked to `admin_init`. The problematic call chain:

```
admin_init
 └─ maybe_auto_create_rocketcdn_free_subscription()
     └─ CDN\Cache::clear_all_cache()           ← removed
         └─ rocket_clean_domain()
             └─ do_action('rocket_after_clean_domain')
                 └─ Preload\Subscriber::clean_full_cache()
                     └─ Preload\Database\Queries\Cache::set_all_to_pending()
                         └─ UPDATE wpr_rocket_cache SET status='pending' WHERE 1=1
```

This `UPDATE … WHERE 1 = 1` acquires a table-level lock. On concurrent admin requests it caused `Lock wait timeout exceeded` and made the WP backend barely accessible.

**The fix** removes `clear_all_cache()` entirely. The subscription creation flow in `create_subscription()` is self-contained and does not require a prior full cache wipe.

```php
// Before (broken)
if ( empty( $this->get_items() ) ) { return; }
$this->cache->clear_all_cache();               // ← removed
$this->subscription_controller->create_subscription();

// After (fixed)
if ( empty( $this->get_items() ) ) { return; }
$this->subscription_controller->create_subscription();
```

### New dependencies

None.

### Risks

- **Low.** One line removed. No new logic introduced.
- The local cache is no longer cleared when the free CDN subscription auto-creates. If there is a specific reason the cache must be cleared at this point, a follow-up issue should document it and reintroduce the call with a proper guard.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

- **Built-in tests**: The change is a single line deletion. The existing unit tests for `maybe_auto_create_rocketcdn_free_subscription` cover all execution paths. A dedicated test asserting `clear_all_cache` is never called will be added in a follow-up test issue.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)