### PR TITLE
fix: match preg_quote() delimiter to the pattern it's used in

### DIFF
--- a/inc/Engine/Optimization/DeferJS/DeferJS.php
+++ b/inc/Engine/Optimization/DeferJS/DeferJS.php
@@ -289,7 +289,8 @@ class DeferJS {
 		$inline_exclusions_list = array_merge( $inline_exclusions_list, (array) $additional_inline_exclusions_list );
 
 		foreach ( $inline_exclusions_list as $inline_exclusions_item ) {
-			$inline_exclusions .= preg_quote( (string) $inline_exclusions_item, '#' ) . '|';
+			// Escape for '/', the delimiter the pattern below is actually matched with.
+			$inline_exclusions .= preg_quote( (string) $inline_exclusions_item, '/' ) . '|';
 		}
 
 		return rtrim( $inline_exclusions, '|' );

--- a/tests/Fixtures/inc/Engine/Optimization/DeferJS/DeferJS/deferInlineJs.php
+++ b/tests/Fixtures/inc/Engine/Optimization/DeferJS/DeferJS/deferInlineJs.php
@@ -174,4 +174,31 @@ return [
 		'html'     => $html,
 		'expected' => $expected,
 	],
+	'testShouldReturnOriginalWhenInlineExclusionContainsSlash' => [
+		'config' => [
+			'donotrocketoptimize' => false,
+			'post_meta'           => false,
+			'options'             => [
+				'defer_all_js'      => 1,
+				'exclude_defer_js'  => [],
+			],
+			'exclusions_list'     => (object) [
+				'defer_js_inline_exclusions' => [
+					'MyApp/legacyInit',
+				],
+			],
+		],
+		'html'     => <<<HTML
+	<script>
+		MyApp/legacyInit();
+	</script>
+HTML
+		,
+		'expected' => <<<HTML
+	<script>
+		MyApp/legacyInit();
+	</script>
+HTML
+		,
+	],
 ];


### PR DESCRIPTION
Fixes #8787.

`get_inline_exclusions_list_pattern()` escapes each exclusion string with `preg_quote($item, '#')`, but `defer_inline_js()` evaluates the combined pattern with `/` delimiters (`"/({$inline_exclusions})/msi"`). An exclusion string containing a literal `/` (e.g. a URL or path fragment added via the `rocket_defer_inline_exclusions` filter) isn't escaped for that delimiter, so it prematurely closes the pattern — this doesn't just fail to match that one exclusion, it breaks the regex compile for every exclusion in the same combined pattern.

Changed the `preg_quote()` delimiter to `/` to match what the pattern is actually built with.

Verified with a real PHPUnit run (`composer test-unit --group DeferJS`): 24/24 pass, including a new fixture case reproducing this exact scenario. Confirmed the new case genuinely catches the bug by stashing the fix and re-running — it fails with `preg_match(): Unknown modifier 'l'`, the exact premature-pattern-termination signature this fix removes. Also ran the full Unit suite (2780 tests) before and after via `git stash` to confirm the 148 pre-existing failures/errors are identical on both trees, i.e. unrelated to this change.

Co-authored with Claude Code (Anthropic); reviewed by @si-kui-a before submission.
