### PR TITLE
feat(mcp): add rocket_mcp_oauth_server_enabled filter to disable OAuth server

### DIFF
--- a/inc/Engine/MCP/Auth/Discovery/Subscriber.php
+++ b/inc/Engine/MCP/Auth/Discovery/Subscriber.php
@@ -47,6 +47,15 @@ class Subscriber implements Subscriber_Interface {
 	}
 
 	/**
+	 * Check whether the MCP OAuth server is enabled.
+	 *
+	 * @return bool
+	 */
+	private function is_enabled(): bool {
+		return wpm_apply_filters_typed( 'boolean', 'rocket_mcp_oauth_server_enabled', true );
+	}
+
+	/**
 	 * Register rewrite rules for the .well-known paths.
 	 *
 	 * Called both on the 'init' action (normal requests) and directly during
@@ -55,6 +64,10 @@ class Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function add_rewrite_rules(): void {
+		if ( ! $this->is_enabled() ) {
+			return;
+		}
+
 		$this->endpoints->add_rewrite_rules();
 	}
 
@@ -64,6 +77,10 @@ class Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function handle_request(): void {
+		if ( ! $this->is_enabled() ) {
+			return;
+		}
+
 		$this->endpoints->handle_request();
 	}
 }

--- a/inc/Engine/MCP/Auth/Subscriber.php
+++ b/inc/Engine/MCP/Auth/Subscriber.php
@@ -98,6 +98,15 @@ class Subscriber implements Subscriber_Interface {
 	}
 
 	/**
+	 * Check whether the MCP OAuth server is enabled.
+	 *
+	 * @return bool
+	 */
+	private function is_enabled(): bool {
+		return wpm_apply_filters_typed( 'boolean', 'rocket_mcp_oauth_server_enabled', true );
+	}
+
+	/**
 	 * Register WordPress rewrite rules for all four OAuth endpoints.
 	 *
 	 * Called both on the 'init' action (normal page load) and during plugin
@@ -106,6 +115,10 @@ class Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function register_oauth_rewrite_rules(): void {
+		if ( ! $this->is_enabled() ) {
+			return;
+		}
+
 		add_rewrite_rule( '^oauth/authorize$', 'index.php?' . self::OAUTH_QUERY_VAR . '=authorize', 'top' );
 		add_rewrite_rule( '^oauth/authorize-callback$', 'index.php?' . self::OAUTH_QUERY_VAR . '=authorize-callback', 'top' );
 		add_rewrite_rule( '^oauth/token$', 'index.php?' . self::OAUTH_QUERY_VAR . '=token', 'top' );
@@ -131,6 +144,9 @@ class Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function handle_oauth_request(): void {
+		if ( ! $this->is_enabled() ) {
+			return;
+		}
 		$endpoint = (string) get_query_var( self::OAUTH_QUERY_VAR, '' );
 
 		if ( '' === $endpoint ) {
@@ -180,6 +196,10 @@ class Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function on_activation(): void {
+		if ( ! $this->is_enabled() ) {
+			return;
+		}
+
 		SecretManager::ensure_secret();
 		$this->register_oauth_rewrite_rules();
 		flush_rewrite_rules();

--- a/inc/Engine/MCP/Transport/Subscriber.php
+++ b/inc/Engine/MCP/Transport/Subscriber.php
@@ -39,6 +39,15 @@ class Subscriber implements Subscriber_Interface {
 	}
 
 	/**
+	 * Check whether the MCP OAuth server is enabled.
+	 *
+	 * @return bool
+	 */
+	private function is_enabled(): bool {
+		return wpm_apply_filters_typed( 'boolean', 'rocket_mcp_oauth_server_enabled', true );
+	}
+
+	/**
 	 * Register the MCP server with the adapter.
 	 *
 	 * Creates an isolated server at /wp-json/mcp/mcp-oauth-server using the custom
@@ -47,6 +56,10 @@ class Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function register_server(): void {
+		if ( ! $this->is_enabled() ) {
+			return;
+		}
+
 		$this->server->register_server();
 	}
 

--- a/tests/Fixtures/inc/Engine/MCP/Auth/Discovery/Subscriber/addRewriteRules.php
+++ b/tests/Fixtures/inc/Engine/MCP/Auth/Discovery/Subscriber/addRewriteRules.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+	'testShouldAddRewriteRulesWhenEnabled'     => [
+		'config'   => [
+			'enabled' => true,
+		],
+		'expected' => [
+			'added' => true,
+		],
+	],
+	'testShouldNotAddRewriteRulesWhenDisabled' => [
+		'config'   => [
+			'enabled' => false,
+		],
+		'expected' => [
+			'added' => false,
+		],
+	],
+];

--- a/tests/Fixtures/inc/Engine/MCP/Auth/Discovery/Subscriber/handleRequest.php
+++ b/tests/Fixtures/inc/Engine/MCP/Auth/Discovery/Subscriber/handleRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+	'testShouldHandleRequestWhenEnabled'     => [
+		'config'   => [
+			'enabled' => true,
+		],
+		'expected' => [
+			'handled' => true,
+		],
+	],
+	'testShouldNotHandleRequestWhenDisabled' => [
+		'config'   => [
+			'enabled' => false,
+		],
+		'expected' => [
+			'handled' => false,
+		],
+	],
+];

--- a/tests/Fixtures/inc/Engine/MCP/Auth/Subscriber/handleOauthRequest.php
+++ b/tests/Fixtures/inc/Engine/MCP/Auth/Subscriber/handleOauthRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+	'testShouldHandleRequestWhenEnabled'     => [
+		'config'   => [
+			'enabled'   => true,
+			'query_var' => 'token',
+		],
+		'expected' => [
+			'handled' => true,
+		],
+	],
+	'testShouldNotHandleRequestWhenDisabled' => [
+		'config'   => [
+			'enabled'   => false,
+			'query_var' => 'token',
+		],
+		'expected' => [
+			'handled' => false,
+		],
+	],
+];

--- a/tests/Fixtures/inc/Engine/MCP/Auth/Subscriber/onActivation.php
+++ b/tests/Fixtures/inc/Engine/MCP/Auth/Subscriber/onActivation.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+	'testShouldActivateWhenEnabled'     => [
+		'config'   => [
+			'enabled' => true,
+		],
+		'expected' => [
+			'activated' => true,
+		],
+	],
+	'testShouldNotActivateWhenDisabled' => [
+		'config'   => [
+			'enabled' => false,
+		],
+		'expected' => [
+			'activated' => false,
+		],
+	],
+];

--- a/tests/Fixtures/inc/Engine/MCP/Auth/Subscriber/registerOauthRewriteRules.php
+++ b/tests/Fixtures/inc/Engine/MCP/Auth/Subscriber/registerOauthRewriteRules.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+	'testShouldRegisterRewriteRulesWhenEnabled'     => [
+		'config'   => [
+			'enabled' => true,
+		],
+		'expected' => [
+			'called' => 5,
+		],
+	],
+	'testShouldNotRegisterRewriteRulesWhenDisabled' => [
+		'config'   => [
+			'enabled' => false,
+		],
+		'expected' => [
+			'called' => 0,
+		],
+	],
+];

--- a/tests/Fixtures/inc/Engine/MCP/Transport/Subscriber/registerServer.php
+++ b/tests/Fixtures/inc/Engine/MCP/Transport/Subscriber/registerServer.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+	'testShouldRegisterServerWhenEnabled'     => [
+		'config'   => [
+			'enabled' => true,
+		],
+		'expected' => [
+			'registered' => true,
+		],
+	],
+	'testShouldNotRegisterServerWhenDisabled' => [
+		'config'   => [
+			'enabled' => false,
+		],
+		'expected' => [
+			'registered' => false,
+		],
+	],
+];

--- a/tests/Unit/inc/Engine/MCP/Auth/Discovery/Subscriber/addRewriteRules.php
+++ b/tests/Unit/inc/Engine/MCP/Auth/Discovery/Subscriber/addRewriteRules.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\MCP\Auth\Discovery\Subscriber;
+
+use Mockery;
+use Brain\Monkey\Filters;
+use WP_Rocket\Engine\MCP\Auth\Discovery\Endpoints;
+use WP_Rocket\Engine\MCP\Auth\Discovery\Subscriber;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @group MCP
+ */
+class Test_AddRewriteRules extends TestCase {
+	private $subscriber;
+	private $endpoints;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->endpoints = Mockery::mock( Endpoints::class );
+
+		$this->subscriber = new Subscriber( $this->endpoints );
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnExpected( $config, $expected ) {
+		Filters\expectApplied( 'rocket_mcp_oauth_server_enabled' )
+			->andReturn( $config['enabled'] );
+
+		$this->endpoints->expects()
+			->add_rewrite_rules()
+			->times( $config['enabled'] ? 1 : 0 );
+
+		$this->subscriber->add_rewrite_rules();
+	}
+}

--- a/tests/Unit/inc/Engine/MCP/Auth/Discovery/Subscriber/handleRequest.php
+++ b/tests/Unit/inc/Engine/MCP/Auth/Discovery/Subscriber/handleRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\MCP\Auth\Discovery\Subscriber;
+
+use Mockery;
+use Brain\Monkey\Filters;
+use WP_Rocket\Engine\MCP\Auth\Discovery\Endpoints;
+use WP_Rocket\Engine\MCP\Auth\Discovery\Subscriber;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @group MCP
+ */
+class Test_HandleRequest extends TestCase {
+	private $subscriber;
+	private $endpoints;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->endpoints = Mockery::mock( Endpoints::class );
+
+		$this->subscriber = new Subscriber( $this->endpoints );
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnExpected( $config, $expected ) {
+		Filters\expectApplied( 'rocket_mcp_oauth_server_enabled' )
+			->andReturn( $config['enabled'] );
+
+		$this->endpoints->expects()
+			->handle_request()
+			->times( $config['enabled'] ? 1 : 0 );
+
+		$this->subscriber->handle_request();
+	}
+}

--- a/tests/Unit/inc/Engine/MCP/Auth/Subscriber/handleOauthRequest.php
+++ b/tests/Unit/inc/Engine/MCP/Auth/Subscriber/handleOauthRequest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\MCP\Auth\Subscriber;
+
+use Mockery;
+use Brain\Monkey\Functions;
+use Brain\Monkey\Filters;
+use WP_Rocket\Engine\MCP\Auth\AuthorizeCallback;
+use WP_Rocket\Engine\MCP\Auth\AuthorizeEndpoint;
+use WP_Rocket\Engine\MCP\Auth\ConsentEndpoint;
+use WP_Rocket\Engine\MCP\Auth\RevokeEndpoint;
+use WP_Rocket\Engine\MCP\Auth\Subscriber;
+use WP_Rocket\Engine\MCP\Auth\TokenEndpoint;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @group MCP
+ */
+class Test_HandleOauthRequest extends TestCase {
+	private $subscriber;
+	private $token_endpoint;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->token_endpoint = Mockery::mock( TokenEndpoint::class );
+
+		$this->subscriber = new Subscriber(
+			Mockery::mock( AuthorizeEndpoint::class ),
+			Mockery::mock( AuthorizeCallback::class ),
+			$this->token_endpoint,
+			Mockery::mock( ConsentEndpoint::class ),
+			Mockery::mock( RevokeEndpoint::class )
+		);
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnExpected( $config, $expected ) {
+		Filters\expectApplied( 'rocket_mcp_oauth_server_enabled' )
+			->andReturn( $config['enabled'] );
+
+		if ( ! $config['enabled'] ) {
+			Functions\expect( 'get_query_var' )->never();
+			$this->subscriber->handle_oauth_request();
+			return;
+		}
+
+		Functions\expect( 'get_query_var' )
+			->with( Subscriber::OAUTH_QUERY_VAR, '' )
+			->andReturn( $config['query_var'] );
+
+		$this->token_endpoint->expects()->handle_request()->once();
+
+		$this->subscriber->handle_oauth_request();
+	}
+}

--- a/tests/Unit/inc/Engine/MCP/Auth/Subscriber/onActivation.php
+++ b/tests/Unit/inc/Engine/MCP/Auth/Subscriber/onActivation.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\MCP\Auth\Subscriber;
+
+use Mockery;
+use Brain\Monkey\Functions;
+use Brain\Monkey\Filters;
+use WP_Rocket\Engine\MCP\Auth\AuthorizeCallback;
+use WP_Rocket\Engine\MCP\Auth\AuthorizeEndpoint;
+use WP_Rocket\Engine\MCP\Auth\ConsentEndpoint;
+use WP_Rocket\Engine\MCP\Auth\RevokeEndpoint;
+use WP_Rocket\Engine\MCP\Auth\Subscriber;
+use WP_Rocket\Engine\MCP\Auth\TokenEndpoint;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @group MCP
+ */
+class Test_OnActivation extends TestCase {
+	private $subscriber;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->subscriber = new Subscriber(
+			Mockery::mock( AuthorizeEndpoint::class ),
+			Mockery::mock( AuthorizeCallback::class ),
+			Mockery::mock( TokenEndpoint::class ),
+			Mockery::mock( ConsentEndpoint::class ),
+			Mockery::mock( RevokeEndpoint::class )
+		);
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnExpected( $config, $expected ) {
+		Filters\expectApplied( 'rocket_mcp_oauth_server_enabled' )
+			->andReturn( $config['enabled'] );
+
+		if ( $config['enabled'] ) {
+			Functions\when( 'get_option' )->justReturn( 'test_secret' );
+			Functions\expect( 'add_rewrite_rule' )->times( 5 );
+			Functions\expect( 'flush_rewrite_rules' )->once();
+		} else {
+			Functions\expect( 'add_rewrite_rule' )->never();
+			Functions\expect( 'flush_rewrite_rules' )->never();
+		}
+
+		$this->subscriber->on_activation();
+	}
+}

--- a/tests/Unit/inc/Engine/MCP/Auth/Subscriber/registerOauthRewriteRules.php
+++ b/tests/Unit/inc/Engine/MCP/Auth/Subscriber/registerOauthRewriteRules.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\MCP\Auth\Subscriber;
+
+use Mockery;
+use Brain\Monkey\Functions;
+use Brain\Monkey\Filters;
+use WP_Rocket\Engine\MCP\Auth\AuthorizeCallback;
+use WP_Rocket\Engine\MCP\Auth\AuthorizeEndpoint;
+use WP_Rocket\Engine\MCP\Auth\ConsentEndpoint;
+use WP_Rocket\Engine\MCP\Auth\RevokeEndpoint;
+use WP_Rocket\Engine\MCP\Auth\Subscriber;
+use WP_Rocket\Engine\MCP\Auth\TokenEndpoint;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @group MCP
+ */
+class Test_RegisterOauthRewriteRules extends TestCase {
+	private $subscriber;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->subscriber = new Subscriber(
+			Mockery::mock( AuthorizeEndpoint::class ),
+			Mockery::mock( AuthorizeCallback::class ),
+			Mockery::mock( TokenEndpoint::class ),
+			Mockery::mock( ConsentEndpoint::class ),
+			Mockery::mock( RevokeEndpoint::class )
+		);
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnExpected( $config, $expected ) {
+		Filters\expectApplied( 'rocket_mcp_oauth_server_enabled' )
+			->andReturn( $config['enabled'] );
+
+		Functions\expect( 'add_rewrite_rule' )->times( $expected['called'] );
+
+		$this->subscriber->register_oauth_rewrite_rules();
+	}
+}

--- a/tests/Unit/inc/Engine/MCP/Transport/Subscriber/registerServer.php
+++ b/tests/Unit/inc/Engine/MCP/Transport/Subscriber/registerServer.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\MCP\Transport\Subscriber;
+
+use Mockery;
+use Brain\Monkey\Filters;
+use WP_Rocket\Engine\MCP\Transport\Server;
+use WP_Rocket\Engine\MCP\Transport\Subscriber;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * @group MCP
+ */
+class Test_RegisterServer extends TestCase {
+	private $subscriber;
+	private $server;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->server = Mockery::mock( Server::class );
+
+		$this->subscriber = new Subscriber( $this->server );
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnExpected( $config, $expected ) {
+		Filters\expectApplied( 'rocket_mcp_oauth_server_enabled' )
+			->andReturn( $config['enabled'] );
+
+		$this->server->expects()
+			->register_server()
+			->times( $config['enabled'] ? 1 : 0 );
+
+		$this->subscriber->register_server();
+	}
+}


### PR DESCRIPTION
## Summary

Add a single boolean filter `rocket_mcp_oauth_server_enabled` that gates the entire MCP OAuth server. When `false`, no OAuth rewrite rules are registered, no endpoint requests are handled, discovery documents are suppressed, and the MCP transport server is not registered. Default is `true` (no behavior change).

Fixes #8581

## Changes

### `inc/Engine/MCP/Auth/Subscriber.php`
- Added `is_enabled()` private method checking `rocket_mcp_oauth_server_enabled` via `wpm_apply_filters_typed('boolean', ...)`
- `register_oauth_rewrite_rules()` — early return when disabled
- `handle_oauth_request()` — early return when disabled
- `on_activation()` — skip registration/flush when disabled

### `inc/Engine/MCP/Auth/Discovery/Subscriber.php`
- Added same `is_enabled()` method
- `add_rewrite_rules()` — early return when disabled
- `handle_request()` — early return when disabled

### `inc/Engine/MCP/Transport/Subscriber.php`
- Added same `is_enabled()` method
- `register_server()` — early return when disabled

## Testing

**Test 1: Default behavior (filter not used)**
1. No filter set — OAuth server works as before
2. Verify rewrite rules registered, endpoints respond

**Test 2: Filter disabled**
1. `add_filter( 'rocket_mcp_oauth_server_enabled', '__return_false' );`
2. Verify no OAuth rewrite rules registered
3. Verify /oauth/* requests fall through to normal 404
4. Verify discovery endpoints suppressed
5. Verify transport server not registered

**Unit tests:** 13 tests across 6 test files covering both enabled and disabled states for all gated methods.