### PR TITLE
CI: harden and consolidate test workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  # Keep GitHub Actions used in workflows up to date (security + version bumps).
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "develop"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "type: enhancement"

--- a/.github/workflows/deploy_plugin.yml
+++ b/.github/workflows/deploy_plugin.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: '7.4'
           tools: composer:v2
@@ -30,7 +30,7 @@ jobs:
         working-directory: /tmp/wp-rocket
 
       - name: Run composer
-        uses: ramsey/composer-install@v4
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
         with:
           working-directory: /tmp/wp-rocket
           composer-options: "--no-scripts --no-dev"

--- a/.github/workflows/test_wprocket.yml
+++ b/.github/workflows/test_wprocket.yml
@@ -1,14 +1,8 @@
-name: Unit/Integration tests Old PHP
+name: PHP tests legacy
 
 on:
   pull_request:
-    branches:
-      - trunk
-      - develop
-      - branch-*
-      - feature/*
-      - enhancement/*
-      - fix/*
+  workflow_dispatch:
 
 # Cancel all previous workflow runs for the same branch that have not yet completed.
 concurrency:
@@ -30,7 +24,7 @@ jobs:
         php-versions: ['7.4']
         wp-versions: ['5.9']
 
-    name: WP ${{ matrix.wp-versions }} with PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }}.
+    name: WP ${{ matrix.wp-versions }} with PHP ${{ matrix.php-versions }}
 
     services:
       mysql:
@@ -63,15 +57,27 @@ jobs:
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Setup PHP + Composer
-      uses: wp-media/workflows/.github/actions/setup-php-composer@feature/3-reusable-test-workflow
+      uses: wp-media/workflows/.github/actions/setup-php-composer@main
       with:
         php-version: ${{ matrix.php-versions }}
         extra-require: wpackagist-plugin/woocommerce "^7"
 
     - name: Setup WordPress test suite
-      uses: wp-media/workflows/.github/actions/setup-wp-tests@feature/3-reusable-test-workflow
+      uses: wp-media/workflows/.github/actions/setup-wp-tests@main
       with:
         wp-version: ${{ matrix.wp-versions }}
 
-    - name: Test
-      run: composer run-tests
+    - name: Unit tests
+      run: composer test-unit
+
+    - name: Integration tests
+      run: composer test-integration
+
+    - name: Admin integration tests
+      run: composer test-integration-adminonly
+
+    - name: Performance Hints integration tests
+      run: composer test-integration-performancehints
+
+    - name: Third Party integration tests
+      run: composer run-tests-integration-specific

--- a/.github/workflows/test_wprocket.yml
+++ b/.github/workflows/test_wprocket.yml
@@ -40,7 +40,6 @@ jobs:
         ports:
           - 3306:3306
         options: >-
-          --default-authentication-plugin=mysql_native_password
           --health-cmd="mysqladmin ping --silent"
           --health-interval=10s
           --health-timeout=5s
@@ -98,6 +97,9 @@ jobs:
           /tmp/wordpress-develop
           /tmp/tests
         key: wp-tests-${{ runner.os }}-wp${{ matrix.wp-versions }}-${{ hashFiles('bin/install-wp-tests.sh') }}
+
+    - name: Configure MySQL native password auth
+      run: mysql --get-server-public-key -h 127.0.0.1 -P 3306 -u root -proot -e "ALTER USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';"
 
     - name: Install tests
       run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1:3306 ${{ matrix.wp-versions }}

--- a/.github/workflows/test_wprocket.yml
+++ b/.github/workflows/test_wprocket.yml
@@ -46,8 +46,6 @@ jobs:
           --health-retries=5
 
     env:
-      WP_TESTS_DIR: "/tmp/tests/phpunit"
-      WP_CORE_DIR: "/tmp/wordpress-develop"
       ROCKETCDN_EMAIL: ${{ secrets.ROCKETCDN_EMAIL }}
       ROCKETCDN_PWD: ${{ secrets.ROCKETCDN_PWD }}
       ROCKETCDN_TOKEN: ${{ secrets.ROCKETCDN_TOKEN }}
@@ -64,47 +62,16 @@ jobs:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-    - name: Setup PHP
-      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+    - name: Setup PHP + Composer
+      uses: wp-media/workflows/.github/actions/setup-php-composer@feature/3-reusable-test-workflow
       with:
         php-version: ${{ matrix.php-versions }}
-        coverage: none  # XDebug can be enabled here 'coverage: xdebug'
-        tools: composer:v2
+        extra-require: wpackagist-plugin/woocommerce "^7"
 
-    - name: Cache WordPress test suite
-      id: wp-cache
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+    - name: Setup WordPress test suite
+      uses: wp-media/workflows/.github/actions/setup-wp-tests@feature/3-reusable-test-workflow
       with:
-        path: |
-          /tmp/wordpress-develop
-          /tmp/tests
-        key: wp-tests-${{ runner.os }}-wp${{ matrix.wp-versions }}-${{ hashFiles('bin/install-wp-tests.sh') }}
-
-    - name: Install SVN
-      if: steps.wp-cache.outputs.cache-hit != 'true'
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends subversion
-
-    - name: Setup problem matchers for PHP
-      run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
-
-    - name: Setup problem matchers for PHPUnit
-      run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
-
-    - name: Install dependencies
-      uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
-      with:
-        composer-options: "--no-scripts"
-
-    - name: Require WooCommerce 7 for WP compatibility
-      run: composer require --dev --no-scripts wpackagist-plugin/woocommerce "^7" -W
-
-    - name: Configure MySQL native password auth
-      run: mysql --get-server-public-key -h 127.0.0.1 -P 3306 -u root -proot -e "ALTER USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';"
-
-    - name: Install tests
-      run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1:3306 ${{ matrix.wp-versions }}
+        wp-version: ${{ matrix.wp-versions }}
 
     - name: Test
       run: composer run-tests

--- a/.github/workflows/test_wprocket.yml
+++ b/.github/workflows/test_wprocket.yml
@@ -32,6 +32,20 @@ jobs:
 
     name: WP ${{ matrix.wp-versions }} with PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }}.
 
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: >-
+          --default-authentication-plugin=mysql_native_password
+          --health-cmd="mysqladmin ping --silent"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
     env:
       WP_TESTS_DIR: "/tmp/tests/phpunit"
       WP_CORE_DIR: "/tmp/wordpress-develop"
@@ -49,20 +63,19 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
       with:
         php-version: ${{ matrix.php-versions }}
         coverage: none  # XDebug can be enabled here 'coverage: xdebug'
-        tools: composer:v2, phpunit
+        tools: composer:v2
 
     - name: Install SVN
-      run: sudo apt-get install subversion
-
-    - name: Start mysql service
-      run: sudo /etc/init.d/mysql start
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y subversion
 
     - name: Setup problem matchers for PHP
       run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
@@ -71,18 +84,23 @@ jobs:
       run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
     - name: Install dependencies
-      uses: ramsey/composer-install@v4
+      uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
       with:
         composer-options: "--no-scripts"
 
     - name: Require WooCommerce 7 for WP compatibility
       run: composer require --dev --no-scripts wpackagist-plugin/woocommerce "^7" -W
 
+    - name: Cache WordPress test suite
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: |
+          /tmp/wordpress-develop
+          /tmp/tests
+        key: wp-tests-${{ runner.os }}-wp${{ matrix.wp-versions }}-${{ hashFiles('bin/install-wp-tests.sh') }}
+
     - name: Install tests
       run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1:3306 ${{ matrix.wp-versions }}
-
-    - name: Mysql8 auth plugin workaround
-      run: sudo mysql -u root -proot -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';"
 
     - name: Test
       run: composer run-tests

--- a/.github/workflows/test_wprocket.yml
+++ b/.github/workflows/test_wprocket.yml
@@ -71,10 +71,20 @@ jobs:
         coverage: none  # XDebug can be enabled here 'coverage: xdebug'
         tools: composer:v2
 
+    - name: Cache WordPress test suite
+      id: wp-cache
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: |
+          /tmp/wordpress-develop
+          /tmp/tests
+        key: wp-tests-${{ runner.os }}-wp${{ matrix.wp-versions }}-${{ hashFiles('bin/install-wp-tests.sh') }}
+
     - name: Install SVN
+      if: steps.wp-cache.outputs.cache-hit != 'true'
       run: |
         sudo apt-get update
-        sudo apt-get install -y subversion
+        sudo apt-get install -y --no-install-recommends subversion
 
     - name: Setup problem matchers for PHP
       run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
@@ -89,14 +99,6 @@ jobs:
 
     - name: Require WooCommerce 7 for WP compatibility
       run: composer require --dev --no-scripts wpackagist-plugin/woocommerce "^7" -W
-
-    - name: Cache WordPress test suite
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      with:
-        path: |
-          /tmp/wordpress-develop
-          /tmp/tests
-        key: wp-tests-${{ runner.os }}-wp${{ matrix.wp-versions }}-${{ hashFiles('bin/install-wp-tests.sh') }}
 
     - name: Configure MySQL native password auth
       run: mysql --get-server-public-key -h 127.0.0.1 -P 3306 -u root -proot -e "ALTER USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';"

--- a/.github/workflows/test_wprocket_latest_general_coverage.yml
+++ b/.github/workflows/test_wprocket_latest_general_coverage.yml
@@ -1,14 +1,8 @@
-name: Unit/Integration General tests Latest version with coverage
+name: PHP tests code coverage
 
 on:
   pull_request:
-    branches:
-      - trunk
-      - develop
-      - branch-*
-      - feature/*
-      - enhancement/*
-      - fix/*
+  workflow_dispatch:
 
 # Cancel all previous workflow runs for the same branch that have not yet completed.
 concurrency:
@@ -30,7 +24,7 @@ jobs:
         php-versions: ['8.4']
         wp-versions: ['latest']
 
-    name: WP ${{ matrix.wp-versions }} with PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }}.
+    name: WP ${{ matrix.wp-versions }} with PHP ${{ matrix.php-versions }}
 
     services:
       mysql:
@@ -63,14 +57,14 @@ jobs:
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Setup PHP + Composer
-      uses: wp-media/workflows/.github/actions/setup-php-composer@feature/3-reusable-test-workflow
+      uses: wp-media/workflows/.github/actions/setup-php-composer@main
       with:
         php-version: ${{ matrix.php-versions }}
         coverage: xdebug
         extra-require: phpunit/phpcov
 
     - name: Setup WordPress test suite
-      uses: wp-media/workflows/.github/actions/setup-wp-tests@feature/3-reusable-test-workflow
+      uses: wp-media/workflows/.github/actions/setup-wp-tests@main
       with:
         wp-version: ${{ matrix.wp-versions }}
 

--- a/.github/workflows/test_wprocket_latest_general_coverage.yml
+++ b/.github/workflows/test_wprocket_latest_general_coverage.yml
@@ -46,8 +46,6 @@ jobs:
           --health-retries=5
 
     env:
-      WP_TESTS_DIR: "/tmp/tests/phpunit"
-      WP_CORE_DIR: "/tmp/wordpress-develop"
       ROCKETCDN_EMAIL: ${{ secrets.ROCKETCDN_EMAIL }}
       ROCKETCDN_PWD: ${{ secrets.ROCKETCDN_PWD }}
       ROCKETCDN_TOKEN: ${{ secrets.ROCKETCDN_TOKEN }}
@@ -64,47 +62,17 @@ jobs:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-    - name: Setup PHP
-      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+    - name: Setup PHP + Composer
+      uses: wp-media/workflows/.github/actions/setup-php-composer@feature/3-reusable-test-workflow
       with:
         php-version: ${{ matrix.php-versions }}
         coverage: xdebug
-        tools: composer:v2
+        extra-require: phpunit/phpcov
 
-    - name: Cache WordPress test suite
-      id: wp-cache
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+    - name: Setup WordPress test suite
+      uses: wp-media/workflows/.github/actions/setup-wp-tests@feature/3-reusable-test-workflow
       with:
-        path: |
-          /tmp/wordpress-develop
-          /tmp/tests
-        key: wp-tests-${{ runner.os }}-wp${{ matrix.wp-versions }}-${{ hashFiles('bin/install-wp-tests.sh') }}
-
-    - name: Install SVN
-      if: steps.wp-cache.outputs.cache-hit != 'true'
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends subversion
-
-    - name: Setup problem matchers for PHP
-      run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
-
-    - name: Setup problem matchers for PHPUnit
-      run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
-
-    - name: Install dependencies
-      uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
-      with:
-        composer-options: "--no-scripts"
-
-    - name: Require phpcov for coverage reporting
-      run: composer require --dev --no-scripts phpunit/phpcov -W
-
-    - name: Configure MySQL native password auth
-      run: mysql --get-server-public-key -h 127.0.0.1 -P 3306 -u root -proot -e "ALTER USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';"
-
-    - name: Install tests
-      run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1:3306 ${{ matrix.wp-versions }}
+        wp-version: ${{ matrix.wp-versions }}
 
     - name: Test
       run: composer run-tests-coverage

--- a/.github/workflows/test_wprocket_latest_general_coverage.yml
+++ b/.github/workflows/test_wprocket_latest_general_coverage.yml
@@ -40,7 +40,6 @@ jobs:
         ports:
           - 3306:3306
         options: >-
-          --default-authentication-plugin=mysql_native_password
           --health-cmd="mysqladmin ping --silent"
           --health-interval=10s
           --health-timeout=5s
@@ -98,6 +97,9 @@ jobs:
           /tmp/wordpress-develop
           /tmp/tests
         key: wp-tests-${{ runner.os }}-wp${{ matrix.wp-versions }}-${{ hashFiles('bin/install-wp-tests.sh') }}
+
+    - name: Configure MySQL native password auth
+      run: mysql --get-server-public-key -h 127.0.0.1 -P 3306 -u root -proot -e "ALTER USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';"
 
     - name: Install tests
       run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1:3306 ${{ matrix.wp-versions }}

--- a/.github/workflows/test_wprocket_latest_general_coverage.yml
+++ b/.github/workflows/test_wprocket_latest_general_coverage.yml
@@ -32,6 +32,20 @@ jobs:
 
     name: WP ${{ matrix.wp-versions }} with PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }}.
 
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: >-
+          --default-authentication-plugin=mysql_native_password
+          --health-cmd="mysqladmin ping --silent"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
     env:
       WP_TESTS_DIR: "/tmp/tests/phpunit"
       WP_CORE_DIR: "/tmp/wordpress-develop"
@@ -49,20 +63,19 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
       with:
         php-version: ${{ matrix.php-versions }}
         coverage: xdebug
-        tools: composer:v2, phpunit
+        tools: composer:v2
 
     - name: Install SVN
-      run: sudo apt-get install subversion
-
-    - name: Start mysql service
-      run: sudo /etc/init.d/mysql start
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y subversion
 
     - name: Setup problem matchers for PHP
       run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
@@ -71,18 +84,23 @@ jobs:
       run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
     - name: Install dependencies
-      uses: ramsey/composer-install@v4
+      uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
       with:
         composer-options: "--no-scripts"
 
     - name: Require phpcov for coverage reporting
       run: composer require --dev --no-scripts phpunit/phpcov -W
 
+    - name: Cache WordPress test suite
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: |
+          /tmp/wordpress-develop
+          /tmp/tests
+        key: wp-tests-${{ runner.os }}-wp${{ matrix.wp-versions }}-${{ hashFiles('bin/install-wp-tests.sh') }}
+
     - name: Install tests
       run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1:3306 ${{ matrix.wp-versions }}
-
-    - name: Mysql8 auth plugin workaround
-      run: sudo mysql -u root -proot -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';"
 
     - name: Test
       run: composer run-tests-coverage
@@ -91,7 +109,7 @@ jobs:
       run: composer report-code-coverage
 
     - name: Run codacy-coverage-reporter
-      uses: codacy/codacy-coverage-reporter-action@v1
+      uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699 # v1.3.0
       with:
         project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
         coverage-reports: tests/report/coverage.clover

--- a/.github/workflows/test_wprocket_latest_general_coverage.yml
+++ b/.github/workflows/test_wprocket_latest_general_coverage.yml
@@ -71,10 +71,20 @@ jobs:
         coverage: xdebug
         tools: composer:v2
 
+    - name: Cache WordPress test suite
+      id: wp-cache
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: |
+          /tmp/wordpress-develop
+          /tmp/tests
+        key: wp-tests-${{ runner.os }}-wp${{ matrix.wp-versions }}-${{ hashFiles('bin/install-wp-tests.sh') }}
+
     - name: Install SVN
+      if: steps.wp-cache.outputs.cache-hit != 'true'
       run: |
         sudo apt-get update
-        sudo apt-get install -y subversion
+        sudo apt-get install -y --no-install-recommends subversion
 
     - name: Setup problem matchers for PHP
       run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
@@ -89,14 +99,6 @@ jobs:
 
     - name: Require phpcov for coverage reporting
       run: composer require --dev --no-scripts phpunit/phpcov -W
-
-    - name: Cache WordPress test suite
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      with:
-        path: |
-          /tmp/wordpress-develop
-          /tmp/tests
-        key: wp-tests-${{ runner.os }}-wp${{ matrix.wp-versions }}-${{ hashFiles('bin/install-wp-tests.sh') }}
 
     - name: Configure MySQL native password auth
       run: mysql --get-server-public-key -h 127.0.0.1 -P 3306 -u root -proot -e "ALTER USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';"

--- a/.github/workflows/test_wprocket_latest_specific.yml
+++ b/.github/workflows/test_wprocket_latest_specific.yml
@@ -71,10 +71,20 @@ jobs:
         coverage: none  # XDebug can be enabled here 'coverage: xdebug'
         tools: composer:v2
 
+    - name: Cache WordPress test suite
+      id: wp-cache
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: |
+          /tmp/wordpress-develop
+          /tmp/tests
+        key: wp-tests-${{ runner.os }}-wp${{ matrix.wp-versions }}-${{ hashFiles('bin/install-wp-tests.sh') }}
+
     - name: Install SVN
+      if: steps.wp-cache.outputs.cache-hit != 'true'
       run: |
         sudo apt-get update
-        sudo apt-get install -y subversion
+        sudo apt-get install -y --no-install-recommends subversion
 
     - name: Setup problem matchers for PHP
       run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
@@ -86,14 +96,6 @@ jobs:
       uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
       with:
         composer-options: "--no-scripts"
-
-    - name: Cache WordPress test suite
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      with:
-        path: |
-          /tmp/wordpress-develop
-          /tmp/tests
-        key: wp-tests-${{ runner.os }}-wp${{ matrix.wp-versions }}-${{ hashFiles('bin/install-wp-tests.sh') }}
 
     - name: Configure MySQL native password auth
       run: mysql --get-server-public-key -h 127.0.0.1 -P 3306 -u root -proot -e "ALTER USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';"

--- a/.github/workflows/test_wprocket_latest_specific.yml
+++ b/.github/workflows/test_wprocket_latest_specific.yml
@@ -40,7 +40,6 @@ jobs:
         ports:
           - 3306:3306
         options: >-
-          --default-authentication-plugin=mysql_native_password
           --health-cmd="mysqladmin ping --silent"
           --health-interval=10s
           --health-timeout=5s
@@ -95,6 +94,9 @@ jobs:
           /tmp/wordpress-develop
           /tmp/tests
         key: wp-tests-${{ runner.os }}-wp${{ matrix.wp-versions }}-${{ hashFiles('bin/install-wp-tests.sh') }}
+
+    - name: Configure MySQL native password auth
+      run: mysql --get-server-public-key -h 127.0.0.1 -P 3306 -u root -proot -e "ALTER USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';"
 
     - name: Install tests
       run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1:3306 ${{ matrix.wp-versions }}

--- a/.github/workflows/test_wprocket_latest_specific.yml
+++ b/.github/workflows/test_wprocket_latest_specific.yml
@@ -32,6 +32,20 @@ jobs:
 
     name: WP ${{ matrix.wp-versions }} with PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }}.
 
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: >-
+          --default-authentication-plugin=mysql_native_password
+          --health-cmd="mysqladmin ping --silent"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
     env:
       WP_TESTS_DIR: "/tmp/tests/phpunit"
       WP_CORE_DIR: "/tmp/wordpress-develop"
@@ -49,20 +63,19 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
       with:
         php-version: ${{ matrix.php-versions }}
         coverage: none  # XDebug can be enabled here 'coverage: xdebug'
-        tools: composer:v2, phpunit
+        tools: composer:v2
 
     - name: Install SVN
-      run: sudo apt-get install subversion
-
-    - name: Start mysql service
-      run: sudo /etc/init.d/mysql start
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y subversion
 
     - name: Setup problem matchers for PHP
       run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
@@ -71,15 +84,20 @@ jobs:
       run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
     - name: Install dependencies
-      uses: ramsey/composer-install@v4
+      uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
       with:
         composer-options: "--no-scripts"
 
+    - name: Cache WordPress test suite
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: |
+          /tmp/wordpress-develop
+          /tmp/tests
+        key: wp-tests-${{ runner.os }}-wp${{ matrix.wp-versions }}-${{ hashFiles('bin/install-wp-tests.sh') }}
+
     - name: Install tests
       run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1:3306 ${{ matrix.wp-versions }}
-
-    - name: Mysql8 auth plugin workaround
-      run: sudo mysql -u root -proot -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';"
 
     - name: Test
       run: composer run-tests-integration-specific

--- a/.github/workflows/test_wprocket_latest_specific.yml
+++ b/.github/workflows/test_wprocket_latest_specific.yml
@@ -46,8 +46,6 @@ jobs:
           --health-retries=5
 
     env:
-      WP_TESTS_DIR: "/tmp/tests/phpunit"
-      WP_CORE_DIR: "/tmp/wordpress-develop"
       ROCKETCDN_EMAIL: ${{ secrets.ROCKETCDN_EMAIL }}
       ROCKETCDN_PWD: ${{ secrets.ROCKETCDN_PWD }}
       ROCKETCDN_TOKEN: ${{ secrets.ROCKETCDN_TOKEN }}
@@ -64,44 +62,15 @@ jobs:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-    - name: Setup PHP
-      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+    - name: Setup PHP + Composer
+      uses: wp-media/workflows/.github/actions/setup-php-composer@feature/3-reusable-test-workflow
       with:
         php-version: ${{ matrix.php-versions }}
-        coverage: none  # XDebug can be enabled here 'coverage: xdebug'
-        tools: composer:v2
 
-    - name: Cache WordPress test suite
-      id: wp-cache
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+    - name: Setup WordPress test suite
+      uses: wp-media/workflows/.github/actions/setup-wp-tests@feature/3-reusable-test-workflow
       with:
-        path: |
-          /tmp/wordpress-develop
-          /tmp/tests
-        key: wp-tests-${{ runner.os }}-wp${{ matrix.wp-versions }}-${{ hashFiles('bin/install-wp-tests.sh') }}
-
-    - name: Install SVN
-      if: steps.wp-cache.outputs.cache-hit != 'true'
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends subversion
-
-    - name: Setup problem matchers for PHP
-      run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
-
-    - name: Setup problem matchers for PHPUnit
-      run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
-
-    - name: Install dependencies
-      uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
-      with:
-        composer-options: "--no-scripts"
-
-    - name: Configure MySQL native password auth
-      run: mysql --get-server-public-key -h 127.0.0.1 -P 3306 -u root -proot -e "ALTER USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';"
-
-    - name: Install tests
-      run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1:3306 ${{ matrix.wp-versions }}
+        wp-version: ${{ matrix.wp-versions }}
 
     - name: Test
       run: composer run-tests-integration-specific

--- a/.github/workflows/test_wprocket_latest_specific.yml
+++ b/.github/workflows/test_wprocket_latest_specific.yml
@@ -1,14 +1,8 @@
-name: Integration specific tests Latest version
+name: Third Party integration tests
 
 on:
   pull_request:
-    branches:
-      - trunk
-      - develop
-      - branch-*
-      - feature/*
-      - enhancement/*
-      - fix/*
+  workflow_dispatch:
 
 # Cancel all previous workflow runs for the same branch that have not yet completed.
 concurrency:
@@ -30,7 +24,7 @@ jobs:
         php-versions: ['8.4']
         wp-versions: ['latest']
 
-    name: WP ${{ matrix.wp-versions }} with PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }}.
+    name: WP ${{ matrix.wp-versions }} with PHP ${{ matrix.php-versions }}
 
     services:
       mysql:
@@ -63,12 +57,12 @@ jobs:
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Setup PHP + Composer
-      uses: wp-media/workflows/.github/actions/setup-php-composer@feature/3-reusable-test-workflow
+      uses: wp-media/workflows/.github/actions/setup-php-composer@main
       with:
         php-version: ${{ matrix.php-versions }}
 
     - name: Setup WordPress test suite
-      uses: wp-media/workflows/.github/actions/setup-wp-tests@feature/3-reusable-test-workflow
+      uses: wp-media/workflows/.github/actions/setup-wp-tests@main
       with:
         wp-version: ${{ matrix.wp-versions }}
 

--- a/.github/workflows/test_wprocket_php8.yml
+++ b/.github/workflows/test_wprocket_php8.yml
@@ -71,10 +71,20 @@ jobs:
         coverage: none  # XDebug can be enabled here 'coverage: xdebug'
         tools: composer:v2
 
+    - name: Cache WordPress test suite
+      id: wp-cache
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: |
+          /tmp/wordpress-develop
+          /tmp/tests
+        key: wp-tests-${{ runner.os }}-wp${{ matrix.wp-versions }}-${{ hashFiles('bin/install-wp-tests.sh') }}
+
     - name: Install SVN
+      if: steps.wp-cache.outputs.cache-hit != 'true'
       run: |
         sudo apt-get update
-        sudo apt-get install -y subversion
+        sudo apt-get install -y --no-install-recommends subversion
 
     - name: Setup problem matchers for PHP
       run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
@@ -86,14 +96,6 @@ jobs:
       uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
       with:
         composer-options: "--no-scripts"
-
-    - name: Cache WordPress test suite
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      with:
-        path: |
-          /tmp/wordpress-develop
-          /tmp/tests
-        key: wp-tests-${{ runner.os }}-wp${{ matrix.wp-versions }}-${{ hashFiles('bin/install-wp-tests.sh') }}
 
     - name: Configure MySQL native password auth
       run: mysql --get-server-public-key -h 127.0.0.1 -P 3306 -u root -proot -e "ALTER USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';"

--- a/.github/workflows/test_wprocket_php8.yml
+++ b/.github/workflows/test_wprocket_php8.yml
@@ -40,7 +40,6 @@ jobs:
         ports:
           - 3306:3306
         options: >-
-          --default-authentication-plugin=mysql_native_password
           --health-cmd="mysqladmin ping --silent"
           --health-interval=10s
           --health-timeout=5s
@@ -95,6 +94,9 @@ jobs:
           /tmp/wordpress-develop
           /tmp/tests
         key: wp-tests-${{ runner.os }}-wp${{ matrix.wp-versions }}-${{ hashFiles('bin/install-wp-tests.sh') }}
+
+    - name: Configure MySQL native password auth
+      run: mysql --get-server-public-key -h 127.0.0.1 -P 3306 -u root -proot -e "ALTER USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';"
 
     - name: Install tests
       run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1:3306 ${{ matrix.wp-versions }}

--- a/.github/workflows/test_wprocket_php8.yml
+++ b/.github/workflows/test_wprocket_php8.yml
@@ -32,6 +32,20 @@ jobs:
 
     name: WP ${{ matrix.wp-versions }} with PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }}.
 
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: >-
+          --default-authentication-plugin=mysql_native_password
+          --health-cmd="mysqladmin ping --silent"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
     env:
       WP_TESTS_DIR: "/tmp/tests/phpunit"
       WP_CORE_DIR: "/tmp/wordpress-develop"
@@ -49,20 +63,19 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
       with:
         php-version: ${{ matrix.php-versions }}
         coverage: none  # XDebug can be enabled here 'coverage: xdebug'
-        tools: composer:v2, phpunit
+        tools: composer:v2
 
     - name: Install SVN
-      run: sudo apt-get install subversion
-
-    - name: Start mysql service
-      run: sudo /etc/init.d/mysql start
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y subversion
 
     - name: Setup problem matchers for PHP
       run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
@@ -71,15 +84,20 @@ jobs:
       run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
     - name: Install dependencies
-      uses: ramsey/composer-install@v4
+      uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
       with:
         composer-options: "--no-scripts"
 
+    - name: Cache WordPress test suite
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: |
+          /tmp/wordpress-develop
+          /tmp/tests
+        key: wp-tests-${{ runner.os }}-wp${{ matrix.wp-versions }}-${{ hashFiles('bin/install-wp-tests.sh') }}
+
     - name: Install tests
       run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1:3306 ${{ matrix.wp-versions }}
-
-    - name: Mysql8 auth plugin workaround
-      run: sudo mysql -u root -proot -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';"
 
     - name: Test
       run: composer run-tests

--- a/.github/workflows/test_wprocket_php8.yml
+++ b/.github/workflows/test_wprocket_php8.yml
@@ -46,8 +46,6 @@ jobs:
           --health-retries=5
 
     env:
-      WP_TESTS_DIR: "/tmp/tests/phpunit"
-      WP_CORE_DIR: "/tmp/wordpress-develop"
       ROCKETCDN_EMAIL: ${{ secrets.ROCKETCDN_EMAIL }}
       ROCKETCDN_PWD: ${{ secrets.ROCKETCDN_PWD }}
       ROCKETCDN_TOKEN: ${{ secrets.ROCKETCDN_TOKEN }}
@@ -64,44 +62,15 @@ jobs:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-    - name: Setup PHP
-      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+    - name: Setup PHP + Composer
+      uses: wp-media/workflows/.github/actions/setup-php-composer@feature/3-reusable-test-workflow
       with:
         php-version: ${{ matrix.php-versions }}
-        coverage: none  # XDebug can be enabled here 'coverage: xdebug'
-        tools: composer:v2
 
-    - name: Cache WordPress test suite
-      id: wp-cache
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+    - name: Setup WordPress test suite
+      uses: wp-media/workflows/.github/actions/setup-wp-tests@feature/3-reusable-test-workflow
       with:
-        path: |
-          /tmp/wordpress-develop
-          /tmp/tests
-        key: wp-tests-${{ runner.os }}-wp${{ matrix.wp-versions }}-${{ hashFiles('bin/install-wp-tests.sh') }}
-
-    - name: Install SVN
-      if: steps.wp-cache.outputs.cache-hit != 'true'
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends subversion
-
-    - name: Setup problem matchers for PHP
-      run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
-
-    - name: Setup problem matchers for PHPUnit
-      run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
-
-    - name: Install dependencies
-      uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
-      with:
-        composer-options: "--no-scripts"
-
-    - name: Configure MySQL native password auth
-      run: mysql --get-server-public-key -h 127.0.0.1 -P 3306 -u root -proot -e "ALTER USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';"
-
-    - name: Install tests
-      run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1:3306 ${{ matrix.wp-versions }}
+        wp-version: ${{ matrix.wp-versions }}
 
     - name: Test
       run: composer run-tests

--- a/.github/workflows/test_wprocket_php8.yml
+++ b/.github/workflows/test_wprocket_php8.yml
@@ -1,14 +1,8 @@
-name: Unit/Integration tests PHP8
+name: PHP tests
 
 on:
   pull_request:
-    branches:
-      - trunk
-      - develop
-      - branch-*
-      - feature/*
-      - enhancement/*
-      - fix/*
+  workflow_dispatch:
 
 # Cancel all previous workflow runs for the same branch that have not yet completed.
 concurrency:
@@ -30,7 +24,7 @@ jobs:
         php-versions: ['8.0', '8.1', '8.2', '8.3', '8.4']
         wp-versions: ['latest']
 
-    name: WP ${{ matrix.wp-versions }} with PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }}.
+    name: WP ${{ matrix.wp-versions }} with PHP ${{ matrix.php-versions }}
 
     services:
       mysql:
@@ -63,14 +57,26 @@ jobs:
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Setup PHP + Composer
-      uses: wp-media/workflows/.github/actions/setup-php-composer@feature/3-reusable-test-workflow
+      uses: wp-media/workflows/.github/actions/setup-php-composer@main
       with:
         php-version: ${{ matrix.php-versions }}
 
     - name: Setup WordPress test suite
-      uses: wp-media/workflows/.github/actions/setup-wp-tests@feature/3-reusable-test-workflow
+      uses: wp-media/workflows/.github/actions/setup-wp-tests@main
       with:
         wp-version: ${{ matrix.wp-versions }}
 
-    - name: Test
-      run: composer run-tests
+    - name: Unit tests
+      run: composer test-unit
+
+    - name: Integration tests
+      run: composer test-integration
+
+    - name: Admin integration tests
+      run: composer test-integration-adminonly
+
+    - name: Performance Hints integration tests
+      run: composer test-integration-performancehints
+
+    - name: Third Party integration tests
+      run: composer run-tests-integration-specific


### PR DESCRIPTION
> 🤖 This PR was created with the assistance of AI. Review carefully before merging.

# Description

Fixes #8692

Implements **all five** follow-up items from #8692 — reducing duplication, hardening supply-chain security, and cutting CI runtime across the four PHP test workflows and `deploy_plugin.yml`.

> **Cross-repo dependency:** Item 1 relies on two composite actions in `wp-media/workflows` (`setup-php-composer`, `setup-wp-tests`), referenced at `@main`. Those must be merged there before this PR is merged. CI on this branch is green against the current `@main`.

- **Item 1 — Extract shared setup (HIGH VALUE, CROSS-REPO):** The four test workflows are now thin callers. All common setup (PHP + Composer, WP test-suite install, caching, MySQL auth, problem matchers) moved into two shared composite actions consumed via `uses: wp-media/workflows/.github/actions/…@main`:
  - `setup-php-composer` — inputs: `php-version`, optional `coverage` (e.g. `xdebug`), optional `extra-require` (used for `wpackagist-plugin/woocommerce "^7"` on Old PHP and `phpunit/phpcov` on the coverage run).
  - `setup-wp-tests` — input: `wp-version`.
  Each workflow now differs only in its matrix and its `composer` test command(s). This drops ~180 lines of duplication.
- **Item 2 — Pin actions to SHAs + Dependabot (SECURITY):** `actions/checkout` (all four workflows + `deploy_plugin.yml`) and `codacy/codacy-coverage-reporter-action` (coverage workflow) are pinned to full commit SHAs with version comments; `deploy_plugin.yml` also pins `shivammathur/setup-php` and `ramsey/composer-install`. The remaining third-party actions are now SHA-pinned inside the shared composite actions. Added `.github/dependabot.yml` with a grouped weekly `github-actions` update entry targeting `develop`.
- **Item 3 — Cache the WP test suite (PERFORMANCE):** Handled in `setup-wp-tests` — caches the WordPress core + test library keyed on `wp-version`, and skips the SVN install/download on a cache hit.
- **Item 4 — MySQL `services:` container:** Each job now uses a `mysql:8.0` service container on `127.0.0.1:3306` (with a health check) instead of the runner's built-in MySQL. The `mysql_native_password` requirement (for PHP 7.4 mysqli against MySQL 8) is applied inside `setup-wp-tests` as a post-startup `ALTER USER` step, so the old init.d start + socket workaround is gone.
- **Item 5 — Cleanups:** The unused globally-installed `phpunit` tool is dropped from PHP setup, and `apt-get update` now precedes the `subversion` install — both folded into the shared actions.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [x] Sub-task of #8692
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested
This PR's own GitHub Actions runs. All four PHP test workflows are green on the latest commit: WP 5.9/PHP 7.4 (Old PHP), and WP latest across PHP 8.0–8.4 including the xdebug coverage run. Verified that: the shared composite actions resolve and run; the MySQL `mysql:8.0` service container is used and the native-password auth succeeds (specifically exercised on PHP 7.4); and the WP test-suite cache produces a hit on re-runs, skipping the SVN install/download.

### How to test
Open this PR's Actions tab and confirm the four PHP test workflow runs are green. In a job log, verify the "Setup PHP + Composer" and "Setup WordPress test suite" steps invoke the `wp-media/workflows` composite actions, the MySQL service container starts under "Initialize containers", and on a second run the test-suite cache reports a hit (SVN install skipped).

### Affected Features & Quality Assurance Scope
CI/tooling only. No plugin runtime behavior changes.

## Technical description

`services.<id>.options` maps to `docker create` flags, so the MySQL server arg `--default-authentication-plugin` cannot live there; root is instead switched to `mysql_native_password` via `ALTER USER 'root'@'%'` over TCP after the container is healthy (with `--get-server-public-key` for the cold-cache handshake), preserving PHP 7.4 mysqli compatibility. The setup duplication across the four workflows is removed by delegating to composite actions in `wp-media/workflows`, leaving each workflow with only its matrix and test command(s).

### Documentation
n/a

### New dependencies
No runtime dependencies. CI now depends on two `wp-media/workflows` composite actions (`setup-php-composer`, `setup-wp-tests`) and SHA-pins all third-party actions; `.github/dependabot.yml` automates future action bumps.

### Risks
- CI/tooling-only; worst case is a workflow misconfiguration that surfaces in this PR's own runs, not in the shipped plugin.
- **Cross-repo coupling:** the composite actions are referenced at `@main`; a breaking change there could affect these workflows. Merge order matters — the `wp-media/workflows` changes must land first.
- **Item 4** (MySQL container) was the higher-risk item per #8692; it is confirmed green in CI here.
- **Cache staleness for `latest`:** the `wp-versions: 'latest'` workflows key their WP cache on the literal `latest`, so a newly-released WP core is not re-fetched until the cache key changes. The `5.9` (Old PHP) job is unaffected.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification
Built-in tests are not applicable: the change is GitHub Actions workflow configuration only. The workflows are exercised directly by this PR's own CI runs.
