### PR TITLE
Fixes #8832: Keep every dynamic cookie declaration in the cache file name

### DIFF
--- a/inc/admin/upgrader.php
+++ b/inc/admin/upgrader.php
@@ -318,5 +318,12 @@ function rocket_new_upgrade( $wp_rocket_version, $actual_version ) {
 	if ( version_compare( $actual_version, '3.23', '<' ) ) {
 		flush_rewrite_rules();
 	}
+
+	// The front end reads the list of dynamic cookies from a generated file, and that list used to
+	// come back short. Pages cached from the short one carry names this release gives other requests.
+	if ( version_compare( $actual_version, '3.24', '<' ) ) {
+		rocket_generate_config_file();
+		rocket_clean_domain();
+	}
 }
 add_action( 'wp_rocket_upgrade', 'rocket_new_upgrade', 10, 2 );

--- a/inc/classes/Buffer/class-cache.php
+++ b/inc/classes/Buffer/class-cache.php
@@ -714,10 +714,23 @@ class Cache extends Abstract_Buffer {
 
 		foreach ( $cache_dynamic_cookies as $key => $cookie_name ) {
 			if ( is_array( $cookie_name ) ) {
-				if ( isset( $_COOKIE[ $key ] ) ) {
+				// The cookies this call was given, as everywhere else in this method: the name is built
+				// from one source, not from this branch reading the request somewhere else.
+				if ( isset( $cookies[ $key ] ) ) {
+					// A cookie declared by its parts can arrive as a plain value instead. Read as no
+					// parts at all, since reading a part of one ends the request on PHP 8.
+					$sent = is_array( $cookies[ $key ] ) ? $cookies[ $key ] : [];
+
 					foreach ( $cookie_name as $cookie_key ) {
-						if ( '' !== $cookies[ $key ][ $cookie_key ] ) {
-							$cache_key = $cookies[ $key ][ $cookie_key ];
+						// A part that did not arrive holds its place in the name, as it always has.
+						if ( ! isset( $sent[ $cookie_key ] ) ) {
+							$filename .= '-';
+
+							continue;
+						}
+
+						if ( '' !== $sent[ $cookie_key ] ) {
+							$cache_key = $sent[ $cookie_key ];
 							$cache_key = preg_replace( '/[^a-z0-9_\-]/i', '-', $cache_key );
 							$filename .= '-' . $cache_key;
 						}

--- a/inc/functions/options.php
+++ b/inc/functions/options.php
@@ -334,6 +334,9 @@ function get_rocket_cache_mandatory_cookies() { // phpcs:ignore WordPress.Naming
 /**
  * Get list of dynamic cookies.
  *
+ * An entry is either a cookie name, or a cookie name mapped to the parts of that cookie the cache
+ * varies by ( 'parent' => [ 'child' ] ). Both shapes reach the cache file name.
+ *
  * @since 2.7
  *
  * @return array List of dynamic cookies.
@@ -350,7 +353,19 @@ function get_rocket_cache_dynamic_cookies() { // phpcs:ignore WordPress.NamingCo
 	 */
 	$cookies = (array) apply_filters( 'rocket_cache_dynamic_cookies', $cookies );
 	$cookies = array_filter( $cookies );
-	$cookies = array_unique( $cookies );
+	$tokens  = [];
+
+	// A name is compared by its value, the parts of a cookie by the key they sit under. Anything else
+	// names no cookie: it is given no token, and the line below drops it.
+	foreach ( $cookies as $key => $cookie ) {
+		if ( is_scalar( $cookie ) ) {
+			$tokens[ $key ] = 'name:' . $cookie;
+		} elseif ( is_array( $cookie ) ) {
+			$tokens[ $key ] = 'key:' . $key;
+		}
+	}
+
+	$cookies = array_intersect_key( $cookies, array_unique( $tokens ) );
 
 	return $cookies;
 }

--- a/tests/Fixtures/inc/functions/getRocketCacheDynamicCookies.php
+++ b/tests/Fixtures/inc/functions/getRocketCacheDynamicCookies.php
@@ -1,0 +1,111 @@
+<?php
+$rocket_fixture_object = new stdClass();
+
+return [
+	// A site that varies the cache by parts of more than one cookie: the file name is built from
+	// every definition, so every definition has to come back.
+	'shouldKeepEveryNestedDefinition'            => [
+		'config'   => [
+			'filter' => [
+				'session_id',
+				'geo'   => [ 'country' ],
+				'prefs' => [ 'currency' ],
+			],
+		],
+		'expected' => [
+			'session_id',
+			'geo'   => [ 'country' ],
+			'prefs' => [ 'currency' ],
+		],
+	],
+	// Two cookies read for the same part of themselves are still two cookies.
+	'shouldKeepCookiesThatNameTheSamePart'       => [
+		'config'   => [
+			'filter' => [
+				'pll_language'             => [ 'lang' ],
+				'wp-wpml_current_language' => [ 'lang' ],
+			],
+		],
+		'expected' => [
+			'pll_language'             => [ 'lang' ],
+			'wp-wpml_current_language' => [ 'lang' ],
+		],
+	],
+	// The file name is built in this order, so the order has to survive.
+	'shouldKeepTheOrderTheListCameIn'            => [
+		'config'   => [
+			'filter' => [
+				'session_id',
+				'geo' => [ 'country' ],
+				'currency',
+			],
+		],
+		'expected' => [
+			0     => 'session_id',
+			'geo' => [ 'country' ],
+			1     => 'currency',
+		],
+	],
+	'shouldDropARepeatedName'                    => [
+		'config'   => [
+			'filter' => [ 'session_id', 'session_id', 'currency' ],
+		],
+		'expected' => [
+			0 => 'session_id',
+			2 => 'currency',
+		],
+	],
+	'shouldDropEmptyEntries'                     => [
+		'config'   => [
+			'filter' => [ 'session_id', '', null, 0 ],
+		],
+		'expected' => [ 0 => 'session_id' ],
+	],
+	// The same cookie given both ways is two entries, as it has always been: one says the whole cookie
+	// varies the cache, the other says which parts of it do.
+	'shouldKeepANameAndADeclarationOfIt'         => [
+		'config'   => [
+			'filter' => [
+				'gdpr',
+				'gdpr' => [ 'allowed_cookies' ],
+			],
+		],
+		'expected' => [
+			0      => 'gdpr',
+			'gdpr' => [ 'allowed_cookies' ],
+		],
+	],
+	// A cookie named by digits is a cookie: PHP holds that name as an integer key, on the declaration
+	// and on the request alike, so both of these are looked up and both are kept.
+	'shouldKeepPartsOfCookiesNamedByDigits'      => [
+		'config'   => [
+			'filter' => [
+				'7' => [ 'country' ],
+				'9' => [ 'currency' ],
+			],
+		],
+		'expected' => [
+			7 => [ 'country' ],
+			9 => [ 'currency' ],
+		],
+	],
+	// Dropped because it names no cookie. That it also keeps a value var_export() cannot write back
+	// out of the config file is what the drop is worth, not what decides it.
+	'shouldDropAnEntryThatIsNeitherNameNorParts' => [
+		'config'   => [
+			'filter' => [
+				'session_id',
+				'geo' => $rocket_fixture_object,
+			],
+		],
+		'expected' => [ 0 => 'session_id' ],
+	],
+	// Two names PHP reads as the same number, kept apart by comparing them as strings, which is what
+	// array_unique() does on its own and what a sort flag would undo.
+	'shouldKeepNamesThatOnlyLookNumeric'         => [
+		'config'   => [
+			'filter' => [ '1e2', '100' ],
+		],
+		'expected' => [ '1e2', '100' ],
+	],
+];

--- a/tests/Unit/inc/admin/rocketNewUpgrade.php
+++ b/tests/Unit/inc/admin/rocketNewUpgrade.php
@@ -24,9 +24,9 @@ class Test_RocketNewUpgrade extends TestCase {
 		Functions\expect( 'rocket_clean_cache_busting' )
 			->once();
 		Functions\expect( 'rocket_clean_domain' )
-			->once();
+			->twice();
 		Functions\expect( 'rocket_generate_config_file' )
-			->once();
+			->twice();
 		Functions\expect( 'rocket_clean_minify' )
 			->with( 'css' )
 			->once();
@@ -85,5 +85,28 @@ class Test_RocketNewUpgrade extends TestCase {
 			->never();
 
 		rocket_new_upgrade( '3.24', '3.23' );
+	}
+
+	public function testShouldRewriteTheConfigFileAndCleanTheDomainWhenUpdatingFromBeforeThisRelease() {
+		// Every gate below this release is passed over, and this is the only call outside them.
+		Functions\when( 'rocket_is_ssl_website' )->justReturn( false );
+
+		Functions\expect( 'rocket_generate_config_file' )
+			->once();
+		Functions\expect( 'rocket_clean_domain' )
+			->once();
+
+		rocket_new_upgrade( '3.24', '3.23.3.3' );
+	}
+
+	public function testShouldNotTouchAnythingWhenAlreadyUpdatedPastThisRelease() {
+		Functions\when( 'rocket_is_ssl_website' )->justReturn( false );
+
+		Functions\expect( 'rocket_generate_config_file' )
+			->never();
+		Functions\expect( 'rocket_clean_domain' )
+			->never();
+
+		rocket_new_upgrade( '3.24.1', '3.24' );
 	}
 }

--- a/tests/Unit/inc/classes/Buffer/Cache/getCachePath.php
+++ b/tests/Unit/inc/classes/Buffer/Cache/getCachePath.php
@@ -1,0 +1,289 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\inc\classes\Buffer\Cache;
+
+use Brain\Monkey\Functions;
+use Mockery;
+use WP_Rocket\Buffer\Cache;
+use WP_Rocket\Buffer\Config;
+use WP_Rocket\Buffer\Tests;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * Test class covering \WP_Rocket\Buffer\Cache::get_cache_path
+ *
+ * @group  Buffer
+ */
+class Test_GetCachePath extends TestCase {
+	/**
+	 * The cookies of the request as they were before the test.
+	 *
+	 * @var array
+	 */
+	private $was_cookies = [];
+
+	/**
+	 * Keeps the cookies of the request, which the tests here write over.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->was_cookies = $_COOKIE;
+	}
+
+	/**
+	 * Puts them back.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		$_COOKIE = $this->was_cookies;
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Builds the path for a request that carries the given cookies.
+	 *
+	 * @param array      $config      What the buffer config holds.
+	 * @param array      $cookies     Cookies this call is given.
+	 * @param array|null $superglobal Cookies in the environment, where they differ from those.
+	 *
+	 * @return string
+	 */
+	private function path_for( array $config, array $cookies, ?array $superglobal = null ) {
+		Functions\when( 'is_ssl' )->justReturn( false );
+
+		// The request is read once to answer it and once to store it, and the second read happens after
+		// everything on the site has had a chance to write to the environment.
+		$_COOKIE = null === $superglobal ? $cookies : $superglobal;
+
+		$config_mock = Mockery::mock( Config::class );
+		$config_mock->shouldReceive( 'get_config' )->andReturnUsing(
+			function ( $name ) use ( $config ) {
+				return $config[ $name ] ?? false;
+			}
+		);
+
+		$config_mock->shouldReceive( 'get_host' )->andReturn( 'example.org' );
+
+		$tests = Mockery::mock( Tests::class );
+		$tests->shouldReceive( 'get_cookies' )->andReturn( $cookies );
+		$tests->shouldReceive( 'has_rejected_cookie' )->andReturn( false );
+		$tests->shouldReceive( 'get_clean_request_uri' )->andReturn( '/hello/' );
+
+		$cache = new Cache( $tests, $config_mock, [ 'cache_dir_path' => '/tmp/cache' ] );
+
+		return $cache->get_cache_path();
+	}
+
+	/**
+	 * A cookie that arrived without the parts it was declared by holds their place in the name.
+	 *
+	 * @return void
+	 */
+	public function testShouldKeepThePlaceOfAPartThatDidNotArrive() {
+		$path = $this->path_for(
+			[ 'cache_dynamic_cookies' => [ 'prefs' => [ 'currency' ] ] ],
+			[ 'prefs' => [ 'lang' => 'fr' ] ]
+		);
+
+		$this->assertStringEndsWith( '/index-.html', $path );
+	}
+
+	/**
+	 * The same when it arrived as a plain value, which is not a part of anything.
+	 *
+	 * @return void
+	 */
+	public function testShouldKeepThePlaceOfPartsOfACookieSentAsAPlainValue() {
+		$path = $this->path_for(
+			[ 'cache_dynamic_cookies' => [ 'prefs' => [ 'currency' ] ] ],
+			[ 'prefs' => 'eur' ]
+		);
+
+		$this->assertStringEndsWith( '/index-.html', $path );
+	}
+
+	/**
+	 * A page named by the part itself is not the page named by its absence.
+	 *
+	 * @return void
+	 */
+	public function testShouldKeepAnArrivedPartApartFromAMissingOne() {
+		$config = [ 'cache_dynamic_cookies' => [ 'prefs' => [ 'currency' ] ] ];
+
+		$this->assertNotSame(
+			$this->path_for( $config, [ 'prefs' => [ 'currency' => 'eur' ] ] ),
+			$this->path_for( $config, [ 'prefs' => 'eur' ] )
+		);
+	}
+
+	/**
+	 * Every declared part of a cookie that arrived without them holds its place, one for one.
+	 *
+	 * @return void
+	 */
+	public function testShouldKeepThePlaceOfEveryPartOfACookieSentAsAPlainValue() {
+		$path = $this->path_for(
+			[ 'cache_dynamic_cookies' => [ 'prefs' => [ 'currency', 'lang' ] ] ],
+			[ 'prefs' => 'eur' ]
+		);
+
+		$this->assertStringEndsWith( '/index--.html', $path );
+	}
+
+	/**
+	 * A part named by digits holds its place too, rather than taking a letter of the plain value.
+	 *
+	 * @return void
+	 */
+	public function testShouldKeepThePlaceOfAPartNamedByDigits() {
+		$path = $this->path_for(
+			[ 'cache_dynamic_cookies' => [ 'prefs' => [ '0' ] ] ],
+			[ 'prefs' => 'eur' ]
+		);
+
+		$this->assertStringEndsWith( '/index-.html', $path );
+	}
+
+	/**
+	 * A part that arrived empty leaves no mark, as it always has, so its place is not held.
+	 *
+	 * This is what the plugin does today, not what it should do: two states of the same cookie share
+	 * a name. Changing it renames files on every site that has one, so it is left as it is.
+	 *
+	 * @return void
+	 */
+	public function testShouldLeaveNoMarkForAPartThatArrivedEmpty() {
+		$config = [ 'cache_dynamic_cookies' => [ 'prefs' => [ 'a', 'b' ] ] ];
+
+		$this->assertSame(
+			$this->path_for(
+				$config,
+				[
+					'prefs' => [
+						'a' => '',
+						'b' => 'x',
+					],
+				]
+				),
+			$this->path_for(
+				$config,
+				[
+					'prefs' => [
+						'a' => 'x',
+						'b' => '',
+					],
+				]
+				)
+		);
+	}
+
+	/**
+	 * A declared cookie that did not arrive at all leaves no mark, the way a plain name never has.
+	 *
+	 * Also today's behaviour rather than a requirement: a name says which values arrived, not which
+	 * cookies were declared, so two requests carrying different cookies can meet here.
+	 *
+	 * @return void
+	 */
+	public function testShouldLeaveNoMarkForACookieThatDidNotArrive() {
+		$path = $this->path_for(
+			[
+				'cache_dynamic_cookies' => [
+					'geo'   => [ 'country' ],
+					'prefs' => [ 'currency' ],
+				],
+			],
+			[ 'geo' => [ 'country' => 'fr' ] ]
+		);
+
+		$this->assertStringEndsWith( '/index-fr.html', $path );
+	}
+
+	/**
+	 * A cookie written into the environment after this call was given its own does not name the file.
+	 *
+	 * @return void
+	 */
+	public function testShouldIgnoreACookieAddedToTheEnvironmentLater() {
+		$config = [ 'cache_dynamic_cookies' => [ 'prefs' => [ 'currency' ] ] ];
+
+		$this->assertSame(
+			$this->path_for( $config, [] ),
+			$this->path_for( $config, [], [ 'prefs' => [ 'currency' => 'eur' ] ] )
+		);
+	}
+
+	/**
+	 * One taken out of the environment afterwards still does.
+	 *
+	 * @return void
+	 */
+	public function testShouldStillNameTheFileFromACookieTakenOutOfTheEnvironment() {
+		$config = [ 'cache_dynamic_cookies' => [ 'prefs' => [ 'currency' ] ] ];
+
+		$this->assertSame(
+			$this->path_for( $config, [ 'prefs' => [ 'currency' => 'eur' ] ] ),
+			$this->path_for( $config, [ 'prefs' => [ 'currency' => 'eur' ] ], [] )
+		);
+	}
+
+	/**
+	 * The same cookie declared both ways names the file twice: by its value, then by its missing part.
+	 *
+	 * @return void
+	 */
+	public function testShouldNameTheFileFromACookieDeclaredBothWays() {
+		$path = $this->path_for(
+			[
+				'cache_dynamic_cookies' => [
+					0      => 'gdpr',
+					'gdpr' => [ 'allowed_cookies' ],
+				],
+			],
+			[ 'gdpr' => 'yes' ]
+		);
+
+		$this->assertStringEndsWith( '/index-yes-.html', $path );
+	}
+
+	/**
+	 * The list this release stopped truncating: both cookies name the file.
+	 *
+	 * @return void
+	 */
+	public function testShouldNameTheFileFromEveryDeclaredCookie() {
+		$path = $this->path_for(
+			[
+				'cache_dynamic_cookies' => [
+					'geo'   => [ 'country' ],
+					'prefs' => [ 'currency' ],
+				],
+			],
+			[
+				'geo'   => [ 'country' => 'fr' ],
+				'prefs' => [ 'currency' => 'eur' ],
+			]
+		);
+
+		$this->assertStringEndsWith( '/index-fr-eur.html', $path );
+	}
+
+	/**
+	 * The same cookie sent as parts still names the file.
+	 *
+	 * @return void
+	 */
+	public function testShouldNameTheFileFromThePartsThatArrived() {
+		$path = $this->path_for(
+			[ 'cache_dynamic_cookies' => [ 'prefs' => [ 'currency' ] ] ],
+			[ 'prefs' => [ 'currency' => 'eur' ] ]
+		);
+
+		$this->assertStringEndsWith( '/index-eur.html', $path );
+	}
+}

--- a/tests/Unit/inc/functions/getRocketCacheDynamicCookies.php
+++ b/tests/Unit/inc/functions/getRocketCacheDynamicCookies.php
@@ -1,0 +1,32 @@
+<?php
+namespace WP_Rocket\Tests\Unit\inc\functions;
+
+use Brain\Monkey\Functions;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * Test class covering ::get_rocket_cache_dynamic_cookies
+ *
+ * @group Functions
+ * @group Options
+ */
+class Test_GetRocketCacheDynamicCookies extends TestCase {
+	/**
+	 * Checks the list the plugin builds the cache file name from.
+	 *
+	 * @dataProvider configTestData
+	 *
+	 * @param array $config   What the filter returns.
+	 * @param array $expected What the function returns for it.
+	 *
+	 * @return void
+	 */
+	public function testShouldGetRocketCacheDynamicCookies( $config, $expected ) {
+		Functions\expect( 'apply_filters' )
+			->once()
+			->with( 'rocket_cache_dynamic_cookies', [] )
+			->andReturn( $config['filter'] );
+
+		$this->assertSame( $expected, get_rocket_cache_dynamic_cookies() );
+	}
+}


### PR DESCRIPTION
# Description

Fixes #8832

`get_rocket_cache_dynamic_cookies()` finished with `array_unique( $cookies )`. A dynamic cookie may be declared as the parts of one cookie, `[ 'parent' => [ 'child' ] ]`, and `Buffer\Cache::maybe_dynamic_cookies_filename()` reads that shape and puts each part in the cache file name. `array_unique()` without a sort flag compares its items as strings, and every array reads as "Array", so only the first such declaration survived and each of the others was dropped with an `Array to string conversion` notice.

The dropped cookie stopped varying the file name, so visitors who differ only by that cookie were served each other's page.

The two kinds of entry are now told apart before they are deduplicated. A cookie name can be given twice and is deduplicated as before. A declaration of parts is keyed by the name of its own cookie, so two of them are never the same declaration and neither is dropped. An entry that is neither names no cookie and is dropped: the list is written to a file with `var_export()` and read back by including it, and a value that does not survive that trip ends every front-end request. Such an entry used to end the call itself, as soon as the list held anything to compare it with. Keys and order are unchanged.

The file the plugin actually reads this list from is generated, so an upgrade gate regenerates it, as the gates for 3.2 and 3.11.1 do, and purges the cache with it, as the 3.6 gate does: a site that declares a cookie by its parts has pages cached under a name this release no longer gives them, and a name it does give them may already hold another request's page. The gate does not ask which sites those are, because at that moment it cannot tell: the list comes from a filter, and a plugin that registers one is not always active, nor always loaded in the admin, when an upgrade runs.

The consumer of that list is corrected with it. It read a declared part of a cookie without looking first, which raises two notices where the part did not arrive and ends the request on PHP 8 where the cookie arrived without parts at all. It now asks whether the cookie came with parts at all, and then whether each part is there; where one is not, the name keeps its place with the dash it has always had. It also asks all of that of the cookies it was given rather than of the environment. The request is read twice, once to answer it from the cache and once to store it, and the second read happens at the end of the request: a cookie written into the environment in between made the two reads name the same page differently, and the page was stored where nothing would look for it. Every name a request produced before it produces now, with one exception. Where a cookie arrived without the parts declared for it, the old code took a character out of the value it did arrive with: the first one on PHP 7.4, and on PHP 8 where the part is named by a digit. That character is gone from the name. Every other request of that shape died, and it now produces the name of a cookie whose parts did not arrive.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

A new unit test covering the function, nine cases: every declaration of parts survives; two different cookies that name the same part of themselves both survive; the order the list came in is kept, because the file name is built in that order; a repeated name is removed and the surviving keys are unchanged; empty entries are dropped; two names that PHP reads as the same number stay two names; the same cookie given both as a name and as a declaration of its parts stays two entries, as it always has; a cookie whose name is written in digits keeps its declaration, since PHP holds that name as an integer key on the declaration and on the request alike; and an entry that is neither a name nor a declaration of parts is dropped.

The test was written before the change and fails on the current code: the notice is raised as an error, and where the entry is an object the comparison that reads it as a string ends the call. Putting the old line back makes it fail again, and so does the shorter form that appends the declarations after the names instead of leaving them where they were, which loses the order.

The upgrade gate has two tests: updating from 3.23.3.3 rewrites the config file and purges the cache, and updating from this release does neither. The test that was already there for an update from 3.4.4 now expects one more of each, since such a site passes this gate as well as the ones for 3.11.1 and 3.6.

`Buffer\Cache::get_cache_path()` had no test in either suite and has twelve here. A part that arrived names the file; a part that did not keeps its place; those two are not the same name; a cookie that arrived without the parts declared for it keeps the place of one, and of every one where more than one was declared; a part named by a digit keeps its place as well, where the old code took a character out of the value; a part that arrived empty leaves no mark, and neither does a cookie that did not arrive at all, both of which are what the plugin does today rather than what it should do, since two different requests can then meet in one name; two cookies declared by their parts both name the file; the same cookie declared once by name and once by its parts names it twice; a cookie appearing in the environment after this call was given its own does not name the file, and one taken out of the environment afterwards still does. Those last two write the environment directly, and every test here puts it back as it was. Putting the old method back fails eight of the twelve: four end in the TypeError, two in the read of a part that is not there, and two name the file differently. Putting back only the read of the environment fails exactly the last two.

The names themselves were compared before and after over every shape a request can take: a part that arrived, a part that arrived empty, a part missing from a cookie that is there, one of two parts missing, a cookie missing from the request, a cookie that arrived without parts, a part holding null, and a part holding an array. Every shape the old code survived is named identically, except the one above, where it read a character out of a value it was never given the parts of. The shapes it did not survive are the plain value and the empty string, which ended the request on PHP 8 and took the first character of the value on PHP 7.4.

Behaviour was measured on PHP 7.4, 8.3 and 8.5 before and after, with the same result on all three.

Full suites after the change: unit 2802 tests / 9066 assertions, integration 976 / 2311, no failures. PHPCS clean, PHPStan reports no errors.

### How to test

1. Declare two cookies whose cache variation is inside them:

```php
add_filter(
	'rocket_cache_dynamic_cookies',
	function ( $cookies ) {
		$cookies['geo']   = [ 'country' ];
		$cookies['prefs'] = [ 'currency' ];

		return $cookies;
	}
);
```

2. Save the settings so the config file is written.
3. `wp-content/wp-rocket-config/<domain>.php` now holds both `geo` and `prefs` in `$rocket_cache_dynamic_cookies`. Before this change it held `geo` only.
4. With `WP_DEBUG` on, the `Array to string conversion` notices are gone.
5. Visit the site twice with the same `geo[country]=fr` and a different `prefs[currency]` each time, and look at `wp-content/cache/wp-rocket/<host>/`:

```
before   index-https-fr.html         one file, so the second visitor is served the first one's page
after    index-https-fr-eur.html     one file each
         index-https-fr-usd.html
```

### Affected Features & Quality Assurance Scope

- **Dynamic cookies.** Two things change: a second and further declaration of parts are no longer lost, and an entry that names no cookie at all is dropped rather than kept. Plain cookie names, a single such declaration, duplicate removal, key order and empty handling are unchanged.
- **Cache file naming.** On a site that declares two or more, the names gain the part that used to be dropped, so files written under the old names are no longer hit. Those pages are rendered once and written again. No other site is affected.
- **Buffer config file.** `$rocket_cache_dynamic_cookies` is written from this function, and `Buffer\Cache` reads the file rather than calling the function, so the upgrade gate is what makes the fix reach a live site.
- **Upgrade routine.** One more version gate in `rocket_new_upgrade()`, which rewrites the config file and purges the cache. The version in it has to be the release this lands in, or the gate fires again on every later patch until that version is reached; it reads 3.24 here, and it is the one number in this PR that has to be checked against the release it goes out in.
- **Cache file naming from cookies.** `Buffer\Cache::get_cache_path()` looks before it reads a declared part, and reads the request from one place instead of two. The name a request is answered from cannot change: that read happens in the same breath as the cookies are taken. It has its first unit tests here.

## Technical description

### Documentation

`array_unique()` casts to string to compare unless it is told otherwise, which is what discarded the arrays. Each entry that names a cookie is now given the token it should be compared by, and `array_unique()` still decides what a duplicate is:

```php
foreach ( $cookies as $key => $cookie ) {
	if ( is_scalar( $cookie ) ) {
		$tokens[ $key ] = 'name:' . $cookie;
	} elseif ( is_array( $cookie ) ) {
		$tokens[ $key ] = 'key:' . $key;
	}
}

$cookies = array_intersect_key( $cookies, array_unique( $tokens ) );
```

A declaration of parts is compared by the key it sits under, which is the name of the cookie it describes and cannot repeat inside one array. A name is compared by itself, exactly as before. An entry of any other shape names no cookie, is given no token, and does not survive the last line, which is where the list is filtered as well as deduplicated. First occurrences win and keys stay attached to their values, so `array_intersect_key()` returns the list in the order it came in.

Two shorter forms were measured and rejected. `array_unique( $cookies, SORT_REGULAR )` compares numerically, so two distinct names that PHP reads as the same number, `'1e2'` and `'100'`, are collapsed into one. `array_unique( array_filter( $cookies, 'is_scalar' ) ) + array_filter( $cookies, 'is_array' )` moves every declaration of parts to the end of the list, and the file name is built in list order, so the names of every affected site would change for a second reason. The test carries a case for each.

The docblock now says what the two shapes of an entry are. That distinction decides which branch of `maybe_dynamic_cookies_filename()` runs, and nothing said it.

### New dependencies

None.

### Risks

- **The upgrade empties the page cache, on every site.** Only a site declaring a cookie by its parts has names that move, and which sites those are cannot be read at upgrade time: the declaration comes from a filter whose plugin may be inactive then, or may register it for front-end requests only. One cold cache on one upgrade is the price of not leaving a page under a name that now belongs to another request.
- **A cookie created during the request no longer changes the name the page is stored under.** The request is read at arrival to answer it and again at the end to store it, and the name now comes from the same cookies both times. Where a plugin creates a declared cookie in between, the page is stored under the name the arriving request asked for, which is also where the plain-name form has always stored it. On a site whose page already reflects that new cookie, that name is now the one cookie-less visitors read, where before it was a name almost nothing reads. No name can tell those two pages apart, since only the body is stored; refusing to store a page whose declared cookies changed while it was being built would, and that is worth its own change rather than a guess inside this one.
- **More than one such declaration now reaches `maybe_dynamic_cookies_filename()`.** What it does with a cookie whose declared part is missing is unchanged, down to the dash in the name; what it no longer does is read that part before knowing it is there. A cookie whose value is an array where a plain name was declared still reaches `preg_replace()` as an array and still names the file `index-Array`: that is untouched here, since changing it would rename files on sites that have it today.

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

All items are ticked.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)