### PR TITLE
Hide renew license button for reseller users on RocketCDN expired notice

### DIFF
--- a/inc/Engine/CDN/Render/Controller.php
+++ b/inc/Engine/CDN/Render/Controller.php
@@ -541,6 +541,7 @@ class Controller extends Abstract_Render {
 
 		$data = [
 			'renewal_url' => $this->user->get_renewal_url(),
+			'is_reseller' => $this->user->is_reseller_account(),
 		];
 
 		echo $this->generate( 'partials/cdn/wpr-licence-expired-notice', $data ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Dynamic content is properly escaped in the view.

--- a/tests/Fixtures/inc/Engine/CDN/Render/Controller/renderExpiredWprLicenceNotice.php
+++ b/tests/Fixtures/inc/Engine/CDN/Render/Controller/renderExpiredWprLicenceNotice.php
@@ -2,7 +2,7 @@
 
 return [
 	// TC-3.2: Free CDN + WPR expired → notice is rendered.
-	'testRendersNoticeForFreeSubscriptionWithExpiredLicense'   => [
+	'testRendersNoticeForFreeSubscriptionWithExpiredLicense' => [
 		'config'   => [
 			'cdn_type'            => 'rocketcdn',
 			'subscription_status' => 'running',
@@ -15,7 +15,7 @@ return [
 	],
 
 	// TC-3.6: Free CDN + site banned → notice is rendered.
-	'testRendersNoticeForFreeSubscriptionWithRevokedLicense'   => [
+	'testRendersNoticeForFreeSubscriptionWithRevokedLicense' => [
 		'config'   => [
 			'cdn_type'            => 'rocketcdn',
 			'subscription_status' => 'running',
@@ -28,7 +28,7 @@ return [
 	],
 
 	// TC-3.4: Free CDN + license renewed/valid → notice is hidden.
-	'testNoNoticeForFreeSubscriptionWithValidLicense'          => [
+	'testNoNoticeForFreeSubscriptionWithValidLicense'   => [
 		'config'   => [
 			'cdn_type'            => 'rocketcdn',
 			'subscription_status' => 'running',
@@ -41,7 +41,7 @@ return [
 	],
 
 	// TC-3.7: Paid CDN + WPR expired → notice never shown for paid subscriptions.
-	'testNoNoticeForPaidSubscriptionWithExpiredLicense'        => [
+	'testNoNoticeForPaidSubscriptionWithExpiredLicense' => [
 		'config'   => [
 			'cdn_type'            => 'rocketcdn',
 			'subscription_status' => 'running',
@@ -54,7 +54,7 @@ return [
 	],
 
 	// TC-3.9: BYOCDN + WPR expired → notice never shown for non-rocketcdn types.
-	'testNoNoticeForByocdnWithExpiredLicense'                  => [
+	'testNoNoticeForByocdnWithExpiredLicense'           => [
 		'config'   => [
 			'cdn_type'            => 'byocdn',
 			'subscription_status' => 'cancelled',
@@ -64,5 +64,33 @@ return [
 			'license_revoked'     => false,
 		],
 		'expected' => false,
+	],
+
+	// Reseller + Free CDN + WPR expired → notice is rendered but Renew Licence button is hidden.
+	'testHidesRenewButtonForResellerWithExpiredLicense' => [
+		'config'   => [
+			'cdn_type'            => 'rocketcdn',
+			'subscription_status' => 'running',
+			'plan_type'           => 'free',
+			'cdn_url'             => 'https://test.delivery.rocketcdn.me',
+			'license_expired'     => true,
+			'license_revoked'     => false,
+			'is_reseller'         => true,
+		],
+		'expected' => true,
+	],
+
+	// Reseller + Free CDN + site banned → notice is rendered but Renew Licence button is hidden.
+	'testHidesRenewButtonForResellerWithRevokedLicense' => [
+		'config'   => [
+			'cdn_type'            => 'rocketcdn',
+			'subscription_status' => 'running',
+			'plan_type'           => 'free',
+			'cdn_url'             => 'https://test.delivery.rocketcdn.me',
+			'license_expired'     => false,
+			'license_revoked'     => true,
+			'is_reseller'         => true,
+		],
+		'expected' => true,
 	],
 ];

--- a/tests/Integration/inc/Engine/CDN/Render/Controller/renderExpiredWprLicenceNotice.php
+++ b/tests/Integration/inc/Engine/CDN/Render/Controller/renderExpiredWprLicenceNotice.php
@@ -88,6 +88,12 @@ class Test_RenderExpiredWprLicenceNotice extends TestCase {
 		} else {
 			$this->assertEmpty( $output );
 		}
+
+		if ( $expected && ! empty( $config['is_reseller'] ) ) {
+			$this->assertStringNotContainsString( 'wpr-notice-close', $output );
+		} elseif ( $expected ) {
+			$this->assertStringContainsString( 'wpr-notice-close', $output );
+		}
 	}
 
 	/**
@@ -123,6 +129,7 @@ class Test_RenderExpiredWprLicenceNotice extends TestCase {
 			: time() + YEAR_IN_SECONDS;
 		$user_data->licence            = $licence;
 		$user_data->renewal_url        = 'https://wp-rocket.me/account/';
+		$user_data->is_reseller        = ! empty( $config['is_reseller'] );
 
 		$this->user->set_user( $user_data );
 	}

--- a/views/settings/partials/cdn/wpr-licence-expired-notice.php
+++ b/views/settings/partials/cdn/wpr-licence-expired-notice.php
@@ -9,6 +9,7 @@
  *     Notice data.
  *
  *     @type string $renewal_url URL to the licence renewal page.
+ *     @type bool   $is_reseller Whether the account is a reseller account.
  * }
  *
  * @since 3.22
@@ -24,8 +25,10 @@
 			</h3>
 			<p><?php esc_html_e( 'Please renew it to keep using RocketCDN.', 'rocket' ); ?></p>
 		</div>
-		<a target="_blank" rel="noopener noreferrer" class="wpr-notice-close" href="<?php echo esc_url( $data['renewal_url'] ); ?>">
-			<?php esc_html_e( 'Renew Licence', 'rocket' ); ?>
-		</a>
+		<?php if ( empty( $data['is_reseller'] ) ) : ?>
+			<a target="_blank" rel="noopener noreferrer" class="wpr-notice-close" href="<?php echo esc_url( $data['renewal_url'] ); ?>">
+				<?php esc_html_e( 'Renew Licence', 'rocket' ); ?>
+			</a>
+		<?php endif; ?>
 	</div>
 </div>


### PR DESCRIPTION
# Description

Fixes #8613
Reseller customers manage their WP Rocket license renewal through their reseller, not through wp-rocket.me. Previously, when a reseller's license expired, RocketCDN still showed the "Renew Licence" button linking to the standard wp-rocket.me renewal page, which is not applicable to them. This PR hides that button for reseller accounts while keeping the informational notice (explaining that RocketCDN is paused due to license expiration) visible.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

Automated (PHPUnit integration test, `tests/Integration/inc/Engine/CDN/Render/Controller/renderExpiredWprLicenceNotice.php`):
- Non-reseller account with an expired/revoked WP Rocket license on the free RocketCDN plan: notice renders and the "Renew Licence" button (`wpr-notice-close`) is present (existing behavior, unchanged).
- Reseller account with an expired/revoked WP Rocket license on the free RocketCDN plan: notice still renders, but the "Renew Licence" button is absent (new test cases added).
- Existing scenarios (valid license, paid plan, BYOCDN) continue to hide the whole notice as before — unaffected by this change.

### How to test

1. On a site with RocketCDN active on the free plan, use/mock the licensing API response so the account has `is_reseller = true` and an expired or revoked license (`licence_expiration` in the past, or `licence->is_revoked = true`), use the snippet mentioned [here](https://group-onecom.slack.com/archives/C08EFCYRQ2X/p1783954095372929).
2. Go to WP Rocket settings → RocketCDN tab.
3. Confirm the "Your WPRocket license has expired / Please renew it to keep using RocketCDN" notice is displayed, but no "Renew Licence" button/link is shown.
4. Repeat with `is_reseller = false` (or unset) and confirm the "Renew Licence" button is still shown, exactly as before this change.
5. Run the automated suite: `tests/Integration/inc/Engine/CDN/Render/Controller/renderExpiredWprLicenceNotice.php`.


https://github.com/user-attachments/assets/009ca107-d457-4f8c-997d-5692ebd5eeb6

@DahmaniAdame As u can see in the screencast, the renew button still appears in the dashboard renewal notice, but this is out of scope for this feature, what do u think?

### Affected Features & Quality Assurance Scope

- RocketCDN settings tab — the "license expired" notice banner (`wpr-cdn-licence-banner` / `wpr-cdn-expired__notice`) shown when the free RocketCDN plan's WP Rocket license is invalid/expired.
- No impact to non-RocketCDN CDN configurations, paid RocketCDN subscriptions, or the CDN-paused status indicator text, since the gating logic (`should_display_licence_expired_notice()`) is unchanged — only the button inside the notice is conditionally hidden.

## Technical description

### Documentation

`Controller::render_expired_wpr_licence_notice()` (`inc/Engine/CDN/Render/Controller.php`) already gated whether to display the expired-license notice via `should_display_licence_expired_notice()`. This PR adds one more piece of data passed to the view: `is_reseller`, sourced from the existing `User::is_reseller_account()` helper (already used elsewhere, e.g. to hide the RocketCDN upsell CTA for resellers).

The view partial `views/settings/partials/cdn/wpr-licence-expired-notice.php` now wraps the "Renew Licence" `<a>` tag in `if ( empty( $data['is_reseller'] ) )`, so the link is simply omitted from the markup for reseller accounts while the rest of the notice (title + description) renders unchanged.

### New dependencies

None.

### Risks

Low risk. The change is additive and purely presentational (conditionally omitting one `<a>` element based on an existing, already-used account flag). It does not alter the CDN pause/disable logic (`should_disable_element_for_rocketcdn()`), the notice's display conditions, or any other RocketCDN behavior — verified no other code depends on `should_display_licence_expired_notice()`'s return value changing for resellers, since that method was intentionally left untouched.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

No screenshot/video is included for the Acceptance Criteria validation since this environment doesn't have a live reseller license fixture to screenshot against; validation was done via the automated integration test cases (`testHidesRenewButtonForResellerWithExpiredLicense`, `testHidesRenewButtonForResellerWithRevokedLicense`) asserting the button markup is absent while the notice remains rendered.

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
