### PR TITLE
Hide RocketCDN Pro upsell banner for reseller accounts

### DIFF
--- a/inc/Engine/CDN/RocketCDN/NoticesSubscriber.php
+++ b/inc/Engine/CDN/RocketCDN/NoticesSubscriber.php
@@ -6,6 +6,7 @@ use WP_Rocket\Admin\Options;
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Engine\Admin\Beacon\Beacon;
 use WP_Rocket\Engine\Common\Utils;
+use WP_Rocket\Engine\License\API\User;
 use WP_Rocket\Engine\License\API\UserClient;
 use WP_Rocket\Engine\Tracking\Tracking;
 use WP_Rocket\Event_Management\Subscriber_Interface;
@@ -62,6 +63,13 @@ class NoticesSubscriber extends Abstract_Render implements Subscriber_Interface 
 	private $subscription_controller;
 
 	/**
+	 * User instance
+	 *
+	 * @var User
+	 */
+	private $user;
+
+	/**
 	 * Constructor
 	 *
 	 * @param APIClient              $api_client    RocketCDN API Client instance.
@@ -71,6 +79,7 @@ class NoticesSubscriber extends Abstract_Render implements Subscriber_Interface 
 	 * @param string                 $template_path Path to the templates.
 	 * @param Options_Data           $options WP Rocket options instance.
 	 * @param SubscriptionController $subscription_controller Subscription controller instance.
+	 * @param User                   $user          User instance.
 	 */
 	public function __construct(
 		APIClient $api_client,
@@ -79,7 +88,8 @@ class NoticesSubscriber extends Abstract_Render implements Subscriber_Interface 
 		Tracking $tracking,
 		$template_path,
 		Options_Data $options,
-		SubscriptionController $subscription_controller
+		SubscriptionController $subscription_controller,
+		User $user
 	) {
 		parent::__construct( $template_path );
 
@@ -89,6 +99,7 @@ class NoticesSubscriber extends Abstract_Render implements Subscriber_Interface 
 		$this->tracking                = $tracking;
 			$this->options             = $options;
 		$this->subscription_controller = $subscription_controller;
+		$this->user                    = $user;
 	}
 
 	/**
@@ -133,6 +144,10 @@ class NoticesSubscriber extends Abstract_Render implements Subscriber_Interface 
 		}
 
 		if ( $this->is_white_label_account() ) {
+			return;
+		}
+
+		if ( $this->user->is_reseller_account() ) {
 			return;
 		}
 

--- a/inc/Engine/CDN/RocketCDN/ServiceProvider.php
+++ b/inc/Engine/CDN/RocketCDN/ServiceProvider.php
@@ -122,6 +122,7 @@ class ServiceProvider extends AbstractServiceProvider {
 					new StringArgument( __DIR__ . '/views' ),
 					'options',
 					'rocketcdn_subscription_controller',
+					'user',
 				]
 			);
 

--- a/tests/Unit/inc/Engine/CDN/RocketCDN/NoticesSubscriber/displayRocketcdnCta.php
+++ b/tests/Unit/inc/Engine/CDN/RocketCDN/NoticesSubscriber/displayRocketcdnCta.php
@@ -1,0 +1,86 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Unit\inc\Engine\CDN\RocketCDN\NoticesSubscriber;
+
+use Brain\Monkey\Functions;
+use Mockery;
+use WP_Rocket\Admin\Options_Data;
+use WP_Rocket\Engine\Admin\Beacon\Beacon;
+use WP_Rocket\Engine\CDN\RocketCDN\APIClient;
+use WP_Rocket\Engine\CDN\RocketCDN\NoticesSubscriber;
+use WP_Rocket\Engine\CDN\RocketCDN\SubscriptionController;
+use WP_Rocket\Engine\License\API\User;
+use WP_Rocket\Engine\License\API\UserClient;
+use WP_Rocket\Engine\Tracking\Tracking;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * Test class covering \WP_Rocket\Engine\CDN\RocketCDN\NoticesSubscriber::display_rocketcdn_cta
+ *
+ * @covers \WP_Rocket\Engine\CDN\RocketCDN\NoticesSubscriber::display_rocketcdn_cta
+ * @group  RocketCDN
+ */
+class Test_DisplayRocketcdnCta extends TestCase {
+
+	/**
+	 * @var Mockery\MockInterface|APIClient
+	 */
+	private $api_client;
+
+	/**
+	 * @var Mockery\MockInterface|SubscriptionController
+	 */
+	private $subscription_controller;
+
+	/**
+	 * @var Mockery\MockInterface|User
+	 */
+	private $user;
+
+	/**
+	 * @var Mockery\MockInterface|NoticesSubscriber
+	 */
+	private $subscriber;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		Functions\stubTranslationFunctions();
+
+		$this->api_client              = Mockery::mock( APIClient::class );
+		$this->subscription_controller = Mockery::mock( SubscriptionController::class );
+		$this->user                    = Mockery::mock( User::class );
+
+		$this->subscriber = Mockery::mock(
+			NoticesSubscriber::class . '[generate]',
+			[
+				$this->api_client,
+				Mockery::mock( Beacon::class ),
+				Mockery::mock( UserClient::class ),
+				Mockery::mock( Tracking::class ),
+				'',
+				Mockery::mock( Options_Data::class ),
+				$this->subscription_controller,
+				$this->user,
+			]
+		);
+	}
+
+	public function testShouldReturnEarlyWhenResellerAccount(): void {
+		Functions\expect( 'apply_filters' )
+			->once()
+			->with( 'rocket_display_rocketcdn_cta', true )
+			->andReturn( true );
+
+		$this->white_label = false;
+
+		$this->user->shouldReceive( 'is_reseller_account' )->once()->andReturn( true );
+
+		$this->api_client->shouldNotReceive( 'get_subscription_data' );
+		$this->subscription_controller->shouldNotReceive( 'has_active_subscription' );
+		$this->subscriber->shouldNotReceive( 'generate' );
+
+		$this->subscriber->display_rocketcdn_cta( [ 'limit_reached' => true ] );
+	}
+}


### PR DESCRIPTION
# Description

Reseller license customers can't purchase a RocketCDN Pro subscription, so showing them the "Nice work! You're using RocketCDN on 3 key pages!" upsell banner (and its "Upgrade to RocketCDN Pro" CTA) on the Content Delivery tab was confusing and irrelevant. This banner is now completely hidden for reseller accounts, matching how it already behaves for white-label accounts.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

- **Automated (unit):** Added `tests/Unit/inc/Engine/CDN/RocketCDN/NoticesSubscriber/displayRocketcdnCta.php` — the first unit test this method has ever had. It asserts `display_rocketcdn_cta()` returns early (no template render, no API/subscription calls) when `User::is_reseller_account()` is true. Passes: `composer test-unit -- --filter=Test_DisplayRocketcdnCta` → 1/1 ✅. Full unit suite still green: 2722 tests, 8838 assertions, only the 2 pre-existing unrelated skips.
- **Investigation:** Traced the actual rendering path behind the screenshot in the issue (`views/settings/sections/cdn/rocketcdn-free.php` → `rocket_cdn_free_before_status_indicator` action → `NoticesSubscriber::display_rocketcdn_cta()` → `cta-big` template) to confirm exactly which method needed the guard. Found that the Content Delivery tab already had a reseller check on a *different, indirect* path (`Render\Controller::maybe_display_rocketcdn_cta`, gating the `rocket_display_rocketcdn_cta` filter that `NoticesSubscriber` also consults), but that check has no test coverage of its own and `NoticesSubscriber` had no direct check — unlike its existing white-label guard. Added the direct check for consistency, testability, and defense-in-depth, rather than relying solely on the cross-module filter.
- **Manual:** Not performed in this environment (no way to flip a live license to reseller here); see "How to test" below for the reviewer/QA steps.

### How to test

1. On a site with WP Rocket active and connected to a license, set the license user's `is_reseller` flag to true (e.g. via a reseller license).
2. Enable RocketCDN Free and add 3 pages to reach the free-tier limit.
3. Open the Content Delivery tab.
4. **Expected:** the "Nice work! You're using RocketCDN on 3 key pages!" banner and its "Upgrade to RocketCDN Pro" CTA are not displayed at all.
5. Repeat with a non-reseller (regular or white-label) account.
6. **Expected:** behavior is unchanged — the banner displays as before for non-reseller accounts (both before and after reaching the 3-page limit), and stays hidden for white-label accounts.

### Affected Features & Quality Assurance Scope

Only the RocketCDN Content Delivery tab upsell banner is affected: `NoticesSubscriber::display_rocketcdn_cta()`, hooked to `rocket_cdn_free_before_status_indicator`. No other RocketCDN surfaces (dashboard section, admin notices, REST endpoints, CDN URL rewriting, page add/remove) are touched. QA should verify the Content Delivery tab banner — both the "under limit" and "3-page limit reached" variants — for reseller, white-label, and regular accounts as described above.

## Technical description

### Documentation

`NoticesSubscriber` (`inc/Engine/CDN/RocketCDN/NoticesSubscriber.php`) now takes `WP_Rocket\Engine\License\API\User` as a constructor dependency, in addition to its existing collaborators. `display_rocketcdn_cta()` now returns early when `$this->user->is_reseller_account()` is true, right alongside its existing `is_white_label_account()` early return.

`User::is_reseller_account()` already existed and is used the same way to hide a different RocketCDN CTA banner (`inc/Engine/CDN/Render/Controller.php::maybe_display_rocketcdn_cta`) — this PR reuses that same helper directly in `NoticesSubscriber` instead of relying only on that other module's filter.

`inc/Engine/CDN/RocketCDN/ServiceProvider.php` now passes the existing `'user'` container service as an argument when constructing `rocketcdn_notices_subscriber`.

### New dependencies

None. `WP_Rocket\Engine\License\API\User` is an existing service already registered in the container (`inc/Engine/License/ServiceProvider.php`) and already consumed elsewhere (e.g. `cdn_render_controller`, and `rocketcdn_admin_subscriber` per #8612).

### Risks

- **None expected.** The added check is a pure early-return with no side effects; for non-reseller accounts (the vast majority of installs) behavior is unchanged.
- **Test coverage gap:** this method had zero unit test coverage before this PR; a fixture file (`tests/Fixtures/inc/Engine/CDN/RocketCDN/NoticesSubscriber/displayRocketcdnCta.php`) exists for it but isn't consumed by any test class. This PR adds one focused test for the new branch but doesn't attempt to resurrect that unrelated, pre-existing gap — flagging it here in case it's worth a follow-up ticket.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

N/A — all mandatory items apply and are ticked. Note: "screenshots or videos" for manual validation were not captured because this environment has no way to flip a live license to a reseller license; see "How to test" for reviewer/QA steps instead.

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
