### PR TITLE
Closes wp-media/wp-rocket.me#6353: encode rocketcdnButtonUrl with wp_json_encode for inline JS

### DIFF
--- a/inc/Engine/CDN/RocketCDN/AdminPageSubscriber.php
+++ b/inc/Engine/CDN/RocketCDN/AdminPageSubscriber.php
@@ -200,7 +200,7 @@ class AdminPageSubscriber extends Abstract_Render implements Subscriber_Interfac
 		);
 		?>
 		<script type="text/javascript">
-			window.rocketcdnButtonUrl = '<?php echo $button_url; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>';
+			window.rocketcdnButtonUrl = <?php echo wp_json_encode( $button_url ); ?>;
 		</script>
 		<div class="wpr-rocketcdn-modal" id="wpr-rocketcdn-modal" aria-hidden="true">
 			<div class="wpr-rocketcdn-modal__overlay" tabindex="-1" data-micromodal-close>

--- a/tests/Fixtures/inc/Engine/CDN/RocketCDN/AdminPageSubscriber/addSubscriptionModal.php
+++ b/tests/Fixtures/inc/Engine/CDN/RocketCDN/AdminPageSubscriber/addSubscriptionModal.php
@@ -1,5 +1,22 @@
 <?php
 
+// Mirrors the button URL construction in AdminPageSubscriber::add_subscription_modal(),
+// so this fixture stays correct regardless of the environment's configured site URL.
+$single_quote_button_url = add_query_arg(
+	'dashboard_url',
+	rawurlencode(
+		add_query_arg(
+			[
+				'page'               => WP_ROCKET_PLUGIN_SLUG,
+				'rocketcdn_checkout' => 'true',
+			],
+			admin_url( 'options-general.php' )
+		)
+	),
+	esc_url_raw( 'https://example.com/checkout/o\'reilly' )
+);
+$single_quote_button_url_json = wp_json_encode( $single_quote_button_url );
+
 return [
 
 	'testShouldDisplayNothingWhenWhiteLabel' => [
@@ -23,7 +40,7 @@ return [
 		],
 		'expected' => <<<HTML
 <script type="text/javascript">
-	window.rocketcdnButtonUrl = '';
+	window.rocketcdnButtonUrl = "";
 </script>
 <div class="wpr-rocketcdn-modal" id="wpr-rocketcdn-modal" aria-hidden="true">
 	<div class="wpr-rocketcdn-modal__overlay" tabindex="-1" data-micromodal-close>
@@ -35,5 +52,32 @@ return [
 	</div>
 </div>
 HTML
-	]
+	],
+
+	'testShouldEscapeSingleQuoteInButtonUrl' => [
+		'config' => [
+			'home_url'  => 'http://example.org',
+			'user_data' => [
+				'rocketcdn' => [
+					'button' => [
+						'url' => 'https://example.com/checkout/o\'reilly',
+					],
+				],
+			],
+		],
+		'expected' => <<<HTML
+<script type="text/javascript">
+	window.rocketcdnButtonUrl = {$single_quote_button_url_json};
+</script>
+<div class="wpr-rocketcdn-modal" id="wpr-rocketcdn-modal" aria-hidden="true">
+	<div class="wpr-rocketcdn-modal__overlay" tabindex="-1" data-micromodal-close>
+		<div class="wpr-loader" id="wpr-rocketcdn-modal-loader"></div>
+		<div class="wpr-rocketcdn-modal__container" role="dialog" aria-modal="true" aria-labelledby="wpr-rocketcdn-modal-title">
+			<div id="wpr-rocketcdn-modal-content">
+				<iframe id="rocketcdn-iframe" data-src="https://api.wp-rocket.me/cdn/iframe?website=http://example.org&#038;callback=http://example.org/index.php?rest_route=/wp-rocket/v1/rocketcdn/&#038;source=plugin" loading="lazy" width="674" height="425"></iframe>			</div>
+		</div>
+	</div>
+</div>
+HTML
+	],
 ];

--- a/tests/Integration/inc/Engine/CDN/RocketCDN/AdminPageSubscriber/addSubscriptionModal.php
+++ b/tests/Integration/inc/Engine/CDN/RocketCDN/AdminPageSubscriber/addSubscriptionModal.php
@@ -21,12 +21,24 @@ class Test_AddSubscriptionModal extends TestCase {
 		add_filter( 'home_url', [ $this, 'home_url_cb' ] );
 	}
 
+	public function tear_down() {
+		delete_transient( 'wp_rocket_customer_data' );
+
+		parent::tear_down();
+	}
+
 	/**
 	 * @dataProvider configTestData
 	 */
 	public function testShouldDisplayExpected( $config, $expected ) {
 		$this->white_label = isset( $config['white_label'] ) ? $config['white_label'] : $this->white_label;
 		$this->home_url = $config['home_url'];
+
+		if ( isset( $config['user_data'] ) ) {
+			// Convert nested arrays to objects to match the actual API response structure.
+			$user_data = json_decode( wp_json_encode( $config['user_data'] ) );
+			set_transient( 'wp_rocket_customer_data', $user_data, MINUTE_IN_SECONDS );
+		}
 
 		ob_start();
 		do_action( 'rocket_settings_page_footer' );
@@ -41,5 +53,15 @@ class Test_AddSubscriptionModal extends TestCase {
 		}
 
 		$this->assertSame( $expected, $actual );
+
+		// AC-2: a button URL containing a single quote must never break out of the
+		// double-quoted JSON string that wp_json_encode() emits into the inline <script> block.
+		if ( isset( $config['user_data'] ) ) {
+			$this->assertMatchesRegularExpression(
+				'/window\.rocketcdnButtonUrl = "[^"]*";/',
+				$actual,
+				'The rendered rocketcdnButtonUrl assignment must be a syntactically valid, double-quoted JS string literal.'
+			);
+		}
 	}
 }


### PR DESCRIPTION
> 🤖 AI-generated — created by an automated pipeline. Review before acting on this.

Closes wp-media/wp-rocket.me#6353

## Description

**Closes:** [wp-media/wp-rocket.me#6353](https://github.com/wp-media/wp-rocket.me/issues/6353)

Fixed an unsafe output-escaping issue in the RocketCDN subscription modal. `AdminPageSubscriber::add_subscription_modal()` was echoing `$button_url` unescaped inside a single-quoted JS string literal within an inline `<script>` block, protected only by a `phpcs:ignore`. The URL-sanitization function `esc_url_raw()` does not escape literal single quotes, allowing potential script injection if the URL contained one (though the attack surface is currently limited by the URL's provenance from WP Rocket's own licensing API).

The fix replaces the unsafe inline echo with `wp_json_encode()`, which provides proper JS string literal encoding and removes the need for the PHPCS suppression comment.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #6353
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

**Automated (backend-agent):**
- **Integration test** (`vendor/bin/phpunit --group AdminOnly --filter Test_AddSubscriptionModal`): 4 tests / 5 assertions, 0 failures. Added a case where the mocked `$user_data->rocketcdn->button->url` contains a single quote in the URL path (`.../checkout/o'reilly`) and asserted the rendered `window.rocketcdnButtonUrl` is a valid, inert JSON-encoded JS string literal.
- **Unit suite** (`composer test-unit`): 2779 tests / 9032 assertions, 0 failures (2 pre-existing unrelated skips).
- **Static analysis**: `composer run-stan` — 0 errors. `vendor/bin/phpcs inc/Engine/CDN/RocketCDN/AdminPageSubscriber.php` — 0 violations, confirming the `phpcs:ignore` suppression is no longer needed (AC 3).

**QA — live verification (qa-engineer), all 4 acceptance criteria PASS:**
- Booted the dev environment and exercised the real production render path (bypassing the license/live-site guard the same way the new integration test does) rather than relying on code review alone.
- AC 1 — modal opens / button navigates: PASS. `rocketcdn.js`'s consumer of `window.rocketcdnButtonUrl` is unchanged, and the URL round-trips identically after the fix.
- AC 2 — single-quote `$button_url` renders as an inert JS string: PASS. Live render with a quote in the URL produced `window.rocketcdnButtonUrl = "https:\/\/example.com\/checkout\/o'reilly?...";`. Also tested an aggressive breakout payload (`.../x';alert(document.cookie);//`) — the output stayed a single valid string; evaluating the exact rendered line in a JS engine confirmed no syntax error and no code execution.
- AC 3 — `phpcs:ignore` removed, PHPCS passes: PASS (diff confirmed + CI `lint / PHP CodeSniffer` green).
- AC 4 — no other unencoded echo-in-`<script>` in scope: PASS (grep confirmed; `Utils.php` sibling correctly deferred, see below).
- Smoke tests: settings page and `/wp-admin/` both HTTP 200, no fatals. QA report: https://github.com/wp-media/wp-rocket/pull/8808#issuecomment-5520370345

### How to test

**Acceptance Criteria:**

1. The RocketCDN subscription modal still opens and the checkout button still navigates to the correct URL.
2. A `$button_url` containing a single quote is rendered as a valid, inert JS string literal (no syntax error, no code execution).
3. The `phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped` suppression is removed and PHPCS passes without it.
4. No other unencoded `<?php echo $var ?>` inside a `<script>` block remains in scope for this issue (a similar-looking but non-exploitable sibling in `inc/Engine/Common/Utils.php` was found during grooming and explicitly deferred to a follow-up ticket — see [wp-media/wp-rocket.me#6353](https://github.com/wp-media/wp-rocket.me/issues/6353) for context).

**Manual test steps:**

1. Configure a valid WP Rocket license on a test site.
2. Navigate to Settings → WP Rocket → main dashboard tab and view the page source.
3. Verify `window.rocketcdnButtonUrl = "...";` is present (double-quoted JSON-encoded string, no unescaped `'`).
4. Click the RocketCDN "Get Started"/checkout button and confirm it navigates to the expected URL.
5. Run `phpcs inc/Engine/CDN/RocketCDN/AdminPageSubscriber.php` and confirm no `WordPress.Security.EscapeOutput.OutputNotEscaped` violations are reported.

### Affected Features & Quality Assurance Scope

- **RocketCDN subscription modal** (`inc/Engine/CDN/RocketCDN/AdminPageSubscriber.php`)
- **WP Rocket settings page footer** (where the modal is rendered via `rocket_settings_page_footer` hook)
- **JS global state** (`window.rocketcdnButtonUrl`, used by `src/js/global/rocketcdn.js`)

## Technical description

### Documentation

**Change:** In `inc/Engine/CDN/RocketCDN/AdminPageSubscriber.php`, line 203 in the `add_subscription_modal()` method, the unsafe inline echo was replaced:

**Before:**
```php
window.rocketcdnButtonUrl = '<?php echo $button_url; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>';
```

**After:**
```php
window.rocketcdnButtonUrl = <?php echo wp_json_encode( $button_url ); ?>;
```

**Key points:**
- `wp_json_encode()` supplies its own double-quote delimiters, so the replacement has no surrounding single quotes.
- The JSON encoding ensures proper escaping of any special characters (single quote, double quote, backslash, etc.) per the JSON spec.
- The `phpcs:ignore` comment is fully removed — `wp_json_encode()` is a recognized WordPress escaping function in the coding standards.
- The test fixture expectation was updated from `window.rocketcdnButtonUrl = '';` to `window.rocketcdnButtonUrl = "";` (JSON's double-quoted encoding of an empty string).
- An integration test case was added to verify that a `$button_url` containing a single quote is rendered correctly (backslash-escaped inside the JSON string, with no JS syntax error).

**Why this fix is correct:**
- URL sanitization (`esc_url_raw()`) and JS string literal escaping (`wp_json_encode()`) are separate concerns. The former sanitizes the URL structure; the latter must escape for the output context (JS inside a `<script>` block).
- `wp_json_encode()` is already established in this codebase as the pattern for emitting values as JS literals inside `<script>` blocks (e.g., `inc/Engine/Common/PerformanceHints/Frontend/Processor.php:187`).
- The value's current provenance (WP Rocket's own licensing API) limits real-world risk, but the fix prevents future trap if the source changes.

**Sibling audit note:** During implementation, a similar pattern was identified in `inc/Engine/Common/Utils.php::display_update_notice()` using `esc_js()` inside a `<script>` block. That code is not exploitable today (the echoed values are restricted to safe character sets by `sanitize_html_class()`, `wp_create_nonce()`, and `rawurlencode()`), and is deferred to a follow-up hardening ticket per [wp-media/wp-rocket.me#6353](https://github.com/wp-media/wp-rocket.me/issues/6353).

### New dependencies

None.

### Risks

**Performance:** None — the fix replaces one escaping function with another at the point of output; no structural changes or additional processing introduced.

**Security:** The fix *improves* security by closing the escape-injection hole. No new risks introduced.

**Compatibility:** `wp_json_encode()` is a core WordPress function (available since WP 5.0) and is already used elsewhere in this codebase. Empty string encoding changes from `''` (JS syntax) to `""` (JSON syntax), but both are semantically equivalent (`=== ''` checks in the consuming JS will still pass, as `"" == ''` in JavaScript).

**Regression:** Low — the change is localized to one output statement and its test fixture. The fixture update is minimal (quote style change), and the new test case exercises the actual vulnerability scenario (single-quote in URL), providing regression coverage.

### Follow-up tickets

None filed. Three low-priority nice-to-have items surfaced during grooming and review are documented in a [PR comment](https://github.com/wp-media/wp-rocket/pull/8808#issuecomment-5520417455) rather than tracked as separate tickets or tackled here (team decision).

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

All items applicable to this change have been completed.

# Additional Checks

- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
