### PR TITLE
Fixes #8838: Name the logged-in cookie once, by one rule

### DIFF
--- a/inc/functions/files.php
+++ b/inc/functions/files.php
@@ -131,16 +131,10 @@ function get_rocket_config_file() { // phpcs:ignore WordPress.NamingConventions.
 		}
 
 		if ( 'cache_reject_cookies' === $option ) {
-			$cookies = get_rocket_cache_reject_cookies();
-
-			if ( $cookies && get_rocket_option( 'cache_logged_user' ) ) {
-				// Make sure the "logged-in cookies" are not rejected.
-				$logged_in_cookie = explode( COOKIEHASH, LOGGED_IN_COOKIE );
-				$logged_in_cookie = array_map( 'preg_quote', $logged_in_cookie );
-				$logged_in_cookie = implode( '[^|]*', $logged_in_cookie );
-				$cookies          = preg_replace( '/\|' . $logged_in_cookie . '\|/', '|', '|' . $cookies . '|' );
-				$cookies          = trim( $cookies, '|' );
-			}
+			// With cache_logged_user on, a logged-in page is cached under a per-user path, so
+			// LOGGED_IN_COOKIE is not a reason to refuse one and is left out of the list.
+			$include_logged_in = ! get_rocket_option( 'cache_logged_user' );
+			$cookies           = get_rocket_cache_reject_cookies( $include_logged_in );
 
 			$buffer .= '$rocket_' . $option . ' = \'' . $cookies . "';\n";
 		}

--- a/inc/functions/htaccess.php
+++ b/inc/functions/htaccess.php
@@ -346,6 +346,8 @@ function get_rocket_htaccess_mod_rewrite() { // phpcs:ignore WordPress.NamingCon
 	$rules .= 'RewriteCond %{REQUEST_METHOD} GET' . PHP_EOL;
 	$rules .= 'RewriteCond %{QUERY_STRING} =""' . PHP_EOL;
 
+	// The whole list, logged-in cookie included: mod_rewrite serves one file per address, and a
+	// logged-in visitor's page is cached under a per-user path these rules cannot build.
 	$cookies = get_rocket_cache_reject_cookies();
 	if ( $cookies ) {
 		$rules .= 'RewriteCond %{HTTP:Cookie} !(' . $cookies . ') [NC]' . PHP_EOL;

--- a/inc/functions/options.php
+++ b/inc/functions/options.php
@@ -275,19 +275,50 @@ function get_rocket_cache_reject_uri( $force = false, $show_safe_content = true 
 }
 
 /**
+ * Gets the name of the logged-in cookie as the pattern it is listed under.
+ *
+ * The hash inside the name is whatever the site is, so the parts around it are what names the
+ * cookie. WordPress leaves the hash empty when it cannot read the site address, and the name is
+ * then the whole cookie.
+ *
+ * @since 3.24
+ *
+ * @return string
+ */
+function rocket_get_logged_in_cookie_pattern() {
+	$hash   = (string) rocket_get_constant( 'COOKIEHASH', '' );
+	$cookie = (string) rocket_get_constant( 'LOGGED_IN_COOKIE', '' );
+
+	// LOGGED_IN_COOKIE can be undefined or empty; fall back to the prefix WordPress builds it from,
+	// so the list never comes out naming no logged-in cookie at all.
+	if ( '' === $cookie ) {
+		$cookie = 'wordpress_logged_in_';
+	}
+
+	$parts = '' === $hash ? [ $cookie ] : explode( $hash, $cookie );
+
+	return implode( '.+', array_map( 'preg_quote', $parts ) );
+}
+
+/**
  * Get all cookie names we don't cache.
  *
+ * A caller that caches pages for logged-in visitors asks for the list without LOGGED_IN_COOKIE in
+ * it, since such a page is cached under a per-user path rather than refused.
+ *
  * @since 2.0
+ * @since 3.24 Added the $include_logged_in parameter.
+ *
+ * @param bool $include_logged_in Whether the logged-in cookie is one of the cookies to reject.
  *
  * @return string A pipe separated list of rejected cookies.
  */
-function get_rocket_cache_reject_cookies() { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
-	$logged_in_cookie = explode( COOKIEHASH, LOGGED_IN_COOKIE );
-	$logged_in_cookie = array_map( 'preg_quote', $logged_in_cookie );
-	$logged_in_cookie = implode( '.+', $logged_in_cookie );
+function get_rocket_cache_reject_cookies( $include_logged_in = true ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
+	$cookies = get_rocket_option( 'cache_reject_cookies', [] );
 
-	$cookies   = get_rocket_option( 'cache_reject_cookies', [] );
-	$cookies[] = $logged_in_cookie;
+	if ( $include_logged_in ) {
+		$cookies[] = rocket_get_logged_in_cookie_pattern();
+	}
 	$cookies[] = 'wp-postpass_';
 	$cookies[] = 'wptouch_switch_toggle';
 	$cookies[] = 'comment_author_';

--- a/tests/Fixtures/inc/functions/getRocketCacheRejectCookies.php
+++ b/tests/Fixtures/inc/functions/getRocketCacheRejectCookies.php
@@ -1,0 +1,70 @@
+<?php
+
+$always = '|wp-postpass_|wptouch_switch_toggle|comment_author_|comment_author_email_';
+$hash   = 'd41d8cd98f00b204e9800998ecf8427e';
+
+return [
+	// The hash sits inside the cookie name, so the name is what is around it.
+	'shouldNameTheCookieAroundTheHash'           => [
+		'config'   => [
+			'hash'     => $hash,
+			'cookie'   => 'wordpress_logged_in_' . $hash,
+			'rejected' => [],
+		],
+		'expected' => 'wordpress_logged_in_.+' . $always,
+	],
+	// WordPress leaves the hash empty when it cannot read the site address: nothing to split on,
+	// and the name is the whole cookie.
+	'shouldNameTheWholeCookieWhenTheHashIsEmpty' => [
+		'config'   => [
+			'hash'     => '',
+			'cookie'   => 'wordpress_logged_in_',
+			'rejected' => [],
+		],
+		'expected' => 'wordpress_logged_in_' . $always,
+	],
+	// The caller that writes the buffer config asks for the list without the logged-in cookie, since
+	// a page held for a logged-in visitor is not a page to refuse.
+	'shouldLeaveTheNameOutWhenItIsNotAskedFor'   => [
+		'config'   => [
+			'hash'     => $hash,
+			'cookie'   => 'wordpress_logged_in_' . $hash,
+			'rejected' => [],
+			'logged_in' => false,
+		],
+		'expected' => ltrim( $always, '|' ),
+	],
+	// Asked with no argument, which is how the rules for the web server ask: they serve one file per
+	// address, and the page a logged-in visitor is given is not that file.
+	'shouldNameItWhenAskedWithNoArgument'        => [
+		'config'   => [
+			'hash'        => $hash,
+			'cookie'      => 'wordpress_logged_in_' . $hash,
+			'rejected'    => [],
+			'no_argument' => true,
+		],
+		'expected' => 'wordpress_logged_in_.+' . $always,
+	],
+	// A plugin naming the logged-in cookie through the filter is asking for it to be rejected, and
+	// it is: the caller left it out of the list, and the filter put a name of its own in.
+	'shouldKeepANameTheFilterAddsBack'           => [
+		'config'   => [
+			'hash'      => $hash,
+			'cookie'    => 'wordpress_logged_in_' . $hash,
+			'rejected'  => [],
+			'logged_in' => false,
+			'filter'    => [ 'wordpress_logged_in_' . $hash ],
+		],
+		'expected' => ltrim( $always, '|' ) . '|wordpress_logged_in_' . $hash,
+	],
+	// The cookies the site rejects come first and the logged-in one after them, which is the order
+	// the consumer of this list has to find it in.
+	'shouldPutTheNameAfterTheCookiesOfTheSite'   => [
+		'config'   => [
+			'hash'     => $hash,
+			'cookie'   => 'wordpress_logged_in_' . $hash,
+			'rejected' => [ 'my_cookie', 'my_cookie' ],
+		],
+		'expected' => 'my_cookie|wordpress_logged_in_.+' . $always,
+	],
+];

--- a/tests/Fixtures/inc/functions/getRocketConfigFile.php
+++ b/tests/Fixtures/inc/functions/getRocketConfigFile.php
@@ -1,0 +1,72 @@
+<?php
+
+$always = 'wp-postpass_|wptouch_switch_toggle|comment_author_|comment_author_email_';
+$hash   = 'd41d8cd98f00b204e9800998ecf8427e';
+
+return [
+	// The site caches pages for logged-in visitors, so the cookie that says who they are is not in
+	// the list the config is written with.
+	'shouldLeaveTheLoggedInCookieOutOfTheList'        => [
+		'config'   => [
+			'hash'        => $hash,
+			'cookie'      => 'wordpress_logged_in_' . $hash,
+			'rejected'    => [],
+			'logged_user' => 1,
+		],
+		'expected' => $always,
+	],
+	// WordPress could not read the site address, and the site caches logged-in visitors: this is the
+	// pair the writer used to split the name on, and end the request with a ValueError on PHP 8.
+	'shouldWriteTheListWhenTheHashIsEmptyAndLoggedInCachingIsOn' => [
+		'config'   => [
+			'hash'        => '',
+			'cookie'      => 'wordpress_logged_in_',
+			'rejected'    => [],
+			'logged_user' => 1,
+		],
+		'expected' => $always,
+	],
+	// The site is not caching logged-in visitors, so the name is in the list, and WordPress could not
+	// read the site address, so the name is the whole cookie.
+	'shouldKeepTheWholeNameWhenTheHashIsEmpty'        => [
+		'config'   => [
+			'hash'        => '',
+			'cookie'      => 'wordpress_logged_in_',
+			'rejected'    => [],
+			'logged_user' => 0,
+		],
+		'expected' => 'wordpress_logged_in_|' . $always,
+	],
+	// The site is not caching logged-in visitors, so the name is in the list, as it always has been.
+	'shouldKeepTheNameWhenLoggedInCachingIsOff'       => [
+		'config'   => [
+			'hash'        => $hash,
+			'cookie'      => 'wordpress_logged_in_' . $hash,
+			'rejected'    => [],
+			'logged_user' => 0,
+		],
+		'expected' => 'wordpress_logged_in_.+|' . $always,
+	],
+	// A cookie the site rejects on its own, whose name begins the same way: it is not the logged-in
+	// cookie and stays.
+	'shouldKeepACookieOfTheSiteThatBeginsTheSameWay'  => [
+		'config'   => [
+			'hash'        => $hash,
+			'cookie'      => 'wordpress_logged_in_' . $hash,
+			'rejected'    => [ 'wordpress_logged_in_myapp' ],
+			'logged_user' => 1,
+		],
+		'expected' => 'wordpress_logged_in_myapp|' . $always,
+	],
+	// A site that rejects the logged-in cookie itself keeps its own entry, and goes on not caching
+	// logged-in visitors, which is what it asked for.
+	'shouldKeepTheCookieTheSiteRejectsItself'         => [
+		'config'   => [
+			'hash'        => $hash,
+			'cookie'      => 'wordpress_logged_in_' . $hash,
+			'rejected'    => [ 'wordpress_logged_in_' ],
+			'logged_user' => 1,
+		],
+		'expected' => 'wordpress_logged_in_|' . $always,
+	],
+];

--- a/tests/Fixtures/inc/functions/rocketGetLoggedInCookiePattern.php
+++ b/tests/Fixtures/inc/functions/rocketGetLoggedInCookiePattern.php
@@ -1,0 +1,50 @@
+<?php
+
+$hash = 'd41d8cd98f00b204e9800998ecf8427e';
+
+return [
+	// The hash sits inside the name, so the pattern is what is around it.
+	'shouldNameWhatIsAroundTheHash'        => [
+		'config'   => [
+			'hash'   => $hash,
+			'cookie' => 'wordpress_logged_in_' . $hash,
+		],
+		'expected' => 'wordpress_logged_in_.+',
+	],
+	// WordPress leaves the hash empty when it cannot read the site address, and the name is then the
+	// whole cookie.
+	'shouldNameTheWholeCookieWithoutAHash' => [
+		'config'   => [
+			'hash'   => '',
+			'cookie' => 'wordpress_logged_in_',
+		],
+		'expected' => 'wordpress_logged_in_',
+	],
+	// A name a site gave characters that mean something to a pattern: they are escaped, and the
+	// slash is not among them.
+	'shouldEscapeWhatAPatternWouldRead'    => [
+		'config'   => [
+			'hash'   => $hash,
+			'cookie' => 'wp-logged/in.' . $hash,
+		],
+		'expected' => 'wp\\-logged/in\\..+',
+	],
+	// The name is not there to read, which is every moment before WordPress has built it: the list
+	// still names the cookie WordPress is going to build.
+	'shouldNameTheCookieWordPressWillBuild' => [
+		'config'   => [
+			'hash'   => $hash,
+			'cookie' => null,
+		],
+		'expected' => 'wordpress_logged_in_',
+	],
+	// The name is there but empty, which a site can do in its wp-config: the same answer as having
+	// none, since an empty name would leave the list naming no logged-in cookie at all.
+	'shouldNameItWhenTheNameIsEmpty'        => [
+		'config'   => [
+			'hash'   => $hash,
+			'cookie' => '',
+		],
+		'expected' => 'wordpress_logged_in_',
+	],
+];

--- a/tests/Unit/inc/functions/getRocketCacheRejectCookies.php
+++ b/tests/Unit/inc/functions/getRocketCacheRejectCookies.php
@@ -1,0 +1,36 @@
+<?php
+namespace WP_Rocket\Tests\Unit\inc\functions;
+
+use Brain\Monkey\Functions;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * Test class covering ::get_rocket_cache_reject_cookies
+ * @group Functions
+ * @group Options
+ */
+class Test_GetRocketCacheRejectCookies extends TestCase {
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldNameTheLoggedInCookie( $config, $expected ) {
+		$this->constants['COOKIEHASH']       = $config['hash'];
+		$this->constants['LOGGED_IN_COOKIE'] = $config['cookie'];
+
+		Functions\expect( 'get_rocket_option' )
+			->once()
+			->with( 'cache_reject_cookies', [] )
+			->andReturn( $config['rejected'] );
+		Functions\when( 'apply_filters' )->alias(
+			function ( $name, $cookies ) use ( $config ) {
+				return array_merge( $cookies, $config['filter'] ?? [] );
+			}
+		);
+
+		$actual = ( $config['no_argument'] ?? false )
+			? get_rocket_cache_reject_cookies()
+			: get_rocket_cache_reject_cookies( $config['logged_in'] ?? true );
+
+		$this->assertSame( $expected, $actual );
+	}
+}

--- a/tests/Unit/inc/functions/getRocketConfigFile.php
+++ b/tests/Unit/inc/functions/getRocketConfigFile.php
@@ -1,0 +1,78 @@
+<?php
+namespace WP_Rocket\Tests\Unit\inc\functions;
+
+use Brain\Monkey\Functions;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * Test class covering ::get_rocket_config_file
+ * @group Functions
+ * @group Files
+ */
+class Test_GetRocketConfigFile extends TestCase {
+	/**
+	 * Answers everything the writer asks the site, so only the cookie name is under test. The list of
+	 * rejected cookies is not among them: it comes from the function this one has to agree with.
+	 *
+	 * @return void
+	 */
+	private function stub_the_site( array $rejected, $logged_user ) {
+		Functions\when( 'get_option' )->alias(
+			function ( $name ) use ( $rejected, $logged_user ) {
+				return WP_ROCKET_SLUG === $name
+					? [
+						'cache_logged_user'    => $logged_user,
+						'cache_reject_cookies' => $rejected,
+					]
+					: '';
+			}
+		);
+		Functions\when( 'get_rocket_option' )->alias(
+			function ( $name, $default = null ) use ( $rejected, $logged_user ) {
+				if ( 'cache_logged_user' === $name ) {
+					return $logged_user;
+				}
+
+				return 'cache_reject_cookies' === $name ? $rejected : $default;
+			}
+		);
+		Functions\when( 'apply_filters' )->returnArg( 2 );
+		Functions\when( 'get_rocket_cache_query_string' )->justReturn( [] );
+		Functions\when( 'get_rocket_cache_reject_ua' )->justReturn( '' );
+		Functions\when( 'get_rocket_cache_reject_uri' )->justReturn( '' );
+		Functions\when( 'get_rocket_cache_mandatory_cookies' )->justReturn( '' );
+		Functions\when( 'get_rocket_cache_dynamic_cookies' )->justReturn( [] );
+		Functions\when( 'rocket_get_ignored_parameters' )->justReturn( [] );
+		Functions\when( 'get_rocket_i18n_subdomains' )->justReturn( [] );
+		Functions\when( 'rocket_get_home_url' )->justReturn( 'http://example.org' );
+		Functions\when( 'get_rocket_parse_url' )->justReturn(
+			[
+				'host' => 'example.org',
+				'path' => '',
+			]
+		);
+		Functions\when( 'wp_slash' )->returnArg();
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function testShouldWriteTheRejectedCookies( $config, $expected ) {
+		// The writer reads all four as constants, so the test gives them. One process per data set,
+		// hence no guard: a data set that lost its own process has to say so.
+		define( 'WP_ROCKET_SLUG', 'wp_rocket_settings' );
+		define( 'WP_ROCKET_CONFIG_PATH', 'vfs://public/wp-content/wp-rocket-config/' );
+		define( 'COOKIEHASH', $config['hash'] );
+		define( 'LOGGED_IN_COOKIE', $config['cookie'] );
+
+		$this->stub_the_site( $config['rejected'], $config['logged_user'] );
+
+		list( , $buffer ) = get_rocket_config_file();
+
+		$this->assertStringContainsString( "\$rocket_cache_reject_cookies = '{$expected}';", $buffer );
+		$this->assertStringContainsString( "\$rocket_cookie_hash = '{$config['hash']}';", $buffer );
+	}
+}

--- a/tests/Unit/inc/functions/rocketGetLoggedInCookiePattern.php
+++ b/tests/Unit/inc/functions/rocketGetLoggedInCookiePattern.php
@@ -1,0 +1,33 @@
+<?php
+namespace WP_Rocket\Tests\Unit\inc\functions;
+
+use Brain\Monkey\Functions;
+use WP_Rocket\Tests\Unit\TestCase;
+
+/**
+ * Test class covering ::rocket_get_logged_in_cookie_pattern
+ * @group Functions
+ * @group Options
+ */
+class Test_RocketGetLoggedInCookiePattern extends TestCase {
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldNameTheLoggedInCookie( $config, $expected ) {
+		$this->constants['COOKIEHASH'] = $config['hash'];
+
+		// A case giving no name asks what the function answers where the constant is not there to
+		// read, whatever the rest of the suite has defined in this process.
+		if ( null === $config['cookie'] ) {
+			Functions\when( 'rocket_has_constant' )->alias(
+				function ( $name ) {
+					return 'LOGGED_IN_COOKIE' !== $name && defined( $name );
+				}
+			);
+		} else {
+			$this->constants['LOGGED_IN_COOKIE'] = $config['cookie'];
+		}
+
+		$this->assertSame( $expected, rocket_get_logged_in_cookie_pattern() );
+	}
+}


### PR DESCRIPTION
# Description

Fixes #8838

The logged-in cookie was named twice. `get_rocket_cache_reject_cookies()` wrote it into the list of rejected cookies as `preg_quote()`d parts joined with `.+`, and `get_rocket_config_file()` took that entry back out, when the site caches pages for logged-in users, with a regular expression it built from the same constants using a different escape and a different separator. Three shapes of input came out wrong.

An empty hash. WordPress defines `COOKIEHASH` as an empty string when it cannot read the site address, and a site may define it in `wp-config.php`, where an unset value is empty too. Splitting on it ends the request on PHP 8 with `ValueError: explode(): Argument #1 ($separator) cannot be empty`; on PHP 7.4 it raises warnings and drops the logged-in cookie out of the list silently.

A name holding a character `preg_quote()` escapes. The list holds `wp\-logged_in_.+`, the removal pattern looks for `wp-logged_in_`, and the entry stays where it is: the site never caches a logged-in visitor, which is the opposite of the setting it turned on.

A cookie of the site whose name begins the same way. The pattern is `\|<name>[^|]*\|` and the site's own entries come first, so on a site rejecting `wordpress_logged_in_myapp` that entry is the one removed and the logged-in cookie is the one left.

One rule now names the cookie, and only one place applies it. `rocket_get_logged_in_cookie_pattern()` builds the name, reading both constants through `rocket_get_constant()`, and answers the whole cookie where there is no hash to split on. `get_rocket_cache_reject_cookies()` takes a parameter saying whether that name belongs in the list, so the writer asks for the list it wants instead of taking one apart: no second escape to disagree with the first, no delimiter to collide with the name, and nothing else in the list that can be mistaken for it. The `.htaccess` rules, which cannot serve a page held for a logged-in visitor, go on asking for the list with the name in it.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

Neither function had a test in either suite.

`rocket_get_logged_in_cookie_pattern()` has five cases of its own: a hash inside the name, no hash at all, a name carrying characters a pattern would read, and two where the name cannot be read, one with the constant absent and one with it empty, where it answers what WordPress builds that name from.

`get_rocket_cache_reject_cookies()` has six: the same two shapes of hash, a site with a rejected cookie of its own, which comes first with the logged-in name after it, a caller asking for the list without that name, a caller asking with no argument at all, which is how the rules for the web server ask, and a filter putting the name back after a caller left it out. Because the constants are read through the accessor, both files run in process.

`get_rocket_config_file()` has six, each asserting the line the config is written with: an ordinary hash, an empty hash with logged-in caching on, which is the pair that used to end the request, the same hash with it off, a site that rejects `wordpress_logged_in_myapp` of its own, and one that rejects the logged-in cookie itself. That test does not stub the list it writes: the real `get_rocket_cache_reject_cookies()` answers it. It runs in its own process per case because the writer puts both constants into the config directly, which is not what this PR is about.

All seventeen were written before the change. Against the current code the writer fails three of its six cases: the empty hash ends in the `ValueError`, and in the two where the site rejects a cookie of its own it is that entry which is removed while the logged-in one stays. The ordinary hash and the site not caching logged-in visitors pass before and after.

Measured on a WordPress site running PHP 7.4, with `wordpress_logged_in_myapp` in the rejected cookies of the site and caching for logged-in users on:

```
before   $rocket_cache_reject_cookies = 'wordpress_logged_in_.+|wp-postpass_|wptouch_switch_toggle|comment_author_|comment_author_email_';
after    $rocket_cache_reject_cookies = 'wordpress_logged_in_myapp|wp-postpass_|wptouch_switch_toggle|comment_author_|comment_author_email_';
```

With `COOKIEHASH` defined empty on the same site, the call raised four warnings across the two files before the change and none after it. On PHP 8.3 it ended in the `ValueError` before, and returns the list after.

Full suites after the change: unit 2797 tests / 9062 assertions, no failures. PHPCS clean, PHPStan reports no errors, and both files pass PHPCompatibility at `testVersion 7.4-`.

### How to test

1. Turn on caching for logged-in users, and add `wordpress_logged_in_myapp` to the rejected cookies.
2. Save the settings, which writes the buffer config.
3. Open `wp-content/wp-rocket-config/<domain>.php`. `$rocket_cache_reject_cookies` holds `wordpress_logged_in_myapp` and no longer holds the logged-in cookie. Before this change it was the other way round.
4. Add `define( 'COOKIEHASH', '' );` to `wp-config.php` and save the settings again. Before this change the request ended with the `ValueError` on PHP 8 and finished with warnings on PHP 7.4. After it, neither.

### Affected Features & Quality Assurance Scope

- **Rejected cookies.** The list gains the logged-in cookie on a site whose hash is empty. Everywhere else it is what it was.
- **Buffer config file.** The logged-in cookie is taken out of the written list where it is meant to be, and only it: a site whose cookie name is escaped in the list keeps its logged-in caching, and a site with an entry of its own that begins the same way keeps that entry.
- **Caching for logged-in users.** Two kinds of site start caching logged-in visitors where they asked to and did not: the one whose hash is empty and the one whose cookie name is escaped in the list. A site that rejects the logged-in cookie itself goes on not caching them, as before, and now keeps its own entry rather than the one the plugin added.
- **Reading constants.** Both constants are read through `rocket_get_constant()` in the new function. Where they are defined, which is every normal request, the value is the same one.

## Technical description

### Documentation

```php
function rocket_get_logged_in_cookie_pattern() {
	$hash   = (string) rocket_get_constant( 'COOKIEHASH', '' );
	$cookie = (string) rocket_get_constant( 'LOGGED_IN_COOKIE', '' );
	$parts  = '' === $hash ? [ $cookie ] : explode( $hash, $cookie );

	return implode( '.+', array_map( 'preg_quote', $parts ) );
}
```

The cast covers the shapes a `wp-config.php` definition can take, `null` among them, which `explode()` reads as an empty separator as well. Where the name itself cannot be read, whether the constant is absent or empty, what WordPress builds that name from is used instead, so a list that names no logged-in cookie is not what comes out. The pattern itself is unchanged for every name that has a hash in it, which is every site that was not hitting one of the three cases.

The writer then asks for the list it wants:

```php
$cookies = get_rocket_cache_reject_cookies( ! get_rocket_option( 'cache_logged_user' ) );
```

This is what removes the second escape, the second separator, and the `preg_replace()` whose `null` return used to empty the whole list on a pattern it could not read. One thing a third party can see: a callback on `rocket_cache_reject_cookies` is given the list without the logged-in name when the buffer config is being written, where before the name was always in it.

The third place `COOKIEHASH` appears needs nothing: `Buffer\Cache` takes the hash out of the cookie name with `str_replace()`, which returns the name unchanged when the hash is empty. That one cannot call this function, since it runs from `advanced-cache.php` before the plugin is loaded, and it wants a literal name rather than a pattern; the two are different answers to different questions and are left apart.

### New dependencies

None.

### Risks

- **One new function in a global namespace, and one new parameter on an existing one.** Together they are the smallest way to stop the two callers from naming the same cookie by two rules, which is what all three defects come from. The parameter defaults to what every caller asked for until now, so the `.htaccess` side is untouched.
- **Three kinds of site start rejecting, or not rejecting, a cookie they did not before.** That is the fix. Pages cached under the old regime are not touched here, so such a site wants its cache cleared once.
- **No upgrade routine is added.** The lists are generated, so they have to be rewritten for the fix to reach a site, and an upgrade already does it: `rocket_upgrader()` flushes the `.htaccess` rules itself, and the option write at the end of it runs `rocket_after_save_options()`, which writes the config file. Verified on a site by removing the config file, running the upgrade from an older version, and finding it written again.

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

All items are ticked.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
