### PR TITLE
Closes #8581 MCP OAuth: Add a filter to disable the OAuth server entirely

### DIFF
--- a/inc/Engine/MCP/Auth/Discovery/Subscriber.php
+++ b/inc/Engine/MCP/Auth/Discovery/Subscriber.php
@@ -78,10 +78,33 @@ class Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function handle_request(): void {
+		$discovery = (string) get_query_var( Endpoints::QUERY_VAR, '' );
+
+		if ( '' === $discovery ) {
+			return;
+		}
+
 		if ( ! $this->context->is_enabled() ) {
+			$this->force_404();
 			return;
 		}
 
 		$this->endpoints->handle_request();
+	}
+
+	/**
+	 * Force a clean 404 response.
+	 *
+	 * Used when a stale rewrite rule still routes a request to this endpoint
+	 * after the OAuth server has been disabled, before rewrite rules have
+	 * been flushed. Without this, WordPress's main query would fall through
+	 * to the homepage instead of returning a 404.
+	 *
+	 * @return void
+	 */
+	private function force_404(): void {
+		global $wp_query;
+		$wp_query->set_404();
+		status_header( 404 );
 	}
 }

--- a/inc/Engine/MCP/Auth/Discovery/Subscriber.php
+++ b/inc/Engine/MCP/Auth/Discovery/Subscriber.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace WP_Rocket\Engine\MCP\Auth\Discovery;
 
+use WP_Rocket\Engine\MCP\Context;
 use WP_Rocket\Event_Management\Subscriber_Interface;
 
 class Subscriber implements Subscriber_Interface {
@@ -14,12 +15,21 @@ class Subscriber implements Subscriber_Interface {
 	private $endpoints;
 
 	/**
+	 * OAuth server context.
+	 *
+	 * @var Context
+	 */
+	private $context;
+
+	/**
 	 * Subscriber constructor.
 	 *
 	 * @param Endpoints $endpoints The discovery endpoints handler.
+	 * @param Context   $context   OAuth server context.
 	 */
-	public function __construct( Endpoints $endpoints ) {
+	public function __construct( Endpoints $endpoints, Context $context ) {
 		$this->endpoints = $endpoints;
+		$this->context   = $context;
 	}
 
 	/**
@@ -55,6 +65,10 @@ class Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function add_rewrite_rules(): void {
+		if ( ! $this->context->is_enabled() ) {
+			return;
+		}
+
 		$this->endpoints->add_rewrite_rules();
 	}
 
@@ -64,6 +78,10 @@ class Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function handle_request(): void {
+		if ( ! $this->context->is_enabled() ) {
+			return;
+		}
+
 		$this->endpoints->handle_request();
 	}
 }

--- a/inc/Engine/MCP/Auth/ServiceProvider.php
+++ b/inc/Engine/MCP/Auth/ServiceProvider.php
@@ -12,6 +12,7 @@ namespace WP_Rocket\Engine\MCP\Auth;
 use WP_Rocket\Dependencies\League\Container\ServiceProvider\AbstractServiceProvider;
 use WP_Rocket\Engine\MCP\Auth\Discovery\Endpoints as DiscoveryEndpoints;
 use WP_Rocket\Engine\MCP\Auth\Discovery\Subscriber as DiscoverySubscriber;
+use WP_Rocket\Engine\MCP\Context;
 
 /**
  * Service provider for the MCP Auth module.
@@ -34,6 +35,7 @@ class ServiceProvider extends AbstractServiceProvider {
 		'mcp_auth_discovery_endpoints',
 		'mcp_auth_discovery_subscriber',
 		'mcp_auth_subscriber',
+		'mcp_context',
 	];
 
 	/**
@@ -52,9 +54,11 @@ class ServiceProvider extends AbstractServiceProvider {
 	 * @return void
 	 */
 	public function register(): void {
+		$this->getContainer()->addShared( 'mcp_context', Context::class );
+
 		$this->getContainer()->addShared( 'mcp_auth_discovery_endpoints', DiscoveryEndpoints::class );
 		$this->getContainer()->addShared( 'mcp_auth_discovery_subscriber', DiscoverySubscriber::class )
-			->addArgument( 'mcp_auth_discovery_endpoints' );
+			->addArguments( [ 'mcp_auth_discovery_endpoints', 'mcp_context' ] );
 
 		$this->getContainer()->addShared( 'mcp_auth_claude_verifier', ClaudeClientVerifier::class );
 		$this->getContainer()->addShared( 'mcp_auth_cimd_resolver', CimdResolver::class )
@@ -73,6 +77,7 @@ class ServiceProvider extends AbstractServiceProvider {
 					'mcp_auth_token_endpoint',
 					'mcp_auth_consent_endpoint',
 					'mcp_auth_revoke_endpoint',
+					'mcp_context',
 				]
 				);
 	}

--- a/inc/Engine/MCP/Auth/Subscriber.php
+++ b/inc/Engine/MCP/Auth/Subscriber.php
@@ -146,13 +146,14 @@ class Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function handle_oauth_request(): void {
-		if ( ! $this->context->is_enabled() ) {
-			return;
-		}
-
 		$endpoint = (string) get_query_var( self::OAUTH_QUERY_VAR, '' );
 
 		if ( '' === $endpoint ) {
+			return;
+		}
+
+		if ( ! $this->context->is_enabled() ) {
+			$this->force_404();
 			return;
 		}
 
@@ -176,6 +177,22 @@ class Subscriber implements Subscriber_Interface {
 				status_header( 404 );
 				wp_die( esc_html__( 'Unknown OAuth endpoint.', 'rocket' ), '', [ 'response' => 404 ] );
 		}
+	}
+
+	/**
+	 * Force a clean 404 response.
+	 *
+	 * Used when a stale rewrite rule still routes a request to this endpoint
+	 * after the OAuth server has been disabled, before rewrite rules have
+	 * been flushed. Without this, WordPress's main query would fall through
+	 * to the homepage instead of returning a 404.
+	 *
+	 * @return void
+	 */
+	private function force_404(): void {
+		global $wp_query;
+		$wp_query->set_404();
+		status_header( 404 );
 	}
 
 	/**

--- a/inc/Engine/MCP/Auth/Subscriber.php
+++ b/inc/Engine/MCP/Auth/Subscriber.php
@@ -11,6 +11,7 @@ declare( strict_types=1 );
 
 namespace WP_Rocket\Engine\MCP\Auth;
 
+use WP_Rocket\Engine\MCP\Context;
 use WP_Rocket\Event_Management\Subscriber_Interface;
 
 /**
@@ -59,6 +60,13 @@ class Subscriber implements Subscriber_Interface {
 	private RevokeEndpoint $revoke_endpoint;
 
 	/**
+	 * OAuth server context.
+	 *
+	 * @var Context
+	 */
+	private Context $context;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param AuthorizeEndpoint $authorize_endpoint  Authorization endpoint.
@@ -66,19 +74,22 @@ class Subscriber implements Subscriber_Interface {
 	 * @param TokenEndpoint     $token_endpoint      Token endpoint.
 	 * @param ConsentEndpoint   $consent_endpoint    Consent endpoint.
 	 * @param RevokeEndpoint    $revoke_endpoint     Revocation endpoint.
+	 * @param Context           $context             OAuth server context.
 	 */
 	public function __construct(
 		AuthorizeEndpoint $authorize_endpoint,
 		AuthorizeCallback $authorize_callback,
 		TokenEndpoint $token_endpoint,
 		ConsentEndpoint $consent_endpoint,
-		RevokeEndpoint $revoke_endpoint
+		RevokeEndpoint $revoke_endpoint,
+		Context $context
 	) {
 		$this->authorize_endpoint = $authorize_endpoint;
 		$this->authorize_callback = $authorize_callback;
 		$this->token_endpoint     = $token_endpoint;
 		$this->consent_endpoint   = $consent_endpoint;
 		$this->revoke_endpoint    = $revoke_endpoint;
+		$this->context            = $context;
 	}
 
 	/**
@@ -106,6 +117,10 @@ class Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function register_oauth_rewrite_rules(): void {
+		if ( ! $this->context->is_enabled() ) {
+			return;
+		}
+
 		add_rewrite_rule( '^oauth/authorize$', 'index.php?' . self::OAUTH_QUERY_VAR . '=authorize', 'top' );
 		add_rewrite_rule( '^oauth/authorize-callback$', 'index.php?' . self::OAUTH_QUERY_VAR . '=authorize-callback', 'top' );
 		add_rewrite_rule( '^oauth/token$', 'index.php?' . self::OAUTH_QUERY_VAR . '=token', 'top' );
@@ -131,6 +146,10 @@ class Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function handle_oauth_request(): void {
+		if ( ! $this->context->is_enabled() ) {
+			return;
+		}
+
 		$endpoint = (string) get_query_var( self::OAUTH_QUERY_VAR, '' );
 
 		if ( '' === $endpoint ) {

--- a/inc/Engine/MCP/Context.php
+++ b/inc/Engine/MCP/Context.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Engine\MCP;
+
+class Context {
+	/**
+	 * Determines whether the MCP OAuth server is enabled.
+	 *
+	 * @return bool True when the OAuth server (rewrite rules, endpoints,
+	 *              discovery documents, transport) should be registered; false otherwise.
+	 */
+	public function is_enabled(): bool {
+		/**
+		 * Filters whether the MCP OAuth server is enabled.
+		 *
+		 * When `false`, WP Rocket does not register the OAuth rewrite rules or
+		 * respond to any /oauth/* endpoint or /.well-known discovery request,
+		 * and does not register the MCP OAuth transport server.
+		 *
+		 * @param bool $enabled Whether the MCP OAuth server is enabled. Default true.
+		 */
+		return wpm_apply_filters_typed( 'boolean', 'rocket_mcp_oauth_server_enabled', true );
+	}
+}

--- a/inc/Engine/MCP/Transport/ServiceProvider.php
+++ b/inc/Engine/MCP/Transport/ServiceProvider.php
@@ -38,6 +38,6 @@ class ServiceProvider extends AbstractServiceProvider {
 	public function register(): void {
 		$this->getContainer()->add( 'mcp_transport_server', Server::class );
 		$this->getContainer()->addShared( 'mcp_transport_subscriber', Subscriber::class )
-			->addArgument( 'mcp_transport_server' );
+			->addArguments( [ 'mcp_transport_server', 'mcp_context' ] );
 	}
 }

--- a/inc/Engine/MCP/Transport/Subscriber.php
+++ b/inc/Engine/MCP/Transport/Subscriber.php
@@ -6,6 +6,7 @@ namespace WP_Rocket\Engine\MCP\Transport;
 use WP\MCP\Abilities\DiscoverAbilitiesAbility;
 use WP\MCP\Abilities\ExecuteAbilityAbility;
 use WP\MCP\Abilities\GetAbilityInfoAbility;
+use WP_Rocket\Engine\MCP\Context;
 use WP_Rocket\Event_Management\Subscriber_Interface;
 
 class Subscriber implements Subscriber_Interface {
@@ -17,12 +18,21 @@ class Subscriber implements Subscriber_Interface {
 	private $server;
 
 	/**
+	 * OAuth server context.
+	 *
+	 * @var Context
+	 */
+	private $context;
+
+	/**
 	 * Constructor.
 	 *
-	 * @param Server $server MCP server instance.
+	 * @param Server  $server  MCP server instance.
+	 * @param Context $context OAuth server context.
 	 */
-	public function __construct( Server $server ) {
-		$this->server = $server;
+	public function __construct( Server $server, Context $context ) {
+		$this->server  = $server;
+		$this->context = $context;
 	}
 
 	/**
@@ -47,6 +57,10 @@ class Subscriber implements Subscriber_Interface {
 	 * @return void
 	 */
 	public function register_server(): void {
+		if ( ! $this->context->is_enabled() ) {
+			return;
+		}
+
 		$this->server->register_server();
 	}
 

--- a/tests/Fixtures/inc/Engine/MCP/Auth/Subscriber/HandleOauthRequestTest.php
+++ b/tests/Fixtures/inc/Engine/MCP/Auth/Subscriber/HandleOauthRequestTest.php
@@ -1,0 +1,34 @@
+<?php
+
+return [
+	'testShouldDispatchToAuthorizeEndpoint'         => [
+		'config' => [
+			'endpoint' => 'authorize',
+			'mock'     => 'authorize_endpoint',
+		],
+	],
+	'testShouldDispatchToAuthorizeCallbackEndpoint' => [
+		'config' => [
+			'endpoint' => 'authorize-callback',
+			'mock'     => 'authorize_callback',
+		],
+	],
+	'testShouldDispatchToConsentEndpoint'           => [
+		'config' => [
+			'endpoint' => 'consent',
+			'mock'     => 'consent_endpoint',
+		],
+	],
+	'testShouldDispatchToRevokeEndpoint'            => [
+		'config' => [
+			'endpoint' => 'revoke',
+			'mock'     => 'revoke_endpoint',
+		],
+	],
+	'testShouldDispatchToTokenEndpoint'             => [
+		'config' => [
+			'endpoint' => 'token',
+			'mock'     => 'token_endpoint',
+		],
+	],
+];

--- a/tests/Fixtures/inc/Engine/MCP/Context/IsEnabledTest.php
+++ b/tests/Fixtures/inc/Engine/MCP/Context/IsEnabledTest.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+	'testShouldReturnTrueWhenFilterIsTrue'          => [
+		'config'   => [
+			'filter_value' => true,
+		],
+		'expected' => true,
+	],
+	'testShouldReturnFalseWhenFilterIsFalse'        => [
+		'config'   => [
+			'filter_value' => false,
+		],
+		'expected' => false,
+	],
+	'testShouldReturnTrueWhenFilterIsTruthyNonBool' => [
+		'config'   => [
+			'filter_value' => 'yes',
+		],
+		'expected' => true,
+	],
+];

--- a/tests/Integration/inc/Engine/MCP/Auth/OauthRewriteRulesTest.php
+++ b/tests/Integration/inc/Engine/MCP/Auth/OauthRewriteRulesTest.php
@@ -1,0 +1,114 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Integration\inc\Engine\MCP\Auth;
+
+use WP_Rocket\Engine\MCP\Auth\AuthorizeCallback;
+use WP_Rocket\Engine\MCP\Auth\AuthorizeEndpoint;
+use WP_Rocket\Engine\MCP\Auth\CimdResolver;
+use WP_Rocket\Engine\MCP\Auth\ClaudeClientVerifier;
+use WP_Rocket\Engine\MCP\Auth\ConsentEndpoint;
+use WP_Rocket\Engine\MCP\Auth\RevokeEndpoint;
+use WP_Rocket\Engine\MCP\Auth\Subscriber;
+use WP_Rocket\Engine\MCP\Auth\TokenEndpoint;
+use WP_Rocket\Engine\MCP\Context;
+use WP_Rocket\Tests\Integration\TestCase;
+
+/**
+ * Integration tests asserting the OAuth rewrite rules respect the
+ * `rocket_mcp_oauth_server_enabled` filter.
+ *
+ * The subscriber is instantiated directly (with its real collaborators) and
+ * its rewrite-registration method invoked in isolation, rather than via
+ * `do_action( 'init' )`. This test bootstrap never runs a real plugin
+ * activation, so WP Rocket's BerlinDB custom tables (hooked to 'init' by
+ * unrelated subscribers) are never created; calling the full 'init' action
+ * more than once per process trips their own table-creation logic. Testing
+ * the Subscriber method directly keeps this test scoped to the guard clause
+ * under test without depending on that unrelated setup.
+ *
+ * @group MCP
+ */
+class OauthRewriteRulesTest extends TestCase {
+	/**
+	 * Subscriber instance under test.
+	 *
+	 * @var Subscriber
+	 */
+	private $subscriber;
+
+	/**
+	 * Set up the test.
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$verifier = new ClaudeClientVerifier();
+		$resolver = new CimdResolver( $verifier );
+		$context  = new Context();
+
+		$this->subscriber = new Subscriber(
+			new AuthorizeEndpoint( $resolver ),
+			new AuthorizeCallback(),
+			new TokenEndpoint(),
+			new ConsentEndpoint(),
+			new RevokeEndpoint(),
+			$context
+		);
+
+		global $wp_rewrite;
+		$wp_rewrite->extra_rules_top = [];
+	}
+
+	/**
+	 * Tear down the test.
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		remove_all_filters( 'rocket_mcp_oauth_server_enabled' );
+
+		global $wp_rewrite;
+		$wp_rewrite->extra_rules_top = [];
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Test the OAuth rewrite rules are present by default (filter unset).
+	 *
+	 * @return void
+	 */
+	public function testShouldRegisterRewriteRulesByDefault(): void {
+		$this->subscriber->register_oauth_rewrite_rules();
+
+		global $wp_rewrite;
+
+		$this->assertArrayHasKey( '^oauth/authorize$', $wp_rewrite->extra_rules_top );
+		$this->assertArrayHasKey( '^oauth/authorize-callback$', $wp_rewrite->extra_rules_top );
+		$this->assertArrayHasKey( '^oauth/token$', $wp_rewrite->extra_rules_top );
+		$this->assertArrayHasKey( '^oauth/consent$', $wp_rewrite->extra_rules_top );
+		$this->assertArrayHasKey( '^oauth/revoke$', $wp_rewrite->extra_rules_top );
+	}
+
+	/**
+	 * Test the OAuth rewrite rules are absent when the filter disables the server.
+	 *
+	 * @return void
+	 */
+	public function testShouldNotRegisterRewriteRulesWhenDisabled(): void {
+		add_filter( 'rocket_mcp_oauth_server_enabled', '__return_false' );
+
+		$this->subscriber->register_oauth_rewrite_rules();
+
+		global $wp_rewrite;
+
+		$this->assertArrayNotHasKey( '^oauth/authorize$', $wp_rewrite->extra_rules_top );
+		$this->assertArrayNotHasKey( '^oauth/authorize-callback$', $wp_rewrite->extra_rules_top );
+		$this->assertArrayNotHasKey( '^oauth/token$', $wp_rewrite->extra_rules_top );
+		$this->assertArrayNotHasKey( '^oauth/consent$', $wp_rewrite->extra_rules_top );
+		$this->assertArrayNotHasKey( '^oauth/revoke$', $wp_rewrite->extra_rules_top );
+	}
+}

--- a/tests/Unit/inc/Engine/MCP/Auth/Discovery/Subscriber/AddRewriteRulesTest.php
+++ b/tests/Unit/inc/Engine/MCP/Auth/Discovery/Subscriber/AddRewriteRulesTest.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\MCP\Auth\Discovery\Subscriber;
+
+use Mockery;
+use WP_Rocket\Engine\MCP\Auth\Discovery\Endpoints;
+use WP_Rocket\Engine\MCP\Auth\Discovery\Subscriber;
+use WP_Rocket\Engine\MCP\Context;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * Tests for WP_Rocket\Engine\MCP\Auth\Discovery\Subscriber::add_rewrite_rules()
+ *
+ * @group MCP
+ */
+class AddRewriteRulesTest extends TestCase {
+	/**
+	 * Context mock.
+	 *
+	 * @var Context|Mockery\MockInterface
+	 */
+	private $context;
+
+	/**
+	 * Endpoints mock.
+	 *
+	 * @var Endpoints|Mockery\MockInterface
+	 */
+	private $endpoints;
+
+	/**
+	 * Subscriber instance under test.
+	 *
+	 * @var Subscriber
+	 */
+	private $subscriber;
+
+	/**
+	 * Set up the test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->context   = Mockery::mock( Context::class );
+		$this->endpoints = Mockery::mock( Endpoints::class );
+
+		$this->subscriber = new Subscriber( $this->endpoints, $this->context );
+	}
+
+	/**
+	 * Test rewrite rules are not registered when the OAuth server is disabled.
+	 *
+	 * @return void
+	 */
+	public function testShouldNotAddRewriteRulesWhenDisabled(): void {
+		$this->context->shouldReceive( 'is_enabled' )->once()->andReturn( false );
+
+		$this->endpoints->shouldNotReceive( 'add_rewrite_rules' );
+
+		$this->subscriber->add_rewrite_rules();
+	}
+
+	/**
+	 * Test rewrite rules are registered when the OAuth server is enabled.
+	 *
+	 * @return void
+	 */
+	public function testShouldAddRewriteRulesWhenEnabled(): void {
+		$this->context->shouldReceive( 'is_enabled' )->once()->andReturn( true );
+
+		$this->endpoints->shouldReceive( 'add_rewrite_rules' )->once();
+
+		$this->subscriber->add_rewrite_rules();
+	}
+}

--- a/tests/Unit/inc/Engine/MCP/Auth/Discovery/Subscriber/HandleRequestTest.php
+++ b/tests/Unit/inc/Engine/MCP/Auth/Discovery/Subscriber/HandleRequestTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace WP_Rocket\Tests\Unit\inc\Engine\MCP\Auth\Discovery\Subscriber;
 
+use Brain\Monkey\Functions;
 use Mockery;
 use WP_Rocket\Engine\MCP\Auth\Discovery\Endpoints;
 use WP_Rocket\Engine\MCP\Auth\Discovery\Subscriber;
@@ -51,12 +52,19 @@ class HandleRequestTest extends TestCase {
 	}
 
 	/**
-	 * Test the discovery document is not served when the OAuth server is disabled.
+	 * Test nothing happens when no route matched, regardless of enabled state.
 	 *
 	 * @return void
 	 */
 	public function testShouldNotHandleRequestWhenDisabled(): void {
-		$this->context->shouldReceive( 'is_enabled' )->once()->andReturn( false );
+		$this->context->shouldNotReceive( 'is_enabled' );
+
+		Functions\expect( 'get_query_var' )
+			->once()
+			->with( Endpoints::QUERY_VAR, '' )
+			->andReturn( '' );
+
+		Functions\expect( 'status_header' )->never();
 
 		$this->endpoints->shouldNotReceive( 'handle_request' );
 
@@ -71,8 +79,41 @@ class HandleRequestTest extends TestCase {
 	public function testShouldHandleRequestWhenEnabled(): void {
 		$this->context->shouldReceive( 'is_enabled' )->once()->andReturn( true );
 
+		Functions\expect( 'get_query_var' )
+			->once()
+			->with( Endpoints::QUERY_VAR, '' )
+			->andReturn( 'protected-resource' );
+
 		$this->endpoints->shouldReceive( 'handle_request' )->once();
 
 		$this->subscriber->handle_request();
+	}
+
+	/**
+	 * Test a clean 404 is forced when a stale rewrite rule routes a request
+	 * here while the OAuth server is disabled.
+	 *
+	 * @return void
+	 */
+	public function testShouldForce404WhenDisabledButRouteMatchedByStaleRewriteRule(): void {
+		global $wp_query;
+
+		$this->context->shouldReceive( 'is_enabled' )->once()->andReturn( false );
+
+		Functions\expect( 'get_query_var' )
+			->once()
+			->with( Endpoints::QUERY_VAR, '' )
+			->andReturn( 'protected-resource' );
+
+		$wp_query = Mockery::mock(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$wp_query->shouldReceive( 'set_404' )->once();
+
+		Functions\expect( 'status_header' )->once()->with( 404 );
+
+		$this->endpoints->shouldNotReceive( 'handle_request' );
+
+		$this->subscriber->handle_request();
+
+		$wp_query = null; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 	}
 }

--- a/tests/Unit/inc/Engine/MCP/Auth/Discovery/Subscriber/HandleRequestTest.php
+++ b/tests/Unit/inc/Engine/MCP/Auth/Discovery/Subscriber/HandleRequestTest.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\MCP\Auth\Discovery\Subscriber;
+
+use Mockery;
+use WP_Rocket\Engine\MCP\Auth\Discovery\Endpoints;
+use WP_Rocket\Engine\MCP\Auth\Discovery\Subscriber;
+use WP_Rocket\Engine\MCP\Context;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * Tests for WP_Rocket\Engine\MCP\Auth\Discovery\Subscriber::handle_request()
+ *
+ * @group MCP
+ */
+class HandleRequestTest extends TestCase {
+	/**
+	 * Context mock.
+	 *
+	 * @var Context|Mockery\MockInterface
+	 */
+	private $context;
+
+	/**
+	 * Endpoints mock.
+	 *
+	 * @var Endpoints|Mockery\MockInterface
+	 */
+	private $endpoints;
+
+	/**
+	 * Subscriber instance under test.
+	 *
+	 * @var Subscriber
+	 */
+	private $subscriber;
+
+	/**
+	 * Set up the test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->context   = Mockery::mock( Context::class );
+		$this->endpoints = Mockery::mock( Endpoints::class );
+
+		$this->subscriber = new Subscriber( $this->endpoints, $this->context );
+	}
+
+	/**
+	 * Test the discovery document is not served when the OAuth server is disabled.
+	 *
+	 * @return void
+	 */
+	public function testShouldNotHandleRequestWhenDisabled(): void {
+		$this->context->shouldReceive( 'is_enabled' )->once()->andReturn( false );
+
+		$this->endpoints->shouldNotReceive( 'handle_request' );
+
+		$this->subscriber->handle_request();
+	}
+
+	/**
+	 * Test the discovery document is served when the OAuth server is enabled.
+	 *
+	 * @return void
+	 */
+	public function testShouldHandleRequestWhenEnabled(): void {
+		$this->context->shouldReceive( 'is_enabled' )->once()->andReturn( true );
+
+		$this->endpoints->shouldReceive( 'handle_request' )->once();
+
+		$this->subscriber->handle_request();
+	}
+}

--- a/tests/Unit/inc/Engine/MCP/Auth/Subscriber/HandleOauthRequestTest.php
+++ b/tests/Unit/inc/Engine/MCP/Auth/Subscriber/HandleOauthRequestTest.php
@@ -95,14 +95,19 @@ class HandleOauthRequestTest extends TestCase {
 	}
 
 	/**
-	 * Test no endpoint handler receives dispatch when the OAuth server is disabled.
+	 * Test nothing happens when no route matched, regardless of enabled state.
 	 *
 	 * @return void
 	 */
 	public function testShouldNotDispatchWhenDisabled(): void {
-		$this->context->shouldReceive( 'is_enabled' )->once()->andReturn( false );
+		$this->context->shouldNotReceive( 'is_enabled' );
 
-		Functions\expect( 'get_query_var' )->never();
+		Functions\expect( 'get_query_var' )
+			->once()
+			->with( Subscriber::OAUTH_QUERY_VAR, '' )
+			->andReturn( '' );
+
+		Functions\expect( 'status_header' )->never();
 
 		$this->authorize_endpoint->shouldNotReceive( 'handle_request' );
 		$this->authorize_callback->shouldNotReceive( 'handle_request' );
@@ -111,6 +116,38 @@ class HandleOauthRequestTest extends TestCase {
 		$this->revoke_endpoint->shouldNotReceive( 'handle_request' );
 
 		$this->subscriber->handle_oauth_request();
+	}
+
+	/**
+	 * Test a clean 404 is forced when a stale rewrite rule routes a request
+	 * here while the OAuth server is disabled.
+	 *
+	 * @return void
+	 */
+	public function testShouldForce404WhenDisabledButRouteMatchedByStaleRewriteRule(): void {
+		global $wp_query;
+
+		$this->context->shouldReceive( 'is_enabled' )->once()->andReturn( false );
+
+		Functions\expect( 'get_query_var' )
+			->once()
+			->with( Subscriber::OAUTH_QUERY_VAR, '' )
+			->andReturn( 'authorize' );
+
+		$wp_query = Mockery::mock(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$wp_query->shouldReceive( 'set_404' )->once();
+
+		Functions\expect( 'status_header' )->once()->with( 404 );
+
+		$this->authorize_endpoint->shouldNotReceive( 'handle_request' );
+		$this->authorize_callback->shouldNotReceive( 'handle_request' );
+		$this->token_endpoint->shouldNotReceive( 'handle_request' );
+		$this->consent_endpoint->shouldNotReceive( 'handle_request' );
+		$this->revoke_endpoint->shouldNotReceive( 'handle_request' );
+
+		$this->subscriber->handle_oauth_request();
+
+		$wp_query = null; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 	}
 
 	/**

--- a/tests/Unit/inc/Engine/MCP/Auth/Subscriber/HandleOauthRequestTest.php
+++ b/tests/Unit/inc/Engine/MCP/Auth/Subscriber/HandleOauthRequestTest.php
@@ -1,0 +1,138 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\MCP\Auth\Subscriber;
+
+use Brain\Monkey\Functions;
+use Mockery;
+use WP_Rocket\Engine\MCP\Auth\AuthorizeCallback;
+use WP_Rocket\Engine\MCP\Auth\AuthorizeEndpoint;
+use WP_Rocket\Engine\MCP\Auth\ConsentEndpoint;
+use WP_Rocket\Engine\MCP\Auth\RevokeEndpoint;
+use WP_Rocket\Engine\MCP\Auth\Subscriber;
+use WP_Rocket\Engine\MCP\Auth\TokenEndpoint;
+use WP_Rocket\Engine\MCP\Context;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * Tests for WP_Rocket\Engine\MCP\Auth\Subscriber::handle_oauth_request()
+ *
+ * @group MCP
+ */
+class HandleOauthRequestTest extends TestCase {
+	/**
+	 * Context mock.
+	 *
+	 * @var Context|Mockery\MockInterface
+	 */
+	private $context;
+
+	/**
+	 * Authorize endpoint mock.
+	 *
+	 * @var AuthorizeEndpoint|Mockery\MockInterface
+	 */
+	private $authorize_endpoint;
+
+	/**
+	 * Authorize callback mock.
+	 *
+	 * @var AuthorizeCallback|Mockery\MockInterface
+	 */
+	private $authorize_callback;
+
+	/**
+	 * Token endpoint mock.
+	 *
+	 * @var TokenEndpoint|Mockery\MockInterface
+	 */
+	private $token_endpoint;
+
+	/**
+	 * Consent endpoint mock.
+	 *
+	 * @var ConsentEndpoint|Mockery\MockInterface
+	 */
+	private $consent_endpoint;
+
+	/**
+	 * Revoke endpoint mock.
+	 *
+	 * @var RevokeEndpoint|Mockery\MockInterface
+	 */
+	private $revoke_endpoint;
+
+	/**
+	 * Subscriber instance under test.
+	 *
+	 * @var Subscriber
+	 */
+	private $subscriber;
+
+	/**
+	 * Set up the test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->context            = Mockery::mock( Context::class );
+		$this->authorize_endpoint = Mockery::mock( AuthorizeEndpoint::class );
+		$this->authorize_callback = Mockery::mock( AuthorizeCallback::class );
+		$this->token_endpoint     = Mockery::mock( TokenEndpoint::class );
+		$this->consent_endpoint   = Mockery::mock( ConsentEndpoint::class );
+		$this->revoke_endpoint    = Mockery::mock( RevokeEndpoint::class );
+
+		$this->subscriber = new Subscriber(
+			$this->authorize_endpoint,
+			$this->authorize_callback,
+			$this->token_endpoint,
+			$this->consent_endpoint,
+			$this->revoke_endpoint,
+			$this->context
+		);
+	}
+
+	/**
+	 * Test no endpoint handler receives dispatch when the OAuth server is disabled.
+	 *
+	 * @return void
+	 */
+	public function testShouldNotDispatchWhenDisabled(): void {
+		$this->context->shouldReceive( 'is_enabled' )->once()->andReturn( false );
+
+		Functions\expect( 'get_query_var' )->never();
+
+		$this->authorize_endpoint->shouldNotReceive( 'handle_request' );
+		$this->authorize_callback->shouldNotReceive( 'handle_request' );
+		$this->token_endpoint->shouldNotReceive( 'handle_request' );
+		$this->consent_endpoint->shouldNotReceive( 'handle_request' );
+		$this->revoke_endpoint->shouldNotReceive( 'handle_request' );
+
+		$this->subscriber->handle_oauth_request();
+	}
+
+	/**
+	 * Test the request is dispatched to the matching endpoint handler when enabled.
+	 *
+	 * @dataProvider configTestData
+	 *
+	 * @param array $config Test configuration containing the 'endpoint' query var value
+	 *                      and 'mock' the mock property name expected to receive the call.
+	 *
+	 * @return void
+	 */
+	public function testShouldDispatchToMatchingHandlerWhenEnabled( array $config ): void {
+		$this->context->shouldReceive( 'is_enabled' )->once()->andReturn( true );
+
+		Functions\expect( 'get_query_var' )
+			->once()
+			->with( Subscriber::OAUTH_QUERY_VAR, '' )
+			->andReturn( $config['endpoint'] );
+
+		$this->{$config['mock']}->shouldReceive( 'handle_request' )->once();
+
+		$this->subscriber->handle_oauth_request();
+	}
+}

--- a/tests/Unit/inc/Engine/MCP/Auth/Subscriber/RegisterOauthRewriteRulesTest.php
+++ b/tests/Unit/inc/Engine/MCP/Auth/Subscriber/RegisterOauthRewriteRulesTest.php
@@ -1,0 +1,82 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\MCP\Auth\Subscriber;
+
+use Brain\Monkey\Functions;
+use Mockery;
+use WP_Rocket\Engine\MCP\Auth\AuthorizeCallback;
+use WP_Rocket\Engine\MCP\Auth\AuthorizeEndpoint;
+use WP_Rocket\Engine\MCP\Auth\ConsentEndpoint;
+use WP_Rocket\Engine\MCP\Auth\RevokeEndpoint;
+use WP_Rocket\Engine\MCP\Auth\Subscriber;
+use WP_Rocket\Engine\MCP\Auth\TokenEndpoint;
+use WP_Rocket\Engine\MCP\Context;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * Tests for WP_Rocket\Engine\MCP\Auth\Subscriber::register_oauth_rewrite_rules()
+ *
+ * @group MCP
+ */
+class RegisterOauthRewriteRulesTest extends TestCase {
+	/**
+	 * Context mock.
+	 *
+	 * @var Context|Mockery\MockInterface
+	 */
+	private $context;
+
+	/**
+	 * Subscriber instance under test.
+	 *
+	 * @var Subscriber
+	 */
+	private $subscriber;
+
+	/**
+	 * Set up the test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->context = Mockery::mock( Context::class );
+
+		$this->subscriber = new Subscriber(
+			Mockery::mock( AuthorizeEndpoint::class ),
+			Mockery::mock( AuthorizeCallback::class ),
+			Mockery::mock( TokenEndpoint::class ),
+			Mockery::mock( ConsentEndpoint::class ),
+			Mockery::mock( RevokeEndpoint::class ),
+			$this->context
+		);
+	}
+
+	/**
+	 * Test rewrite rules are not registered when the OAuth server is disabled.
+	 *
+	 * @return void
+	 */
+	public function testShouldNotRegisterRewriteRulesWhenDisabled(): void {
+		$this->context->shouldReceive( 'is_enabled' )->once()->andReturn( false );
+
+		Functions\expect( 'add_rewrite_rule' )->never();
+
+		$this->subscriber->register_oauth_rewrite_rules();
+	}
+
+	/**
+	 * Test all five rewrite rules are registered when the OAuth server is enabled.
+	 *
+	 * @return void
+	 */
+	public function testShouldRegisterAllRewriteRulesWhenEnabled(): void {
+		$this->context->shouldReceive( 'is_enabled' )->once()->andReturn( true );
+
+		Functions\expect( 'add_rewrite_rule' )->times( 5 );
+
+		$this->subscriber->register_oauth_rewrite_rules();
+	}
+}

--- a/tests/Unit/inc/Engine/MCP/Context/IsEnabledTest.php
+++ b/tests/Unit/inc/Engine/MCP/Context/IsEnabledTest.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\MCP\Context;
+
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+use WP_Rocket\Engine\MCP\Context;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * Tests for WP_Rocket\Engine\MCP\Context::is_enabled()
+ *
+ * @group MCP
+ */
+class IsEnabledTest extends TestCase {
+	/**
+	 * Test should return expected result based on filter value.
+	 *
+	 * @dataProvider configTestData
+	 *
+	 * @param array $config   Test configuration.
+	 * @param bool  $expected Expected return value.
+	 *
+	 * @return void
+	 */
+	public function testShouldReturnExpected( array $config, bool $expected ): void {
+		Functions\when( '_doing_it_wrong' )->justReturn( null );
+		Functions\when( 'esc_attr' )->returnArg();
+
+		Filters\expectApplied( 'rocket_mcp_oauth_server_enabled' )
+			->once()
+			->with( true )
+			->andReturn( $config['filter_value'] );
+
+		$context = new Context();
+
+		$this->assertSame( $expected, $context->is_enabled() );
+	}
+}

--- a/tests/Unit/inc/Engine/MCP/Transport/Subscriber/RegisterServerTest.php
+++ b/tests/Unit/inc/Engine/MCP/Transport/Subscriber/RegisterServerTest.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\MCP\Transport\Subscriber;
+
+use Mockery;
+use WP_Rocket\Engine\MCP\Context;
+use WP_Rocket\Engine\MCP\Transport\Server;
+use WP_Rocket\Engine\MCP\Transport\Subscriber;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * Tests for WP_Rocket\Engine\MCP\Transport\Subscriber::register_server()
+ *
+ * @group MCP
+ */
+class RegisterServerTest extends TestCase {
+	/**
+	 * Context mock.
+	 *
+	 * @var Context|Mockery\MockInterface
+	 */
+	private $context;
+
+	/**
+	 * Server mock.
+	 *
+	 * @var Server|Mockery\MockInterface
+	 */
+	private $server;
+
+	/**
+	 * Subscriber instance under test.
+	 *
+	 * @var Subscriber
+	 */
+	private $subscriber;
+
+	/**
+	 * Set up the test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->context = Mockery::mock( Context::class );
+		$this->server  = Mockery::mock( Server::class );
+
+		$this->subscriber = new Subscriber( $this->server, $this->context );
+	}
+
+	/**
+	 * Test the MCP server is not registered when the OAuth server is disabled.
+	 *
+	 * @return void
+	 */
+	public function testShouldNotRegisterServerWhenDisabled(): void {
+		$this->context->shouldReceive( 'is_enabled' )->once()->andReturn( false );
+
+		$this->server->shouldNotReceive( 'register_server' );
+
+		$this->subscriber->register_server();
+	}
+
+	/**
+	 * Test the MCP server is registered when the OAuth server is enabled.
+	 *
+	 * @return void
+	 */
+	public function testShouldRegisterServerWhenEnabled(): void {
+		$this->context->shouldReceive( 'is_enabled' )->once()->andReturn( true );
+
+		$this->server->shouldReceive( 'register_server' )->once();
+
+		$this->subscriber->register_server();
+	}
+}


### PR DESCRIPTION
# Description

Closes #8581

The MCP OAuth rewrite rules, `/.well-known` discovery documents, and the MCP transport server were all wired up unconditionally, with no way to disable the surface without a code release. This adds a `rocket_mcp_oauth_server_enabled` filter (default `true`) that gates all three.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

### What was tested

**Automated:**
- New unit tests for `MCP\Context::is_enabled()` (default true, filter override).
- New unit tests for `Auth\Subscriber::register_oauth_rewrite_rules()` and `handle_oauth_request()` (disabled → no-op; enabled → unchanged behavior).
- New unit tests for `Auth\Discovery\Subscriber::add_rewrite_rules()` and `handle_request()` (same coverage for the `/.well-known` documents).
- New unit test for `Transport\Subscriber::register_server()` (same coverage for the MCP transport server registration).
- New integration test asserting the actual `$wp_rewrite` rule set: OAuth rules present by default, absent when the filter returns `false`.

**Manual, end-to-end, live HTTP testing** (real WP install on this branch, real requests via `curl`):

<details>
<summary><strong>✅ Enabled (default) — all three surfaces respond normally</strong></summary>

```
GET /oauth/authorize            → 400 Bad Request ("client_id is required.")
GET /.well-known/oauth-protected-resource → 200 OK, valid discovery JSON
GET /wp-json/mcp/mcp-oauth-server → 401 Unauthorized (route exists, needs a bearer token)
```

All three respond as live, dispatched endpoints — a 400/401 here means the request reached real endpoint logic, not a 404. This is the pre-existing baseline, confirming the guard clauses don't change default behavior.

</details>

<details>
<summary><strong>❌ Disabled via filter — all three surfaces 404</strong></summary>

With `add_filter( 'rocket_mcp_oauth_server_enabled', '__return_false' )` active and permalinks flushed:

```
GET /oauth/authorize            → 404 Not Found
GET /.well-known/oauth-protected-resource → 404 Not Found
GET /wp-json/mcp/mcp-oauth-server → 404 Not Found (REST route no longer registered)
```

Removing the filter and re-flushing restores all three to the exact baseline above.

**Also confirmed the edge case documented in the spec**: with the filter disabled but *before* flushing permalinks (stale rewrite rule still in the DB), the request no longer reaches any OAuth logic — `handle_oauth_request()`'s guard clause returns early regardless. It does *not* produce a clean 404 in that specific transitional state though; WordPress's main query falls through to rendering the site's normal homepage output (200) rather than triggering `is_404()`, since a recognized-but-unmatched query var doesn't auto-404 on its own. This only matters in the narrow window between toggling the filter and the next permalink flush — the fully-settled state (after any flush) 404s correctly as shown above, and this doesn't affect anything else about the feature's actual security/correctness properties (nothing OAuth-related executes either way).

</details>

<details>
<summary><strong>⚠️ Unrelated finding — WP Rocket's own page cache doesn't exclude these routes</strong></summary>

While testing, found that WP Rocket's own full-page cache caches `/oauth/*` and `/.well-known/*` responses like any other page, including a page-cache hit that briefly masked the disabled-state test until the cache was cleared. This is a pre-existing behavior, not introduced or worsened by this change — it existed before this PR since these routes were never excluded from caching in the first place. Flagging it since it's arguably a candidate for a follow-up issue (these endpoints are inherently dynamic/security-sensitive and probably shouldn't be page-cached at all), but it's out of scope for this PR.

</details>

### How to test

```
vendor/bin/phpunit --configuration tests/Unit/phpunit.xml.dist --filter "MCP"
vendor/bin/phpunit --configuration tests/Integration/phpunit.xml.dist --group MCP
```

Manually:
1. On this branch, confirm `/oauth/authorize` and `/.well-known/oauth-protected-resource` respond normally (default, filter untouched).
2. Add `add_filter( 'rocket_mcp_oauth_server_enabled', '__return_false' );`, flush permalinks.
3. Confirm `/oauth/authorize`, the other `/oauth/*` endpoints, and both `/.well-known/*` discovery documents now 404 (normal WordPress not-found handling, not an OAuth-specific error).
4. Confirm the MCP transport server (`/wp-json/mcp/mcp-oauth-server`) is no longer registered.
5. Remove the filter and confirm everything returns to normal.

### Affected Features & Quality Assurance Scope

- MCP OAuth server: `Auth\Subscriber`, `Auth\Discovery\Subscriber`, `Transport\Subscriber`. No other module affected. The mcp-adapter package's shared abilities (used by other, unrelated MCP integrations on the same site) are intentionally untouched by this filter.

## Technical description

### Documentation

New `MCP\Context` class (mirrors the existing `Abilities\Context` pattern in this codebase) wraps `wpm_apply_filters_typed( 'boolean', 'rocket_mcp_oauth_server_enabled', true )`, documented inline. Injected into all three subscribers as a guard clause at the top of every method that registers a rewrite rule or dispatches/serves a request.

Note: the original request only named `Auth\Subscriber` and `Transport\Subscriber`. `Auth\Discovery\Subscriber` (serves the `/.well-known` documents) is wired unconditionally in `inc/Plugin.php` too and needed the same guard, or the discovery documents would stay reachable with the server otherwise "disabled."

`mcp_context` is registered once as a shared service in `Auth\ServiceProvider` and referenced by container-key string from `Transport\ServiceProvider` — the same cross-provider pattern already used elsewhere in this codebase (`Abilities\ServiceProvider` references `'options'`, registered by an unrelated provider).

### New dependencies

None.

### Risks

Low. Default behavior (filter untouched) is unchanged — confirmed by both the "enabled" test cases and by the fact that every guard is an early-return added at the top of an existing method, with no other logic touched. Rewrite-rule flushing on deactivation is left unguarded intentionally so no rules linger regardless of the filter's state.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs. — N/A, `Context::is_enabled()` takes no parameters.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable. — N/A, no new user-facing messages; disabled endpoints simply 404 as WordPress normally would for an unregistered route.

## Unticked items justification

None — all mandatory items apply and are checked.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it. — inline docblock on `Context::is_enabled()` documents the filter.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.). — N/A, no new observability surface.
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.) — N/A, no new HTTP/filesystem calls introduced.

