### PR TITLE
Fix #8540: disable delete buttons when CDN is paused

### DIFF
--- a/inc/Engine/CDN/Render/Controller.php
+++ b/inc/Engine/CDN/Render/Controller.php
@@ -714,7 +714,7 @@ class Controller extends Abstract_Render {
 	 * @return array Row data for the table-list-row partial.
 	 */
 	private function build_page_row( object $page ): array {
-		$disable_class = $this->is_subscription_loading() ? 'wpr-cdn-disabled' : '';
+		$disable_class = $this->should_disable_element_for_rocketcdn() ? 'wpr-cdn-disabled' : '';
 		$delete_button = '<button type="button" class="wpr-table-list__delete ' . esc_attr( $disable_class ) . '" data-id="' . esc_attr( $page->id ) . '" aria-label="' . esc_attr__( 'Remove page', 'rocket' ) . '">'
 			. '<span class="wpr-icon-trash"></span>'
 			. '</button>';

--- a/tests/Fixtures/inc/Engine/CDN/Render/Controller/buildPageRow.php
+++ b/tests/Fixtures/inc/Engine/CDN/Render/Controller/buildPageRow.php
@@ -1,0 +1,62 @@
+<?php
+return [
+	// Delete button is disabled while subscription is being created.
+	'testShouldDisableDeleteButtonWhenSubscriptionLoading' => [
+		'config'   => [
+			'is_subscription_loading' => true,
+			'cdn'                     => true,
+			'has_active_subscription' => true,
+			'is_free'                 => true,
+			'is_license_invalid'      => false,
+		],
+		'expected' => true,
+	],
+
+	// Delete button is disabled when the CDN is paused.
+	'testShouldDisableDeleteButtonWhenCdnPaused'           => [
+		'config'   => [
+			'is_subscription_loading' => false,
+			'cdn'                     => false,
+			'has_active_subscription' => true,
+			'is_free'                 => true,
+			'is_license_invalid'      => false,
+		],
+		'expected' => true,
+	],
+
+	// Delete button is disabled when the user has no active subscription.
+	'testShouldDisableDeleteButtonWhenNoActiveSubscription' => [
+		'config'   => [
+			'is_subscription_loading' => false,
+			'cdn'                     => true,
+			'has_active_subscription' => false,
+			'is_free'                 => true,
+			'is_license_invalid'      => false,
+		],
+		'expected' => true,
+	],
+
+	// Delete button is disabled when the free plan has an invalid WP Rocket licence.
+	'testShouldDisableDeleteButtonWhenLicenseInvalid'      => [
+		'config'   => [
+			'is_subscription_loading' => false,
+			'cdn'                     => true,
+			'has_active_subscription' => true,
+			'is_free'                 => true,
+			'is_license_invalid'      => true,
+		],
+		'expected' => true,
+	],
+
+	// Delete button is enabled when the subscription is active and the CDN is not paused.
+	'testShouldEnableDeleteButtonWhenActive'               => [
+		'config'   => [
+			'is_subscription_loading' => false,
+			'cdn'                     => true,
+			'has_active_subscription' => true,
+			'is_free'                 => false,
+			'is_license_invalid'      => false,
+		],
+		'expected' => false,
+	],
+];

--- a/tests/Unit/inc/Engine/CDN/Render/Controller/buildPageRow.php
+++ b/tests/Unit/inc/Engine/CDN/Render/Controller/buildPageRow.php
@@ -1,0 +1,169 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\CDN\Render\Controller;
+
+use Mockery;
+use WP_Rocket\Engine\Admin\Beacon\Beacon;
+use WP_Rocket\Engine\CDN\Cache;
+use WP_Rocket\Engine\CDN\Context;
+use WP_Rocket\Engine\CDN\Render\Controller;
+use WP_Rocket\Engine\CDN\RocketCDN\Database\Queries\RocketCDN as RocketCDNQuery;
+use WP_Rocket\Engine\CDN\RocketCDN\SubscriptionController;
+use WP_Rocket\Engine\License\API\User;
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * Test class covering \WP_Rocket\Engine\CDN\Render\Controller::build_page_row
+ *
+ * @covers \WP_Rocket\Engine\CDN\Render\Controller::build_page_row
+ * @group  CDN
+ * @group  RocketCDN
+ */
+class Test_BuildPageRow extends TestCase {
+
+	/**
+	 * Beacon mock instance.
+	 *
+	 * @var Mockery\MockInterface|Beacon
+	 */
+	private $beacon;
+
+	/**
+	 * CDN Context mock instance.
+	 *
+	 * @var Mockery\MockInterface|Context
+	 */
+	private $context;
+
+	/**
+	 * Options_Data mock instance.
+	 *
+	 * @var Mockery\MockInterface|Options_Data
+	 */
+	private $options;
+
+	/**
+	 * RocketCDNQuery mock instance.
+	 *
+	 * @var \PHPUnit\Framework\MockObject\MockObject|RocketCDNQuery
+	 */
+	private $cdn_query;
+
+	/**
+	 * SubscriptionController mock instance.
+	 *
+	 * @var Mockery\MockInterface|SubscriptionController
+	 */
+	private $subscription_controller;
+
+	/**
+	 * User mock instance.
+	 *
+	 * @var Mockery\MockInterface|User
+	 */
+	private $user;
+
+	/**
+	 * Cache mock instance.
+	 *
+	 * @var Mockery\MockInterface|Cache
+	 */
+	private $cache;
+
+	/**
+	 * Sets up the test fixture.
+	 *
+	 * @return void
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->stubTranslationFunctions();
+		$this->stubEscapeFunctions();
+
+		$this->beacon                  = Mockery::mock( Beacon::class );
+		$this->context                 = Mockery::mock( Context::class );
+		$this->options                 = Mockery::mock( Options_Data::class );
+		$this->cdn_query               = $this->createMock( RocketCDNQuery::class );
+		$this->subscription_controller = Mockery::mock( SubscriptionController::class );
+		$this->user                    = Mockery::mock( User::class );
+		$this->cache                   = Mockery::mock( Cache::class );
+	}
+
+	/**
+	 * Creates a Controller instance under test.
+	 *
+	 * @return Controller
+	 */
+	private function get_controller(): Controller {
+		return new Controller(
+			$this->beacon,
+			'',
+			$this->context,
+			$this->options,
+			$this->cdn_query,
+			$this->subscription_controller,
+			$this->user,
+			$this->cache
+		);
+	}
+
+	/**
+	 * Provides test data for the disabled class tests.
+	 *
+	 * @return array
+	 */
+	public function configTestData(): array {
+		return $this->getTestData( __DIR__, basename( __FILE__, '.php' ) );
+	}
+
+	/**
+	 * Tests that delete button disabled class is set according to the disabled state.
+	 *
+	 * @dataProvider configTestData
+	 *
+	 * @param array $config   Test configuration.
+	 * @param bool  $expected Expected value of disabled class presence.
+	 *
+	 * @return void
+	 */
+	public function testShouldDisableDeleteButtonWhenExpected( array $config, bool $expected ): void {
+		$this->subscription_controller->shouldReceive( 'is_subscription_creation_loading' )
+			->andReturn( $config['is_subscription_loading'] );
+
+		$this->options->shouldReceive( 'get' )
+			->with( 'cdn' )
+			->andReturn( $config['cdn'] );
+
+		$this->subscription_controller->shouldReceive( 'has_active_subscription' )
+			->andReturn( $config['has_active_subscription'] );
+
+		$this->subscription_controller->shouldReceive( 'is_free' )
+			->andReturn( $config['is_free'] );
+
+		$this->subscription_controller->shouldReceive( 'is_license_invalid' )
+			->andReturn( $config['is_license_invalid'] );
+
+		$page = (object) [
+			'id'    => 1,
+			'url'   => 'http://example.org/',
+			'title' => 'Page',
+		];
+
+		$controller = $this->get_controller();
+		$reflection = new \ReflectionClass( $controller );
+		$method     = $reflection->getMethod( 'build_page_row' );
+		$method->setAccessible( true );
+		$row = $method->invoke( $controller, $page );
+
+		$delete_button = $row['columns'][1]['content'] ?? '';
+
+		if ( $expected ) {
+			$this->assertStringContainsString( 'wpr-cdn-disabled', $delete_button );
+		} else {
+			$this->assertStringNotContainsString( 'wpr-cdn-disabled', $delete_button );
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Delete buttons (bin icons) on the RocketCDN Free page list stay active while the CDN is paused. This change uses the existing `should_disable_element_for_rocketcdn()` helper to apply the `wpr-cdn-disabled` class, which disables the buttons when the CDN is paused, the subscription is loading, the licence is invalid, or there is no active subscription.

Fixes #8540

## Changes
### inc/Engine/CDN/Render/Controller.php
**Before:**
```php
$disable_class = $this->is_subscription_loading() ? 'wpr-cdn-disabled' : '';
```
**After:**
```php
$disable_class = $this->should_disable_element_for_rocketcdn() ? 'wpr-cdn-disabled' : '';
```
**Why:** `should_disable_element_for_rocketcdn()` already covers all the states that should disable CDN UI elements (loading, paused, expired licence, no active subscription). Using it here keeps the delete buttons consistent with the purge section, exclude section, and exclusion fields.

## Testing
**Test 1: Delete buttons disabled when CDN is paused**
1. Add pages to RocketCDN Free on the CDN tab
2. Click Pause CDN
3. Hover over a bin icon next to an added page
Result: bin icon is greyed out and not clickable

**Test 2: Delete buttons enabled when CDN is active**
1. Click Resume CDN
2. Click a bin icon
Result: page is removed as expected