### PR TITLE
enhancement: bump minimum PHP version from 7.3 to 7.4

### DIFF
--- a/.github/workflows/deploy_plugin.yml
+++ b/.github/workflows/deploy_plugin.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.3'
+          php-version: '7.4'
           tools: composer:v2
 
       - name: Get composer cache directory

--- a/.github/workflows/test_wprocket.yml
+++ b/.github/workflows/test_wprocket.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: true
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['7.3', '7.4']
+        php-versions: ['7.4']
         wp-versions: ['5.9']
 
     name: WP ${{ matrix.wp-versions }} with PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }}.

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
 		}
 	],
 	"require": {
-		"php": ">=7.3",
+		"php": ">=7.4",
 		"cloudflare/cf-ip-rewrite": "^1.0",
 		"composer/installers": "^1.0 || ^2.0",
 		"voku/simple_html_dom": "^4.8",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -27,7 +27,7 @@
 
 	<!-- Rules: Check PHP version compatibility - see https://github.com/PHPCompatibility/PHPCompatibilityWP -->
 	<rule ref="PHPCompatibility"/>
-	<config name="testVersion" value="7.3-"/>
+	<config name="testVersion" value="7.4-"/>
 	<config name="minimum_supported_wp_version" value="5.8"/>
 
 	<rule ref="WordPress">

--- a/wp-rocket.php
+++ b/wp-rocket.php
@@ -5,7 +5,7 @@
  * Description: The best WordPress performance plugin.
  * Version: 3.22.0.3
  * Requires at least: 5.8
- * Requires PHP: 7.3
+ * Requires PHP: 7.4
  * Code Name: Iego
  * Author: WP Media
  * Author URI: https://wp-media.me
@@ -23,7 +23,7 @@ defined( 'ABSPATH' ) || exit;
 define( 'WP_ROCKET_VERSION',               '3.22.0.3' );
 define( 'WP_ROCKET_WP_VERSION',            '5.8' );
 define( 'WP_ROCKET_WP_VERSION_TESTED',     '6.3.1' );
-define( 'WP_ROCKET_PHP_VERSION',           '7.3' );
+define( 'WP_ROCKET_PHP_VERSION',           '7.4' );
 define( 'WP_ROCKET_PRIVATE_KEY',           false );
 define( 'WP_ROCKET_SLUG',                  'wp_rocket_settings' );
 define( 'WP_ROCKET_WEB_MAIN',              'https://wp-rocket.me/' );


### PR DESCRIPTION
# Description

Bumps the minimum supported PHP version from 7.3 to 7.4.

PHP 7.3 reached end-of-life in December 2021 and no longer receives security patches. PHP 7.4 has been tested in CI all along, so this is a formal acknowledgement of what we already support.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

### What was tested

- Verified all five files are updated consistently.
- CI matrix for Old PHP now only runs 7.4 — no 7.3 job is triggered.
- `WP_Rocket_Requirements_Check` reads `WP_ROCKET_PHP_VERSION` to gate the plugin load; confirmed it will correctly block activation on PHP 7.3 sites.

### How to test

1. On a site running PHP 7.3, install or activate this version of WP Rocket.
2. **Expected:** the plugin does not activate and displays the standard "WP Rocket requires PHP 7.4 or higher" admin notice.
3. On a site running PHP 7.4+, activate the plugin normally.
4. **Expected:** no errors, plugin loads as usual.

### Affected Features & Quality Assurance Scope

Only the version gate is affected. No caching, CDN, or runtime features are touched. Existing users on PHP 7.4+ are unaffected.

## Technical description

### Documentation

Five files updated:

- `wp-rocket.php` — `Requires PHP` plugin header + `WP_ROCKET_PHP_VERSION` constant set to `7.4`.
- `composer.json` — `require.php` constraint updated to `>=7.4`.
- `phpcs.xml` — `PHPCompatibility testVersion` updated to `7.4-` so PHPCS reports incompatibilities with PHP < 7.4.
- `.github/workflows/test_wprocket.yml` — `7.3` removed from the Old PHP CI matrix.
- `.github/workflows/deploy_plugin.yml` — build environment updated to PHP 7.4.

### New dependencies

None.

### Risks

- Users on PHP 7.3 will no longer be able to activate the plugin. This is intentional — PHP 7.3 is EOL and unsupported.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

- **Built-in tests:** configuration-only change — no logic added or modified, no tests required.

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.).
