### PR TITLE
fix(abilities): change get-recommendations input_schema from null to empty array

### DIFF
--- a/inc/Engine/Admin/RocketInsights/Abilities/GetRecommendations.php
+++ b/inc/Engine/Admin/RocketInsights/Abilities/GetRecommendations.php
@@ -88,9 +88,7 @@ For each recommendation, mcp_actionable: true means it can be applied with set-o
 					'rocket'
 					),
 				'category'            => 'wp-rocket-insights',
-				'input_schema'        => [
-					'type' => 'null',
-				],
+				'input_schema'        => [],
 				'output_schema'       => [
 					'type'       => 'object',
 					'properties' => [


### PR DESCRIPTION
## Summary

Changed `wp-rocket/get-recommendations` input_schema from `['type' => 'null']` to `[]` (empty array). This fixes WP-CLI compatibility — the null-type schema causes WP-CLI's ability command to reject the ability with "input must be an object, null given."

Fixes #8561

## Changes

### inc/Engine/Admin/RocketInsights/Abilities/GetRecommendations.php

**Before:**
```php
'input_schema' => [
    'type' => 'null',
],
```

**After:**
```php
'input_schema' => [],
```

**Why:** The WP-CLI ability-command expects an object-type schema for input validation. A null-type schema breaks validation even when no input is expected. Empty array represents "no input properties" in JSON Schema and is WP-CLI compatible.

## Testing

**Test 1: Activation**
1. Install plugin zip
2. Activate — no fatal errors

**Test 2: REST API execution**
1. Enable abilities: `add_filter('rocket_enable_abilities', '__return_true');`
2. `GET /wp-json/wp-abilities/v1/abilities` — lists `wp-rocket/get-recommendations`
3. `POST /wp-json/wp-abilities/v1/abilities/wp-rocket%2Fget-recommendations/run` — returns JSON with `status` and `recommendations` fields