### PR TITLE
feat: back up WP Rocket options automatically on each plugin update

### DIFF
--- a/inc/Engine/Plugin/OptionsBackup.php
+++ b/inc/Engine/Plugin/OptionsBackup.php
@@ -1,0 +1,94 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Engine\Plugin;
+
+class OptionsBackup {
+
+	const KEEP_COUNT = 4;
+
+	private string $config_path;
+	private string $options_slug;
+
+	public function __construct( string $config_path, string $options_slug ) {
+		$this->config_path  = $config_path;
+		$this->options_slug = $options_slug;
+	}
+
+	/**
+	 * Backs up the current options before a plugin upgrade runs.
+	 *
+	 * Skips if the upgrade is a rollback (new < old) or if a backup for
+	 * $new_version already exists (only the first snapshot per version is kept).
+	 *
+	 * @param string $new_version Incoming plugin version.
+	 * @param string $old_version Currently installed plugin version.
+	 * @return bool True when a backup was written, false when skipped or failed.
+	 */
+	public function backup( string $new_version, string $old_version ): bool {
+		if ( version_compare( $new_version, $old_version, '<' ) ) {
+			return false;
+		}
+
+		if ( $this->backup_exists_for_version( $new_version ) ) {
+			return false;
+		}
+
+		$options = get_option( $this->options_slug );
+
+		if ( false === $options ) {
+			return false;
+		}
+
+		rocket_init_config_dir();
+
+		$filename = 'wp_rocket_settings_backup_' . $new_version . '_' . gmdate( 'Y-m-d-H-i-s' ) . '.json';
+		$written  = rocket_put_content(
+			$this->config_path . $filename,
+			(string) wp_json_encode( $options, JSON_PRETTY_PRINT )
+		);
+
+		if ( ! $written ) {
+			return false;
+		}
+
+		$this->garbage_collect();
+
+		return true;
+	}
+
+	/**
+	 * Checks whether a backup file for the given version already exists.
+	 *
+	 * @param string $version Plugin version to look up.
+	 * @return bool
+	 */
+	private function backup_exists_for_version( string $version ): bool {
+		$files = glob( $this->config_path . 'wp_rocket_settings_backup_' . $version . '_*.json' );
+		return ! empty( $files );
+	}
+
+	/**
+	 * Deletes oldest backup files beyond KEEP_COUNT, sorted by modification time.
+	 */
+	private function garbage_collect(): void {
+		$files = glob( $this->config_path . 'wp_rocket_settings_backup_*.json' );
+
+		if ( ! $files || count( $files ) <= self::KEEP_COUNT ) {
+			return;
+		}
+
+		usort(
+			$files,
+			function ( string $a, string $b ): int {
+				return filemtime( $b ) - filemtime( $a );
+			}
+		);
+
+		$filesystem = rocket_direct_filesystem();
+
+		foreach ( array_slice( $files, self::KEEP_COUNT ) as $old_file ) {
+			$filesystem->delete( $old_file );
+		}
+	}
+}

--- a/inc/Engine/Plugin/OptionsBackupSubscriber.php
+++ b/inc/Engine/Plugin/OptionsBackupSubscriber.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Engine\Plugin;
+
+use WP_Rocket\Event_Management\Subscriber_Interface;
+
+class OptionsBackupSubscriber implements Subscriber_Interface {
+
+	private OptionsBackup $backup;
+
+	public function __construct( OptionsBackup $backup ) {
+		$this->backup = $backup;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public static function get_subscribed_events(): array {
+		return [
+			'wp_rocket_upgrade' => [ 'backup_options', 1, 2 ],
+		];
+	}
+
+	/**
+	 * Triggers the backup before the upgrade routines run.
+	 *
+	 * @param string $new_version Incoming plugin version.
+	 * @param string $old_version Currently installed plugin version.
+	 */
+	public function backup_options( string $new_version, string $old_version ): void {
+		$this->backup->backup( $new_version, $old_version );
+	}
+}

--- a/inc/Engine/Plugin/ServiceProvider.php
+++ b/inc/Engine/Plugin/ServiceProvider.php
@@ -21,6 +21,8 @@ class ServiceProvider extends AbstractServiceProvider {
 		'plugin_updater_common_subscriber',
 		'plugin_information_subscriber',
 		'plugin_updater_subscriber',
+		'options_backup',
+		'options_backup_subscriber',
 	];
 
 	/**
@@ -84,5 +86,14 @@ class ServiceProvider extends AbstractServiceProvider {
 					),
 				]
 			);
+		$this->getContainer()->addShared( 'options_backup', OptionsBackup::class )
+			->addArguments(
+				[
+					new StringArgument( WP_ROCKET_CONFIG_PATH ),
+					new StringArgument( WP_ROCKET_SLUG ),
+				]
+			);
+		$this->getContainer()->addShared( 'options_backup_subscriber', OptionsBackupSubscriber::class )
+			->addArgument( 'options_backup' );
 	}
 }

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -334,6 +334,7 @@ class Plugin {
 			'plugin_updater_common_subscriber',
 			'plugin_information_subscriber',
 			'plugin_updater_subscriber',
+			'options_backup_subscriber',
 			'capabilities_subscriber',
 			'varnish_subscriber',
 			'rocketcdn_rest_subscriber',

--- a/patchwork.json
+++ b/patchwork.json
@@ -1,0 +1,3 @@
+{
+	"redefinable-internals": ["glob", "filemtime", "gmdate"]
+}

--- a/tests/Fixtures/inc/Engine/Plugin/OptionsBackup/backup.php
+++ b/tests/Fixtures/inc/Engine/Plugin/OptionsBackup/backup.php
@@ -1,0 +1,118 @@
+<?php
+
+return [
+	'shouldReturnFalseOnRollback' => [
+		'config' => [
+			'new_version'    => '3.21.0',
+			'old_version'    => '3.22.0',
+			'existing_files' => [],
+			'options'        => false,
+		],
+		'expected' => [
+			'result'        => false,
+			'write_called'  => false,
+			'delete_called' => false,
+		],
+	],
+	'shouldReturnFalseWhenSameVersion' => [
+		'config' => [
+			'new_version'    => '3.22.0',
+			'old_version'    => '3.22.0',
+			'existing_files' => [],
+			'options'        => false,
+		],
+		'expected' => [
+			'result'        => false,
+			'write_called'  => false,
+			'delete_called' => false,
+		],
+	],
+	'shouldReturnFalseWhenBackupAlreadyExists' => [
+		'config' => [
+			'new_version'    => '3.22.1',
+			'old_version'    => '3.22.0',
+			'existing_files' => [ '/wp-rocket-config/wp_rocket_settings_backup_3.22.1_2026-06-01-10-00-00.json' ],
+			'options'        => false,
+		],
+		'expected' => [
+			'result'        => false,
+			'write_called'  => false,
+			'delete_called' => false,
+		],
+	],
+	'shouldReturnFalseWhenNoOptions' => [
+		'config' => [
+			'new_version'    => '3.22.1',
+			'old_version'    => '3.22.0',
+			'existing_files' => [],
+			'options'        => false,
+		],
+		'expected' => [
+			'result'        => false,
+			'write_called'  => false,
+			'delete_called' => false,
+		],
+	],
+	'shouldReturnFalseWhenWriteFails' => [
+		'config' => [
+			'new_version'    => '3.22.1',
+			'old_version'    => '3.22.0',
+			'existing_files' => [],
+			'options'        => [ 'version' => '3.22.0', 'minify_css' => 1 ],
+			'write_result'   => false,
+		],
+		'expected' => [
+			'result'        => false,
+			'write_called'  => true,
+			'delete_called' => false,
+		],
+	],
+	'shouldWriteBackupSuccessfullyUnderKeepCount' => [
+		'config' => [
+			'new_version'    => '3.22.1',
+			'old_version'    => '3.22.0',
+			'existing_files' => [],
+			'options'        => [ 'version' => '3.22.0', 'minify_css' => 1 ],
+			'write_result'   => true,
+			'all_backups'    => [
+				'/wp-rocket-config/wp_rocket_settings_backup_3.22.1_2026-06-29-10-00-00.json',
+			],
+		],
+		'expected' => [
+			'result'        => true,
+			'write_called'  => true,
+			'delete_called' => false,
+		],
+	],
+	'shouldGarbageCollectWhenExceedsKeepCount' => [
+		'config' => [
+			'new_version'    => '3.22.4',
+			'old_version'    => '3.22.3',
+			'existing_files' => [],
+			'options'        => [ 'version' => '3.22.3', 'minify_css' => 1 ],
+			'write_result'   => true,
+			'all_backups'    => [
+				'/wp-rocket-config/wp_rocket_settings_backup_3.22.4_2026-06-29-10-00-04.json',
+				'/wp-rocket-config/wp_rocket_settings_backup_3.22.3_2026-06-29-10-00-03.json',
+				'/wp-rocket-config/wp_rocket_settings_backup_3.22.2_2026-06-29-10-00-02.json',
+				'/wp-rocket-config/wp_rocket_settings_backup_3.22.1_2026-06-29-10-00-01.json',
+				'/wp-rocket-config/wp_rocket_settings_backup_3.22.0_2026-06-29-10-00-00.json',
+			],
+			'mtimes'        => [
+				'/wp-rocket-config/wp_rocket_settings_backup_3.22.4_2026-06-29-10-00-04.json' => 1751189204,
+				'/wp-rocket-config/wp_rocket_settings_backup_3.22.3_2026-06-29-10-00-03.json' => 1751189203,
+				'/wp-rocket-config/wp_rocket_settings_backup_3.22.2_2026-06-29-10-00-02.json' => 1751189202,
+				'/wp-rocket-config/wp_rocket_settings_backup_3.22.1_2026-06-29-10-00-01.json' => 1751189201,
+				'/wp-rocket-config/wp_rocket_settings_backup_3.22.0_2026-06-29-10-00-00.json' => 1751189200,
+			],
+			'files_to_delete' => [
+				'/wp-rocket-config/wp_rocket_settings_backup_3.22.0_2026-06-29-10-00-00.json',
+			],
+		],
+		'expected' => [
+			'result'        => true,
+			'write_called'  => true,
+			'delete_called' => true,
+		],
+	],
+];

--- a/tests/Unit/inc/Engine/Plugin/OptionsBackup/backup.php
+++ b/tests/Unit/inc/Engine/Plugin/OptionsBackup/backup.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\Plugin\OptionsBackup;
+
+use Brain\Monkey\Functions;
+use Mockery;
+use WP_Filesystem_Direct;
+use WP_Rocket\Engine\Plugin\OptionsBackup;
+use WPMedia\PHPUnit\Unit\TestCase as BaseTestCase;
+
+/**
+ * Test class covering \WP_Rocket\Engine\Plugin\OptionsBackup::backup
+ *
+ * @group Plugin
+ */
+class TestBackup extends BaseTestCase {
+
+	const CONFIG_PATH  = '/wp-rocket-config/';
+	const OPTIONS_SLUG = 'wp_rocket_settings';
+	const FIXED_DATE   = '2026-06-29-10-00-00';
+
+	private OptionsBackup $subject;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->subject = new OptionsBackup( self::CONFIG_PATH, self::OPTIONS_SLUG );
+	}
+
+	public function testShouldReturnFalseOnRollback(): void {
+		$this->assertFalse( $this->subject->backup( '3.21.0', '3.22.0' ) );
+	}
+
+	public function testShouldReturnFalseWhenBackupAlreadyExistsForVersion(): void {
+		Functions\expect( 'glob' )
+			->once()
+			->with( self::CONFIG_PATH . 'wp_rocket_settings_backup_3.22.1_*.json' )
+			->andReturn( [ self::CONFIG_PATH . 'wp_rocket_settings_backup_3.22.1_2026-06-01-10-00-00.json' ] );
+
+		Functions\expect( 'get_option' )->never();
+
+		$this->assertFalse( $this->subject->backup( '3.22.1', '3.22.0' ) );
+	}
+
+	public function testShouldReturnFalseWhenOptionsNotFound(): void {
+		Functions\expect( 'glob' )
+			->once()
+			->with( self::CONFIG_PATH . 'wp_rocket_settings_backup_3.22.1_*.json' )
+			->andReturn( [] );
+
+		Functions\expect( 'get_option' )
+			->once()
+			->with( self::OPTIONS_SLUG )
+			->andReturn( false );
+
+		Functions\expect( 'rocket_put_content' )->never();
+
+		$this->assertFalse( $this->subject->backup( '3.22.1', '3.22.0' ) );
+	}
+
+	public function testShouldReturnFalseWhenWriteFails(): void {
+		$options = [ 'version' => '3.22.0', 'minify_css' => 1 ];
+
+		Functions\expect( 'glob' )
+			->once()
+			->with( self::CONFIG_PATH . 'wp_rocket_settings_backup_3.22.1_*.json' )
+			->andReturn( [] );
+
+		Functions\expect( 'get_option' )
+			->once()
+			->with( self::OPTIONS_SLUG )
+			->andReturn( $options );
+
+		Functions\expect( 'rocket_init_config_dir' )->once();
+		Functions\when( 'gmdate' )->justReturn( self::FIXED_DATE );
+		Functions\when( 'wp_json_encode' )->justReturn( (string) json_encode( $options, JSON_PRETTY_PRINT ) );
+
+		Functions\expect( 'rocket_put_content' )
+			->once()
+			->andReturn( false );
+
+		$this->assertFalse( $this->subject->backup( '3.22.1', '3.22.0' ) );
+	}
+
+	public function testShouldReturnTrueAndSkipGcWhenUnderLimit(): void {
+		$options = [ 'version' => '3.22.0', 'minify_css' => 1 ];
+
+		Functions\expect( 'glob' )
+			->once()
+			->with( self::CONFIG_PATH . 'wp_rocket_settings_backup_3.22.1_*.json' )
+			->andReturn( [] );
+
+		Functions\expect( 'get_option' )
+			->once()
+			->with( self::OPTIONS_SLUG )
+			->andReturn( $options );
+
+		Functions\expect( 'rocket_init_config_dir' )->once();
+		Functions\when( 'gmdate' )->justReturn( self::FIXED_DATE );
+		Functions\when( 'wp_json_encode' )->justReturn( (string) json_encode( $options, JSON_PRETTY_PRINT ) );
+
+		Functions\expect( 'rocket_put_content' )
+			->once()
+			->andReturn( true );
+
+		Functions\expect( 'glob' )
+			->once()
+			->with( self::CONFIG_PATH . 'wp_rocket_settings_backup_*.json' )
+			->andReturn( [ self::CONFIG_PATH . 'wp_rocket_settings_backup_3.22.1_' . self::FIXED_DATE . '.json' ] );
+
+		Functions\expect( 'rocket_direct_filesystem' )->never();
+
+		$this->assertTrue( $this->subject->backup( '3.22.1', '3.22.0' ) );
+	}
+
+	public function testShouldDeleteOldestFileWhenGcThresholdExceeded(): void {
+		$options   = [ 'version' => '3.22.3', 'minify_css' => 1 ];
+		$all_files = [
+			self::CONFIG_PATH . 'wp_rocket_settings_backup_3.22.4_2026-06-29-10-00-04.json',
+			self::CONFIG_PATH . 'wp_rocket_settings_backup_3.22.3_2026-06-29-10-00-03.json',
+			self::CONFIG_PATH . 'wp_rocket_settings_backup_3.22.2_2026-06-29-10-00-02.json',
+			self::CONFIG_PATH . 'wp_rocket_settings_backup_3.22.1_2026-06-29-10-00-01.json',
+			self::CONFIG_PATH . 'wp_rocket_settings_backup_3.22.0_2026-06-29-10-00-00.json',
+		];
+		$mtimes    = [
+			self::CONFIG_PATH . 'wp_rocket_settings_backup_3.22.4_2026-06-29-10-00-04.json' => 1751189204,
+			self::CONFIG_PATH . 'wp_rocket_settings_backup_3.22.3_2026-06-29-10-00-03.json' => 1751189203,
+			self::CONFIG_PATH . 'wp_rocket_settings_backup_3.22.2_2026-06-29-10-00-02.json' => 1751189202,
+			self::CONFIG_PATH . 'wp_rocket_settings_backup_3.22.1_2026-06-29-10-00-01.json' => 1751189201,
+			self::CONFIG_PATH . 'wp_rocket_settings_backup_3.22.0_2026-06-29-10-00-00.json' => 1751189200,
+		];
+
+		Functions\expect( 'glob' )
+			->once()
+			->with( self::CONFIG_PATH . 'wp_rocket_settings_backup_3.22.4_*.json' )
+			->andReturn( [] );
+
+		Functions\expect( 'get_option' )
+			->once()
+			->with( self::OPTIONS_SLUG )
+			->andReturn( $options );
+
+		Functions\expect( 'rocket_init_config_dir' )->once();
+		Functions\when( 'gmdate' )->justReturn( '2026-06-29-10-00-04' );
+		Functions\when( 'wp_json_encode' )->justReturn( (string) json_encode( $options, JSON_PRETTY_PRINT ) );
+
+		Functions\expect( 'rocket_put_content' )
+			->once()
+			->andReturn( true );
+
+		Functions\expect( 'glob' )
+			->once()
+			->with( self::CONFIG_PATH . 'wp_rocket_settings_backup_*.json' )
+			->andReturn( $all_files );
+
+		// filemtime is called repeatedly by usort — use when() alias to avoid count issues.
+		Functions\when( 'filemtime' )->alias(
+			function ( string $file ) use ( $mtimes ): int {
+				return $mtimes[ $file ] ?? 0;
+			}
+		);
+
+		$filesystem = Mockery::mock( WP_Filesystem_Direct::class );
+		Functions\expect( 'rocket_direct_filesystem' )
+			->once()
+			->andReturn( $filesystem );
+
+		$filesystem->shouldReceive( 'delete' )
+			->once()
+			->with( self::CONFIG_PATH . 'wp_rocket_settings_backup_3.22.0_2026-06-29-10-00-00.json' );
+
+		$this->assertTrue( $this->subject->backup( '3.22.4', '3.22.3' ) );
+	}
+}


### PR DESCRIPTION
## Linked issue

Closes #8532

## Summary

- **`OptionsBackup`** — new service class that snapshots `wp_rocket_settings` to a versioned JSON file inside `wp-rocket-config/` before each upgrade's migration callbacks run.
- **`OptionsBackupSubscriber`** — hooks `wp_rocket_upgrade` at priority 1 (before migration routines at priority 10) and delegates to `OptionsBackup::backup()`.
- **`ServiceProvider`** — registers both classes in the Plugin DI container.
- **`Plugin.php`** — adds `options_backup_subscriber` to the common subscribers list.
- **`patchwork.json`** — enables Brain\Monkey to mock `glob`, `filemtime`, and `gmdate` in unit tests.
- **Unit tests** — 6 tests covering every code path.

## Grooming decisions (from #8532 comment)

| Decision | Detail |
|---|---|
| Storage | JSON file in `wp-rocket-config/` (approach 2 from the issue) |
| Rollback detection | `version_compare($new, $old, '<')` → skip; no separate rollback backup needed |
| One backup per version | Check for `wp_rocket_settings_backup_{new_version}_*.json` before writing; skip if found |
| Retention | Keep the 4 most recent files by mtime; delete the rest |
| Hook priority | Priority 1 on `wp_rocket_upgrade` — runs before `rocket_new_upgrade` at priority 10 |

## File naming

```
wp-rocket-config/wp_rocket_settings_backup_{version}_{Y-m-d-H-i-s}.json
```

Example: `wp_rocket_settings_backup_3.22.1_2026-06-29-14-30-00.json`

## Test plan

- [x] Unit tests pass: `composer test-unit -- --filter=TestBackup` → 6/6 ✅
- [ ] Manual: upgrade WP Rocket on a local install and verify the JSON file appears in `wp-content/wp-rocket-config/`
- [ ] Manual: downgrade (rollback) and confirm no new file is created
- [ ] Manual: upgrade to the same version a second time and confirm the existing backup is not overwritten
- [ ] Manual: perform 5+ upgrades and confirm only 4 backup files are retained