### PR TITLE
Fixes #7523: defer license-notice translation to avoid _load_textdomain_just_in_time notice

### DIFF
--- a/inc/functions/admin.php
+++ b/inc/functions/admin.php
@@ -11,6 +11,19 @@ function rocket_need_api_key() {
 	$errors  = (array) get_transient( 'rocket_check_key_errors' );
 
 	foreach ( $errors as $error ) {
+		/**
+		 * The `invalid_license_data` sentinel is stored by `rocket_valid_key()`, which can run before
+		 * the `rocket` textdomain is loaded. Translate it here, at render time, on the `admin_notices`
+		 * hook (after `init`). Other errors are server-returned strings that are stored, already
+		 * translated, during the live license check, so they are echoed as-is.
+		 */
+		if ( 'invalid_license_data' === $error ) {
+			$error = __( 'The provided license data are not valid.', 'rocket' ) .
+				' <br>' .
+				// Translators: %1$s = opening link tag, %2$s = closing link tag.
+				sprintf( __( 'To resolve, please %1$scontact support%2$s.', 'rocket' ), '<a href="https://wp-rocket.me/support/" rel="noopener noreferrer" target=_"blank">', '</a>' );
+		}
+
 		$message .= '<p>' . $error . '</p>';
 	}
 

--- a/inc/functions/options.php
+++ b/inc/functions/options.php
@@ -423,15 +423,13 @@ function rocket_valid_key() {
 	$valid_details = 8 === strlen( (string) get_rocket_option( 'consumer_key', '' ) ) && hash_equals( $rocket_secret_key, hash( 'crc32', get_rocket_option( 'consumer_email', '' ) ) );
 
 	if ( ! $valid_details ) {
-		set_transient(
-			'rocket_check_key_errors',
-			[
-				__( 'The provided license data are not valid.', 'rocket' ) .
-				' <br>' .
-				// Translators: %1$s = opening link tag, %2$s = closing link tag.
-				sprintf( __( 'To resolve, please %1$scontact support%2$s.', 'rocket' ), '<a href="https://wp-rocket.me/support/" rel="noopener noreferrer" target=_"blank">', '</a>' ),
-			]
-		);
+		/**
+		 * This function can run on `plugins_loaded`, before the `rocket` textdomain is loaded on `init`.
+		 * Store a stable sentinel instead of a translated string to avoid triggering the
+		 * `_load_textdomain_just_in_time` notice on WordPress 6.7+. The sentinel is expanded to the
+		 * translated messages later, at render time, in `rocket_need_api_key()`.
+		 */
+		set_transient( 'rocket_check_key_errors', [ 'invalid_license_data' ] );
 
 		return $valid_details;
 	}

--- a/tests/Unit/inc/functions/admin/rocketNeedApiKey.php
+++ b/tests/Unit/inc/functions/admin/rocketNeedApiKey.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\functions\admin;
+
+use Brain\Monkey\Functions;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * Test class covering ::rocket_need_api_key
+ *
+ * @group Functions
+ * @group Admin
+ */
+class Test_RocketNeedApiKey extends TestCase {
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
+		if ( ! defined( 'WP_ROCKET_PLUGIN_NAME' ) ) {
+			define( 'WP_ROCKET_PLUGIN_NAME', 'WP Rocket' );
+		}
+
+		require_once WP_ROCKET_PLUGIN_ROOT . 'inc/functions/admin.php';
+	}
+
+	public function setUp(): void {
+		parent::setUp();
+
+		Functions\stubTranslationFunctions();
+		Functions\stubEscapeFunctions();
+		Functions\when( 'wp_kses_post' )->returnArg();
+	}
+
+	public function testShouldExpandSentinelToTranslatedMessage() {
+		Functions\expect( 'get_transient' )
+			->once()
+			->with( 'rocket_check_key_errors' )
+			->andReturn( [ 'invalid_license_data' ] );
+
+		ob_start();
+		rocket_need_api_key();
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'invalid_license_data', $output );
+		$this->assertStringContainsString( 'The provided license data are not valid.', $output );
+		$this->assertStringContainsString( 'contact support', $output );
+	}
+
+	public function testShouldEchoServerReturnedStringUnchanged() {
+		$server_message = 'License validation failed. This user account is blocked.';
+
+		Functions\expect( 'get_transient' )
+			->once()
+			->with( 'rocket_check_key_errors' )
+			->andReturn( [ $server_message ] );
+
+		ob_start();
+		rocket_need_api_key();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( $server_message, $output );
+		$this->assertStringNotContainsString( 'The provided license data are not valid.', $output );
+	}
+}

--- a/tests/Unit/inc/functions/rocketValidKey.php
+++ b/tests/Unit/inc/functions/rocketValidKey.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\functions;
+
+use Brain\Monkey\Functions;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * Test class covering ::rocket_valid_key
+ *
+ * @group Functions
+ * @group Options
+ */
+class Test_RocketValidKey extends TestCase {
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
+		require_once WP_ROCKET_PLUGIN_ROOT . 'inc/functions/options.php';
+	}
+
+	public function testShouldReturnFalseWhenNoSecretKey() {
+		Functions\expect( 'get_rocket_option' )
+			->once()
+			->with( 'secret_key', '' )
+			->andReturn( '' );
+		Functions\expect( 'set_transient' )->never();
+
+		$this->assertFalse( rocket_valid_key() );
+	}
+
+	public function testShouldStoreSentinelWithoutTranslatingWhenInvalidLicenseData() {
+		Functions\when( 'get_rocket_option' )->alias(
+			function ( $option ) {
+				switch ( $option ) {
+					case 'secret_key':
+						return 'not_a_matching_secret';
+					case 'consumer_key':
+						return 'tooshort';
+					case 'consumer_email':
+						return 'example@example.org';
+					default:
+						return '';
+				}
+			}
+		);
+
+		// The sentinel must be stored, not a translated sentence.
+		Functions\expect( 'set_transient' )
+			->once()
+			->with( 'rocket_check_key_errors', [ 'invalid_license_data' ] )
+			->andReturn( true );
+
+		// No eager translation must happen during this early call.
+		Functions\expect( '__' )->never();
+		Functions\expect( '_n' )->never();
+
+		$this->assertFalse( rocket_valid_key() );
+	}
+
+	public function testShouldReturnTrueWhenLicenseDataIsValid() {
+		$consumer_email = 'example@example.org';
+		$secret_key     = hash( 'crc32', $consumer_email );
+
+		Functions\when( 'get_rocket_option' )->alias(
+			function ( $option ) use ( $consumer_email, $secret_key ) {
+				switch ( $option ) {
+					case 'secret_key':
+						return $secret_key;
+					case 'consumer_key':
+						return '12345678'; // 8 characters.
+					case 'consumer_email':
+						return $consumer_email;
+					default:
+						return '';
+				}
+			}
+		);
+
+		Functions\expect( 'set_transient' )->never();
+
+		$this->assertTrue( rocket_valid_key() );
+	}
+}


### PR DESCRIPTION
# Description

Fixes #7523

On WordPress 6.7+ with an invalid WP Rocket license, `debug.log` fills with `_load_textdomain_just_in_time was called incorrectly ... rocket domain ... triggered too early` notices.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

Enter invalid license data (or run with a license that no longer validates) on WP 6.7+. The notice is logged on every admin page load. With this PR it is gone.

## Technical description

`rocket_valid_key()` runs on `plugins_loaded` (via `rocket_init`), before the `rocket` textdomain loads on `init`, yet it translated the "license data are not valid" message and stored it in the `rocket_check_key_errors` transient. That string is only rendered later, in `rocket_need_api_key()` on `admin_notices`.

This defers the translation to render time, following the pattern from #7103: `rocket_valid_key()` now stores a stable `invalid_license_data` sentinel, and `rocket_need_api_key()` expands it to the translated sentences when the notice is displayed. Server-returned error strings, written during the live license check in `rocket_check_key()` (which runs after `init`), are still echoed as-is.

Unit tests added for both sides: that the sentinel is stored without any eager translation, and that the renderer expands it while passing plain strings through unchanged.
