### PR TITLE
Update version to 3.23.3.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
 		"composer/installers": "^1.0 || ^2.0",
 		"voku/simple_html_dom": "^4.8",
 		"wp-media/apply-filters-typed": "^1.0",
-		"wp-media/mcp-oauth": "^1.0.1",
+		"wp-media/mcp-oauth": "1.1.1",
 		"wp-media/plugin-family": "1.0.8",
 		"wp-media/wp-mixpanel": "^1.4.4"
 	},

--- a/wp-rocket.php
+++ b/wp-rocket.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Rocket
  * Plugin URI: https://wp-rocket.me
  * Description: The best WordPress performance plugin.
- * Version: 3.23.3.1
+ * Version: 3.23.3.2
  * Requires at least: 5.8
  * Requires PHP: 7.4
  * Code Name: Iego
@@ -20,7 +20,7 @@
 defined( 'ABSPATH' ) || exit;
 
 // Rocket defines.
-define( 'WP_ROCKET_VERSION',               '3.23.3.1' );
+define( 'WP_ROCKET_VERSION',               '3.23.3.2' );
 define( 'WP_ROCKET_WP_VERSION',            '5.8' );
 define( 'WP_ROCKET_WP_VERSION_TESTED',     '6.3.1' );
 define( 'WP_ROCKET_PHP_VERSION',           '7.4' );


### PR DESCRIPTION
# Description

N/A — not tied to a wp-rocket issue number directly.

Bumps the plugin version from 3.23.3.1 to 3.23.3.2 ahead of release, and pins the `wp-media/mcp-oauth` Composer dependency from the caret range `^1.0.1` to the exact version `1.1.1`.

This isn't just a version-string bookkeeping bump: `1.1.1` includes [wp-media/mcp-oauth#53](https://github.com/wp-media/mcp-oauth/pull/53), which downgrades the "MCP OAuth discovery documents" Site Health test from `critical` to `recommended` when it detects the `.well-known/acme-challenge/` hosting-interception fingerprint (OVH, cPanel/AutoSSL, Plesk, and most managed-WP hosts). That `critical` badge was a non-blocking, optional-feature misconfiguration that was nonetheless generating support tickets. Pinning to `1.1.1` here ships that fix as part of this release.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [x] Release

## Detailed scenario

### What was tested

Manual: diffed the two changed files and confirmed only the version string (plugin header `Version:` and the `WP_ROCKET_VERSION` constant) and the `wp-media/mcp-oauth` version constraint changed in this repo — no other wp-rocket code paths are touched by this PR.

Confirmed locally that `vendor/wp-media/mcp-oauth` already resolves to `v1.1.1` (source ref `0b07f7616a5776ef59aa333cbb949eaa3749421d`, matching mcp-oauth PR #53's merge commit) and that `HealthCheck.php` now contains the `critical` → `recommended` downgrade mapping.

From upstream [mcp-oauth#53](https://github.com/wp-media/mcp-oauth/pull/53) itself (13 automated tests / 84 assertions, all passing), [@remyperona's before/after verification](https://github.com/wp-media/mcp-oauth/pull/53#issuecomment-5397888071):

Before the change:
<img width="1684" height="1356" alt="before" src="https://github.com/user-attachments/assets/2f7009f6-669b-42dc-8ade-c7e0647afd35" />

After the change:
<img width="1680" height="1360" alt="after" src="https://github.com/user-attachments/assets/7e5bc5b3-2a0b-43a6-9cec-a16092b3f869" />

### How to test

1. Check out this branch.
2. Confirm `wp-rocket.php` reports `Version: 3.23.3.2` in both the plugin header comment and the `WP_ROCKET_VERSION` constant.
3. Confirm the Plugins list page and Site Health → Info tab display `3.23.3.2`.
4. Run `composer install` and confirm `wp-media/mcp-oauth` resolves to `1.1.1`.
5. To reproduce the Site Health severity fix itself without needing a real acme-challenge-intercepting host, use this snippet from [@remyperona, mcp-oauth#53](https://github.com/wp-media/mcp-oauth/pull/53#issuecomment-5397945084) to mock the bare-404 fingerprint, then load Tools → Site Health → Status and confirm the "MCP OAuth discovery documents" test now reports `recommended` (not `critical`):

```php
add_filter( 'pre_http_request', function ( $pre, $args, $url ) {
	if ( false !== strpos( $url, '/.well-known/oauth-' ) ) {
		return [
			'headers'  => [],                                 // no X-Powered-By / X-Redirect-By → critical fingerprint
			'body'     => '',
			'response' => [ 'code' => 404, 'message' => 'Not Found' ],
		];
	}
	return $pre;
}, 10, 3 );
```

### Affected Features & Quality Assurance Scope

Version-number display (Plugins list page, Site Health Info tab, update-checker version comparison), plus the resolved behavior of the "MCP OAuth discovery documents" Site Health test (Tools → Site Health → Status) via the `wp-media/mcp-oauth` dependency bump. No other wp-rocket code changed.

## Technical description

### Documentation

Literal version-string update in two places in `wp-rocket.php`, plus tightening the `wp-media/mcp-oauth` Composer version constraint from a caret range to the exact version that ships the Site Health severity fix described above.

### New dependencies

None — `wp-media/mcp-oauth` was already a dependency; only its version constraint changed (`^1.0.1` → `1.1.1`).

### Risks

Minimal. The user-visible effect is that sites on `.well-known/acme-challenge/`-intercepting hosts will see this Site Health test move from `critical` to `recommended` — a reduction in alarm level, not a functional behavior change to caching or the OAuth endpoints themselves. Separately, pinning to an exact version removes automatic minor/patch drift on `composer update`; future `wp-media/mcp-oauth` releases will need an explicit follow-up bump in this file rather than being picked up automatically.

# Mandatory Checklist

## Code validation

- [ ] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

No new tests were added in this repo — the behavior change being shipped (critical → recommended downgrade) already has its own automated coverage upstream in mcp-oauth PR #53 (13 tests / 84 assertions). "Acceptance Criteria" isn't applicable since this PR isn't tied to a wp-rocket issue with its own criteria. "Protected entry points" and "Output messages" don't apply — no entry points or user-facing output were added or changed in this repo.

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
