### PR TITLE
fix(alr): prevent element hiding on iOS 18 Safari with Automatic Lazy Rendering

### DIFF
--- a/inc/Engine/Optimization/LazyRenderContent/Frontend/Controller.php
+++ b/inc/Engine/Optimization/LazyRenderContent/Frontend/Controller.php
@@ -102,7 +102,7 @@ class Controller implements ControllerInterface {
 	 * @return string
 	 */
 	private function add_css( $html ) {
-		$css = '<style id="rocket-lazyrender-inline-css">[data-wpr-lazyrender] {content-visibility: auto;}</style>';
+		$css = '<style id="rocket-lazyrender-inline-css">[data-wpr-lazyrender] {content-visibility: auto; contain-intrinsic-size: 0 0;}@supports (-webkit-touch-callout: none) {[data-wpr-lazyrender]{content-visibility:visible!important;}}</style>';
 
 		$result = preg_replace( '/<\/head>/i', $css . '</head>', $html, 1 );
 

--- a/tests/Fixtures/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/HTML/input_with_only_lrc_opt.html
+++ b/tests/Fixtures/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/HTML/input_with_only_lrc_opt.html
@@ -1,7 +1,7 @@
 <html>
 <head>
 	<title>Test</title>
-    <style>[data-wpr-lazyrender] {content-visibility: auto;}</style>
+    <style>[data-wpr-lazyrender] {content-visibility: auto; contain-intrinsic-size: 0 0;}@supports (-webkit-touch-callout: none) {[data-wpr-lazyrender]{content-visibility:visible!important;}}</style>
 </head>
 <body>
     <div class="main">

--- a/tests/Fixtures/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/HTML/output_with_beacon_and_only_lrc_opt.html
+++ b/tests/Fixtures/inc/Engine/Common/PerformanceHints/Frontend/Subscriber/HTML/output_with_beacon_and_only_lrc_opt.html
@@ -3,7 +3,7 @@
 	<title>
 		Test</title>
 	<style>
-		[data-wpr-lazyrender] {content-visibility: auto;}</style>
+		[data-wpr-lazyrender] {content-visibility: auto; contain-intrinsic-size: 0 0;}@supports (-webkit-touch-callout: none) {[data-wpr-lazyrender]{content-visibility:visible!important;}}</style>
 </head>
 <body>
     <div class="main">

--- a/tests/Fixtures/inc/Engine/Optimization/LazyRenderContent/Frontend/Controller/expected-single-line.html
+++ b/tests/Fixtures/inc/Engine/Optimization/LazyRenderContent/Frontend/Controller/expected-single-line.html
@@ -1,7 +1,7 @@
 <html>
 <head>
 	<title>Single line element</title>
-	<style id="rocket-lazyrender-inline-css">[data-wpr-lazyrender] {content-visibility: auto;}</style>
+	<style id="rocket-lazyrender-inline-css">[data-wpr-lazyrender] {content-visibility: auto; contain-intrinsic-size: 0 0;}@supports (-webkit-touch-callout: none) {[data-wpr-lazyrender]{content-visibility:visible!important;}}</style>
 </head>
 <body>
 <div data-wpr-lazyrender="1"> div in body <div data-wpr-lazyrender="1"> another div in body <header data-wpr-lazyrender="1"> header in div in div in body<div>another div in header in div in div in body</div></header></div></div>

--- a/tests/Fixtures/inc/Engine/Optimization/LazyRenderContent/Frontend/Controller/expected.html
+++ b/tests/Fixtures/inc/Engine/Optimization/LazyRenderContent/Frontend/Controller/expected.html
@@ -1,7 +1,7 @@
 <html>
 	<head>
 		<title>Original</title>
-		<style id="rocket-lazyrender-inline-css">[data-wpr-lazyrender] {content-visibility: auto;}</style>
+		<style id="rocket-lazyrender-inline-css">[data-wpr-lazyrender] {content-visibility: auto; contain-intrinsic-size: 0 0;}@supports (-webkit-touch-callout: none) {[data-wpr-lazyrender]{content-visibility:visible!important;}}</style>
 	</head>
 	<body>
 		<main data-wpr-lazyrender="1">

--- a/tests/Unit/inc/Engine/Optimization/LazyRenderContent/Frontend/Controller/optimize.php
+++ b/tests/Unit/inc/Engine/Optimization/LazyRenderContent/Frontend/Controller/optimize.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace WP_Rocket\Tests\Unit\inc\Engine\Optimization\LazyRenderContent\Frontend\Controller;
 
 use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
 use Mockery;
 use WP_Rocket\Engine\Optimization\LazyRenderContent\Context\Context;
 use WP_Rocket\Engine\Optimization\LazyRenderContent\Database\Rows\LazyRenderContent as LRCRow;
@@ -27,6 +28,8 @@ class TestOptimize extends TestCase {
 	 * @dataProvider configTestData
 	 */
 	public function testShouldReturnExpected( $config, $html, $expected ) {
+		Functions\when( 'rocket_bypass' )->justReturn( false );
+
 		Filters\expectApplied( 'rocket_disable_meta_generator' )
 			->atMost()
 			->once()


### PR DESCRIPTION
## Summary

On iOS 18, Safari enables CSS content-visibility by default. When ALR applies content-visibility: auto to [data-wpr-lazyrender] elements, Safari on iOS 18 can fail to render those elements after scrolling.

Fixes #8574

## Changes

### Controller.php
Added two CSS properties to the ALR inline stylesheet:

1. **contain-intrinsic-size: 0 0** — standard CSS companion for content-visibility, provides size hint before rendering
2. **@supports (-webkit-touch-callout: none)** — targets iOS Safari specifically, overrides content-visibility to visible

Before:
```css
[data-wpr-lazyrender] {content-visibility: auto;}
```

After:
```css
[data-wpr-lazyrender] {content-visibility: auto; contain-intrinsic-size: 0 0;}@supports (-webkit-touch-callout: none) {[data-wpr-lazyrender]{content-visibility:visible!important;}}
```

## Testing

1. Enable ALR in WP Rocket settings
2. Open a page with below-fold content on iPhone/iPad with iOS 18 Safari
3. Scroll down — footer/sections should render normally
4. Verify no regression on desktop browsers (Chrome, Firefox, Safari)
5. Verify no regression on Android Chrome