### PR TITLE
fix(htaccess): normalize Windows paths for cache rewrite rules

### DIFF
--- a/inc/functions/htaccess.php
+++ b/inc/functions/htaccess.php
@@ -280,10 +280,18 @@ function get_rocket_htaccess_mod_rewrite() { // phpcs:ignore WordPress.NamingCon
 	$site_root = isset( $site_root ) ? trailingslashit( $site_root ) : '';
 
 	// Get cache root.
-	if ( strpos( WP_ROCKET_CACHE_PATH, ABSPATH ) === false && isset( $_SERVER['DOCUMENT_ROOT'] ) ) {
-		$cache_root = '/' . ltrim( str_replace( sanitize_text_field( wp_unslash( $_SERVER['DOCUMENT_ROOT'] ) ), '', WP_ROCKET_CACHE_PATH ), '/' );
+	// Normalize separators so the comparison and replacement work on Windows,
+	// where ABSPATH and DOCUMENT_ROOT use backslashes but the cache path uses forward slashes.
+	$document_root = isset( $_SERVER['DOCUMENT_ROOT'] )
+		? wp_normalize_path( sanitize_text_field( wp_unslash( $_SERVER['DOCUMENT_ROOT'] ) ) )
+		: '';
+	$cache_path    = wp_normalize_path( rocket_get_constant( 'WP_ROCKET_CACHE_PATH' ) );
+	$abspath       = wp_normalize_path( rocket_get_constant( 'ABSPATH' ) );
+
+	if ( strpos( $cache_path, $abspath ) === false && '' !== $document_root ) {
+		$cache_root = '/' . ltrim( str_replace( $document_root, '', $cache_path ), '/' );
 	} else {
-		$cache_root = '/' . ltrim( $site_root . str_replace( ABSPATH, '', WP_ROCKET_CACHE_PATH ), '/' );
+		$cache_root = '/' . ltrim( $site_root . str_replace( $abspath, '', $cache_path ), '/' );
 	}
 
 	/**
@@ -302,14 +310,14 @@ function get_rocket_htaccess_mod_rewrite() { // phpcs:ignore WordPress.NamingCon
 	 *
 	 * @param bool true will force the path to be full.
 	 */
-	$is_1and1_or_force = apply_filters( 'rocket_force_full_path', strpos( sanitize_text_field( wp_unslash( $_SERVER['DOCUMENT_ROOT'] ) ), '/kunden/' ) === 0 );
+	$is_1and1_or_force = apply_filters( 'rocket_force_full_path', strpos( $document_root, '/kunden/' ) === 0 );
 
 	$rules      = '';
 	$gzip_rules = '';
 	$enc        = '';
 
 	if ( $is_1and1_or_force ) {
-		$cache_dir_path = str_replace( '/kunden/', '/', WP_ROCKET_CACHE_PATH ) . $http_host . '%{REQUEST_URI}';
+		$cache_dir_path = str_replace( '/kunden/', '/', $cache_path ) . $http_host . '%{REQUEST_URI}';
 	} else {
 		$cache_dir_path = '%{DOCUMENT_ROOT}/' . ltrim( $cache_root, '/' ) . $http_host . '%{REQUEST_URI}';
 	}

--- a/tests/Fixtures/inc/functions/getRocketHtaccessModRewrite.php
+++ b/tests/Fixtures/inc/functions/getRocketHtaccessModRewrite.php
@@ -1,0 +1,87 @@
+<?php
+declare(strict_types=1);
+
+return [
+	'vfs_dir'   => '',
+	'structure' => [],
+	'test_data' => [
+		// Linux: cache path inside ABSPATH.
+		[
+			'config'   => [
+				'abspath'       => '/var/www/wp/',
+				'cache_path'    => '/var/www/wp/wp-content/cache/wp-rocket/',
+				'document_root' => '/var/www/wp/',
+			],
+			'expected' => [
+				'RewriteBase /',
+				'RewriteCond "%{DOCUMENT_ROOT}/wp-content/cache/wp-rocket/%{HTTP_HOST}%{REQUEST_URI}/index%{ENV:WPR_SSL}%{ENV:WPR_WEBP}.html" -f',
+				'RewriteRule .* "/wp-content/cache/wp-rocket/%{HTTP_HOST}%{REQUEST_URI}/index%{ENV:WPR_SSL}%{ENV:WPR_WEBP}.html" [L]',
+			],
+		],
+		// Windows: cache path inside ABSPATH.
+		[
+			'config'   => [
+				'abspath'       => 'C:\\xampp\\htdocs\\wp\\',
+				'cache_path'    => 'C:/xampp/htdocs/wp/wp-content/cache/wp-rocket/',
+				'document_root' => 'C:\\xampp\\htdocs\\wp',
+			],
+			'expected' => [
+				'RewriteBase /',
+				'RewriteCond "%{DOCUMENT_ROOT}/wp-content/cache/wp-rocket/%{HTTP_HOST}%{REQUEST_URI}/index%{ENV:WPR_SSL}%{ENV:WPR_WEBP}.html" -f',
+				'RewriteRule .* "/wp-content/cache/wp-rocket/%{HTTP_HOST}%{REQUEST_URI}/index%{ENV:WPR_SSL}%{ENV:WPR_WEBP}.html" [L]',
+			],
+		],
+		// Linux: cache path outside ABSPATH but under DOCUMENT_ROOT.
+		[
+			'config'   => [
+				'abspath'       => '/var/www/wp/',
+				'cache_path'    => '/var/www/wp-content/cache/wp-rocket/',
+				'document_root' => '/var/www/',
+			],
+			'expected' => [
+				'RewriteBase /',
+				'RewriteCond "%{DOCUMENT_ROOT}/wp-content/cache/wp-rocket/%{HTTP_HOST}%{REQUEST_URI}/index%{ENV:WPR_SSL}%{ENV:WPR_WEBP}.html" -f',
+				'RewriteRule .* "/wp-content/cache/wp-rocket/%{HTTP_HOST}%{REQUEST_URI}/index%{ENV:WPR_SSL}%{ENV:WPR_WEBP}.html" [L]',
+			],
+		],
+		// Windows: cache path outside ABSPATH but under DOCUMENT_ROOT.
+		[
+			'config'   => [
+				'abspath'       => 'C:\\xampp\\htdocs\\wp\\',
+				'cache_path'    => 'C:/xampp/htdocs/wp-content/cache/wp-rocket/',
+				'document_root' => 'C:\\xampp\\htdocs',
+			],
+			'expected' => [
+				'RewriteBase /',
+				'RewriteCond "%{DOCUMENT_ROOT}/wp-content/cache/wp-rocket/%{HTTP_HOST}%{REQUEST_URI}/index%{ENV:WPR_SSL}%{ENV:WPR_WEBP}.html" -f',
+				'RewriteRule .* "/wp-content/cache/wp-rocket/%{HTTP_HOST}%{REQUEST_URI}/index%{ENV:WPR_SSL}%{ENV:WPR_WEBP}.html" [L]',
+			],
+		],
+		// 1&1 hosting: full path is forced.
+		[
+			'config'   => [
+				'abspath'       => '/kunden/12345/webseiten/wordpress/',
+				'cache_path'    => '/kunden/12345/webseiten/wordpress/wp-content/cache/wp-rocket/',
+				'document_root' => '/kunden/12345/webseiten/wordpress/',
+			],
+			'expected' => [
+				'RewriteBase /',
+				'RewriteCond "/12345/webseiten/wordpress/wp-content/cache/wp-rocket/%{HTTP_HOST}%{REQUEST_URI}/index%{ENV:WPR_SSL}%{ENV:WPR_WEBP}.html" -f',
+				'RewriteRule .* "/wp-content/cache/wp-rocket/%{HTTP_HOST}%{REQUEST_URI}/index%{ENV:WPR_SSL}%{ENV:WPR_WEBP}.html" [L]',
+			],
+		],
+		// Windows without DOCUMENT_ROOT: falls back to ABSPATH.
+		[
+			'config'   => [
+				'abspath'       => 'C:\\xampp\\htdocs\\wp\\',
+				'cache_path'    => 'C:/xampp/htdocs/wp/wp-content/cache/wp-rocket/',
+				'document_root' => null,
+			],
+			'expected' => [
+				'RewriteBase /',
+				'RewriteCond "%{DOCUMENT_ROOT}/wp-content/cache/wp-rocket/%{HTTP_HOST}%{REQUEST_URI}/index%{ENV:WPR_SSL}%{ENV:WPR_WEBP}.html" -f',
+				'RewriteRule .* "/wp-content/cache/wp-rocket/%{HTTP_HOST}%{REQUEST_URI}/index%{ENV:WPR_SSL}%{ENV:WPR_WEBP}.html" [L]',
+			],
+		],
+	],
+];

--- a/tests/Unit/inc/functions/getRocketHtaccessModRewrite.php
+++ b/tests/Unit/inc/functions/getRocketHtaccessModRewrite.php
@@ -1,0 +1,131 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Unit\inc\functions;
+
+use Brain\Monkey\Functions;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * Test class covering ::get_rocket_htaccess_mod_rewrite
+ *
+ * @group Functions
+ */
+class Test_GetRocketHtaccessModRewrite extends TestCase {
+	/**
+	 * ABSPATH value for the current test case.
+	 *
+	 * @var string
+	 */
+	protected $test_abs_path = '';
+
+	/**
+	 * WP_ROCKET_CACHE_PATH value for the current test case.
+	 *
+	 * @var string
+	 */
+	protected $test_cache_path = '';
+
+	/**
+	 * Returns the requested constant, using test-case values for ABSPATH and WP_ROCKET_CACHE_PATH.
+	 *
+	 * @param string     $constant_name Constant name.
+	 * @param mixed|null $default       Optional default value.
+	 * @return mixed
+	 */
+	public function getConstant( $constant_name, $default = null ) {
+		if ( 'ABSPATH' === $constant_name ) {
+			return $this->test_abs_path ?: parent::getConstant( $constant_name, $default );
+		}
+
+		if ( 'WP_ROCKET_CACHE_PATH' === $constant_name ) {
+			return $this->test_cache_path ?: parent::getConstant( $constant_name, $default );
+		}
+
+		return parent::getConstant( $constant_name, $default );
+	}
+
+	/**
+	 * Sets up the test environment.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		Functions\when( 'wp_normalize_path' )->alias(
+			function ( $path ) {
+				$path = str_replace( '\\', '/', $path );
+				$path = preg_replace( '|(?<=.)/+|', '/', $path );
+
+				if ( ':' === substr( $path, 1, 1 ) ) {
+					$path = ucfirst( $path );
+				}
+
+				return $path;
+			}
+		);
+		Functions\when( 'is_multisite' )->justReturn( false );
+		Functions\when( 'get_locale' )->justReturn( 'en_US' );
+		Functions\when( 'home_url' )->justReturn( 'http://example.org' );
+		Functions\when( 'site_url' )->justReturn( 'http://example.org' );
+		Functions\when( 'rocket_extract_url_component' )->justReturn( '' );
+		Functions\when( 'trailingslashit' )->alias(
+			function ( $value ) {
+				return rtrim( $value, '/\\' ) . '/';
+			}
+		);
+		Functions\when( 'sanitize_text_field' )->returnArg( 1 );
+		Functions\when( 'wp_unslash' )->returnArg( 1 );
+		Functions\when( 'get_rocket_htaccess_ssl_rewritecond' )->justReturn( '' );
+		Functions\when( 'rocket_get_webp_rewritecond' )->justReturn( '' );
+		Functions\when( 'get_rocket_cache_reject_cookies' )->justReturn( '' );
+		Functions\when( 'get_rocket_cache_reject_uri' )->justReturn( '' );
+		Functions\when( 'is_rocket_cache_mobile' )->justReturn( false );
+		Functions\when( 'get_rocket_htaccess_mobile_rewritecond' )->justReturn( '' );
+		Functions\when( 'get_rocket_cache_reject_ua' )->justReturn( '' );
+		Functions\when( 'apply_filters' )->alias(
+			function ( $tag, $value ) {
+				if ( 'rocket_force_gzip_htaccess_rules' === $tag ) {
+					return false;
+				}
+
+				return $value;
+			}
+		);
+	}
+
+	/**
+	 * Tears down the test environment.
+	 */
+	protected function tearDown(): void {
+		$this->test_abs_path   = '';
+		$this->test_cache_path = '';
+		unset( $_SERVER['DOCUMENT_ROOT'] );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Tests that the generated rewrite rules contain the expected cache paths.
+	 *
+	 * @dataProvider configTestData
+	 *
+	 * @param array $config   Test configuration.
+	 * @param array $expected Expected substrings in the generated rules.
+	 */
+	public function testShouldGenerateCorrectRewriteRules( $config, $expected ) {
+		$this->test_abs_path   = $config['abspath'];
+		$this->test_cache_path = $config['cache_path'];
+
+		if ( null !== $config['document_root'] ) {
+			$_SERVER['DOCUMENT_ROOT'] = $config['document_root'];
+		} else {
+			unset( $_SERVER['DOCUMENT_ROOT'] );
+		}
+
+		$rules = get_rocket_htaccess_mod_rewrite();
+
+		foreach ( $expected as $substring ) {
+			$this->assertStringContainsString( $substring, $rules );
+		}
+	}
+}


### PR DESCRIPTION
## Summary
On Windows, "ABSPATH" and "$_SERVER['DOCUMENT_ROOT']" use backslashes while "WP_ROCKET_CACHE_PATH" uses forward slashes. "str_replace()" failed to strip the path, producing an incorrect absolute cache path in ".htaccess" and causing Apache to fall through to PHP on every request.

Fixes #8523

## Changes
### inc/functions/htaccess.php
**Before:**
```php
if ( strpos( WP_ROCKET_CACHE_PATH, ABSPATH ) === false && isset( $_SERVER['DOCUMENT_ROOT'] ) ) {
    $cache_root = '/' . ltrim( str_replace( sanitize_text_field( wp_unslash( $_SERVER['DOCUMENT_ROOT'] ) ), '', WP_ROCKET_CACHE_PATH ), '/' );
} else {
    $cache_root = '/' . ltrim( $site_root . str_replace( ABSPATH, '', WP_ROCKET_CACHE_PATH ), '/' );
}
```

**After:**
```php
$document_root = isset( $_SERVER['DOCUMENT_ROOT'] )
    ? wp_normalize_path( sanitize_text_field( wp_unslash( $_SERVER['DOCUMENT_ROOT'] ) ) )
    : '';
$cache_path    = wp_normalize_path( rocket_get_constant( 'WP_ROCKET_CACHE_PATH' ) );
$abspath       = wp_normalize_path( rocket_get_constant( 'ABSPATH' ) );

if ( strpos( $cache_path, $abspath ) === false && '' !== $document_root ) {
    $cache_root = '/' . ltrim( str_replace( $document_root, '', $cache_path ), '/' );
} else {
    $cache_root = '/' . ltrim( $site_root . str_replace( $abspath, '', $cache_path ), '/' );
}
```

**Why:** Normalizes separators before comparing or replacing, so backslashes on Windows match forward slashes. Reuses the normalized document root for the 1&1 hosting detection.

### Tests
Added "tests/Unit/inc/functions/getRocketHtaccessModRewrite.php" with fixtures for Linux, Windows, 1&1, and missing DOCUMENT_ROOT cases.

## Testing
- "composer test-unit" passes.
- "composer phpcs" passes.
- "composer run-stan" passes.

Manual test on Windows/Apache: inspect ".htaccess" and confirm rewrite rules point to a forward-slash cache path; Apache serves cached HTML directly.