### PR TITLE
Fix: update wp-media/wp-mixpanel to 1.4.4 (fixes Mixpanel JS lib access-denied, #8677)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
 		"wp-media/apply-filters-typed": "^1.0",
 		"wp-media/mcp-oauth": "^1.0.1",
 		"wp-media/plugin-family": "1.0.8",
-		"wp-media/wp-mixpanel": "^1.4.3"
+		"wp-media/wp-mixpanel": "^1.4.4"
 	},
 	"require-dev": {
 		"php": "^7.4 || ^8",


### PR DESCRIPTION
# Description

Fixes #8677

wp-media/wp-mixpanel 1.4.3 (pulled in via #8673) derived the client-side Mixpanel JS library URL (`MIXPANEL_CUSTOM_LIB_URL`) from the same `Tracking::HOST` constant used for the tracking API endpoint. `api-eu.mixpanel.com` is a data-ingestion API only — it doesn't serve static assets — so `https://api-eu.mixpanel.com/lib.min.js` returned a 403 and the Mixpanel JS library silently failed to load in the browser. Server-side tracking (`WPConsumer::persist()`) was unaffected; this only broke client-side (browser) tracking.

This PR bumps `wp-media/wp-mixpanel` to `1.4.4`, which adds a dedicated `Tracking::LIB_URL` constant pointing at Mixpanel's real CDN (`https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js`) and uses it for the library URL instead of deriving it from `HOST`. The tracking API host (`api_host`) is untouched.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

Manual, code-level verification: ran `composer update wp-media/wp-mixpanel` locally and inspected the resulting `vendor/wp-media/wp-mixpanel/src/Tracking.php`:
- `LIB_URL` is now `https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js` and `MIXPANEL_CUSTOM_LIB_URL` uses it directly.
- `api_host` still uses `HOST` (`api-eu.mixpanel.com`), unchanged.

Also confirmed live with `curl`: `https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js` returns 200 (previously `https://api-eu.mixpanel.com/lib.min.js` returned 403).

No live browser/staging validation of the actual `add_script()` output was done as part of this PR — see "How to test" below for what the reviewer/QA should confirm before merging.

### How to test

1. On `develop` (pre-fix), enable Rocket Analytics and load a front-end page.
2. Open browser dev tools → Network tab, and confirm the request for the Mixpanel JS library (`lib.min.js` from `api-eu.mixpanel.com`) returns 403/access denied, and that `window.mixpanel` never becomes a real client (stays a stub queuing calls).
3. Checkout this branch, run `composer install`, repeat step 1 — the library should now load from `cdn.mxpnl.com` (200), and `window.mixpanel` should initialize properly.
4. Confirm tracking events still hit `api-eu.mixpanel.com` (`/track/` requests in the Network tab) and land in the Mixpanel EU project dashboard.

### Affected Features & Quality Assurance Scope

- Rocket Analytics / Mixpanel tracking (`inc/Engine/Tracking`) — only the client-side JS library source URL changes; the tracking API endpoint and server-side `WPConsumer::persist()` behavior (already fixed in #8673) are unaffected.
- QA should specifically confirm the JS library now loads successfully in a browser and that events still reach the Mixpanel EU project.
- No other feature areas are touched; this is a single dependency version bump.

## Technical description

### Documentation

No architectural change on the wp-rocket side. `wp-media/wp-mixpanel` 1.4.4 adds a `Tracking::LIB_URL` constant (`https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js`) and uses it for `MIXPANEL_CUSTOM_LIB_URL` instead of deriving it from `HOST`. See https://github.com/wp-media/wp-mixpanel/releases/tag/v1.4.4 and https://github.com/wp-media/wp-mixpanel/pull/38.

### New dependencies

None added. Existing dependency `wp-media/wp-mixpanel` constraint bumped from `^1.4.3` to `^1.4.4` in `composer.json` (vendor/ and composer.lock are not versioned in this repo, so builds resolve directly from the `composer.json` constraint).

### Risks

Low risk: this only changes the source URL of a static JS asset load. Reverts client-side tracking to working order; no behavior change to the tracking API endpoint or server-side request handling.

# Mandatory Checklist

## Code validation

- [ ] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [ ] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

The actual behavior change (correct library CDN URL) lives in the `wp-media/wp-mixpanel` package itself, not in this repo's code. This PR only bumps the required version, so:
- Acceptance criteria / triggering changed lines: verified via `composer update` + code inspection and a direct `curl` check of both URLs (see "What was tested"); no live browser/staging validation was performed as part of this PR.
- Built-in tests: none added here since there is no new wp-rocket code path, only a dependency version constraint change; test coverage for the fix itself belongs to `wp-media/wp-mixpanel`.

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
