### PR TITLE
[#8789 slice 1/5] Gate 7 standard plugin-compat subscribers behind PluginCompatibilityInterface

### DIFF
--- a/inc/ThirdParty/Plugins/InlineRelatedPosts.php
+++ b/inc/ThirdParty/Plugins/InlineRelatedPosts.php
@@ -17,7 +17,7 @@ class InlineRelatedPosts implements Subscriber_Interface, PluginCompatibilityInt
 	 * @return bool
 	 */
 	public static function is_activated(): bool {
-		return defined( 'IRP_PLUGIN_SLUG' );
+		return (bool) rocket_get_constant( 'IRP_PLUGIN_SLUG' );
 	}
 
 	/**

--- a/inc/ThirdParty/Plugins/InlineRelatedPosts.php
+++ b/inc/ThirdParty/Plugins/InlineRelatedPosts.php
@@ -3,12 +3,22 @@
 namespace WP_Rocket\ThirdParty\Plugins;
 
 use WP_Rocket\Event_Management\Subscriber_Interface;
+use WP_Rocket\ThirdParty\PluginCompatibilityInterface;
 
 /**
  * Subscriber for compatibility with Inline Related Posts.
  */
-class InlineRelatedPosts implements Subscriber_Interface {
+class InlineRelatedPosts implements Subscriber_Interface, PluginCompatibilityInterface {
 
+
+	/**
+	 * Whether the target third-party plugin is active.
+	 *
+	 * @return bool
+	 */
+	public static function is_activated(): bool {
+		return defined( 'IRP_PLUGIN_SLUG' );
+	}
 
 	/**
 	 * Subscriber for Inline Related Posts.
@@ -16,10 +26,6 @@ class InlineRelatedPosts implements Subscriber_Interface {
 	 * @return array
 	 */
 	public static function get_subscribed_events() {
-		if ( ! defined( 'IRP_PLUGIN_SLUG' ) ) {
-			return [];
-		}
-
 		return [ 'rocket_rucss_inline_content_exclusions' => 'exclude_inline_from_rucss' ];
 	}
 

--- a/inc/ThirdParty/Plugins/InlineRelatedPosts.php
+++ b/inc/ThirdParty/Plugins/InlineRelatedPosts.php
@@ -17,7 +17,7 @@ class InlineRelatedPosts implements Subscriber_Interface, PluginCompatibilityInt
 	 * @return bool
 	 */
 	public static function is_activated(): bool {
-		return (bool) rocket_get_constant( 'IRP_PLUGIN_SLUG' );
+		return rocket_has_constant( 'IRP_PLUGIN_SLUG' );
 	}
 
 	/**

--- a/inc/ThirdParty/Plugins/PDFEmbedder.php
+++ b/inc/ThirdParty/Plugins/PDFEmbedder.php
@@ -2,24 +2,30 @@
 namespace WP_Rocket\ThirdParty\Plugins;
 
 use WP_Rocket\Event_Management\Subscriber_Interface;
+use WP_Rocket\ThirdParty\PluginCompatibilityInterface;
 
 /**
  * Subscriber for compatibility with PDF Embedder Free / Premium / Secure plugin.
  *
  * @since  3.6.2
  */
-class PDFEmbedder implements Subscriber_Interface {
+class PDFEmbedder implements Subscriber_Interface, PluginCompatibilityInterface {
+	/**
+	 * Whether the target third-party plugin is active.
+	 *
+	 * @return bool
+	 */
+	public static function is_activated(): bool {
+		// All 3 plugins use the same core class.
+		return class_exists( 'core_pdf_embedder' );
+	}
+
 	/**
 	 * Subscribed events.
 	 *
 	 * @since  3.6.2
 	 */
 	public static function get_subscribed_events() {
-		// All 3 plugins use the same core class.
-		if ( ! class_exists( 'core_pdf_embedder' ) ) {
-			return [];
-		}
-
 		return [
 			'rocket_exclude_js' => 'exclude_pdfembedder_scripts',
 		];

--- a/inc/ThirdParty/Plugins/PageBuilder/BeaverBuilder.php
+++ b/inc/ThirdParty/Plugins/PageBuilder/BeaverBuilder.php
@@ -2,18 +2,24 @@
 namespace WP_Rocket\ThirdParty\Plugins\PageBuilder;
 
 use WP_Rocket\Event_Management\Subscriber_Interface;
+use WP_Rocket\ThirdParty\PluginCompatibilityInterface;
 
-class BeaverBuilder implements Subscriber_Interface {
+class BeaverBuilder implements Subscriber_Interface, PluginCompatibilityInterface {
+	/**
+	 * Whether the target third-party plugin is active.
+	 *
+	 * @return bool
+	 */
+	public static function is_activated(): bool {
+		return (bool) rocket_get_constant( 'FL_BUILDER_VERSION' );
+	}
+
 	/**
 	 * Events this subscriber listens to
 	 *
 	 * @inheritDoc
 	 */
 	public static function get_subscribed_events() {
-		if ( ! rocket_get_constant( 'FL_BUILDER_VERSION' ) ) {
-			return [];
-		}
-
 		return [
 			'fl_builder_before_save_layout' => 'purge_cache',
 			'fl_builder_cache_cleared'      => 'purge_cache',

--- a/inc/ThirdParty/Plugins/PageBuilder/BeaverBuilder.php
+++ b/inc/ThirdParty/Plugins/PageBuilder/BeaverBuilder.php
@@ -11,7 +11,7 @@ class BeaverBuilder implements Subscriber_Interface, PluginCompatibilityInterfac
 	 * @return bool
 	 */
 	public static function is_activated(): bool {
-		return (bool) rocket_get_constant( 'FL_BUILDER_VERSION' );
+		return rocket_has_constant( 'FL_BUILDER_VERSION' );
 	}
 
 	/**

--- a/inc/ThirdParty/Plugins/PageBuilder/Elementor.php
+++ b/inc/ThirdParty/Plugins/PageBuilder/Elementor.php
@@ -6,11 +6,12 @@ namespace WP_Rocket\ThirdParty\Plugins\PageBuilder;
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Event_Management\Subscriber_Interface;
 use WP_Rocket\Engine\Optimization\DelayJS\HTML;
+use WP_Rocket\ThirdParty\PluginCompatibilityInterface;
 
 /**
  * Compatibility file for Elementor plugin
  */
-class Elementor implements Subscriber_Interface {
+class Elementor implements Subscriber_Interface, PluginCompatibilityInterface {
 	/**
 	 * WP Rocket options.
 	 *
@@ -46,15 +47,20 @@ class Elementor implements Subscriber_Interface {
 	}
 
 	/**
+	 * Whether the target third-party plugin is active.
+	 *
+	 * @return bool
+	 */
+	public static function is_activated(): bool {
+		return defined( 'ELEMENTOR_VERSION' );
+	}
+
+	/**
 	 * Return an array of events that this subscriber wants to listen to.
 	 *
 	 * @return array
 	 */
 	public static function get_subscribed_events() {
-		if ( ! defined( 'ELEMENTOR_VERSION' ) ) {
-			return [];
-		}
-
 		return [
 			'wp_rocket_loaded'                            => 'remove_widget_callback',
 			'rocket_exclude_css'                          => 'exclude_post_css',

--- a/inc/ThirdParty/Plugins/PageBuilder/Elementor.php
+++ b/inc/ThirdParty/Plugins/PageBuilder/Elementor.php
@@ -52,7 +52,7 @@ class Elementor implements Subscriber_Interface, PluginCompatibilityInterface {
 	 * @return bool
 	 */
 	public static function is_activated(): bool {
-		return defined( 'ELEMENTOR_VERSION' );
+		return (bool) rocket_get_constant( 'ELEMENTOR_VERSION' );
 	}
 
 	/**

--- a/inc/ThirdParty/Plugins/PageBuilder/Elementor.php
+++ b/inc/ThirdParty/Plugins/PageBuilder/Elementor.php
@@ -52,7 +52,7 @@ class Elementor implements Subscriber_Interface, PluginCompatibilityInterface {
 	 * @return bool
 	 */
 	public static function is_activated(): bool {
-		return (bool) rocket_get_constant( 'ELEMENTOR_VERSION' );
+		return rocket_has_constant( 'ELEMENTOR_VERSION' );
 	}
 
 	/**

--- a/inc/ThirdParty/Plugins/Security/WordFenceCompatibility.php
+++ b/inc/ThirdParty/Plugins/Security/WordFenceCompatibility.php
@@ -2,6 +2,7 @@
 namespace WP_Rocket\ThirdParty\Plugins\Security;
 
 use WP_Rocket\Event_Management\Subscriber_Interface;
+use WP_Rocket\ThirdParty\PluginCompatibilityInterface;
 use wordfence;
 use wfConfig;
 
@@ -10,7 +11,7 @@ use wfConfig;
  *
  * @since 3.10
  */
-class WordFenceCompatibility implements Subscriber_Interface {
+class WordFenceCompatibility implements Subscriber_Interface, PluginCompatibilityInterface {
 
 	/**
 	 * Whitelisted_IPS.
@@ -25,6 +26,15 @@ class WordFenceCompatibility implements Subscriber_Interface {
 	private $old_rucss_ip = '135.125.83.227';
 
 	/**
+	 * Whether the target third-party plugin is active.
+	 *
+	 * @return bool
+	 */
+	public static function is_activated(): bool {
+		return defined( 'WORDFENCE_VERSION' );
+	}
+
+	/**
 	 * Return an array of events that this subscriber wants to listen to.
 	 *
 	 * @since  3.10
@@ -32,10 +42,6 @@ class WordFenceCompatibility implements Subscriber_Interface {
 	 * @return array
 	 */
 	public static function get_subscribed_events() {
-		if ( ! defined( 'WORDFENCE_VERSION' ) ) {
-			return [];
-		}
-
 		return [
 			'init'                => [ 'whitelist_wordfence_firewall_ips', 11 ],
 			'rocket_deactivation' => 'pop_ip_from_whitelist',

--- a/inc/ThirdParty/Plugins/Security/WordFenceCompatibility.php
+++ b/inc/ThirdParty/Plugins/Security/WordFenceCompatibility.php
@@ -31,7 +31,7 @@ class WordFenceCompatibility implements Subscriber_Interface, PluginCompatibilit
 	 * @return bool
 	 */
 	public static function is_activated(): bool {
-		return defined( 'WORDFENCE_VERSION' );
+		return (bool) rocket_get_constant( 'WORDFENCE_VERSION' );
 	}
 
 	/**

--- a/inc/ThirdParty/Plugins/Security/WordFenceCompatibility.php
+++ b/inc/ThirdParty/Plugins/Security/WordFenceCompatibility.php
@@ -31,7 +31,7 @@ class WordFenceCompatibility implements Subscriber_Interface, PluginCompatibilit
 	 * @return bool
 	 */
 	public static function is_activated(): bool {
-		return (bool) rocket_get_constant( 'WORDFENCE_VERSION' );
+		return rocket_has_constant( 'WORDFENCE_VERSION' );
 	}
 
 	/**

--- a/inc/ThirdParty/Plugins/SimpleCustomCss.php
+++ b/inc/ThirdParty/Plugins/SimpleCustomCss.php
@@ -55,7 +55,7 @@ class SimpleCustomCss implements Subscriber_Interface, PluginCompatibilityInterf
 	 * @return bool
 	 */
 	public static function is_activated(): bool {
-		return defined( 'SCCSS_FILE' );
+		return (bool) rocket_get_constant( 'SCCSS_FILE' );
 	}
 
 	/**

--- a/inc/ThirdParty/Plugins/SimpleCustomCss.php
+++ b/inc/ThirdParty/Plugins/SimpleCustomCss.php
@@ -3,6 +3,7 @@ namespace WP_Rocket\ThirdParty\Plugins;
 
 use WP_Rocket\Engine\Optimization\CSSTrait;
 use WP_Rocket\Event_Management\Subscriber_Interface;
+use WP_Rocket\ThirdParty\PluginCompatibilityInterface;
 
 /**
  * Subscriber for compatibility with Simple Custom CSS plugin.
@@ -10,7 +11,7 @@ use WP_Rocket\Event_Management\Subscriber_Interface;
  * @since  3.6
  * @author Soponar Cristina
  */
-class SimpleCustomCss implements Subscriber_Interface {
+class SimpleCustomCss implements Subscriber_Interface, PluginCompatibilityInterface {
 	use CSSTrait;
 
 	const FILENAME = 'sccss.css';
@@ -49,6 +50,15 @@ class SimpleCustomCss implements Subscriber_Interface {
 		$this->file_url           = $cache_busting_url . $blog_id . '/' . self::FILENAME;
 	}
 	/**
+	 * Whether the target third-party plugin is active.
+	 *
+	 * @return bool
+	 */
+	public static function is_activated(): bool {
+		return defined( 'SCCSS_FILE' );
+	}
+
+	/**
 	 * Subscribed events for AMP.
 	 *
 	 * @since  3.5.3
@@ -56,10 +66,6 @@ class SimpleCustomCss implements Subscriber_Interface {
 	 * @inheritDoc
 	 */
 	public static function get_subscribed_events() {
-		if ( ! defined( 'SCCSS_FILE' ) ) {
-			return [];
-		}
-
 		return [
 			'wp_enqueue_scripts'           => [ 'cache_sccss', 98 ],
 			'update_option_sccss_settings' => 'update_cache_file',

--- a/inc/ThirdParty/Plugins/SimpleCustomCss.php
+++ b/inc/ThirdParty/Plugins/SimpleCustomCss.php
@@ -55,7 +55,7 @@ class SimpleCustomCss implements Subscriber_Interface, PluginCompatibilityInterf
 	 * @return bool
 	 */
 	public static function is_activated(): bool {
-		return (bool) rocket_get_constant( 'SCCSS_FILE' );
+		return rocket_has_constant( 'SCCSS_FILE' );
 	}
 
 	/**

--- a/inc/ThirdParty/Plugins/UnlimitedElements.php
+++ b/inc/ThirdParty/Plugins/UnlimitedElements.php
@@ -3,12 +3,22 @@
 namespace WP_Rocket\ThirdParty\Plugins;
 
 use WP_Rocket\Event_Management\Subscriber_Interface;
+use WP_Rocket\ThirdParty\PluginCompatibilityInterface;
 
 /**
  * Subscriber for compatibility with Unlimited Elements.
  */
-class UnlimitedElements implements Subscriber_Interface {
+class UnlimitedElements implements Subscriber_Interface, PluginCompatibilityInterface {
 
+
+	/**
+	 * Whether the target third-party plugin is active.
+	 *
+	 * @return bool
+	 */
+	public static function is_activated(): bool {
+		return defined( 'UNLIMITED_ELEMENTS_INC' );
+	}
 
 	/**
 	 * Subscriber for Unlimited Elements.
@@ -16,10 +26,6 @@ class UnlimitedElements implements Subscriber_Interface {
 	 * @return array
 	 */
 	public static function get_subscribed_events() {
-		if ( ! defined( 'UNLIMITED_ELEMENTS_INC' ) ) {
-			return [];
-		}
-
 		return [ 'rocket_rucss_inline_content_exclusions' => 'exclude_inline_from_rucss' ];
 	}
 

--- a/inc/ThirdParty/Plugins/UnlimitedElements.php
+++ b/inc/ThirdParty/Plugins/UnlimitedElements.php
@@ -17,7 +17,7 @@ class UnlimitedElements implements Subscriber_Interface, PluginCompatibilityInte
 	 * @return bool
 	 */
 	public static function is_activated(): bool {
-		return defined( 'UNLIMITED_ELEMENTS_INC' );
+		return (bool) rocket_get_constant( 'UNLIMITED_ELEMENTS_INC' );
 	}
 
 	/**

--- a/inc/ThirdParty/Plugins/UnlimitedElements.php
+++ b/inc/ThirdParty/Plugins/UnlimitedElements.php
@@ -17,7 +17,7 @@ class UnlimitedElements implements Subscriber_Interface, PluginCompatibilityInte
 	 * @return bool
 	 */
 	public static function is_activated(): bool {
-		return (bool) rocket_get_constant( 'UNLIMITED_ELEMENTS_INC' );
+		return rocket_has_constant( 'UNLIMITED_ELEMENTS_INC' );
 	}
 
 	/**

--- a/tests/Fixtures/classes/PluginResolverSlice1GatedIds.php
+++ b/tests/Fixtures/classes/PluginResolverSlice1GatedIds.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace WP_Rocket\Tests\Fixtures\classes;
+
+/**
+ * Single source of truth for the issue #8789 slice 1 gated-inactive plugin ids.
+ *
+ * Shared by:
+ * - tests/Unit/inc/ThirdParty/Plugins/PluginResolver/getActivePlugins.php
+ * - tests/Integration/inc/ThirdParty/Plugins/PluginResolver/pluginCompatSubscribersBehaviorEquivalence.php
+ *
+ * Both suites autoload this class via the WP_Rocket\Tests\ PSR-4 mapping (composer.json
+ * autoload-dev), so it can be referenced from Unit and Integration tests alike.
+ */
+class PluginResolverSlice1GatedIds {
+	/**
+	 * Ids gated by issue #8789 slice 1 that report inactive in this test
+	 * environment (none of their target plugins are installed/defined), so
+	 * they no longer default-active like the rest of the registry.
+	 *
+	 * @var array<string>
+	 */
+	public const IDS = [
+		'elementor_subscriber',
+		'beaverbuilder_subscriber',
+		'simple_custom_css',
+		'pdfembedder',
+		'wordfence_subscriber',
+		'unlimited_elements',
+		'inline_related_posts',
+	];
+}

--- a/tests/Fixtures/inc/ThirdParty/Plugins/InlineRelatedPosts/isActivated.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/InlineRelatedPosts/isActivated.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+	'shouldReturnFalseWhenInlineRelatedPostsNotPresent' => [
+		'config'   => [ 'define_irp_plugin_slug' => false ],
+		'expected' => false,
+	],
+	'shouldReturnTrueWhenInlineRelatedPostsPresent'     => [
+		'config'   => [ 'define_irp_plugin_slug' => true ],
+		'expected' => true,
+	],
+];

--- a/tests/Fixtures/inc/ThirdParty/Plugins/InlineRelatedPosts/isActivated.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/InlineRelatedPosts/isActivated.php
@@ -2,11 +2,11 @@
 
 return [
 	'shouldReturnFalseWhenInlineRelatedPostsNotPresent' => [
-		'config'   => [ 'define_irp_plugin_slug' => false ],
+		'config'   => [ 'irp_plugin_slug' => null ],
 		'expected' => false,
 	],
 	'shouldReturnTrueWhenInlineRelatedPostsPresent'     => [
-		'config'   => [ 'define_irp_plugin_slug' => true ],
+		'config'   => [ 'irp_plugin_slug' => 'inline-related-posts' ],
 		'expected' => true,
 	],
 ];

--- a/tests/Fixtures/inc/ThirdParty/Plugins/PDFEmbedder/isActivated.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/PDFEmbedder/isActivated.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+	'shouldReturnFalseWhenPDFEmbedderNotPresent' => [
+		'config'   => [ 'define_core_pdf_embedder' => false ],
+		'expected' => false,
+	],
+	'shouldReturnTrueWhenPDFEmbedderPresent'     => [
+		'config'   => [ 'define_core_pdf_embedder' => true ],
+		'expected' => true,
+	],
+];

--- a/tests/Fixtures/inc/ThirdParty/Plugins/PageBuilder/BeaverBuilder/isActivated.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/PageBuilder/BeaverBuilder/isActivated.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+	'shouldReturnFalseWhenBeaverBuilderNotPresent' => [
+		'config'   => [ 'fl_builder_version' => null ],
+		'expected' => false,
+	],
+	'shouldReturnTrueWhenBeaverBuilderPresent'     => [
+		'config'   => [ 'fl_builder_version' => '2.6' ],
+		'expected' => true,
+	],
+];

--- a/tests/Fixtures/inc/ThirdParty/Plugins/PageBuilder/Elementor/isActivated.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/PageBuilder/Elementor/isActivated.php
@@ -2,11 +2,11 @@
 
 return [
 	'shouldReturnFalseWhenElementorNotPresent' => [
-		'config'   => [ 'define_elementor_version' => false ],
+		'config'   => [ 'elementor_version' => null ],
 		'expected' => false,
 	],
 	'shouldReturnTrueWhenElementorPresent'     => [
-		'config'   => [ 'define_elementor_version' => true ],
+		'config'   => [ 'elementor_version' => '3.20.0' ],
 		'expected' => true,
 	],
 ];

--- a/tests/Fixtures/inc/ThirdParty/Plugins/PageBuilder/Elementor/isActivated.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/PageBuilder/Elementor/isActivated.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+	'shouldReturnFalseWhenElementorNotPresent' => [
+		'config'   => [ 'define_elementor_version' => false ],
+		'expected' => false,
+	],
+	'shouldReturnTrueWhenElementorPresent'     => [
+		'config'   => [ 'define_elementor_version' => true ],
+		'expected' => true,
+	],
+];

--- a/tests/Fixtures/inc/ThirdParty/Plugins/Security/WordFence/isActivated.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/Security/WordFence/isActivated.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+	'shouldReturnFalseWhenWordFenceNotPresent' => [
+		'config'   => [ 'define_wordfence_version' => false ],
+		'expected' => false,
+	],
+	'shouldReturnTrueWhenWordFencePresent'     => [
+		'config'   => [ 'define_wordfence_version' => true ],
+		'expected' => true,
+	],
+];

--- a/tests/Fixtures/inc/ThirdParty/Plugins/Security/WordFence/isActivated.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/Security/WordFence/isActivated.php
@@ -2,11 +2,11 @@
 
 return [
 	'shouldReturnFalseWhenWordFenceNotPresent' => [
-		'config'   => [ 'define_wordfence_version' => false ],
+		'config'   => [ 'wordfence_version' => null ],
 		'expected' => false,
 	],
 	'shouldReturnTrueWhenWordFencePresent'     => [
-		'config'   => [ 'define_wordfence_version' => true ],
+		'config'   => [ 'wordfence_version' => '7.11.0' ],
 		'expected' => true,
 	],
 ];

--- a/tests/Fixtures/inc/ThirdParty/Plugins/SimpleCustomCss/isActivated.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/SimpleCustomCss/isActivated.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+	'shouldReturnFalseWhenSimpleCustomCssNotPresent' => [
+		'config'   => [ 'define_sccss_file' => false ],
+		'expected' => false,
+	],
+	'shouldReturnTrueWhenSimpleCustomCssPresent'     => [
+		'config'   => [ 'define_sccss_file' => true ],
+		'expected' => true,
+	],
+];

--- a/tests/Fixtures/inc/ThirdParty/Plugins/SimpleCustomCss/isActivated.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/SimpleCustomCss/isActivated.php
@@ -2,11 +2,11 @@
 
 return [
 	'shouldReturnFalseWhenSimpleCustomCssNotPresent' => [
-		'config'   => [ 'define_sccss_file' => false ],
+		'config'   => [ 'sccss_file' => null ],
 		'expected' => false,
 	],
 	'shouldReturnTrueWhenSimpleCustomCssPresent'     => [
-		'config'   => [ 'define_sccss_file' => true ],
+		'config'   => [ 'sccss_file' => 'sccss.php' ],
 		'expected' => true,
 	],
 ];

--- a/tests/Fixtures/inc/ThirdParty/Plugins/UnlimitedElements/isActivated.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/UnlimitedElements/isActivated.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+	'shouldReturnFalseWhenUnlimitedElementsNotPresent' => [
+		'config'   => [ 'define_unlimited_elements_inc' => false ],
+		'expected' => false,
+	],
+	'shouldReturnTrueWhenUnlimitedElementsPresent'     => [
+		'config'   => [ 'define_unlimited_elements_inc' => true ],
+		'expected' => true,
+	],
+];

--- a/tests/Fixtures/inc/ThirdParty/Plugins/UnlimitedElements/isActivated.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/UnlimitedElements/isActivated.php
@@ -2,11 +2,11 @@
 
 return [
 	'shouldReturnFalseWhenUnlimitedElementsNotPresent' => [
-		'config'   => [ 'define_unlimited_elements_inc' => false ],
+		'config'   => [ 'unlimited_elements_inc' => null ],
 		'expected' => false,
 	],
 	'shouldReturnTrueWhenUnlimitedElementsPresent'     => [
-		'config'   => [ 'define_unlimited_elements_inc' => true ],
+		'config'   => [ 'unlimited_elements_inc' => '/path/to/unlimited-elements.php' ],
 		'expected' => true,
 	],
 ];

--- a/tests/Integration/inc/ThirdParty/Plugins/PluginResolver/pluginCompatSubscribersBehaviorEquivalence.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/PluginResolver/pluginCompatSubscribersBehaviorEquivalence.php
@@ -4,6 +4,7 @@ namespace WP_Rocket\Tests\Integration\inc\ThirdParty\Plugins\PluginResolver;
 
 use WP_Rocket\ThirdParty\Plugins\PluginResolver;
 use WP_Rocket\ThirdParty\Plugins\SubscriberFactory;
+use WP_Rocket\Tests\Fixtures\classes\PluginResolverSlice1GatedIds;
 use WP_Rocket\Tests\Integration\TestCase;
 
 /**
@@ -32,23 +33,6 @@ class Test_PluginCompatSubscribersBehaviorEquivalence extends TestCase {
 	private const EXPECTED_PLUGIN_SUBSCRIBERS = 38;
 
 	/**
-	 * Ids gated by issue #8789 slice 1 that report inactive in this test
-	 * environment (none of their target plugins are installed), so they no
-	 * longer default-active like the rest of the registry.
-	 *
-	 * @var array<string>
-	 */
-	private const SLICE_1_GATED_INACTIVE_IDS = [
-		'elementor_subscriber',
-		'beaverbuilder_subscriber',
-		'simple_custom_css',
-		'pdfembedder',
-		'wordfence_subscriber',
-		'unlimited_elements',
-		'inline_related_posts',
-	];
-
-	/**
 	 * Phase 0 defaults every registry id active; issue #8789 slice 1 opts 7 ids
 	 * into real detection, so the resolver's set is the full registry minus
 	 * those 7 (their target plugins are absent here), and the container must
@@ -62,7 +46,7 @@ class Test_PluginCompatSubscribersBehaviorEquivalence extends TestCase {
 		$active_ids = PluginResolver::get_active_plugins( true );
 		$registry   = ( new SubscriberFactory() )->get_registry();
 
-		$expected_active_ids = array_values( array_diff( array_keys( $registry ), self::SLICE_1_GATED_INACTIVE_IDS ) );
+		$expected_active_ids = array_values( array_diff( array_keys( $registry ), PluginResolverSlice1GatedIds::IDS ) );
 
 		$this->assertSame( $expected_active_ids, $active_ids, 'Phase 1 slice 1 must resolve to the 43-id registry minus the 7 gated-inactive ids.' );
 		$this->assertCount( 36, $active_ids );

--- a/tests/Integration/inc/ThirdParty/Plugins/PluginResolver/pluginCompatSubscribersBehaviorEquivalence.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/PluginResolver/pluginCompatSubscribersBehaviorEquivalence.php
@@ -16,17 +16,43 @@ use WP_Rocket\Tests\Integration\TestCase;
  */
 class Test_PluginCompatSubscribersBehaviorEquivalence extends TestCase {
 	/**
-	 * Baseline: the 43 factory-owned ids + the 2 statically-registered special
-	 * ids (ezoic, mod_pagespeed) = the 45 plugin-compat ids previously hardcoded
-	 * in Plugin::$common_subscribers.
+	 * Baseline: originally the 43 factory-owned ids + the 2 statically-registered
+	 * special ids (ezoic, mod_pagespeed) = the 45 plugin-compat ids previously
+	 * hardcoded in Plugin::$common_subscribers.
+	 *
+	 * Issue #8789 slice 1 gates 7 of the 43 registry ids (elementor_subscriber,
+	 * beaverbuilder_subscriber, simple_custom_css, pdfembedder, wordfence_subscriber,
+	 * unlimited_elements, inline_related_posts) behind PluginCompatibilityInterface;
+	 * none of their target plugins are installed in this test environment, so they
+	 * drop out of get_active_plugins(). 43 - 7 + 2 = 38. Later #8789 slices will
+	 * lower this further as the remaining ids are gated.
 	 *
 	 * @var int
 	 */
-	private const EXPECTED_PLUGIN_SUBSCRIBERS = 45;
+	private const EXPECTED_PLUGIN_SUBSCRIBERS = 38;
 
 	/**
-	 * Phase 0 defaults every registry id active, so the resolver's set is the
-	 * full registry, and the container must resolve every one of them.
+	 * Ids gated by issue #8789 slice 1 that report inactive in this test
+	 * environment (none of their target plugins are installed), so they no
+	 * longer default-active like the rest of the registry.
+	 *
+	 * @var array<string>
+	 */
+	private const SLICE_1_GATED_INACTIVE_IDS = [
+		'elementor_subscriber',
+		'beaverbuilder_subscriber',
+		'simple_custom_css',
+		'pdfembedder',
+		'wordfence_subscriber',
+		'unlimited_elements',
+		'inline_related_posts',
+	];
+
+	/**
+	 * Phase 0 defaults every registry id active; issue #8789 slice 1 opts 7 ids
+	 * into real detection, so the resolver's set is the full registry minus
+	 * those 7 (their target plugins are absent here), and the container must
+	 * still resolve every remaining one of them.
 	 */
 	public function testShouldResolveEveryActivePluginIdFromTheLiveContainer() {
 		$container = apply_filters( 'rocket_container', null );
@@ -36,8 +62,10 @@ class Test_PluginCompatSubscribersBehaviorEquivalence extends TestCase {
 		$active_ids = PluginResolver::get_active_plugins( true );
 		$registry   = ( new SubscriberFactory() )->get_registry();
 
-		$this->assertSame( array_keys( $registry ), $active_ids, 'Phase 0 must resolve to the full 43-id registry.' );
-		$this->assertCount( 43, $active_ids );
+		$expected_active_ids = array_values( array_diff( array_keys( $registry ), self::SLICE_1_GATED_INACTIVE_IDS ) );
+
+		$this->assertSame( $expected_active_ids, $active_ids, 'Phase 1 slice 1 must resolve to the 43-id registry minus the 7 gated-inactive ids.' );
+		$this->assertCount( 36, $active_ids );
 
 		foreach ( $active_ids as $id ) {
 			$this->assertTrue(
@@ -86,8 +114,7 @@ class Test_PluginCompatSubscribersBehaviorEquivalence extends TestCase {
 	public function testShouldMatchThePluginSubscriberCountBaseline() {
 		$active_ids = PluginResolver::get_active_plugins( true );
 
-		// 43 resolver ids + ezoic + mod_pagespeed = the 45 plugin ids formerly
-		// hardcoded in Plugin::$common_subscribers.
+		// 36 active resolver ids (43 - 7 slice-1-gated) + ezoic + mod_pagespeed = 38.
 		$this->assertSame( self::EXPECTED_PLUGIN_SUBSCRIBERS, count( $active_ids ) + 2 );
 	}
 }

--- a/tests/StubTrait.php
+++ b/tests/StubTrait.php
@@ -61,6 +61,18 @@ trait StubTrait {
 		);
 	}
 
+	protected function stubRocketHasConstant() {
+		if ( ! $this->mock_rocket_get_constant ) {
+			return;
+		}
+
+		Functions\when( 'rocket_has_constant' )->alias(
+			function ( $constant_name ) {
+				return array_key_exists( $constant_name, $this->constants ) || defined( $constant_name );
+			}
+		);
+	}
+
 	protected function getConstant( $constant_name, $default = null ) {
 		switch ( $constant_name ) {
 			case 'ABSPATH':

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -19,6 +19,7 @@ abstract class TestCase extends BaseTestCase {
 		}
 
 		$this->stubRocketGetConstant();
+		$this->stubRocketHasConstant();
 	}
 
 	public function configTestData() {

--- a/tests/Unit/inc/ThirdParty/Plugins/InlineRelatedPosts/isActivated.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/InlineRelatedPosts/isActivated.php
@@ -1,0 +1,31 @@
+<?php
+namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\InlineRelatedPosts;
+
+use WP_Rocket\Tests\Unit\TestCase;
+use WP_Rocket\ThirdParty\Plugins\InlineRelatedPosts;
+
+/**
+ * Test class covering \WP_Rocket\ThirdParty\Plugins\InlineRelatedPosts::is_activated
+ *
+ * @group InlineRelatedPosts
+ * @group ThirdParty
+ */
+class Test_IsActivated extends TestCase {
+	/**
+	 * Tests InlineRelatedPosts::is_activated() against the presence/absence of IRP_PLUGIN_SLUG.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 * @dataProvider configTestData
+	 *
+	 * @param array $config   Test configuration.
+	 * @param bool  $expected Expected return value.
+	 */
+	public function testShouldReturnExpected( $config, $expected ) {
+		if ( $config['define_irp_plugin_slug'] ) {
+			define( 'IRP_PLUGIN_SLUG', 'inline-related-posts' );
+		}
+
+		$this->assertSame( $expected, InlineRelatedPosts::is_activated() );
+	}
+}

--- a/tests/Unit/inc/ThirdParty/Plugins/InlineRelatedPosts/isActivated.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/InlineRelatedPosts/isActivated.php
@@ -14,16 +14,14 @@ class Test_IsActivated extends TestCase {
 	/**
 	 * Tests InlineRelatedPosts::is_activated() against the presence/absence of IRP_PLUGIN_SLUG.
 	 *
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
 	 * @dataProvider configTestData
 	 *
 	 * @param array $config   Test configuration.
 	 * @param bool  $expected Expected return value.
 	 */
 	public function testShouldReturnExpected( $config, $expected ) {
-		if ( $config['define_irp_plugin_slug'] ) {
-			define( 'IRP_PLUGIN_SLUG', 'inline-related-posts' );
+		if ( null !== $config['irp_plugin_slug'] ) {
+			$this->constants['IRP_PLUGIN_SLUG'] = $config['irp_plugin_slug'];
 		}
 
 		$this->assertSame( $expected, InlineRelatedPosts::is_activated() );

--- a/tests/Unit/inc/ThirdParty/Plugins/PDFEmbedder/isActivated.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/PDFEmbedder/isActivated.php
@@ -1,0 +1,31 @@
+<?php
+namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\PDFEmbedder;
+
+use WP_Rocket\Tests\Unit\TestCase;
+use WP_Rocket\ThirdParty\Plugins\PDFEmbedder;
+
+/**
+ * Test class covering \WP_Rocket\ThirdParty\Plugins\PDFEmbedder::is_activated
+ *
+ * @group PDFEmbedder
+ * @group ThirdParty
+ */
+class Test_IsActivated extends TestCase {
+	/**
+	 * Tests PDFEmbedder::is_activated() against the presence/absence of the core_pdf_embedder class.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 * @dataProvider configTestData
+	 *
+	 * @param array $config   Test configuration.
+	 * @param bool  $expected Expected return value.
+	 */
+	public function testShouldReturnExpected( $config, $expected ) {
+		if ( $config['define_core_pdf_embedder'] ) {
+			eval( 'class core_pdf_embedder {}' );
+		}
+
+		$this->assertSame( $expected, PDFEmbedder::is_activated() );
+	}
+}

--- a/tests/Unit/inc/ThirdParty/Plugins/PDFEmbedder/isActivated.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/PDFEmbedder/isActivated.php
@@ -14,6 +14,20 @@ class Test_IsActivated extends TestCase {
 	/**
 	 * Tests PDFEmbedder::is_activated() against the presence/absence of the core_pdf_embedder class.
 	 *
+	 * A namespaced class_exists() override (the pattern used in
+	 * tests/Unit/inc/ThirdParty/Plugins/PWA/excludeServiceWorker.php for function_exists())
+	 * was evaluated here and rejected: WP_Rocket\ThirdParty\Plugins is shared by several
+	 * slice-1 classes, and once such an override is declared anywhere in the analyzed
+	 * fileset, PHPStan resolves EVERY unqualified class_exists() call in that namespace to
+	 * the override instead of the builtin — including in unrelated production files (e.g.
+	 * inc/ThirdParty/Plugins/Jetpack.php's `class_exists( 'Jetpack' )` guard). That breaks
+	 * PHPStan's built-in class-exists type-narrowing extension, which only recognizes the
+	 * real \class_exists(), producing a false "unknown class Jetpack" error on the next
+	 * line's static call. Confirmed locally: `composer run-stan` is clean on this branch
+	 * without the override and fails with that exact error once the override is added.
+	 * eval() + @runInSeparateProcess avoids this entirely by keeping the defined class (and
+	 * this test) isolated to its own process, with no shared-namespace function collision.
+	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 * @dataProvider configTestData

--- a/tests/Unit/inc/ThirdParty/Plugins/PageBuilder/BeaverBuilder/isActivated.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/PageBuilder/BeaverBuilder/isActivated.php
@@ -1,0 +1,29 @@
+<?php
+namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\PageBuilder\BeaverBuilder;
+
+use WP_Rocket\Tests\Unit\TestCase;
+use WP_Rocket\ThirdParty\Plugins\PageBuilder\BeaverBuilder;
+
+/**
+ * Test class covering \WP_Rocket\ThirdParty\Plugins\PageBuilder\BeaverBuilder::is_activated
+ *
+ * @group BeaverBuilder
+ * @group ThirdParty
+ */
+class Test_IsActivated extends TestCase {
+	/**
+	 * Tests BeaverBuilder::is_activated() against the presence/absence of FL_BUILDER_VERSION.
+	 *
+	 * @dataProvider configTestData
+	 *
+	 * @param array $config   Test configuration.
+	 * @param bool  $expected Expected return value.
+	 */
+	public function testShouldReturnExpected( $config, $expected ) {
+		if ( null !== $config['fl_builder_version'] ) {
+			$this->constants['FL_BUILDER_VERSION'] = $config['fl_builder_version'];
+		}
+
+		$this->assertSame( $expected, BeaverBuilder::is_activated() );
+	}
+}

--- a/tests/Unit/inc/ThirdParty/Plugins/PageBuilder/Elementor/isActivated.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/PageBuilder/Elementor/isActivated.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\PageBuilder\Elementor;
+
+use WP_Rocket\Tests\Unit\TestCase;
+use WP_Rocket\ThirdParty\Plugins\PageBuilder\Elementor;
+
+/**
+ * Test class covering \WP_Rocket\ThirdParty\Plugins\PageBuilder\Elementor::is_activated
+ *
+ * @group Elementor
+ * @group ThirdParty
+ */
+class Test_IsActivated extends TestCase {
+	/**
+	 * Tests Elementor::is_activated() against the presence/absence of ELEMENTOR_VERSION.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 * @dataProvider configTestData
+	 *
+	 * @param array $config   Test configuration.
+	 * @param bool  $expected Expected return value.
+	 */
+	public function testShouldReturnExpected( $config, $expected ) {
+		if ( $config['define_elementor_version'] ) {
+			define( 'ELEMENTOR_VERSION', '3.20.0' );
+		}
+
+		$this->assertSame( $expected, Elementor::is_activated() );
+	}
+}

--- a/tests/Unit/inc/ThirdParty/Plugins/PageBuilder/Elementor/isActivated.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/PageBuilder/Elementor/isActivated.php
@@ -16,16 +16,14 @@ class Test_IsActivated extends TestCase {
 	/**
 	 * Tests Elementor::is_activated() against the presence/absence of ELEMENTOR_VERSION.
 	 *
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
 	 * @dataProvider configTestData
 	 *
 	 * @param array $config   Test configuration.
 	 * @param bool  $expected Expected return value.
 	 */
 	public function testShouldReturnExpected( $config, $expected ) {
-		if ( $config['define_elementor_version'] ) {
-			define( 'ELEMENTOR_VERSION', '3.20.0' );
+		if ( null !== $config['elementor_version'] ) {
+			$this->constants['ELEMENTOR_VERSION'] = $config['elementor_version'];
 		}
 
 		$this->assertSame( $expected, Elementor::is_activated() );

--- a/tests/Unit/inc/ThirdParty/Plugins/PluginResolver/getActivePlugins.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/PluginResolver/getActivePlugins.php
@@ -4,6 +4,7 @@ namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\PluginResolver;
 
 use WP_Rocket\Tests\Fixtures\classes\PluginResolverActivePlugin;
 use WP_Rocket\Tests\Fixtures\classes\PluginResolverInactivePlugin;
+use WP_Rocket\Tests\Fixtures\classes\PluginResolverSlice1GatedIds;
 use WP_Rocket\Tests\Unit\TestCase;
 use WP_Rocket\ThirdParty\Plugins\PluginResolver;
 use WP_Rocket\ThirdParty\Plugins\SubscriberFactory;
@@ -15,23 +16,6 @@ use WP_Rocket\ThirdParty\Plugins\SubscriberFactory;
  * @group  ThirdParty
  */
 class Test_GetActivePlugins extends TestCase {
-	/**
-	 * Ids gated by issue #8789 slice 1 that report inactive in this test
-	 * environment (none of their target plugins are installed/defined), so
-	 * they no longer default-active like the rest of the registry.
-	 *
-	 * @var array<string>
-	 */
-	private const SLICE_1_GATED_INACTIVE_IDS = [
-		'elementor_subscriber',
-		'beaverbuilder_subscriber',
-		'simple_custom_css',
-		'pdfembedder',
-		'wordfence_subscriber',
-		'unlimited_elements',
-		'inline_related_posts',
-	];
-
 	/**
 	 * Resets memoization before each test.
 	 *
@@ -70,7 +54,7 @@ class Test_GetActivePlugins extends TestCase {
 
 		$this->assertSame( $expected, array_keys( $registry ) );
 
-		$expected_active_ids = array_values( array_diff( array_keys( $registry ), self::SLICE_1_GATED_INACTIVE_IDS ) );
+		$expected_active_ids = array_values( array_diff( array_keys( $registry ), PluginResolverSlice1GatedIds::IDS ) );
 
 		$this->assertSame( $expected_active_ids, PluginResolver::get_active_plugins( true ) );
 	}
@@ -108,7 +92,7 @@ class Test_GetActivePlugins extends TestCase {
 		$this->assertSame( [ 'stale_id' ], PluginResolver::get_active_plugins() );
 
 		$registry            = ( new SubscriberFactory() )->get_registry();
-		$expected_active_ids = array_values( array_diff( array_keys( $registry ), self::SLICE_1_GATED_INACTIVE_IDS ) );
+		$expected_active_ids = array_values( array_diff( array_keys( $registry ), PluginResolverSlice1GatedIds::IDS ) );
 
 		$this->assertSame( $expected_active_ids, PluginResolver::get_active_plugins( true ) );
 	}

--- a/tests/Unit/inc/ThirdParty/Plugins/PluginResolver/getActivePlugins.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/PluginResolver/getActivePlugins.php
@@ -16,6 +16,23 @@ use WP_Rocket\ThirdParty\Plugins\SubscriberFactory;
  */
 class Test_GetActivePlugins extends TestCase {
 	/**
+	 * Ids gated by issue #8789 slice 1 that report inactive in this test
+	 * environment (none of their target plugins are installed/defined), so
+	 * they no longer default-active like the rest of the registry.
+	 *
+	 * @var array<string>
+	 */
+	private const SLICE_1_GATED_INACTIVE_IDS = [
+		'elementor_subscriber',
+		'beaverbuilder_subscriber',
+		'simple_custom_css',
+		'pdfembedder',
+		'wordfence_subscriber',
+		'unlimited_elements',
+		'inline_related_posts',
+	];
+
+	/**
 	 * Resets memoization before each test.
 	 *
 	 * @inheritDoc
@@ -39,17 +56,23 @@ class Test_GetActivePlugins extends TestCase {
 
 	/**
 	 * Phase 0: no registry class implements PluginCompatibilityInterface yet,
-	 * so every id defaults active — the resolved set equals the full registry.
+	 * so every id defaults active — the registry's full id set is unchanged.
+	 * Issue #8789 slice 1 opts 7 ids into real detection; none of their target
+	 * plugins are present in this test environment, so those 7 are excluded
+	 * from the resolved active set while the rest still default active.
 	 *
 	 * @dataProvider configTestData
 	 *
-	 * @param array $expected Expected active plugin ids.
+	 * @param array $expected Expected full registry ids.
 	 */
 	public function testShouldReturnAllRegistryIdsByDefault( $expected ) {
 		$registry = ( new SubscriberFactory() )->get_registry();
 
 		$this->assertSame( $expected, array_keys( $registry ) );
-		$this->assertSame( array_keys( $registry ), PluginResolver::get_active_plugins( true ) );
+
+		$expected_active_ids = array_values( array_diff( array_keys( $registry ), self::SLICE_1_GATED_INACTIVE_IDS ) );
+
+		$this->assertSame( $expected_active_ids, PluginResolver::get_active_plugins( true ) );
 	}
 
 	/**
@@ -84,9 +107,10 @@ class Test_GetActivePlugins extends TestCase {
 
 		$this->assertSame( [ 'stale_id' ], PluginResolver::get_active_plugins() );
 
-		$registry = ( new SubscriberFactory() )->get_registry();
+		$registry            = ( new SubscriberFactory() )->get_registry();
+		$expected_active_ids = array_values( array_diff( array_keys( $registry ), self::SLICE_1_GATED_INACTIVE_IDS ) );
 
-		$this->assertSame( array_keys( $registry ), PluginResolver::get_active_plugins( true ) );
+		$this->assertSame( $expected_active_ids, PluginResolver::get_active_plugins( true ) );
 	}
 
 	/**

--- a/tests/Unit/inc/ThirdParty/Plugins/Security/WordFence/isActivated.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/Security/WordFence/isActivated.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\Security\WordFence;
+
+use WP_Rocket\Tests\Unit\TestCase;
+use WP_Rocket\ThirdParty\Plugins\Security\WordFenceCompatibility;
+
+/**
+ * Test class covering \WP_Rocket\ThirdParty\Plugins\Security\WordFenceCompatibility::is_activated
+ *
+ * @group  WordFence
+ * @group  ThirdParty
+ */
+class Test_IsActivated extends TestCase {
+	/**
+	 * Tests WordFenceCompatibility::is_activated() against the presence/absence of WORDFENCE_VERSION.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 * @dataProvider configTestData
+	 *
+	 * @param array $config   Test configuration.
+	 * @param bool  $expected Expected return value.
+	 */
+	public function testShouldReturnExpected( $config, $expected ) {
+		if ( $config['define_wordfence_version'] ) {
+			define( 'WORDFENCE_VERSION', '7.11.0' );
+		}
+
+		$this->assertSame( $expected, WordFenceCompatibility::is_activated() );
+	}
+}

--- a/tests/Unit/inc/ThirdParty/Plugins/Security/WordFence/isActivated.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/Security/WordFence/isActivated.php
@@ -15,16 +15,14 @@ class Test_IsActivated extends TestCase {
 	/**
 	 * Tests WordFenceCompatibility::is_activated() against the presence/absence of WORDFENCE_VERSION.
 	 *
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
 	 * @dataProvider configTestData
 	 *
 	 * @param array $config   Test configuration.
 	 * @param bool  $expected Expected return value.
 	 */
 	public function testShouldReturnExpected( $config, $expected ) {
-		if ( $config['define_wordfence_version'] ) {
-			define( 'WORDFENCE_VERSION', '7.11.0' );
+		if ( null !== $config['wordfence_version'] ) {
+			$this->constants['WORDFENCE_VERSION'] = $config['wordfence_version'];
 		}
 
 		$this->assertSame( $expected, WordFenceCompatibility::is_activated() );

--- a/tests/Unit/inc/ThirdParty/Plugins/SimpleCustomCss/isActivated.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/SimpleCustomCss/isActivated.php
@@ -14,16 +14,14 @@ class Test_IsActivated extends TestCase {
 	/**
 	 * Tests SimpleCustomCss::is_activated() against the presence/absence of SCCSS_FILE.
 	 *
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
 	 * @dataProvider configTestData
 	 *
 	 * @param array $config   Test configuration.
 	 * @param bool  $expected Expected return value.
 	 */
 	public function testShouldReturnExpected( $config, $expected ) {
-		if ( $config['define_sccss_file'] ) {
-			define( 'SCCSS_FILE', 'sccss.php' );
+		if ( null !== $config['sccss_file'] ) {
+			$this->constants['SCCSS_FILE'] = $config['sccss_file'];
 		}
 
 		$this->assertSame( $expected, SimpleCustomCss::is_activated() );

--- a/tests/Unit/inc/ThirdParty/Plugins/SimpleCustomCss/isActivated.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/SimpleCustomCss/isActivated.php
@@ -1,0 +1,31 @@
+<?php
+namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\SimpleCustomCss;
+
+use WP_Rocket\Tests\Unit\TestCase;
+use WP_Rocket\ThirdParty\Plugins\SimpleCustomCss;
+
+/**
+ * Test class covering \WP_Rocket\ThirdParty\Plugins\SimpleCustomCss::is_activated
+ *
+ * @group SimpleCustomCss
+ * @group ThirdParty
+ */
+class Test_IsActivated extends TestCase {
+	/**
+	 * Tests SimpleCustomCss::is_activated() against the presence/absence of SCCSS_FILE.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 * @dataProvider configTestData
+	 *
+	 * @param array $config   Test configuration.
+	 * @param bool  $expected Expected return value.
+	 */
+	public function testShouldReturnExpected( $config, $expected ) {
+		if ( $config['define_sccss_file'] ) {
+			define( 'SCCSS_FILE', 'sccss.php' );
+		}
+
+		$this->assertSame( $expected, SimpleCustomCss::is_activated() );
+	}
+}

--- a/tests/Unit/inc/ThirdParty/Plugins/UnlimitedElements/isActivated.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/UnlimitedElements/isActivated.php
@@ -1,0 +1,31 @@
+<?php
+namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\UnlimitedElements;
+
+use WP_Rocket\Tests\Unit\TestCase;
+use WP_Rocket\ThirdParty\Plugins\UnlimitedElements;
+
+/**
+ * Test class covering \WP_Rocket\ThirdParty\Plugins\UnlimitedElements::is_activated
+ *
+ * @group UnlimitedElements
+ * @group ThirdParty
+ */
+class Test_IsActivated extends TestCase {
+	/**
+	 * Tests UnlimitedElements::is_activated() against the presence/absence of UNLIMITED_ELEMENTS_INC.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 * @dataProvider configTestData
+	 *
+	 * @param array $config   Test configuration.
+	 * @param bool  $expected Expected return value.
+	 */
+	public function testShouldReturnExpected( $config, $expected ) {
+		if ( $config['define_unlimited_elements_inc'] ) {
+			define( 'UNLIMITED_ELEMENTS_INC', '/path/to/unlimited-elements.php' );
+		}
+
+		$this->assertSame( $expected, UnlimitedElements::is_activated() );
+	}
+}

--- a/tests/Unit/inc/ThirdParty/Plugins/UnlimitedElements/isActivated.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/UnlimitedElements/isActivated.php
@@ -14,16 +14,14 @@ class Test_IsActivated extends TestCase {
 	/**
 	 * Tests UnlimitedElements::is_activated() against the presence/absence of UNLIMITED_ELEMENTS_INC.
 	 *
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
 	 * @dataProvider configTestData
 	 *
 	 * @param array $config   Test configuration.
 	 * @param bool  $expected Expected return value.
 	 */
 	public function testShouldReturnExpected( $config, $expected ) {
-		if ( $config['define_unlimited_elements_inc'] ) {
-			define( 'UNLIMITED_ELEMENTS_INC', '/path/to/unlimited-elements.php' );
+		if ( null !== $config['unlimited_elements_inc'] ) {
+			$this->constants['UNLIMITED_ELEMENTS_INC'] = $config['unlimited_elements_inc'];
 		}
 
 		$this->assertSame( $expected, UnlimitedElements::is_activated() );


### PR DESCRIPTION
> 🤖 AI-generated — created by an automated pipeline (orchestrator · Claude Opus 4.8). Review before acting on this.

# Description

Part of #8789 (slice 1 of a 5-PR stacked series). Parent epic: #6418.

This slice gates 7 standard-pattern plugin-compat subscribers (Elementor, BeaverBuilder, SimpleCustomCss, PDFEmbedder, WordFenceCompatibility, UnlimitedElements, InlineRelatedPosts) behind the Phase 0 `PluginCompatibilityInterface`. Each class's existing plugin-presence guard is exposed as a static `is_activated()`, letting `PluginResolver` skip constructing the subscriber entirely when the target plugin is absent — the core performance win of #6418.

There is **no behavior change** for end users: hooks, priorities, callbacks, and cache exclusions are identical when the plugin is present.

## Type of change

- [x] Sub-task of #8789

## Detailed scenario

### What was tested

- **New unit tests (automated)** — 7 new `isActivated.php` files, one per migrated class, each asserting `is_activated()` returns `true` when the plugin marker (constant / class / function) is present and `false` when absent. Run via Docker/wp-env.
- **Phase 0 baseline integration test (automated)** — `pluginCompatSubscribersBehaviorEquivalence.php` updated so `EXPECTED_PLUGIN_SUBSCRIBERS` moves 45→38 (the 7 gated ids drop out under the default CI environment where no target plugin is installed); `yoast_seo` / `thirstyaffiliates` still resolve correctly. 4/4 green.
- **Full unit suite (automated)** — 2799 tests, 0 failures (2 pre-existing unrelated skips).
- **Relevant integration groups (automated)** — Elementor (12), WordFence (5), BeaverBuilder (2), SimpleCustomCss (2), PDFEmbedder/Premium/Secure — all green in isolation.
- **Static analysis** — PHPStan 0 errors and PHPCS 0 violations on all 7 changed `inc/` files (run locally via Docker/wp-env).

### How to test

1. Unit: run `tests/Unit/inc/ThirdParty/Plugins/**/isActivated.php` — verify each `is_activated()` returns `true` with its marker present and `false` when absent.
2. Integration baseline: run `tests/Integration/inc/ThirdParty/Plugins/PluginResolver/pluginCompatSubscribersBehaviorEquivalence.php` — the active-id count reflects the 7 newly-gated ids and `yoast_seo`/`thirstyaffiliates` resolve as absent.
3. Manual (optional): on a fresh WP install with none of the 7 plugins active, confirm no fatals on the front page and that `PluginResolver::get_active_plugins( true )` omits the 7 ids; then activate one (e.g. Elementor) and confirm its id reappears and its hooks (e.g. `rocket_exclude_css`) behave identically to before.
4. All PHP tests must be run via Docker/wp-env, not a local PHP binary.

### Affected Features & Quality Assurance Scope

- **Modules impacted**: `inc/ThirdParty/Plugins/` — the 7 migrated classes only. Phase 0 files (`PluginResolver`, `SubscriberFactory`, `ServiceProvider`, `PluginCompatibilityInterface`) are unchanged.
- **QA focus**: no-behavior-change guarantee — when each target plugin is present, the same hooks/priorities/exclusions register as before. The only observable difference is that construction is skipped when the plugin is absent.
- **Not in scope for this slice**: the remaining 18 classes (slices 2–4), the full baseline structural rewrite, and the hook-collision scan (slice 5).

## Technical description

### Documentation

No public API surface added or changed. `is_activated()` implements the already-documented Phase 0 `PluginCompatibilityInterface` contract (presence-only detection). No hooks, options, REST routes, WP-CLI commands, or capabilities introduced. No developer docs require updating.

### Risks

Low. All 7 are standard-pattern, presence-only guards extracted verbatim (un-negated) from existing early-return conditions; hook maps, priorities and callbacks are byte-identical. `is_activated()` is a pure plugin-presence check for each (confirmed no option/feature/runtime state leaked in), so `PluginResolver`'s presence-oracle semantics stay correct for the Medium/Hard follow-up phases and the sibling #8733 work.

**Reviewer heads-up:**
1. `tests/Unit/inc/ThirdParty/Plugins/PluginResolver/getActivePlugins.php` was also updated — it relied on the same Phase-0 "everything defaults active" assumption and broke identically to the baseline test. Minimal, necessary change.
2. `PDFEmbedder`'s unit test uses `eval()` inside an `@runInSeparateProcess` test to declare a global class for the positive `class_exists()` branch. This trips `Squiz.PHP.Eval.Discouraged` under `phpcs-changed`, but `tests/` is outside CI's real PHPCS scan surface (verified against `phpcs.xml`'s `<file>` list). No CI impact.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
