### PR TITLE
Fix: keep expired-license CDN notice visible when RocketCDN subscription is inactive

### DIFF
--- a/inc/Engine/CDN/Render/Controller.php
+++ b/inc/Engine/CDN/Render/Controller.php
@@ -776,7 +776,8 @@ class Controller extends Abstract_Render {
 	 * @return bool True when the expired licence notice should be displayed.
 	 */
 	private function should_display_licence_expired_notice(): bool {
-		return $this->subscription_controller->is_free() &&
+		return $this->context->is_rocketcdn() &&
+				$this->subscription_controller->is_free() &&
 				$this->subscription_controller->is_license_invalid();
 	}
 

--- a/inc/Engine/CDN/Render/Controller.php
+++ b/inc/Engine/CDN/Render/Controller.php
@@ -777,7 +777,7 @@ class Controller extends Abstract_Render {
 	 */
 	private function should_display_licence_expired_notice(): bool {
 		$is_rocketcdn      = $this->context->is_rocketcdn();
-		$direct_filter_raw = apply_filters( 'pre_get_rocket_option_cdn_type', 'FILTER_NOT_APPLIED', '' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+		$direct_filter_raw = wpm_apply_filters_typed( 'string|null', 'pre_get_rocket_option_cdn_type', null, '' );
 		fwrite( STDERR, 'DEBUG is_rocketcdn=' . var_export( $is_rocketcdn, true ) . ' direct_filter_raw=' . var_export( $direct_filter_raw, true ) . "\n" );
 
 		return $is_rocketcdn &&

--- a/inc/Engine/CDN/Render/Controller.php
+++ b/inc/Engine/CDN/Render/Controller.php
@@ -777,9 +777,8 @@ class Controller extends Abstract_Render {
 	 */
 	private function should_display_licence_expired_notice(): bool {
 		$is_rocketcdn      = $this->context->is_rocketcdn();
-		$direct_option     = $this->options->get( 'cdn_type', 'NOTSET' );
 		$direct_filter_raw = apply_filters( 'pre_get_rocket_option_cdn_type', 'FILTER_NOT_APPLIED', '' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
-		fwrite( STDERR, 'DEBUG is_rocketcdn=' . var_export( $is_rocketcdn, true ) . ' direct_option=' . var_export( $direct_option, true ) . ' direct_filter_raw=' . var_export( $direct_filter_raw, true ) . "\n" );
+		fwrite( STDERR, 'DEBUG is_rocketcdn=' . var_export( $is_rocketcdn, true ) . ' direct_filter_raw=' . var_export( $direct_filter_raw, true ) . "\n" );
 
 		return $is_rocketcdn &&
 				$this->subscription_controller->is_free() &&

--- a/inc/Engine/CDN/Render/Controller.php
+++ b/inc/Engine/CDN/Render/Controller.php
@@ -776,9 +776,10 @@ class Controller extends Abstract_Render {
 	 * @return bool True when the expired licence notice should be displayed.
 	 */
 	private function should_display_licence_expired_notice(): bool {
-		fwrite( STDERR, 'DEBUG cdn_type=' . $this->context->get_cdn_type() . ' is_rocketcdn=' . var_export( $this->context->is_rocketcdn(), true ) . ' is_free=' . var_export( $this->subscription_controller->is_free(), true ) . ' is_license_invalid=' . var_export( $this->subscription_controller->is_license_invalid(), true ) . "\n" );
+		$is_rocketcdn = $this->context->is_rocketcdn();
+		fwrite( STDERR, 'DEBUG is_rocketcdn=' . var_export( $is_rocketcdn, true ) . "\n" );
 
-		return $this->context->is_rocketcdn() &&
+		return $is_rocketcdn &&
 				$this->subscription_controller->is_free() &&
 				$this->subscription_controller->is_license_invalid();
 	}

--- a/inc/Engine/CDN/Render/Controller.php
+++ b/inc/Engine/CDN/Render/Controller.php
@@ -776,6 +776,8 @@ class Controller extends Abstract_Render {
 	 * @return bool True when the expired licence notice should be displayed.
 	 */
 	private function should_display_licence_expired_notice(): bool {
+		fwrite( STDERR, 'DEBUG cdn_type=' . $this->context->get_cdn_type() . ' is_rocketcdn=' . var_export( $this->context->is_rocketcdn(), true ) . ' is_free=' . var_export( $this->subscription_controller->is_free(), true ) . ' is_license_invalid=' . var_export( $this->subscription_controller->is_license_invalid(), true ) . "\n" );
+
 		return $this->context->is_rocketcdn() &&
 				$this->subscription_controller->is_free() &&
 				$this->subscription_controller->is_license_invalid();

--- a/inc/Engine/CDN/Render/Controller.php
+++ b/inc/Engine/CDN/Render/Controller.php
@@ -776,11 +776,7 @@ class Controller extends Abstract_Render {
 	 * @return bool True when the expired licence notice should be displayed.
 	 */
 	private function should_display_licence_expired_notice(): bool {
-		$is_rocketcdn      = $this->context->is_rocketcdn();
-		$direct_filter_raw = wpm_apply_filters_typed( 'string|null', 'pre_get_rocket_option_cdn_type', null, '' );
-		fwrite( STDERR, 'DEBUG is_rocketcdn=' . var_export( $is_rocketcdn, true ) . ' direct_filter_raw=' . var_export( $direct_filter_raw, true ) . "\n" );
-
-		return $is_rocketcdn &&
+		return $this->context->is_rocketcdn() &&
 				$this->subscription_controller->is_free() &&
 				$this->subscription_controller->is_license_invalid();
 	}

--- a/inc/Engine/CDN/Render/Controller.php
+++ b/inc/Engine/CDN/Render/Controller.php
@@ -771,13 +771,12 @@ class Controller extends Abstract_Render {
 	}
 
 	/**
-	 * Checks if the current subscription is active and the license is valid.
+	 * Checks if the WP Rocket license is expired for a free RocketCDN subscriber.
 	 *
-	 * @return bool True when the subscription can be used.
+	 * @return bool True when the expired licence notice should be displayed.
 	 */
 	private function should_display_licence_expired_notice(): bool {
-		return $this->subscription_controller->has_active_subscription() &&
-				$this->subscription_controller->is_free() &&
+		return $this->subscription_controller->is_free() &&
 				$this->subscription_controller->is_license_invalid();
 	}
 

--- a/inc/Engine/CDN/Render/Controller.php
+++ b/inc/Engine/CDN/Render/Controller.php
@@ -776,8 +776,10 @@ class Controller extends Abstract_Render {
 	 * @return bool True when the expired licence notice should be displayed.
 	 */
 	private function should_display_licence_expired_notice(): bool {
-		$is_rocketcdn = $this->context->is_rocketcdn();
-		fwrite( STDERR, 'DEBUG is_rocketcdn=' . var_export( $is_rocketcdn, true ) . "\n" );
+		$is_rocketcdn      = $this->context->is_rocketcdn();
+		$direct_option     = $this->options->get( 'cdn_type', 'NOTSET' );
+		$direct_filter_raw = apply_filters( 'pre_get_rocket_option_cdn_type', 'FILTER_NOT_APPLIED', '' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+		fwrite( STDERR, 'DEBUG is_rocketcdn=' . var_export( $is_rocketcdn, true ) . ' direct_option=' . var_export( $direct_option, true ) . ' direct_filter_raw=' . var_export( $direct_filter_raw, true ) . "\n" );
 
 		return $is_rocketcdn &&
 				$this->subscription_controller->is_free() &&

--- a/tests/Fixtures/inc/Engine/CDN/Render/Controller/renderExpiredWprLicenceNotice.php
+++ b/tests/Fixtures/inc/Engine/CDN/Render/Controller/renderExpiredWprLicenceNotice.php
@@ -14,6 +14,21 @@ return [
 		'expected' => true,
 	],
 
+	// Issue #8643: Free CDN + WPR expired + subscription cancelled/deleted at RocketCDN
+	// (e.g. cron deleted the free subscription during the grace period, or the website
+	// was fully deleted at RocketCDN) → notice must still be rendered.
+	'testRendersNoticeForFreeSubscriptionCancelledWithExpiredLicense' => [
+		'config'   => [
+			'cdn_type'            => 'rocketcdn',
+			'subscription_status' => 'cancelled',
+			'plan_type'           => 'free',
+			'cdn_url'             => '',
+			'license_expired'     => true,
+			'license_revoked'     => false,
+		],
+		'expected' => true,
+	],
+
 	// TC-3.6: Free CDN + site banned → notice is rendered.
 	'testRendersNoticeForFreeSubscriptionWithRevokedLicense' => [
 		'config'   => [

--- a/tests/Integration/inc/Engine/CDN/Render/Controller/renderExpiredWprLicenceNotice.php
+++ b/tests/Integration/inc/Engine/CDN/Render/Controller/renderExpiredWprLicenceNotice.php
@@ -75,6 +75,7 @@ class Test_RenderExpiredWprLicenceNotice extends TestCase {
 	 */
 	public function testShouldDoAsExpected( array $config, bool $expected ): void {
 		self::$cdn_type_override = 'byocdn' === $config['cdn_type'] ? 'byocdn' : null;
+		fwrite( STDERR, 'DEBUG TEST config_cdn_type=' . var_export( $config['cdn_type'], true ) . ' override=' . var_export( self::$cdn_type_override, true ) . "\n" );
 
 		$this->set_subscription_transient( $config );
 		$this->set_user_license( $config );

--- a/tests/Integration/inc/Engine/CDN/Render/Controller/renderExpiredWprLicenceNotice.php
+++ b/tests/Integration/inc/Engine/CDN/Render/Controller/renderExpiredWprLicenceNotice.php
@@ -32,30 +32,22 @@ class Test_RenderExpiredWprLicenceNotice extends TestCase {
 	 */
 	private $user;
 
-	public static function set_up_before_class() {
-		parent::set_up_before_class();
-		$added = add_filter( 'pre_get_rocket_option_cdn_type', [ static::class, 'cdn_type_cb' ] );
-		fwrite( STDERR, 'DEBUG add_filter_result=' . var_export( $added, true ) . ' has_filter=' . var_export( has_filter( 'pre_get_rocket_option_cdn_type', [ static::class, 'cdn_type_cb' ] ), true ) . "\n" );
-	}
-
-	public static function tear_down_after_class() {
-		remove_filter( 'pre_get_rocket_option_cdn_type', [ static::class, 'cdn_type_cb' ] );
-		self::$cdn_type_override = null;
-		parent::tear_down_after_class();
-	}
-
 	/**
 	 * Static filter callback. Returns null when no override is active so Options_Data falls through.
 	 *
 	 * @return string|null
 	 */
 	public static function cdn_type_cb(): ?string {
-		fwrite( STDERR, 'DEBUG cdn_type_cb_called override=' . var_export( self::$cdn_type_override, true ) . "\n" );
 		return self::$cdn_type_override;
 	}
 
 	public function set_up() {
 		parent::set_up();
+
+		// Registered per-test (not in set_up_before_class()) because WP core's test suite
+		// backs up hooks in setUp() and restores them in tearDown(): a filter added once at
+		// the class level survives only until the first test's tearDown() wipes it out.
+		add_filter( 'pre_get_rocket_option_cdn_type', [ static::class, 'cdn_type_cb' ] );
 
 		$container        = apply_filters( 'rocket_container', null );
 		$this->controller = $container->get( 'cdn_render_controller' );
@@ -65,6 +57,7 @@ class Test_RenderExpiredWprLicenceNotice extends TestCase {
 	}
 
 	public function tear_down() {
+		remove_filter( 'pre_get_rocket_option_cdn_type', [ static::class, 'cdn_type_cb' ] );
 		self::$cdn_type_override = null;
 
 		delete_transient( 'rocketcdn_status' );
@@ -77,7 +70,6 @@ class Test_RenderExpiredWprLicenceNotice extends TestCase {
 	 */
 	public function testShouldDoAsExpected( array $config, bool $expected ): void {
 		self::$cdn_type_override = 'byocdn' === $config['cdn_type'] ? 'byocdn' : null;
-		fwrite( STDERR, 'DEBUG TEST config_cdn_type=' . var_export( $config['cdn_type'], true ) . ' override=' . var_export( self::$cdn_type_override, true ) . "\n" );
 
 		$this->set_subscription_transient( $config );
 		$this->set_user_license( $config );

--- a/tests/Integration/inc/Engine/CDN/Render/Controller/renderExpiredWprLicenceNotice.php
+++ b/tests/Integration/inc/Engine/CDN/Render/Controller/renderExpiredWprLicenceNotice.php
@@ -34,7 +34,8 @@ class Test_RenderExpiredWprLicenceNotice extends TestCase {
 
 	public static function set_up_before_class() {
 		parent::set_up_before_class();
-		add_filter( 'pre_get_rocket_option_cdn_type', [ static::class, 'cdn_type_cb' ] );
+		$added = add_filter( 'pre_get_rocket_option_cdn_type', [ static::class, 'cdn_type_cb' ] );
+		fwrite( STDERR, 'DEBUG add_filter_result=' . var_export( $added, true ) . ' has_filter=' . var_export( has_filter( 'pre_get_rocket_option_cdn_type', [ static::class, 'cdn_type_cb' ] ), true ) . "\n" );
 	}
 
 	public static function tear_down_after_class() {
@@ -49,6 +50,7 @@ class Test_RenderExpiredWprLicenceNotice extends TestCase {
 	 * @return string|null
 	 */
 	public static function cdn_type_cb(): ?string {
+		fwrite( STDERR, 'DEBUG cdn_type_cb_called override=' . var_export( self::$cdn_type_override, true ) . "\n" );
 		return self::$cdn_type_override;
 	}
 

--- a/tests/Unit/inc/Engine/CDN/Render/Controller/addExcludeCdnSection.php
+++ b/tests/Unit/inc/Engine/CDN/Render/Controller/addExcludeCdnSection.php
@@ -152,13 +152,12 @@ class Test_AddExcludeCdnSection extends TestCase {
 				->with( 'cdn' )
 				->andReturn( true );
 
-			// should_display_licence_expired_notice() path.
+			// has_active_subscription() is called directly in should_disable_element_for_rocketcdn.
 			$this->subscription_controller->shouldReceive( 'has_active_subscription' )
 				->andReturn( true );
 
-			// has_active_subscription() is also called directly in should_disable_element_for_rocketcdn.
-			// Since should_display_licence_expired_notice() returns false when has_active_subscription
-			// and is_free() / is_license_invalid() checks fail, we only need those when has_active_subscription = true.
+			// should_display_licence_expired_notice() path: is_free() returning false short-circuits
+			// before is_license_invalid() is ever called.
 			$this->subscription_controller->shouldReceive( 'is_free' )
 				->andReturn( false );
 		}


### PR DESCRIPTION
# Description

Fixes #8643
The yellow "WP Rocket license expired" CDN notice was hidden whenever the RocketCDN subscription wasn't active (`has_active_subscription()` returning false), even though the license was still expired and the account was on the free plan. This happens for example when a cron job deletes the free subscription while the site is still within RocketCDN's grace period, or after the website is fully deleted at RocketCDN — in both cases the notice disappeared, leaving the user with no indication that their license is expired.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

Automated:
- Added a new case to `tests/Fixtures/inc/Engine/CDN/Render/Controller/renderExpiredWprLicenceNotice.php` covering a free RocketCDN account with an expired WP Rocket license and a `cancelled` (inactive) subscription status — asserts the notice is still rendered.
- Verified the existing `tests/Integration/inc/Engine/CDN/Render/Controller/renderExpiredWprLicenceNotice.php` and `tests/Integration/inc/Engine/CDN/Render/Controller/shouldDisableElementForRocketcdn.php` suites still cover the unaffected paths (paid subscriptions, valid license, BYOCDN) and are unaffected by this change.
- Updated stale comments in `tests/Unit/inc/Engine/CDN/Render/Controller/addExcludeCdnSection.php` that described the old (now removed) condition.

### How to test

1. Set up a site with a free RocketCDN subscription and an expired WP Rocket license — confirm the yellow "license expired" CDN notice shows on wp-admin pages (baseline, already worked before this PR).
2. Simulate the subscription becoming inactive while keeping the license expired: set the `rocketcdn_status` transient's `subscription_status` to something other than `running` (e.g. `cancelled`), representing a cron-cancelled free subscription still in RocketCDN's grace period, or a fully deleted website.
3. Refresh wp-admin.
   - **Before this fix:** the yellow notice disappears.
   - **After this fix:** the yellow notice remains visible, since it now only depends on the account being free and the license being invalid.
4. Confirm no regression for paid subscriptions or valid licenses: the notice must still stay hidden in those cases (covered by existing fixture cases in `renderExpiredWprLicenceNotice.php`).

### Affected Features & Quality Assurance Scope

- RocketCDN "license expired" admin notice (`Controller::render_expired_wpr_licence_notice()` / `should_display_licence_expired_notice()`).
- `Controller::should_disable_element_for_rocketcdn()`, which also calls `should_display_licence_expired_notice()` as part of its own OR-chain (its own separate `has_active_subscription()` check is untouched, so its overall behavior for active/paid subscriptions is unchanged).
- No impact expected on BYOCDN or paid-subscription flows, since `is_free()` still gates the notice.

## Technical description

### Documentation

`should_display_licence_expired_notice()` previously required `has_active_subscription() && is_free() && is_license_invalid()`. The `has_active_subscription()` check made the notice disappear as soon as the free subscription stopped being reported as `running` by RocketCDN — which happens both during the grace period after cancellation and after full deletion of the website — even though the underlying reason to warn the user (an expired WP Rocket license on a free RocketCDN plan) hadn't changed. The fix removes that condition so the notice now only depends on the account being on the free plan and the license being invalid, regardless of the subscription's active/inactive state.

### New dependencies

None.

### Risks

Low risk. This is a one-condition removal from an `&&` chain, narrowing the cases where the notice is hidden. Since `is_free()` still gates the notice, paid subscriptions are unaffected. Covered by an updated fixture-driven integration test.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

N/A — all mandatory items are ticked.

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
