### PR TITLE
Fix test double for wp_normalize_path collapsing vfs:// stream paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 /vendor/*
 /tests/env/local/
 composer.lock
-vfs:/
 /tests/Integration/.phpunit.result.cache
 /tests/Unit/.phpunit.result.cache
 package-lock.json

--- a/tests/StubTrait.php
+++ b/tests/StubTrait.php
@@ -177,20 +177,50 @@ trait StubTrait {
 	}
 
 	protected function stubWpNormalizePath() {
+		// wp_normalize_path() uses wp_is_stream() to keep stream wrappers (e.g. vfs://) intact.
+		$this->stubWpIsStream();
+
+		// Mirrors WordPress core's wp_normalize_path(), minus its static cache.
 		Functions\when( 'wp_normalize_path' )->alias(
 			function ( $path ) {
 				if ( true === $this->just_return_path ) {
 					return $path;
 				}
 
+				$path    = (string) $path;
+				$wrapper = '';
+
+				if ( wp_is_stream( $path ) ) {
+					list( $wrapper, $path ) = explode( '://', $path, 2 );
+
+					$wrapper .= '://';
+				}
+
 				$path = str_replace( '\\', '/', $path );
-				$path = preg_replace( '|(?<=.)/+|', '/', $path );
+				$path = (string) preg_replace( '|(?<=.)/+|', '/', $path );
 
 				if ( ':' === substr( $path, 1, 1 ) ) {
 					$path = ucfirst( $path );
 				}
 
-				return $path;
+				return $wrapper . $path;
+			}
+		);
+	}
+
+	protected function stubWpIsStream() {
+		// Mirrors WordPress core's wp_is_stream().
+		Functions\when( 'wp_is_stream' )->alias(
+			function ( $path ) {
+				$scheme_separator = strpos( $path, '://' );
+
+				if ( false === $scheme_separator ) {
+					return false;
+				}
+
+				$stream = substr( $path, 0, $scheme_separator );
+
+				return in_array( $stream, stream_get_wrappers(), true );
 			}
 		);
 	}

--- a/tests/Unit/inc/Engine/Media/Fonts/Filesystem/writeFontCss.php
+++ b/tests/Unit/inc/Engine/Media/Fonts/Filesystem/writeFontCss.php
@@ -32,13 +32,6 @@ class test_WriteFontCss extends FilesystemTestCase {
 		Functions\when( 'wp_remote_retrieve_body' )
 			->justReturn( $config['css_content'] );
 
-		Functions\when('rocket_mkdir_p')->alias(function($dir) {
-			if (!file_exists($dir)) {
-				mkdir($dir, 0777, true);
-			}
-			return true;
-		});
-
 		Functions\when( 'wp_safe_remote_get' )
 			->justReturn( $config['response'] );
 


### PR DESCRIPTION
> [!NOTE]
> This PR was created with the assistance of AI. The changes have been reviewed and verified locally.

# Description

Running the test suite created a stray `vfs:` directory on the real disk at the plugin root (previously hidden by a `vfs:/` `.gitignore` entry added back in 2020).

**Root cause:** the `stubWpNormalizePath()` test double in `tests/StubTrait.php` reimplemented `wp_normalize_path()` **without** the `wp_is_stream()` guard that WordPress core uses to preserve stream wrappers. It therefore collapsed `vfs://…` down to `vfs:/…`, which is no longer a valid stream URL. When such a path reached a native filesystem call that bypassed the vfs-mocked `rocket_direct_filesystem()` (e.g. the `write_font_css` unit test overriding `rocket_mkdir_p` with a raw `mkdir()`), PHP treated `vfs:` as a plain relative directory and created it on the real disk at the current working directory.

**Fix:**
- `stubWpNormalizePath()` now mirrors WordPress core's `wp_normalize_path()` faithfully, including its `wp_is_stream()` sub-function (also stubbed), so stream schemes survive normalization.
- Removed the native `mkdir()` override in the `write_font_css` unit test so it routes through the vfs-mocked filesystem like every other test.
- Dropped the `vfs:/` `.gitignore` entry that papered over the symptom.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

- Full unit suite (2728 tests) — green, no `vfs:` folder created.
- All 67 `FilesystemTestCase` subclasses run individually — pass, none create a `vfs:` folder.
- `write_font_css` unit test — passes through the mocked filesystem.
- Confirmed the mechanism with a standalone repro: a collapsed `vfs:/…` path passed to native `mkdir` materialises a real folder, while a proper `vfs://…` path stays in-memory.

### How to test

1. From the plugin root, ensure no `vfs:` directory exists: `rm -rf 'vfs:'`.
2. Run the unit suite: `composer test-unit`.
3. Confirm no `vfs:` directory was created at the plugin root and the suite is green.

### Affected Features & Quality Assurance Scope

- Test harness only — no production code changes. Affects `wp_normalize_path()` behaviour inside unit tests and the Host Fonts Locally `write_font_css` unit test.

## Technical description

No runtime/production behaviour changes. The stub now returns `$wrapper . $path`, leaving `vfs://`, `file://`, etc. intact, matching core `wp_normalize_path()`. The core static cache is intentionally omitted from the stub because the set of registered stream wrappers changes between tests.

### Documentation

No documentation changes required — test-only change, no public API surface affected.

### New dependencies

None.

### Risks

Low: changes are limited to the test harness. No caching/optimization code paths are touched.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

Output messages: N/A — this change produces no user-facing errors, notices, or logs; it corrects the behaviour of a test double.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
