### PR TITLE
Fix: resolve bundled dependencies from disk when the Composer map is outdated

### DIFF
--- a/inc/functions/autoload-fallback.php
+++ b/inc/functions/autoload-fallback.php
@@ -9,7 +9,7 @@
  * then unresolvable, even though its files are present, which surfaces as a fatal
  * error while linking a bundled class.
  *
- * @since 3.24
+ * @since 3.23.2
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -25,7 +25,7 @@ defined( 'ABSPATH' ) || exit;
  * vendor/composer/autoload_psr4.php on purpose, since that file is precisely what
  * can be outdated in memory when this autoloader is needed.
  *
- * @since 3.24
+ * @since 3.23.2
  *
  * @return array<string,string> Namespace prefix as key, directory relative to the plugin root as value.
  */
@@ -39,7 +39,7 @@ function rocket_get_vendor_autoload_fallback_map(): array {
 /**
  * Converts a class name into the path of the file declaring it, relative to the plugin root.
  *
- * @since 3.24
+ * @since 3.23.2
  *
  * @param string $class_name Fully qualified class name.
  *
@@ -66,7 +66,7 @@ function rocket_get_vendor_class_relative_path( string $class_name ): string {
  * copy of a bundled dependency provided by another plugin is therefore never
  * overridden: that plugin's autoloader resolves the class before this one runs.
  *
- * @since 3.24
+ * @since 3.23.2
  *
  * @return void
  */

--- a/inc/functions/autoload-fallback.php
+++ b/inc/functions/autoload-fallback.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Last resort autoloader for the vendor namespaces WP Rocket bundles without Mozart.
+ *
+ * Composer keeps its namespace prefix table in memory for the whole request. When
+ * WordPress swaps the plugin directory in place during an update, a request that
+ * started on the previous version keeps that table while the files on disk are
+ * already the new ones. Any namespace the previous version did not know about is
+ * then unresolvable, even though its files are present, which surfaces as a fatal
+ * error while linking a bundled class.
+ *
+ * @since 3.24
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Namespace prefixes resolved by the fallback autoloader.
+ *
+ * Restricted to the bundled dependencies that keep their upstream namespace: the
+ * Mozart prefixed ones live under a namespace only WP Rocket declares, so their
+ * prefix is present in every version of the Composer table.
+ *
+ * The mapping is repeated here instead of being read back from
+ * vendor/composer/autoload_psr4.php on purpose, since that file is precisely what
+ * can be outdated in memory when this autoloader is needed.
+ *
+ * @since 3.24
+ *
+ * @return array<string,string> Namespace prefix as key, directory relative to the plugin root as value.
+ */
+function rocket_get_vendor_autoload_fallback_map(): array {
+	return [
+		'WP\\MCP\\'       => 'vendor/wordpress/mcp-adapter/includes/',
+		'WP\\McpSchema\\' => 'vendor/wordpress/php-mcp-schema/src/',
+	];
+}
+
+/**
+ * Converts a class name into the path of the file declaring it, relative to the plugin root.
+ *
+ * @since 3.24
+ *
+ * @param string $class_name Fully qualified class name.
+ *
+ * @return string Relative path, or an empty string when the class is not one of the bundled dependencies.
+ */
+function rocket_get_vendor_class_relative_path( string $class_name ): string {
+	foreach ( rocket_get_vendor_autoload_fallback_map() as $prefix => $directory ) {
+		if ( 0 !== strpos( $class_name, $prefix ) ) {
+			continue;
+		}
+
+		$relative_class = substr( $class_name, strlen( $prefix ) );
+
+		return $directory . str_replace( '\\', '/', $relative_class ) . '.php';
+	}
+
+	return '';
+}
+
+/**
+ * Registers the fallback autoloader at the end of the SPL stack.
+ *
+ * Appended, so it is only consulted once every other autoloader has missed. A
+ * copy of a bundled dependency provided by another plugin is therefore never
+ * overridden: that plugin's autoloader resolves the class before this one runs.
+ *
+ * @since 3.24
+ *
+ * @return void
+ */
+function rocket_register_vendor_autoload_fallback(): void {
+	static $registered = false;
+
+	if ( $registered ) {
+		return;
+	}
+
+	$registered = true;
+
+	spl_autoload_register(
+		function ( $class_name ) {
+			$relative_path = rocket_get_vendor_class_relative_path( (string) $class_name );
+
+			if ( '' === $relative_path ) {
+				return;
+			}
+
+			$file = WP_ROCKET_PATH . $relative_path;
+
+			if ( ! is_readable( $file ) ) {
+				return;
+			}
+
+			require_once $file;
+		},
+		true,
+		false
+	);
+}

--- a/inc/main.php
+++ b/inc/main.php
@@ -12,6 +12,10 @@ if ( file_exists( WP_ROCKET_PATH . 'vendor/autoload.php' ) ) {
 	require WP_ROCKET_PATH . 'vendor/autoload.php';
 }
 
+// Resolves bundled dependencies from disk when the Composer map in memory predates them.
+require_once WP_ROCKET_FUNCTIONS_PATH . 'autoload-fallback.php';
+rocket_register_vendor_autoload_fallback();
+
 $rocket_can_boot_mcp_adapter =
 	class_exists( McpAdapter::class )
 	&& version_compare( $GLOBALS['wp_version'] ?? '0', '6.9', '>=' )

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -45,6 +45,7 @@ parameters:
 		- %currentWorkingDirectory%/vendor/wpackagist-plugin/the-events-calendar/
 		- %currentWorkingDirectory%/vendor/wpackagist-plugin/woocommerce/
 	scanFiles:
+		- %currentWorkingDirectory%/inc/functions/autoload-fallback.php
 		- %currentWorkingDirectory%/inc/admin/upgrader.php
 		- %currentWorkingDirectory%/inc/admin/options.php
 		- %currentWorkingDirectory%/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php

--- a/tests/Unit/inc/functions/rocketGetVendorClassRelativePath.php
+++ b/tests/Unit/inc/functions/rocketGetVendorClassRelativePath.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\functions;
+
+use WPMedia\PHPUnit\Unit\TestCase;
+
+/**
+ * Test class covering ::rocket_get_vendor_class_relative_path
+ *
+ * @uses  ::rocket_get_vendor_autoload_fallback_map
+ *
+ * @group Functions
+ * @group Autoload
+ */
+class Test_RocketGetVendorClassRelativePath extends TestCase {
+
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
+		require_once WP_ROCKET_PLUGIN_ROOT . 'inc/functions/autoload-fallback.php';
+	}
+
+	/**
+	 * @dataProvider addDataProvider
+	 */
+	public function testShouldReturnExpectedPath( $class_name, $expected ) {
+		$this->assertSame( $expected, rocket_get_vendor_class_relative_path( $class_name ) );
+	}
+
+	/**
+	 * Class names to resolve, with the path expected in return.
+	 *
+	 * @return array<string,array<int,string>>
+	 */
+	public function addDataProvider(): array {
+		return [
+			'should map a mcp-adapter class'           => [
+				'WP\MCP\Domain\Tools\McpTool',
+				'vendor/wordpress/mcp-adapter/includes/Domain/Tools/McpTool.php',
+			],
+			'should map a php-mcp-schema class'        => [
+				'WP\McpSchema\Server\Tools\DTO\Tool',
+				'vendor/wordpress/php-mcp-schema/src/Server/Tools/DTO/Tool.php',
+			],
+			'should map a class at the prefix root'    => [
+				'WP\MCP\Autoloader',
+				'vendor/wordpress/mcp-adapter/includes/Autoloader.php',
+			],
+			'should ignore a WP Rocket class'          => [
+				'WP_Rocket\Engine\License\ServiceProvider',
+				'',
+			],
+			'should ignore a Mozart prefixed class'    => [
+				'WP_Rocket\Dependencies\League\Container\Container',
+				'',
+			],
+			'should ignore a namespace merely sharing the prefix start' => [
+				'WP\MCPSomethingElse\Thing',
+				'',
+			],
+			'should ignore a class outside any prefix' => [
+				'WP_Query',
+				'',
+			],
+			'should ignore an empty class name'        => [
+				'',
+				'',
+			],
+		];
+	}
+}


### PR DESCRIPTION
# Description

Fixes #8652

Some users hit a fatal error right after updating to 3.23.1. WordPress' fatal error protection then pauses WP Rocket and emails the site owner, who reads it as WP Rocket having been uninstalled by WordPress. The error is:

```
PHP Fatal error: Could not check compatibility between
WP\MCP\Domain\Tools\McpTool::get_protocol_dto(): WP\McpSchema\Server\Tools\DTO\Tool and
WP\MCP\Domain\Contracts\McpComponentInterface::get_protocol_dto(): WP\McpSchema\Common\AbstractDataTransferObject,
because class WP\McpSchema\Server\Tools\DTO\Tool is not available in
.../wp-rocket/vendor/wordpress/mcp-adapter/includes/Domain/Tools/McpTool.php on line 251
```

Every file is present and correct on disk the whole time, which is why reinstalling changes nothing and why it looks impossible to reproduce. After this change the same conditions produce no fatal error, the plugin stays active, and MCP keeps working.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

**Automated.** New unit test covering `rocket_get_vendor_class_relative_path()`, 8 cases: both bundled prefixes, a class at the prefix root, and the cases that must be ignored (WP Rocket classes, Mozart prefixed classes, a namespace that merely shares the start of a prefix, an unrelated class, an empty class name).

```
vendor/bin/phpunit --testsuite unit --configuration tests/Unit/phpunit.xml.dist \
  --filter Test_RocketGetVendorClassRelativePath
OK (8 tests, 8 assertions)
```

**Manual.** Reproduced the reported fatal error against a real 3.23.1 install, by registering a namespace prefix table that knows `WP\MCP\` but not `WP\McpSchema\`, which is exactly what 3.23.0 shipped, with 3.23.1's files on disk, then linking `McpTool`:

- Without the fallback: the fatal error above, byte for byte, same file, same line 251.
- With the fallback registered: `WP\McpSchema\Server\Tools\DTO\Tool` resolves and `McpTool` links with no error.

PHPCS and PHPStan are clean on both changed source files.

### How to test

MCP only initialises on REST requests (`rest_api_init` priority 15), on WP 6.9+ with the Abilities API available, so a plain page view is not enough.

1. On WP 7.0 with 3.23.1 installed, confirm `vendor/wordpress/php-mcp-schema/` is present and `GET /wp-json/` returns normally.
2. Reproduce the broken state in one request, which is what the update window creates: register an autoloader that resolves `WP\MCP\` from `vendor/wordpress/mcp-adapter/includes/` and nothing else, then call `class_exists( 'WP\MCP\Domain\Tools\McpTool' )`. On `develop` this fatals with the error above. On this branch it does not.
3. Regression: with everything normal, check that `GET /wp-json/` and the MCP route still respond, and that no extra file is loaded on a front end page view (the fallback only runs on an autoload miss).

### Affected Features & Quality Assurance Scope

- Plugin bootstrap, `inc/main.php`, so smoke testing the whole plugin is relevant: activation, deactivation, admin pages, cache clearing.
- MCP and the OAuth MCP server, since those are the bundled dependencies the fallback covers.
- Plugin update path, updating from 3.23.x to this build, and the auto update path.

## Technical description

### Documentation

Composer builds its namespace prefix table once, when `vendor/autoload.php` is required, and the `ClassLoader` object keeps it in memory for the rest of the request. WordPress replaces the plugin directory in place during an update, so a request that started on the previous version keeps that version's table while the files on disk are already the new ones. Any namespace the previous version did not know about is then unresolvable, even though its files are there.

3.23.1 is where this became visible: 3.23.0 shipped mcp-adapter 0.4.1, whose table contains a single prefix, `WP\MCP\`. 3.23.1 ships 0.5.0 plus the new `wordpress/php-mcp-schema` package, and `McpTool::get_protocol_dto()` narrows its return type to a class in the new `WP\McpSchema\` namespace. PHP resolves that class when it links `McpTool`, and a table without the prefix cannot provide it, so the request dies with `E_COMPILE_ERROR`. That error type cannot be caught, so it has to be prevented rather than handled.

This adds a last resort autoloader, appended to the SPL stack, that maps the bundled dependency prefixes to their directory and resolves them straight from disk:

- `WP\MCP\` to `vendor/wordpress/mcp-adapter/includes/`
- `WP\McpSchema\` to `vendor/wordpress/php-mcp-schema/src/`

Three properties matter:

- It is **appended**, so it only runs after every other autoloader has missed. A copy of the same dependency provided by another plugin is never overridden, since that plugin's autoloader resolves the class first.
- It names **no class and no version**, so it also covers whatever changes in a future version. This is deliberately not the narrower guard of checking that one specific DTO or method exists.
- The prefix mapping is **repeated in our own code** rather than read back from `vendor/composer/autoload_psr4.php`, because that file is precisely what can be outdated in memory when the fallback is needed.

Only the dependencies that keep their upstream namespace are listed. The Mozart prefixed ones live under `WP_Rocket\Dependencies\`, a prefix present in every version of the table, so they are not exposed to this.

Same approach as WooCommerce, which added an appended PSR-4 fallback for the same failure, see `plugins/woocommerce/woocommerce.php` and `src/Autoloader.php` in their repository.

### New dependencies

None.

### Risks

- **Performance.** The closure only runs on an autoload miss for one of two namespace prefixes, and returns immediately on a prefix mismatch. In a healthy request Composer resolves those classes first, so the fallback is never reached. Worst case is one `is_readable()` call.
- **Loading the wrong copy of a dependency.** Prevented by appending instead of prepending: if another plugin provides the class, its autoloader answers before ours.
- **Path traversal through the class name.** The class name is only used after a strict prefix match, and `\` becomes `/` with `.php` appended, so the result stays under the plugin directory. `is_readable()` guards the include.
- **Masking a genuinely broken install.** If the files really are missing, `is_readable()` fails and the fallback stays silent, exactly like Composer would.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

The autoloader is deliberately silent. It runs during class linking, before the plugin is in a state where logging is safe, and anything it cannot resolve is left to the other autoloaders exactly as before. There is no user facing message to make actionable.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)

Observability was left out on purpose, for the reason above. The fix is verifiable from the outside instead: the fatal error stops appearing in `debug.log`, and WordPress stops pausing the plugin after an update.
