### PR TITLE
[#8789 slice 5/5] Finalize plugin-resolver baseline + add Easy-25 hook-collision scan

### DIFF
--- a/inc/ThirdParty/Plugins/SubscriberFactory.php
+++ b/inc/ThirdParty/Plugins/SubscriberFactory.php
@@ -52,10 +52,9 @@ use WP_Rocket\ThirdParty\Plugins\WPGeotargeting;
  * Authoritative id => class registry and constructor argument builder for the
  * resolver-gate-able plugin compatibility subscribers.
  *
- * Single source of truth for the factory-owned plugin ids (Phase 0 scaffolding
- * for issue #6418). `get_registry()` is a pure literal map, safe to enumerate
- * without side effects; `get_arguments()` builds the runtime args for a single
- * id only, at register time.
+ * Single source of truth for the factory-owned plugin ids. `get_registry()` is
+ * a pure literal map, safe to enumerate without side effects; `get_arguments()`
+ * builds the runtime args for a single id only, at register time.
  */
 class SubscriberFactory {
 	/**
@@ -67,8 +66,7 @@ class SubscriberFactory {
 		return [
 			'mobile_subscriber'            => Mobile_Subscriber::class,
 			// syntaxhighlighter_subscriber is ordered before elementor_subscriber: both hook
-			// `rocket_exclude_js` at the default priority (hook-collision scan, issue #6418
-			// Phase 0); this preserves their pre-refactor relative registration order.
+			// `rocket_exclude_js` at the default priority, and this order is relied upon.
 			'syntaxhighlighter_subscriber' => SyntaxHighlighter::class,
 			'elementor_subscriber'         => Elementor::class,
 			'woocommerce_subscriber'       => WooCommerceSubscriber::class,

--- a/tests/Fixtures/classes/Jetpack.php
+++ b/tests/Fixtures/classes/Jetpack.php
@@ -3,7 +3,8 @@
  * Minimal global stub for the real Jetpack plugin's root-namespace `Jetpack` class.
  *
  * Used only by the issue #8789 slice 5 Easy-25 hook-collision scan
- * (tests/Integration/inc/ThirdParty/Plugins/PluginResolver/easy25HookCollisionScan.php)
+ * (tests/Unit/inc/ThirdParty/Plugins/PluginResolver/easy25HookCollisionScan.php;
+ * moved there from the Integration suite in a later slice-5 regression fix)
  * to simulate Jetpack being present with its sitemaps module active, so
  * \WP_Rocket\ThirdParty\Plugins\Jetpack::get_subscribed_events() emits its
  * 'rocket_sitemap_preload_list' hook instead of bailing out early. Mirrors the

--- a/tests/Fixtures/classes/Jetpack.php
+++ b/tests/Fixtures/classes/Jetpack.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Minimal global stub for the real Jetpack plugin's root-namespace `Jetpack` class.
+ *
+ * Used only by the issue #8789 slice 5 Easy-25 hook-collision scan
+ * (tests/Integration/inc/ThirdParty/Plugins/PluginResolver/easy25HookCollisionScan.php)
+ * to simulate Jetpack being present with its sitemaps module active, so
+ * \WP_Rocket\ThirdParty\Plugins\Jetpack::get_subscribed_events() emits its
+ * 'rocket_sitemap_preload_list' hook instead of bailing out early. Mirrors the
+ * TRP_Translate_Press.php stub convention in this same directory.
+ */
+
+if ( ! class_exists( 'Jetpack' ) ) {
+	class Jetpack {
+		/**
+		 * Always reports the queried module as active.
+		 *
+		 * @param string $module Module slug.
+		 *
+		 * @return bool
+		 */
+		public static function is_module_active( $module ) {
+			return true;
+		}
+	}
+}

--- a/tests/Fixtures/classes/Jetpack.php
+++ b/tests/Fixtures/classes/Jetpack.php
@@ -2,9 +2,7 @@
 /**
  * Minimal global stub for the real Jetpack plugin's root-namespace `Jetpack` class.
  *
- * Used only by the issue #8789 slice 5 Easy-25 hook-collision scan
- * (tests/Unit/inc/ThirdParty/Plugins/PluginResolver/easy25HookCollisionScan.php;
- * moved there from the Integration suite in a later slice-5 regression fix)
+ * Used by tests/Unit/inc/ThirdParty/Plugins/PluginResolver/easy25HookCollisionScan.php
  * to simulate Jetpack being present with its sitemaps module active, so
  * \WP_Rocket\ThirdParty\Plugins\Jetpack::get_subscribed_events() emits its
  * 'rocket_sitemap_preload_list' hook instead of bailing out early. Mirrors the

--- a/tests/Fixtures/classes/PluginResolverGatedIds.php
+++ b/tests/Fixtures/classes/PluginResolverGatedIds.php
@@ -3,8 +3,8 @@
 namespace WP_Rocket\Tests\Fixtures\classes;
 
 /**
- * Single source of truth for the issue #8789 gated-inactive plugin ids, across
- * all slices.
+ * Single source of truth for the gated plugin-compat subscriber ids that report
+ * inactive in this test environment.
  *
  * Shared by:
  * - tests/Unit/inc/ThirdParty/Plugins/PluginResolver/getActivePlugins.php
@@ -12,21 +12,16 @@ namespace WP_Rocket\Tests\Fixtures\classes;
  *
  * Both suites autoload this class via the WP_Rocket\Tests\ PSR-4 mapping (composer.json
  * autoload-dev), so it can be referenced from Unit and Integration tests alike.
- *
- * Renamed from PluginResolverSlice1GatedIds (issue #8789 slice 2): the list now
- * spans multiple slices, so a slice-agnostic name keeps it a single source of
- * truth as later slices append their own gated ids instead of forking the list.
  */
 class PluginResolverGatedIds {
 	/**
-	 * Ids gated by issue #8789 (slices 1-4, so far) that report inactive in this
-	 * test environment (none of their target plugins are installed/defined), so
-	 * they no longer default-active like the rest of the registry.
+	 * Ids gated behind PluginCompatibilityInterface whose target plugins are not
+	 * installed/defined in this test environment, so they no longer default-active
+	 * like the rest of the registry.
 	 *
 	 * @var array<string>
 	 */
 	public const IDS = [
-		// Slice 1.
 		'elementor_subscriber',
 		'beaverbuilder_subscriber',
 		'simple_custom_css',
@@ -34,7 +29,6 @@ class PluginResolverGatedIds {
 		'wordfence_subscriber',
 		'unlimited_elements',
 		'inline_related_posts',
-		// Slice 2.
 		'rank_math_seo',
 		'rocket_lazy_load',
 		'the_events_calendar',
@@ -44,10 +38,8 @@ class PluginResolverGatedIds {
 		'termly_subscriber',
 		'optimole_subscriber',
 		'convertplug',
-		// Slice 3.
 		'syntaxhighlighter_subscriber',
 		'ngg_subscriber',
-		// Slice 4.
 		'pwa',
 		'yoast_seo',
 		'thirstyaffiliates',

--- a/tests/Integration/inc/ThirdParty/Plugins/Optimization/Autoptimize/warnWhenAggregateInlineCssAndCPCSSActive.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Optimization/Autoptimize/warnWhenAggregateInlineCssAndCPCSSActive.php
@@ -26,13 +26,8 @@ class Test_WarnWhenAggregateInlineCssAndCPCSSActive extends TestCase {
 	public function set_up() {
 		parent::set_up();
 
-		// Issue #8789 slice 4 gates Autoptimize behind PluginCompatibilityInterface;
-		// AUTOPTIMIZE_PLUGIN_VERSION is genuinely undefined at real plugin boot in this
-		// test environment, so the live container no longer constructs/hooks Autoptimize
-		// on admin_notices the way unregisterAllCallbacksExcept() previously relied on
-		// (it would silently keep every original callback, including RocketInsights's,
-		// when it can't find a matching one to except). Construct our own instance and
-		// hook it manually instead.
+		// Autoptimize is gated behind PluginCompatibilityInterface and its target
+		// constant is undefined here, so construct and hook it manually instead.
 		$this->unregisterAllCallbacks( 'admin_notices' );
 
 		$container = apply_filters( 'rocket_container', null );

--- a/tests/Integration/inc/ThirdParty/Plugins/Optimization/Autoptimize/warnWhenJsAggregationAndDelayJsActive.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/Optimization/Autoptimize/warnWhenJsAggregationAndDelayJsActive.php
@@ -26,13 +26,8 @@ class Test_WarnWhenJsAggregationAndDelayJsActive extends TestCase {
 	public function set_up() {
 		parent::set_up();
 
-		// Issue #8789 slice 4 gates Autoptimize behind PluginCompatibilityInterface;
-		// AUTOPTIMIZE_PLUGIN_VERSION is genuinely undefined at real plugin boot in this
-		// test environment, so the live container no longer constructs/hooks Autoptimize
-		// on admin_notices the way unregisterAllCallbacksExcept() previously relied on
-		// (it would silently keep every original callback, including RocketInsights's,
-		// when it can't find a matching one to except). Construct our own instance and
-		// hook it manually instead.
+		// Autoptimize is gated behind PluginCompatibilityInterface and its target
+		// constant is undefined here, so construct and hook it manually instead.
 		$this->unregisterAllCallbacks( 'admin_notices' );
 
 		$container = apply_filters( 'rocket_container', null );

--- a/tests/Integration/inc/ThirdParty/Plugins/PluginResolver/easy25HookCollisionScan.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/PluginResolver/easy25HookCollisionScan.php
@@ -59,7 +59,7 @@ use WP_Rocket\ThirdParty\Plugins\UnlimitedElements;
  *   (already declares these guarded globally, no override needed).
  * - TheSEOFramework: needs `the_seo_framework()` to return an object with a
  *   truthy `$loaded` and a truthy `can_run_sitemap()`. Reuses the existing
- *   tests/Fixtures/inc/ThirdParty/Plugins/SEO/TheSEOFramework/Fixtures.php.
+ *   tests/Fixtures/inc/ThirdParty/Plugins/SEO/TheSEOFramework/fixtures.php.
  *
  * All 25 classes are otherwise driven with zero stubbing — a genuine capture
  * of their real, unconditional hook maps, not a guess.
@@ -152,7 +152,7 @@ class Test_Easy25HookCollisionScan extends TestCase {
 	private static function load_deviation_marker_stubs(): void {
 		require_once WP_ROCKET_TESTS_FIXTURES_DIR . '/classes/Jetpack.php';
 		require_once WP_ROCKET_TESTS_FIXTURES_DIR . '/inc/ThirdParty/Plugins/SEO/SEOPress/fixtures.php';
-		require_once WP_ROCKET_TESTS_FIXTURES_DIR . '/inc/ThirdParty/Plugins/SEO/TheSEOFramework/Fixtures.php';
+		require_once WP_ROCKET_TESTS_FIXTURES_DIR . '/inc/ThirdParty/Plugins/SEO/TheSEOFramework/fixtures.php';
 	}
 
 	/**

--- a/tests/Integration/inc/ThirdParty/Plugins/PluginResolver/easy25HookCollisionScan.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/PluginResolver/easy25HookCollisionScan.php
@@ -1,0 +1,327 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\inc\ThirdParty\Plugins\PluginResolver;
+
+use WP_Rocket\Subscriber\Third_Party\Plugins\NGG_Subscriber;
+use WP_Rocket\Subscriber\Third_Party\Plugins\SyntaxHighlighter_Subscriber;
+use WP_Rocket\Tests\Fixtures\classes\PluginResolverGatedIds;
+use WP_Rocket\Tests\Integration\TestCase;
+use WP_Rocket\ThirdParty\Plugins\ConvertPlug;
+use WP_Rocket\ThirdParty\Plugins\Cookie\Termly;
+use WP_Rocket\ThirdParty\Plugins\I18n\TranslatePress;
+use WP_Rocket\ThirdParty\Plugins\I18n\Weglot;
+use WP_Rocket\ThirdParty\Plugins\InlineRelatedPosts;
+use WP_Rocket\ThirdParty\Plugins\Jetpack;
+use WP_Rocket\ThirdParty\Plugins\Optimization\Autoptimize;
+use WP_Rocket\ThirdParty\Plugins\Optimization\Perfmatters;
+use WP_Rocket\ThirdParty\Plugins\Optimization\RocketLazyLoad;
+use WP_Rocket\ThirdParty\Plugins\Optimole;
+use WP_Rocket\ThirdParty\Plugins\PageBuilder\BeaverBuilder;
+use WP_Rocket\ThirdParty\Plugins\PageBuilder\Elementor;
+use WP_Rocket\ThirdParty\Plugins\PDFEmbedder;
+use WP_Rocket\ThirdParty\Plugins\PWA;
+use WP_Rocket\ThirdParty\Plugins\Security\WordFenceCompatibility;
+use WP_Rocket\ThirdParty\Plugins\SEO\RankMathSEO;
+use WP_Rocket\ThirdParty\Plugins\SEO\SEOPress;
+use WP_Rocket\ThirdParty\Plugins\SEO\TheSEOFramework;
+use WP_Rocket\ThirdParty\Plugins\SEO\Yoast;
+use WP_Rocket\ThirdParty\Plugins\SimpleCustomCss;
+use WP_Rocket\ThirdParty\Plugins\TheEventsCalendar;
+use WP_Rocket\ThirdParty\Plugins\ThirstyAffiliates;
+use WP_Rocket\ThirdParty\Plugins\UnlimitedElements;
+
+/**
+ * AC-required hook-collision scan for issue #8789's Easy-25 batch (slices 1-4):
+ * proves that the 25 migrated classes don't accidentally clash on the same
+ * WordPress hook + priority once they're all resolver-gated.
+ *
+ * Methodology: `get_subscribed_events()` is a *static* method on every one of
+ * the 25 classes, so it is called directly (`Class::get_subscribed_events()`),
+ * with no container/instantiation involved. 22 of the 25 classes already
+ * return their hook map unconditionally — issue #8789 slices 1-4 moved their
+ * presence guard out of `get_subscribed_events()` and into `is_activated()`
+ * (Implementation Plan §1 step 3 / §2's "leave get_subscribed_events()
+ * untouched" rule for the 7 deviation classes), so no "target plugin present"
+ * simulation is needed for them at all: the guard that used to gate the
+ * return value is simply gone.
+ *
+ * Only 3 of the 7 deviation classes still have a guard *inside*
+ * `get_subscribed_events()` itself (their business/feature-toggle checks,
+ * deliberately left untouched per §2), so only these 3 need their markers
+ * simulated to reveal their real (maximal) hook set:
+ * - Jetpack: needs a real `\Jetpack` class + `is_module_active('sitemaps')`
+ *   truthy. Stubbed via tests/Fixtures/classes/Jetpack.php (new fixture,
+ *   mirrors the TRP_Translate_Press.php stub-class convention already in
+ *   that directory).
+ * - SEOPress: needs `seopress_get_toggle_option('xml-sitemap')` to return 1
+ *   AND `seopress_get_service('SitemapOption')->isEnabled()` to return 1.
+ *   Reuses the existing tests/Fixtures/inc/ThirdParty/Plugins/SEO/SEOPress/fixtures.php
+ *   (already declares these guarded globally, no override needed).
+ * - TheSEOFramework: needs `the_seo_framework()` to return an object with a
+ *   truthy `$loaded` and a truthy `can_run_sitemap()`. Reuses the existing
+ *   tests/Fixtures/inc/ThirdParty/Plugins/SEO/TheSEOFramework/Fixtures.php.
+ *
+ * All 25 classes are otherwise driven with zero stubbing — a genuine capture
+ * of their real, unconditional hook maps, not a guess.
+ *
+ * @group ThirdParty
+ * @group Plugins
+ */
+class Test_Easy25HookCollisionScan extends TestCase {
+
+	/**
+	 * Pre-existing (hook, priority) pairs registered by 2+ of the Easy-25
+	 * classes, reviewed and accepted as intentional. Keyed by "hook:priority".
+	 *
+	 * Only the `rocket_exclude_js:10` pair (elementor_subscriber vs
+	 * syntaxhighlighter_subscriber) is documented today by the
+	 * `SubscriberFactory` registry-order comment. This scan additionally
+	 * found 4 more pre-existing pairs that were not previously documented
+	 * anywhere: they are unrelated to this migration (hook maps are
+	 * byte-identical before/after issue #8789 slices 1-4 — only the presence
+	 * guard moved, per the Implementation Plan) and are all instances of the
+	 * same benign pattern: a WP Rocket "collector" filter (an exclusions or
+	 * preload-list array that callbacks *append* to) that several
+	 * plugin-compat classes legitimately contribute to. None of them mutate
+	 * shared state in a way where registration order matters, unlike the
+	 * documented pair. Flagged here for visibility per the AC, not because
+	 * they are bugs.
+	 *
+	 * @var array<string,array<string>>
+	 */
+	private const ACCEPTED_COLLISIONS = [
+		// Documented by SubscriberFactory::get_registry()'s own comment (order
+		// preserved intentionally); this scan additionally found pdfembedder
+		// also on the same hook + priority, which that comment does not
+		// mention.
+		'rocket_exclude_js:10'                      => [
+			'elementor_subscriber',
+			'pdfembedder',
+			'syntaxhighlighter_subscriber',
+		],
+		// rocket_sitemap_preload_list is a collector array of sitemap URLs to
+		// preload; every SEO-plugin compat class appends its own entry at
+		// priority 15 (jetpack uses the default priority 10 instead, so it
+		// does not collide with this group).
+		'rocket_sitemap_preload_list:15'            => [
+			'rank_math_seo',
+			'seopress',
+			'the_seo_framework',
+			'yoast_seo',
+		],
+		// rocket_rucss_inline_content_exclusions is a collector array of RUCSS
+		// inline-content exclusion patterns.
+		'rocket_rucss_inline_content_exclusions:10' => [
+			'inline_related_posts',
+			'unlimited_elements',
+		],
+		// rocket_delay_js_exclusions is a collector array of delay-JS
+		// exclusion patterns.
+		'rocket_delay_js_exclusions:10'             => [
+			'rocket_lazy_load',
+			'termly_subscriber',
+		],
+		// rocket_exclude_defer_js is a collector array of defer-JS exclusion
+		// patterns.
+		'rocket_exclude_defer_js:10'                => [
+			'syntaxhighlighter_subscriber',
+			'termly_subscriber',
+		],
+	];
+
+	/**
+	 * Loads the marker stubs needed by the 3 deviation classes whose
+	 * `get_subscribed_events()` still has its own internal guard.
+	 *
+	 * Deliberately NOT wired into set_up_before_class(): that hook only ever
+	 * runs once, in the main (non-isolated) PHPUnit process, even for test
+	 * methods annotated `@runInSeparateProcess` below. These stubs declare
+	 * real global classes/functions (`Jetpack`, `seopress_get_toggle_option()`,
+	 * `the_seo_framework()`) that PHP can never "undeclare" afterwards, so
+	 * loading them there would leak into every other test that shares this
+	 * suite's single PHP process for the rest of the run — e.g. it would
+	 * silently flip PluginResolver::get_active_plugins()'s jetpack/seopress/
+	 * the_seo_framework detection to "active" for the remainder of the suite,
+	 * breaking Test_PluginCompatSubscribersBehaviorEquivalence's absence
+	 * assertions (confirmed locally: this exact leak was caught by a full
+	 * --group ThirdParty run before this method was isolated). Called instead
+	 * from inside each `@runInSeparateProcess` test method that needs it, so
+	 * the pollution is contained to that method's own forked, throwaway
+	 * process.
+	 */
+	private static function load_deviation_marker_stubs(): void {
+		require_once WP_ROCKET_TESTS_FIXTURES_DIR . '/classes/Jetpack.php';
+		require_once WP_ROCKET_TESTS_FIXTURES_DIR . '/inc/ThirdParty/Plugins/SEO/SEOPress/fixtures.php';
+		require_once WP_ROCKET_TESTS_FIXTURES_DIR . '/inc/ThirdParty/Plugins/SEO/TheSEOFramework/Fixtures.php';
+	}
+
+	/**
+	 * Authoritative id => FQCN map for the Easy-25 batch, reconciled against
+	 * PluginResolverGatedIds::IDS (the single source of truth for this issue's
+	 * gated ids, shared with the baseline equivalence test).
+	 *
+	 * @return array<string,string>
+	 */
+	private function easy_25_classes(): array {
+		return [
+			'elementor_subscriber'         => Elementor::class,
+			'beaverbuilder_subscriber'     => BeaverBuilder::class,
+			'simple_custom_css'            => SimpleCustomCss::class,
+			'pdfembedder'                  => PDFEmbedder::class,
+			'wordfence_subscriber'         => WordFenceCompatibility::class,
+			'thirstyaffiliates'            => ThirstyAffiliates::class,
+			'pwa'                          => PWA::class,
+			'yoast_seo'                    => Yoast::class,
+			'convertplug'                  => ConvertPlug::class,
+			'unlimited_elements'           => UnlimitedElements::class,
+			'inline_related_posts'         => InlineRelatedPosts::class,
+			'jetpack'                      => Jetpack::class,
+			'rank_math_seo'                => RankMathSEO::class,
+			'seopress'                     => SEOPress::class,
+			'the_seo_framework'            => TheSEOFramework::class,
+			'rocket_lazy_load'             => RocketLazyLoad::class,
+			'the_events_calendar'          => TheEventsCalendar::class,
+			'perfmatters'                  => Perfmatters::class,
+			'weglot'                       => Weglot::class,
+			'translatepress'               => TranslatePress::class,
+			'termly_subscriber'            => Termly::class,
+			'optimole_subscriber'          => Optimole::class,
+			'syntaxhighlighter_subscriber' => SyntaxHighlighter_Subscriber::class,
+			'ngg_subscriber'               => NGG_Subscriber::class,
+			'autoptimize'                  => Autoptimize::class,
+		];
+	}
+
+	/**
+	 * Sanity-check the enumeration itself: this scan must cover exactly the
+	 * 25 ids issue #8789 gates, no more, no less, so a future slice can't
+	 * silently drift out of sync with PluginResolverGatedIds::IDS.
+	 */
+	public function testShouldEnumerateExactlyTheEasy25GatedIds() {
+		$ids = array_keys( $this->easy_25_classes() );
+
+		sort( $ids );
+		$expected = PluginResolverGatedIds::IDS;
+		sort( $expected );
+
+		$this->assertSame( $expected, $ids, 'The collision scan must cover exactly the Easy-25 gated ids, no more, no less.' );
+	}
+
+	/**
+	 * The 3 deviation classes whose is_activated() presence oracle relies on
+	 * the same marker this scan simulates for get_subscribed_events(): a
+	 * quick consistency proof that the simulated markers genuinely represent
+	 * "target plugin present", not just an accident of the guard's own logic.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function testShouldReportDeviationClassesActiveUnderSimulatedMarkers() {
+		self::load_deviation_marker_stubs();
+
+		$this->assertTrue( Jetpack::is_activated(), 'Jetpack::is_activated() should be true once the Jetpack stub class is loaded.' );
+		$this->assertTrue( SEOPress::is_activated(), 'SEOPress::is_activated() should be true once seopress_get_toggle_option() is stubbed.' );
+		$this->assertTrue( TheSEOFramework::is_activated(), 'TheSEOFramework::is_activated() should be true once the_seo_framework() is stubbed.' );
+	}
+
+	/**
+	 * The AC-required assertion: no WordPress hook is registered by 2+ of the
+	 * Easy-25 classes at the same priority, except the reviewed, documented
+	 * pairs in self::ACCEPTED_COLLISIONS.
+	 *
+	 * Isolated (see load_deviation_marker_stubs()'s docblock): capturing
+	 * Jetpack/SEOPress/TheSEOFramework's real hook maps requires declaring
+	 * real global markers that must not leak into the rest of the suite.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function testShouldNotCollideOnHookAndPriorityExceptAcceptedPairs() {
+		self::load_deviation_marker_stubs();
+
+		$hook_priority_to_ids = [];
+
+		foreach ( $this->easy_25_classes() as $id => $class ) {
+			$events = $class::get_subscribed_events();
+
+			foreach ( $events as $hook => $callback ) {
+				foreach ( self::priorities_for_callback( $callback ) as $priority ) {
+					$key = $hook . ':' . $priority;
+
+					// Keyed by id to dedupe a class registering the same
+					// hook+priority twice with itself (e.g. Autoptimize's two
+					// admin_notices callbacks) - that's not a cross-class collision.
+					$hook_priority_to_ids[ $key ][ $id ] = true;
+				}
+			}
+		}
+
+		$unexpected = [];
+
+		foreach ( $hook_priority_to_ids as $key => $ids_map ) {
+			$ids = array_keys( $ids_map );
+
+			if ( count( $ids ) < 2 ) {
+				continue;
+			}
+
+			sort( $ids );
+
+			$allowed = self::ACCEPTED_COLLISIONS[ $key ] ?? null;
+
+			if ( null !== $allowed ) {
+				$allowed_sorted = $allowed;
+				sort( $allowed_sorted );
+
+				if ( $ids === $allowed_sorted ) {
+					continue;
+				}
+			}
+
+			$unexpected[] = sprintf( '%s registered by: %s', $key, implode( ', ', $ids ) );
+		}
+
+		$this->assertSame(
+			[],
+			$unexpected,
+			"Unexpected hook/priority collision(s) among the Easy-25 batch (format 'hook:priority registered by: id1, id2'):\n" . implode( "\n", $unexpected )
+		);
+	}
+
+	/**
+	 * Normalizes a get_subscribed_events() callback value into the list of
+	 * priorities it registers at, handling all 3 WP Rocket subscriber
+	 * shapes:
+	 * - 'hook' => 'method' (priority 10)
+	 * - 'hook' => [ 'method', priority ] (or with a 3rd num-args element)
+	 * - 'hook' => [ [ 'method', priority ], [ 'method2', priority2 ] ]
+	 *
+	 * @param mixed $callback The get_subscribed_events() value for one hook.
+	 *
+	 * @return array<int>
+	 */
+	private static function priorities_for_callback( $callback ): array {
+		if ( is_string( $callback ) ) {
+			return [ 10 ];
+		}
+
+		if ( ! is_array( $callback ) ) {
+			return [ 10 ];
+		}
+
+		// Single-callback shorthand: [ method ] or [ method, priority ] or
+		// [ method, priority, num_args ].
+		if ( isset( $callback[0] ) && is_string( $callback[0] ) ) {
+			return [ isset( $callback[1] ) ? (int) $callback[1] : 10 ];
+		}
+
+		// Multiple-callback shorthand: [ [ method, priority ], ... ].
+		$priorities = [];
+
+		foreach ( $callback as $sub_callback ) {
+			$priorities = array_merge( $priorities, self::priorities_for_callback( $sub_callback ) );
+		}
+
+		return $priorities;
+	}
+}

--- a/tests/Integration/inc/ThirdParty/Plugins/PluginResolver/pluginCompatSubscribersBehaviorEquivalence.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/PluginResolver/pluginCompatSubscribersBehaviorEquivalence.php
@@ -8,60 +8,37 @@ use WP_Rocket\Tests\Fixtures\classes\PluginResolverGatedIds;
 use WP_Rocket\Tests\Integration\TestCase;
 
 /**
- * Behavior-equivalence proof for issue #6418 Phase 0: the plugin resolver
- * scaffolding must reach the event manager with the identical set of
- * plugin-compat subscriber ids as the pre-refactor static list.
+ * Verifies the plugin resolver's active-id set is exactly reflected in the
+ * live container: every id the resolver reports active must resolve to an
+ * object, and every id gated behind PluginCompatibilityInterface (whose
+ * target plugin is absent in this test environment) must resolve to absent
+ * rather than being force-registered.
  *
- * Issue #8789 (all 5 slices) gates the complete Easy-25 batch behind
- * PluginCompatibilityInterface; this is the final, structural update to this
- * harness (see the "resolves every registry id" assertion below, which is now
- * fully diff-derived so later batches don't need to touch this file's
- * assertions again, only PluginResolverGatedIds::IDS).
- *
- * This class stays the id-set-equivalence half of AC #3 (needs the live
- * container, so it stays in Integration). The other half — the AC-required
- * hook-collision scan — lives in the Unit suite instead:
- * tests/Unit/inc/ThirdParty/Plugins/PluginResolver/easy25HookCollisionScan.php
- * (moved out of Integration in a slice 5 regression fix: its
- * `@runInSeparateProcess` isolation, needed to simulate 3 deviation classes'
- * markers, corrupted shared DB/option state when forked from an Integration
- * test process). `get_subscribed_events()` is a static method with no
- * WordPress dependency, so no coverage is lost by running that scan from
- * Unit instead.
+ * The hook-collision half of this coverage lives in the Unit suite instead
+ * (tests/Unit/inc/ThirdParty/Plugins/PluginResolver/easy25HookCollisionScan.php):
+ * `get_subscribed_events()` is a static method with no WordPress dependency,
+ * and its `@runInSeparateProcess` isolation is incompatible with the shared
+ * Integration bootstrap.
  *
  * @group ThirdParty
  * @group Plugins
  */
 class Test_PluginCompatSubscribersBehaviorEquivalence extends TestCase {
 	/**
-	 * Baseline: originally the 43 factory-owned ids + the 2 statically-registered
-	 * special ids (ezoic, mod_pagespeed) = the 45 plugin-compat ids previously
-	 * hardcoded in Plugin::$common_subscribers.
-	 *
-	 * Issue #8789 (slices 1-5, now COMPLETE) gates all 25 of the Easy-25 registry
-	 * ids (slice 1: elementor_subscriber, beaverbuilder_subscriber, simple_custom_css,
-	 * pdfembedder, wordfence_subscriber, unlimited_elements, inline_related_posts;
-	 * slice 2: rank_math_seo, rocket_lazy_load, the_events_calendar, perfmatters,
-	 * weglot, translatepress, termly_subscriber, optimole_subscriber, convertplug;
-	 * slice 3: syntaxhighlighter_subscriber, ngg_subscriber; slice 4: pwa, yoast_seo,
-	 * thirstyaffiliates, autoptimize, jetpack, seopress, the_seo_framework; slice 5:
-	 * no further gating, only this harness's own finalization + the AC-required
-	 * hook-collision scan) behind PluginCompatibilityInterface; none of their target
-	 * plugins are installed in this test environment, so they drop out of
-	 * get_active_plugins().
-	 * 43 - 25 + 2 = 20. This is a deliberate perf-baseline (not a tautology): later
-	 * #8789 batches (Medium/Hard) will lower this further as the remaining ids are
-	 * gated, at which point this constant must be updated again.
+	 * Total plugin-compat subscribers expected in the live container: the
+	 * registry ids that are not gated behind PluginCompatibilityInterface, plus
+	 * the 2 statically-registered special ids (ezoic, mod_pagespeed) that bypass
+	 * the resolver entirely. Update this constant whenever the gated-id list or
+	 * the registry size changes.
 	 *
 	 * @var int
 	 */
 	private const EXPECTED_PLUGIN_SUBSCRIBERS = 20;
 
 	/**
-	 * Phase 0 defaults every registry id active; issue #8789 (slices 1-5) opts all
-	 * 25 Easy-25 ids into real detection, so the resolver's set is the full registry
-	 * minus those 25 (their target plugins are absent here), and the container
-	 * must still resolve every remaining one of them.
+	 * Every id the resolver reports as active (the full registry minus the ids
+	 * gated behind PluginCompatibilityInterface) must resolve to an object
+	 * through the live container.
 	 */
 	public function testShouldResolveEveryActivePluginIdFromTheLiveContainer() {
 		$container = apply_filters( 'rocket_container', null );
@@ -73,7 +50,7 @@ class Test_PluginCompatSubscribersBehaviorEquivalence extends TestCase {
 
 		$expected_active_ids = array_values( array_diff( array_keys( $registry ), PluginResolverGatedIds::IDS ) );
 
-		$this->assertSame( $expected_active_ids, $active_ids, 'Phase 1 (issue #8789, slices 1-5) must resolve to the 43-id registry minus the 25 gated-inactive ids.' );
+		$this->assertSame( $expected_active_ids, $active_ids, 'Must resolve to the full registry minus the gated-inactive ids.' );
 
 		foreach ( $active_ids as $id ) {
 			$this->assertTrue(
@@ -88,9 +65,9 @@ class Test_PluginCompatSubscribersBehaviorEquivalence extends TestCase {
 	}
 
 	/**
-	 * Drift/dedup proof: cloudflare_plugin_facade is the internal `->add()`
-	 * dependency of cloudflare_plugin_subscriber, not a registry id, so it is
-	 * never gated and must still resolve regardless of #8789's progress.
+	 * cloudflare_plugin_facade is an internal `->add()` dependency of
+	 * cloudflare_plugin_subscriber, not a registry id, so it is never gated and
+	 * must always resolve.
 	 */
 	public function testShouldResolveThePreviouslyDriftingAndDependencyIds() {
 		$container = apply_filters( 'rocket_container', null );
@@ -102,10 +79,9 @@ class Test_PluginCompatSubscribersBehaviorEquivalence extends TestCase {
 	}
 
 	/**
-	 * Correctness proof (was a drift-proof pre-#8789): convertplug is gated by
-	 * issue #8789 slice 2, and its target plugin (CP_VERSION) is not installed
-	 * in this test environment, so it must now correctly resolve to absent
-	 * instead of being force-registered regardless of activation state.
+	 * convertplug is gated behind PluginCompatibilityInterface; its target
+	 * constant (CP_VERSION) is undefined in this test environment, so it must
+	 * resolve to absent.
 	 */
 	public function testShouldNotResolveConvertPlugWhenAbsent() {
 		$container = apply_filters( 'rocket_container', null );
@@ -114,13 +90,10 @@ class Test_PluginCompatSubscribersBehaviorEquivalence extends TestCase {
 	}
 
 	/**
-	 * Correctness proof (was a drift-proof pre-#8789): yoast_seo and
-	 * thirstyaffiliates are gated by issue #8789 slice 4, and neither target
-	 * plugin (WPSEO_VERSION / thirstyaffiliates/thirstyaffiliates.php) is
-	 * installed in this test environment, so both must now correctly resolve
-	 * to absent instead of being force-registered regardless of activation
-	 * state — flipping their historical $provides-drift proof into a
-	 * gated-correctness proof.
+	 * yoast_seo and thirstyaffiliates are gated behind
+	 * PluginCompatibilityInterface; neither target plugin (WPSEO_VERSION /
+	 * thirstyaffiliates/thirstyaffiliates.php) is present in this test
+	 * environment, so both must resolve to absent.
 	 */
 	public function testShouldNotResolveYoastOrThirstyAffiliatesWhenAbsent() {
 		$container = apply_filters( 'rocket_container', null );
@@ -144,13 +117,13 @@ class Test_PluginCompatSubscribersBehaviorEquivalence extends TestCase {
 	}
 
 	/**
-	 * Perf-baseline harness: records the expected plugin-compat subscriber
-	 * count so Phase 1 (which drops inactive ids) updates it deliberately.
+	 * Baseline check: the active resolver ids plus the 2 special always-load
+	 * ids (ezoic, mod_pagespeed) must match EXPECTED_PLUGIN_SUBSCRIBERS.
 	 */
 	public function testShouldMatchThePluginSubscriberCountBaseline() {
 		$active_ids = PluginResolver::get_active_plugins( true );
 
-		// 18 active resolver ids (43 - the complete 25-id Easy-25 batch, issue #8789 slices 1-5) + ezoic + mod_pagespeed = 20.
+		// +2 accounts for ezoic and mod_pagespeed, which bypass the resolver.
 		$this->assertSame( self::EXPECTED_PLUGIN_SUBSCRIBERS, count( $active_ids ) + 2 );
 	}
 }

--- a/tests/Integration/inc/ThirdParty/Plugins/PluginResolver/pluginCompatSubscribersBehaviorEquivalence.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/PluginResolver/pluginCompatSubscribersBehaviorEquivalence.php
@@ -18,6 +18,17 @@ use WP_Rocket\Tests\Integration\TestCase;
  * fully diff-derived so later batches don't need to touch this file's
  * assertions again, only PluginResolverGatedIds::IDS).
  *
+ * This class stays the id-set-equivalence half of AC #3 (needs the live
+ * container, so it stays in Integration). The other half — the AC-required
+ * hook-collision scan — lives in the Unit suite instead:
+ * tests/Unit/inc/ThirdParty/Plugins/PluginResolver/easy25HookCollisionScan.php
+ * (moved out of Integration in a slice 5 regression fix: its
+ * `@runInSeparateProcess` isolation, needed to simulate 3 deviation classes'
+ * markers, corrupted shared DB/option state when forked from an Integration
+ * test process). `get_subscribed_events()` is a static method with no
+ * WordPress dependency, so no coverage is lost by running that scan from
+ * Unit instead.
+ *
  * @group ThirdParty
  * @group Plugins
  */
@@ -63,7 +74,6 @@ class Test_PluginCompatSubscribersBehaviorEquivalence extends TestCase {
 		$expected_active_ids = array_values( array_diff( array_keys( $registry ), PluginResolverGatedIds::IDS ) );
 
 		$this->assertSame( $expected_active_ids, $active_ids, 'Phase 1 (issue #8789, slices 1-5) must resolve to the 43-id registry minus the 25 gated-inactive ids.' );
-		$this->assertCount( count( $expected_active_ids ), $active_ids );
 
 		foreach ( $active_ids as $id ) {
 			$this->assertTrue(

--- a/tests/Integration/inc/ThirdParty/Plugins/PluginResolver/pluginCompatSubscribersBehaviorEquivalence.php
+++ b/tests/Integration/inc/ThirdParty/Plugins/PluginResolver/pluginCompatSubscribersBehaviorEquivalence.php
@@ -12,6 +12,12 @@ use WP_Rocket\Tests\Integration\TestCase;
  * scaffolding must reach the event manager with the identical set of
  * plugin-compat subscriber ids as the pre-refactor static list.
  *
+ * Issue #8789 (all 5 slices) gates the complete Easy-25 batch behind
+ * PluginCompatibilityInterface; this is the final, structural update to this
+ * harness (see the "resolves every registry id" assertion below, which is now
+ * fully diff-derived so later batches don't need to touch this file's
+ * assertions again, only PluginResolverGatedIds::IDS).
+ *
  * @group ThirdParty
  * @group Plugins
  */
@@ -21,25 +27,28 @@ class Test_PluginCompatSubscribersBehaviorEquivalence extends TestCase {
 	 * special ids (ezoic, mod_pagespeed) = the 45 plugin-compat ids previously
 	 * hardcoded in Plugin::$common_subscribers.
 	 *
-	 * Issue #8789 slices 1-4 gate all 25 of the Easy-25 registry ids (slice 1:
-	 * elementor_subscriber, beaverbuilder_subscriber, simple_custom_css, pdfembedder,
-	 * wordfence_subscriber, unlimited_elements, inline_related_posts; slice 2:
-	 * rank_math_seo, rocket_lazy_load, the_events_calendar, perfmatters, weglot,
-	 * translatepress, termly_subscriber, optimole_subscriber, convertplug; slice 3:
-	 * syntaxhighlighter_subscriber, ngg_subscriber; slice 4: pwa, yoast_seo,
-	 * thirstyaffiliates, autoptimize, jetpack, seopress, the_seo_framework) behind
-	 * PluginCompatibilityInterface; none of their target plugins are installed in
-	 * this test environment, so they drop out of get_active_plugins().
-	 * 43 - 25 + 2 = 20. Later #8789 batches (Medium/Hard) will lower this further
-	 * as the remaining ids are gated.
+	 * Issue #8789 (slices 1-5, now COMPLETE) gates all 25 of the Easy-25 registry
+	 * ids (slice 1: elementor_subscriber, beaverbuilder_subscriber, simple_custom_css,
+	 * pdfembedder, wordfence_subscriber, unlimited_elements, inline_related_posts;
+	 * slice 2: rank_math_seo, rocket_lazy_load, the_events_calendar, perfmatters,
+	 * weglot, translatepress, termly_subscriber, optimole_subscriber, convertplug;
+	 * slice 3: syntaxhighlighter_subscriber, ngg_subscriber; slice 4: pwa, yoast_seo,
+	 * thirstyaffiliates, autoptimize, jetpack, seopress, the_seo_framework; slice 5:
+	 * no further gating, only this harness's own finalization + the AC-required
+	 * hook-collision scan) behind PluginCompatibilityInterface; none of their target
+	 * plugins are installed in this test environment, so they drop out of
+	 * get_active_plugins().
+	 * 43 - 25 + 2 = 20. This is a deliberate perf-baseline (not a tautology): later
+	 * #8789 batches (Medium/Hard) will lower this further as the remaining ids are
+	 * gated, at which point this constant must be updated again.
 	 *
 	 * @var int
 	 */
 	private const EXPECTED_PLUGIN_SUBSCRIBERS = 20;
 
 	/**
-	 * Phase 0 defaults every registry id active; issue #8789 slices 1-4 opt all 25
-	 * Easy-25 ids into real detection, so the resolver's set is the full registry
+	 * Phase 0 defaults every registry id active; issue #8789 (slices 1-5) opts all
+	 * 25 Easy-25 ids into real detection, so the resolver's set is the full registry
 	 * minus those 25 (their target plugins are absent here), and the container
 	 * must still resolve every remaining one of them.
 	 */
@@ -53,8 +62,8 @@ class Test_PluginCompatSubscribersBehaviorEquivalence extends TestCase {
 
 		$expected_active_ids = array_values( array_diff( array_keys( $registry ), PluginResolverGatedIds::IDS ) );
 
-		$this->assertSame( $expected_active_ids, $active_ids, 'Phase 1 slices 1-4 must resolve to the 43-id registry minus the 25 gated-inactive ids.' );
-		$this->assertCount( 18, $active_ids );
+		$this->assertSame( $expected_active_ids, $active_ids, 'Phase 1 (issue #8789, slices 1-5) must resolve to the 43-id registry minus the 25 gated-inactive ids.' );
+		$this->assertCount( count( $expected_active_ids ), $active_ids );
 
 		foreach ( $active_ids as $id ) {
 			$this->assertTrue(
@@ -131,7 +140,7 @@ class Test_PluginCompatSubscribersBehaviorEquivalence extends TestCase {
 	public function testShouldMatchThePluginSubscriberCountBaseline() {
 		$active_ids = PluginResolver::get_active_plugins( true );
 
-		// 18 active resolver ids (43 - 25 slice-1/2/3/4-gated) + ezoic + mod_pagespeed = 20.
+		// 18 active resolver ids (43 - the complete 25-id Easy-25 batch, issue #8789 slices 1-5) + ezoic + mod_pagespeed = 20.
 		$this->assertSame( self::EXPECTED_PLUGIN_SUBSCRIBERS, count( $active_ids ) + 2 );
 	}
 }

--- a/tests/Unit/inc/ThirdParty/Plugins/I18n/Weglot/isActivated.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/I18n/Weglot/isActivated.php
@@ -15,19 +15,11 @@ class Test_IsActivated extends TestCase {
 	/**
 	 * Tests Weglot::is_activated() against the presence/absence of the Context_Weglot class.
 	 *
-	 * A namespaced class_exists() override (the pattern used in
-	 * tests/Unit/inc/ThirdParty/Plugins/PWA/excludeServiceWorker.php for function_exists())
-	 * was evaluated here and rejected: WP_Rocket\ThirdParty\Plugins is shared by several
-	 * slice-1/slice-2 classes, and once such an override is declared anywhere in the analyzed
-	 * fileset, PHPStan resolves EVERY unqualified class_exists() call in that namespace to
-	 * the override instead of the builtin — including in unrelated production files (e.g.
-	 * inc/ThirdParty/Plugins/Jetpack.php's `class_exists( 'Jetpack' )` guard). That breaks
-	 * PHPStan's built-in class-exists type-narrowing extension, which only recognizes the
-	 * real \class_exists(), producing a false "unknown class Jetpack" error on the next
-	 * line's static call. Confirmed locally: `composer run-stan` is clean on this branch
-	 * without the override and fails with that exact error once the override is added.
-	 * eval() + @runInSeparateProcess avoids this entirely by keeping the defined class (and
-	 * this test) isolated to its own process, with no shared-namespace function collision.
+	 * Uses eval() + @runInSeparateProcess, rather than a namespaced class_exists()
+	 * override, to define the class in isolation: a namespaced override would make
+	 * PHPStan resolve every unqualified class_exists() call in this shared
+	 * namespace to the override, breaking its class-exists type-narrowing for
+	 * unrelated production files.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled

--- a/tests/Unit/inc/ThirdParty/Plugins/PDFEmbedder/isActivated.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/PDFEmbedder/isActivated.php
@@ -14,19 +14,11 @@ class Test_IsActivated extends TestCase {
 	/**
 	 * Tests PDFEmbedder::is_activated() against the presence/absence of the core_pdf_embedder class.
 	 *
-	 * A namespaced class_exists() override (the pattern used in
-	 * tests/Unit/inc/ThirdParty/Plugins/PWA/excludeServiceWorker.php for function_exists())
-	 * was evaluated here and rejected: WP_Rocket\ThirdParty\Plugins is shared by several
-	 * slice-1 classes, and once such an override is declared anywhere in the analyzed
-	 * fileset, PHPStan resolves EVERY unqualified class_exists() call in that namespace to
-	 * the override instead of the builtin — including in unrelated production files (e.g.
-	 * inc/ThirdParty/Plugins/Jetpack.php's `class_exists( 'Jetpack' )` guard). That breaks
-	 * PHPStan's built-in class-exists type-narrowing extension, which only recognizes the
-	 * real \class_exists(), producing a false "unknown class Jetpack" error on the next
-	 * line's static call. Confirmed locally: `composer run-stan` is clean on this branch
-	 * without the override and fails with that exact error once the override is added.
-	 * eval() + @runInSeparateProcess avoids this entirely by keeping the defined class (and
-	 * this test) isolated to its own process, with no shared-namespace function collision.
+	 * Uses eval() + @runInSeparateProcess, rather than a namespaced class_exists()
+	 * override, to define the class in isolation: a namespaced override would make
+	 * PHPStan resolve every unqualified class_exists() call in this shared
+	 * namespace to the override, breaking its class-exists type-narrowing for
+	 * unrelated production files.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled

--- a/tests/Unit/inc/ThirdParty/Plugins/PluginResolver/easy25HookCollisionScan.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/PluginResolver/easy25HookCollisionScan.php
@@ -32,64 +32,27 @@ use WP_Rocket\ThirdParty\Plugins\ThirstyAffiliates;
 use WP_Rocket\ThirdParty\Plugins\UnlimitedElements;
 
 /**
- * AC-required hook-collision scan for issue #8789's Easy-25 batch (slices 1-4):
- * proves that the 25 migrated classes don't accidentally clash on the same
- * WordPress hook + priority once they're all resolver-gated.
+ * Verifies that none of the Easy-25 plugin-compat classes accidentally clash
+ * on the same WordPress hook + priority.
  *
- * Moved here from tests/Integration/inc/ThirdParty/Plugins/PluginResolver/
- * easy25HookCollisionScan.php (slice 5 regression fix): `get_subscribed_events()`
- * is a *static* method with zero WordPress/container dependency, so its output
- * is byte-identical whether captured from the Unit or the Integration suite —
- * no coverage is lost by moving it. It was originally written against the
- * Integration suite and used `@runInSeparateProcess` there to simulate 3
- * deviation classes' internal guards; forking a *WordPress integration* test
- * process re-runs the full WP integration bootstrap in the child, which
- * corrupted shared DB/option state for the parent process and deterministically
- * broke an unrelated test (Test_GetRocketOption's `cdn` dataset) on every CI
- * matrix job. `@runInSeparateProcess` has an established, non-disruptive
- * precedent in the *Unit* suite only (see Jetpack/isActivated.php,
- * PDFEmbedder/isActivated.php) — the Unit bootstrap is a lightweight,
- * file-based one with no WordPress DB/options layer to corrupt.
- *
- * Methodology (unchanged): `get_subscribed_events()` is called directly
- * (`Class::get_subscribed_events()`), with no container/instantiation involved.
- * 22 of the 25 classes already return their hook map unconditionally — issue
- * #8789 slices 1-4 moved their presence guard out of `get_subscribed_events()`
- * and into `is_activated()`, so no "target plugin present" simulation is
- * needed for them at all: the guard that used to gate the return value is
- * simply gone.
- *
- * Only 3 of the 7 deviation classes still have a guard *inside*
- * `get_subscribed_events()` itself (their business/feature-toggle checks,
- * deliberately left untouched per the Implementation Plan), so only these 3
- * need their markers simulated to reveal their real (maximal) hook set:
- * - SEOPress: needs `seopress_get_toggle_option('xml-sitemap')` to return 1
- *   AND `seopress_get_service('SitemapOption')->isEnabled()` to return 1.
- *   Simulated with Brain\Monkey `Functions\when()` — no process isolation
- *   needed for this: `seopress_get_toggle_option`/`seopress_get_service` are
- *   plain functions with no class to declare.
+ * `get_subscribed_events()` is a static method with no WordPress/container
+ * dependency, so it is called directly (`Class::get_subscribed_events()`) with
+ * no instantiation involved. Most of the 25 classes return their hook map
+ * unconditionally. Only 3 deviation classes still guard their hook map with a
+ * business/feature-toggle check *inside* `get_subscribed_events()` itself, so
+ * only these 3 need their "target plugin present" markers simulated to reveal
+ * their real (maximal) hook set:
+ * - SEOPress: needs `seopress_get_toggle_option('xml-sitemap')` and
+ *   `seopress_get_service('SitemapOption')->isEnabled()` to both return 1,
+ *   simulated with Brain\Monkey `Functions\when()`.
  * - TheSEOFramework: needs `the_seo_framework()` to return an object with a
- *   truthy `$loaded` and a truthy `can_run_sitemap()`. Needs zero stubbing
- *   here: tests/Unit/bootstrap.php unconditionally preloads
- *   tests/Fixtures/inc/ThirdParty/Plugins/SEO/TheSEOFramework/fixtures.php
- *   for every Unit test (needed by the pre-existing addTsfSitemapToPreload.php
- *   callback test), which already declares a real global the_seo_framework()
- *   returning a Sitemap stub whose $loaded/can_run_sitemap() are truthy — see
- *   the same reasoning documented in the pre-existing
- *   SEO/TheSEOFramework/isActivated.php and PluginResolver/getActivePlugins.php.
- * - Jetpack: needs a real `\Jetpack` class + `is_module_active('sitemaps')`
- *   truthy. Stubbed via the pre-existing tests/Fixtures/classes/Jetpack.php
- *   (mirrors the TRP_Translate_Press.php stub-class convention already in
- *   that directory; kept/reused as-is from the Integration version of this
- *   scan). Unlike the other two, this requires a real global *class*
- *   declaration, which — same as the pre-existing Jetpack/isActivated.php
- *   precedent — must be isolated (`@runInSeparateProcess`) so the declared
- *   class doesn't leak into the rest of the Unit suite. Since the main
- *   collision assertion needs Jetpack's contribution captured alongside the
- *   other 24 classes to check for cross-class collisions, the whole capture +
- *   assertion is done in one isolated method rather than splitting Jetpack out
- *   on its own (both are threaded through the same shared, throwaway forked
- *   process, so nothing declared here reaches any other Unit test).
+ *   truthy `$loaded` and `can_run_sitemap()`; tests/Unit/bootstrap.php already
+ *   preloads a fixture that declares this global with truthy values.
+ * - Jetpack: needs a real `\Jetpack` class with `is_module_active('sitemaps')`
+ *   truthy, stubbed via tests/Fixtures/classes/Jetpack.php. Declaring that
+ *   global class requires `@runInSeparateProcess` isolation so it doesn't leak
+ *   into the rest of the Unit suite; the Unit bootstrap has no WordPress
+ *   DB/options layer for a forked process to corrupt.
  *
  * All 25 classes are otherwise driven with zero stubbing beyond the above — a
  * genuine capture of their real, unconditional hook maps, not a guess.
@@ -100,30 +63,23 @@ use WP_Rocket\ThirdParty\Plugins\UnlimitedElements;
 class Test_Easy25HookCollisionScan extends TestCase {
 
 	/**
-	 * Pre-existing (hook, priority) pairs registered by 2+ of the Easy-25
-	 * classes, reviewed and accepted as intentional. Keyed by "hook:priority".
+	 * (hook, priority) pairs registered by 2+ of the Easy-25 classes, reviewed
+	 * and accepted as intentional. Keyed by "hook:priority".
 	 *
 	 * Only the `rocket_exclude_js:10` pair (elementor_subscriber vs
-	 * syntaxhighlighter_subscriber) is documented today by the
-	 * `SubscriberFactory` registry-order comment. This scan additionally
-	 * found 4 more pre-existing pairs that were not previously documented
-	 * anywhere: they are unrelated to this migration (hook maps are
-	 * byte-identical before/after issue #8789 slices 1-4 — only the presence
-	 * guard moved, per the Implementation Plan) and are all instances of the
-	 * same benign pattern: a WP Rocket "collector" filter (an exclusions or
-	 * preload-list array that callbacks *append* to) that several
-	 * plugin-compat classes legitimately contribute to. None of them mutate
-	 * shared state in a way where registration order matters, unlike the
-	 * documented pair. Flagged here for visibility per the AC, not because
-	 * they are bugs.
+	 * syntaxhighlighter_subscriber) is documented elsewhere, by the
+	 * `SubscriberFactory` registry-order comment. The remaining pairs are all
+	 * instances of the same benign pattern: a WP Rocket "collector" filter (an
+	 * exclusions or preload-list array that callbacks *append* to) that
+	 * several plugin-compat classes legitimately contribute to. None of them
+	 * mutate shared state in a way where registration order matters, unlike
+	 * the documented pair.
 	 *
 	 * @var array<string,array<string>>
 	 */
 	private const ACCEPTED_COLLISIONS = [
-		// Documented by SubscriberFactory::get_registry()'s own comment (order
-		// preserved intentionally); this scan additionally found pdfembedder
-		// also on the same hook + priority, which that comment does not
-		// mention.
+		// Documented by SubscriberFactory's registry-order comment; this scan
+		// also found pdfembedder on the same hook + priority (not mentioned there).
 		'rocket_exclude_js:10'                      => [
 			'elementor_subscriber',
 			'pdfembedder',
@@ -183,8 +139,8 @@ class Test_Easy25HookCollisionScan extends TestCase {
 
 	/**
 	 * Authoritative id => FQCN map for the Easy-25 batch, reconciled against
-	 * PluginResolverGatedIds::IDS (the single source of truth for this issue's
-	 * gated ids, shared with the baseline equivalence test).
+	 * PluginResolverGatedIds::IDS (the single source of truth for the gated
+	 * ids, shared with the baseline equivalence test).
 	 *
 	 * @return array<string,string>
 	 */
@@ -220,8 +176,8 @@ class Test_Easy25HookCollisionScan extends TestCase {
 
 	/**
 	 * Sanity-check the enumeration itself: this scan must cover exactly the
-	 * 25 ids issue #8789 gates, no more, no less, so a future slice can't
-	 * silently drift out of sync with PluginResolverGatedIds::IDS.
+	 * ids gated behind PluginCompatibilityInterface, no more, no less, so it
+	 * can't silently drift out of sync with PluginResolverGatedIds::IDS.
 	 */
 	public function testShouldEnumerateExactlyTheEasy25GatedIds() {
 		$ids = array_keys( $this->easy_25_classes() );
@@ -251,9 +207,9 @@ class Test_Easy25HookCollisionScan extends TestCase {
 	}
 
 	/**
-	 * The AC-required assertion: no WordPress hook is registered by 2+ of the
-	 * Easy-25 classes at the same priority, except the reviewed, documented
-	 * pairs in self::ACCEPTED_COLLISIONS.
+	 * The core assertion: no WordPress hook is registered by 2+ of the Easy-25
+	 * classes at the same priority, except the reviewed, documented pairs in
+	 * self::ACCEPTED_COLLISIONS.
 	 *
 	 * Isolated (see load_deviation_marker_stubs()'s docblock): capturing
 	 * Jetpack's real hook map requires declaring a real global class that
@@ -274,9 +230,8 @@ class Test_Easy25HookCollisionScan extends TestCase {
 				foreach ( self::priorities_for_callback( $callback ) as $priority ) {
 					$key = $hook . ':' . $priority;
 
-					// Keyed by id to dedupe a class registering the same
-					// hook+priority twice with itself (e.g. Autoptimize's two
-					// admin_notices callbacks) - that's not a cross-class collision.
+					// Keyed by id to dedupe a class registering the same hook+priority
+					// twice with itself (not a cross-class collision).
 					$hook_priority_to_ids[ $key ][ $id ] = true;
 				}
 			}

--- a/tests/Unit/inc/ThirdParty/Plugins/PluginResolver/easy25HookCollisionScan.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/PluginResolver/easy25HookCollisionScan.php
@@ -3,8 +3,6 @@
 namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\PluginResolver;
 
 use Brain\Monkey\Functions;
-use WP_Rocket\Subscriber\Third_Party\Plugins\NGG_Subscriber;
-use WP_Rocket\Subscriber\Third_Party\Plugins\SyntaxHighlighter_Subscriber;
 use WP_Rocket\Tests\Fixtures\classes\PluginResolverGatedIds;
 use WP_Rocket\Tests\Unit\TestCase;
 use WP_Rocket\ThirdParty\Plugins\ConvertPlug;
@@ -13,6 +11,7 @@ use WP_Rocket\ThirdParty\Plugins\I18n\TranslatePress;
 use WP_Rocket\ThirdParty\Plugins\I18n\Weglot;
 use WP_Rocket\ThirdParty\Plugins\InlineRelatedPosts;
 use WP_Rocket\ThirdParty\Plugins\Jetpack;
+use WP_Rocket\ThirdParty\Plugins\NGG;
 use WP_Rocket\ThirdParty\Plugins\Optimization\Autoptimize;
 use WP_Rocket\ThirdParty\Plugins\Optimization\Perfmatters;
 use WP_Rocket\ThirdParty\Plugins\Optimization\RocketLazyLoad;
@@ -27,6 +26,7 @@ use WP_Rocket\ThirdParty\Plugins\SEO\SEOPress;
 use WP_Rocket\ThirdParty\Plugins\SEO\TheSEOFramework;
 use WP_Rocket\ThirdParty\Plugins\SEO\Yoast;
 use WP_Rocket\ThirdParty\Plugins\SimpleCustomCss;
+use WP_Rocket\ThirdParty\Plugins\SyntaxHighlighter;
 use WP_Rocket\ThirdParty\Plugins\TheEventsCalendar;
 use WP_Rocket\ThirdParty\Plugins\ThirstyAffiliates;
 use WP_Rocket\ThirdParty\Plugins\UnlimitedElements;
@@ -212,8 +212,8 @@ class Test_Easy25HookCollisionScan extends TestCase {
 			'translatepress'               => TranslatePress::class,
 			'termly_subscriber'            => Termly::class,
 			'optimole_subscriber'          => Optimole::class,
-			'syntaxhighlighter_subscriber' => SyntaxHighlighter_Subscriber::class,
-			'ngg_subscriber'               => NGG_Subscriber::class,
+			'syntaxhighlighter_subscriber' => SyntaxHighlighter::class,
+			'ngg_subscriber'               => NGG::class,
 			'autoptimize'                  => Autoptimize::class,
 		];
 	}

--- a/tests/Unit/inc/ThirdParty/Plugins/PluginResolver/easy25HookCollisionScan.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/PluginResolver/easy25HookCollisionScan.php
@@ -1,11 +1,12 @@
 <?php
 
-namespace WP_Rocket\Tests\Integration\inc\ThirdParty\Plugins\PluginResolver;
+namespace WP_Rocket\Tests\Unit\inc\ThirdParty\Plugins\PluginResolver;
 
+use Brain\Monkey\Functions;
 use WP_Rocket\Subscriber\Third_Party\Plugins\NGG_Subscriber;
 use WP_Rocket\Subscriber\Third_Party\Plugins\SyntaxHighlighter_Subscriber;
 use WP_Rocket\Tests\Fixtures\classes\PluginResolverGatedIds;
-use WP_Rocket\Tests\Integration\TestCase;
+use WP_Rocket\Tests\Unit\TestCase;
 use WP_Rocket\ThirdParty\Plugins\ConvertPlug;
 use WP_Rocket\ThirdParty\Plugins\Cookie\Termly;
 use WP_Rocket\ThirdParty\Plugins\I18n\TranslatePress;
@@ -35,34 +36,63 @@ use WP_Rocket\ThirdParty\Plugins\UnlimitedElements;
  * proves that the 25 migrated classes don't accidentally clash on the same
  * WordPress hook + priority once they're all resolver-gated.
  *
- * Methodology: `get_subscribed_events()` is a *static* method on every one of
- * the 25 classes, so it is called directly (`Class::get_subscribed_events()`),
- * with no container/instantiation involved. 22 of the 25 classes already
- * return their hook map unconditionally — issue #8789 slices 1-4 moved their
- * presence guard out of `get_subscribed_events()` and into `is_activated()`
- * (Implementation Plan §1 step 3 / §2's "leave get_subscribed_events()
- * untouched" rule for the 7 deviation classes), so no "target plugin present"
- * simulation is needed for them at all: the guard that used to gate the
- * return value is simply gone.
+ * Moved here from tests/Integration/inc/ThirdParty/Plugins/PluginResolver/
+ * easy25HookCollisionScan.php (slice 5 regression fix): `get_subscribed_events()`
+ * is a *static* method with zero WordPress/container dependency, so its output
+ * is byte-identical whether captured from the Unit or the Integration suite —
+ * no coverage is lost by moving it. It was originally written against the
+ * Integration suite and used `@runInSeparateProcess` there to simulate 3
+ * deviation classes' internal guards; forking a *WordPress integration* test
+ * process re-runs the full WP integration bootstrap in the child, which
+ * corrupted shared DB/option state for the parent process and deterministically
+ * broke an unrelated test (Test_GetRocketOption's `cdn` dataset) on every CI
+ * matrix job. `@runInSeparateProcess` has an established, non-disruptive
+ * precedent in the *Unit* suite only (see Jetpack/isActivated.php,
+ * PDFEmbedder/isActivated.php) — the Unit bootstrap is a lightweight,
+ * file-based one with no WordPress DB/options layer to corrupt.
+ *
+ * Methodology (unchanged): `get_subscribed_events()` is called directly
+ * (`Class::get_subscribed_events()`), with no container/instantiation involved.
+ * 22 of the 25 classes already return their hook map unconditionally — issue
+ * #8789 slices 1-4 moved their presence guard out of `get_subscribed_events()`
+ * and into `is_activated()`, so no "target plugin present" simulation is
+ * needed for them at all: the guard that used to gate the return value is
+ * simply gone.
  *
  * Only 3 of the 7 deviation classes still have a guard *inside*
  * `get_subscribed_events()` itself (their business/feature-toggle checks,
- * deliberately left untouched per §2), so only these 3 need their markers
- * simulated to reveal their real (maximal) hook set:
- * - Jetpack: needs a real `\Jetpack` class + `is_module_active('sitemaps')`
- *   truthy. Stubbed via tests/Fixtures/classes/Jetpack.php (new fixture,
- *   mirrors the TRP_Translate_Press.php stub-class convention already in
- *   that directory).
+ * deliberately left untouched per the Implementation Plan), so only these 3
+ * need their markers simulated to reveal their real (maximal) hook set:
  * - SEOPress: needs `seopress_get_toggle_option('xml-sitemap')` to return 1
  *   AND `seopress_get_service('SitemapOption')->isEnabled()` to return 1.
- *   Reuses the existing tests/Fixtures/inc/ThirdParty/Plugins/SEO/SEOPress/fixtures.php
- *   (already declares these guarded globally, no override needed).
+ *   Simulated with Brain\Monkey `Functions\when()` — no process isolation
+ *   needed for this: `seopress_get_toggle_option`/`seopress_get_service` are
+ *   plain functions with no class to declare.
  * - TheSEOFramework: needs `the_seo_framework()` to return an object with a
- *   truthy `$loaded` and a truthy `can_run_sitemap()`. Reuses the existing
- *   tests/Fixtures/inc/ThirdParty/Plugins/SEO/TheSEOFramework/fixtures.php.
+ *   truthy `$loaded` and a truthy `can_run_sitemap()`. Needs zero stubbing
+ *   here: tests/Unit/bootstrap.php unconditionally preloads
+ *   tests/Fixtures/inc/ThirdParty/Plugins/SEO/TheSEOFramework/fixtures.php
+ *   for every Unit test (needed by the pre-existing addTsfSitemapToPreload.php
+ *   callback test), which already declares a real global the_seo_framework()
+ *   returning a Sitemap stub whose $loaded/can_run_sitemap() are truthy — see
+ *   the same reasoning documented in the pre-existing
+ *   SEO/TheSEOFramework/isActivated.php and PluginResolver/getActivePlugins.php.
+ * - Jetpack: needs a real `\Jetpack` class + `is_module_active('sitemaps')`
+ *   truthy. Stubbed via the pre-existing tests/Fixtures/classes/Jetpack.php
+ *   (mirrors the TRP_Translate_Press.php stub-class convention already in
+ *   that directory; kept/reused as-is from the Integration version of this
+ *   scan). Unlike the other two, this requires a real global *class*
+ *   declaration, which — same as the pre-existing Jetpack/isActivated.php
+ *   precedent — must be isolated (`@runInSeparateProcess`) so the declared
+ *   class doesn't leak into the rest of the Unit suite. Since the main
+ *   collision assertion needs Jetpack's contribution captured alongside the
+ *   other 24 classes to check for cross-class collisions, the whole capture +
+ *   assertion is done in one isolated method rather than splitting Jetpack out
+ *   on its own (both are threaded through the same shared, throwaway forked
+ *   process, so nothing declared here reaches any other Unit test).
  *
- * All 25 classes are otherwise driven with zero stubbing — a genuine capture
- * of their real, unconditional hook maps, not a guess.
+ * All 25 classes are otherwise driven with zero stubbing beyond the above — a
+ * genuine capture of their real, unconditional hook maps, not a guess.
  *
  * @group ThirdParty
  * @group Plugins
@@ -130,29 +160,25 @@ class Test_Easy25HookCollisionScan extends TestCase {
 	];
 
 	/**
-	 * Loads the marker stubs needed by the 3 deviation classes whose
+	 * Simulates the markers needed by the 3 deviation classes whose
 	 * `get_subscribed_events()` still has its own internal guard.
 	 *
-	 * Deliberately NOT wired into set_up_before_class(): that hook only ever
-	 * runs once, in the main (non-isolated) PHPUnit process, even for test
-	 * methods annotated `@runInSeparateProcess` below. These stubs declare
-	 * real global classes/functions (`Jetpack`, `seopress_get_toggle_option()`,
-	 * `the_seo_framework()`) that PHP can never "undeclare" afterwards, so
-	 * loading them there would leak into every other test that shares this
-	 * suite's single PHP process for the rest of the run — e.g. it would
-	 * silently flip PluginResolver::get_active_plugins()'s jetpack/seopress/
-	 * the_seo_framework detection to "active" for the remainder of the suite,
-	 * breaking Test_PluginCompatSubscribersBehaviorEquivalence's absence
-	 * assertions (confirmed locally: this exact leak was caught by a full
-	 * --group ThirdParty run before this method was isolated). Called instead
-	 * from inside each `@runInSeparateProcess` test method that needs it, so
-	 * the pollution is contained to that method's own forked, throwaway
-	 * process.
+	 * Only called from inside `@runInSeparateProcess` test methods: the
+	 * Jetpack class declaration below is a real global that PHP can never
+	 * "undeclare", so it must stay contained to its own forked, throwaway
+	 * process rather than leaking into the rest of the Unit suite.
 	 */
 	private static function load_deviation_marker_stubs(): void {
+		Functions\when( 'seopress_get_toggle_option' )->justReturn( 1 );
+		Functions\when( 'seopress_get_service' )->justReturn(
+			new class() {
+				public function isEnabled() {
+					return 1;
+				}
+			}
+		);
+
 		require_once WP_ROCKET_TESTS_FIXTURES_DIR . '/classes/Jetpack.php';
-		require_once WP_ROCKET_TESTS_FIXTURES_DIR . '/inc/ThirdParty/Plugins/SEO/SEOPress/fixtures.php';
-		require_once WP_ROCKET_TESTS_FIXTURES_DIR . '/inc/ThirdParty/Plugins/SEO/TheSEOFramework/fixtures.php';
 	}
 
 	/**
@@ -230,8 +256,8 @@ class Test_Easy25HookCollisionScan extends TestCase {
 	 * pairs in self::ACCEPTED_COLLISIONS.
 	 *
 	 * Isolated (see load_deviation_marker_stubs()'s docblock): capturing
-	 * Jetpack/SEOPress/TheSEOFramework's real hook maps requires declaring
-	 * real global markers that must not leak into the rest of the suite.
+	 * Jetpack's real hook map requires declaring a real global class that
+	 * must not leak into the rest of the suite.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled

--- a/tests/Unit/inc/ThirdParty/Plugins/PluginResolver/getActivePlugins.php
+++ b/tests/Unit/inc/ThirdParty/Plugins/PluginResolver/getActivePlugins.php
@@ -63,12 +63,10 @@ class Test_GetActivePlugins extends TestCase {
 	}
 
 	/**
-	 * Phase 0: no registry class implements PluginCompatibilityInterface yet,
-	 * so every id defaults active — the registry's full id set is unchanged.
-	 * Issue #8789 slices 1-2 opt a growing set of ids into real detection; none
-	 * of their target plugins are present in this test environment, so those
-	 * ids are excluded from the resolved active set while the rest still
-	 * default active.
+	 * Registry ids that do not implement PluginCompatibilityInterface default
+	 * active. The ids gated behind that interface are excluded from the
+	 * resolved active set, since none of their target plugins are present in
+	 * this test environment.
 	 *
 	 * @dataProvider configTestData
 	 *


### PR DESCRIPTION
> 🤖 AI-generated — created by an automated pipeline. Review before acting on this.

Part of #8789

# Description

Slice 5 of 5 (final) of #8789 — TEST-ONLY. (a) Finalizes the Phase 0 baseline test now that all 25 Easy classes are gated (fully diff-derived active-id assertion against the shared gated-ids fixture; keeps EXPECTED_PLUGIN_SUBSCRIBERS=20 as the deliberate perf-baseline). (b) Adds the AC-required hook-collision scan (`easy25HookCollisionScan.php`) across the 25 classes' `get_subscribed_events()`. This closes the last acceptance criterion. No production code changes.

## Type of change

- [x] Sub-task of #8789

## Detailed scenario

### What was tested

New collision scan 3/3; updated baseline 6/6; `--group ThirdParty` 41/41; `--group Plugins` 9/9; full unit suite 2833/2833; PHPStan 0; PHPCS 0. (Full `composer test-integration` had 1 pre-existing unrelated failure — `Test_GetRocketOption` 'cdn' dataset — reproduced identically on the slice-4 tip, not caused by this PR.) Via Docker/wp-env.

### How to test

Run the test suite via Docker/wp-env:
```bash
composer test-integration -- --group ThirdParty
composer test-integration -- --group Plugins
composer test-unit
composer test-phpstan
composer test-phpcs
```

The new hook-collision scan test will verify no duplicate hooks across the 25 migrated Easy classes.

### Affected Features & Quality Assurance Scope

ThirdParty plugin-compatibility gateway and Easy-25 class integration. Hook-collision baseline for all 25 migrated Easy plugin-compat classes.

## Technical description

### Documentation

The collision scan surfaced **5 pre-existing cross-class hook-collision groups**, where the spec had documented only 1. All 5 are verified pre-existing (hook maps byte-identical before/after the migration — only the presence guard moved) and are the same benign WP Rocket "collector filter" pattern (multiple plugin-compat classes legitimately appending to one filter). They are encoded as an explicit, commented `ACCEPTED_COLLISIONS` allowlist so any genuinely NEW collision fails the test.

The 5 accepted groups:
- `rocket_exclude_js@10` (elementor, pdfembedder, syntaxhighlighter)
- `rocket_sitemap_preload_list@15` (rank_math_seo, seopress, the_seo_framework, yoast_seo)
- `rocket_rucss_inline_content_exclusions@10` (inline_related_posts, unlimited_elements)
- `rocket_delay_js_exclusions@10` (rocket_lazy_load, termly)
- `rocket_exclude_defer_js@10` (syntaxhighlighter, termly)

Three classes (Jetpack, SEOPress, TheSEOFramework) whose `get_subscribed_events()` keeps an internal feature guard are driven via fixture stubs inside `@runInSeparateProcess` test methods to avoid global-state leakage (mirrors the Unit-suite Jetpack precedent). One new fixture `tests/Fixtures/classes/Jetpack.php` was added.

### Risks

**IMPORTANT — requires human reviewer to bless the `ACCEPTED_COLLISIONS` allowlist**: The 5 pre-existing collision groups are all verified safe (identical hook maps before/after, legitimate "collector filter" pattern), but the explicit allowlist means any new collision will fail the test. A human should review the 5 groups to confirm they match the spec and are intentional.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

# Additional Checks

- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)