### PR TITLE
Register vfs wrapper in integration bootstrap to stop stray vfs: directory

### DIFF
--- a/tests/Integration/bootstrap.php
+++ b/tests/Integration/bootstrap.php
@@ -2,6 +2,7 @@
 
 namespace WP_Rocket\Tests\Integration;
 
+use org\bovigo\vfs\vfsStream;
 use WC_Install;
 use WP_Rocket\Tests\Fixtures\Kinsta\Kinsta_Cache;
 use WPMedia\PHPUnit\BootstrapManager;
@@ -65,6 +66,16 @@ tests_add_filter(
 		// Set the path and URL to our virtual filesystem.
 		define( 'WP_ROCKET_CACHE_ROOT_PATH', 'vfs://public/wp-content/cache/' );
 		define( 'WP_ROCKET_CACHE_ROOT_URL', 'http://example.org/wp-content/cache/' );
+
+		// The cache path constants above (and everything wp-rocket.php derives from them) live under the
+		// vfs:// scheme, so register its stream wrapper for the whole suite. Without it, tests that run
+		// without a FilesystemTestCase having registered it first (e.g. the standalone AdminOnly run) let
+		// cache writes — advanced-cache/cache-dir generation on admin_init, notices, etc. — collapse
+		// "vfs://" to "vfs:/" and create a real "vfs:" directory on disk. FilesystemTestCase/RESTVfsTestCase
+		// call vfsStream::setup() again with their own structure, replacing this empty root.
+		if ( ! in_array( 'vfs', stream_get_wrappers(), true ) ) {
+			vfsStream::setup( 'public' );
+		}
 
 		if ( BootstrapManager::isGroup( 'WithSmush' ) ) {
 			// Load WP Smush.


### PR DESCRIPTION
> [!NOTE]
> This PR was created with the assistance of AI. The changes have been reviewed and verified locally.

# Description

Follow-up to the vfs test-artifact fix (the unit-side change already merged into `develop`). This closes the **integration-side** cause of the stray `vfs:` directory created on disk when the suite runs.

**Root cause:** `tests/Integration/bootstrap.php` defines `WP_ROCKET_CACHE_ROOT_PATH` — and, via `wp-rocket.php`, every cache-path constant derived from it (`WP_ROCKET_CACHE_PATH`, `…MINIFY…`, `…BUSTING…`, `…CRITICAL_CSS…`, `…USED_CSS…`) — under the `vfs://` scheme for the whole integration suite. So cache writes during integration tests are *meant to be virtual*. But the `vfs` stream wrapper was only registered inside `FilesystemTestCase` / `RESTVfsTestCase`.

When a group runs without one of those having registered the wrapper first — as CI does via the dedicated `test-integration-adminonly` invocation — the wrapper is absent. A cache write triggered by production code (advanced-cache / cache-dir generation on `admin_init`, `admin_notices`, etc. — e.g. `Settings\Test_SanitizeCallback` firing `admin_init` → `rocket_init_cache_dir`) then reaches `rocket_mkdir_p()`, whose `rocket_is_stream()` check returns `false`; it collapses `vfs://` to `vfs:/` and the real `WP_Filesystem_Direct` native-`mkdir`s a real `vfs:` directory in the working tree.

**Fix:** register the `vfs` wrapper once in the bootstrap, right where the `vfs://` cache root is defined, so the suite-wide "cache is virtual" contract holds from the first test. Guarded with `stream_get_wrappers()` so `FilesystemTestCase` / `RESTVfsTestCase` can still call `vfsStream::setup()` with their own structure afterwards.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

- `composer test-integration-adminonly` (the isolated invocation that reproduced the bug): passes and no longer creates a `vfs:` directory.
- Full integration suite: no `vfs:` directory; failure set matches baseline (A/B compared in-session) — zero regressions.
- `FilesystemTestCase`-backed groups (CriticalPath, Files, AdvancedCache): unchanged; the guarded bootstrap registration does not clobber their structured vfs.

### How to test

1. From the plugin root, ensure no `vfs:` directory exists: `rm -rf 'vfs:'`.
2. Run `composer test-integration-adminonly`.
3. Confirm no `vfs:` directory was created at the plugin root.

### Affected Features & Quality Assurance Scope

- Test harness only — no production code changes. Affects `tests/Integration/bootstrap.php`.

## Technical description

No runtime/production behaviour changes. The registration is idempotent (guarded on `in_array( 'vfs', stream_get_wrappers(), true )`) and runs where the `vfs://` cache constants are declared; `FilesystemTestCase` / `RESTVfsTestCase` still call `vfsStream::setup()` with their own structure afterwards, replacing the empty root.

### Documentation

No documentation changes required — test-only change, no public API surface affected.

### New dependencies

None.

### Risks

Low: change is limited to the integration test bootstrap. No caching/optimization code paths are touched.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

Output messages: N/A — this change produces no user-facing errors, notices, or logs; it wires up the test environment.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
