### PR TITLE
Fix invalid @uses annotations causing 33 unit-test coverage warnings

### DIFF
--- a/tests/Unit/inc/Engine/Cache/UrlValidation/PostSubscriber/disableCacheOnNotValidUrl.php
+++ b/tests/Unit/inc/Engine/Cache/UrlValidation/PostSubscriber/disableCacheOnNotValidUrl.php
@@ -11,7 +11,7 @@ use WP_Rocket\Tests\Unit\TestCase;
  * Test class covering PostSubscriber::disable_cache_on_not_valid_url
  * @covers \WP_Rocket\Engine\Cache\UrlValidation\PostSubscriber::disable_cache_on_not_valid_url
  *
- * @uses PostSubscriber::is_not_valid_url
+ * @uses \WP_Rocket\Engine\Cache\UrlValidation\PostSubscriber::is_not_valid_url
  *
  * @group Cache
  */

--- a/tests/Unit/inc/Engine/Optimization/GoogleFonts/Combine/optimize.php
+++ b/tests/Unit/inc/Engine/Optimization/GoogleFonts/Combine/optimize.php
@@ -15,7 +15,6 @@ use WP_Rocket\Tests\Unit\TestCase;
  * @uses \WP_Rocket\Logger\Logger::debug
  * @uses \WP_Rocket\Engine\Optimization\GoogleFonts\Combine::parse
  * @uses \WP_Rocket\Engine\Optimization\GoogleFonts\Combine::get_combined_url
- * @uses \WP_Rocket\Engine\Optimization\GoogleFonts\Combine::get_optimized_markup
  *
  * @group  Optimize
  * @group  GoogleFonts

--- a/tests/Unit/inc/Engine/Optimization/GoogleFonts/CombineV2/optimize.php
+++ b/tests/Unit/inc/Engine/Optimization/GoogleFonts/CombineV2/optimize.php
@@ -13,9 +13,8 @@ use WP_Rocket\Tests\Unit\TestCase;
  *
  * @uses \WP_Rocket\Logger\Logger::info
  * @uses \WP_Rocket\Logger\Logger::debug
- * @uses \WP_Rocket\Engine\Optimization\GoogleFonts\Combine::parse
- * @uses \WP_Rocket\Engine\Optimization\GoogleFonts\Combine::get_combined_url
- * @uses \WP_Rocket\Engine\Optimization\GoogleFonts\Combine::get_optimized_markup
+ * @uses \WP_Rocket\Engine\Optimization\GoogleFonts\CombineV2::parse
+ * @uses \WP_Rocket\Engine\Optimization\GoogleFonts\CombineV2::get_combined_url
  *
  * @group  Optimize
  * @group  GoogleFonts


### PR DESCRIPTION
# Description

The PHP tests code coverage workflow reports `Warnings: 33`, all from invalid `@uses` docblock annotations in three unit test classes. This PR corrects those annotations so the warning count drops to 0. No production code and no test behavior changes — docblocks only.

The 33 warnings broke down as:

| Count | Test class | Problem |
|-------|-----------|---------|
| 7 | `TestDisableCacheOnNotValidUrl` | `@uses PostSubscriber::is_not_valid_url` used the short class name, which PHPUnit cannot resolve in annotations |
| 15 | `Test_Optimize` (GoogleFonts Combine) | `@uses …\Combine::get_optimized_markup` references a method that does not exist on `Combine` |
| 11 | `Test_OptimizeV2` (GoogleFonts CombineV2) | same non-existent `Combine::get_optimized_markup` |

`get_optimized_markup` only exists on `Media\Fonts\Frontend\Controller`, never on `Combine`.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [x] Chore
- [ ] Release

## Detailed scenario

### What was tested

Ran the three affected unit test classes locally with PHP 8.2 (`TestDisableCacheOnNotValidUrl`, `Test_Optimize`, `Test_OptimizeV2`): 67 tests, 308 assertions, all green (automated). Also confirmed by inspection that every remaining `@uses` resolves to a method that exists on the named, fully-qualified class.

### How to test

1. Check out this branch.
2. Run the PHP tests code coverage workflow, or the unit suite with a coverage driver enabled (pcov/xdebug): `vendor/bin/phpunit -c tests/Unit/phpunit.xml.dist`.
3. Confirm the run no longer emits the 33 `"@uses … is invalid"` warnings and reports `Warnings: 0`.

### Affected Features & Quality Assurance Scope

Test suite only. Google Fonts optimization (Combine / CombineV2) and Cache URL validation (PostSubscriber) unit test annotations are touched; no runtime code changes, so no user-facing feature is impacted.

## Technical description

### Documentation

- `tests/Unit/inc/Engine/Cache/UrlValidation/PostSubscriber/disableCacheOnNotValidUrl.php`: fully-qualified `@uses` to `\WP_Rocket\Engine\Cache\UrlValidation\PostSubscriber::is_not_valid_url`.
- `tests/Unit/inc/Engine/Optimization/GoogleFonts/Combine/optimize.php`: removed the stale `@uses …\Combine::get_optimized_markup` line.
- `tests/Unit/inc/Engine/Optimization/GoogleFonts/CombineV2/optimize.php`: removed `get_optimized_markup`, and retargeted `@uses` for `parse` and `get_combined_url` from `Combine` (copy-paste leftovers) to `CombineV2`, whose own methods this test exercises.

### New dependencies

None.

### Risks

None. Changes are limited to PHPDoc `@uses` annotations in test files; no production code or test assertions are affected.

# Mandatory Checklist

## Code validation

- [ ] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [ ] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [ ] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [ ] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

This is a test-annotation-only change (PHPDoc `@uses` corrections) with no production code and no new/changed test logic, so the code-validation and code-style items above are not applicable. The three affected test classes were run locally and pass (67 tests, 308 assertions).

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
