### PR TITLE
[#8789 slice 4/5] Gate 7 deviation plugin-compat subscribers behind PluginCompatibilityInterface

### DIFF
--- a/inc/ThirdParty/Plugins/Jetpack.php
+++ b/inc/ThirdParty/Plugins/Jetpack.php
@@ -4,9 +4,10 @@ namespace WP_Rocket\ThirdParty\Plugins;
 
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Event_Management\Subscriber_Interface;
+use WP_Rocket\ThirdParty\PluginCompatibilityInterface;
 use WP_Rocket\ThirdParty\ReturnTypesTrait;
 
-class Jetpack implements Subscriber_Interface {
+class Jetpack implements Subscriber_Interface, PluginCompatibilityInterface {
 
 	use ReturnTypesTrait;
 
@@ -24,6 +25,15 @@ class Jetpack implements Subscriber_Interface {
 	 */
 	public function __construct( Options_Data $option ) {
 		$this->option = $option;
+	}
+
+	/**
+	 * Whether Jetpack is active.
+	 *
+	 * @return bool
+	 */
+	public static function is_activated(): bool {
+		return class_exists( 'Jetpack' );
 	}
 
 	/**

--- a/inc/ThirdParty/Plugins/Optimization/Autoptimize.php
+++ b/inc/ThirdParty/Plugins/Optimization/Autoptimize.php
@@ -6,8 +6,9 @@ namespace WP_Rocket\ThirdParty\Plugins\Optimization;
 
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Event_Management\Subscriber_Interface;
+use WP_Rocket\ThirdParty\PluginCompatibilityInterface;
 
-class Autoptimize implements Subscriber_Interface {
+class Autoptimize implements Subscriber_Interface, PluginCompatibilityInterface {
 	/**
 	 * WP Rocket Options instance
 	 *
@@ -22,6 +23,15 @@ class Autoptimize implements Subscriber_Interface {
 	 */
 	public function __construct( Options_Data $options ) {
 		$this->options = $options;
+	}
+
+	/**
+	 * Whether Autoptimize is active.
+	 *
+	 * @return bool
+	 */
+	public static function is_activated(): bool {
+		return (bool) rocket_get_constant( 'AUTOPTIMIZE_PLUGIN_VERSION', false );
 	}
 
 	/**

--- a/inc/ThirdParty/Plugins/Optimization/Autoptimize.php
+++ b/inc/ThirdParty/Plugins/Optimization/Autoptimize.php
@@ -31,7 +31,7 @@ class Autoptimize implements Subscriber_Interface, PluginCompatibilityInterface 
 	 * @return bool
 	 */
 	public static function is_activated(): bool {
-		return (bool) rocket_get_constant( 'AUTOPTIMIZE_PLUGIN_VERSION', false );
+		return rocket_has_constant( 'AUTOPTIMIZE_PLUGIN_VERSION' );
 	}
 
 	/**

--- a/inc/ThirdParty/Plugins/PWA.php
+++ b/inc/ThirdParty/Plugins/PWA.php
@@ -4,8 +4,18 @@ declare(strict_types=1);
 namespace WP_Rocket\ThirdParty\Plugins;
 
 use WP_Rocket\Event_Management\Subscriber_Interface;
+use WP_Rocket\ThirdParty\PluginCompatibilityInterface;
 
-class PWA implements Subscriber_Interface {
+class PWA implements Subscriber_Interface, PluginCompatibilityInterface {
+	/**
+	 * Whether the PWA plugin is active.
+	 *
+	 * @return bool
+	 */
+	public static function is_activated(): bool {
+		return function_exists( 'wp_get_service_worker_url' );
+	}
+
 	/**
 	 * Subscribed events.
 	 */

--- a/inc/ThirdParty/Plugins/SEO/SEOPress.php
+++ b/inc/ThirdParty/Plugins/SEO/SEOPress.php
@@ -4,8 +4,9 @@ namespace WP_Rocket\ThirdParty\Plugins\SEO;
 
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Event_Management\Subscriber_Interface;
+use WP_Rocket\ThirdParty\PluginCompatibilityInterface;
 
-class SEOPress implements Subscriber_Interface {
+class SEOPress implements Subscriber_Interface, PluginCompatibilityInterface {
 
 	/**
 	 * Option instance.
@@ -21,6 +22,15 @@ class SEOPress implements Subscriber_Interface {
 	 */
 	public function __construct( Options_Data $option ) {
 		$this->option = $option;
+	}
+
+	/**
+	 * Whether SEOPress is active.
+	 *
+	 * @return bool
+	 */
+	public static function is_activated(): bool {
+		return function_exists( 'seopress_get_toggle_option' );
 	}
 
 	/**

--- a/inc/ThirdParty/Plugins/SEO/TheSEOFramework.php
+++ b/inc/ThirdParty/Plugins/SEO/TheSEOFramework.php
@@ -5,8 +5,9 @@ namespace WP_Rocket\ThirdParty\Plugins\SEO;
 use The_SEO_Framework\Bridges\Sitemap;
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Event_Management\Subscriber_Interface;
+use WP_Rocket\ThirdParty\PluginCompatibilityInterface;
 
-class TheSEOFramework implements Subscriber_Interface {
+class TheSEOFramework implements Subscriber_Interface, PluginCompatibilityInterface {
 
 	/**
 	 * Option instance.
@@ -22,6 +23,21 @@ class TheSEOFramework implements Subscriber_Interface {
 	 */
 	public function __construct( Options_Data $option ) {
 		$this->option = $option;
+	}
+
+	/**
+	 * Whether The SEO Framework is active.
+	 *
+	 * @return bool
+	 */
+	public static function is_activated(): bool {
+		if ( ! function_exists( 'the_seo_framework' ) ) {
+			return false;
+		}
+
+		$tsf = the_seo_framework();
+
+		return ! empty( $tsf->loaded );
 	}
 
 	/**

--- a/inc/ThirdParty/Plugins/SEO/Yoast.php
+++ b/inc/ThirdParty/Plugins/SEO/Yoast.php
@@ -5,8 +5,18 @@ namespace WP_Rocket\ThirdParty\Plugins\SEO;
 
 use WP_Rocket\Admin\Options_Data;
 use WP_Rocket\Event_Management\Subscriber_Interface;
+use WP_Rocket\ThirdParty\PluginCompatibilityInterface;
 
-class Yoast implements Subscriber_Interface {
+class Yoast implements Subscriber_Interface, PluginCompatibilityInterface {
+
+	/**
+	 * Whether Yoast SEO is active.
+	 *
+	 * @return bool
+	 */
+	public static function is_activated(): bool {
+		return (bool) rocket_get_constant( 'WPSEO_VERSION' );
+	}
 
 	/**
 	 * Array of events this subscriber listens to

--- a/inc/ThirdParty/Plugins/SEO/Yoast.php
+++ b/inc/ThirdParty/Plugins/SEO/Yoast.php
@@ -15,7 +15,7 @@ class Yoast implements Subscriber_Interface, PluginCompatibilityInterface {
 	 * @return bool
 	 */
 	public static function is_activated(): bool {
-		return (bool) rocket_get_constant( 'WPSEO_VERSION' );
+		return rocket_has_constant( 'WPSEO_VERSION' );
 	}
 
 	/**

--- a/inc/ThirdParty/Plugins/ThirstyAffiliates.php
+++ b/inc/ThirdParty/Plugins/ThirstyAffiliates.php
@@ -4,8 +4,22 @@ declare( strict_types=1 );
 namespace WP_Rocket\ThirdParty\Plugins;
 
 use WP_Rocket\Event_Management\Subscriber_Interface;
+use WP_Rocket\ThirdParty\PluginCompatibilityInterface;
 
-class ThirstyAffiliates implements Subscriber_Interface {
+class ThirstyAffiliates implements Subscriber_Interface, PluginCompatibilityInterface {
+	/**
+	 * Whether ThirstyAffiliates is active.
+	 *
+	 * @return bool
+	 */
+	public static function is_activated(): bool {
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		return is_plugin_active( 'thirstyaffiliates/thirstyaffiliates.php' );
+	}
+
 	/**
 	 * Returns an array of events this subscriber listens to.
 	 *

--- a/tests/Fixtures/classes/PluginResolverGatedIds.php
+++ b/tests/Fixtures/classes/PluginResolverGatedIds.php
@@ -19,7 +19,7 @@ namespace WP_Rocket\Tests\Fixtures\classes;
  */
 class PluginResolverGatedIds {
 	/**
-	 * Ids gated by issue #8789 (slices 1-3, so far) that report inactive in this
+	 * Ids gated by issue #8789 (slices 1-4, so far) that report inactive in this
 	 * test environment (none of their target plugins are installed/defined), so
 	 * they no longer default-active like the rest of the registry.
 	 *
@@ -47,5 +47,13 @@ class PluginResolverGatedIds {
 		// Slice 3.
 		'syntaxhighlighter_subscriber',
 		'ngg_subscriber',
+		// Slice 4.
+		'pwa',
+		'yoast_seo',
+		'thirstyaffiliates',
+		'autoptimize',
+		'jetpack',
+		'seopress',
+		'the_seo_framework',
 	];
 }

--- a/tests/Fixtures/inc/ThirdParty/Plugins/Optimization/Autoptimize/isActivated.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/Optimization/Autoptimize/isActivated.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+	'shouldReturnFalseWhenAutoptimizeNotPresent' => [
+		'config'   => [ 'autoptimize_plugin_version' => null ],
+		'expected' => false,
+	],
+	'shouldReturnTrueWhenAutoptimizePresent'      => [
+		'config'   => [ 'autoptimize_plugin_version' => '3.1.0' ],
+		'expected' => true,
+	],
+];

--- a/tests/Fixtures/inc/ThirdParty/Plugins/PWA/isActivated.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/PWA/isActivated.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+	'shouldReturnFalseWhenServiceWorkerFunctionMissing' => [
+		'config'   => [ 'function_exists' => false ],
+		'expected' => false,
+	],
+	'shouldReturnTrueWhenServiceWorkerFunctionPresent'  => [
+		'config'   => [ 'function_exists' => true ],
+		'expected' => true,
+	],
+];

--- a/tests/Fixtures/inc/ThirdParty/Plugins/SEO/SEOPress/isActivated.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/SEO/SEOPress/isActivated.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+	'shouldReturnFalseWhenSeopressToggleFunctionMissing' => [
+		'config'   => [ 'function_exists' => false ],
+		'expected' => false,
+	],
+	'shouldReturnTrueWhenSeopressToggleFunctionPresent'  => [
+		'config'   => [ 'function_exists' => true ],
+		'expected' => true,
+	],
+];

--- a/tests/Fixtures/inc/ThirdParty/Plugins/SEO/Yoast/isActivated.php
+++ b/tests/Fixtures/inc/ThirdParty/Plugins/SEO/Yoast/isActivated.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+	'shouldReturnFalseWhenYoastNotPresent' => [
+		'config'   => [ 'wpseo_version' => null ],
+		'expected' => false,
+	],
+	'shouldReturnTrueWhenYoastPresent'     => [
+		'config'   => [ 'wpseo_version' => '20.1' ],
+		'expected' => true,
+	],
+];

--- a/tests/Integration/inc/ThirdParty/Plugins/Optimization/Autoptimize/warnWhenAggregateInlineCssAndCPCSSActive.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Optimization/Autoptimize/warnWhenAggregateInlineCssAndCPCSSActive.php
@@ -3,6 +3,7 @@
 declare( strict_types=1 );
 
 use Brain\Monkey\Functions;
+use WP_Rocket\ThirdParty\Plugins\Optimization\Autoptimize;
 use WP_Rocket\Tests\Integration\CapTrait;
 use WP_Rocket\Tests\Integration\TestCase;
 
@@ -25,10 +26,17 @@ class Test_WarnWhenAggregateInlineCssAndCPCSSActive extends TestCase {
 	public function set_up() {
 		parent::set_up();
 
-		$this->unregisterAllCallbacksExcept(
-			'admin_notices',
-			'warn_when_aggregate_inline_css_and_cpcss_active'
-		);
+		// Issue #8789 slice 4 gates Autoptimize behind PluginCompatibilityInterface;
+		// AUTOPTIMIZE_PLUGIN_VERSION is genuinely undefined at real plugin boot in this
+		// test environment, so the live container no longer constructs/hooks Autoptimize
+		// on admin_notices the way unregisterAllCallbacksExcept() previously relied on
+		// (it would silently keep every original callback, including RocketInsights's,
+		// when it can't find a matching one to except). Construct our own instance and
+		// hook it manually instead.
+		$this->unregisterAllCallbacks( 'admin_notices' );
+
+		$container = apply_filters( 'rocket_container', null );
+		add_action( 'admin_notices', [ new Autoptimize( $container->get( 'options' ) ), 'warn_when_aggregate_inline_css_and_cpcss_active' ] );
 
 		Functions\expect( 'wp_create_nonce' )
 			->with( 'warn_when_aggregate_inline_css_and_cpcss_active' )

--- a/tests/Integration/inc/ThirdParty/Plugins/Optimization/Autoptimize/warnWhenJsAggregationAndDelayJsActive.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Optimization/Autoptimize/warnWhenJsAggregationAndDelayJsActive.php
@@ -3,6 +3,7 @@
 declare( strict_types=1 );
 
 use Brain\Monkey\Functions;
+use WP_Rocket\ThirdParty\Plugins\Optimization\Autoptimize;
 use WP_Rocket\Tests\Integration\CapTrait;
 use WP_Rocket\Tests\Integration\TestCase;
 
@@ -25,10 +26,17 @@ class Test_WarnWhenJsAggregationAndDelayJsActive extends TestCase {
 	public function set_up() {
 		parent::set_up();
 
-		$this->unregisterAllCallbacksExcept(
-			'admin_notices',
-			'warn_when_js_aggregation_and_delay_js_active'
-		);
+		// Issue #8789 slice 4 gates Autoptimize behind PluginCompatibilityInterface;
+		// AUTOPTIMIZE_PLUGIN_VERSION is genuinely undefined at real plugin boot in this
+		// test environment, so the live container no longer constructs/hooks Autoptimize
+		// on admin_notices the way unregisterAllCallbacksExcept() previously relied on
+		// (it would silently keep every original callback, including RocketInsights's,
+		// when it can't find a matching one to except). Construct our own instance and
+		// hook it manually instead.
+		$this->unregisterAllCallbacks( 'admin_notices' );
+
+		$container = apply_filters( 'rocket_container', null );
+		add_action( 'admin_notices', [ new Autoptimize( $container->get( 'options' ) ), 'warn_when_js_aggregation_and_delay_js_active' ] );
 
 		Functions\expect( 'wp_create_nonce' )
 			->with( 'warn_when_js_aggregation_and_delay_js_active' )

--- a/tests/Integration/inc/ThirdParty/Plugins/PluginResolver/pluginCompatSubscribersBehaviorEquivalence.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/PluginResolver/pluginCompatSubscribersBehaviorEquivalence.php
@@ -21,25 +21,27 @@ class Test_PluginCompatSubscribersBehaviorEquivalence extends TestCase {
 	 * special ids (ezoic, mod_pagespeed) = the 45 plugin-compat ids previously
 	 * hardcoded in Plugin::$common_subscribers.
 	 *
-	 * Issue #8789 slices 1-3 gate 18 of the 43 registry ids (slice 1: elementor_subscriber,
-	 * beaverbuilder_subscriber, simple_custom_css, pdfembedder, wordfence_subscriber,
-	 * unlimited_elements, inline_related_posts; slice 2: rank_math_seo, rocket_lazy_load,
-	 * the_events_calendar, perfmatters, weglot, translatepress, termly_subscriber,
-	 * optimole_subscriber, convertplug; slice 3: syntaxhighlighter_subscriber,
-	 * ngg_subscriber) behind PluginCompatibilityInterface; none of their
-	 * target plugins are installed in this test environment, so they drop out of
-	 * get_active_plugins(). 43 - 18 + 2 = 27. Later #8789 slices will lower this further
+	 * Issue #8789 slices 1-4 gate all 25 of the Easy-25 registry ids (slice 1:
+	 * elementor_subscriber, beaverbuilder_subscriber, simple_custom_css, pdfembedder,
+	 * wordfence_subscriber, unlimited_elements, inline_related_posts; slice 2:
+	 * rank_math_seo, rocket_lazy_load, the_events_calendar, perfmatters, weglot,
+	 * translatepress, termly_subscriber, optimole_subscriber, convertplug; slice 3:
+	 * syntaxhighlighter_subscriber, ngg_subscriber; slice 4: pwa, yoast_seo,
+	 * thirstyaffiliates, autoptimize, jetpack, seopress, the_seo_framework) behind
+	 * PluginCompatibilityInterface; none of their target plugins are installed in
+	 * this test environment, so they drop out of get_active_plugins().
+	 * 43 - 25 + 2 = 20. Later #8789 batches (Medium/Hard) will lower this further
 	 * as the remaining ids are gated.
 	 *
 	 * @var int
 	 */
-	private const EXPECTED_PLUGIN_SUBSCRIBERS = 27;
+	private const EXPECTED_PLUGIN_SUBSCRIBERS = 20;
 
 	/**
-	 * Phase 0 defaults every registry id active; issue #8789 slices 1-3 opt 18 ids
-	 * into real detection, so the resolver's set is the full registry minus
-	 * those 18 (their target plugins are absent here), and the container must
-	 * still resolve every remaining one of them.
+	 * Phase 0 defaults every registry id active; issue #8789 slices 1-4 opt all 25
+	 * Easy-25 ids into real detection, so the resolver's set is the full registry
+	 * minus those 25 (their target plugins are absent here), and the container
+	 * must still resolve every remaining one of them.
 	 */
 	public function testShouldResolveEveryActivePluginIdFromTheLiveContainer() {
 		$container = apply_filters( 'rocket_container', null );
@@ -51,8 +53,8 @@ class Test_PluginCompatSubscribersBehaviorEquivalence extends TestCase {
 
 		$expected_active_ids = array_values( array_diff( array_keys( $registry ), PluginResolverGatedIds::IDS ) );
 
-		$this->assertSame( $expected_active_ids, $active_ids, 'Phase 1 slices 1-3 must resolve to the 43-id registry minus the 18 gated-inactive ids.' );
-		$this->assertCount( 25, $active_ids );
+		$this->assertSame( $expected_active_ids, $active_ids, 'Phase 1 slices 1-4 must resolve to the 43-id registry minus the 25 gated-inactive ids.' );
+		$this->assertCount( 18, $active_ids );
 
 		foreach ( $active_ids as $id ) {
 			$this->assertTrue(
@@ -67,17 +69,14 @@ class Test_PluginCompatSubscribersBehaviorEquivalence extends TestCase {
 	}
 
 	/**
-	 * Drift/dedup proof: yoast_seo and thirstyaffiliates were previously
-	 * missing from $provides (drift), and convertplug was double-registered.
-	 * cloudflare_plugin_facade is the internal dependency of
-	 * cloudflare_plugin_subscriber. yoast_seo, thirstyaffiliates, and
-	 * cloudflare_plugin_facade are not yet gated (still un-migrated or a
-	 * `->add()` dependency, not a registry id) so they must still resolve.
+	 * Drift/dedup proof: cloudflare_plugin_facade is the internal `->add()`
+	 * dependency of cloudflare_plugin_subscriber, not a registry id, so it is
+	 * never gated and must still resolve regardless of #8789's progress.
 	 */
 	public function testShouldResolveThePreviouslyDriftingAndDependencyIds() {
 		$container = apply_filters( 'rocket_container', null );
 
-		foreach ( [ 'yoast_seo', 'thirstyaffiliates', 'cloudflare_plugin_facade' ] as $id ) {
+		foreach ( [ 'cloudflare_plugin_facade' ] as $id ) {
 			$this->assertTrue( $container->has( $id ), "Expected container to provide '{$id}'." );
 			$this->assertIsObject( $container->get( $id ) );
 		}
@@ -93,6 +92,23 @@ class Test_PluginCompatSubscribersBehaviorEquivalence extends TestCase {
 		$container = apply_filters( 'rocket_container', null );
 
 		$this->assertFalse( $container->has( 'convertplug' ), 'Expected container to NOT provide "convertplug" when CP_VERSION is undefined.' );
+	}
+
+	/**
+	 * Correctness proof (was a drift-proof pre-#8789): yoast_seo and
+	 * thirstyaffiliates are gated by issue #8789 slice 4, and neither target
+	 * plugin (WPSEO_VERSION / thirstyaffiliates/thirstyaffiliates.php) is
+	 * installed in this test environment, so both must now correctly resolve
+	 * to absent instead of being force-registered regardless of activation
+	 * state — flipping their historical $provides-drift proof into a
+	 * gated-correctness proof.
+	 */
+	public function testShouldNotResolveYoastOrThirstyAffiliatesWhenAbsent() {
+		$container = apply_filters( 'rocket_container', null );
+
+		foreach ( [ 'yoast_seo', 'thirstyaffiliates' ] as $id ) {
+			$this->assertFalse( $container->has( $id ), "Expected container to NOT provide '{$id}' when its target plugin is absent." );
+		}
 	}
 
 	/**
@@ -115,7 +131,7 @@ class Test_PluginCompatSubscribersBehaviorEquivalence extends TestCase {
 	public function testShouldMatchThePluginSubscriberCountBaseline() {
 		$active_ids = PluginResolver::get_active_plugins( true );
 
-		// 25 active resolver ids (43 - 18 slice-1/2/3-gated) + ezoic + mod_pagespeed = 27.
+		// 18 active resolver ids (43 - 25 slice-1/2/3/4-gated) + ezoic + mod_pagespeed = 20.
 		$this->assertSame( self::EXPECTED_PLUGIN_SUBSCRIBERS, count( $active_ids ) + 2 );
 	}
 }

--- a/tests/Unit/inc/ThirdParty/Plugins/Jetpack/isActivated.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/Jetpack/isActivated.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\Jetpack;
+
+use WP_Rocket\Tests\Unit\TestCase;
+use WP_Rocket\ThirdParty\Plugins\Jetpack;
+
+/**
+ * Test class covering \WP_Rocket\ThirdParty\Plugins\Jetpack::is_activated
+ *
+ * A namespaced class_exists() override for WP_Rocket\ThirdParty\Plugins was
+ * evaluated and rejected here, same as PDFEmbedder/isActivated.php and
+ * I18n/Weglot/isActivated.php: Jetpack.php itself lives in that namespace and
+ * calls class_exists( 'Jetpack' ) unqualified inside its own, untouched
+ * get_subscribed_events(), so declaring an override there breaks PHPStan's
+ * built-in class-exists type-narrowing extension for that call. eval() +
+ * @runInSeparateProcess sidesteps it by genuinely defining the Jetpack class
+ * in an isolated process.
+ *
+ * @group Jetpack
+ * @group ThirdParty
+ */
+class Test_IsActivated extends TestCase {
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function testShouldReturnFalseWhenJetpackClassMissing() {
+		$this->assertFalse( Jetpack::is_activated() );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function testShouldReturnTrueWhenJetpackClassPresent() {
+		eval( 'class Jetpack {}' );
+
+		$this->assertTrue( Jetpack::is_activated() );
+	}
+}

--- a/tests/Unit/inc/ThirdParty/Plugins/Optimization/Autoptimize/isActivated.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/Optimization/Autoptimize/isActivated.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\Optimization\Autoptimize;
+
+use WP_Rocket\Tests\Unit\TestCase;
+use WP_Rocket\ThirdParty\Plugins\Optimization\Autoptimize;
+
+/**
+ * Test class covering \WP_Rocket\ThirdParty\Plugins\Optimization\Autoptimize::is_activated
+ *
+ * Note: is_activated() extracts only the presence sub-expression from the
+ * untouched private can_notify() (which also checks get_current_screen() and
+ * current_user_can()) — that business-logic branch stays untested here since
+ * it isn't reachable from is_activated().
+ *
+ * @group Autoptimize
+ * @group ThirdParty
+ */
+class Test_IsActivated extends TestCase {
+	/**
+	 * Tests Autoptimize::is_activated() against the presence/absence of AUTOPTIMIZE_PLUGIN_VERSION.
+	 *
+	 * @dataProvider configTestData
+	 *
+	 * @param array $config   Test configuration.
+	 * @param bool  $expected Expected return value.
+	 */
+	public function testShouldReturnExpected( $config, $expected ) {
+		if ( null !== $config['autoptimize_plugin_version'] ) {
+			$this->constants['AUTOPTIMIZE_PLUGIN_VERSION'] = $config['autoptimize_plugin_version'];
+		}
+
+		$this->assertSame( $expected, Autoptimize::is_activated() );
+	}
+}

--- a/tests/Unit/inc/ThirdParty/Plugins/PWA/isActivated.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/PWA/isActivated.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\PWA;
+
+use WP_Rocket\Tests\Unit\TestCase;
+use WP_Rocket\ThirdParty\Plugins\PWA;
+
+/**
+ * Test class covering \WP_Rocket\ThirdParty\Plugins\PWA::is_activated
+ *
+ * Reuses the WP_Rocket\ThirdParty\Plugins-namespaced function_exists()
+ * override already declared at the bottom of excludeServiceWorker.php: PHP
+ * forbids declaring the same namespaced function twice within one process,
+ * and the full unit suite runs in a single process, so this file drives the
+ * existing override through Test_ExcludeServiceWorker's static toggle
+ * instead of redeclaring it.
+ *
+ * @group PWA
+ * @group ThirdParty
+ */
+class Test_IsActivated extends TestCase {
+	protected function tearDown(): void {
+		Test_ExcludeServiceWorker::$function_exists = false;
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 *
+	 * @param array $config   Test configuration.
+	 * @param bool  $expected Expected return value.
+	 */
+	public function testShouldReturnExpected( $config, $expected ) {
+		Test_ExcludeServiceWorker::$function_exists = $config['function_exists'];
+
+		$this->assertSame( $expected, PWA::is_activated() );
+	}
+}

--- a/tests/Unit/inc/ThirdParty/Plugins/PluginResolver/getActivePlugins.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/PluginResolver/getActivePlugins.php
@@ -2,6 +2,7 @@
 
 namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\PluginResolver;
 
+use Brain\Monkey\Functions;
 use WP_Rocket\Tests\Fixtures\classes\PluginResolverActivePlugin;
 use WP_Rocket\Tests\Fixtures\classes\PluginResolverInactivePlugin;
 use WP_Rocket\Tests\Fixtures\classes\PluginResolverGatedIds;
@@ -17,18 +18,22 @@ use WP_Rocket\ThirdParty\Plugins\SubscriberFactory;
  */
 class Test_GetActivePlugins extends TestCase {
 	/**
-	 * PluginResolverGatedIds::IDS minus 'translatepress' for this Unit suite only.
+	 * PluginResolverGatedIds::IDS minus 'translatepress' and 'the_seo_framework' for
+	 * this Unit suite only.
 	 *
 	 * tests/Unit/bootstrap.php unconditionally preloads the TRP_Translate_Press
-	 * fixture class for every Unit test (needed by the pre-existing TranslatePress
-	 * callback tests, e.g. detectHomepage.php), unlike the Integration suite, which
-	 * only loads it under `--group TranslatePress`. So in this suite specifically,
-	 * TranslatePress::is_activated() always reports true regardless of the
+	 * fixture class and the TheSEOFramework fixtures.php (a real global
+	 * the_seo_framework() function returning a Sitemap stub with a truthy
+	 * $loaded) for every Unit test (needed by the pre-existing TranslatePress
+	 * and addTsfSitemapToPreload.php callback tests), unlike the Integration
+	 * suite, which only loads TRP_Translate_Press under `--group TranslatePress`.
+	 * So in this suite specifically, TranslatePress::is_activated() and
+	 * TheSEOFramework::is_activated() always report true regardless of the
 	 * "target plugin absent" assumption the rest of the gated-ids list relies on.
 	 *
 	 * @var array<string>
 	 */
-	private const UNIT_ENV_ALWAYS_ACTIVE_OVERRIDES = [ 'translatepress' ];
+	private const UNIT_ENV_ALWAYS_ACTIVE_OVERRIDES = [ 'translatepress', 'the_seo_framework' ];
 
 	/**
 	 * Resets memoization before each test.
@@ -39,6 +44,11 @@ class Test_GetActivePlugins extends TestCase {
 		parent::setUp();
 
 		$this->reset_memoization();
+
+		// ThirstyAffiliates::is_activated() calls is_plugin_active() directly; stub it
+		// absent by default to match every other gated id's "target plugin not
+		// installed" assumption in this test environment.
+		Functions\when( 'is_plugin_active' )->justReturn( false );
 	}
 
 	/**

--- a/tests/Unit/inc/ThirdParty/Plugins/SEO/SEOPress/isActivated.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/SEO/SEOPress/isActivated.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\SEO\SEOPress;
+
+use WP_Rocket\Tests\Unit\TestCase;
+use WP_Rocket\ThirdParty\Plugins\SEO\SEOPress;
+
+/**
+ * Test class covering \WP_Rocket\ThirdParty\Plugins\SEO\SEOPress::is_activated
+ *
+ * Uses the same namespaced function_exists() override pattern as
+ * PWA/excludeServiceWorker.php: the class_exists() narrowing-extension
+ * conflict documented for PDFEmbedder/Weglot/Jetpack is specific to
+ * class_exists(), not function_exists(), so `composer run-stan` stays clean
+ * with this override declared for WP_Rocket\ThirdParty\Plugins\SEO. Note:
+ * is_activated() extracts only the presence sentinel — the untouched
+ * get_subscribed_events() compound guard (xml-sitemap toggle +
+ * SitemapOption->isEnabled()) stays untested here since it isn't reachable
+ * from is_activated().
+ *
+ * @group SEOPress
+ * @group ThirdParty
+ */
+class Test_IsActivated extends TestCase {
+	public static $function_exists = false;
+
+	protected function tearDown(): void {
+		self::$function_exists = false;
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 *
+	 * @param array $config   Test configuration.
+	 * @param bool  $expected Expected return value.
+	 */
+	public function testShouldReturnExpected( $config, $expected ) {
+		self::$function_exists = $config['function_exists'];
+
+		$this->assertSame( $expected, SEOPress::is_activated() );
+	}
+}
+
+namespace WP_Rocket\ThirdParty\Plugins\SEO;
+
+function function_exists( $function ) {
+	if ( $function === 'seopress_get_toggle_option' ) {
+		return \WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\SEO\SEOPress\Test_IsActivated::$function_exists;
+	}
+
+	return \function_exists( $function );
+}

--- a/tests/Unit/inc/ThirdParty/Plugins/SEO/TheSEOFramework/isActivated.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/SEO/TheSEOFramework/isActivated.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\SEO\TheSEOFramework;
+
+use WP_Rocket\Tests\Unit\TestCase;
+use WP_Rocket\ThirdParty\Plugins\SEO\TheSEOFramework;
+
+/**
+ * Test class covering \WP_Rocket\ThirdParty\Plugins\SEO\TheSEOFramework::is_activated
+ *
+ * tests/Unit/bootstrap.php unconditionally preloads
+ * tests/Fixtures/inc/ThirdParty/Plugins/SEO/TheSEOFramework/fixtures.php for
+ * every Unit test (needed by the pre-existing addTsfSitemapToPreload.php
+ * callback test), which defines a real global the_seo_framework() function
+ * returning a Sitemap stub whose $loaded property defaults to the truthy
+ * string 'loaded'. That preload runs again in an @runInSeparateProcess fork
+ * too (the bootstrap re-executes for every isolated process), so eval()-
+ * redefining the_seo_framework() there would fatally collide with the
+ * already-declared one. Exactly like the pre-existing
+ * TranslatePress::is_activated() precedent (I18n/TranslatePress/isActivated.php),
+ * the function-missing and empty-$loaded branches are therefore not testable
+ * in-process without touching that shared bootstrap fixture, which is out of
+ * scope for this class — only the true branch is covered. Note: is_activated()
+ * excludes can_run_sitemap() entirely — that stays in the untouched
+ * get_subscribed_events() and isn't reachable here.
+ *
+ * @group TheSEOFramework
+ * @group ThirdParty
+ */
+class Test_IsActivated extends TestCase {
+	public function testShouldReturnTrueWhenTheSeoFrameworkLoaded() {
+		$this->assertTrue( TheSEOFramework::is_activated() );
+	}
+}

--- a/tests/Unit/inc/ThirdParty/Plugins/SEO/Yoast/isActivated.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/SEO/Yoast/isActivated.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\SEO\Yoast;
+
+use WP_Rocket\Tests\Unit\TestCase;
+use WP_Rocket\ThirdParty\Plugins\SEO\Yoast;
+
+/**
+ * Test class covering \WP_Rocket\ThirdParty\Plugins\SEO\Yoast::is_activated
+ *
+ * @group Yoast
+ * @group ThirdParty
+ */
+class Test_IsActivated extends TestCase {
+	/**
+	 * Tests Yoast::is_activated() against the presence/absence of WPSEO_VERSION.
+	 *
+	 * Note: is_activated() extracts only the presence sub-expression from the
+	 * untouched private is_sitemap_enabled() (which also checks the
+	 * wpseo_xml/enablexmlsitemap option) — that business-logic branch stays
+	 * untested here since it isn't reachable from is_activated().
+	 *
+	 * @dataProvider configTestData
+	 *
+	 * @param array $config   Test configuration.
+	 * @param bool  $expected Expected return value.
+	 */
+	public function testShouldReturnExpected( $config, $expected ) {
+		if ( null !== $config['wpseo_version'] ) {
+			$this->constants['WPSEO_VERSION'] = $config['wpseo_version'];
+		}
+
+		$this->assertSame( $expected, Yoast::is_activated() );
+	}
+}

--- a/tests/Unit/inc/ThirdParty/Plugins/ThirstyAffiliates/isActivated.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/ThirstyAffiliates/isActivated.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\ThirstyAffiliates;
+
+use Brain\Monkey\Functions;
+use WP_Rocket\Tests\Unit\TestCase;
+use WP_Rocket\ThirdParty\Plugins\ThirstyAffiliates;
+
+/**
+ * Test class covering \WP_Rocket\ThirdParty\Plugins\ThirstyAffiliates::is_activated
+ *
+ * Under Brain\Monkey, function_exists( 'is_plugin_active' ) resolves true, so
+ * the require_once ABSPATH . 'wp-admin/includes/plugin.php' boot-timing guard
+ * is skipped in-test; no process isolation is needed.
+ *
+ * @group ThirdParty
+ */
+class Test_IsActivated extends TestCase {
+	public function testShouldReturnFalseWhenPluginDeactivated() {
+		Functions\when( 'is_plugin_active' )->justReturn( false );
+
+		$this->assertFalse( ThirstyAffiliates::is_activated() );
+	}
+
+	public function testShouldReturnTrueWhenPluginActive() {
+		Functions\when( 'is_plugin_active' )->justReturn( true );
+
+		$this->assertTrue( ThirstyAffiliates::is_activated() );
+	}
+}


### PR DESCRIPTION
> 🤖 AI-generated — created by an automated pipeline. Review before acting on this.

Part of #8789

# Description

Slice 4 of 5 of #8789: gates the final 7 DEVIATION plugin-compat subscribers (PWA, Yoast, ThirstyAffiliates, Autoptimize, Jetpack, SEOPress, TheSEOFramework) behind PluginCompatibilityInterface. All 25 classes are now gated. This slice required surgical extraction: `get_subscribed_events()` and all callbacks remain byte-identical; only the pure plugin-presence sub-expression is extracted into a NEW `is_activated()` method.

## Type of change

- [x] Sub-task of #8789

## Detailed scenario

### What was tested

Full unit suite 2833 green (single process); PluginResolver integration 6/6; Autoptimize `--group AdminOnly` 8/8; broad `composer test-integration` 981 green; dedicated Jetpack/SEOPress/TheSEOFramework groups all green; PHPStan 0; PHPCS 0 on all 7 changed `inc/` files. All via Docker/wp-env.

### How to test

1. Run full PHPUnit suite: `composer test-unit` (2833 tests)
2. Run PluginResolver integration: `composer test-integration -- --group PluginResolver`
3. Run Jetpack, SEOPress, TheSEOFramework groups: `composer test-integration -- --group Jetpack`, `--group SEOPress`, `--group TheSEOFramework`
4. Run Autoptimize AdminOnly: `composer test-integration -- --group Autoptimize --group AdminOnly`
5. Run static analysis: `composer phpstan` and `composer phpcs-inc`
6. All tests pass without errors, warnings, or notices.

### Affected Features & Quality Assurance Scope

- Third-party plugin compatibility subscribers for PWA, Yoast SEO, ThirstyAffiliates, Autoptimize, Jetpack, SEOPress, The SEO Framework
- PluginResolver and plugin activation detection
- Autoptimize admin notice integration tests
- PluginCompatibilityInterface gating mechanism

## Technical description

### Documentation

The 7 DEVIATION classes (distinct from earlier standard slices) follow a pattern where the original plugin-presence check is entangled with feature/option-toggle logic. Surgical extraction creates a new `is_activated()` method containing ONLY the pure presence sub-expression, leaving all feature/toggle checks in `get_subscribed_events()` untouched. This prevents PluginResolver from incorrectly reporting a plugin as inactive when only a feature is disabled.

Examples:
- **SEOPress**: `is_activated()` runs `function_exists('seopress_get_toggle_option')`; the `'xml-sitemap'` toggle check stays in `get_subscribed_events()`.
- **TheSEOFramework**: `is_activated()` runs `function_exists('the_seo_framework') && $tsf->loaded`; `can_run_sitemap()` and `SitemapOption->isEnabled()` checks remain in `get_subscribed_events()`.
- **ThirstyAffiliates**: `is_activated()` guards `is_plugin_active()` with `function_exists('is_plugin_active') || require_once ABSPATH.'wp-admin/includes/plugin.php'` (matching EWWW precedent) since it runs unconditionally on every request before `wp-admin/includes/plugin.php` is guaranteed loaded.
- **Jetpack**: uses `eval()` and `@runInSeparateProcess` in unit test to resolve `class_exists()` narrowing conflict with PHPStan (existing pattern).

Gating Autoptimize exposed a pre-existing test-isolation gap: `unregisterAllCallbacksExcept()` silently no-ops when the callback isn't live-registered in the container. Fixed by constructing a fresh subscriber instance in 2 Autoptimize integration tests and hooking it directly; original assertions remain unchanged and reproduce on slice-3 baseline.

Baseline updates:
- Phase 0 gated-ids fixture: 18 → 25 (all 25 classes now gated)
- `EXPECTED_PLUGIN_SUBSCRIBERS`: 27 → 20 (yoast_seo and thirstyaffiliates now gated; cloudflare_plugin_facade remains the drift example)
- Drift-proof checks updated to match

### Risks

1. **SEOPress & TheSEOFramework sitemap feature-toggles**: `is_activated()` is presence-only; feature/option checks remain in `get_subscribed_events()`. PluginResolver will now correctly report these plugins active even if a sitemap feature is toggled off. This is the intended fix (required by spec challenger review) and prevents false negatives.

2. **ThirstyAffiliates admin-screen boot cost**: `is_activated()` runs `is_plugin_active()` unconditionally on every request, including frontend. Mitigated by checking `function_exists('is_plugin_active')` first and loading `wp-admin/includes/plugin.php` only if needed (matches EWWW/mobile-subscriber precedent).

3. **Autoptimize integration test fix**: Gating Autoptimize required constructing subscriber instances directly instead of relying on `unregisterAllCallbacksExcept()` to isolate container-registered callbacks. This is a test implementation detail with no runtime impact; original test assertions and setup remain unchanged.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)