### PR TITLE
Sanitize img-srcset beacon data at storage time

### DIFF
--- a/inc/Engine/Media/AboveTheFold/AJAX/Controller.php
+++ b/inc/Engine/Media/AboveTheFold/AJAX/Controller.php
@@ -155,14 +155,30 @@ class Controller implements ControllerInterface {
 		$object       = new \stdClass();
 		$object->type = $image->type ?? 'img';
 
+		// Every branch below stores raw string data supplied via the unauthenticated
+		// `rocket_beacon` AJAX action. It must be sanitized/validated at storage time,
+		// independent of any render-time escaping — a future new `case` must not skip this.
 		switch ( $object->type ) {
 			case 'img-srcset':
 				// If the type is 'img-srcset', add all the required parameters to the object.
 				if ( isset( $image->src ) && ! empty( $image->src ) && is_string( $image->src ) ) {
 					$object->src = $this->sanitize_image_url( $image->src );
 				}
-				$object->srcset = $image->srcset;
-				$object->sizes  = $image->sizes;
+
+				$raw_srcset       = ( isset( $image->srcset ) && is_string( $image->srcset ) ) ? $image->srcset : '';
+				$sanitized_srcset = $this->sanitize_srcset( $raw_srcset );
+
+				if ( empty( $sanitized_srcset ) ) {
+					// srcset is required for this type (no <img> fallback like `picture` has);
+					// reject the whole object, mirroring how array_filter() drops invalid
+					// `picture` sources below. Do not fall back to storing an empty string.
+					return null;
+				}
+
+				$object->srcset = $sanitized_srcset;
+
+				$raw_sizes     = ( isset( $image->sizes ) && is_string( $image->sizes ) ) ? $image->sizes : '';
+				$object->sizes = ! empty( $raw_sizes ) ? $this->sanitize_sizes( $raw_sizes ) : '';
 				break;
 			case 'picture':
 				if ( isset( $image->src ) && ! empty( $image->src ) && is_string( $image->src ) ) {
@@ -187,10 +203,16 @@ class Controller implements ControllerInterface {
 						if ( is_array( $image->$key ) ) {
 							$sanitized_array = array_map(
 								function ( $item ) {
-									if ( ! empty( $item->src ) ) {
-										$item->src = $this->sanitize_image_url( $item->src );
-									}
-									return $item;
+									// Rebuild each item from a whitelist rather than mutating and
+									// returning the attacker-supplied object as-is, so unrecognized
+									// properties never ride through to the stored JSON.
+									$sanitized_item = new \stdClass();
+
+									$sanitized_item->src = ( is_object( $item ) && isset( $item->src ) && is_string( $item->src ) )
+										? $this->sanitize_image_url( $item->src )
+										: '';
+
+									return $sanitized_item;
 								},
 								$image->$key
 							);

--- a/inc/Engine/Media/AboveTheFold/AJAX/Controller.php
+++ b/inc/Engine/Media/AboveTheFold/AJAX/Controller.php
@@ -165,7 +165,7 @@ class Controller implements ControllerInterface {
 					$object->src = $this->sanitize_image_url( $image->src );
 				}
 
-				$raw_srcset       = ( isset( $image->srcset ) && is_string( $image->srcset ) ) ? $image->srcset : '';
+				$raw_srcset       = $this->get_string_prop( $image, 'srcset' );
 				$sanitized_srcset = $this->sanitize_srcset( $raw_srcset );
 
 				if ( empty( $sanitized_srcset ) ) {
@@ -177,7 +177,7 @@ class Controller implements ControllerInterface {
 
 				$object->srcset = $sanitized_srcset;
 
-				$raw_sizes     = ( isset( $image->sizes ) && is_string( $image->sizes ) ) ? $image->sizes : '';
+				$raw_sizes     = $this->get_string_prop( $image, 'sizes' );
 				$object->sizes = ! empty( $raw_sizes ) ? $this->sanitize_sizes( $raw_sizes ) : '';
 				break;
 			case 'picture':
@@ -208,9 +208,8 @@ class Controller implements ControllerInterface {
 									// properties never ride through to the stored JSON.
 									$sanitized_item = new \stdClass();
 
-									$sanitized_item->src = ( is_object( $item ) && isset( $item->src ) && is_string( $item->src ) )
-										? $this->sanitize_image_url( $item->src )
-										: '';
+									$item_src            = is_object( $item ) ? $this->get_string_prop( $item, 'src' ) : '';
+									$sanitized_item->src = '' !== $item_src ? $this->sanitize_image_url( $item_src ) : '';
 
 									return $sanitized_item;
 								},
@@ -241,6 +240,17 @@ class Controller implements ControllerInterface {
 		}
 
 		return $object;
+	}
+
+	/**
+	 * Safely read a string property from an untrusted, attacker-supplied object.
+	 *
+	 * @param object $data The object to read the property from.
+	 * @param string $key  The property name to read.
+	 * @return string The property value if it's set and is a string, empty string otherwise.
+	 */
+	private function get_string_prop( $data, string $key ): string {
+		return isset( $data->$key ) && is_string( $data->$key ) ? $data->$key : '';
 	}
 
 	/**

--- a/tests/Fixtures/inc/Engine/Media/AboveTheFold/AJAX/Controller/addData.php
+++ b/tests/Fixtures/inc/Engine/Media/AboveTheFold/AJAX/Controller/addData.php
@@ -1912,6 +1912,393 @@ return [
 	],
 
 	// ========================================================================
+	// XSS VULNERABILITY TEST CASES - img-srcset
+	// ========================================================================
+
+	/**
+	 * Test Case: XSS attempt via img-srcset's srcset with onerror event handler
+	 * Should reject the whole img-srcset object (no partial storage).
+	 */
+	'testXSSInImgSrcsetOnerror' => [
+		'config' => [
+			'filter'  => true,
+			'url'     => 'http://example.org/test-page/',
+			'is_mobile' => false,
+			'results' => json_encode(
+				[
+					'lcp' => [
+						[
+							'type'   => 'img-srcset',
+							'src'    => 'http://example.org/wp-content/uploads/image.jpg',
+							'srcset' => 'image.jpg" onerror="alert(1)',
+							'sizes'  => '',
+							'label'  => 'lcp',
+						],
+					],
+				]
+			),
+		],
+		'expected' => [
+			'result'  => true,
+			'message' => [
+				'url' => 'http://example.org/test-page',
+				'is_mobile' => false,
+				'status' => 'completed',
+				'error_message' => '',
+				'lcp' => 'not found',
+				'viewport' => '[]',
+				'last_accessed' => null,
+			],
+			'item'    => [
+				'url' => 'http://example.org/test-page',
+				'is_mobile' => false,
+				'lcp' => 'not found',
+				'viewport' => '[]',
+				'last_accessed' => null,
+				'status' => 'completed',
+				'error_message' => '',
+			],
+		],
+	],
+
+	/**
+	 * Test Case: XSS attempt via img-srcset's srcset with angle brackets/<script>
+	 * Should reject the whole img-srcset object.
+	 */
+	'testXSSInImgSrcsetAngleBrackets' => [
+		'config' => [
+			'filter'  => true,
+			'url'     => 'http://example.org/test-page/',
+			'is_mobile' => false,
+			'results' => json_encode(
+				[
+					'lcp' => [
+						[
+							'type'   => 'img-srcset',
+							'src'    => 'http://example.org/wp-content/uploads/image.jpg',
+							'srcset' => 'image.jpg<script>alert(1)</script>',
+							'sizes'  => '',
+							'label'  => 'lcp',
+						],
+					],
+				]
+			),
+		],
+		'expected' => [
+			'result'  => true,
+			'message' => [
+				'url' => 'http://example.org/test-page',
+				'is_mobile' => false,
+				'status' => 'completed',
+				'error_message' => '',
+				'lcp' => 'not found',
+				'viewport' => '[]',
+				'last_accessed' => null,
+			],
+			'item'    => [
+				'url' => 'http://example.org/test-page',
+				'is_mobile' => false,
+				'lcp' => 'not found',
+				'viewport' => '[]',
+				'last_accessed' => null,
+				'status' => 'completed',
+				'error_message' => '',
+			],
+		],
+	],
+
+	/**
+	 * Test Case: XSS attempt via img-srcset's srcset with quote-breakout
+	 * Should reject the whole img-srcset object.
+	 */
+	'testXSSInImgSrcsetSingleQuotes' => [
+		'config' => [
+			'filter'  => true,
+			'url'     => 'http://example.org/test-page/',
+			'is_mobile' => false,
+			'results' => json_encode(
+				[
+					'lcp' => [
+						[
+							'type'   => 'img-srcset',
+							'src'    => 'http://example.org/wp-content/uploads/image.jpg',
+							'srcset' => "image.jpg' onclick='alert(1)",
+							'sizes'  => '',
+							'label'  => 'lcp',
+						],
+					],
+				]
+			),
+		],
+		'expected' => [
+			'result'  => true,
+			'message' => [
+				'url' => 'http://example.org/test-page',
+				'is_mobile' => false,
+				'status' => 'completed',
+				'error_message' => '',
+				'lcp' => 'not found',
+				'viewport' => '[]',
+				'last_accessed' => null,
+			],
+			'item'    => [
+				'url' => 'http://example.org/test-page',
+				'is_mobile' => false,
+				'lcp' => 'not found',
+				'viewport' => '[]',
+				'last_accessed' => null,
+				'status' => 'completed',
+				'error_message' => '',
+			],
+		],
+	],
+
+	/**
+	 * Test Case: hostile `sizes` with an otherwise-valid `srcset`
+	 * The object is kept, `srcset` is stored normally, `sizes` falls back to ''.
+	 */
+	'testXSSInImgSizesAttribute' => [
+		'config' => [
+			'filter'  => true,
+			'url'     => 'http://example.org/test-page/',
+			'is_mobile' => false,
+			'results' => json_encode(
+				[
+					'lcp' => [
+						[
+							'type'   => 'img-srcset',
+							'src'    => 'http://example.org/wp-content/uploads/image.jpg',
+							'srcset' => 'http://example.org/wp-content/uploads/image-480.jpg 480w, http://example.org/wp-content/uploads/image-800.jpg 800w',
+							'sizes'  => '100vw" onload="alert(1)',
+							'label'  => 'lcp',
+						],
+					],
+				]
+			),
+			'allowed_mime_types' => $mime_types,
+			'filetype' => [
+				'ext'  => 'jpg',
+				'type' => 'image/jpeg',
+			],
+		],
+		'expected' => [
+			'result'  => true,
+			'message' => [
+				'url' => 'http://example.org/test-page',
+				'is_mobile' => false,
+				'status' => 'completed',
+				'error_message' => '',
+				'lcp' => json_encode(
+					(object) [
+						'type'   => 'img-srcset',
+						'src'    => 'http://example.org/wp-content/uploads/image.jpg',
+						'srcset' => 'http://example.org/wp-content/uploads/image-480.jpg 480w, http://example.org/wp-content/uploads/image-800.jpg 800w',
+						'sizes'  => '',
+					]
+				),
+				'viewport' => '[]',
+				'last_accessed' => null,
+			],
+			'item'    => [
+				'url' => 'http://example.org/test-page',
+				'is_mobile' => false,
+				'lcp' => json_encode(
+					(object) [
+						'type'   => 'img-srcset',
+						'src'    => 'http://example.org/wp-content/uploads/image.jpg',
+						'srcset' => 'http://example.org/wp-content/uploads/image-480.jpg 480w, http://example.org/wp-content/uploads/image-800.jpg 800w',
+						'sizes'  => '',
+					]
+				),
+				'viewport' => '[]',
+				'last_accessed' => null,
+				'status' => 'completed',
+				'error_message' => '',
+			],
+		],
+	],
+
+	/**
+	 * Test Case: missing/empty `srcset` on an img-srcset object
+	 * Should reject the whole object, same as an explicitly empty string.
+	 */
+	'testImgSrcsetMissingField' => [
+		'config' => [
+			'filter'  => true,
+			'url'     => 'http://example.org/test-page/',
+			'is_mobile' => false,
+			'results' => json_encode(
+				[
+					'lcp' => [
+						[
+							'type'  => 'img-srcset',
+							'src'   => 'http://example.org/wp-content/uploads/image.jpg',
+							'sizes' => '',
+							'label' => 'lcp',
+						],
+					],
+				]
+			),
+		],
+		'expected' => [
+			'result'  => true,
+			'message' => [
+				'url' => 'http://example.org/test-page',
+				'is_mobile' => false,
+				'status' => 'completed',
+				'error_message' => '',
+				'lcp' => 'not found',
+				'viewport' => '[]',
+				'last_accessed' => null,
+			],
+			'item'    => [
+				'url' => 'http://example.org/test-page',
+				'is_mobile' => false,
+				'lcp' => 'not found',
+				'viewport' => '[]',
+				'last_accessed' => null,
+				'status' => 'completed',
+				'error_message' => '',
+			],
+		],
+	],
+
+	/**
+	 * Test Case: legitimate multi-descriptor srcset + valid sizes
+	 * Proves Acceptance Criterion 1 - no regression for valid img-srcset payloads.
+	 */
+	'testValidImgSrcset' => [
+		'config' => [
+			'filter'  => true,
+			'url'     => 'http://example.org/test-page/',
+			'is_mobile' => false,
+			'results' => json_encode(
+				[
+					'lcp' => [
+						[
+							'type'   => 'img-srcset',
+							'src'    => 'http://example.org/wp-content/uploads/image.jpg',
+							'srcset' => 'http://example.org/wp-content/uploads/image-480.jpg 480w, http://example.org/wp-content/uploads/image-800.jpg 800w',
+							'sizes'  => '(max-width: 600px) 480px, 800px',
+							'label'  => 'lcp',
+						],
+					],
+				]
+			),
+			'allowed_mime_types' => $mime_types,
+			'filetype' => [
+				'ext'  => 'jpg',
+				'type' => 'image/jpeg',
+			],
+		],
+		'expected' => [
+			'result'  => true,
+			'message' => [
+				'url' => 'http://example.org/test-page',
+				'is_mobile' => false,
+				'status' => 'completed',
+				'error_message' => '',
+				'lcp' => json_encode(
+					(object) [
+						'type'   => 'img-srcset',
+						'src'    => 'http://example.org/wp-content/uploads/image.jpg',
+						'srcset' => 'http://example.org/wp-content/uploads/image-480.jpg 480w, http://example.org/wp-content/uploads/image-800.jpg 800w',
+						'sizes'  => '(max-width: 600px) 480px, 800px',
+					]
+				),
+				'viewport' => '[]',
+				'last_accessed' => null,
+			],
+			'item'    => [
+				'url' => 'http://example.org/test-page',
+				'is_mobile' => false,
+				'lcp' => json_encode(
+					(object) [
+						'type'   => 'img-srcset',
+						'src'    => 'http://example.org/wp-content/uploads/image.jpg',
+						'srcset' => 'http://example.org/wp-content/uploads/image-480.jpg 480w, http://example.org/wp-content/uploads/image-800.jpg 800w',
+						'sizes'  => '(max-width: 600px) 480px, 800px',
+					]
+				),
+				'viewport' => '[]',
+				'last_accessed' => null,
+				'status' => 'completed',
+				'error_message' => '',
+			],
+		],
+	],
+
+	/**
+	 * Test Case: bg_set item carries an extra attacker-added property
+	 * Only `src` (sanitized) should survive into the stored object.
+	 */
+	'testBgSetExtraPropertyStripped' => [
+		'config' => [
+			'filter'  => true,
+			'url'     => 'http://example.org/test-page/',
+			'is_mobile' => false,
+			'results' => json_encode(
+				[
+					'lcp' => [
+						[
+							'type'   => 'bg-img',
+							'src'    => '',
+							'bg_set' => [
+								[
+									'src'     => 'http://example.org/anotherlcp.jpg',
+									'onerror' => 'alert(document.domain)',
+								],
+							],
+							'label'  => 'lcp',
+						],
+					],
+				]
+			),
+		],
+		'expected' => [
+			'result'  => true,
+			'message' => [
+				'url' => 'http://example.org/test-page',
+				'is_mobile' => false,
+				'status' => 'completed',
+				'error_message' => '',
+				'lcp' => json_encode(
+					(object) [
+						'type'   => 'bg-img',
+						'bg_set' => [
+							[
+								'src' => 'http://example.org/anotherlcp.jpg',
+							],
+						],
+						'src'    => '',
+					]
+				),
+				'viewport' => '[]',
+				'last_accessed' => null,
+			],
+			'item'    => [
+				'url' => 'http://example.org/test-page',
+				'is_mobile' => false,
+				'lcp' => json_encode(
+					(object) [
+						'type'   => 'bg-img',
+						'bg_set' => [
+							[
+								'src' => 'http://example.org/anotherlcp.jpg',
+							],
+						],
+						'src'    => '',
+					]
+				),
+				'viewport' => '[]',
+				'last_accessed' => null,
+				'status' => 'completed',
+				'error_message' => '',
+			],
+		],
+	],
+
+	// ========================================================================
 	// EDGE CASES
 	// ========================================================================
 


### PR DESCRIPTION
> 🤖 AI-generated — created by an automated pipeline. Review before acting on this.

Fixes wp-media/wp-rocket.me#6354

# Description

Storage-time sanitization for `img-srcset` beacon data, matching the existing `picture` branch hardening. Closes the asymmetry where `img-srcset` relied solely on render-time `esc_attr()` while `picture` sources were validated at storage time. This is a security hardening fix — the existing render-time escaping already prevents exploitation, but closing the storage-time gap ensures future refactors of the render path cannot silently reopen the vulnerability.

## Acceptance Criteria

- [x] A legitimate `img-srcset` beacon payload still stores and renders correctly; LCP preload tags are unchanged for valid input.
- [x] A payload whose `srcset` contains `"` or `<` is rejected or sanitized at storage time — the raw value does not reach the `wpr_above_the_fold` table.
- [x] The same applies to `sizes`.
- [x] The render-time `esc_attr()` calls at `Frontend/Controller.php:287` are kept (defence in depth — not swapped for the new guard).
- [x] Test fixtures gain `img-srcset` XSS cases mirroring the existing "Picture Sources" block.
- [x] A short comment or test documents that both `img-srcset` and `picture` inputs are validated, so a future contributor does not reintroduce the asymmetry.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

**Full QA report** (posted to the PR, see [comment](https://github.com/wp-media/wp-rocket/pull/8809#issuecomment-5520822900)):

- Automated: `tests/Fixtures/inc/Engine/Media/AboveTheFold/AJAX/Controller/addData.php` extended with a new "XSS VULNERABILITY TEST CASES - img-srcset" block (7 cases) mirroring the existing "Picture Sources" block — `on*=` handler, `<script>`/angle-brackets, quote-breakout, hostile `sizes` with valid `srcset`, missing `srcset`, valid multi-descriptor `srcset`/`sizes` (no regression), and a `bg_set` extra-property-stripped case. Result: 45/45 pass in the `AboveTheFold` group; full unit suite 2786/2786 pass, 0 failures.
- Live end-to-end (QA agent, against the real `wpr_above_the_fold` table in the dev environment): fired the actual `rocket_beacon` AJAX handler with a real anonymous nonce. Legitimate `srcset`/`sizes` stored unchanged; hostile `srcset` (`onerror=` handler) rejected — DB row shows `lcp = "not found"`, no raw payload persisted; hostile `sizes` with valid `srcset` — object kept, `sizes` emptied to `''`.
- `Frontend/Controller.php`'s `esc_attr()` calls at line 287 confirmed untouched by diff.
- Lead review (2 passes — initial fix + the helper-extraction refactor below): both **PASS**, no blockers. Second pass specifically traced and confirmed `sanitize_image_url('')` equivalence for the refactored `bg_set` call site.
- Static analysis: `phpcs` 0 new violations, `phpstan` (`run-stan`, all 4 custom rules) 0 errors.
- CI: all checks green (PHP 7.4–8.5 matrix, PHPCS, PHPStan, Codacy, PR template check).

**Follow-up refactor (commit `ebe99c65e`):** lead review's one nice-to-have — extracting the repeated `isset()`/`is_string()` defensive-read pattern into a `get_string_prop()` helper — was tackled in this same PR at request. Re-verified: same 45/45 tests pass, lead review and QA both re-confirmed no regression.

### How to test

1. Load a page with a responsive `<img srcset>` element not yet tracked by Above-The-Fold. Log out and wait for the `rocket_beacon` AJAX action to fire; inspect the `wpr_above_the_fold` table to confirm a valid `img-srcset` entry with correct `srcset` and `sizes` values is stored.
2. Reload the page and verify the `<link rel="preload" imagesrcset="..." imagesizes="...">` tag is present and unchanged (no functional regression).
3. Replay a crafted `rocket_beacon` request (via REST client or devtools) with a hostile `img-srcset` (e.g. `srcset: 'image.jpg" onerror="alert(1)"'`); confirm via DB inspection that the `wpr_above_the_fold` row is either absent or shows `lcp: "not found"` (payload rejected at storage time).
4. Run `vendor/bin/phpunit -c tests/Unit/phpunit.xml.dist --filter Test_AddBeaconData` — all fixtures (existing Picture Sources cases + new img-srcset cases) pass.

### Affected Features & Quality Assurance Scope

- **Above-The-Fold feature**: LCP preload tag generation for responsive images (`<img srcset>`), background images (`bg_set`), and picture sources (`<picture>`).
- **Security hardening**: Storage-time validation of unauthenticated beacon data (`rocket_beacon` AJAX action).
- **Database**: `wpr_above_the_fold` table (`lcp`/`viewport` columns for beacon-supplied image/source entries).

## Technical description

### Documentation

The `rocket_beacon` AJAX handler (`create_object()`) validates `picture` sources through `validate_source_object()` → `sanitize_srcset()` / `sanitize_sizes()`, but stored `img-srcset` data verbatim, relying solely on render-time `esc_attr()` at `Frontend/Controller.php:287` as the sole guard against unauthenticated stored XSS. Similarly, the `default:` branch (`bg_set` array items) sanitized `src` but passed every other property through untouched. This closes both asymmetries by applying the same storage-time sanitization uniformly, without touching the existing render-time escaping (kept as defence in depth).

**Option chosen: Direct reuse (Option A from spec).** Call `$this->sanitize_srcset()` and `$this->sanitize_sizes()` directly in the `img-srcset` case — low effort, low risk, no new helper methods. The two branches remain separate call sites into the same shared sanitizers (a pattern already used elsewhere in the method).

**Reject-vs-sanitize semantics, mirroring `picture` behaviour:**
- `srcset` is required; if `sanitize_srcset()` yields empty, `create_object()` returns `null` (whole image object rejected, loop continues in caller).
- `sizes` is optional; if `sanitize_sizes()` yields empty, store as `''` (object kept, only the `sizes` field emptied).

**Implementation:**
- `img-srcset` case: guard `$image->srcset` and `$image->sizes` with `isset()` / `is_string()`, pass through sanitizers, reject the object if `srcset` sanitization fails.
- `default:` branch (`bg_set`): rebuild each array item as a new object containing only the whitelisted `src` key (sanitized), dropping unrecognized properties.
- Add a comment above the `switch ( $object->type )` statement noting that every branch storing raw beacon data must sanitize at storage time.
- Follow-up refactor: extracted `get_string_prop( $data, string $key ): string` to deduplicate the `isset()`/`is_string()` defensive-read pattern used at all 3 call sites above.

This is not a documentation-affecting change (no new hooks, options, REST routes, or AJAX actions) — no developer docs needed updating.

### New dependencies

None.

### Risks

Low. This is a storage-time hardening of already-validated data patterns:
- Legitimate `srcset` / `sizes` values are unchanged (existing + new tests cover this).
- Invalid/hostile input is rejected or sanitized (new fixtures verify this).
- Render-time escaping is unchanged (defence in depth, not replaced) — confirmed by diff that `Frontend/Controller.php` was not touched.
- The reused helpers (`sanitize_srcset()`, `sanitize_sizes()`) already ship in production for the `picture` branch; no new sanitization logic was designed.
- No performance impact: same regex validation applied at a different point in the pipeline (storage instead of only render).
- No current exploit path exists prior to this fix (render-time `esc_attr()` already prevents XSS) — this is defence-in-depth, not a hotfix for an active vulnerability.

## Follow-up tickets

None — the sole nice-to-have identified during review (extracting a `get_string_prop()` helper) was tackled directly in this PR (commit `ebe99c65e`).

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

None — all mandatory items apply and are ticked. No screenshots/videos attached since this is a backend-only, non-UI change; verification is via automated tests and DB inspection as described above.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)

*No new error-prone calls (HTTP/API/filesystem) were introduced by this change — not applicable.*
