### PR TITLE
fix(cdn): correct WP Rocket brand spelling

### DIFF
--- a/inc/Engine/CDN/Render/Controller.php
+++ b/inc/Engine/CDN/Render/Controller.php
@@ -624,7 +624,7 @@ class Controller extends Abstract_Render {
 
 		if ( $this->subscription_controller->is_license_invalid() ) {
 			$texts['class']         .= ' wpr-cdn-status--expired';
-			$texts['paused_details'] = __( 'RocketCDN is currently paused because your WPRocket licence has expired.', 'rocket' );
+			$texts['paused_details'] = __( 'RocketCDN is currently paused because your WP Rocket licence has expired.', 'rocket' );
 		}
 
 		return $texts;

--- a/languages/rocket-cs_CZ.po
+++ b/languages/rocket-cs_CZ.po
@@ -3317,7 +3317,7 @@ msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:627
 msgid ""
-"RocketCDN is currently paused because your WPRocket licence has expired."
+"RocketCDN is currently paused because your WP Rocket licence has expired."
 msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:652
@@ -5772,7 +5772,7 @@ msgid "RESUME CDN"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:23
-msgid "Your WPRocket license has expired"
+msgid "Your WP Rocket license has expired"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:25

--- a/languages/rocket-da_DK.po
+++ b/languages/rocket-da_DK.po
@@ -3276,7 +3276,7 @@ msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:627
 msgid ""
-"RocketCDN is currently paused because your WPRocket licence has expired."
+"RocketCDN is currently paused because your WP Rocket licence has expired."
 msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:652
@@ -5692,7 +5692,7 @@ msgid "RESUME CDN"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:23
-msgid "Your WPRocket license has expired"
+msgid "Your WP Rocket license has expired"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:25

--- a/languages/rocket-de_DE.po
+++ b/languages/rocket-de_DE.po
@@ -3350,7 +3350,7 @@ msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:627
 msgid ""
-"RocketCDN is currently paused because your WPRocket licence has expired."
+"RocketCDN is currently paused because your WP Rocket licence has expired."
 msgstr ""
 "RocketCDN ist derzeit pausiert, weil deine WP-Rocket-Lizenz abgelaufen ist."
 
@@ -5862,7 +5862,7 @@ msgid "RESUME CDN"
 msgstr "CDN REAKTIVIEREN"
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:23
-msgid "Your WPRocket license has expired"
+msgid "Your WP Rocket license has expired"
 msgstr "Deine Lizenz für WP Rocket ist abgelaufen"
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:25

--- a/languages/rocket-es_ES.po
+++ b/languages/rocket-es_ES.po
@@ -3383,7 +3383,7 @@ msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:627
 msgid ""
-"RocketCDN is currently paused because your WPRocket licence has expired."
+"RocketCDN is currently paused because your WP Rocket licence has expired."
 msgstr ""
 "RocketCDN está actualmente en pausa porque tu licencia de WP Rocket ha "
 "expirado."
@@ -5879,7 +5879,7 @@ msgid "RESUME CDN"
 msgstr "REANUDAR CDN"
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:23
-msgid "Your WPRocket license has expired"
+msgid "Your WP Rocket license has expired"
 msgstr "Tu licencia de WP Rocket ha expirado"
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:25

--- a/languages/rocket-fa_IR.po
+++ b/languages/rocket-fa_IR.po
@@ -3277,9 +3277,9 @@ msgstr "ارائه فایل‌ها از 10 مکان حاشیه‌ای. پوشش 
 
 #: inc/Engine/CDN/Render/Controller.php:627
 msgid ""
-"RocketCDN is currently paused because your WPRocket licence has expired."
+"RocketCDN is currently paused because your WP Rocket licence has expired."
 msgstr ""
-"RocketCDN در حال حاضر متوقف شده است زیرا مجوز WPRocket شما منقضی شده است."
+"RocketCDN در حال حاضر متوقف شده است زیرا مجوز WP Rocket شما منقضی شده است."
 
 #: inc/Engine/CDN/Render/Controller.php:652
 msgid "Serving files from 100+ edge locations"
@@ -5696,7 +5696,7 @@ msgid "RESUME CDN"
 msgstr "ادامه CDN"
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:23
-msgid "Your WPRocket license has expired"
+msgid "Your WP Rocket license has expired"
 msgstr "لایسنس شما منقضی شده است"
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:25

--- a/languages/rocket-fi.po
+++ b/languages/rocket-fi.po
@@ -3284,7 +3284,7 @@ msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:627
 msgid ""
-"RocketCDN is currently paused because your WPRocket licence has expired."
+"RocketCDN is currently paused because your WP Rocket licence has expired."
 msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:652
@@ -5727,7 +5727,7 @@ msgid "RESUME CDN"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:23
-msgid "Your WPRocket license has expired"
+msgid "Your WP Rocket license has expired"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:25

--- a/languages/rocket-fr_CA.po
+++ b/languages/rocket-fr_CA.po
@@ -3303,7 +3303,7 @@ msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:627
 msgid ""
-"RocketCDN is currently paused because your WPRocket licence has expired."
+"RocketCDN is currently paused because your WP Rocket licence has expired."
 msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:652
@@ -5761,7 +5761,7 @@ msgid "RESUME CDN"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:23
-msgid "Your WPRocket license has expired"
+msgid "Your WP Rocket license has expired"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:25

--- a/languages/rocket-fr_FR.po
+++ b/languages/rocket-fr_FR.po
@@ -3416,9 +3416,9 @@ msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:627
 msgid ""
-"RocketCDN is currently paused because your WPRocket licence has expired."
+"RocketCDN is currently paused because your WP Rocket licence has expired."
 msgstr ""
-"RocketCDN est actuellement en pause car votre licence WPRocket a expiré."
+"RocketCDN est actuellement en pause car votre licence WP Rocket a expiré."
 
 #: inc/Engine/CDN/Render/Controller.php:652
 msgid "Serving files from 100+ edge locations"
@@ -5941,8 +5941,8 @@ msgid "RESUME CDN"
 msgstr "REPRENDRE LE CDN"
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:23
-msgid "Your WPRocket license has expired"
-msgstr "Votre licence WPRocket a expiré"
+msgid "Your WP Rocket license has expired"
+msgstr "Votre licence WP Rocket a expiré"
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:25
 msgid "Please renew it to keep using RocketCDN."

--- a/languages/rocket-hr.po
+++ b/languages/rocket-hr.po
@@ -3279,7 +3279,7 @@ msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:627
 msgid ""
-"RocketCDN is currently paused because your WPRocket licence has expired."
+"RocketCDN is currently paused because your WP Rocket licence has expired."
 msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:652
@@ -5612,7 +5612,7 @@ msgid "RESUME CDN"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:23
-msgid "Your WPRocket license has expired"
+msgid "Your WP Rocket license has expired"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:25

--- a/languages/rocket-hu_HU.po
+++ b/languages/rocket-hu_HU.po
@@ -3300,7 +3300,7 @@ msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:627
 msgid ""
-"RocketCDN is currently paused because your WPRocket licence has expired."
+"RocketCDN is currently paused because your WP Rocket licence has expired."
 msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:652
@@ -5663,7 +5663,7 @@ msgid "RESUME CDN"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:23
-msgid "Your WPRocket license has expired"
+msgid "Your WP Rocket license has expired"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:25

--- a/languages/rocket-it_IT.po
+++ b/languages/rocket-it_IT.po
@@ -3223,7 +3223,7 @@ msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:627
 msgid ""
-"RocketCDN is currently paused because your WPRocket licence has expired."
+"RocketCDN is currently paused because your WP Rocket licence has expired."
 msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:652
@@ -5522,7 +5522,7 @@ msgid "RESUME CDN"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:23
-msgid "Your WPRocket license has expired"
+msgid "Your WP Rocket license has expired"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:25

--- a/languages/rocket-ja_JP.po
+++ b/languages/rocket-ja_JP.po
@@ -3029,7 +3029,7 @@ msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:627
 msgid ""
-"RocketCDN is currently paused because your WPRocket licence has expired."
+"RocketCDN is currently paused because your WP Rocket licence has expired."
 msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:652
@@ -5251,7 +5251,7 @@ msgid "RESUME CDN"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:23
-msgid "Your WPRocket license has expired"
+msgid "Your WP Rocket license has expired"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:25

--- a/languages/rocket-ko.po
+++ b/languages/rocket-ko.po
@@ -3057,7 +3057,7 @@ msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:627
 msgid ""
-"RocketCDN is currently paused because your WPRocket licence has expired."
+"RocketCDN is currently paused because your WP Rocket licence has expired."
 msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:652
@@ -5333,7 +5333,7 @@ msgid "RESUME CDN"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:23
-msgid "Your WPRocket license has expired"
+msgid "Your WP Rocket license has expired"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:25

--- a/languages/rocket-ko_KR.po
+++ b/languages/rocket-ko_KR.po
@@ -3058,7 +3058,7 @@ msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:627
 msgid ""
-"RocketCDN is currently paused because your WPRocket licence has expired."
+"RocketCDN is currently paused because your WP Rocket licence has expired."
 msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:652
@@ -5331,7 +5331,7 @@ msgid "RESUME CDN"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:23
-msgid "Your WPRocket license has expired"
+msgid "Your WP Rocket license has expired"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:25

--- a/languages/rocket-nb_NO.po
+++ b/languages/rocket-nb_NO.po
@@ -3250,7 +3250,7 @@ msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:627
 msgid ""
-"RocketCDN is currently paused because your WPRocket licence has expired."
+"RocketCDN is currently paused because your WP Rocket licence has expired."
 msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:652
@@ -5660,7 +5660,7 @@ msgid "RESUME CDN"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:23
-msgid "Your WPRocket license has expired"
+msgid "Your WP Rocket license has expired"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:25

--- a/languages/rocket-nl_NL.po
+++ b/languages/rocket-nl_NL.po
@@ -3257,7 +3257,7 @@ msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:627
 msgid ""
-"RocketCDN is currently paused because your WPRocket licence has expired."
+"RocketCDN is currently paused because your WP Rocket licence has expired."
 msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:652
@@ -5673,7 +5673,7 @@ msgid "RESUME CDN"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:23
-msgid "Your WPRocket license has expired"
+msgid "Your WP Rocket license has expired"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:25

--- a/languages/rocket-pl_PL.po
+++ b/languages/rocket-pl_PL.po
@@ -3296,7 +3296,7 @@ msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:627
 msgid ""
-"RocketCDN is currently paused because your WPRocket licence has expired."
+"RocketCDN is currently paused because your WP Rocket licence has expired."
 msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:652
@@ -5695,7 +5695,7 @@ msgid "RESUME CDN"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:23
-msgid "Your WPRocket license has expired"
+msgid "Your WP Rocket license has expired"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:25

--- a/languages/rocket-pt_BR.po
+++ b/languages/rocket-pt_BR.po
@@ -3361,7 +3361,7 @@ msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:627
 msgid ""
-"RocketCDN is currently paused because your WPRocket licence has expired."
+"RocketCDN is currently paused because your WP Rocket licence has expired."
 msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:652
@@ -5831,7 +5831,7 @@ msgid "RESUME CDN"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:23
-msgid "Your WPRocket license has expired"
+msgid "Your WP Rocket license has expired"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:25

--- a/languages/rocket-pt_PT.po
+++ b/languages/rocket-pt_PT.po
@@ -3358,7 +3358,7 @@ msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:627
 msgid ""
-"RocketCDN is currently paused because your WPRocket licence has expired."
+"RocketCDN is currently paused because your WP Rocket licence has expired."
 msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:652
@@ -5840,7 +5840,7 @@ msgid "RESUME CDN"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:23
-msgid "Your WPRocket license has expired"
+msgid "Your WP Rocket license has expired"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:25

--- a/languages/rocket-ro_RO.po
+++ b/languages/rocket-ro_RO.po
@@ -3305,7 +3305,7 @@ msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:627
 msgid ""
-"RocketCDN is currently paused because your WPRocket licence has expired."
+"RocketCDN is currently paused because your WP Rocket licence has expired."
 msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:652
@@ -5758,7 +5758,7 @@ msgid "RESUME CDN"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:23
-msgid "Your WPRocket license has expired"
+msgid "Your WP Rocket license has expired"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:25

--- a/languages/rocket-ru_RU.po
+++ b/languages/rocket-ru_RU.po
@@ -3196,7 +3196,7 @@ msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:627
 msgid ""
-"RocketCDN is currently paused because your WPRocket licence has expired."
+"RocketCDN is currently paused because your WP Rocket licence has expired."
 msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:652
@@ -5480,7 +5480,7 @@ msgid "RESUME CDN"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:23
-msgid "Your WPRocket license has expired"
+msgid "Your WP Rocket license has expired"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:25

--- a/languages/rocket-sk_SK.po
+++ b/languages/rocket-sk_SK.po
@@ -3303,7 +3303,7 @@ msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:627
 msgid ""
-"RocketCDN is currently paused because your WPRocket licence has expired."
+"RocketCDN is currently paused because your WP Rocket licence has expired."
 msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:652
@@ -5745,7 +5745,7 @@ msgid "RESUME CDN"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:23
-msgid "Your WPRocket license has expired"
+msgid "Your WP Rocket license has expired"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:25

--- a/languages/rocket-sv_SE.po
+++ b/languages/rocket-sv_SE.po
@@ -3266,7 +3266,7 @@ msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:627
 msgid ""
-"RocketCDN is currently paused because your WPRocket licence has expired."
+"RocketCDN is currently paused because your WP Rocket licence has expired."
 msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:652
@@ -5681,7 +5681,7 @@ msgid "RESUME CDN"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:23
-msgid "Your WPRocket license has expired"
+msgid "Your WP Rocket license has expired"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:25

--- a/languages/rocket-tr_TR.po
+++ b/languages/rocket-tr_TR.po
@@ -3347,9 +3347,9 @@ msgstr "Dosyalar 10 uç konumdan sunuluyor. 3 sayfaya kadar kapsar."
 
 #: inc/Engine/CDN/Render/Controller.php:627
 msgid ""
-"RocketCDN is currently paused because your WPRocket licence has expired."
+"RocketCDN is currently paused because your WP Rocket licence has expired."
 msgstr ""
-"WPRocket lisansınızın süresi dolduğundan RocketCDN şu anda duraklatıldı."
+"WP Rocket lisansınızın süresi dolduğundan RocketCDN şu anda duraklatıldı."
 
 #: inc/Engine/CDN/Render/Controller.php:652
 msgid "Serving files from 100+ edge locations"
@@ -5847,8 +5847,8 @@ msgid "RESUME CDN"
 msgstr "CDN’yi SÜRDÜR"
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:23
-msgid "Your WPRocket license has expired"
-msgstr "WPRocket lisansınızın süresi doldu"
+msgid "Your WP Rocket license has expired"
+msgstr "WP Rocket lisansınızın süresi doldu"
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:25
 msgid "Please renew it to keep using RocketCDN."

--- a/languages/rocket-uk_UA.po
+++ b/languages/rocket-uk_UA.po
@@ -3219,7 +3219,7 @@ msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:627
 msgid ""
-"RocketCDN is currently paused because your WPRocket licence has expired."
+"RocketCDN is currently paused because your WP Rocket licence has expired."
 msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:652
@@ -5496,7 +5496,7 @@ msgid "RESUME CDN"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:23
-msgid "Your WPRocket license has expired"
+msgid "Your WP Rocket license has expired"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:25

--- a/languages/rocket-zh_CN.po
+++ b/languages/rocket-zh_CN.po
@@ -2982,7 +2982,7 @@ msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:627
 msgid ""
-"RocketCDN is currently paused because your WPRocket licence has expired."
+"RocketCDN is currently paused because your WP Rocket licence has expired."
 msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:652
@@ -5222,7 +5222,7 @@ msgid "RESUME CDN"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:23
-msgid "Your WPRocket license has expired"
+msgid "Your WP Rocket license has expired"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:25

--- a/languages/rocket.pot
+++ b/languages/rocket.pot
@@ -2670,7 +2670,7 @@ msgid "Serving files from 10 edge locations. Covering up to 3 pages."
 msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:627
-msgid "RocketCDN is currently paused because your WPRocket licence has expired."
+msgid "RocketCDN is currently paused because your WP Rocket licence has expired."
 msgstr ""
 
 #: inc/Engine/CDN/Render/Controller.php:652
@@ -4649,7 +4649,7 @@ msgid "RESUME CDN"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:23
-msgid "Your WPRocket license has expired"
+msgid "Your WP Rocket license has expired"
 msgstr ""
 
 #: views/settings/partials/cdn/wpr-licence-expired-notice.php:25

--- a/views/settings/partials/cdn/wpr-licence-expired-notice.php
+++ b/views/settings/partials/cdn/wpr-licence-expired-notice.php
@@ -20,7 +20,7 @@
 	<div class="wpr-notice-container">
 		<div class="wpr-notice-description wpr-notice-70">
 			<h3 class="wpr-cdn-expired__notice-title">
-				<?php esc_html_e( 'Your WPRocket license has expired', 'rocket' ); ?>
+				<?php esc_html_e( 'Your WP Rocket license has expired', 'rocket' ); ?>
 			</h3>
 			<p><?php esc_html_e( 'Please renew it to keep using RocketCDN.', 'rocket' ); ?></p>
 		</div>


### PR DESCRIPTION
Summary
---------------
- Correct `WPRocket` to `WP Rocket` in the RocketCDN expired-license UI strings.
- Update the editable `.po`/`.pot` catalog entries for the same brand-name typo.
- Leave internal identifiers such as `WPRocketUninstall` unchanged.

Backward Compatibility
---------------
Breaking Change? **No**

Validation
---------------
- `git diff --check`
- `rg -n "WPRocket licence|WPRocket license|Your WPRocket|licence WPRocket|lisans.*WPRocket" inc views languages -g "*.php" -g "*.po" -g "*.pot"` returned no matches.

Not run locally
---------------
- `php -l ...`, `composer phpcs-changed`, `composer phpcs`, and `composer run-stan`: PHP and Composer are not installed on this machine.
- `.mo` regeneration: `msgfmt` and `wp` CLI are not installed, so compiled translation binaries were left untouched.

Closes #8588