### PR TITLE
fix: define missing disableAddUrlElements() in Rocket Insights

### DIFF
--- a/src/js/global/ajax.js
+++ b/src/js/global/ajax.js
@@ -321,6 +321,16 @@ document.addEventListener('DOMContentLoaded', function() {
 		rocketInsightsIds = rocketInsightsIds.filter(x => parseInt(x, 10) !== idToRemove);
 	}
 
+	function disableAddUrlElements() {
+		$pageUrlInput.prop('disabled', true);
+
+		const addButton = document.getElementById('wpr-action-add_page_speed_radar');
+		if (addButton) {
+			addButton.classList.add('wpr-ri-action--disabled');
+			addButton.setAttribute('disabled', 'true');
+		}
+	}
+
 	function updateQuotaBanner(canAddPages) {
 		const $summaryInfo    = $('.wpr-ri-summary-info');
 		const isFree  = window.rocket_ajax_data?.is_free === '1';


### PR DESCRIPTION
Fixes #8377.

`handleAddPage()`'s URL-limit-exceeded error handler calls `disableAddUrlElements()`, which isn't defined anywhere in `ajax.js` or `wpr-admin.js` — this throws a `ReferenceError` the moment that path fires. `handleAddPage()` itself already guards on `$(this).attr('disabled')` before doing anything, and `updateAllRetestButtons()` already has an established disable/enable pattern for actions in this same Rocket Insights panel, so the intent was clearly to disable the input and add button once the limit is hit — the call just never got implemented.

Defines it following that existing pattern: disables the URL input, and disables + visually marks the add button with the `wpr-ri-action--disabled` class `updateAllRetestButtons()` already uses for the same purpose.

No JS test framework exists in this repo yet (`"test": "echo Error: no test specified && exit 1"`), so I verified with a real Node execution of the function body (copied verbatim) against mock jQuery/DOM objects — confirmed the input gets disabled, the button gets both the class and the disabled attribute, and the missing-button case (defensive `if (addButton)` check) doesn't throw.

Co-authored with Claude Code (Anthropic); reviewed by @si-kui-a before submission.


