### PR TITLE
Fix #8740: cast hook callback key to string in Cloudflare unregister_callback

### DIFF
--- a/inc/ThirdParty/Plugins/CDN/Cloudflare.php
+++ b/inc/ThirdParty/Plugins/CDN/Cloudflare.php
@@ -559,7 +559,8 @@ class Cloudflare implements Subscriber_Interface, DeactivationInterface {
 
 		foreach ( $original_wp_filter[ $priority ] as $key => $config ) {
 
-			if ( substr( $key, - strlen( $method ) ) !== $method ) {
+			// PHP casts numeric-string array keys to int, so $key is not always a string.
+			if ( substr( (string) $key, - strlen( $method ) ) !== $method ) {
 				continue;
 			}
 


### PR DESCRIPTION
Fixes #8740 (and the earlier report in #8596).

## Problem

On WordPress 7.1, `Cloudflare::unregister_callback()` throws an uncaught `TypeError` on every request, taking the whole site down:

```
Uncaught TypeError: substr(): Argument #1 ($string) must be of type string, int given
in inc/ThirdParty/Plugins/CDN/Cloudflare.php:562
```

The loop passes a `$wp_filter` callback ID straight into `substr()`. Those IDs used to be strings, but WordPress 7.1 produces purely numeric ones, and PHP stores numeric-string array keys as `int`. Because this file declares `strict_types=1`, PHP will not coerce the `int` back to `string`, so it throws. The caller runs during `wp-settings.php`, so front-end, admin and WP-CLI all die.

This is not limited to sites running the Cloudflare plugin. `unregister_cloudflare_clean_on_post()` has no `is_plugin_active()` guard, unlike the other public methods in the class, so the code path runs everywhere.

## Fix

Cast the key to string before the suffix comparison.

An `int` key can never equal a method-name suffix, so the cast does not change behaviour in any case that previously worked. It just lets the loop `continue` instead of throwing.

## Verification

Applied against `3.23.2.1` on three independent production installs running WordPress 7.1 (PHP 8.3, Plesk/nginx). All three were returning hard `500`s on every request, including `/wp-login.php`; all three recovered immediately and page caching resumed normally. Two of them reach `Cloudflare.php:562` via `deleted_post` at priority 10, matching the trace in #8740.

## Notes

I deliberately kept this to the minimal one-line change so it is easy to ship as a hotfix, since sites are currently going down as WordPress 7.1 rolls out.

Two follow-ups worth considering separately, which I have not touched here:

- adding the missing `is_plugin_active()` bail-out to `unregister_cloudflare_clean_on_post()`, so the Cloudflare compatibility code does not run on sites without Cloudflare at all
- PR #8647 hardens the same method against a `null` callbacks array for #6759; these two changes are independent and should not conflict
