### PR TITLE
Expose GetOptions' per-option schema

### DIFF
--- a/inc/Engine/Abilities/Options/GetOptions.php
+++ b/inc/Engine/Abilities/Options/GetOptions.php
@@ -36,15 +36,23 @@ class GetOptions implements AbilitiesInterface {
 	}
 
 	/**
-	 * Registers the ability to get WP Rocket options.
+	 * The type of every option Fleet or an MCP client may be shown.
 	 *
-	 * @return void
+	 * Extracted from register() so it has one definition and two readers.
+	 * The ability advertises it as its output schema; the Fleet route serves
+	 * it so a remote caller can render a real control per option instead of
+	 * guessing a type from whatever value happens to be stored — an unset
+	 * boolean and an unset text field both arrive empty, and only this says
+	 * which is which.
+	 *
+	 * Intersected with the allowlist, so an option that may not be read has
+	 * no schema entry either and cannot be rendered as though it did.
+	 *
+	 * @since 3.23.4
+	 *
+	 * @return array Keyed by option name.
 	 */
-	public function register(): void {
-		if ( ! function_exists( 'wp_register_ability' ) ) {
-			return;
-		}
-
+	public function schema(): array {
 		$schema_definitions = [
 			// Cache settings.
 			'cache_logged_user'                         => [
@@ -413,7 +421,20 @@ class GetOptions implements AbilitiesInterface {
 			],
 		];
 
-		$properties = array_intersect_key( $schema_definitions, array_flip( $this->allowed_options->get() ) );
+		return array_intersect_key( $schema_definitions, array_flip( $this->allowed_options->get() ) );
+	}
+
+	/**
+	 * Registers the ability to get WP Rocket options.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			return;
+		}
+
+		$properties = $this->schema();
 
 		wp_register_ability(
 			'wp-rocket/get-options',


### PR DESCRIPTION
# Description

Fixes #8844

> ### ✅ QA already performed by the author
>
> **Automated:** full unit suite green — **2808 tests**, 9151 assertions. Full PHPCS green. Codacy green.
> **Functional:** the ability still registers with the same output schema, checked in a WordPress 6.9 install.
>
> This is a pure refactor with no behaviour change, so there is no functional surface to QA beyond that. The Fleet feature it enables is in #8847, which carries its own evidence.
>
> **What still needs a human:** a second pair of eyes on the extraction being genuinely equivalent. Nothing environmental.

Pulls the per-option schema out of `GetOptions::register()` into a `schema()` method, so it has one definition and two readers. No behaviour change: `register()` still builds the same `$properties` from the same array, still behind the same `function_exists( 'wp_register_ability' )` guard.

**Why it is wanted.** A remote caller that is shown a list of options and their values cannot render a control for each without knowing the type. An unset boolean and an unset text field both arrive empty, and only the schema says which is which. #8845 serves this over the Fleet route; the ability keeps advertising it as its output schema exactly as before.

Users see nothing from this PR on its own.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [x] Sub-task of wp-media/fleet#6
- [ ] Chore
- [ ] Release

### What is Fleet, for context

Fleet is a new WP Media dashboard where an agency manages WP Rocket across every site on its licence from one place, instead of opening one wp-admin per site. It is reached from wp-rocket.me. For it to show or change a setting it has to ask the site, and it deliberately holds **no credential** for any site — it signs a short-lived token per request which the plugin verifies. This PR is the first of two on the plugin side; it is a pure refactor and adds nothing that talks to anything.

## Detailed scenario

### What was tested

Automated. The existing unit and integration suites for the abilities cover both readers of the extracted method:

- `tests/Unit/inc/Engine/Abilities/Options/GetOptions/ExecuteTest.php`
- `tests/Integration/inc/Engine/Abilities/Options/GetOptions/RegisterGetOptionsAbilityTest.php`

Full unit suite green (2808 tests), full PHPCS green.

### How to test

Nothing to set up. The ability is unchanged, so the check is that it still registers with the same output schema:

```bash
composer test-unit -- --filter Abilities
wp rocket abilities list       # get-options still present, same schema
```

Or in a WordPress 6.9 install, confirm `wp-rocket/get-options` still advertises a `properties` entry per allowlisted option.

### Affected Features & Quality Assurance Scope

The MCP / Abilities surface only — `wp-rocket/get-options`. Nothing else reads the schema today. Caching, optimisation and the admin UI are untouched.

## Technical description

### Documentation

`register()` used to declare a ~380 line `$schema_definitions` array inline, intersect it with the allowlist, and pass the result to `wp_register_ability()`. The array and the intersection moved to:

```php
public function schema(): array {
    $schema_definitions = [ /* … unchanged … */ ];

    return array_intersect_key( $schema_definitions, array_flip( $this->allowed_options->get() ) );
}
```

and `register()` now reads `$properties = $this->schema();`.

Two properties preserved deliberately:

- **The `function_exists` guard stays in `register()`.** The array is only built when something asks for it, so this costs no work on a site below WordPress 6.9.
- **The intersection with the allowlist stays inside `schema()`.** An option that may not be read has no schema entry either, so a caller cannot be handed a type for something it will never be shown. Putting the intersection at the call site would have made that a caller's responsibility to remember.

### New dependencies

None.

### Risks

Low. One method extracted, no call site outside this class, no change to what is registered. The risk of getting it wrong would be a schema that no longer matches the allowlist, which the existing integration test for the ability's registration covers.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented tests to cover the new/changed code.

## Code style

- [x] I wrote self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionable.

## Unticked items justification

Tests: covered by the existing suites for both readers rather than by new ones. The extracted method has no behaviour of its own to test that `register()` did not already have tested — a new test asserting `schema()` returns the array would restate the implementation.

# Additional Checks

- [x] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, metrics, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)

Observability: nothing to observe. No I/O, no failure mode.
