### PR TITLE
Fix dev-env license setup: auto-fill credentials and stop wp-config.php corruption

### DIFF
--- a/bin/dev-down.sh
+++ b/bin/dev-down.sh
@@ -7,7 +7,7 @@ cd "$(dirname "$0")/.."
 
 if [[ "${1:-}" == "--destroy" ]]; then
   echo "Destroying wp-env (volumes and DB will be removed)..."
-  npx @wordpress/env destroy --yes
+  npx @wordpress/env destroy --force
 else
   echo "Stopping wp-env..."
   npx @wordpress/env stop

--- a/bin/dev-seed.sh
+++ b/bin/dev-seed.sh
@@ -30,11 +30,11 @@ if [[ -n "${WP_ROCKET_TESTS_LICENSE_KEY:-}" ]]; then
 
   # Set WP_ROCKET_EMAIL and WP_ROCKET_KEY as wp-config constants for dual validation.
   # Always set the key constant if we have a license key
-  $WP config set WP_ROCKET_KEY "${WP_ROCKET_TESTS_LICENSE_KEY}" --raw
+  $WP config set WP_ROCKET_KEY "${WP_ROCKET_TESTS_LICENSE_KEY}"
 
   # Only set the email constant if explicitly provided
   if [[ -n "${WP_ROCKET_EMAIL:-}" ]]; then
-    $WP config set WP_ROCKET_EMAIL "$WP_ROCKET_EMAIL" --raw
+    $WP config set WP_ROCKET_EMAIL "$WP_ROCKET_EMAIL"
   fi
   echo "  wp-config constants set."
 fi

--- a/bin/dev-seed.sh
+++ b/bin/dev-seed.sh
@@ -9,6 +9,16 @@ WP="npx @wordpress/env run cli wp"
 
 echo "Seeding test data..."
 
+# Fall back to the local PHPUnit credentials file if no env vars were passed in.
+LICENSE_FILE="tests/env/local/license.php"
+if [[ -z "${WP_ROCKET_TESTS_LICENSE_KEY:-}" && -f "$LICENSE_FILE" ]]; then
+  WP_ROCKET_TESTS_LICENSE_KEY="$(php -r "require '$LICENSE_FILE'; echo defined('ROCKET_KEY') ? ROCKET_KEY : '';")"
+  WP_ROCKET_EMAIL="${WP_ROCKET_EMAIL:-$(php -r "require '$LICENSE_FILE'; echo defined('ROCKET_EMAIL') ? ROCKET_EMAIL : '';")}"
+  if [[ -n "$WP_ROCKET_TESTS_LICENSE_KEY" ]]; then
+    echo "  Using credentials from $LICENSE_FILE."
+  fi
+fi
+
 # Set a dummy license key if provided via env var (enables PRO features).
 if [[ -n "${WP_ROCKET_TESTS_LICENSE_KEY:-}" ]]; then
   $WP eval "


### PR DESCRIPTION
# Description

Fixes #(issue number)

Local `wp-env` dev environment setup required manually exporting `WP_ROCKET_TESTS_LICENSE_KEY` (and optionally `WP_ROCKET_EMAIL`) before running `bin/dev-up.sh` / `bin/dev-seed.sh` to unlock PRO features. Developers already keep working credentials in the gitignored `tests/env/local/license.php` used by the PHPUnit integration tests, so `dev-seed.sh` now reuses them instead of requiring a separate manual export.

While testing this end-to-end, exercising that code path for the first time surfaced a pre-existing bug: `dev-seed.sh` wrote `WP_ROCKET_KEY`/`WP_ROCKET_EMAIL` into `wp-config.php` using `wp config set --raw`, which writes the value as literal (unquoted) PHP source. For an email address this produces `define( 'WP_ROCKET_EMAIL', ahmed@wp-media.me );` — invalid PHP — which corrupts `wp-config.php` and breaks every subsequent request against the site (parse error surfaced from unrelated commands like `wp eval`, `wp plugin activate`, etc.). This had likely never been hit before because nobody had `WP_ROCKET_EMAIL` set locally. Also fixed `bin/dev-down.sh --destroy`, which passed the nonexistent `--yes` flag to `wp-env destroy` (correct flag is `--force`) and silently cancelled instead of confirming.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [x] Chore
- [ ] Release

## Detailed scenario

### What was tested

Manual, on a fresh `wp-env` rebuild (`wp-env destroy --force && wp-env start`):
- Ran `bash bin/dev-seed.sh` without exporting `WP_ROCKET_TESTS_LICENSE_KEY` and confirmed it picked up `ROCKET_KEY`/`ROCKET_EMAIL` from `tests/env/local/license.php`.
- Confirmed `wp option get wp_rocket_settings` shows `consumer_key` matching `ROCKET_KEY`.
- Inspected `wp-config.php` and confirmed `WP_ROCKET_KEY`/`WP_ROCKET_EMAIL` are now written as properly quoted strings (`define( 'WP_ROCKET_KEY', 'a7086488' );`), not raw unquoted tokens.
- Confirmed the full script now completes ("Done seeding.") including the final `rocket_clean_domain()` cache-flush step, which previously failed with a PHP parse error caused by the corrupted config file.
- Reproduced the original bug in isolation beforehand: with the old `--raw` flag, even a bare `wp eval "echo 'hello';"` failed with the same parse error, confirming the corruption was in `wp-config.php` itself and not specific to any wp-rocket code path.

### How to test

1. Ensure `tests/env/local/license.php` exists with valid `ROCKET_KEY`/`ROCKET_EMAIL` constants (already required for PHPUnit integration tests).
2. Without exporting `WP_ROCKET_TESTS_LICENSE_KEY`, run `bash bin/dev-up.sh` (or `bash bin/dev-seed.sh` if the env is already up).
3. Confirm the script prints "Using credentials from tests/env/local/license.php." and finishes with "Done seeding." (no PHP parse errors).
4. Confirm `wp option get wp_rocket_settings` shows a `consumer_key` matching `ROCKET_KEY`, and that `wp-config.php` has properly quoted `WP_ROCKET_KEY`/`WP_ROCKET_EMAIL` constants.
5. Confirm an explicitly exported `WP_ROCKET_TESTS_LICENSE_KEY` still takes precedence over the file.
6. `bin/dev-down.sh --destroy` now actually prompts/destroys instead of silently cancelling.

### Affected Features & Quality Assurance Scope

Local dev tooling only (`bin/dev-seed.sh`, `bin/dev-down.sh`), used to seed/manage the `wp-env` Docker environment for E2E/manual testing. No production plugin code paths are affected.

## Technical description

### Documentation

- `bin/dev-seed.sh` falls back to `tests/env/local/license.php` (gitignored, already required for PHPUnit) when `WP_ROCKET_TESTS_LICENSE_KEY` is not set in the environment, extracting the `ROCKET_KEY`/`ROCKET_EMAIL` PHP constants via `php -r "require '...'; echo ...;"`. An explicitly set env var still takes precedence.
- Dropped the `--raw` flag from both `wp config set WP_ROCKET_KEY` / `wp config set WP_ROCKET_EMAIL` calls so wp-cli writes them as normal quoted PHP strings instead of literal unquoted source.
- `bin/dev-down.sh --destroy` now passes `--force` (the actual `wp-env destroy` flag) instead of the nonexistent `--yes`.

### New dependencies

None (`php` CLI is already a project prerequisite).

### Risks

The credentials file is gitignored and never committed, so no credentials are exposed. If `tests/env/local/license.php` doesn't define the constants, extraction yields an empty string and the script behaves exactly as before (no license set). The `--raw` fix only affects local dev tooling, not shipped plugin code.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

This is local dev-tooling shell script (not shipped plugin code), so no PHPUnit coverage was added — it was verified manually per "How to test" above.

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)